### PR TITLE
feat(frontend): Add ICPunks-like tokens in derived store for all tokens

### DIFF
--- a/src/frontend/src/lib/derived/all-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/all-tokens.derived.ts
@@ -6,6 +6,7 @@ import { erc721Tokens } from '$eth/derived/erc721.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { extTokens } from '$icp/derived/ext.derived';
+import { icPunksTokens } from '$icp/derived/icpunks.derived';
 import { enabledIcrcTokens, icrcTokens } from '$icp/derived/icrc.derived';
 import { defaultIcpTokens } from '$icp/derived/tokens.derived';
 import type { IcTokenWithIcrc2Supported } from '$icp/types/ic-token';
@@ -75,6 +76,7 @@ export const allTokens = derived(
 		erc1155Tokens,
 		allIcrcTokens,
 		extTokens,
+		icPunksTokens,
 		splTokens
 	],
 	([
@@ -88,6 +90,7 @@ export const allTokens = derived(
 		$erc1155Tokens,
 		$allIcrcTokens,
 		$extTokens,
+		$icPunksTokens,
 		$splTokens
 	]) => [
 		...$defaultIcpTokens.map((token) => ({ ...token, enabled: true })),
@@ -100,6 +103,7 @@ export const allTokens = derived(
 		...$erc1155Tokens,
 		...$allIcrcTokens,
 		...$extTokens,
+		...$icPunksTokens,
 		...$splTokens
 	]
 );

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -12,6 +12,7 @@ import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { extTokens } from '$icp/derived/ext.derived';
+import { icPunksTokens } from '$icp/derived/icpunks.derived';
 import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
 import { defaultIcpTokens } from '$icp/derived/tokens.derived';
 import type { IcToken } from '$icp/types/ic-token';
@@ -40,6 +41,7 @@ export const tokens: Readable<Token[]> = derived(
 		erc1155Tokens,
 		sortedIcrcTokens,
 		extTokens,
+		icPunksTokens,
 		splTokens
 	],
 	([
@@ -53,6 +55,7 @@ export const tokens: Readable<Token[]> = derived(
 		$erc1155Tokens,
 		$icrcTokens,
 		$extTokens,
+		$icPunksTokens,
 		$splTokens
 	]) => [
 		...$defaultIcpTokens,
@@ -65,6 +68,7 @@ export const tokens: Readable<Token[]> = derived(
 		...$erc1155Tokens,
 		...$icrcTokens,
 		...$extTokens,
+		...$icPunksTokens,
 		...$splTokens
 	]
 );
@@ -74,11 +78,12 @@ export const fungibleTokens: Readable<Token[]> = derived([tokens], ([$tokens]) =
 );
 
 export const nonFungibleTokens: Readable<NonFungibleToken[]> = derived(
-	[erc721Tokens, erc1155Tokens, extTokens],
-	([$erc721Tokens, $erc1155Tokens, $extTokens]) => [
+	[erc721Tokens, erc1155Tokens, extTokens, icPunksTokens],
+	([$erc721Tokens, $erc1155Tokens, $extTokens, $icPunksTokens]) => [
 		...$erc721Tokens,
 		...$erc1155Tokens,
-		...$extTokens
+		...$extTokens,
+		...$icPunksTokens
 	]
 );
 

--- a/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
@@ -35,10 +35,12 @@ import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc20CustomToken } from '$eth/types/erc20-custom-token';
 import type { Erc721CustomToken } from '$eth/types/erc721-custom-token';
 import { extCustomTokensStore } from '$icp/stores/ext-custom-tokens.store';
+import { icPunksCustomTokensStore } from '$icp/stores/icpunks-custom-tokens.store';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 import type { ExtCustomToken } from '$icp/types/ext-custom-token';
 import type { IcToken } from '$icp/types/ic-token';
+import type { IcPunksCustomToken } from '$icp/types/icpunks-custom-token';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import * as appConstants from '$lib/constants/app.constants';
 import {
@@ -60,6 +62,7 @@ import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockValidErc721Token } from '$tests/mocks/erc721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 import { mockSplCustomToken, mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
@@ -115,6 +118,12 @@ describe('tokens.derived', () => {
 	const mockExtCustomToken: ExtCustomToken = {
 		...mockValidExtV2Token,
 		version: 7n,
+		enabled: true
+	};
+
+	const mockIcPunksCustomToken: IcPunksCustomToken = {
+		...mockValidIcPunksToken,
+		version: 1n,
 		enabled: true
 	};
 
@@ -196,6 +205,7 @@ describe('tokens.derived', () => {
 		icrcDefaultTokensStore.resetAll();
 		icrcCustomTokensStore.resetAll();
 		extCustomTokensStore.resetAll();
+		icPunksCustomTokensStore.resetAll();
 		splDefaultTokensStore.reset();
 		splCustomTokensStore.resetAll();
 
@@ -214,6 +224,7 @@ describe('tokens.derived', () => {
 			icrcDefaultTokensStore.set({ data: mockIcrcDefaultToken, certified: false });
 			icrcCustomTokensStore.setAll([{ data: mockIcrcCustomToken, certified: false }]);
 			extCustomTokensStore.setAll([{ data: mockExtCustomToken, certified: false }]);
+			icPunksCustomTokensStore.setAll([{ data: mockIcPunksCustomToken, certified: false }]);
 			splDefaultTokensStore.add(mockSplDefaultToken);
 			splCustomTokensStore.setAll([{ data: mockSplCustomToken, certified: false }]);
 
@@ -235,6 +246,7 @@ describe('tokens.derived', () => {
 				{ ...mockIcrcDefaultToken, enabled: false, version: undefined, id: result[12].id },
 				{ ...mockIcrcCustomToken, id: result[13].id },
 				{ ...mockExtCustomToken, id: result[14].id },
+				{ ...mockIcPunksCustomToken, id: result[15].id },
 				{ ...mockSplDefaultToken, enabled: false, version: undefined },
 				mockSplCustomToken
 			]);
@@ -326,6 +338,7 @@ describe('tokens.derived', () => {
 			icrcDefaultTokensStore.set({ data: mockIcrcDefaultToken, certified: false });
 			icrcCustomTokensStore.setAll([{ data: mockIcrcCustomToken, certified: false }]);
 			extCustomTokensStore.setAll([{ data: mockExtCustomToken, certified: false }]);
+			icPunksCustomTokensStore.setAll([{ data: mockIcPunksCustomToken, certified: false }]);
 			splDefaultTokensStore.add(mockSplDefaultToken);
 			splCustomTokensStore.setAll([{ data: mockSplCustomToken, certified: false }]);
 


### PR DESCRIPTION
# Motivation

We can finally add the list of ICPunks-like tokens to the derived stores with all the tokens.