### PR TITLE
feat(frontend): Include pseudo-standard ICPunks in the IC NFT send service

### DIFF
--- a/src/frontend/src/icp/services/nft-send.services.ts
+++ b/src/frontend/src/icp/services/nft-send.services.ts
@@ -1,6 +1,11 @@
-import { transferDip721, transferExtV2 } from '$icp/services/nft-transfer.services';
+import {
+	transferDip721,
+	transferExtV2,
+	transferIcPunks
+} from '$icp/services/nft-transfer.services';
 import { isTokenDip721 } from '$icp/utils/dip721.utils';
 import { isTokenExt } from '$icp/utils/ext.utils';
+import { isTokenIcPunks } from '$icp/utils/icpunks.utils';
 import type { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { SendNftCommonParams, TransferParams } from '$lib/types/send';
 import { isNetworkIdICP } from '$lib/utils/network.utils';
@@ -37,6 +42,16 @@ export const sendNft = async ({
 
 		if (isTokenDip721(token)) {
 			await transferDip721({
+				identity,
+				canisterId: token.canisterId,
+				to: Principal.fromText(to),
+				tokenIdentifier: BigInt(tokenId),
+				progress
+			});
+		}
+
+		if (isTokenIcPunks(token)) {
+			await transferIcPunks({
 				identity,
 				canisterId: token.canisterId,
 				to: Principal.fromText(to),

--- a/src/frontend/src/icp/services/nft-transfer.services.ts
+++ b/src/frontend/src/icp/services/nft-transfer.services.ts
@@ -1,5 +1,6 @@
 import { transfer as transferDip721Api } from '$icp/api/dip721.api';
 import { transfer as transferExtApi } from '$icp/api/ext-v2-token.api';
+import { transfer as transferIcPunksApi } from '$icp/api/icpunks.api';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -37,6 +38,23 @@ export const transferDip721 = async ({
 	progress?.(ProgressStepsSendIc.SEND);
 
 	await transferDip721Api(rest);
+
+	progress?.(ProgressStepsSendIc.RELOAD);
+};
+
+export const transferIcPunks = async ({
+	progress,
+	...rest
+}: {
+	identity: Identity;
+	canisterId: CanisterIdText;
+	to: Principal;
+	tokenIdentifier: bigint;
+	progress?: (step: ProgressStepsSendIc) => void;
+}) => {
+	progress?.(ProgressStepsSendIc.SEND);
+
+	await transferIcPunksApi(rest);
 
 	progress?.(ProgressStepsSendIc.RELOAD);
 };

--- a/src/frontend/src/tests/icp/services/nft-send.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/nft-send.service.spec.ts
@@ -1,14 +1,20 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { sendNft } from '$icp/services/nft-send.services';
-import { transferDip721, transferExtV2 } from '$icp/services/nft-transfer.services';
+import {
+	transferDip721,
+	transferExtV2,
+	transferIcPunks
+} from '$icp/services/nft-transfer.services';
 import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
+import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
-import { mockValidDip721Nft, mockValidExtNft } from '$tests/mocks/nfts.mock';
+import { mockValidDip721Nft, mockValidExtNft, mockValidIcPunksNft } from '$tests/mocks/nfts.mock';
 
 vi.mock('$icp/services/nft-transfer.services', () => ({
 	transferExtV2: vi.fn(),
-	transferDip721: vi.fn()
+	transferDip721: vi.fn(),
+	transferIcPunks: vi.fn()
 }));
 
 describe('nft-send.services', () => {
@@ -33,6 +39,8 @@ describe('nft-send.services', () => {
 			await sendNft({ ...mockParams, identity: null });
 
 			expect(transferExtV2).not.toHaveBeenCalled();
+			expect(transferDip721).not.toHaveBeenCalled();
+			expect(transferIcPunks).not.toHaveBeenCalled();
 		});
 
 		it('should return early if network is not ICP', async () => {
@@ -42,6 +50,8 @@ describe('nft-send.services', () => {
 			});
 
 			expect(transferExtV2).not.toHaveBeenCalled();
+			expect(transferDip721).not.toHaveBeenCalled();
+			expect(transferIcPunks).not.toHaveBeenCalled();
 		});
 
 		it('should return early if token is not supported standard', async () => {
@@ -51,6 +61,8 @@ describe('nft-send.services', () => {
 			});
 
 			expect(transferExtV2).not.toHaveBeenCalled();
+			expect(transferDip721).not.toHaveBeenCalled();
+			expect(transferIcPunks).not.toHaveBeenCalled();
 		});
 
 		it('should call the EXT transfer service', async () => {
@@ -67,6 +79,10 @@ describe('nft-send.services', () => {
 			await sendNft(mockParams);
 
 			expect(transferExtV2).toHaveBeenCalledExactlyOnceWith(expectedParams);
+
+			expect(transferDip721).not.toHaveBeenCalled();
+
+			expect(transferIcPunks).not.toHaveBeenCalled();
 		});
 
 		it('should call the DIP721 transfer service', async () => {
@@ -81,6 +97,32 @@ describe('nft-send.services', () => {
 			await sendNft({ ...mockParams, token: mockValidDip721Token, tokenId: mockValidDip721Nft.id });
 
 			expect(transferDip721).toHaveBeenCalledExactlyOnceWith(expectedParams);
+
+			expect(transferExtV2).not.toHaveBeenCalled();
+
+			expect(transferIcPunks).not.toHaveBeenCalled();
+		});
+
+		it('should call the ICPunks transfer service', async () => {
+			const expectedParams = {
+				identity: mockIdentity,
+				canisterId: mockValidIcPunksToken.canisterId,
+				to: mockPrincipal2,
+				tokenIdentifier: BigInt(mockValidIcPunksNft.id),
+				progress: mockProgress
+			};
+
+			await sendNft({
+				...mockParams,
+				token: mockValidIcPunksToken,
+				tokenId: mockValidIcPunksNft.id
+			});
+
+			expect(transferIcPunks).toHaveBeenCalledExactlyOnceWith(expectedParams);
+
+			expect(transferExtV2).not.toHaveBeenCalled();
+
+			expect(transferDip721).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/frontend/src/tests/icp/services/nft-transfer.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/nft-transfer.service.spec.ts
@@ -1,10 +1,16 @@
 import { transfer as transferDip721Api } from '$icp/api/dip721.api';
 import { transfer as transferExtApi } from '$icp/api/ext-v2-token.api';
-import { transferDip721, transferExtV2 } from '$icp/services/nft-transfer.services';
+import { transfer as transferIcPunksApi } from '$icp/api/icpunks.api';
+import {
+	transferDip721,
+	transferExtV2,
+	transferIcPunks
+} from '$icp/services/nft-transfer.services';
 import { ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import { bn3Bi } from '$tests/mocks/balances.mock';
 import { mockDip721TokenCanisterId } from '$tests/mocks/dip721-tokens.mock';
 import { mockExtV2TokenCanisterId, mockExtV2TokenIdentifier } from '$tests/mocks/ext-v2-token.mock';
+import { mockIcPunksCanisterId } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
 
 vi.mock('$icp/api/ext-v2-token.api', () => ({
@@ -12,6 +18,10 @@ vi.mock('$icp/api/ext-v2-token.api', () => ({
 }));
 
 vi.mock('$icp/api/dip721.api', () => ({
+	transfer: vi.fn()
+}));
+
+vi.mock('$icp/api/icpunks.api', () => ({
 	transfer: vi.fn()
 }));
 
@@ -75,6 +85,38 @@ describe('nft-transfer.services', () => {
 
 		it('should call the progress callback with the transfer progress', async () => {
 			await transferDip721(mockParams);
+
+			expect(mockProgress).toHaveBeenCalledTimes(2);
+			expect(mockProgress).toHaveBeenNthCalledWith(1, ProgressStepsSendIc.SEND);
+			expect(mockProgress).toHaveBeenNthCalledWith(2, ProgressStepsSendIc.RELOAD);
+		});
+	});
+
+	describe('transferIcPunks', () => {
+		const mockProgress = vi.fn();
+
+		const mockParams = {
+			identity: mockIdentity,
+			canisterId: mockIcPunksCanisterId,
+			to: mockPrincipal2,
+			tokenIdentifier: 123n,
+			progress: mockProgress
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should call the transfer endpoint of ICPunks canister', async () => {
+			await transferIcPunks(mockParams);
+
+			const { progress: _, ...expected } = mockParams;
+
+			expect(transferIcPunksApi).toHaveBeenCalledExactlyOnceWith(expected);
+		});
+
+		it('should call the progress callback with the transfer progress', async () => {
+			await transferIcPunks(mockParams);
 
 			expect(mockProgress).toHaveBeenCalledTimes(2);
 			expect(mockProgress).toHaveBeenNthCalledWith(1, ProgressStepsSendIc.SEND);

--- a/src/frontend/src/tests/mocks/icpunks-tokens.mock.ts
+++ b/src/frontend/src/tests/mocks/icpunks-tokens.mock.ts
@@ -1,4 +1,16 @@
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import type { IcPunksToken } from '$icp/types/icpunks-token';
 import type { CanisterIdText } from '$lib/types/canister';
+import { parseTokenId } from '$lib/validation/token.validation';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
 
 export const mockIcPunksCanisterId: CanisterIdText = 'qcg3w-tyaaa-aaaah-qakea-cai';
 export const mockICatsCanisterId2: CanisterIdText = '4nvhy-3qaaa-aaaah-qcnoq-cai';
+
+export const mockValidIcPunksToken: IcPunksToken = {
+	...mockValidToken,
+	id: parseTokenId('IcPunksTokenId'),
+	network: ICP_NETWORK,
+	standard: { code: 'icpunks' },
+	canisterId: mockIcPunksCanisterId
+};

--- a/src/frontend/src/tests/mocks/nfts.mock.ts
+++ b/src/frontend/src/tests/mocks/nfts.mock.ts
@@ -7,6 +7,7 @@ import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidErc1155Token } from '$tests/mocks/erc1155-tokens.mock';
 import { mockValidErc721Token } from '$tests/mocks/erc721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
+import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 
 export const getMockNonFungibleToken = (params: {
 	addresses: string[];
@@ -88,6 +89,19 @@ export const mockValidDip721Nft: Nft = {
 	collection: {
 		...mockValidDip721Token,
 		address: mockValidDip721Token.canisterId
+	},
+	mediaStatus: {
+		image: NftMediaStatusEnum.OK,
+		thumbnail: NftMediaStatusEnum.OK
+	}
+};
+
+export const mockValidIcPunksNft: Nft = {
+	name: 'Mock ICPunks NFT',
+	id: parseNftId('11111'),
+	collection: {
+		...mockValidIcPunksToken,
+		address: mockValidIcPunksToken.canisterId
 	},
 	mediaStatus: {
 		image: NftMediaStatusEnum.OK,


### PR DESCRIPTION
# Motivation

Like the other standard, we can include the pseudo-standard ICPunks in the service to send IC NFTs.
