### PR TITLE
feat(backend): More verbose error when saving user tokens

### DIFF
--- a/src/backend/src/token.rs
+++ b/src/backend/src/token.rs
@@ -21,8 +21,7 @@ pub fn add_to_user_token<T>(
             *existing_token = token.with_incremented_version();
         } else {
             ic_cdk::trap(&format!(
-                "Version mismatch, token update not allowed. Existing token: {:?}, New token: {:?}",
-                existing_token, token
+                "Version mismatch, token update not allowed. Existing token: {existing_token:?}, New token: {token:?}"
             ));
         }
     } else {


### PR DESCRIPTION
# Motivation

It is useful to have more details when the error traps during saving user tokens in the backend.
