### PR TITLE
refactor(frontend): Use ERC20 custom tokens in derived stores for initialization

### DIFF
--- a/src/frontend/src/eth/components/tokens/EthTokenMenu.svelte
+++ b/src/frontend/src/eth/components/tokens/EthTokenMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
-	import { erc20UserTokensInitialized } from '$eth/derived/erc20.derived';
+	import { erc20CustomTokensInitialized } from '$eth/derived/erc20.derived';
 	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import { getExplorerUrl } from '$eth/utils/eth.utils';
 	import TokenMenu from '$lib/components/tokens/TokenMenu.svelte';
@@ -23,7 +23,7 @@
 </script>
 
 <TokenMenu testId={TOKEN_MENU_ETH}>
-	{#if nonNullish(explorerUrl) && $erc20UserTokensInitialized}
+	{#if nonNullish(explorerUrl) && $erc20CustomTokensInitialized}
 		<div in:fade>
 			<ExternalLink
 				ariaLabel={$i18n.tokens.alt.open_etherscan}

--- a/src/frontend/src/eth/derived/erc20.derived.ts
+++ b/src/frontend/src/eth/derived/erc20.derived.ts
@@ -1,7 +1,6 @@
 import { enabledEthereumNetworksIds } from '$eth/derived/networks.derived';
 import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
-import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20CustomToken } from '$eth/types/erc20-custom-token';
 import { enabledEvmNetworksIds } from '$evm/derived/networks.derived';
@@ -112,12 +111,12 @@ export const enabledErc20Tokens: Readable<Erc20CustomToken[]> = derived(
 	]
 );
 
-export const erc20UserTokensInitialized: Readable<boolean> = derived(
-	[erc20UserTokensStore],
-	([$erc20UserTokensStore]) => $erc20UserTokensStore !== undefined
+export const erc20CustomTokensInitialized: Readable<boolean> = derived(
+	[erc20CustomTokensStore],
+	([$erc20CustomTokensStore]) => $erc20CustomTokensStore !== undefined
 );
 
-export const erc20UserTokensNotInitialized: Readable<boolean> = derived(
-	[erc20UserTokensInitialized],
+export const erc20CustomTokensNotInitialized: Readable<boolean> = derived(
+	[erc20CustomTokensInitialized],
 	([$erc20TokensInitialized]) => !$erc20TokensInitialized
 );

--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -6,7 +6,7 @@
 	import ConvertToCkEth from '$eth/components/convert/ConvertToCkEth.svelte';
 	import EthReceive from '$eth/components/receive/EthReceive.svelte';
 	import ConvertToCkErc20 from '$eth/components/send/ConvertToCkErc20.svelte';
-	import { erc20UserTokensInitialized } from '$eth/derived/erc20.derived';
+	import { erc20CustomTokensInitialized } from '$eth/derived/erc20.derived';
 	import ConvertToBtc from '$icp/components/convert/ConvertToBtc.svelte';
 	import ConvertToEthereum from '$icp/components/convert/ConvertToEthereum.svelte';
 	import IcReceive from '$icp/components/receive/IcReceive.svelte';
@@ -33,12 +33,12 @@
 	import { isNetworkIdBTCMainnet } from '$lib/utils/network.utils';
 	import SolReceive from '$sol/components/receive/SolReceive.svelte';
 
-	let convertEth = $derived($ethToCkETHEnabled && $erc20UserTokensInitialized);
+	let convertEth = $derived($ethToCkETHEnabled && $erc20CustomTokensInitialized);
 
-	let convertErc20 = $derived($erc20ToCkErc20Enabled && $erc20UserTokensInitialized);
+	let convertErc20 = $derived($erc20ToCkErc20Enabled && $erc20CustomTokensInitialized);
 
 	let convertCkBtc = $derived(
-		$networkBitcoinMainnetEnabled && $tokenCkBtcLedger && $erc20UserTokensInitialized
+		$networkBitcoinMainnetEnabled && $tokenCkBtcLedger && $erc20CustomTokensInitialized
 	);
 
 	let convertBtc = $derived($networkBitcoinMainnetEnabled && isNetworkIdBTCMainnet($networkId));

--- a/src/frontend/src/lib/components/loaders/LoaderTokens.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderTokens.svelte
@@ -2,7 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { erc1155CustomTokensNotInitialized } from '$eth/derived/erc1155.derived';
-	import { erc20UserTokensNotInitialized } from '$eth/derived/erc20.derived';
+	import { erc20CustomTokensNotInitialized } from '$eth/derived/erc20.derived';
 	import { erc721CustomTokensNotInitialized } from '$eth/derived/erc721.derived';
 	import { loadErc1155Tokens } from '$eth/services/erc1155.services';
 	import { loadErc20Tokens } from '$eth/services/erc20.services';
@@ -49,7 +49,7 @@
 				$networkEvmMainnetEnabled ||
 				($testnetsEnabled && ($networkSepoliaEnabled || $networkEvmTestnetEnabled)))
 	);
-	let loadErc20 = $derived(loadErc && $erc20UserTokensNotInitialized);
+	let loadErc20 = $derived(loadErc && $erc20CustomTokensNotInitialized);
 	let loadErc721 = $derived(loadErc && $erc721CustomTokensNotInitialized);
 	let loadErc1155 = $derived(loadErc && $erc1155CustomTokensNotInitialized);
 

--- a/src/frontend/src/tests/lib/components/loaders/LoaderTokens.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderTokens.spec.ts
@@ -101,7 +101,7 @@ describe('LoaderTokens', () => {
 		extNotInitStore.set(true);
 		splNotInitStore.set(true);
 
-		vi.spyOn(erc20Derived, 'erc20UserTokensNotInitialized', 'get').mockReturnValue(
+		vi.spyOn(erc20Derived, 'erc20CustomTokensNotInitialized', 'get').mockReturnValue(
 			erc20NotInitStore
 		);
 


### PR DESCRIPTION
# Motivation

We can replace the user tokens store with the custom tokens store for ERC20 to check initialization.
