### PR TITLE
feat(frontend): Add ICPunks in service to load NFTs for each canister

### DIFF
--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -2,6 +2,7 @@ import type { TokenIndex } from '$declarations/ext_v2_token/ext_v2_token.did';
 import { getExtMetadata } from '$icp/services/ext-metadata.services';
 import type { Dip721Token } from '$icp/types/dip721-token';
 import type { ExtToken } from '$icp/types/ext-token';
+import type { IcPunksToken } from '$icp/types/icpunks-token';
 import { extIndexToIdentifier, parseExtTokenIndex } from '$icp/utils/ext.utils';
 import { NftMediaStatusEnum } from '$lib/schema/nft.schema';
 import type { Nft, NftCollection } from '$lib/types/nft';
@@ -75,5 +76,24 @@ export const mapDip721Nft = ({ index, token }: { index: bigint; token: Dip721Tok
 		id: parseNftId(index.toString()),
 		mediaStatus,
 		collection: mapDip721Collection(token)
+	};
+};
+
+const mapIcPunksCollection = ({ canisterId, ...rest }: IcPunksToken): NftCollection => ({
+	...rest,
+	address: canisterId
+});
+
+// TODO: Fetch metadata of the NFT
+export const mapIcPunksNft = ({ index, token }: { index: bigint; token: IcPunksToken }): Nft => {
+	const mediaStatus = {
+		image: NftMediaStatusEnum.INVALID_DATA,
+		thumbnail: NftMediaStatusEnum.INVALID_DATA
+	};
+
+	return {
+		id: parseNftId(index.toString()),
+		mediaStatus,
+		collection: mapIcPunksCollection(token)
 	};
 };

--- a/src/frontend/src/tests/icp/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/nft.services.spec.ts
@@ -2,13 +2,16 @@ import * as dip721Api from '$icp/api/dip721.api';
 import { getTokensByOwner as getDip721TokensByOwner } from '$icp/api/dip721.api';
 import * as extTokenApi from '$icp/api/ext-v2-token.api';
 import { getTokensByOwner as getExtTokensByOwner } from '$icp/api/ext-v2-token.api';
+import * as icPunksApi from '$icp/api/icpunks.api';
+import { getTokensByOwner as getIcPunksTokensByOwner } from '$icp/api/icpunks.api';
 import { loadNfts } from '$icp/services/nft.services';
