### PR TITLE
fix(frontend): remove incorrect tailwind class

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
@@ -101,7 +101,7 @@
 
 <label for="to">{$i18n.transaction.text.status}</label>
 
-<span id="to" class="font-normal break-all first-letter:capitalize">
+<span id="to" class="font-normal break-all">
 	{#if nonNullish(status)}
 		<span in:fade>{$i18n.transaction.status[status]}</span>
 	{:else}

--- a/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
@@ -29,7 +29,7 @@
 
 <div class="mb-10 flex flex-col gap-4" data-tid={testId}>
 	{#if nonNullish(title)}
-		<span class="text-lg font-bold first-letter:capitalize"><Html text={title} /></span>
+		<span class="text-lg font-bold"><Html text={title} /></span>
 	{/if}
 
 	{#each sortedRewards as reward (reward.id)}

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -166,7 +166,7 @@
 	<span class="block w-full rounded-xl px-2 py-2 hover:bg-brand-subtle-10">
 		<Card noMargin withGap>
 			<span class="flex min-w-0 flex-1 basis-0 items-center gap-1">
-				<span class="truncate first-letter:capitalize">
+				<span class="truncate">
 					{@render children()}
 				</span>
 


### PR DESCRIPTION
# Motivation

There is no such a tailwind class `first-letter:capitalize`, therefore we can clean it up in all places where it's used.

P.S.: the strings are already capitalized in all those places, so no further adjustments needed.
