### PR TITLE
feat(frontend): Use existing minting account in service `isUserMintingAccount`

### DIFF
--- a/src/frontend/src/icp/services/icrc-minting.services.ts
+++ b/src/frontend/src/icp/services/icrc-minting.services.ts
@@ -7,7 +7,7 @@ import { encodeIcrcAccount, type IcrcAccount } from '@icp-sdk/canisters/ledger/i
 export const isUserMintingAccount = async ({
 	identity,
 	account,
-	token: { ledgerCanisterId }
+	token: { ledgerCanisterId, mintingAccount: tokenMintingAccount }
 }: {
 	identity: OptionIdentity;
 	account: IcrcAccount | undefined;
@@ -17,10 +17,12 @@ export const isUserMintingAccount = async ({
 		return false;
 	}
 
-	const mintingAccount = await getMintingAccount({
-		identity,
-		ledgerCanisterId
-	});
+	const mintingAccount =
+		tokenMintingAccount ??
+		(await getMintingAccount({
+			identity,
+			ledgerCanisterId
+		}));
 
 	if (isNullish(mintingAccount)) {
 		return false;

--- a/src/frontend/src/tests/icp/services/icrc-minting.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc-minting.services.spec.ts
@@ -6,10 +6,12 @@ import { mockIcrcAccount, mockIdentity } from '$tests/mocks/identity.mock';
 
 describe('icrc-minting.services', () => {
 	describe('isUserMintingAccount', () => {
+		const { mintingAccount: _, ...mockToken } = mockValidIcrcToken;
+
 		const params = {
 			identity: mockIdentity,
 			account: mockIcrcAccount,
-			token: mockValidIcrcToken
+			token: mockToken
 		};
 
 		beforeEach(() => {
@@ -28,7 +30,7 @@ describe('icrc-minting.services', () => {
 			await expect(isUserMintingAccount({ ...params, account: undefined })).resolves.toBeFalsy();
 		});
 
-		it('should return false if minting account is nullish', async () => {
+		it('should return false if minting account service returns a nullish account', async () => {
 			vi.spyOn(icrcLedgerApi, 'getMintingAccount').mockResolvedValueOnce(undefined);
 
 			await expect(isUserMintingAccount(params)).resolves.toBeFalsy();
@@ -52,7 +54,7 @@ describe('icrc-minting.services', () => {
 
 			expect(getMintingAccount).toHaveBeenCalledExactlyOnceWith({
 				identity: mockIdentity,
-				ledgerCanisterId: mockValidIcrcToken.ledgerCanisterId
+				ledgerCanisterId: mockToken.ledgerCanisterId
 			});
 		});
 
@@ -73,6 +75,12 @@ describe('icrc-minting.services', () => {
 			await expect(
 				isUserMintingAccount({ ...params, account: { ...mockIcrcAccount, subaccount } })
 			).resolves.toBeTruthy();
+		});
+
+		it('should not call getMintingAccount if minting account is already in the token information', async () => {
+			await isUserMintingAccount({ ...params, token: mockValidIcrcToken });
+
+			expect(getMintingAccount).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Some token already has the minting account among their information (we have added this information recently). So we don't really need to fetch it again.