### PR TITLE
fix(frontend): Make token balance skeleton more reactive

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenExchangeValueSkeleton.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenExchangeValueSkeleton.svelte
@@ -10,9 +10,11 @@
 	}
 
 	let { data, children }: Props = $props();
+
+	let { balance } = $derived(data);
 </script>
 
-{#if data.balance === undefined || $exchangeNotInitialized}
+{#if balance === undefined || $exchangeNotInitialized}
 	<span class="mt-1 block w-full max-w-[50px]"><SkeletonText /></span>
 {:else}
 	{@render children()}


### PR DESCRIPTION
# Motivation

To avoid that the component is not re-rendered when the prop `data.balance` changes in component `TokenExchangeValueSkeleton`, we decompose it to a reactive `derived`.
