### PR TITLE
feat(frontend): Remove IC pre-sorting in derived store of tokens

### DIFF
--- a/src/frontend/src/icp/derived/icrc.derived.ts
+++ b/src/frontend/src/icp/derived/icrc.derived.ts
@@ -11,7 +11,6 @@ import type { IcToken } from '$icp/types/ic-token';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { isTokenIcTestnet } from '$icp/utils/ic-ledger.utils';
-import { sortIcTokens } from '$icp/utils/icrc.utils';
 import { testnetsEnabled } from '$lib/derived/testnets.derived';
 import type { CanisterIdText } from '$lib/types/canister';
 import { mapDefaultTokenToToggleable } from '$lib/utils/token.utils';
@@ -115,11 +114,6 @@ export const icrcTokens: Readable<IcrcCustomToken[]> = derived(
 		...$icrcDefaultTokensToggleable,
 		...$icrcCustomTokensToggleable
 	]
-);
-
-export const sortedIcrcTokens: Readable<IcrcCustomToken[]> = derived(
-	[icrcTokens],
-	([$icrcTokens]) => $icrcTokens.sort(sortIcTokens)
 );
 
 /**

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -13,7 +13,7 @@ import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { extTokens } from '$icp/derived/ext.derived';
 import { icPunksTokens } from '$icp/derived/icpunks.derived';
-import { icrcChainFusionDefaultTokens, sortedIcrcTokens } from '$icp/derived/icrc.derived';
+import { icrcChainFusionDefaultTokens, icrcTokens } from '$icp/derived/icrc.derived';
 import { defaultIcpTokens } from '$icp/derived/tokens.derived';
 import type { IcToken } from '$icp/types/ic-token';
 import { isTokenIc } from '$icp/utils/icrc.utils';
@@ -52,7 +52,7 @@ export const nativeTokens: Readable<Token[]> = derived(
 );
 
 export const fungibleTokens: Readable<Token[]> = derived(
-	[nativeTokens, erc20Tokens, sortedIcrcTokens, splTokens],
+	[nativeTokens, erc20Tokens, icrcTokens, splTokens],
 	([$nativeTokens, $erc20Tokens, $icrcTokens, $splTokens]) => [
 		...$nativeTokens,
 		...$erc20Tokens,


### PR DESCRIPTION
# Motivation

In derived store `tokens`, there is really no need to pre-sort the ICRC tokens, since they will be all sorted afterwards.
