### PR TITLE
chore(frontend): Remove default update call when fetching ICRC minting account

### DIFF
--- a/src/frontend/src/icp/api/icrc-ledger.api.ts
+++ b/src/frontend/src/icp/api/icrc-ledger.api.ts
@@ -203,7 +203,7 @@ export const allowance = async ({
 };
 
 export const getBlocks = async ({
-	certified = true,
+	certified,
 	identity,
 	ledgerCanisterId,
 	...rest
@@ -267,7 +267,7 @@ export const icrc10SupportedStandards = async ({
 };
 
 export const getMintingAccount = async ({
-	certified = true,
+	certified,
 	identity,
 	ledgerCanisterId
 }: {

--- a/src/frontend/src/icp/services/icrc-minting.services.ts
+++ b/src/frontend/src/icp/services/icrc-minting.services.ts
@@ -19,6 +19,7 @@ export const isUserMintingAccount = async ({
 
 	const mintingAccount =
 		tokenMintingAccount ??
+		// TODO: use queryAndUpdate
 		(await getMintingAccount({
 			identity,
 			ledgerCanisterId


### PR DESCRIPTION
# Motivation

There is no need to enforce a default of update call when fetching ICRC minting account, since the parameters are already passed in all the consumers.