-import { mapDip721Nft, mapExtNft } from '$icp/utils/nft.utils';
+import { mapDip721Nft, mapExtNft, mapIcPunksNft } from '$icp/utils/nft.utils';
 import { TRACK_COUNT_IC_LOADING_NFTS_FROM_COLLECTION_ERROR } from '$lib/constants/analytics.constants';
 import { trackEvent } from '$lib/services/analytics.services';
 import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidExtV2Token, mockValidExtV2Token2 } from '$tests/mocks/ext-tokens.mock';
 import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 
 vi.mock('$lib/services/analytics.services', () => ({
@@ -19,15 +22,17 @@ describe('nft.services', () => {
 	describe('loadNfts', async () => {
 		const mockExtTokens = [mockValidExtV2Token, mockValidExtV2Token2];
 		const mockDip721Tokens = [mockValidDip721Token];
+		const mockIcPunksTokens = [mockValidIcPunksToken];
 
 		const mockParams = {
-			tokens: [...mockExtTokens, ...mockDip721Tokens],
+			tokens: [...mockExtTokens, ...mockDip721Tokens, ...mockIcPunksTokens],
 			identity: mockIdentity
 		};
 
 		const mockTokenIndices1 = [1, 2, 3];
 		const mockTokenIndices2 = [4, 5];
 		const mockTokenIndices3 = [6n, 7n, 8n];
+		const mockTokenIndices4 = [9n];
 
 		const expected1 = await Promise.all(
 			mockTokenIndices1.map((index) =>
@@ -42,7 +47,10 @@ describe('nft.services', () => {
 		const expected3 = await Promise.all(
 			mockTokenIndices3.map((index) => mapDip721Nft({ index, token: mockValidDip721Token }))
 		);
-		const expected = [...expected1, ...expected2, ...expected3];
+		const expected4 = await Promise.all(
+			mockTokenIndices4.map((index) => mapIcPunksNft({ index, token: mockValidIcPunksToken }))
+		);
+		const expected = [...expected1, ...expected2, ...expected3, ...expected4];
 
 		beforeEach(() => {
 			vi.clearAllMocks();
@@ -68,6 +76,15 @@ describe('nft.services', () => {
 
 				return [];
 			});
+
+			// @ts-expect-error This is a mocked implementation that is not asynchronous as the original method is.
+			vi.spyOn(icPunksApi, 'getTokensByOwner').mockImplementation(({ canisterId }) => {
+				if (canisterId === mockValidIcPunksToken.canisterId) {
+					return mockTokenIndices4;
+				}
+
+				return [];
+			});
 		});
 
 		it('should return an empty array if the identity is nullish', async () => {
@@ -77,6 +94,7 @@ describe('nft.services', () => {
 
 			expect(getExtTokensByOwner).not.toHaveBeenCalled();
 			expect(getDip721TokensByOwner).not.toHaveBeenCalled();
+			expect(getIcPunksTokensByOwner).not.toHaveBeenCalled();
 		});
 
 		it('should return an empty array if the tokens list is empty', async () => {
@@ -84,11 +102,13 @@ describe('nft.services', () => {
 
 			expect(getExtTokensByOwner).not.toHaveBeenCalled();
 			expect(getDip721TokensByOwner).not.toHaveBeenCalled();
+			expect(getIcPunksTokensByOwner).not.toHaveBeenCalled();
 		});
 
 		it('should return an empty array if there are not tokens owned by the user', async () => {
 			vi.spyOn(extTokenApi, 'getTokensByOwner').mockResolvedValue([]);
 			vi.spyOn(dip721Api, 'getTokensByOwner').mockResolvedValue([]);
+			vi.spyOn(icPunksApi, 'getTokensByOwner').mockResolvedValue([]);
 
 			await expect(loadNfts(mockParams)).resolves.toEqual([]);
 
@@ -106,6 +126,16 @@ describe('nft.services', () => {
 
 			mockDip721Tokens.forEach(({ canisterId }) => {
 				expect(getDip721TokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getIcPunksTokensByOwner).toHaveBeenCalledTimes(mockIcPunksTokens.length);
+
+			mockIcPunksTokens.forEach(({ canisterId }) => {
+				expect(getIcPunksTokensByOwner).toHaveBeenCalledWith({
 					identity: mockIdentity,
 					owner: mockPrincipal,
 					canisterId
@@ -135,13 +165,27 @@ describe('nft.services', () => {
 					canisterId
 				});
 			});
+
+			expect(getIcPunksTokensByOwner).toHaveBeenCalledTimes(mockIcPunksTokens.length);
+
+			mockIcPunksTokens.forEach(({ canisterId }) => {
+				expect(getIcPunksTokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
 		});
 
 		it('should handle EXT service errors gracefully', async () => {
 			const mockError = new Error('Mock EXT error');
 			vi.spyOn(extTokenApi, 'getTokensByOwner').mockRejectedValueOnce(mockError);
 
-			await expect(loadNfts(mockParams)).resolves.toEqual([...expected2, ...expected3]);
+			await expect(loadNfts(mockParams)).resolves.toEqual([
+				...expected2,
+				...expected3,
+				...expected4
+			]);
 
 			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
 
@@ -157,6 +201,16 @@ describe('nft.services', () => {
 
 			mockDip721Tokens.forEach(({ canisterId }) => {
 				expect(getDip721TokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getIcPunksTokensByOwner).toHaveBeenCalledTimes(mockIcPunksTokens.length);
+
+			mockIcPunksTokens.forEach(({ canisterId }) => {
+				expect(getIcPunksTokensByOwner).toHaveBeenCalledWith({
 					identity: mockIdentity,
 					owner: mockPrincipal,
 					canisterId
@@ -177,7 +231,11 @@ describe('nft.services', () => {
 			const mockError = new Error('Mock DIP721 error');
 			vi.spyOn(dip721Api, 'getTokensByOwner').mockRejectedValueOnce(mockError);
 
-			await expect(loadNfts(mockParams)).resolves.toEqual([...expected1, ...expected2]);
+			await expect(loadNfts(mockParams)).resolves.toEqual([
+				...expected1,
+				...expected2,
+				...expected4
+			]);
 
 			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
 
@@ -199,12 +257,72 @@ describe('nft.services', () => {
 				});
 			});
 
+			expect(getIcPunksTokensByOwner).toHaveBeenCalledTimes(mockIcPunksTokens.length);
+
+			mockIcPunksTokens.forEach(({ canisterId }) => {
+				expect(getIcPunksTokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: TRACK_COUNT_IC_LOADING_NFTS_FROM_COLLECTION_ERROR,
 				metadata: {
 					error: mockError.message,
 					canisterId: mockValidDip721Token.canisterId,
 					standard: mockValidDip721Token.standard.code
+				}
+			});
+		});
+
+		it('should handle ICPunks service errors gracefully', async () => {
+			const mockError = new Error('Mock ICPunks error');
+			vi.spyOn(icPunksApi, 'getTokensByOwner').mockRejectedValueOnce(mockError);
+
+			await expect(loadNfts(mockParams)).resolves.toEqual([
+				...expected1,
+				...expected2,
+				...expected3
+			]);
+
+			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
+
+			mockExtTokens.forEach(({ canisterId }) => {
+				expect(getExtTokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getDip721TokensByOwner).toHaveBeenCalledTimes(mockDip721Tokens.length);
+
+			mockDip721Tokens.forEach(({ canisterId }) => {
+				expect(getDip721TokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getIcPunksTokensByOwner).toHaveBeenCalledTimes(mockIcPunksTokens.length);
+
+			mockIcPunksTokens.forEach(({ canisterId }) => {
+				expect(getIcPunksTokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_IC_LOADING_NFTS_FROM_COLLECTION_ERROR,
+				metadata: {
+					error: mockError.message,
+					canisterId: mockValidIcPunksToken.canisterId,
+					standard: mockValidIcPunksToken.standard.code
 				}
 			});
 		});
@@ -216,6 +334,8 @@ describe('nft.services', () => {
 			);
 
 			expect(getExtTokensByOwner).not.toHaveBeenCalled();
+			expect(getDip721TokensByOwner).not.toHaveBeenCalled();
+			expect(getIcPunksTokensByOwner).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
@@ -1,10 +1,11 @@
 import { getExtMetadata } from '$icp/services/ext-metadata.services';
 import { extIndexToIdentifier } from '$icp/utils/ext.utils';
-import { mapDip721Nft, mapExtNft } from '$icp/utils/nft.utils';
+import { mapDip721Nft, mapExtNft, mapIcPunksNft } from '$icp/utils/nft.utils';
 import { NftMediaStatusEnum } from '$lib/schema/nft.schema';
 import type { NftMetadataWithoutId } from '$lib/types/nft';
 import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
+import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { Principal } from '@icp-sdk/core/principal';
 import { SvelteMap } from 'svelte/reactivity';
@@ -124,6 +125,31 @@ describe('nft.utils', () => {
 				collection: {
 					...rest,
 					address: mockValidDip721Token.canisterId
+				}
+			});
+		});
+	});
+
+	describe('mapIcPunksNft', () => {
+		const mockIndex = 123n;
+
+		it('should map correctly an ICPunks NFT', () => {
+			const result = mapIcPunksNft({
+				index: mockIndex,
+				token: mockValidIcPunksToken
+			});
+
+			const { canisterId: _, ...rest } = mockValidIcPunksToken;
+
+			expect(result).toStrictEqual({
+				id: result.id,
+				mediaStatus: {
+					image: NftMediaStatusEnum.INVALID_DATA,
+					thumbnail: NftMediaStatusEnum.INVALID_DATA
+				},
+				collection: {
+					...rest,
+					address: mockValidIcPunksToken.canisterId
 				}
 			});
 		});


### PR DESCRIPTION
# Motivation

Like the other IC NFT standard, we include ICPunks in the service to load NFTs for each canister.
