### PR TITLE
feat(frontend): Add ICPunks metadata checks to detect IC NFT standard

### DIFF
--- a/src/frontend/src/icp/services/ic-standard.services.ts
+++ b/src/frontend/src/icp/services/ic-standard.services.ts
@@ -7,7 +7,11 @@ import {
 	getTokensByOwner as extGetTokensByOwner,
 	metadata as extMetadata
 } from '$icp/api/ext-v2-token.api';
-import { getTokensByOwner as icPunksGetTokensByOwner } from '$icp/api/icpunks.api';
+import {
+	collectionMetadata as icPunksCollectionMetadata,
+	getTokensByOwner as icPunksGetTokensByOwner,
+	metadata as icPunksMetadata
+} from '$icp/api/icpunks.api';
 import { extIndexToIdentifier } from '$icp/utils/ext.utils';
 import {
 	ResolveByProbingError,
@@ -61,7 +65,11 @@ export const detectNftCanisterStandard = async ({
 	};
 
 	const icPunksCanister: ResolveGroup<AcceptedStandards> = {
-		probes: [() => icPunksGetTokensByOwner({ ...baseParams, owner: identity.getPrincipal() })],
+		probes: [
+			() => icPunksGetTokensByOwner({ ...baseParams, owner: identity.getPrincipal() }),
+			() => icPunksMetadata({ ...baseParams, tokenIdentifier: 1n }),
+			() => icPunksCollectionMetadata(baseParams)
+		],
 		onResolve: () => 'icpunks'
 	};
 

--- a/src/frontend/src/tests/icp/api/icpunks.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icpunks.api.spec.ts
@@ -1,7 +1,10 @@
 import { collectionMetadata, getTokensByOwner, metadata, transfer } from '$icp/api/icpunks.api';
 import { IcPunksCanister } from '$icp/canisters/icpunks.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
-import { mockIcPunksMetadata } from '$tests/mocks/icpunks-token.mock';
+import {
+	mockIcPunksCollectionMetadata,
+	mockIcPunksMetadata
+} from '$tests/mocks/icpunks-token.mock';
 import { mockIcPunksCanisterId } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
 import { mock } from 'vitest-mock-extended';
@@ -134,13 +137,6 @@ describe('icpunks.api', () => {
 	});
 
 	describe('collectionMetadata', () => {
-		const mockMetadata = {
-			symbol: 'ICPUNKS',
-			name: 'ICPUNKS Collection',
-			description: 'A collection of ICPUNKS NFTs',
-			icon: 'https://example.com/icon.png'
-		};
-
 		const params = {
 			identity: mockIdentity,
 			owner: mockPrincipal,
@@ -148,13 +144,13 @@ describe('icpunks.api', () => {
 		};
 
 		beforeEach(() => {
-			tokenCanisterMock.collectionMetadata.mockResolvedValue(mockMetadata);
+			tokenCanisterMock.collectionMetadata.mockResolvedValue(mockIcPunksCollectionMetadata);
 		});
 
 		it('should call successfully collectionMetadata endpoint', async () => {
 			const result = await collectionMetadata(params);
 
-			expect(result).toStrictEqual(mockMetadata);
+			expect(result).toStrictEqual(mockIcPunksCollectionMetadata);
 
 			expect(tokenCanisterMock.collectionMetadata).toHaveBeenCalledExactlyOnceWith({});
 		});

--- a/src/frontend/src/tests/icp/canisters/icpunks.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/icpunks.canister.spec.ts
@@ -1,7 +1,10 @@
 import type { _SERVICE as IcPunksService } from '$declarations/icpunks/icpunks.did';
 import { IcPunksCanister } from '$icp/canisters/icpunks.canister';
 import type { CreateCanisterOptions } from '$lib/types/canister';
-import { mockIcPunksMetadata } from '$tests/mocks/icpunks-token.mock';
+import {
+	mockIcPunksCollectionMetadata,
+	mockIcPunksMetadata
+} from '$tests/mocks/icpunks-token.mock';
 import { mockIcPunksCanisterId } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
@@ -131,27 +134,15 @@ describe('icpunks.canister', () => {
 	});
 
 	describe('collectionMetadata', () => {
-		const mockSymbol = 'ICPU';
-		const mockName = 'ICPunks';
-		const mockDescription = 'ICPunks NFT Collection';
-		const mockIconUrl = 'https://example.com/icon.png';
-
 		const mockParams = { certified };
-
-		const expected = {
-			symbol: mockSymbol,
-			name: mockName,
-			description: mockDescription,
-			icon: mockIconUrl
-		};
 
 		beforeEach(() => {
 			vi.clearAllMocks();
 
-			service.symbol.mockResolvedValue(mockSymbol);
-			service.name.mockResolvedValue(mockName);
-			service.description.mockResolvedValue(mockDescription);
-			service.icon_url.mockResolvedValue(mockIconUrl);
+			service.symbol.mockResolvedValue(mockIcPunksCollectionMetadata.symbol);
+			service.name.mockResolvedValue(mockIcPunksCollectionMetadata.name);
+			service.description.mockResolvedValue(mockIcPunksCollectionMetadata.description);
+			service.icon_url.mockResolvedValue(mockIcPunksCollectionMetadata.icon);
 		});
 
 		it('should correctly call the metadata methods', async () => {
@@ -159,7 +150,7 @@ describe('icpunks.canister', () => {
 
 			const res = await collectionMetadata(mockParams);
 
-			expect(res).toStrictEqual(expected);
+			expect(res).toStrictEqual(mockIcPunksCollectionMetadata);
 			expect(service.symbol).toHaveBeenCalledExactlyOnceWith();
 			expect(service.name).toHaveBeenCalledExactlyOnceWith();
 			expect(service.description).toHaveBeenCalledExactlyOnceWith();
@@ -173,7 +164,7 @@ describe('icpunks.canister', () => {
 
 			const res = await collectionMetadata(mockParams);
 
-			const { icon: _, ...expectedWithoutIcon } = expected;
+			const { icon: _, ...expectedWithoutIcon } = mockIcPunksCollectionMetadata;
 
 			expect(res).toStrictEqual(expectedWithoutIcon);
 			expect(service.symbol).toHaveBeenCalledExactlyOnceWith();

--- a/src/frontend/src/tests/icp/services/ic-standard.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-standard.services.spec.ts
@@ -7,12 +7,20 @@ import {
 	getTokensByOwner as extGetTokensByOwner,
 	metadata as extMetadata
 } from '$icp/api/ext-v2-token.api';
-import { getTokensByOwner as icPunksGetTokensByOwner } from '$icp/api/icpunks.api';
+import {
+	collectionMetadata as icPunksCollectionMetadata,
+	getTokensByOwner as icPunksGetTokensByOwner,
+	metadata as icPunksMetadata
+} from '$icp/api/icpunks.api';
 import { detectNftCanisterStandard } from '$icp/services/ic-standard.services';
 import { extIndexToIdentifier } from '$icp/utils/ext.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import * as probingServices from '$lib/services/probing.services';
 import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
+import {
+	mockIcPunksCollectionMetadata,
+	mockIcPunksMetadata
+} from '$tests/mocks/icpunks-token.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { Principal } from '@icp-sdk/core/principal';
 
@@ -28,7 +36,9 @@ vi.mock('$icp/api/dip721.api', () => ({
 }));
 
 vi.mock('$icp/api/icpunks.api', () => ({
-	getTokensByOwner: vi.fn()
+	getTokensByOwner: vi.fn(),
+	metadata: vi.fn(),
+	collectionMetadata: vi.fn()
 }));
 
 describe('ic-standard.services', () => {
@@ -60,6 +70,8 @@ describe('ic-standard.services', () => {
 			vi.mocked(dip721GetTokensByOwner).mockResolvedValue([]);
 
 			vi.mocked(icPunksGetTokensByOwner).mockResolvedValue([]);
+			vi.mocked(icPunksMetadata).mockResolvedValue(mockIcPunksMetadata);
+			vi.mocked(icPunksCollectionMetadata).mockResolvedValue(mockIcPunksCollectionMetadata);
 		});
 
 		it('should detect an EXT canister', async () => {
@@ -84,6 +96,8 @@ describe('ic-standard.services', () => {
 			expect(dip721GetTokensByOwner).not.toHaveBeenCalled();
 
 			expect(icPunksGetTokensByOwner).not.toHaveBeenCalled();
+			expect(icPunksMetadata).not.toHaveBeenCalled();
+			expect(icPunksCollectionMetadata).not.toHaveBeenCalled();
 		});
 
 		it('should detect a DIP721 canister', async () => {
@@ -111,6 +125,8 @@ describe('ic-standard.services', () => {
 			});
 
 			expect(icPunksGetTokensByOwner).not.toHaveBeenCalled();
+			expect(icPunksMetadata).not.toHaveBeenCalled();
+			expect(icPunksCollectionMetadata).not.toHaveBeenCalled();
 		});
 
 		it('should detect an ICPunks canister', async () => {
@@ -142,6 +158,11 @@ describe('ic-standard.services', () => {
 				...expected,
 				owner: mockIdentity.getPrincipal()
 			});
+			expect(icPunksMetadata).toHaveBeenCalledExactlyOnceWith({
+				...expected,
+				tokenIdentifier: 1n
+			});
+			expect(icPunksCollectionMetadata).toHaveBeenCalledExactlyOnceWith(expected);
 		});
 
 		it('should return undefined for unrecognized canisters', async () => {
@@ -174,6 +195,11 @@ describe('ic-standard.services', () => {
 				...expected,
 				owner: mockIdentity.getPrincipal()
 			});
+			expect(icPunksMetadata).toHaveBeenCalledExactlyOnceWith({
+				...expected,
+				tokenIdentifier: 1n
+			});
+			expect(icPunksCollectionMetadata).toHaveBeenCalledExactlyOnceWith(expected);
 		});
 
 		it('should throw any other error from the service', async () => {
@@ -191,6 +217,8 @@ describe('ic-standard.services', () => {
 			expect(dip721GetTokensByOwner).not.toHaveBeenCalled();
 
 			expect(icPunksGetTokensByOwner).not.toHaveBeenCalled();
+			expect(icPunksMetadata).not.toHaveBeenCalled();
+			expect(icPunksCollectionMetadata).not.toHaveBeenCalled();
 		});
 
 		it('should prioritize EXT over any other standard', async () => {
@@ -213,6 +241,8 @@ describe('ic-standard.services', () => {
 			expect(dip721GetTokensByOwner).not.toHaveBeenCalled();
 
 			expect(icPunksGetTokensByOwner).not.toHaveBeenCalled();
+			expect(icPunksMetadata).not.toHaveBeenCalled();
+			expect(icPunksCollectionMetadata).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/icpunks-token.mock.ts
+++ b/src/frontend/src/tests/mocks/icpunks-token.mock.ts
@@ -38,3 +38,10 @@ export const mockIcPunksMetadata: TokenDesc = {
 		}
 	]
 };
+
+export const mockIcPunksCollectionMetadata = {
+	symbol: 'ICPUNKS',
+	name: 'ICPUNKS Collection',
+	description: 'A collection of ICPUNKS NFTs',
+	icon: 'https://example.com/icon.png'
+};


### PR DESCRIPTION
# Motivation

Now that we have more methods for ICPunks-like canisters, we can include them in the service that detects what kind of standard an IC NFT canister is.
