### PR TITLE
refactor(frontend): Replace `UserToken` flow in `EthHideTokenModal`

### DIFF
--- a/src/frontend/src/eth/components/tokens/EthHideTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/EthHideTokenModal.svelte
@@ -5,13 +5,13 @@
 	import { onMount } from 'svelte';
 	import { loadCustomTokens } from '$eth/services/erc20.services';
 	import type { OptionErc20UserToken } from '$eth/types/erc20-user-token';
-	import { setUserToken } from '$icp-eth/services/erc20-token.services';
 	import HideTokenModal from '$lib/components/tokens/HideTokenModal.svelte';
 	import {
 		HIDE_TOKEN_MODAL_ROUTE,
 		TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS
 	} from '$lib/constants/analytics.constants';
 	import { trackEvent } from '$lib/services/analytics.services';
+	import { saveCustomTokens } from '$lib/services/save-custom-tokens.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { token } from '$lib/stores/token.store';
@@ -55,7 +55,17 @@
 			}
 		});
 
-		await setUserToken({ ...params, token: selectedToken, enabled: false });
+		await saveCustomTokens({
+			...params,
+			tokens: [
+				{
+					...selectedToken,
+					chainId: selectedToken.network.chainId,
+					networkKey: 'Erc20',
+					enabled: false
+				}
+			]
+		});
 	};
 
 	// TODO(GIX-2740): no call to Infura - remove only the selected token from stores

--- a/src/frontend/src/icp-eth/services/erc20-token.services.ts
+++ b/src/frontend/src/icp-eth/services/erc20-token.services.ts
@@ -2,12 +2,9 @@ import type { UserToken } from '$declarations/backend/backend.did';
 import { loadCustomTokens } from '$eth/services/erc20.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20CustomToken } from '$eth/types/erc20-custom-token';
-import type { Erc20UserToken, SaveUserToken } from '$eth/types/erc20-user-token';
+import type { SaveUserToken } from '$eth/types/erc20-user-token';
 import type { IcCkToken } from '$icp/types/ic-token';
-import {
-	setCustomToken as setCustomTokenApi,
-	setUserToken as setUserTokenApi
-} from '$lib/api/backend.api';
+import { setCustomToken as setCustomTokenApi } from '$lib/api/backend.api';
 import { autoLoadToken, type AutoLoadTokenResult } from '$lib/services/token.services';
 import { i18n } from '$lib/stores/i18n.store';
 import type { OptionIdentity } from '$lib/types/identity';
@@ -85,24 +82,6 @@ export const toUserToken = ({
 	version: toNullable(version),
 	enabled: toNullable(enabled)
 });
-
-export const setUserToken = async ({
-	token,
-	identity,
-	enabled
-}: {
-	identity: Identity;
-	token: Erc20UserToken;
-	enabled: boolean;
-}) =>
-	await setUserTokenApi({
-		identity,
-		token: toUserToken({
-			...token,
-			enabled
-		}),
-		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
-	});
 
 export const setCustomToken = async ({
 	token,


### PR DESCRIPTION
# Motivation

Since `UserToken` is deprecated in favour of `CustomToken`, we can replace it in the flow of component `EthHideTokenModal`.