### PR TITLE
chore(frontend): Rename service to load IC NFTs

### DIFF
--- a/src/frontend/src/lib/services/nft.services.ts
+++ b/src/frontend/src/lib/services/nft.services.ts
@@ -3,7 +3,7 @@ import type { OptionEthAddress } from '$eth/types/address';
 import type { EthNonFungibleToken } from '$eth/types/nft';
 import { isTokenErc1155CustomToken } from '$eth/utils/erc1155.utils';
 import { isTokenErc721CustomToken } from '$eth/utils/erc721.utils';
-import { loadNfts as loadExtNfts } from '$icp/services/nft.services';
+import { loadNfts as loadIcNfts } from '$icp/services/nft.services';
 import type { IcNonFungibleToken } from '$icp/types/nft';
 import { isTokenExtCustomToken } from '$icp/utils/ext.utils';
 import { CustomTokenSection } from '$lib/enums/custom-token-section';
@@ -42,7 +42,7 @@ export const loadNftsByNetwork = async ({
 	}
 
 	if (isNetworkIdICP(networkId)) {
-		return await loadExtNfts({
+		return await loadIcNfts({
 			// For now, it is acceptable to cast it since we checked before if the network is ICP.
 			tokens: tokens as IcNonFungibleToken[],
 			identity

--- a/src/frontend/src/tests/lib/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/nft.services.spec.ts
@@ -6,7 +6,7 @@ import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 import * as ethNftServices from '$eth/services/nft.services';
 import { loadNftsByNetwork as loadErcNftsByNetwork } from '$eth/services/nft.services';
 import * as icNftServices from '$icp/services/nft.services';
-import { loadNfts as loadExtNfts } from '$icp/services/nft.services';
+import { loadNfts as loadIcNfts } from '$icp/services/nft.services';
 import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import {
 	loadNfts,
@@ -60,7 +60,7 @@ describe('nft.services', () => {
 			await expect(loadNftsByNetwork({ ...mockParams, tokens: [] })).resolves.toEqual([]);
 
 			expect(loadErcNftsByNetwork).not.toHaveBeenCalled();
-			expect(loadExtNfts).not.toHaveBeenCalled();
+			expect(loadIcNfts).not.toHaveBeenCalled();
 		});
 
 		it('should call the ETH NFT loader if the network is Ethereum', async () => {
@@ -74,7 +74,7 @@ describe('nft.services', () => {
 				walletAddress: mockEthAddress
 			});
 
-			expect(loadExtNfts).not.toHaveBeenCalled();
+			expect(loadIcNfts).not.toHaveBeenCalled();
 		});
 
 		it('should call the ETH NFT loader if the network is EVM', async () => {
@@ -88,7 +88,7 @@ describe('nft.services', () => {
 				walletAddress: mockEthAddress
 			});
 
-			expect(loadExtNfts).not.toHaveBeenCalled();
+			expect(loadIcNfts).not.toHaveBeenCalled();
 		});
 
 		it('should call the IC NFT loader if the network is ICP', async () => {
@@ -96,7 +96,7 @@ describe('nft.services', () => {
 				loadNftsByNetwork({ ...mockParams, networkId: ICP_NETWORK_ID })
 			).resolves.toEqual(mockIcNfts);
 
-			expect(loadExtNfts).toHaveBeenCalledExactlyOnceWith({
+			expect(loadIcNfts).toHaveBeenCalledExactlyOnceWith({
 				tokens: mockTokens,
 				identity: mockIdentity
 			});
@@ -113,7 +113,7 @@ describe('nft.services', () => {
 			).resolves.toEqual([]);
 
 			expect(loadErcNftsByNetwork).not.toHaveBeenCalled();
-			expect(loadExtNfts).not.toHaveBeenCalled();
+			expect(loadIcNfts).not.toHaveBeenCalled();
 		});
 	});
 
@@ -226,7 +226,7 @@ describe('nft.services', () => {
 
 			await loadNfts({ tokens, identity: mockIdentity, ethAddress: mockWalletAddress });
 
-			expect(loadExtNfts).toHaveBeenCalled();
+			expect(loadIcNfts).toHaveBeenCalled();
 			expect(get(nftStore)).toBeUndefined();
 		});
 


### PR DESCRIPTION
# Motivation

Since the service will be used for more standard than EXT (for example DIP721), we should rename it to `loadIcNfts`.
