### PR TITLE
feat(frontend): Add DIP721 transfer service to IC sendNft

### DIFF
--- a/src/frontend/src/icp/services/nft-send.services.ts
+++ b/src/frontend/src/icp/services/nft-send.services.ts
@@ -1,4 +1,5 @@
-import { transferExtV2 } from '$icp/services/nft-transfer.services';
+import { transferDip721, transferExtV2 } from '$icp/services/nft-transfer.services';
+import { isTokenDip721 } from '$icp/utils/dip721.utils';
 import { isTokenExt } from '$icp/utils/ext.utils';
 import type { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { SendNftCommonParams, TransferParams } from '$lib/types/send';
@@ -30,6 +31,16 @@ export const sendNft = async ({
 				to: Principal.fromText(to),
 				tokenIdentifier: tokenId,
 				amount: 1n, // currently fixed at 1
+				progress
+			});
+		}
+
+		if (isTokenDip721(token)) {
+			await transferDip721({
+				identity,
+				canisterId: token.canisterId,
+				to: Principal.fromText(to),
+				tokenIdentifier: BigInt(tokenId),
 				progress
 			});
 		}

--- a/src/frontend/src/icp/services/nft-transfer.services.ts
+++ b/src/frontend/src/icp/services/nft-transfer.services.ts
@@ -1,4 +1,5 @@
-import { transfer } from '$icp/api/ext-v2-token.api';
+import { transfer as transferDip721Api } from '$icp/api/dip721.api';
+import { transfer as transferExtApi } from '$icp/api/ext-v2-token.api';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -18,7 +19,24 @@ export const transferExtV2 = async ({
 }) => {
 	progress?.(ProgressStepsSendIc.SEND);
 
-	await transfer(rest);
+	await transferExtApi(rest);
+
+	progress?.(ProgressStepsSendIc.RELOAD);
+};
+
+export const transferDip721 = async ({
+	progress,
+	...rest
+}: {
+	identity: Identity;
+	canisterId: CanisterIdText;
+	to: Principal;
+	tokenIdentifier: bigint;
+	progress?: (step: ProgressStepsSendIc) => void;
+}) => {
+	progress?.(ProgressStepsSendIc.SEND);
+
+	await transferDip721Api(rest);
 
 	progress?.(ProgressStepsSendIc.RELOAD);
 };

--- a/src/frontend/src/icp/types/nft.ts
+++ b/src/frontend/src/icp/types/nft.ts
@@ -1,3 +1,4 @@
+import type { Dip721Token } from '$icp/types/dip721-token';
 import type { ExtToken } from '$icp/types/ext-token';
 
-export type IcNonFungibleToken = ExtToken;
+export type IcNonFungibleToken = ExtToken | Dip721Token;

--- a/src/frontend/src/tests/icp/services/nft-transfer.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/nft-transfer.service.spec.ts
@@ -1,11 +1,17 @@
-import { transfer } from '$icp/api/ext-v2-token.api';
-import { transferExtV2 } from '$icp/services/nft-transfer.services';
+import { transfer as transferDip721Api } from '$icp/api/dip721.api';
+import { transfer as transferExtApi } from '$icp/api/ext-v2-token.api';
+import { transferDip721, transferExtV2 } from '$icp/services/nft-transfer.services';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { bn3Bi } from '$tests/mocks/balances.mock';
+import { mockDip721TokenCanisterId } from '$tests/mocks/dip721-tokens.mock';
 import { mockExtV2TokenCanisterId, mockExtV2TokenIdentifier } from '$tests/mocks/ext-v2-token.mock';
 import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
 
 vi.mock('$icp/api/ext-v2-token.api', () => ({
+	transfer: vi.fn()
+}));
+
+vi.mock('$icp/api/dip721.api', () => ({
 	transfer: vi.fn()
 }));
 
