### PR TITLE
build(frontend): temporarily revert update agentjs @icp-sdk/core and auth to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/gix-components": "^9.0.0-next-2025-11-07.2",
-				"@dfinity/oisy-wallet-signer": "^4.1.0",
-				"@dfinity/utils": "^4.1.0",
+				"@dfinity/oisy-wallet-signer": "^4.0.0",
+				"@dfinity/utils": "^4.0.2",
 				"@dfinity/verifiable-credentials": "^1.2.0",
 				"@dfinity/zod-schemas": "^3.0.2",
-				"@icp-sdk/auth": "^5.0.0",
-				"@icp-sdk/canisters": "^3.2.0",
-				"@icp-sdk/core": "^5.0.0",
+				"@icp-sdk/auth": "^4.2.0",
+				"@icp-sdk/canisters": "^3.0.0",
+				"@icp-sdk/core": "^4.2.1",
 				"@metamask/detect-provider": "^2.0.0",
 				"@noble/ed25519": "^2.3.0",
 				"@noble/hashes": "^1.8.0",
@@ -391,6 +391,32 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@dfinity/agent": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.4.1.tgz",
+			"integrity": "sha512-pudmNdDkfIobKdBEMl5FHviNSTCAHdo2r32/NOPY3vSiDH7VpLNfjOa4be5Ki6MKJpjEYdJh18vCZy5uxrx/kg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@dfinity/cbor": "^0.2.2",
+				"@noble/curves": "^1.9.2"
+			},
+			"peerDependencies": {
+				"@dfinity/candid": "3.4.1",
+				"@dfinity/principal": "3.4.1",
+				"@noble/hashes": "^1.8.0"
+			}
+		},
+		"node_modules/@dfinity/candid": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.4.1.tgz",
+			"integrity": "sha512-vNG0XGS2roQsz9bHPWwllfJ3n1YNjjY88YmGTwZhq/SiLNRNycjE9dIyKx64lpzH8g3PmUJmzfvGOAyVC8O7bw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"peerDependencies": {
+				"@dfinity/principal": "3.4.1"
+			}
+		},
 		"node_modules/@dfinity/cbor": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/@dfinity/cbor/-/cbor-0.2.2.tgz",
@@ -451,6 +477,38 @@
 				"svelte": "^5"
 			}
 		},
+		"node_modules/@dfinity/identity": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.4.1.tgz",
+			"integrity": "sha512-8oHmFbkkpyHN8jwPbxOiLZq0vuTRNGhTcbgm/G5SAgl9LwNlCLPFKa4osTuO2ef0SUhW+baBLOgvKPoAQhvahw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"peerDependencies": {
+				"@dfinity/agent": "3.4.1",
+				"@dfinity/candid": "3.4.1",
+				"@dfinity/principal": "3.4.1",
+				"@noble/curves": "^1.9.2",
+				"@noble/hashes": "^1.8.0"
+			}
+		},
+		"node_modules/@dfinity/identity-secp256k1": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity-secp256k1/-/identity-secp256k1-3.4.1.tgz",
+			"integrity": "sha512-gq1Rz946fAJ77rto8iKZOGdkHf5zwDACn5HJUSf9uF6HgzniIpWFE1PSKzNUHjn9maTBFw36xVZyhlMbVhukug==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@dfinity/agent": "3.4.1",
+				"@scure/bip32": "^1.7.0",
+				"@scure/bip39": "^1.6.0",
+				"asn1js": "^3.0.5"
+			},
+			"peerDependencies": {
+				"@dfinity/candid": "3.4.1",
+				"@noble/curves": "^1.9.2",
+				"@noble/hashes": "^1.8.0"
+			}
+		},
 		"node_modules/@dfinity/internet-identity-playwright": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/@dfinity/internet-identity-playwright/-/internet-identity-playwright-0.0.5.tgz",
@@ -465,26 +523,36 @@
 			}
 		},
 		"node_modules/@dfinity/oisy-wallet-signer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/oisy-wallet-signer/-/oisy-wallet-signer-4.1.0.tgz",
