### PR TITLE
refactor(frontend): Correct name for util `isTokenIcrcCustomToken`

### DIFF
--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -171,7 +171,7 @@ export const isTokenDip20 = (token: Partial<IcToken>): token is IcToken =>
 export const isTokenIc = (token: Partial<IcToken>): token is IcToken =>
 	isTokenIcp(token) || isTokenIcrc(token) || isTokenDip20(token);
 
-export const icTokenIcrcCustomToken = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
+export const isTokenIcrcCustomToken = (token: Partial<IcrcCustomToken>): token is IcrcCustomToken =>
 	isTokenIc(token) && isTokenToggleable(token);
 
 const isIcCkInterface = (token: IcInterface): token is IcCkInterface =>

--- a/src/frontend/src/lib/components/tokens/EnableTokenToggle.svelte
+++ b/src/frontend/src/lib/components/tokens/EnableTokenToggle.svelte
@@ -8,7 +8,7 @@
 	import { isTokenDip721CustomToken } from '$icp/utils/dip721.utils';
 	import { isTokenExtCustomToken } from '$icp/utils/ext.utils';
 	import { isTokenIcPunksCustomToken } from '$icp/utils/icpunks.utils';
-	import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
+	import { isTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
 	import type { Token } from '$lib/types/token';
 	import SolManageTokenToggle from '$sol/components/tokens/SolManageTokenToggle.svelte';
@@ -23,7 +23,7 @@
 	const { token, onToggle }: Props = $props();
 </script>
 
-{#if icTokenIcrcCustomToken(token)}
+{#if isTokenIcrcCustomToken(token)}
 	<IcManageTokenToggle onIcToken={(t) => onToggle(t)} {token} />
 {:else if isTokenErc20CustomToken(token) || isTokenSplCustomToken(token) || isTokenErc721CustomToken(token) || isTokenErc1155CustomToken(token) || isTokenExtCustomToken(token) || isTokenDip721CustomToken(token) || isTokenIcPunksCustomToken(token)}
 	<ManageTokenToggle onShowOrHideToken={(t) => onToggle(t)} {token} />

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -9,7 +9,7 @@
 	import { assertIndexLedgerId } from '$icp/services/ic-add-custom-tokens.service';
 	import { loadCustomTokens } from '$icp/services/icrc.services';
 	import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
-	import { icTokenIcrcCustomToken, isTokenIcrc } from '$icp/utils/icrc.utils';
+	import { isTokenIcrcCustomToken, isTokenIcrc } from '$icp/utils/icrc.utils';
 	import { removeCustomToken, setCustomToken } from '$lib/api/backend.api';
 	import { deleteIdbIcToken, deleteIdbSolToken, deleteIdbEthToken } from '$lib/api/idb-tokens.api';
 	import AddTokenByNetworkDropdown from '$lib/components/manage/AddTokenByNetworkDropdown.svelte';
@@ -227,7 +227,7 @@
 		}
 
 		try {
-			if (icTokenIcrcCustomToken(tokenToEdit)) {
+			if (isTokenIcrcCustomToken(tokenToEdit)) {
 				loading = true;
 				gotoStep(TokenModalSteps.EDIT_PROGRESS);
 				progress(ProgressStepsAddToken.SAVE);

--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -6,7 +6,7 @@ import { isTokenEthereumCustomToken } from '$eth/utils/erc20.utils';
 import { isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
-import { icTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
+import { isTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
 import { routeNetwork, routeToken } from '$lib/derived/nav.derived';
 import { pageNft } from '$lib/derived/page-nft.derived';
 import { defaultFallbackToken } from '$lib/derived/token.derived';
@@ -89,7 +89,7 @@ export const pageTokenStandard: Readable<OptionTokenStandardCode> = derived(
 
 export const pageTokenToggleable: Readable<boolean> = derived([pageToken], ([$pageToken]) => {
 	if (nonNullish($pageToken)) {
-		return icTokenIcrcCustomToken($pageToken)
+		return isTokenIcrcCustomToken($pageToken)
 			? isIcrcTokenToggleEnabled($pageToken)
 			: isTokenEthereumCustomToken($pageToken)
 				? isNotDefaultEthereumToken($pageToken)

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -13,10 +13,10 @@ import { isTokenExt, isTokenExtCustomToken } from '$icp/utils/ext.utils';
 import { isTokenIcNft } from '$icp/utils/ic-nft.utils';
 import { isTokenIcPunks, isTokenIcPunksCustomToken } from '$icp/utils/icpunks.utils';
 import {
-	icTokenIcrcCustomToken,
 	isTokenDip20,
 	isTokenIc,
-	isTokenIcrc
+	isTokenIcrc,
+	isTokenIcrcCustomToken
 } from '$icp/utils/icrc.utils';
 import { isIcCkToken, isIcToken } from '$icp/validation/ic-token.validation';
 import { LOCAL, ZERO } from '$lib/constants/app.constants';
@@ -265,7 +265,7 @@ export const filterTokens = <T extends Token>({
 		}
 
 		if (
-			icTokenIcrcCustomToken(token) &&
+			isTokenIcrcCustomToken(token) &&
 			nonNullish(token.alternativeName) &&
 			token.alternativeName.toLowerCase().includes(filter.toLowerCase())
 		) {

--- a/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
@@ -2,12 +2,12 @@ import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
 import * as icrcLedgerApi from '$icp/api/icrc-ledger.api';
 import {
 	buildIcrcCustomTokenMetadataPseudoResponse,
-	icTokenIcrcCustomToken,
 	isIcrcTokenSupportIcrc2,
 	isTokenDip20,
 	isTokenIc,
 	isTokenIcp,
 	isTokenIcrc,
+	isTokenIcrcCustomToken,
 	mapIcrcToken,
 	sortIcTokens,
 	type IcrcLoadData
@@ -370,10 +370,10 @@ describe('icrc.utils', () => {
 		);
 	});
 
-	describe('icTokenIcrcCustomToken', () => {
+	describe('isTokenIcrcCustomToken', () => {
 		it.each(['icp', 'icrc'])('should return true for valid token standards: %s', (standard) => {
 			expect(
-				icTokenIcrcCustomToken({
+				isTokenIcrcCustomToken({
 					...mockIcrcCustomToken,
 					standard: { code: standard as TokenStandardCode }
 				})
@@ -384,7 +384,7 @@ describe('icrc.utils', () => {
 			'should return false for invalid token standards: %s',
 			(standard) => {
 				expect(
-					icTokenIcrcCustomToken({
+					isTokenIcrcCustomToken({
 						...mockIcrcCustomToken,
 						standard: { code: standard as TokenStandardCode }
 					})
@@ -393,15 +393,15 @@ describe('icrc.utils', () => {
 		);
 
 		it('should return true is the token has the prop `enabled`', () => {
-			expect(icTokenIcrcCustomToken({ ...mockIcrcCustomToken, enabled: true })).toBeTruthy();
+			expect(isTokenIcrcCustomToken({ ...mockIcrcCustomToken, enabled: true })).toBeTruthy();
 
-			expect(icTokenIcrcCustomToken({ ...mockIcrcCustomToken, enabled: false })).toBeTruthy();
+			expect(isTokenIcrcCustomToken({ ...mockIcrcCustomToken, enabled: false })).toBeTruthy();
 		});
 
 		it('should return false is the token has no prop `enabled`', () => {
 			const { enabled: _, ...mockIcrcCustomTokenWithoutEnabled } = mockIcrcCustomToken;
 
-			expect(icTokenIcrcCustomToken(mockIcrcCustomTokenWithoutEnabled)).toBeFalsy();
+			expect(isTokenIcrcCustomToken(mockIcrcCustomTokenWithoutEnabled)).toBeFalsy();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

There was a typo in the name of util `isTokenIcrcCustomToken`.