### PR TITLE
feat(frontend): hide II 2.0 AuthHelpForm entries

### DIFF
--- a/src/frontend/src/lib/components/auth/AuthHelpForm.svelte
+++ b/src/frontend/src/lib/components/auth/AuthHelpForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { PRIMARY_INTERNET_IDENTITY_VERSION } from '$env/auth.env';
 	import helpAuthBanner from '$lib/assets/help-auth-banner.svg';
 	import Button from '$lib/components/ui/Button.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
@@ -25,6 +26,8 @@
 	let { onLostIdentity, onOther }: Props = $props();
 
 	const trackingEventKey = 'main_page_button';
+
+	let isPrimaryIdentityVersion2 = $derived(PRIMARY_INTERNET_IDENTITY_VERSION === '2.0');
 </script>
 
 <div class="grid gap-6">
@@ -34,40 +37,42 @@
 
 	<div>
 		<div class="grid gap-2">
-			<Button
-				colorStyle="secondary-light"
-				fullWidth
-				onclick={() => {
-					trackEvent({
-						name: PLAUSIBLE_EVENTS.SIGN_IN_CANCELLED_HELP,
-						metadata: { event_key: trackingEventKey, event_value: 'new_auth_version' }
-					});
-					onLostIdentity();
-				}}
-				testId={HELP_AUTH_NEW_IDENTITY_VERSION_BUTTON}
-				type="button"
-			>
-				{$i18n.auth.help.text.new_auth_version}
-			</Button>
+			{#if isPrimaryIdentityVersion2}
+				<Button
+					colorStyle="secondary-light"
+					fullWidth
+					onclick={() => {
+						trackEvent({
+							name: PLAUSIBLE_EVENTS.SIGN_IN_CANCELLED_HELP,
+							metadata: { event_key: trackingEventKey, event_value: 'new_auth_version' }
+						});
+						onLostIdentity();
+					}}
+					testId={HELP_AUTH_NEW_IDENTITY_VERSION_BUTTON}
+					type="button"
+				>
+					{$i18n.auth.help.text.new_auth_version}
+				</Button>
 
-			<Button
-				colorStyle="secondary-light"
-				fullWidth
-				onclick={() => {
-					trackEvent({
-						name: PLAUSIBLE_EVENTS.SIGN_IN_CANCELLED_HELP,
-						metadata: {
-							event_key: trackingEventKey,
-							event_value: 'could_not_enter_identity_number'
-						}
-					});
-					onLostIdentity();
-				}}
-				testId={HELP_AUTH_COULD_NOT_ENTER_IDENTITY_NUMBER_BUTTON}
-				type="button"
-			>
-				{$i18n.auth.help.text.could_not_enter_identity_number}
-			</Button>
+				<Button
+					colorStyle="secondary-light"
+					fullWidth
+					onclick={() => {
+						trackEvent({
+							name: PLAUSIBLE_EVENTS.SIGN_IN_CANCELLED_HELP,
+							metadata: {
+								event_key: trackingEventKey,
+								event_value: 'could_not_enter_identity_number'
+							}
+						});
+						onLostIdentity();
+					}}
+					testId={HELP_AUTH_COULD_NOT_ENTER_IDENTITY_NUMBER_BUTTON}
+					type="button"
+				>
+					{$i18n.auth.help.text.could_not_enter_identity_number}
+				</Button>
+			{/if}
 
 			<Button
 				colorStyle="secondary-light"
@@ -126,24 +131,26 @@
 				{$i18n.auth.help.text.got_confused}
 			</Button>
 
-			<Button
-				colorStyle="secondary-light"
-				fullWidth
-				onclick={() => {
-					trackEvent({
-						name: PLAUSIBLE_EVENTS.SIGN_IN_CANCELLED_HELP,
-						metadata: {
-							event_key: trackingEventKey,
-							event_value: 'no_signup_needed'
-						}
-					});
-					onLostIdentity();
-				}}
-				testId={HELP_AUTH_NO_SIGN_UP_NEEDED_BUTTON}
-				type="button"
-			>
-				{$i18n.auth.help.text.no_signup_needed}
-			</Button>
+			{#if isPrimaryIdentityVersion2}
+				<Button
+					colorStyle="secondary-light"
+					fullWidth
+					onclick={() => {
+						trackEvent({
+							name: PLAUSIBLE_EVENTS.SIGN_IN_CANCELLED_HELP,
+							metadata: {
+								event_key: trackingEventKey,
+								event_value: 'no_signup_needed'
+							}
+						});
+						onLostIdentity();
+					}}
+					testId={HELP_AUTH_NO_SIGN_UP_NEEDED_BUTTON}
+					type="button"
+				>
+					{$i18n.auth.help.text.no_signup_needed}
+				</Button>
+			{/if}
 
 			<Button
 				colorStyle="secondary-light"

--- a/src/frontend/src/tests/lib/components/auth/AuthHelpForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/auth/AuthHelpForm.spec.ts
@@ -1,3 +1,4 @@
+import * as authEnv from '$env/auth.env';
 import AuthHelpForm from '$lib/components/auth/AuthHelpForm.svelte';
 import {
 	HELP_AUTH_COULD_NOT_ENTER_IDENTITY_NUMBER_BUTTON,
@@ -15,6 +16,8 @@ import { i18n } from '$lib/stores/i18n.store';
 import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
+
+vi.spyOn(authEnv, 'PRIMARY_INTERNET_IDENTITY_VERSION', 'get').mockImplementation(() => '2.0');
 
 describe('AuthHelpForm', () => {
 	const imageBannerSelector = `img[data-tid="${HELP_AUTH_IMAGE_BANNER}"]`;


### PR DESCRIPTION
# Motivation

Before showing the new II 2.0 AuthHelpForm entries, we need to check if the related feature flag is `2.0`.