-			"integrity": "sha512-Xfaqtg7sEFgUnViGZVV/HWulzX/H2bP0/ZZ0UaoomxBMFCKwAdZ/6BMv5bzJCYN7lsdbAb5m2y2lJt9VsvZk2Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/oisy-wallet-signer/-/oisy-wallet-signer-4.0.0.tgz",
+			"integrity": "sha512-qCaFC9MNW482MplES2tzPSrMl42n1+6fEUZBdgk/VSdD7SGl/lR8rx8leox6CJw1XFKmepNi8ozUeWzN+iajpw==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/utils": "^4.1",
+				"@dfinity/utils": "^4",
 				"@dfinity/zod-schemas": "^3",
-				"@icp-sdk/canisters": "^3.2",
-				"@icp-sdk/core": "^5",
+				"@icp-sdk/canisters": "^3",
+				"@icp-sdk/core": "^4",
 				"zod": "^4"
 			}
 		},
+		"node_modules/@dfinity/principal": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.4.1.tgz",
+			"integrity": "sha512-pXabsgcJDhRhj7/AaV7dLZKF8L4sK0vuzaGVBBtQ+8FxWXeXlvKn/Vxbwy8BCkIU7SHzJuBpYT2tz1oE6oNmbA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@noble/hashes": "^1.8.0"
+			}
+		},
 		"node_modules/@dfinity/utils": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-4.1.0.tgz",
-			"integrity": "sha512-dCtBW9lCW6TtgOoHig2/r7SqHL4KHsuiy+cOPcxPKnA+iyBASGZgRSA2/v4zZB9umfvLI0x5gbBW/va/7EwKDg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-4.0.2.tgz",
+			"integrity": "sha512-K3VPflH3EXWVHLZw9ouvY6fT+FwZNCcHcVtxI1Et/QJvk2A360929BqUE2SsotzN6HnHCaaBmwmyINh1oetpag==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"peerDependencies": {
-				"@icp-sdk/core": "^5"
+				"@icp-sdk/core": "^4"
 			}
 		},
 		"node_modules/@dfinity/verifiable-credentials": {
@@ -1933,15 +2001,15 @@
 			}
 		},
 		"node_modules/@icp-sdk/auth": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@icp-sdk/auth/-/auth-5.0.0.tgz",
-			"integrity": "sha512-TaPfdaELT7s0vTIFOmCnlCmhPdL7kABA7+2Q0YNAUWIa/FFiwq6ffGPLvr0U0+2zFLaLQ4l7UCB2zf7vo6PFPQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@icp-sdk/auth/-/auth-4.2.0.tgz",
+			"integrity": "sha512-LAs1AZia/UNgWjpnm82UDySpZsjTWKIW0x5JI2/PTEZqvaC3WSvHZfNkLacazE4Zdks+tpTDIV8HUmbssTJ+EA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"idb": "^7.1.1"
 			},
 			"peerDependencies": {
-				"@icp-sdk/core": "^5"
+				"@icp-sdk/core": "^4"
 			}
 		},
 		"node_modules/@icp-sdk/bindgen": {
@@ -1958,20 +2026,19 @@
 			}
 		},
 		"node_modules/@icp-sdk/canisters": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@icp-sdk/canisters/-/canisters-3.2.0.tgz",
-			"integrity": "sha512-TJwE74qr5Y1P4eNevBJvI6ncSIjMo//SfjjoXLEiZpxYGCVyE3kSyr3GDK/+sQmKMyT6bf4wMW2aOBqfNHtY4w==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@icp-sdk/canisters/-/canisters-3.0.0.tgz",
+			"integrity": "sha512-O2xAQdXfG7hwYPbwNP2wxW1+9wR2TLVyOLYFqghtGand+2A1hM6seABUvMD6SLKgPggNCam9n1ZCg6iTvR9JjA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"@noble/hashes": "^1.8.0",
 				"base58-js": "^3.0.3",
