### PR TITLE
feat(frontend): Create API service for ICPunks tokens

### DIFF
--- a/src/frontend/src/icp/api/icpunks.api.ts
+++ b/src/frontend/src/icp/api/icpunks.api.ts
@@ -1,0 +1,39 @@
+import { IcPunksCanister } from '$icp/canisters/icpunks.canister';
+import type { CanisterApiFunctionParamsWithCanisterId } from '$lib/types/canister';
+import { assertNonNullish, isNullish, type QueryParams } from '@dfinity/utils';
+import { Principal } from '@icp-sdk/core/principal';
+
+export const getTokensByOwner = async ({
+	certified,
+	identity,
+	owner: principal,
+	canisterId,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<{ owner: Principal } & QueryParams>): Promise<
+	bigint[]
+> => {
+	if (isNullish(identity)) {
+		return [];
+	}
+
+	const { getTokensByOwner } = await icPunksCanister({
+		identity,
+		canisterId,
+		...rest
+	});
+
+	return await getTokensByOwner({ certified, principal });
+};
+
+const icPunksCanister = async ({
+	identity,
+	nullishIdentityErrorMessage,
+	canisterId
+}: CanisterApiFunctionParamsWithCanisterId): Promise<IcPunksCanister> => {
+	assertNonNullish(identity, nullishIdentityErrorMessage);
+
+	return await IcPunksCanister.create({
+		identity,
+		canisterId: Principal.fromText(canisterId)
+	});
+};

--- a/src/frontend/src/tests/icp/api/icpunks.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icpunks.api.spec.ts
@@ -1,0 +1,60 @@
+import { getTokensByOwner } from '$icp/api/icpunks.api';
+import { IcPunksCanister } from '$icp/canisters/icpunks.canister';
+import { CanisterInternalError } from '$lib/canisters/errors';
+import { mockIcPunksCanisterId } from '$tests/mocks/icpunks-tokens.mock';
+import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+import { mock } from 'vitest-mock-extended';
+
+describe('icpunks.api', () => {
+	const tokenCanisterMock = mock<IcPunksCanister>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.spyOn(IcPunksCanister, 'create').mockResolvedValue(tokenCanisterMock);
+	});
+
+	describe('getTokensByOwner', () => {
+		const mockTokens = [123n, 456n, 789n];
+
+		const params = {
+			identity: mockIdentity,
+			owner: mockPrincipal,
+			canisterId: mockIcPunksCanisterId
+		};
+
+		const expectedParams = {
+			principal: mockPrincipal
+		};
+
+		beforeEach(() => {
+			tokenCanisterMock.getTokensByOwner.mockResolvedValue(mockTokens);
+		});
+
+		it('should call successfully getTokensByOwner endpoint', async () => {
+			const result = await getTokensByOwner(params);
+
+			expect(result).toEqual(mockTokens);
+
+			expect(tokenCanisterMock.getTokensByOwner).toHaveBeenCalledExactlyOnceWith(expectedParams);
+		});
+
+		it('should return an empty array if identity is nullish', async () => {
+			await expect(getTokensByOwner({ ...params, identity: undefined })).resolves.toEqual([]);
+
+			await expect(getTokensByOwner({ ...params, identity: null })).resolves.toEqual([]);
+
+			expect(tokenCanisterMock.getTokensByOwner).not.toHaveBeenCalled();
+		});
+
+		it('should throw an error if getTokensByOwner fails', async () => {
+			const mockError = new CanisterInternalError('Generic error');
+
+			tokenCanisterMock.getTokensByOwner.mockRejectedValueOnce(mockError);
+
+			await expect(getTokensByOwner(params)).rejects.toThrowError(mockError);
+
+			expect(tokenCanisterMock.getTokensByOwner).toHaveBeenCalledExactlyOnceWith(expectedParams);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Similar to other canisters, we create generic methods for the ICPunks canister. In this PR we focus on method `getTokensByOwner`.