### PR TITLE
feat(frontend): Component to review custom-added ICPunks tokens

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcAddIcPunksTokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddIcPunksTokenReview.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
+	import { blur, fade } from 'svelte/transition';
+	import { icPunksTokens } from '$icp/derived/icpunks.derived';
+	import {
+		loadAndAssertAddCustomToken,
+		type ValidateTokenData
+	} from '$icp/services/icpunks-add-custom-tokens.service';
+	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
+	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import Card from '$lib/components/ui/Card.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import SkeletonCardWithoutAmount from '$lib/components/ui/SkeletonCardWithoutAmount.svelte';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		icPunksCanisterId?: string;
+		metadata?: ValidateTokenData;
+		onBack: () => void;
+		onSave: () => void;
+	}
+
+	let { icPunksCanisterId, metadata = $bindable(), onBack, onSave }: Props = $props();
+
+	let invalid = $derived(isNullish(metadata));
+
+	const back = () => onBack();
+
+	onMount(() => {
+		const { result, data } = loadAndAssertAddCustomToken({
+			canisterId: icPunksCanisterId,
+			identity: $authIdentity,
+			icPunksTokens: $icPunksTokens
+		});
+
+		if (result === 'error' || isNullish(data)) {
+			back();
+			return;
+		}
+
+		metadata = data;
+	});
+</script>
+
+<ContentWithToolbar>
+	<div class="mb-4 rounded-lg bg-brand-subtle-20 p-4">
+		{#if isNullish(metadata)}
+			<SkeletonCardWithoutAmount>{$i18n.tokens.import.text.verifying}</SkeletonCardWithoutAmount>
+		{:else}
+			<div in:blur>
+				<Card noMargin>
+					{metadata.token.name}
+
+					{#snippet icon()}
+						{#if nonNullish(metadata)}
+							<Logo
+								alt={replacePlaceholders($i18n.core.alt.logo, { $name: metadata.token.name })}
+								color="white"
+								size="lg"
+								src={metadata.token.icon}
+							/>
+						{/if}
+					{/snippet}
+
+					{#snippet description()}
+						{#if nonNullish(metadata)}
+							<span class="break-all">
+								{metadata.token.symbol}
+							</span>
+						{/if}
+					{/snippet}
+				</Card>
+			</div>
+		{/if}
+	</div>
+
+	{#if nonNullish(metadata)}
+		{@const { network: safeNetwork, canisterId: safeCanisterId } = metadata.token}
+		<div in:fade>
+			<Value element="div" ref="network">
+				{#snippet label()}
+					{$i18n.tokens.manage.text.network}
+				{/snippet}
+				{#snippet content()}
+					<NetworkWithLogo network={safeNetwork} />
+				{/snippet}
+			</Value>
+
+			<Value element="div" ref="canisterId">
+				{#snippet label()}{$i18n.tokens.import.text.canister_id}{/snippet}
+				{#snippet content()}
+					{safeCanisterId}
+				{/snippet}
+			</Value>
+
+			<AddTokenWarning />
+		</div>
+	{/if}
+
+	{#snippet toolbar()}
+		<div in:fade>
+			{#if nonNullish(metadata)}
+				<ButtonGroup>
+					<ButtonBack onclick={back} />
+					<Button disabled={invalid} onclick={onSave}>
+						{$i18n.tokens.import.text.add_the_token}
+					</Button>
+				</ButtonGroup>
+			{/if}
+		</div>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
@@ -7,9 +7,11 @@
 	import type { Erc20Metadata } from '$eth/types/erc20';
 	import type { Erc721Metadata } from '$eth/types/erc721';
 	import IcAddExtTokenReview from '$icp/components/tokens/IcAddExtTokenReview.svelte';
+	import IcAddIcPunksTokenReview from '$icp/components/tokens/IcAddIcPunksTokenReview.svelte';
 	import IcAddIcrcTokenReview from '$icp/components/tokens/IcAddIcrcTokenReview.svelte';
 	import type { ValidateTokenData as ValidateExtTokenData } from '$icp/services/ext-add-custom-tokens.service';
 	import type { ValidateTokenData as ValidateIcrcTokenData } from '$icp/services/ic-add-custom-tokens.service';
+	import type { ValidateTokenData as ValidateIcPunksTokenData } from '$icp/services/icpunks-add-custom-tokens.service';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import { TRACK_UNRECOGNISED_ERC_INTERFACE } from '$lib/constants/analytics.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -87,6 +89,23 @@
 				enabled: true,
 				networkKey: 'ExtV2',
 				canisterId: extCanisterId
+			}
+		]);
+	};
+
+	const addIcPunksToken = async () => {
+		if (isNullish(icPunksCanisterId)) {
+			toastsError({
+				msg: { text: get(i18n).tokens.import.error.missing_canister_id }
+			});
+			return;
+		}
+
+		await saveTokens([
+			{
+				enabled: true,
+				networkKey: 'IcPunks',
+				canisterId: icPunksCanisterId
 			}
 		]);
 	};
@@ -199,22 +218,39 @@
 
 	let extMetadata: ValidateExtTokenData | undefined = $state();
 
+	let icPunksMetadata: ValidateIcPunksTokenData | undefined = $state();
+
 	let ethMetadata: Erc20Metadata | Erc721Metadata | undefined = $state();
 
 	let splMetadata: TokenMetadata | undefined = $state();
 
-	let { ledgerCanisterId, indexCanisterId, extCanisterId, ethContractAddress, splTokenAddress } =
-		$derived(tokenData);
+	let {
+		ledgerCanisterId,
+		indexCanisterId,
+		extCanisterId,
+		icPunksCanisterId,
+		ethContractAddress,
+		splTokenAddress
+	} = $derived(tokenData);
 </script>
 
 {#if isNetworkIdICP(network?.id)}
 	{#if isNftsPage}
-		<IcAddExtTokenReview
-			{extCanisterId}
-			{onBack}
-			onSave={addExtToken}
-			bind:metadata={extMetadata}
-		/>
+		{#if nonNullish(extCanisterId)}
+			<IcAddExtTokenReview
+				{extCanisterId}
+				{onBack}
+				onSave={addExtToken}
+				bind:metadata={extMetadata}
+			/>
+		{:else if nonNullish(icPunksCanisterId)}
+			<IcAddIcPunksTokenReview
+				{icPunksCanisterId}
+				{onBack}
+				onSave={addIcPunksToken}
+				bind:metadata={icPunksMetadata}
+			/>
+		{/if}
 	{:else}
 		<IcAddIcrcTokenReview
 			{indexCanisterId}


### PR DESCRIPTION
# Motivation

To include pseudo-standard ICPunks in the flow to review a custom-added token, we copy component `IcAddExtTokenReview` and adapt to the new standard.
