### PR TITLE
chore(frontend): Remove old TODO from `EthTransactionStatus`

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionStatus.svelte
@@ -16,7 +16,6 @@
 
 	let { blockNumber, token }: Props = $props();
 
-
 	let listener = $state<WebSocketListener | undefined>();
 
 	let currentBlockNumber = $state<number | undefined>();


### PR DESCRIPTION
# Motivation

Component `EthTransactionStatus` was migrated to Svelte 5, so we can remove the TODO.