### PR TITLE
refactor(frontend): Rename `UserTokenState` type to `CustomTokenState`

### DIFF
--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -4,7 +4,7 @@ import type { Dip721Token } from '$icp/types/dip721-token';
 import type { ExtToken } from '$icp/types/ext-token';
 import type { IcToken } from '$icp/types/ic-token';
 import type { Token } from '$lib/types/token';
-import type { TokenToggleable, UserTokenState } from '$lib/types/token-toggleable';
+import type { CustomTokenState, TokenToggleable } from '$lib/types/token-toggleable';
 import type { SplToken } from '$sol/types/spl';
 import type { QueryAndUpdateRequestParams } from '@dfinity/utils';
 
@@ -27,10 +27,10 @@ export type ErcSaveCustomToken = Pick<Erc20Token, 'address'> &
 
 export type SplSaveCustomToken = Pick<SplToken, 'address' | 'decimals' | 'symbol'>;
 
-export type SaveCustomToken = UserTokenState &
+export type SaveCustomToken = CustomTokenState &
 	(IcrcSaveCustomToken | ExtSaveCustomToken | ErcSaveCustomToken | SplSaveCustomToken);
 
-export type SaveCustomTokenWithKey = UserTokenState &
+export type SaveCustomTokenWithKey = CustomTokenState &
 	(
 		| TokenVariant<'Icrc', IcrcSaveCustomToken>
 		| TokenVariant<'Erc20' | 'Erc721' | 'Erc1155', ErcSaveCustomToken>
@@ -39,11 +39,12 @@ export type SaveCustomTokenWithKey = UserTokenState &
 		| TokenVariant<'Dip721', Dip721SaveCustomToken>
 	);
 
-export type SaveCustomErcVariant = UserTokenState &
+export type SaveCustomErcVariant = CustomTokenState &
 	TokenVariant<'Erc20' | 'Erc721' | 'Erc1155', ErcSaveCustomToken>;
-export type SaveCustomErc721Variant = UserTokenState & TokenVariant<'Erc721', ErcSaveCustomToken>;
-export type SaveCustomErc1155Variant = UserTokenState & TokenVariant<'Erc1155', ErcSaveCustomToken>;
-export type SaveCustomExtVariant = UserTokenState & TokenVariant<'ExtV2', ExtSaveCustomToken>;
+export type SaveCustomErc721Variant = CustomTokenState & TokenVariant<'Erc721', ErcSaveCustomToken>;
+export type SaveCustomErc1155Variant = CustomTokenState &
+	TokenVariant<'Erc1155', ErcSaveCustomToken>;
+export type SaveCustomExtVariant = CustomTokenState & TokenVariant<'ExtV2', ExtSaveCustomToken>;
 
 export type CustomToken<T extends Token> = TokenToggleable<T>;
 

--- a/src/frontend/src/lib/types/token-toggleable.ts
+++ b/src/frontend/src/lib/types/token-toggleable.ts
@@ -1,14 +1,14 @@
-import type { CustomToken, UserToken } from '$declarations/backend/backend.did';
+import type { CustomToken } from '$declarations/backend/backend.did';
 import type { NonFungibleTokenAppearance } from '$lib/types/nft-ui';
 import type { Token } from '$lib/types/token';
 
 // Type pick and omit fields to make the reader aware that we are redefining the two fields we are interested in.
-export type UserTokenState = Omit<
-	Pick<UserToken | CustomToken, 'version' | 'enabled'>,
+export type CustomTokenState = Omit<
+	Pick<CustomToken, 'version' | 'enabled'>,
 	'version' | 'enabled' | 'section' | 'allowExternalContentSource'
 > & {
 	version?: bigint;
 	enabled: boolean;
 } & NonFungibleTokenAppearance;
 
-export type TokenToggleable<T extends Token> = T & UserTokenState;
+export type TokenToggleable<T extends Token> = T & CustomTokenState;


### PR DESCRIPTION
# Motivation

Since `UserToken` type is not used anymore, we can rename `UserTokenState` type to `CustomTokenState`.