### PR TITLE
fix(frontend): incorrect store for calculating balances via AI tool

### DIFF
--- a/src/frontend/src/lib/derived/tokens-ui.derived.ts
+++ b/src/frontend/src/lib/derived/tokens-ui.derived.ts
@@ -24,12 +24,18 @@ export const enabledFungibleTokensUi: Readable<TokenUi[]> = derived(
 		)
 );
 
-export const enabledMainnetFungibleTokensUsdBalance: Readable<number> = derived(
+/**
+ * All mainnet user-enabled fungible tokens with financial data.
+ */
+export const enabledMainnetFungibleTokensUi: Readable<TokenUi[]> = derived(
 	[enabledFungibleTokensUi],
 	([$enabledFungibleTokensUi]) =>
-		sumTokensUiUsdBalance(
-			$enabledFungibleTokensUi.filter(({ network: { env } }) => env !== 'testnet')
-		)
+		$enabledFungibleTokensUi.filter(({ network: { env } }) => env !== 'testnet')
+);
+
+export const enabledMainnetFungibleTokensUsdBalance: Readable<number> = derived(
+	[enabledMainnetFungibleTokensUi],
+	([$enabledMainnetFungibleTokensUi]) => sumTokensUiUsdBalance($enabledMainnetFungibleTokensUi)
 );
 
 export const enabledMainnetFungibleIcTokensUsdBalance: Readable<number> = derived(

--- a/src/frontend/src/lib/services/ai-assistant.services.ts
+++ b/src/frontend/src/lib/services/ai-assistant.services.ts
@@ -11,7 +11,7 @@ import {
 } from '$lib/constants/analytics.constants';
 import { extendedAddressContacts as extendedAddressContactsStore } from '$lib/derived/contacts.derived';
 import { networks } from '$lib/derived/networks.derived';
-import { enabledFungibleTokensUi } from '$lib/derived/tokens-ui.derived';
+import { enabledMainnetFungibleTokensUi } from '$lib/derived/tokens-ui.derived';
 import { enabledTokens, enabledUniqueTokensSymbols } from '$lib/derived/tokens.derived';
 import { trackEvent } from '$lib/services/analytics.services';
 import {
@@ -129,7 +129,7 @@ export const executeTool = ({
 	} else if (name === ToolResultType.SHOW_BALANCE) {
 		result = parseShowBalanceToolArguments({
 			filterParams,
-			tokensUi: get(enabledFungibleTokensUi),
+			tokensUi: get(enabledMainnetFungibleTokensUi),
 			networks: get(networks)
 		});
 

--- a/src/frontend/src/tests/lib/derived/tokens-ui.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/tokens-ui.derived.spec.ts
@@ -11,6 +11,7 @@ import * as appConstants from '$lib/constants/app.constants';
 import {
 	enabledFungibleTokensUi,
 	enabledMainnetFungibleIcTokensUsdBalance,
+	enabledMainnetFungibleTokensUi,
 	enabledMainnetFungibleTokensUsdBalance
 } from '$lib/derived/tokens-ui.derived';
 import { tokens } from '$lib/derived/tokens.derived';
@@ -45,6 +46,8 @@ describe('tokens-ui.derived', () => {
 
 	describe('enabledFungibleTokensUi', () => {
 		it('returns correct data', () => {
+			setupTestnetsStore('enabled');
+
 			expect(get(enabledFungibleTokensUi)).toStrictEqual(
 				get(tokens).map((token) =>
 					mapTokenUi({ token, $balances: {}, $stakeBalances: {}, $exchanges: {} })
@@ -54,6 +57,22 @@ describe('tokens-ui.derived', () => {
 
 		it('should not include NFTs', () => {
 			expect(get(enabledFungibleTokensUi).every(isTokenNonFungible)).toBeFalsy();
+		});
+	});
+
+	describe('enabledMainnetFungibleTokensUi', () => {
+		it('returns correct data', () => {
+			setupTestnetsStore('enabled');
+
+			expect(get(enabledMainnetFungibleTokensUi)).toStrictEqual(
+				get(tokens)
+					.filter(({ network: { env } }) => env !== 'testnet')
+					.map((token) => mapTokenUi({ token, $balances: {}, $stakeBalances: {}, $exchanges: {} }))
+			);
+		});
+
+		it('should not include NFTs', () => {
+			expect(get(enabledMainnetFungibleTokensUi).every(isTokenNonFungible)).toBeFalsy();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The store that was previously used for calculation balances via AI tool contained testnet tokens and therefore was giving incorrect results. This PR fixes it.
