### PR TITLE
feat(frontend): Add `metadata` method to ICPunks canister

### DIFF
--- a/src/frontend/src/icp/api/icpunks.api.ts
+++ b/src/frontend/src/icp/api/icpunks.api.ts
@@ -1,3 +1,4 @@
+import type { TokenDesc } from '$declarations/icpunks/icpunks.did';
 import { IcPunksCanister } from '$icp/canisters/icpunks.canister';
 import type { CanisterApiFunctionParamsWithCanisterId } from '$lib/types/canister';
 import { assertNonNullish, isNullish, type QueryParams } from '@dfinity/utils';
@@ -42,6 +43,24 @@ export const transfer = async ({
 	});
 
 	await transfer({ certified, to, tokenIdentifier });
+};
+
+export const metadata = async ({
+	certified,
+	identity,
+	canisterId,
+	tokenIdentifier,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<
+	{ tokenIdentifier: bigint } & QueryParams
+>): Promise<TokenDesc> => {
+	const { metadata } = await icPunksCanister({
+		identity,
+		canisterId,
+		...rest
+	});
+
+	return await metadata({ certified, tokenIdentifier });
 };
 
 const icPunksCanister = async ({

--- a/src/frontend/src/icp/canisters/icpunks.canister.ts
+++ b/src/frontend/src/icp/canisters/icpunks.canister.ts
@@ -1,4 +1,4 @@
-import type { _SERVICE as IcPunksService } from '$declarations/icpunks/icpunks.did';
+import type { _SERVICE as IcPunksService, TokenDesc } from '$declarations/icpunks/icpunks.did';
 import { idlFactory as idlCertifiedFactoryIcPunks } from '$declarations/icpunks/icpunks.factory.certified.did';
 import { idlFactory as idlFactoryIcPunks } from '$declarations/icpunks/icpunks.factory.did';
 import { getAgent } from '$lib/actors/agents.ic';
@@ -43,5 +43,14 @@ export class IcPunksCanister extends Canister<IcPunksService> {
 		const { transfer_to } = this.caller({ certified });
 
 		return await transfer_to(to, tokenIdentifier);
+	};
+
+	metadata = async ({
+		certified,
+		tokenIdentifier
+	}: { tokenIdentifier: bigint } & QueryParams): Promise<TokenDesc> => {
+		const { data_of } = this.caller({ certified });
+
+		return await data_of(tokenIdentifier);
 	};
 }

--- a/src/frontend/src/tests/icp/api/icpunks.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icpunks.api.spec.ts
@@ -1,6 +1,7 @@
-import { getTokensByOwner, transfer } from '$icp/api/icpunks.api';
+import { getTokensByOwner, metadata, transfer } from '$icp/api/icpunks.api';
 import { IcPunksCanister } from '$icp/canisters/icpunks.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
+import { mockIcPunksMetadata } from '$tests/mocks/icpunks-token.mock';
 import { mockIcPunksCanisterId } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
 import { mock } from 'vitest-mock-extended';
@@ -92,6 +93,43 @@ describe('icpunks.api', () => {
 			await expect(transfer(params)).rejects.toThrowError(mockError);
 
 			expect(tokenCanisterMock.transfer).toHaveBeenCalledExactlyOnceWith(expectedParams);
+		});
+	});
+
+	describe('metadata', () => {
+		const mockTokenId = 987_456_123n;
+
+		const params = {
+			identity: mockIdentity,
+			owner: mockPrincipal,
+			canisterId: mockIcPunksCanisterId,
+			tokenIdentifier: mockTokenId
+		};
+
+		const expectedParams = {
+			tokenIdentifier: mockTokenId
+		};
+
+		beforeEach(() => {
+			tokenCanisterMock.metadata.mockResolvedValue(mockIcPunksMetadata);
+		});
+
+		it('should call successfully metadata endpoint', async () => {
+			const result = await metadata(params);
+
+			expect(result).toStrictEqual(mockIcPunksMetadata);
+
+			expect(tokenCanisterMock.metadata).toHaveBeenCalledExactlyOnceWith(expectedParams);
+		});
+
+		it('should throw an error if metadata fails', async () => {
+			const mockError = new CanisterInternalError('Generic error');
+
+			tokenCanisterMock.metadata.mockRejectedValueOnce(mockError);
+
+			await expect(metadata(params)).rejects.toThrowError(mockError);
+
+			expect(tokenCanisterMock.metadata).toHaveBeenCalledExactlyOnceWith(expectedParams);
 		});
 	});
 });

--- a/src/frontend/src/tests/icp/canisters/icpunks.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/icpunks.canister.spec.ts
@@ -1,6 +1,7 @@
 import type { _SERVICE as IcPunksService } from '$declarations/icpunks/icpunks.did';
 import { IcPunksCanister } from '$icp/canisters/icpunks.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';
+import { mockIcPunksMetadata } from '$tests/mocks/icpunks-token.mock';
 import { mockIcPunksCanisterId } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
@@ -92,6 +93,40 @@ describe('icpunks.canister', () => {
 			await expect(res).rejects.toThrowError(mockError);
 
 			expect(service.transfer_to).toHaveBeenCalledExactlyOnceWith(mockTo, mockTokenId);
+		});
+	});
+
+	describe('metadata', () => {
+		const mockTokenId = 12345n;
+
+		const mockParams = { certified, tokenIdentifier: mockTokenId };
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should correctly call the data_of method', async () => {
+			service.data_of.mockResolvedValue(mockIcPunksMetadata);
+
+			const { metadata } = await createIcPunksCanister({ serviceOverride: service });
+
+			const res = await metadata(mockParams);
+
+			expect(res).toStrictEqual(mockIcPunksMetadata);
+			expect(service.data_of).toHaveBeenCalledExactlyOnceWith(mockTokenId);
+		});
+
+		it('should throw an error if data_of throws', async () => {
+			const mockError = new Error('Test response error');
+			service.data_of.mockRejectedValue(mockError);
+
+			const { metadata } = await createIcPunksCanister({ serviceOverride: service });
+
+			const res = metadata(mockParams);
+
+			await expect(res).rejects.toThrowError(mockError);
+
+			expect(service.data_of).toHaveBeenCalledExactlyOnceWith(mockTokenId);
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/icpunks-token.mock.ts
+++ b/src/frontend/src/tests/mocks/icpunks-token.mock.ts
@@ -1,0 +1,40 @@
+import type { TokenDesc } from '$declarations/icpunks/icpunks.did';
+import { mockPrincipal } from '$tests/mocks/identity.mock';
+
+export const mockIcPunksMetadata: TokenDesc = {
+	id: 4803n,
+	url: '/Token/4803',
+	owner: mockPrincipal,
+	desc: 'Description for a mock ICPunks NFT',
+	name: 'Mock ICPunks NFT',
+	properties: [
+		{
+			value: 'Yellow',
+			name: 'Background'
+		},
+		{
+			value: 'Blue Hoodie',
+			name: 'Body'
+		},
+		{
+			value: 'None',
+			name: 'Nose'
+		},
+		{
+			value: 'None',
+			name: 'Mouth'
+		},
+		{
+			value: 'Love Sunglasses',
+			name: 'Eyes'
+		},
+		{
+			value: 'Red Shocked',
+			name: 'Head'
+		},
+		{
+			value: 'Blue Cap',
+			name: 'Top'
+		}
+	]
+};


### PR DESCRIPTION
# Motivation

Adding the method to fetch the metadata of a ICPunks NFT to class `IcPunksCanister`.
