### PR TITLE
feat(frontend): increase the II modal height a bit more

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -146,7 +146,7 @@ export const AUTH_DERIVATION_ORIGIN =
 export const AUTH_POPUP_WIDTH = 576;
 // we need to temporarily increase the height so II 2.0 in "guided mode" fits the popup
 // TODO: revert to 625 after II provides a fix on their end
-export const AUTH_POPUP_HEIGHT = 825;
+export const AUTH_POPUP_HEIGHT = 826;
 export const VC_POPUP_WIDTH = AUTH_POPUP_WIDTH;
 // Screen to allow credential presentation is longer than the authentication screen.
 export const VC_POPUP_HEIGHT = 900;


### PR DESCRIPTION
# Motivation

Brand new users see a larger main section, and thus will still see a scrollbar
<img width="321" height="444" alt="image" src="https://github.com/user-attachments/assets/f561d27c-4b8a-4ed1-850a-b6a519c5330b" />


# Changes

- increase window height to 826

# Tests
<img width="867" height="541" alt="image" src="https://github.com/user-attachments/assets/2debe241-5e6b-4880-9a5d-dc374ec0c4f7" />

<img width="697" height="480" alt="image" src="https://github.com/user-attachments/assets/56d64c38-5a82-4470-af40-d91df88a1d24" />
