### PR TITLE
refactor(frontend): Consistent sorting of input for tokens derived stores

### DIFF
--- a/src/frontend/src/lib/derived/all-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/all-tokens.derived.ts
@@ -65,33 +65,30 @@ export const allSwappableTokensDerived: Readable<IcTokenWithIcrc2Supported[]> = 
 
 export const allTokens = derived(
 	[
-		// The entire list of Erc20 tokens to display to the user.
-		erc20Tokens,
-		// The entire list of Erc721 tokens to display to the user.
-		erc721Tokens,
-		// The entire list of Erc1155 tokens to display to the user.
-		erc1155Tokens,
 		defaultIcpTokens,
 		enabledBitcoinTokens,
 		enabledEthereumTokens,
+		enabledEvmTokens,
+		enabledSolanaTokens,
+		erc20Tokens,
+		erc721Tokens,
+		erc1155Tokens,
 		allIcrcTokens,
 		extTokens,
-		enabledSolanaTokens,
-		splTokens,
-		enabledEvmTokens
+		splTokens
 	],
 	([
-		$erc20Tokens,
-		$erc721Tokens,
-		$erc1155Tokens,
 		$defaultIcpTokens,
 		$enabledBitcoinTokens,
 		$enabledEthereumTokens,
+		$enabledEvmTokens,
+		$enabledSolanaTokens,
+		$erc20Tokens,
+		$erc721Tokens,
+		$erc1155Tokens,
 		$allIcrcTokens,
 		$extTokens,
-		$enabledSolanaTokens,
-		$splTokens,
-		$enabledEvmTokens
+		$splTokens
 	]) => [
 		...$defaultIcpTokens.map((token) => ({ ...token, enabled: true })),
 		...$enabledBitcoinTokens.map((token) => ({ ...token, enabled: true })),

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -30,30 +30,30 @@ import { derived, type Readable } from 'svelte/store';
 
 export const tokens: Readable<Token[]> = derived(
 	[
+		defaultIcpTokens,
+		enabledBitcoinTokens,
+		enabledEthereumTokens,
+		enabledEvmTokens,
+		enabledSolanaTokens,
 		erc20Tokens,
 		erc721Tokens,
 		erc1155Tokens,
 		sortedIcrcTokens,
-		splTokens,
-		defaultIcpTokens,
 		extTokens,
-		enabledEthereumTokens,
-		enabledBitcoinTokens,
-		enabledSolanaTokens,
-		enabledEvmTokens
+		splTokens
 	],
 	([
+		$defaultIcpTokens,
+		$enabledBitcoinTokens,
+		$enabledEthereumTokens,
+		$enabledEvmTokens,
+		$enabledSolanaTokens,
 		$erc20Tokens,
 		$erc721Tokens,
 		$erc1155Tokens,
 		$icrcTokens,
-		$splTokens,
-		$defaultIcpTokens,
 		$extTokens,
-		$enabledEthereumTokens,
-		$enabledBitcoinTokens,
-		$enabledSolanaTokens,
-		$enabledEvmTokens
+		$splTokens
 	]) => [
 		...$defaultIcpTokens,
 		...$enabledBitcoinTokens,


### PR DESCRIPTION
# Motivation

Just to be more consistent, we organize the input of the derived stores of `tokens` and `allTokens` to be consistent.

The logic per-se does not change.