### PR TITLE
feat(frontend): DIP721 method to transfer NFTs

### DIFF
--- a/src/frontend/src/icp/api/dip721.api.ts
+++ b/src/frontend/src/icp/api/dip721.api.ts
@@ -55,6 +55,30 @@ export const getTokensByOwner = async ({
 	return await getTokensByOwner({ certified, principal });
 };
 
+/**
+ * Sends the caller's NFT token_identifier.
+ *
+ * @link https://github.com/Psychedelic/DIP721/blob/develop/spec.md#transfer
+ */
+export const transfer = async ({
+	certified,
+	identity,
+	canisterId,
+	to,
+	tokenIdentifier,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<
+	{ to: Principal; tokenIdentifier: bigint } & QueryParams
+>) => {
+	const { transfer } = await dip721Canister({
+		identity,
+		canisterId,
+		...rest
+	});
+
+	await transfer({ certified, to, tokenIdentifier });
+};
+
 const dip721Canister = async ({
 	identity,
 	nullishIdentityErrorMessage,

--- a/src/frontend/src/tests/icp/api/dip721.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/dip721.api.spec.ts
@@ -1,9 +1,9 @@
-import { balance, getTokensByOwner } from '$icp/api/dip721.api';
+import { balance, getTokensByOwner, transfer } from '$icp/api/dip721.api';
 import { Dip721Canister } from '$icp/canisters/dip721.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { ZERO } from '$lib/constants/app.constants';
 import { mockDip721TokenCanisterId } from '$tests/mocks/dip721-tokens.mock';
-import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
 import { mock } from 'vitest-mock-extended';
 
 describe('dip721.api', () => {
@@ -89,6 +89,43 @@ describe('dip721.api', () => {
 			await expect(getTokensByOwner(params)).rejects.toThrowError(mockError);
 
 			expect(tokenCanisterMock.getTokensByOwner).toHaveBeenCalledExactlyOnceWith(expectedParams);
+		});
+	});
+
+	describe('transfer', () => {
+		const mockTokenId = 987_456_123n;
+
+		const params = {
+			identity: mockIdentity,
+			owner: mockPrincipal,
+			canisterId: mockDip721TokenCanisterId,
+			to: mockPrincipal2,
+			tokenIdentifier: mockTokenId
+		};
+
+		const expectedParams = {
+			to: mockPrincipal2,
+			tokenIdentifier: mockTokenId
+		};
+
+		beforeEach(() => {
+			tokenCanisterMock.transfer.mockResolvedValue(123n);
+		});
+
+		it('should call successfully transfer endpoint', async () => {
+			await transfer(params);
+
+			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+		});
+
+		it('should throw an error if transfer fails', async () => {
+			const mockError = new CanisterInternalError('Generic error');
+
+			tokenCanisterMock.transfer.mockRejectedValueOnce(mockError);
+
+			await expect(transfer(params)).rejects.toThrowError(mockError);
+
+			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

As per the other methods, we create a specific API service to transfer DIP721 NFTs.
