### PR TITLE
refactor(frontend): Replace `EthereumUserToken` with `EthereumCustomToken`

### DIFF
--- a/src/frontend/src/eth/types/erc20-custom-token.ts
+++ b/src/frontend/src/eth/types/erc20-custom-token.ts
@@ -8,3 +8,6 @@ export type SaveErc20CustomToken = Pick<
 	'enabled' | 'version' | 'symbol' | 'decimals' | 'address' | 'network'
 > &
 	Partial<Pick<Erc20CustomToken, 'id'>>;
+
+export type EthereumCustomToken = Omit<Erc20CustomToken, 'address' | 'exchange'> &
+	Partial<Pick<Erc20Token, 'address' | 'exchange'>>;

--- a/src/frontend/src/eth/types/erc20-user-token.ts
+++ b/src/frontend/src/eth/types/erc20-user-token.ts
@@ -1,7 +1,0 @@
-import type { Erc20Token } from '$eth/types/erc20';
-import type { UserToken } from '$lib/types/user-token';
-
-export type Erc20UserToken = UserToken<Erc20Token>;
-
-export type EthereumUserToken = Omit<Erc20UserToken, 'address' | 'exchange'> &
-	Partial<Pick<Erc20Token, 'address' | 'exchange'>>;

--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -1,6 +1,5 @@
 import type { Erc20Contract, Erc20Metadata, Erc20Token } from '$eth/types/erc20';
-import type { Erc20CustomToken } from '$eth/types/erc20-custom-token';
-import type { EthereumUserToken } from '$eth/types/erc20-user-token';
+import type { Erc20CustomToken, EthereumCustomToken } from '$eth/types/erc20-custom-token';
 import type { EthereumNetwork } from '$eth/types/network';
 import icpDark from '$icp/assets/icp-dark.svg';
 import type { Token } from '$lib/types/token';
@@ -36,5 +35,5 @@ export const isTokenErc20 = (token: Token): token is Erc20Token => token.standar
 export const isTokenErc20CustomToken = (token: Token): token is Erc20CustomToken =>
 	isTokenErc20(token) && isTokenToggleable(token);
 
-export const isTokenEthereumUserToken = (token: Token): token is EthereumUserToken =>
+export const isTokenEthereumCustomToken = (token: Token): token is EthereumCustomToken =>
 	(token.standard.code === 'ethereum' || isTokenErc20(token)) && isTokenToggleable(token);

--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -2,7 +2,7 @@ import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
 import { ICP_TOKEN, TESTICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
-import { isTokenEthereumUserToken } from '$eth/utils/erc20.utils';
+import { isTokenEthereumCustomToken } from '$eth/utils/erc20.utils';
 import { isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
@@ -91,7 +91,7 @@ export const pageTokenToggleable: Readable<boolean> = derived([pageToken], ([$pa
 	if (nonNullish($pageToken)) {
 		return icTokenIcrcCustomToken($pageToken)
 			? isIcrcTokenToggleEnabled($pageToken)
-			: isTokenEthereumUserToken($pageToken)
+			: isTokenEthereumCustomToken($pageToken)
 				? isNotDefaultEthereumToken($pageToken)
 				: isTokenSpl($pageToken)
 					? isTokenSplCustomToken($pageToken)

--- a/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc20.utils.spec.ts
@@ -9,7 +9,7 @@ import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import {
 	isTokenErc20,
 	isTokenErc20CustomToken,
-	isTokenEthereumUserToken,
+	isTokenEthereumCustomToken,
 	mapErc20Token
 } from '$eth/utils/erc20.utils';
 import icpDark from '$icp/assets/icp-dark.svg';
@@ -131,7 +131,7 @@ describe('erc20.utils', () => {
 		});
 	});
 
-	describe('isTokenEthereumUserToken', () => {
+	describe('isTokenEthereumCustomToken', () => {
 		const tokens = [
 			...SUPPORTED_ETHEREUM_TOKENS,
 			...SUPPORTED_EVM_TOKENS,
@@ -145,20 +145,20 @@ describe('erc20.utils', () => {
 				enabled: Math.random() < 0.5
 			}))
 		)('should return true for token $name that has the enabled field', (token) => {
-			expect(isTokenEthereumUserToken(token)).toBeTruthy();
+			expect(isTokenEthereumCustomToken(token)).toBeTruthy();
 		});
 
 		it.each(tokens)(
 			'should return false for token $name that has not the enabled field',
 			(token) => {
-				expect(isTokenEthereumUserToken(token)).toBeFalsy();
+				expect(isTokenEthereumCustomToken(token)).toBeFalsy();
 			}
 		);
 
 		it.each([ICP_TOKEN, ...SUPPORTED_BITCOIN_TOKENS, ...SUPPORTED_SOLANA_TOKENS, ...SPL_TOKENS])(
 			'should return false for token $name',
 			(token) => {
-				expect(isTokenEthereumUserToken(token)).toBeFalsy();
+				expect(isTokenEthereumCustomToken(token)).toBeFalsy();
 			}
 		);
 	});


### PR DESCRIPTION
# Motivation

Since we don't use `UserToken` type anymore we can completely replace it with `CustomToken` in the leftover types.