### PR TITLE
chore(frontend): Unnecessary default update calls in backend API

### DIFF
--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -60,7 +60,7 @@ export class BackendCanister extends Canister<BackendService> {
 		return new BackendCanister(canisterId, service, certifiedService);
 	}
 
-	listCustomTokens = ({ certified = true }: QueryParams): Promise<CustomToken[]> => {
+	listCustomTokens = ({ certified }: QueryParams): Promise<CustomToken[]> => {
 		const { list_custom_tokens } = this.caller({ certified });
 
 		return list_custom_tokens();
@@ -90,7 +90,7 @@ export class BackendCanister extends Canister<BackendService> {
 		return create_user_profile();
 	};
 
-	getUserProfile = ({ certified = true }: QueryParams): Promise<GetUserProfileResponse> => {
+	getUserProfile = ({ certified }: QueryParams): Promise<GetUserProfileResponse> => {
 		const { get_user_profile } = this.caller({ certified });
 
 		return get_user_profile();


### PR DESCRIPTION
# Motivation

The backend API has some default parameters for update calls, but the parameter is passed anyway in the consumer.
