### PR TITLE
feat(frontend): display ICRC tokens fee in token details

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenModalContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModalContent.svelte
@@ -24,6 +24,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OptionToken } from '$lib/types/token';
+	import { formatToken } from '$lib/utils/format.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
@@ -171,6 +172,23 @@
 					{token.decimals}
 				{/snippet}
 			</ModalListItem>
+
+			{#if isTokenIcrc(token)}
+				<ModalListItem>
+					{#snippet label()}
+						{$i18n.fee.text.fee}
+					{/snippet}
+
+					{#snippet content()}
+						{formatToken({
+							value: token.fee,
+							unitName: token.decimals,
+							displayDecimals: token.decimals
+						})}
+						{token.symbol}
+					{/snippet}
+				</ModalListItem>
+			{/if}
 		</List>
 
 		{#if nonNullish(onDeleteClick)}

--- a/src/frontend/src/tests/lib/components/tokens/TokenModalContent.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModalContent.spec.ts
@@ -1,6 +1,7 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import TokenModalContent from '$lib/components/tokens/TokenModalContent.svelte';
 import type { Token } from '$lib/types/token';
+import { formatToken } from '$lib/utils/format.utils';
 import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockIndexCanisterId, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
@@ -53,6 +54,17 @@ describe('TokenModalContent', () => {
 
 		expect(getByText(en.core.text.decimals)).toBeInTheDocument();
 		expect(getByText(mockValidIcrcToken.decimals)).toBeInTheDocument();
+
+		expect(getByText(en.fee.text.fee)).toBeInTheDocument();
+		expect(
+			getByText(
+				`${formatToken({
+					value: mockValidIcrcToken.fee,
+					unitName: mockValidIcrcToken.decimals,
+					displayDecimals: mockValidIcrcToken.decimals
+				})} ${mockValidIcrcToken.symbol}`
+			)
+		).toBeInTheDocument();
 	});
 
 	it('renders all values correctly for ICRC token without index canister', () => {
@@ -82,5 +94,16 @@ describe('TokenModalContent', () => {
 
 		expect(getByText(en.core.text.decimals)).toBeInTheDocument();
 		expect(getByText(mockValidIcrcToken.decimals)).toBeInTheDocument();
+
+		expect(getByText(en.fee.text.fee)).toBeInTheDocument();
+		expect(
+			getByText(
+				`${formatToken({
+					value: mockValidIcrcToken.fee,
+					unitName: mockValidIcrcToken.decimals,
+					displayDecimals: mockValidIcrcToken.decimals
+				})} ${mockValidIcrcToken.symbol}`
+			)
+		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

We want to display ICRC tokens fee in token details.

<img width="629" height="818" alt="Screenshot 2026-01-07 at 12 34 20" src="https://github.com/user-attachments/assets/48ab08a9-bc53-416d-8b73-8f571ac497f5" />
