### PR TITLE
feat(frontend): Fallback to undefined is errors in service `getMintingAccount`

### DIFF
--- a/src/frontend/src/icp/api/icrc-ledger.api.ts
+++ b/src/frontend/src/icp/api/icrc-ledger.api.ts
@@ -278,9 +278,13 @@ export const getMintingAccount = async ({
 
 	const { getMintingAccount } = await ledgerCanister({ identity, ledgerCanisterId });
 
-	const account = await getMintingAccount({ certified });
+	try {
+		const account = await getMintingAccount({ certified });
 
-	return fromCandidAccount(fromDefinedNullable(account));
+		return fromCandidAccount(fromDefinedNullable(account));
+	} catch (_: unknown) {
+		// In case the method is not implemented, return undefined
+	}
 };
 
 const ledgerCanister = async ({

--- a/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc-ledger.api.spec.ts
@@ -647,5 +647,19 @@ describe('icrc-ledger.api', () => {
 		it('throws an error if identity is undefined', async () => {
 			await expect(getMintingAccount({ ...params, identity: undefined })).rejects.toThrowError();
 		});
+
+		it('returns undefined if getMintingAccount throws', async () => {
+			ledgerCanisterMock.getMintingAccount.mockRejectedValue(
+				new Error('Minting account not found')
+			);
+
+			const result = await getMintingAccount(params);
+
+			expect(result).toBeUndefined();
+
+			expect(ledgerCanisterMock.getMintingAccount).toHaveBeenCalledExactlyOnceWith({
+				certified: true
+			});
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

Some ICRC tokens do not really support the method to get the minting account (for example the `TCYCLES` token). So, we can indeed safely ignore errors on that service.

