### PR TITLE
feat(frontend): DIP721 method to check balance of NFTs

### DIFF
--- a/src/frontend/src/icp/canisters/dip721.canister.ts
+++ b/src/frontend/src/icp/canisters/dip721.canister.ts
@@ -1,0 +1,48 @@
+import type { _SERVICE as Dip721Service } from '$declarations/dip721/dip721.did';
+import { idlFactory as idlCertifiedFactoryDip721 } from '$declarations/dip721/dip721.factory.certified.did';
+import { idlFactory as idlFactoryDip721 } from '$declarations/dip721/dip721.factory.did';
+import { mapDip721NftError } from '$icp/canisters/dip721.errors';
+import { getAgent } from '$lib/actors/agents.ic';
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import { Canister, createServices, type QueryParams } from '@dfinity/utils';
+import type { Principal } from '@icp-sdk/core/principal';
+
+export class Dip721Canister extends Canister<Dip721Service> {
+	static async create({
+		identity,
+		...options
+	}: CreateCanisterOptions<Dip721Service>): Promise<Dip721Canister> {
+		const agent = await getAgent({ identity });
+
+		const { service, certifiedService, canisterId } = createServices<Dip721Service>({
+			options: {
+				...options,
+				agent
+			},
+			idlFactory: idlFactoryDip721,
+			certifiedIdlFactory: idlCertifiedFactoryDip721
+		});
+
+		return new Dip721Canister(canisterId, service, certifiedService);
+	}
+
+	/**
+	 * Returns the count of NFTs owned by the principal.
+	 *
+	 * @link https://github.com/Psychedelic/DIP721/blob/develop/spec.md#balanceof
+	 */
+	balanceOf = async ({
+		principal,
+		certified
+	}: { principal: Principal } & QueryParams): Promise<bigint> => {
+		const { balanceOf } = this.caller({ certified });
+
+		const response = await balanceOf(principal);
+
+		if ('Ok' in response) {
+			return response.Ok;
+		}
+
+		throw mapDip721NftError(response.Err);
+	};
+}

--- a/src/frontend/src/icp/canisters/dip721.errors.ts
+++ b/src/frontend/src/icp/canisters/dip721.errors.ts
@@ -1,0 +1,38 @@
+import type { NftError } from '$declarations/dip721/dip721.did';
+import { CanisterInternalError } from '$lib/canisters/errors';
+
+export const mapDip721NftError = (err: NftError): CanisterInternalError => {
+	if ('UnauthorizedOperator' in err) {
+		return new CanisterInternalError('Unauthorized operator');
+	}
+
+	if ('SelfTransfer' in err) {
+		return new CanisterInternalError('Cannot transfer NFT to self');
+	}
+
+	if ('TokenNotFound' in err) {
+		return new CanisterInternalError('NFT token not found');
+	}
+
+	if ('UnauthorizedOwner' in err) {
+		return new CanisterInternalError('Unauthorized owner for the NFT');
+	}
+
+	if ('SelfApprove' in err) {
+		return new CanisterInternalError('Cannot approve self for the NFT');
+	}
+
+	if ('OperatorNotFound' in err) {
+		return new CanisterInternalError('Operator not found for the NFT');
+	}
+
+	if ('ExistedNFT' in err) {
+		return new CanisterInternalError('NFT already exists');
+	}
+
+	if ('OwnerNotFound' in err) {
+		return new CanisterInternalError('Owner not found for the NFT');
+	}
+
+	return new CanisterInternalError('Unknown Dip721CanisterError');
+};

