### PR TITLE
feat(frontend): API service to transfer ICPunks NFTs

### DIFF
--- a/src/frontend/src/icp/api/icpunks.api.ts
+++ b/src/frontend/src/icp/api/icpunks.api.ts
@@ -25,6 +25,25 @@ export const getTokensByOwner = async ({
 	return await getTokensByOwner({ certified, principal });
 };
 
+export const transfer = async ({
+	certified,
+	identity,
+	canisterId,
+	to,
+	tokenIdentifier,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<
+	{ to: Principal; tokenIdentifier: bigint } & QueryParams
+>) => {
+	const { transfer } = await icPunksCanister({
+		identity,
+		canisterId,
+		...rest
+	});
+
+	await transfer({ certified, to, tokenIdentifier });
+};
+
 const icPunksCanister = async ({
 	identity,
 	nullishIdentityErrorMessage,

--- a/src/frontend/src/tests/icp/api/icpunks.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icpunks.api.spec.ts
@@ -1,8 +1,8 @@
-import { getTokensByOwner } from '$icp/api/icpunks.api';
+import { getTokensByOwner, transfer } from '$icp/api/icpunks.api';
 import { IcPunksCanister } from '$icp/canisters/icpunks.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { mockIcPunksCanisterId } from '$tests/mocks/icpunks-tokens.mock';
-import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
 import { mock } from 'vitest-mock-extended';
 
 describe('icpunks.api', () => {
@@ -55,6 +55,43 @@ describe('icpunks.api', () => {
 			await expect(getTokensByOwner(params)).rejects.toThrowError(mockError);
 
 			expect(tokenCanisterMock.getTokensByOwner).toHaveBeenCalledExactlyOnceWith(expectedParams);
+		});
+	});
+
+	describe('transfer', () => {
+		const mockTokenId = 987_456_123n;
+
+		const params = {
+			identity: mockIdentity,
+			owner: mockPrincipal,
+			canisterId: mockIcPunksCanisterId,
+			to: mockPrincipal2,
+			tokenIdentifier: mockTokenId
+		};
+
+		const expectedParams = {
+			to: mockPrincipal2,
+			tokenIdentifier: mockTokenId
+		};
+
+		beforeEach(() => {
+			tokenCanisterMock.transfer.mockResolvedValue(true);
+		});
+
+		it('should call successfully transfer endpoint', async () => {
+			await transfer(params);
+
+			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+		});
+
+		it('should throw an error if transfer fails', async () => {
+			const mockError = new CanisterInternalError('Generic error');
+
+			tokenCanisterMock.transfer.mockRejectedValueOnce(mockError);
+
+			await expect(transfer(params)).rejects.toThrowError(mockError);
+
+			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Like other methods, we create a service to transfer ICPunks NFTs.
