### PR TITLE
feat(frontend): Remove unnecessary console error when loading the BTC transactions

### DIFF
--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -150,9 +150,7 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 				})),
 				latestBitcoinBlockHeight
 			};
-		} catch (error) {
-			// We don't want to disrupt the user experience if we can't fetch the transactions or latest block height.
-			console.error('Error fetching BTC transactions data:', error);
+		} catch (_: unknown) {
 			// TODO: Return an error instead of an empty array.
 			return {
 				transactions: [],


### PR DESCRIPTION
# Motivation

The console error that warns about failure during BTC transaction loading just pollutes the console, it is not really helpful.