### PR TITLE
feat(frontend): "guided upgrade" II feature param

### DIFF
--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -100,7 +100,7 @@ const initAuthStore = (): AuthStore => {
 					? /apple/i.test(navigator?.vendor)
 						? `http://localhost:4943?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
 						: `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:4943`
-					: `https://${domain ?? InternetIdentityDomain.VERSION_1_0}`;
+					: `https://${domain ?? InternetIdentityDomain.VERSION_1_0}${domain === InternetIdentityDomain.VERSION_2_0 ? '/?feature_flag_guided_upgrade=true' : ''}`;
 
 				await authClient.login({
 					maxTimeToLive: AUTH_MAX_TIME_TO_LIVE,


### PR DESCRIPTION
# Motivation

We need to pass an additional query param when initializing II 2.0 client to show to the users the upgrade guide.

<img width="572" height="658" alt="Screenshot 2026-01-08 at 15 24 55" src="https://github.com/user-attachments/assets/7bf60dd4-6a15-408c-864c-07fcc97b8743" />
