### PR TITLE
chore(frontend): Add TODO to mock of DIP721 canister IDs

### DIFF
--- a/src/frontend/src/tests/mocks/dip721-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/dip721-tokens.mock.ts
@@ -4,7 +4,7 @@ import type { CanisterIdText } from '$lib/types/canister';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidToken } from '$tests/mocks/tokens.mock';
 
-// TODO: Find some DIP721 examples; the canisters below belong to other standard.
+// TODO: Find some DIP721 examples; the canisters below belong to other standards.
 export const mockDip721TokenCanisterId: CanisterIdText = 'qcg3w-tyaaa-aaaah-qakea-cai';
 export const mockDip721TokenCanisterId2: CanisterIdText = '4nvhy-3qaaa-aaaah-qcnoq-cai';
 export const mockDip721TokenCanisterId3: CanisterIdText = 'fl5nr-xiaaa-aaaai-qbjmq-cai';


### PR DESCRIPTION
# Motivation

We don't really have some example of DIP721 canisters, so the mocks are actually for other standards. Just for posterity, we add a TODO.