### PR TITLE
feat(frontend): Show Mint button for IC minting accounts

### DIFF
--- a/src/frontend/src/lib/components/icons/IconPickaxe.svelte
+++ b/src/frontend/src/lib/components/icons/IconPickaxe.svelte
@@ -1,0 +1,25 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+	interface Props {
+		size?: string;
+	}
+
+	let { size = '24' }: Props = $props();
+</script>
+
+<svg fill="none" height={size} viewBox="0 0 24 24" width={size} xmlns="http://www.w3.org/2000/svg">
+	<rect
+		fill="currentColor"
+		height="21.5672"
+		opacity="0.4"
+		rx="2"
+		transform="rotate(39.1335 14.6938 3.68994)"
+		width="4"
+		x="14.6938"
+		y="3.68994"
+	/>
+	<path
+		d="M5.93287 0.99243C6.2226 0.623612 6.73437 0.51568 7.14747 0.737764C13.8135 4.3215 19.0852 10.1221 22.1311 17.1038C22.3065 17.5058 22.0162 17.9447 21.5796 17.9026C21.4221 17.8874 21.2433 17.8055 21.144 17.6823C16.7274 12.1984 11.2058 7.65132 4.88295 4.41961C4.31597 4.12982 4.14175 3.39499 4.52007 2.88283C5.00129 2.23136 5.38605 1.68853 5.93287 0.99243Z"
+		fill="currentColor"
+	/>
+</svg>

--- a/src/frontend/src/lib/components/send/SendButton.svelte
+++ b/src/frontend/src/lib/components/send/SendButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
+	import { isIcMintingAccount } from '$icp/stores/ic-minting-account.store';
 	import ButtonHero from '$lib/components/hero/ButtonHero.svelte';
+	import IconPickaxe from '$lib/components/icons/IconPickaxe.svelte';
 	import IconlySend from '$lib/components/icons/iconly/IconlySend.svelte';
 	import { SEND_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
 	import { isBusy } from '$lib/derived/busy.derived';
@@ -23,9 +25,13 @@
 	testId={SEND_TOKENS_MODAL_OPEN_BUTTON}
 >
 	{#snippet icon()}
-		<IconlySend size="24" />
+		{#if $isIcMintingAccount}
+			<IconPickaxe size="24" />
+		{:else}
+			<IconlySend size="24" />
+		{/if}
 	{/snippet}
 	{#snippet label()}
-		{$i18n.send.text.send}
+		{$isIcMintingAccount ? $i18n.mint.text.mint : $i18n.send.text.send}
 	{/snippet}
 </ButtonHero>

--- a/src/frontend/src/tests/lib/components/send/SendButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendButton.spec.ts
@@ -1,8 +1,10 @@
+import { isIcMintingAccount } from '$icp/stores/ic-minting-account.store';
 import SendButton from '$lib/components/send/SendButton.svelte';
 import { SEND_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
 import { isBusy } from '$lib/derived/busy.derived';
 import { busy } from '$lib/stores/busy.store';
 import { HERO_CONTEXT_KEY, initHeroContext, type HeroContext } from '$lib/stores/hero.store';
+import en from '$tests/mocks/i18n.mock';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
@@ -23,15 +25,19 @@ describe('SendButton', () => {
 		mockContextStore = initHeroContext();
 
 		mockContextStore.outflowActionsDisabled.set(false);
+
+		isIcMintingAccount.set(false);
 	});
 
 	it('should render the Hero button', () => {
-		const { getByTestId } = render(SendButton, {
+		const { getByTestId, getByText } = render(SendButton, {
 			props,
 			context: mockContext(mockContextStore)
 		});
 
 		expect(getByTestId(SEND_TOKENS_MODAL_OPEN_BUTTON)).toBeInTheDocument();
+
+		expect(getByText(en.send.text.send)).toBeInTheDocument();
 	});
 
 	it('should be enabled if not busy and outflow actions enabled', async () => {
@@ -89,5 +95,18 @@ describe('SendButton', () => {
 		btn.click();
 
 		expect(mockOnClick).not.toHaveBeenCalled();
+	});
+
+	it('should render the correct text if the user is the minting account', () => {
+		isIcMintingAccount.set(true);
+
+		const { getByTestId, getByText } = render(SendButton, {
+			props,
+			context: mockContext(mockContextStore)
+		});
+
+		expect(getByTestId(SEND_TOKENS_MODAL_OPEN_BUTTON)).toBeInTheDocument();
+
+		expect(getByText(en.mint.text.mint)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

If a user is the minting account for a specific ICRC token, we want to show a different button, instead of send.


<img width="1279" height="831" alt="Screenshot 2026-01-07 at 16 16 14" src="https://github.com/user-attachments/assets/fce80e4c-f578-4c97-9adf-240d199451ed" />
