### PR TITLE
feat(frontend): Add Minting Account to data in IC Tokens

### DIFF
--- a/src/frontend/src/env/networks/networks.icp.env.ts
+++ b/src/frontend/src/env/networks/networks.icp.env.ts
@@ -1,9 +1,11 @@
 import { ICP_EXPLORER_URL } from '$env/explorers.env';
+import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
 import icpIcon from '$lib/assets/networks/icp.svg';
 import { LOCAL } from '$lib/constants/app.constants';
 import type { OptionCanisterIdText } from '$lib/types/canister';
 import type { Network, NetworkId } from '$lib/types/network';
 import { parseNetworkId } from '$lib/validation/network.validation';
+import { Principal } from '@icp-sdk/core/principal';
 
 export const ICP_LEDGER_CANISTER_ID =
 	(LOCAL
@@ -16,6 +18,15 @@ export const ICP_INDEX_CANISTER_ID =
 		? (import.meta.env.VITE_LOCAL_ICP_INDEX_CANISTER_ID as OptionCanisterIdText)
 		: (import.meta.env.VITE_IC_ICP_INDEX_CANISTER_ID as OptionCanisterIdText)) ??
 	'qhbym-qaaaa-aaaaa-aaafq-cai';
+
+export const ICP_MINTING_ACCOUNT = getIcrcAccount(
+	Principal.fromText(
+		(LOCAL
+			? (import.meta.env.VITE_LOCAL_ICP_MINTING_ACCOUNT_PRINCIPAL_TEXT as OptionCanisterIdText)
+			: (import.meta.env.VITE_IC_ICP_MINTING_ACCOUNT_PRINCIPAL_TEXT as OptionCanisterIdText)) ??
+			'rrkah-fqaaa-aaaaa-aaaaq-cai'
+	)
+);
 
 /**
  * ICP

--- a/src/frontend/src/env/tokens/tokens.icp.env.ts
+++ b/src/frontend/src/env/tokens/tokens.icp.env.ts
@@ -2,6 +2,7 @@ import { ICP_EXPLORER_URL } from '$env/explorers.env';
 import {
 	ICP_INDEX_CANISTER_ID,
 	ICP_LEDGER_CANISTER_ID,
+	ICP_MINTING_ACCOUNT,
 	ICP_NETWORK,
 	ICP_PSEUDO_TESTNET_NETWORK
 } from '$env/networks/networks.icp.env';
@@ -10,9 +11,11 @@ import { ICP_TRANSACTION_FEE_E8S } from '$icp/constants/icp.constants';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import type { IcToken } from '$icp/types/ic-token';
 import { buildIndexedIcTokens } from '$icp/utils/ic-tokens.utils';
+import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
 import type { RequiredToken, TokenId } from '$lib/types/token';
 import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
+import { Principal } from '@icp-sdk/core/principal';
 
 /**
  * ICP
@@ -35,6 +38,7 @@ export const ICP_TOKEN: RequiredToken<Omit<IcToken, 'deprecated' | 'alternativeN
 	fee: ICP_TRANSACTION_FEE_E8S,
 	ledgerCanisterId: ICP_LEDGER_CANISTER_ID,
 	indexCanisterId: ICP_INDEX_CANISTER_ID,
+	mintingAccount: ICP_MINTING_ACCOUNT,
 	explorerUrl: ICP_EXPLORER_URL,
 	buy: {
 		onramperId: 'icp_icp'
@@ -63,7 +67,8 @@ export const TESTICP_TOKEN: RequiredToken<
 	icon: icpLight,
 	fee: 10_000n,
 	ledgerCanisterId: 'xafvr-biaaa-aaaai-aql5q-cai',
-	indexCanisterId: 'qcuy6-bqaaa-aaaai-aqmqq-cai'
+	indexCanisterId: 'qcuy6-bqaaa-aaaai-aqmqq-cai',
+	mintingAccount: getIcrcAccount(Principal.fromText('bnuz2-zaaaa-aaaal-arrba-cai'))
 };
 
 export const SUPPORTED_ICP_TOKENS: RequiredToken<

--- a/src/frontend/src/icp/schema/ic-token.schema.ts
+++ b/src/frontend/src/icp/schema/ic-token.schema.ts
@@ -5,6 +5,7 @@ import { TokenGroupPropSchema } from '$lib/schema/token-group.schema';
 import { TokenSchema } from '$lib/schema/token.schema';
 import { CanisterIdTextSchema } from '$lib/types/canister';
 import { UrlSchema } from '$lib/validation/url.validation';
+import type { IcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
 import * as z from 'zod';
 
 export const IcFeeSchema = z.object({
@@ -35,9 +36,14 @@ export const IcCkMetadataSchema = IcCkLinkedAssetsSchema.partial().extend({
 	minterCanisterId: CanisterIdTextSchema
 });
 
+export const IcMetadataSchema = z.object({
+	mintingAccount: z.custom<IcrcAccount>().optional()
+});
+
 export const IcInterfaceSchema = z.object({
 	...IcCanistersSchema.shape,
-	...IcAppMetadataSchema.shape
+	...IcAppMetadataSchema.shape,
+	...IcMetadataSchema.shape
 });
 
 export const IcTokenSchema = z.object({


### PR DESCRIPTION
# Motivation

We want to facilitate the minting/burning analysis in OISY. So, as first step we need to map the minting account for all the tokens. In this PR, we start adding the fields to the `IcToken` type and then the minting account to ICP token.