@@ -32,11 +38,43 @@ describe('nft-transfer.services', () => {
 
 			const { progress: _, ...expected } = mockParams;
 
-			expect(transfer).toHaveBeenCalledExactlyOnceWith(expected);
+			expect(transferExtApi).toHaveBeenCalledExactlyOnceWith(expected);
 		});
 
 		it('should call the progress callback with the transfer progress', async () => {
 			await transferExtV2(mockParams);
+
+			expect(mockProgress).toHaveBeenCalledTimes(2);
+			expect(mockProgress).toHaveBeenNthCalledWith(1, ProgressStepsSendIc.SEND);
+			expect(mockProgress).toHaveBeenNthCalledWith(2, ProgressStepsSendIc.RELOAD);
+		});
+	});
+
+	describe('transferDip721', () => {
+		const mockProgress = vi.fn();
+
+		const mockParams = {
+			identity: mockIdentity,
+			canisterId: mockDip721TokenCanisterId,
+			to: mockPrincipal2,
+			tokenIdentifier: 123n,
+			progress: mockProgress
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should call the transfer endpoint of DIP721 canister', async () => {
+			await transferDip721(mockParams);
+
+			const { progress: _, ...expected } = mockParams;
+
+			expect(transferDip721Api).toHaveBeenCalledExactlyOnceWith(expected);
+		});
+
+		it('should call the progress callback with the transfer progress', async () => {
+			await transferDip721(mockParams);
 
 			expect(mockProgress).toHaveBeenCalledTimes(2);
 			expect(mockProgress).toHaveBeenNthCalledWith(1, ProgressStepsSendIc.SEND);

--- a/src/frontend/src/tests/mocks/dip721-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/dip721-tokens.mock.ts
@@ -5,6 +5,8 @@ import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidToken } from '$tests/mocks/tokens.mock';
 
 export const mockDip721TokenCanisterId: CanisterIdText = 'qcg3w-tyaaa-aaaah-qakea-cai';
+export const mockDip721TokenCanisterId2: CanisterIdText = '4nvhy-3qaaa-aaaah-qcnoq-cai';
+export const mockDip721TokenCanisterId3: CanisterIdText = 'fl5nr-xiaaa-aaaai-qbjmq-cai';
 
 export const mockValidDip721Token: ExtToken = {
 	...mockValidToken,

--- a/src/frontend/src/tests/mocks/nfts.mock.ts
+++ b/src/frontend/src/tests/mocks/nfts.mock.ts
@@ -3,6 +3,7 @@ import { NftMediaStatusEnum } from '$lib/schema/nft.schema';
 import type { Nft, NftCollectionUi, NonFungibleToken } from '$lib/types/nft';
 import { parseNftId } from '$lib/validation/nft.validation';
 import { parseTokenId } from '$lib/validation/token.validation';
+import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidErc1155Token } from '$tests/mocks/erc1155-tokens.mock';
 import { mockValidErc721Token } from '$tests/mocks/erc721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
@@ -74,6 +75,19 @@ export const mockValidExtNft: Nft = {
 	collection: {
 		...mockValidExtV2Token,
 		address: mockValidExtV2Token.canisterId
+	},
+	mediaStatus: {
+		image: NftMediaStatusEnum.OK,
+		thumbnail: NftMediaStatusEnum.OK
+	}
+};
+
+export const mockValidDip721Nft: Nft = {
+	name: 'Mock DIP721 NFT',
+	id: parseNftId('987654'),
+	collection: {
+		...mockValidDip721Token,
+		address: mockValidDip721Token.canisterId
 	},
 	mediaStatus: {
 		image: NftMediaStatusEnum.OK,


### PR DESCRIPTION
# Motivation

We integrate the DIP721 tokens in the send process for NFTs in IC network.

# Changes

- Create service `transferDip721` mirroring existing `transferExtV2`.
- Add check for DIP721 tokens to service `sendNft` for IC tokens.

# Tests

Added tests.