-				"bech32": "^2.0.0",
-				"mime": "^3.0.0"
+				"bech32": "^2.0.0"
 			},
 			"peerDependencies": {
-				"@dfinity/utils": "^4.1",
-				"@icp-sdk/core": "^5"
+				"@dfinity/utils": "^4",
+				"@icp-sdk/core": "^4"
 			}
 		},
 		"node_modules/@icp-sdk/canisters/node_modules/bech32": {
@@ -1981,18 +2048,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@icp-sdk/core": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@icp-sdk/core/-/core-5.0.0.tgz",
-			"integrity": "sha512-t6iRbdylHG57MicWRpR1uMTFXRW7GCzec6KAg55CBwDHbHLQDKikQ252lmlcEa80DrKa3LPvMKYZEUYjEq5XUQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@icp-sdk/core/-/core-4.2.1.tgz",
+			"integrity": "sha512-9Fvl/8uvTiTVCF8vQAqS0vX4ik/gNtqqd5yLhh1YR1xy8BCwmXsLAfgKnu6QqSdpnH9h1CBJU+JiYg14WdUUsw==",
 			"license": "Apache-2.0",
 			"peer": true,
-			"dependencies": {
-				"@dfinity/cbor": "^0.2.2",
-				"@noble/curves": "^1.9.2",
-				"@noble/hashes": "^1.8.0",
-				"@scure/bip32": "^1.7.0",
-				"@scure/bip39": "^1.6.0",
-				"asn1js": "^3.0.5"
+			"peerDependencies": {
+				"@dfinity/agent": "3.4.1",
+				"@dfinity/candid": "3.4.1",
+				"@dfinity/identity": "3.4.1",
+				"@dfinity/identity-secp256k1": "3.4.1",
+				"@dfinity/principal": "3.4.1"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -2074,6 +2140,7 @@
 			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
 			"integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@noble/hashes": "1.8.0"
 			},
@@ -2098,6 +2165,7 @@
 			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
 			"integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^14.21.3 || >=16"
 			},
@@ -6718,9 +6786,9 @@
 			}
 		},
 		"node_modules/asn1js": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-			"integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
+			"integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"pvtsutils": "^1.3.6",
@@ -7583,9 +7651,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-			"integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+			"integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -10589,18 +10657,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-			"license": "MIT",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -69,13 +69,13 @@
 	},
 	"dependencies": {
 		"@dfinity/gix-components": "^9.0.0-next-2025-11-07.2",
-		"@dfinity/oisy-wallet-signer": "^4.1.0",
-		"@dfinity/utils": "^4.1.0",
+		"@dfinity/oisy-wallet-signer": "^4.0.0",
+		"@dfinity/utils": "^4.0.2",
 		"@dfinity/verifiable-credentials": "^1.2.0",
 		"@dfinity/zod-schemas": "^3.0.2",
-		"@icp-sdk/auth": "^5.0.0",
-		"@icp-sdk/canisters": "^3.2.0",
-		"@icp-sdk/core": "^5.0.0",
+		"@icp-sdk/auth": "^4.2.0",
+		"@icp-sdk/canisters": "^3.0.0",
+		"@icp-sdk/core": "^4.2.1",
 		"@metamask/detect-provider": "^2.0.0",
 		"@noble/ed25519": "^2.3.0",
 		"@noble/hashes": "^1.8.0",
@@ -142,7 +142,9 @@
 			"ws": "^7.5.10"
 		},
 		"elliptic": "^6.6.1",
-		"cookie": "^0.7.0"
+		"cookie": "^0.7.0",
+		"@icp-sdk/core": "^4.2.1",
+		"@dfinity/utils": "^4.0.2"
 	},
 	"engines": {
 		"node": ">=24",


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/10933 we bumped agentjs, @icp-sdk/core, and auth to v5 (plus related libraries for compatibility, like OISY Wallet Signer).

We tested our Signer before going live and didn't have any issues - all good from our perspective.

However, some user is experiencing issues with the Signer.

So, it's likely because something isn't compatible when the client uses signer-js with Agent-JS v4.

This should be reported to the SDK team if that's the case - incompatibility between client in v4 and signer in v5.
Or signer-js can be upgraded to v5 but, then it requires all clients to upgrade it.

As temporarily patch in OISY, we roll back ic-js and signer to the previous versions (rolling back PR https://github.com/dfinity/oisy-wallet/pull/10933).

Credits to @peterpeterparker to finding it out.