### PR TITLE
refactor(frontend): Remove one loop from service `loadNetworkCustomTokens`

### DIFF
--- a/src/frontend/src/lib/services/custom-tokens.services.ts
+++ b/src/frontend/src/lib/services/custom-tokens.services.ts
@@ -133,11 +133,7 @@ export const loadNetworkCustomTokens = async ({
 			return cachedTokens.reduce<CustomToken[]>((acc, token) => {
 				const parsed = parsePrincipal(token);
 
-				if (filterTokens(parsed)) {
-					acc.push(parsed);
-				}
-
-				return acc;
+				return filterTokens(parsed) ? [...acc, parsed] : acc;
 			}, []);
 		}
 	}


### PR DESCRIPTION
# Motivation

To improve performance, we can remove one loop from service `loadNetworkCustomTokens` using `reduce`.
