### PR TITLE
feat(build): Add a list of ignored EXT token canister

### DIFF
--- a/scripts/build.tokens.ext.ts
+++ b/scripts/build.tokens.ext.ts
@@ -2,11 +2,16 @@
 
 import { EnvExtTokenStandardVersionSchema } from '$env/schema/env-ext-token.schema';
 import type { EnvExtToken } from '$env/types/env-ext-token';
+import type { CanisterIdText } from '$lib/types/canister';
 import { jsonReplacer } from '@dfinity/utils';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { EXT_COLLECTIONS_JSON_FILE } from './constants.mjs';
 
 const ACCEPTED_STANDARDS = ['ext', 'legacy1.5', 'legacy'];
+
+const IGNORED_TOKEN_CANISTER_IDS: CanisterIdText[] = [
+	'bxdf4-baaaa-aaaah-qaruq-cai' // ICPunks
+];
 
 // This URL was extracted analysing the network request of https://toniq.io/
 const TONIQ_COLLECTION_LIST_URL =
@@ -117,7 +122,9 @@ const getCollections = async (): Promise<EnvExtToken[]> => {
 		return acc;
 	}, {});
 
-	return Object.values(collectionsMap).sort((a, b) => a.canisterId.localeCompare(b.canisterId));
+	return Object.values(collectionsMap)
+		.filter(({ canisterId }) => !IGNORED_TOKEN_CANISTER_IDS.includes(canisterId))
+		.sort((a, b) => a.canisterId.localeCompare(b.canisterId));
 };
 
 try {

--- a/src/frontend/src/env/tokens/tokens-ext/tokens.ext.json
+++ b/src/frontend/src/env/tokens/tokens-ext/tokens.ext.json
@@ -1449,13 +1449,6 @@
 		}
 	},
 	{
-		"canisterId": "bxdf4-baaaa-aaaah-qaruq-cai",
-		"standardVersion": "legacy",
-		"metadata": {
-			"name": "ICPunks"
-		}
-	},
-	{
 		"canisterId": "byowe-niaaa-aaaag-qdiva-cai",
 		"standardVersion": "ext",
 		"metadata": {


### PR DESCRIPTION
# Motivation

We want to ignore some of the EXT token canisters in our curated list, since a few of them are wrapped canisters, around the old original one (for example [ICPunks](https://dgdg.app/nfts/collections/punks/activity?mintNumber=4803))
