### PR TITLE
chore(frontend): Remove default update call when fetching ICRC metadata

### DIFF
--- a/src/frontend/src/icp/api/icrc-ledger.api.ts
+++ b/src/frontend/src/icp/api/icrc-ledger.api.ts
@@ -27,7 +27,7 @@ import { Principal } from '@icp-sdk/core/principal';
  * @returns {Promise<IcrcTokenMetadataResponse>} The metadata response for the ICRC token.
  */
 export const metadata = async ({
-	certified = true,
+	certified,
 	identity,
 	...rest
 }: {


### PR DESCRIPTION
# Motivation

There is no need to enforce a default of update call when fetching ICRC metadata, since the parameters are already passed in all the consumers.
