### PR TITLE
fix(frontend): Correct EXT token identifier in service `detectNftCanisterStandard`

### DIFF
--- a/src/frontend/src/icp/services/ic-standard.services.ts
+++ b/src/frontend/src/icp/services/ic-standard.services.ts
@@ -7,6 +7,7 @@ import {
 	getTokensByOwner as extGetTokensByOwner,
 	metadata as extMetadata
 } from '$icp/api/ext-v2-token.api';
+import { extIndexToIdentifier } from '$icp/utils/ext.utils';
 import {
 	ResolveByProbingError,
 	resolveByProbing,
@@ -14,6 +15,7 @@ import {
 } from '$lib/services/probing.services';
 import type { TokenStandardCode } from '$lib/types/token';
 import type { Identity } from '@icp-sdk/core/agent';
+import { Principal } from '@icp-sdk/core/principal';
 
 type AcceptedStandards = Extract<TokenStandardCode, 'ext' | 'dip721'>;
 
@@ -34,12 +36,17 @@ export const detectNftCanisterStandard = async ({
 		canisterId
 	};
 
-	// The token identifier is not really important, since we only want to check if the method works for the canister.
+	// The EXT token identifier is not really important, since we only want to check if the method works for the canister.
+	const extTokenIdentifier = extIndexToIdentifier({
+		collectionId: Principal.fromText(canisterId),
+		index: 0
+	});
+
 	const extCanister: ResolveGroup<AcceptedStandards> = {
 		probes: [
-			() => extBalance({ ...baseParams, tokenIdentifier: '0' }),
+			() => extBalance({ ...baseParams, tokenIdentifier: extTokenIdentifier }),
 			() => extGetTokensByOwner({ ...baseParams, owner: identity.getPrincipal() }),
-			() => extMetadata({ ...baseParams, tokenIdentifier: '0' })
+			() => extMetadata({ ...baseParams, tokenIdentifier: extTokenIdentifier })
 		],
 		onResolve: () => 'ext'
 	};

--- a/src/frontend/src/tests/icp/services/ic-standard.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-standard.services.spec.ts
@@ -8,10 +8,12 @@ import {
 	metadata as extMetadata
 } from '$icp/api/ext-v2-token.api';
 import { detectNftCanisterStandard } from '$icp/services/ic-standard.services';
+import { extIndexToIdentifier } from '$icp/utils/ext.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import * as probingServices from '$lib/services/probing.services';
 import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
+import { Principal } from '@icp-sdk/core/principal';
 
 vi.mock('$icp/api/ext-v2-token.api', () => ({
 	balance: vi.fn(),
@@ -30,6 +32,11 @@ describe('ic-standard.services', () => {
 			identity: mockIdentity,
 			canisterId: mockLedgerCanisterId
 		};
+
+		const tokenIdentifier = extIndexToIdentifier({
+			collectionId: Principal.fromText(params.canisterId),
+			index: 0
+		});
 
 		const expected = {
 			certified: false,
@@ -55,7 +62,7 @@ describe('ic-standard.services', () => {
 
 			expect(extBalance).toHaveBeenCalledExactlyOnceWith({
 				...expected,
-				tokenIdentifier: '0'
+				tokenIdentifier
 			});
 			expect(extGetTokensByOwner).toHaveBeenCalledExactlyOnceWith({
 				...expected,
@@ -63,7 +70,7 @@ describe('ic-standard.services', () => {
 			});
 			expect(extMetadata).toHaveBeenCalledExactlyOnceWith({
 				...expected,
-				tokenIdentifier: '0'
+				tokenIdentifier
 			});
 
 			expect(dip721Balance).not.toHaveBeenCalled();
@@ -77,7 +84,7 @@ describe('ic-standard.services', () => {
 
 			expect(extBalance).toHaveBeenCalledExactlyOnceWith({
 				...expected,
-				tokenIdentifier: '0'
+				tokenIdentifier
 			});
 			expect(extGetTokensByOwner).toHaveBeenCalledExactlyOnceWith({
 				...expected,
@@ -85,7 +92,7 @@ describe('ic-standard.services', () => {
 			});
 			expect(extMetadata).toHaveBeenCalledExactlyOnceWith({
 				...expected,
-				tokenIdentifier: '0'
+				tokenIdentifier
 			});
 
 			expect(dip721Balance).toHaveBeenCalledExactlyOnceWith(expected);
@@ -103,7 +110,7 @@ describe('ic-standard.services', () => {
 
 			expect(extBalance).toHaveBeenCalledExactlyOnceWith({
 				...expected,
-				tokenIdentifier: '0'
+				tokenIdentifier
 			});
 			expect(extGetTokensByOwner).toHaveBeenCalledExactlyOnceWith({
 				...expected,
@@ -111,7 +118,7 @@ describe('ic-standard.services', () => {
 			});
 			expect(extMetadata).toHaveBeenCalledExactlyOnceWith({
 				...expected,
-				tokenIdentifier: '0'
+				tokenIdentifier
 			});
 
 			expect(dip721Balance).toHaveBeenCalledExactlyOnceWith(expected);
@@ -141,7 +148,7 @@ describe('ic-standard.services', () => {
 
 			expect(extBalance).toHaveBeenCalledExactlyOnceWith({
 				...expected,
-				tokenIdentifier: '0'
+				tokenIdentifier
 			});
 			expect(extGetTokensByOwner).toHaveBeenCalledExactlyOnceWith({
 				...expected,
@@ -149,7 +156,7 @@ describe('ic-standard.services', () => {
 			});
 			expect(extMetadata).toHaveBeenCalledExactlyOnceWith({
 				...expected,
-				tokenIdentifier: '0'
+				tokenIdentifier
 			});
 
 			expect(dip721Balance).not.toHaveBeenCalled();


### PR DESCRIPTION
# Motivation

In service `detectNftCanisterStandard`, the definition of the EXT token identifier is wrong. We must use the util `extIndexToIdentifier` to calculate it.