### PR TITLE
feat(frontend): Integrate DIP721 in service to load IC NFTs

### DIFF
--- a/src/frontend/src/icp/services/nft.services.ts
+++ b/src/frontend/src/icp/services/nft.services.ts
@@ -1,7 +1,9 @@
+import { getTokensByOwner as getDip721TokensByOwner } from '$icp/api/dip721.api';
 import { getTokensByOwner as getExtTokensByOwner } from '$icp/api/ext-v2-token.api';
 import type { IcNonFungibleToken } from '$icp/types/nft';
+import { isTokenDip721 } from '$icp/utils/dip721.utils';
 import { isTokenExt } from '$icp/utils/ext.utils';
-import { mapExtNft } from '$icp/utils/nft.utils';
+import { mapDip721Nft, mapExtNft } from '$icp/utils/nft.utils';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Nft } from '$lib/types/nft';
 import type { Token } from '$lib/types/token';
@@ -36,6 +38,34 @@ const loadExtNfts = async ({
 	}
 };
 
+const loadDip721Nfts = async ({
+	token,
+	identity
+}: {
+	token: IcNonFungibleToken;
+	identity: Identity;
+}) => {
+	const { canisterId } = token;
+
+	const owner = identity.getPrincipal();
+
+	try {
+		const tokenIndices = await getDip721TokensByOwner({
+			identity,
+			owner,
+			canisterId
+		});
+
+		const promises = tokenIndices.map(async (index) => await mapDip721Nft({ index, token }));
+
+		return await Promise.all(promises);
+	} catch (error: unknown) {
+		console.warn(`Error loading DIP721 tokens from collection ${canisterId}:`, error);
+
+		return [];
+	}
+};
+
 export const loadNfts = async ({
 	tokens,
 	identity
@@ -50,6 +80,10 @@ export const loadNfts = async ({
 	const nftPromises = tokens.map(async (token) => {
 		if (isTokenExt(token)) {
 			return await loadExtNfts({ token, identity });
+		}
+
+		if (isTokenDip721(token)) {
+			return await loadDip721Nfts({ token, identity });
 		}
 
 		assertNever(token, `Unsupported NFT IC token ${(token as Token).standard.code}`);

--- a/src/frontend/src/icp/types/nft.ts
+++ b/src/frontend/src/icp/types/nft.ts
@@ -1,3 +1,4 @@
+import type { Dip721Token } from '$icp/types/dip721-token';
 import type { ExtToken } from '$icp/types/ext-token';
 
-export type IcNonFungibleToken = ExtToken;
+export type IcNonFungibleToken = ExtToken | Dip721Token;

--- a/src/frontend/src/tests/icp/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/nft.services.spec.ts
@@ -1,20 +1,27 @@
+import * as dip721Api from '$icp/api/dip721.api';
+import { getTokensByOwner as getDip721TokensByOwner } from '$icp/api/dip721.api';
 import * as extTokenApi from '$icp/api/ext-v2-token.api';
 import { getTokensByOwner as getExtTokensByOwner } from '$icp/api/ext-v2-token.api';
 import { loadNfts } from '$icp/services/nft.services';
-import { mapExtNft } from '$icp/utils/nft.utils';
+import { mapDip721Nft, mapExtNft } from '$icp/utils/nft.utils';
+import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidExtV2Token, mockValidExtV2Token2 } from '$tests/mocks/ext-tokens.mock';
 import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 
 describe('nft.services', () => {
 	describe('loadNfts', async () => {
+		const mockExtTokens = [mockValidExtV2Token, mockValidExtV2Token2];
+		const mockDip721Tokens = [mockValidDip721Token];
+
 		const mockParams = {
-			tokens: [mockValidExtV2Token, mockValidExtV2Token2],
+			tokens: [...mockExtTokens, ...mockDip721Tokens],
 			identity: mockIdentity
 		};
 
 		const mockTokenIndices1 = [1, 2, 3];
 		const mockTokenIndices2 = [4, 5];
+		const mockTokenIndices3 = [6n, 7n, 8n];
 
 		const expected1 = await Promise.all(
 			mockTokenIndices1.map((index) =>
@@ -26,7 +33,10 @@ describe('nft.services', () => {
 				mapExtNft({ index, token: mockValidExtV2Token2, identity: mockIdentity })
 			)
 		);
-		const expected = [...expected1, ...expected2];
+		const expected3 = await Promise.all(
+			mockTokenIndices3.map((index) => mapDip721Nft({ index, token: mockValidDip721Token }))
+		);
+		const expected = [...expected1, ...expected2, ...expected3];
 
 		beforeEach(() => {
 			vi.clearAllMocks();
@@ -43,6 +53,15 @@ describe('nft.services', () => {
 
 				return [];
 			});
+
+			// @ts-expect-error This is a mocked implementation that is not asynchronous as the original method is.
+			vi.spyOn(dip721Api, 'getTokensByOwner').mockImplementation(({ canisterId }) => {
+				if (canisterId === mockValidDip721Token.canisterId) {
+					return mockTokenIndices3;
+				}
+
+				return [];
+			});
 		});
 
 		it('should return an empty array if the identity is nullish', async () => {
@@ -51,23 +70,36 @@ describe('nft.services', () => {
 			await expect(loadNfts({ ...mockParams, identity: undefined })).resolves.toEqual([]);
 
 			expect(getExtTokensByOwner).not.toHaveBeenCalled();
+			expect(getDip721TokensByOwner).not.toHaveBeenCalled();
 		});
 
 		it('should return an empty array if the tokens list is empty', async () => {
 			await expect(loadNfts({ ...mockParams, tokens: [] })).resolves.toEqual([]);
 
 			expect(getExtTokensByOwner).not.toHaveBeenCalled();
+			expect(getDip721TokensByOwner).not.toHaveBeenCalled();
 		});
 
 		it('should return an empty array if there are not tokens owned by the user', async () => {
 			vi.spyOn(extTokenApi, 'getTokensByOwner').mockResolvedValue([]);
+			vi.spyOn(dip721Api, 'getTokensByOwner').mockResolvedValue([]);
 
 			await expect(loadNfts(mockParams)).resolves.toEqual([]);
 
-			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockParams.tokens.length);
+			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
 
-			mockParams.tokens.forEach(({ canisterId }) => {
+			mockExtTokens.forEach(({ canisterId }) => {
 				expect(getExtTokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getDip721TokensByOwner).toHaveBeenCalledTimes(mockDip721Tokens.length);
+
+			mockDip721Tokens.forEach(({ canisterId }) => {
+				expect(getDip721TokensByOwner).toHaveBeenCalledWith({
 					identity: mockIdentity,
 					owner: mockPrincipal,
 					canisterId
@@ -78,10 +110,20 @@ describe('nft.services', () => {
 		it('should return the list of NFTs owned by the user', async () => {
 			await expect(loadNfts(mockParams)).resolves.toEqual(expected);
 
-			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockParams.tokens.length);
+			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
 
-			mockParams.tokens.forEach(({ canisterId }) => {
+			mockExtTokens.forEach(({ canisterId }) => {
 				expect(getExtTokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getDip721TokensByOwner).toHaveBeenCalledTimes(mockDip721Tokens.length);
+
+			mockDip721Tokens.forEach(({ canisterId }) => {
+				expect(getDip721TokensByOwner).toHaveBeenCalledWith({
 					identity: mockIdentity,
 					owner: mockPrincipal,
 					canisterId
@@ -90,15 +132,25 @@ describe('nft.services', () => {
 		});
 
 		it('should handle EXT service errors gracefully', async () => {
-			const mockError = new Error('Mock error');
+			const mockError = new Error('Mock EXT error');
 			vi.spyOn(extTokenApi, 'getTokensByOwner').mockRejectedValueOnce(mockError);
 
-			await expect(loadNfts(mockParams)).resolves.toEqual(expected2);
+			await expect(loadNfts(mockParams)).resolves.toEqual([...expected2, ...expected3]);
 
-			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockParams.tokens.length);
+			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
 
-			mockParams.tokens.forEach(({ canisterId }) => {
+			mockExtTokens.forEach(({ canisterId }) => {
 				expect(getExtTokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getDip721TokensByOwner).toHaveBeenCalledTimes(mockDip721Tokens.length);
+
+			mockDip721Tokens.forEach(({ canisterId }) => {
+				expect(getDip721TokensByOwner).toHaveBeenCalledWith({
 					identity: mockIdentity,
 					owner: mockPrincipal,
 					canisterId
@@ -107,6 +159,38 @@ describe('nft.services', () => {
 
 			expect(console.warn).toHaveBeenCalledExactlyOnceWith(
 				`Error loading EXT tokens from collection ${mockValidExtV2Token.canisterId}:`,
+				mockError
+			);
+		});
+
+		it('should handle DIP721 service errors gracefully', async () => {
+			const mockError = new Error('Mock DIP721 error');
+			vi.spyOn(dip721Api, 'getTokensByOwner').mockRejectedValueOnce(mockError);
+
+			await expect(loadNfts(mockParams)).resolves.toEqual([...expected1, ...expected2]);
+
+			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
+
+			mockExtTokens.forEach(({ canisterId }) => {
+				expect(getExtTokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getDip721TokensByOwner).toHaveBeenCalledTimes(mockDip721Tokens.length);
+
+			mockDip721Tokens.forEach(({ canisterId }) => {
+				expect(getDip721TokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(console.warn).toHaveBeenCalledExactlyOnceWith(
+				`Error loading DIP721 tokens from collection ${mockValidDip721Token.canisterId}:`,
 				mockError
 			);
 		});


### PR DESCRIPTION
# Motivation

Similar to what we did for EXT tokens, we integrate the DIP721 standard in the service that fetches the IC NFTs by owner.