--- a/src/frontend/src/tests/icp/canisters/dip721.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/dip721.canister.spec.ts
@@ -1,0 +1,174 @@
+import type { _SERVICE as Dip721Service } from '$declarations/dip721/dip721.did';
+import { Dip721Canister } from '$icp/canisters/dip721.canister';
+import { CanisterInternalError } from '$lib/canisters/errors';
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import { mockDip721TokenCanisterId } from '$tests/mocks/dip721-tokens.mock';
+import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
+import { Principal } from '@icp-sdk/core/principal';
+import { mock } from 'vitest-mock-extended';
+
+describe('dip721.canister', () => {
+	const certified = false;
+
+	const createDip721Canister = ({
+		serviceOverride
+	}: Pick<CreateCanisterOptions<Dip721Service>, 'serviceOverride'>): Promise<Dip721Canister> =>
+		Dip721Canister.create({
+			canisterId: Principal.fromText(mockDip721TokenCanisterId),
+			identity: mockIdentity,
+			certifiedServiceOverride: serviceOverride,
+			serviceOverride
+		});
+
+	const service = mock<ActorSubclass<Dip721Service>>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('balanceOf', () => {
+		const mockParams = { principal: mockPrincipal, certified };
+
+		const mockBalance = 12345n;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should correctly call the balanceOf method', async () => {
+			service.balanceOf.mockResolvedValue({ Ok: mockBalance });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			const res = await balanceOf(mockParams);
+
+			expect(res).toEqual(mockBalance);
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle unauthorized operator error', async () => {
+			service.balanceOf.mockResolvedValue({ Err: { UnauthorizedOperator: null } });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('Unauthorized operator')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle self transfer error', async () => {
+			service.balanceOf.mockResolvedValue({ Err: { SelfTransfer: null } });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('Cannot transfer NFT to self')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle token not found error', async () => {
+			service.balanceOf.mockResolvedValue({ Err: { TokenNotFound: null } });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('NFT token not found')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle unauthorized owner error', async () => {
+			service.balanceOf.mockResolvedValue({ Err: { UnauthorizedOwner: null } });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('Unauthorized owner for the NFT')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle self approve error', async () => {
+			service.balanceOf.mockResolvedValue({ Err: { SelfApprove: null } });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('Cannot approve self for the NFT')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle operator not found error', async () => {
+			service.balanceOf.mockResolvedValue({ Err: { OperatorNotFound: null } });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('Operator not found for the NFT')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle existed NFT error', async () => {
+			service.balanceOf.mockResolvedValue({ Err: { ExistedNFT: null } });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('NFT already exists')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle owner not found error', async () => {
+			service.balanceOf.mockResolvedValue({ Err: { OwnerNotFound: null } });
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('Owner not found for the NFT')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should handle a generic canister error', async () => {
+			// @ts-expect-error we test this on purpose
+			service.balanceOf.mockResolvedValue({ Err: { CanisterError: null } });
+
+			const { balanceOf } = await createDip721Canister({
+				serviceOverride: service
+			});
+
+			await expect(balanceOf(mockParams)).rejects.toThrowError(
+				new CanisterInternalError('Unknown Dip721CanisterError')
+			);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+
+		it('should throw an error if balanceOf throws', async () => {
+			const mockError = new Error('Test response error');
+			service.balanceOf.mockRejectedValue(mockError);
+
+			const { balanceOf } = await createDip721Canister({ serviceOverride: service });
+
+			const res = balanceOf(mockParams);
+
+			await expect(res).rejects.toThrowError(mockError);
+
+			expect(service.balanceOf).toHaveBeenCalledExactlyOnceWith(mockPrincipal);
+		});
+	});
+});

--- a/src/frontend/src/tests/mocks/dip721-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/dip721-tokens.mock.ts
@@ -1,0 +1,3 @@
+import type { CanisterIdText } from '$lib/types/canister';
+
+export const mockDip721TokenCanisterId: CanisterIdText = 'qcg3w-tyaaa-aaaah-qakea-cai';


### PR DESCRIPTION
# Motivation

Similar to EXT V2 canisters, we create an interface to interact with any DIP721. And we initialize it with the first method `balanceOf` that checks how many NFTs a user has for that specific collection.
