### PR TITLE
refactor(frontend): Rename transfers methods of EXT canister

### DIFF
--- a/src/frontend/src/icp/canisters/ext-v2-token.canister.ts
+++ b/src/frontend/src/icp/canisters/ext-v2-token.canister.ts
@@ -180,53 +180,6 @@ export class ExtV2TokenCanister extends Canister<ExtV2TokenService> {
 		tokenIdentifier: TokenIdentifier;
 		amount: bigint;
 	} & QueryParams): Promise<Balance> => {
-		const { ext_transfer } = this.caller({ certified });
-
-		const args: TransferRequest = {
-			from: toUser(from),
-			to: toUser(to),
-			token,
-			amount,
-			notify: false,
-			memo: new Uint8Array(),
-			subaccount: toNullable()
-		};
-
-		const response = await ext_transfer(args);
-
-		if ('ok' in response) {
-			return response.ok;
-		}
-
-		throw mapExtV2TokenTransferError(response);
-	};
-
-	/**
-	 * Transfer NFT of a collection from one user to another (legacy method).
-	 *
-	 * @link https://github.com/Toniq-Labs/ext-v2-token/blob/main/API-REFERENCE.md#transfer--ext_transfer
-	 *
-	 * @param {Object} params - The parameters for the transfer.
-	 * @param {Principal} params.from - The ICRC principal of the sender.
-	 * @param {Principal} params.to - The ICRC principal of the receiver.
-	 * @param {TokenIdentifier} params.tokenIdentifier - The token identifier of the NFT as string.
-	 * @param {bigint} params.amount - The amount to transfer.
-	 * @param {boolean} [params.certified=true] - Whether the data should be certified.
-	 * @returns {Promise<Balance>} The new balance of the sender after the transfer.
-	 * @throws CanisterInternalError if the token identifier is invalid or if the transfer fails.
-	 */
-	transferLegacy = async ({
-		certified,
-		from,
-		to,
-		tokenIdentifier: token,
-		amount
-	}: {
-		from: Principal;
-		to: Principal;
-		tokenIdentifier: TokenIdentifier;
-		amount: bigint;
-	} & QueryParams): Promise<Balance> => {
 		const { transfer } = this.caller({ certified });
 
 		const args: TransferRequest = {
@@ -240,6 +193,53 @@ export class ExtV2TokenCanister extends Canister<ExtV2TokenService> {
 		};
 
 		const response = await transfer(args);
+
+		if ('ok' in response) {
+			return response.ok;
+		}
+
+		throw mapExtV2TokenTransferError(response);
+	};
+
+	/**
+	 * Transfer NFT of a collection from one user to another (alias method).
+	 *
+	 * @link https://github.com/Toniq-Labs/ext-v2-token/blob/main/API-REFERENCE.md#transfer--ext_transfer
+	 *
+	 * @param {Object} params - The parameters for the transfer.
+	 * @param {Principal} params.from - The ICRC principal of the sender.
+	 * @param {Principal} params.to - The ICRC principal of the receiver.
+	 * @param {TokenIdentifier} params.tokenIdentifier - The token identifier of the NFT as string.
+	 * @param {bigint} params.amount - The amount to transfer.
+	 * @param {boolean} [params.certified=true] - Whether the data should be certified.
+	 * @returns {Promise<Balance>} The new balance of the sender after the transfer.
+	 * @throws CanisterInternalError if the token identifier is invalid or if the transfer fails.
+	 */
+	transferAlias = async ({
+		certified,
+		from,
+		to,
+		tokenIdentifier: token,
+		amount
+	}: {
+		from: Principal;
+		to: Principal;
+		tokenIdentifier: TokenIdentifier;
+		amount: bigint;
+	} & QueryParams): Promise<Balance> => {
+		const { ext_transfer } = this.caller({ certified });
+
+		const args: TransferRequest = {
+			from: toUser(from),
+			to: toUser(to),
+			token,
+			amount,
+			notify: false,
+			memo: new Uint8Array(),
+			subaccount: toNullable()
+		};
+
+		const response = await ext_transfer(args);
 
 		if ('ok' in response) {
 			return response.ok;

--- a/src/frontend/src/tests/icp/api/ext-v2-token.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/ext-v2-token.api.spec.ts
@@ -205,7 +205,7 @@ describe('ext-v2-token.api', () => {
 		beforeEach(() => {
 			tokenCanisterMock.transfer.mockResolvedValue(mockBalance);
 
-			tokenCanisterMock.transferLegacy.mockResolvedValue(mockBalance);
+			tokenCanisterMock.transferAlias.mockResolvedValue(mockBalance);
 		});
 
 		it('should call successfully transfer endpoint', async () => {
@@ -229,7 +229,7 @@ describe('ext-v2-token.api', () => {
 
 			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 
-			expect(tokenCanisterMock.transferLegacy).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(tokenCanisterMock.transferAlias).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should raise the error of the legacy transfer if it is handled', async () => {
@@ -237,13 +237,13 @@ describe('ext-v2-token.api', () => {
 
 			tokenCanisterMock.transfer.mockRejectedValueOnce(new Error('First transfer error'));
 
-			tokenCanisterMock.transferLegacy.mockRejectedValueOnce(mockError);
+			tokenCanisterMock.transferAlias.mockRejectedValueOnce(mockError);
 
 			await expect(transfer(params)).rejects.toThrowError(mockError);
 
 			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 
-			expect(tokenCanisterMock.transferLegacy).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(tokenCanisterMock.transferAlias).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should raise the error of the first transfer if both errors are handled', async () => {
@@ -252,13 +252,13 @@ describe('ext-v2-token.api', () => {
 
 			tokenCanisterMock.transfer.mockRejectedValueOnce(mockError1);
 
-			tokenCanisterMock.transferLegacy.mockRejectedValueOnce(mockError2);
+			tokenCanisterMock.transferAlias.mockRejectedValueOnce(mockError2);
 
 			await expect(transfer(params)).rejects.toThrowError(mockError1);
 
 			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 
-			expect(tokenCanisterMock.transferLegacy).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(tokenCanisterMock.transferAlias).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should raise the error of the first transfer if fallback fails', async () => {
@@ -266,13 +266,13 @@ describe('ext-v2-token.api', () => {
 
 			tokenCanisterMock.transfer.mockRejectedValueOnce(mockError);
 
-			tokenCanisterMock.transferLegacy.mockRejectedValueOnce(new Error('Legacy transfer error'));
+			tokenCanisterMock.transferAlias.mockRejectedValueOnce(new Error('Legacy transfer error'));
 
 			await expect(transfer(params)).rejects.toThrowError(mockError);
 
 			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 
-			expect(tokenCanisterMock.transferLegacy).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(tokenCanisterMock.transferAlias).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 	});
 

--- a/src/frontend/src/tests/icp/canisters/ext-v2-token.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/ext-v2-token.canister.spec.ts
@@ -446,8 +446,8 @@ describe('ext-v2-token.canister', () => {
 			vi.clearAllMocks();
 		});
 
-		it('should correctly call the ext_transfer method', async () => {
-			service.ext_transfer.mockResolvedValue({ ok: 456n });
+		it('should correctly call the transfer method', async () => {
+			service.transfer.mockResolvedValue({ ok: 456n });
 
 			const { transfer } = await createExtV2TokenCanister({
 				serviceOverride: service
@@ -456,13 +456,13 @@ describe('ext-v2-token.canister', () => {
 			const res = await transfer(mockParams);
 
 			expect(res).toEqual(456n);
-			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle cannot notify error', async () => {
 			const mockAccountIdentifier = encodeIcrcAccount({ owner: mockParams.to });
 
-			service.ext_transfer.mockResolvedValue({
+			service.transfer.mockResolvedValue({
 				err: { CannotNotify: mockAccountIdentifier }
 			});
 
@@ -474,11 +474,11 @@ describe('ext-v2-token.canister', () => {
 				new CanisterInternalError(`Cannot notify account: ${mockAccountIdentifier}`)
 			);
 
-			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle insufficient balance error', async () => {
-			service.ext_transfer.mockResolvedValue({
+			service.transfer.mockResolvedValue({
 				err: { InsufficientBalance: null }
 			});
 
@@ -490,11 +490,11 @@ describe('ext-v2-token.canister', () => {
 				new CanisterInternalError('Insufficient balance for the transfer')
 			);
 
-			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle reject error', async () => {
-			service.ext_transfer.mockResolvedValue({
+			service.transfer.mockResolvedValue({
 				err: { Rejected: null }
 			});
 
@@ -506,13 +506,13 @@ describe('ext-v2-token.canister', () => {
 				new CanisterInternalError('The transfer was rejected')
 			);
 
-			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle unauthorized error', async () => {
 			const mockAccountIdentifier = encodeIcrcAccount({ owner: mockParams.from });
 
-			service.ext_transfer.mockResolvedValue({
+			service.transfer.mockResolvedValue({
 				err: { Unauthorized: mockAccountIdentifier }
 			});
 
@@ -524,11 +524,11 @@ describe('ext-v2-token.canister', () => {
 				new CanisterInternalError(`Unauthorized account: ${mockAccountIdentifier}`)
 			);
 
-			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle invalid token error', async () => {
-			service.ext_transfer.mockResolvedValue({
+			service.transfer.mockResolvedValue({
 				err: { InvalidToken: mockExtV2TokenIdentifier }
 			});
 
@@ -540,11 +540,11 @@ describe('ext-v2-token.canister', () => {
 				new CanisterInternalError(`The specified token is invalid: ${mockExtV2TokenIdentifier}`)
 			);
 
-			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle other unexpected errors', async () => {
-			service.ext_transfer.mockResolvedValue({
+			service.transfer.mockResolvedValue({
 				err: { Other: 'other error' }
 			});
 
@@ -556,12 +556,12 @@ describe('ext-v2-token.canister', () => {
 				new CanisterInternalError('other error')
 			);
 
-			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle a generic canister error', async () => {
 			// @ts-expect-error we test this on purpose
-			service.ext_transfer.mockResolvedValue({ err: { CanisterError: null } });
+			service.transfer.mockResolvedValue({ err: { CanisterError: null } });
 
 			const { transfer } = await createExtV2TokenCanister({
 				serviceOverride: service
@@ -571,12 +571,12 @@ describe('ext-v2-token.canister', () => {
 				new CanisterInternalError('Unknown ExtV2TokenCanisterError')
 			);
 
-			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
-		it('should throw an error if ext_transfer throws', async () => {
+		it('should throw an error if transfer throws', async () => {
 			const mockError = new Error('Test response error');
-			service.ext_transfer.mockRejectedValue(mockError);
+			service.transfer.mockRejectedValue(mockError);
 
 			const { transfer } = await createExtV2TokenCanister({
 				serviceOverride: service
@@ -588,7 +588,7 @@ describe('ext-v2-token.canister', () => {
 		});
 	});
 
-	describe('transferLegacy', () => {
+	describe('transferAlias', () => {
 		const mockParams = {
 			certified,
 			from: mockPrincipal,
@@ -611,143 +611,143 @@ describe('ext-v2-token.canister', () => {
 			vi.clearAllMocks();
 		});
 
-		it('should correctly call the transfer method', async () => {
-			service.transfer.mockResolvedValue({ ok: 456n });
+		it('should correctly call the ext_transfer method', async () => {
+			service.ext_transfer.mockResolvedValue({ ok: 456n });
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			const res = await transferLegacy(mockParams);
+			const res = await transferAlias(mockParams);
 
 			expect(res).toEqual(456n);
-			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle cannot notify error', async () => {
 			const mockAccountIdentifier = encodeIcrcAccount({ owner: mockParams.to });
 
-			service.transfer.mockResolvedValue({
+			service.ext_transfer.mockResolvedValue({
 				err: { CannotNotify: mockAccountIdentifier }
 			});
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			await expect(transferLegacy(mockParams)).rejects.toThrowError(
+			await expect(transferAlias(mockParams)).rejects.toThrowError(
 				new CanisterInternalError(`Cannot notify account: ${mockAccountIdentifier}`)
 			);
 
-			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle insufficient balance error', async () => {
-			service.transfer.mockResolvedValue({
+			service.ext_transfer.mockResolvedValue({
 				err: { InsufficientBalance: null }
 			});
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			await expect(transferLegacy(mockParams)).rejects.toThrowError(
+			await expect(transferAlias(mockParams)).rejects.toThrowError(
 				new CanisterInternalError('Insufficient balance for the transfer')
 			);
 
-			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle reject error', async () => {
-			service.transfer.mockResolvedValue({
+			service.ext_transfer.mockResolvedValue({
 				err: { Rejected: null }
 			});
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			await expect(transferLegacy(mockParams)).rejects.toThrowError(
+			await expect(transferAlias(mockParams)).rejects.toThrowError(
 				new CanisterInternalError('The transfer was rejected')
 			);
 
-			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle unauthorized error', async () => {
 			const mockAccountIdentifier = encodeIcrcAccount({ owner: mockParams.from });
 
-			service.transfer.mockResolvedValue({
+			service.ext_transfer.mockResolvedValue({
 				err: { Unauthorized: mockAccountIdentifier }
 			});
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			await expect(transferLegacy(mockParams)).rejects.toThrowError(
+			await expect(transferAlias(mockParams)).rejects.toThrowError(
 				new CanisterInternalError(`Unauthorized account: ${mockAccountIdentifier}`)
 			);
 
-			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle invalid token error', async () => {
-			service.transfer.mockResolvedValue({
+			service.ext_transfer.mockResolvedValue({
 				err: { InvalidToken: mockExtV2TokenIdentifier }
 			});
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			await expect(transferLegacy(mockParams)).rejects.toThrowError(
+			await expect(transferAlias(mockParams)).rejects.toThrowError(
 				new CanisterInternalError(`The specified token is invalid: ${mockExtV2TokenIdentifier}`)
 			);
 
-			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle other unexpected errors', async () => {
-			service.transfer.mockResolvedValue({
+			service.ext_transfer.mockResolvedValue({
 				err: { Other: 'other error' }
 			});
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			await expect(transferLegacy(mockParams)).rejects.toThrowError(
+			await expect(transferAlias(mockParams)).rejects.toThrowError(
 				new CanisterInternalError('other error')
 			);
 
-			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
 		it('should handle a generic canister error', async () => {
 			// @ts-expect-error we test this on purpose
-			service.transfer.mockResolvedValue({ err: { CanisterError: null } });
+			service.ext_transfer.mockResolvedValue({ err: { CanisterError: null } });
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			await expect(transferLegacy(mockParams)).rejects.toThrowError(
+			await expect(transferAlias(mockParams)).rejects.toThrowError(
 				new CanisterInternalError('Unknown ExtV2TokenCanisterError')
 			);
 
-			expect(service.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+			expect(service.ext_transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 
-		it('should throw an error if transfer throws', async () => {
+		it('should throw an error if ext_transfer throws', async () => {
 			const mockError = new Error('Test response error');
-			service.transfer.mockRejectedValue(mockError);
+			service.ext_transfer.mockRejectedValue(mockError);
 
-			const { transferLegacy } = await createExtV2TokenCanister({
+			const { transferAlias } = await createExtV2TokenCanister({
 				serviceOverride: service
 			});
 
-			const res = transferLegacy(mockParams);
+			const res = transferAlias(mockParams);
 
 			await expect(res).rejects.toThrowError(mockError);
 		});


### PR DESCRIPTION
# Motivation

Endpoints `transfer` and `ext_transfer` of EXT token canister are actually equivalent, with the latter being an alias of the first one.

However, not all of them implement `ext_transfer`, so we can actually always try `transfer` first and fall back on the alias for redundancy.

To this scope, it does not make sense to name them with `legacy` suffix, but only with alias suffix.
