### PR TITLE
feat(frontend): Util to check a ERC20 Custom Token

### DIFF
--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -50,11 +50,11 @@ export const mapErc20Icon = (symbol: string): string | undefined => {
 
 export const isTokenErc20 = (token: Token): token is Erc20Token => token.standard.code === 'erc20';
 
+export const isTokenErc20CustomToken = (token: Token): token is Erc20CustomToken =>
+	isTokenErc20(token) && isTokenToggleable(token);
+
 export const isTokenEthereumUserToken = (token: Token): token is EthereumUserToken =>
 	(token.standard.code === 'ethereum' || isTokenErc20(token)) && isTokenToggleable(token);
 
 export const isTokenErc20UserToken = (token: Token): token is Erc20UserToken =>
 	isTokenErc20(token) && isTokenToggleable(token) && 'address' in token && 'exchange' in token;
-
-export const isTokenErc20CustomToken = (token: Token): token is Erc20CustomToken =>
-	isTokenErc20(token) && isTokenToggleable(token);

--- a/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
@@ -155,6 +155,40 @@ describe('erc20.utils', () => {
 		});
 	});
 
+	describe('isTokenErc20CustomToken', () => {
+		const tokens = [...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS];
+
+		it.each(
+			tokens.map((token) => ({
+				...token,
+				enabled: Math.random() < 0.5
+			}))
+		)('should return true for token $name that has the enabled field', (token) => {
+			expect(isTokenErc20CustomToken(token)).toBeTruthy();
+		});
+
+		it.each(tokens)(
+			'should return false for token $name that has not the enabled field',
+			(token) => {
+				expect(isTokenErc20CustomToken(token)).toBeFalsy();
+			}
+		);
+
+		it.each([
+			ICP_TOKEN,
+			...SUPPORTED_BITCOIN_TOKENS,
+			...SUPPORTED_ETHEREUM_TOKENS,
+			...SUPPORTED_EVM_TOKENS,
+			...SUPPORTED_SOLANA_TOKENS,
+			...SPL_TOKENS,
+			...ERC20_TWIN_TOKENS,
+			...EVM_ERC20_TOKENS,
+			...MOCK_ERC721_TOKENS
+		])('should return false for token $name', (token) => {
+			expect(isTokenErc20CustomToken(token)).toBeFalsy();
+		});
+	});
+
 	describe('isTokenEthereumUserToken', () => {
 		const tokens = [
 			...SUPPORTED_ETHEREUM_TOKENS,
@@ -233,40 +267,6 @@ describe('erc20.utils', () => {
 			...SPL_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isTokenErc20UserToken(token)).toBeFalsy();
-		});
-	});
-
-	describe('isTokenErc20CustomToken', () => {
-		const tokens = [...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS];
-
-		it.each(
-			tokens.map((token) => ({
-				...token,
-				enabled: Math.random() < 0.5
-			}))
-		)('should return true for token $name that has the enabled field', (token) => {
-			expect(isTokenErc20CustomToken(token)).toBeTruthy();
-		});
-
-		it.each(tokens)(
-			'should return false for token $name that has not the enabled field',
-			(token) => {
-				expect(isTokenErc20CustomToken(token)).toBeFalsy();
-			}
-		);
-
-		it.each([
-			ICP_TOKEN,
-			...SUPPORTED_BITCOIN_TOKENS,
-			...SUPPORTED_ETHEREUM_TOKENS,
-			...SUPPORTED_EVM_TOKENS,
-			...SUPPORTED_SOLANA_TOKENS,
-			...SPL_TOKENS,
-			...ERC20_TWIN_TOKENS,
-			...EVM_ERC20_TOKENS,
-			...MOCK_ERC721_TOKENS
-		])('should return false for token $name', (token) => {
-			expect(isTokenErc20CustomToken(token)).toBeFalsy();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

In the next step to migrate to ERC20 Custom Tokens from User Tokens, we require an util to check if a token is a ERC20 CustomToken.