### PR TITLE
feat(frontend): Replace deprecated User Token from `TokenModal` flow

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -3,16 +3,15 @@
 	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import type { Snippet } from 'svelte';
-	import { erc20UserTokensStore } from '$eth/stores/erc20-user-tokens.store';
-	import { isTokenErc20UserToken } from '$eth/utils/erc20.utils';
+	import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
+	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import IcAddIcrcTokenForm from '$icp/components/tokens/IcAddIcrcTokenForm.svelte';
 	import { assertIndexLedgerId } from '$icp/services/ic-add-custom-tokens.service';
 	import { loadCustomTokens } from '$icp/services/icrc.services';
 	import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 	import { icTokenIcrcCustomToken, isTokenIcrc } from '$icp/utils/icrc.utils';
-	import { toUserToken } from '$icp-eth/services/erc20-token.services';
-	import { removeCustomToken, removeUserToken, setCustomToken } from '$lib/api/backend.api';
-	import { deleteIdbIcToken, deleteIdbSolToken } from '$lib/api/idb-tokens.api';
+	import { removeCustomToken, setCustomToken } from '$lib/api/backend.api';
+	import { deleteIdbIcToken, deleteIdbSolToken, deleteIdbEthToken } from '$lib/api/idb-tokens.api';
 	import AddTokenByNetworkDropdown from '$lib/components/manage/AddTokenByNetworkDropdown.svelte';
 	import TokenModalContent from '$lib/components/tokens/TokenModalContent.svelte';
 	import TokenModalDeleteConfirmation from '$lib/components/tokens/TokenModalDeleteConfirmation.svelte';
@@ -150,19 +149,23 @@
 		}
 
 		try {
-			// TODO: update this function to handle ICRC/SPL when BE supports removing custom tokens
-			if (isTokenErc20UserToken(tokenToDelete)) {
+			if (isTokenErc20(tokenToDelete)) {
 				loading = true;
 
-				const userToken = toUserToken(tokenToDelete);
-
-				await removeUserToken({
-					chain_id: userToken.chain_id,
-					contract_address: userToken.contract_address,
-					identity: $authIdentity
+				const customToken = toCustomToken({
+					...tokenToDelete,
+					chainId: tokenToDelete.network.chainId,
+					enabled: true,
+					networkKey: 'Erc20'
 				});
 
-				erc20UserTokensStore.reset(tokenToDelete.id);
+				await removeCustomToken({
+					identity: $authIdentity,
+					token: customToken
+				});
+
+				erc20CustomTokensStore.reset(tokenToDelete.id);
+				await deleteIdbEthToken({ identity: $authIdentity, token: customToken });
 
 				await onTokenDeleteSuccess(tokenToDelete);
 			} else if (isTokenIcrc(tokenToDelete)) {

--- a/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenModal.spec.ts
@@ -29,8 +29,8 @@ vi.mock('$icp/services/icrc.services', () => ({
 }));
 
 describe('TokenModal', () => {
-	const mockRemoveUserToken = () =>
-		vi.spyOn(backendApi, 'removeUserToken').mockResolvedValue(undefined);
+	const mockRemoveCustomToken = () =>
+		vi.spyOn(backendApi, 'removeCustomToken').mockResolvedValue(undefined);
 	const mockSetCustomToken = () =>
 		vi.spyOn(backendApi, 'setCustomToken').mockResolvedValue(undefined);
 	const mockIcAddCustomTokensService = (result = true) =>
@@ -61,7 +61,7 @@ describe('TokenModal', () => {
 			}
 		});
 
-		const removeUserTokenMock = mockRemoveUserToken();
+		const removeCustomTokenMock = mockRemoveCustomToken();
 		const toasts = mockToastsShow();
 		const gotoReplaceRoot = mockGoToRoot();
 		mockAuthStore();
@@ -75,7 +75,7 @@ describe('TokenModal', () => {
 		await fireEvent.click(getByTestId(TOKEN_MODAL_DELETE_BUTTON));
 
 		await waitFor(() => {
-			expect(removeUserTokenMock).toHaveBeenCalledOnce();
+			expect(removeCustomTokenMock).toHaveBeenCalledOnce();
 			expect(toasts).toHaveBeenCalledOnce();
 			expect(gotoReplaceRoot).toHaveBeenCalledOnce();
 		});
@@ -193,7 +193,7 @@ describe('TokenModal', () => {
 			}
 		});
 
-		const removeUserTokenMock = mockRemoveUserToken();
+		const removeCustomTokenMock = mockRemoveCustomToken();
 		const toasts = mockToastsShow();
 		const gotoReplaceRoot = mockGoToRoot();
 		mockAuthStore();
@@ -206,7 +206,7 @@ describe('TokenModal', () => {
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_DELETE_BUTTON));
 
-		expect(removeUserTokenMock).not.toHaveBeenCalledOnce();
+		expect(removeCustomTokenMock).not.toHaveBeenCalledOnce();
 		expect(toasts).not.toHaveBeenCalledOnce();
 		expect(gotoReplaceRoot).not.toHaveBeenCalledOnce();
 	});
@@ -222,7 +222,7 @@ describe('TokenModal', () => {
 			}
 		});
 
-		const removeUserTokenMock = mockRemoveUserToken();
+		const removeCustomTokenMock = mockRemoveCustomToken();
 		const toasts = mockToastsShow();
 		const gotoReplaceRoot = mockGoToRoot();
 
@@ -234,7 +234,7 @@ describe('TokenModal', () => {
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_DELETE_BUTTON));
 
-		expect(removeUserTokenMock).not.toHaveBeenCalledOnce();
+		expect(removeCustomTokenMock).not.toHaveBeenCalledOnce();
 		expect(toasts).not.toHaveBeenCalledOnce();
 		expect(gotoReplaceRoot).not.toHaveBeenCalledOnce();
 	});
@@ -260,8 +260,8 @@ describe('TokenModal', () => {
 			}
 		});
 
-		const removeUserTokenMock = vi
-			.spyOn(backendApi, 'removeUserToken')
+		const removeCustomTokenMock = vi
+			.spyOn(backendApi, 'removeCustomToken')
 			.mockRejectedValue(new Error('test'));
 		const toastsError = mockToastsError();
 		const gotoReplaceRoot = mockGoToRoot();
@@ -275,7 +275,7 @@ describe('TokenModal', () => {
 
 		await fireEvent.click(getByTestId(TOKEN_MODAL_DELETE_BUTTON));
 
-		expect(removeUserTokenMock).toHaveBeenCalledOnce();
+		expect(removeCustomTokenMock).toHaveBeenCalledOnce();
 		expect(toastsError).toHaveBeenCalledOnce();
 		expect(gotoReplaceRoot).not.toHaveBeenCalledOnce();
 	});


### PR DESCRIPTION
# Motivation

Since User token is deprecated in favour of Custom token, we can replace it in the flow of `TokenModal`.
