### PR TITLE
feat(frontend): API method to get the DIP721 NFTs owned by the user

### DIFF
--- a/src/frontend/src/icp/api/dip721.api.ts
+++ b/src/frontend/src/icp/api/dip721.api.ts
@@ -28,6 +28,33 @@ export const balance = async ({
 	return await balance({ principal: identity.getPrincipal(), certified });
 };
 
+/**
+ * Returns the list of the token_identifier of the NFT associated with the principal.
+ *
+ * @link https://github.com/Psychedelic/DIP721/blob/develop/spec.md#ownertokenidentifiers
+ */
+export const getTokensByOwner = async ({
+	certified,
+	identity,
+	owner: principal,
+	canisterId,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<{ owner: Principal } & QueryParams>): Promise<
+	bigint[]
+> => {
+	if (isNullish(identity)) {
+		return [];
+	}
+
+	const { getTokensByOwner } = await dip721Canister({
+		identity,
+		canisterId,
+		...rest
+	});
+
+	return await getTokensByOwner({ certified, principal });
+};
+
 const dip721Canister = async ({
 	identity,
 	nullishIdentityErrorMessage,


### PR DESCRIPTION
# Motivation

As per the other methods we open the service `getTokensByOwner` of DIP721 Canister as a generic function.
