### PR TITLE
feat(frontend): increase the II modal height

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -144,7 +144,9 @@ export const AUTH_DERIVATION_ORIGIN =
 			: undefined;
 
 export const AUTH_POPUP_WIDTH = 576;
-export const AUTH_POPUP_HEIGHT = 625;
+// we need to temporarily increase the height so II 2.0 in "guided mode" fits the popup
+// TODO: revert to 625 after II provides a fix on their end
+export const AUTH_POPUP_HEIGHT = 790;
 export const VC_POPUP_WIDTH = AUTH_POPUP_WIDTH;
 // Screen to allow credential presentation is longer than the authentication screen.
 export const VC_POPUP_HEIGHT = 900;


### PR DESCRIPTION
# Motivation

To fit all the II 2.0 popup content, we need to increase its height. We will revert the value once it's handled on the II side.
