### PR TITLE
feat(frontend): Util to check if a token is standard DIP721

### DIFF
--- a/src/frontend/src/icp/utils/dip721.utils.ts
+++ b/src/frontend/src/icp/utils/dip721.utils.ts
@@ -1,0 +1,5 @@
+import type { Dip721Token } from '$icp/types/dip721-token';
+import type { IcToken } from '$icp/types/ic-token';
+
+export const isTokenDip721 = (token: Partial<IcToken>): token is Dip721Token =>
+	token.standard?.code === 'dip721';

--- a/src/frontend/src/tests/icp/utils/dip721.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/dip721.utils.spec.ts
@@ -1,0 +1,25 @@
+import { isTokenDip721 } from '$icp/utils/dip721.utils';
+import type { TokenStandardCode } from '$lib/types/token';
+import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
+
+describe('dip721.utils', () => {
+	describe('isTokenDip721', () => {
+		it.each(['dip721'])('should return true for valid token standards: %s', (standard) => {
+			expect(
+				isTokenDip721({ ...mockIcrcCustomToken, standard: { code: standard as TokenStandardCode } })
+			).toBeTruthy();
+		});
+
+		it.each(['icrc', 'ethereum', 'erc20', 'bitcoin', 'solana', 'spl'])(
+			'should return false for invalid token standards: %s',
+			(standard) => {
+				expect(
+					isTokenDip721({
+						...mockIcrcCustomToken,
+						standard: { code: standard as TokenStandardCode }
+					})
+				).toBeFalsy();
+			}
+		);
+	});
+});


### PR DESCRIPTION
# Motivation

As per the other standards, we require an util to check if a token is standard `dip721`.
