### PR TITLE
refactor(frontend): Avoid loop import for util `isBtcAddress`

### DIFF
--- a/src/frontend/src/btc/schema/address.schema.ts
+++ b/src/frontend/src/btc/schema/address.schema.ts
@@ -1,7 +1,6 @@
-import { parseBtcAddress } from '$btc/utils/btc-address.utils';
+import { isBtcAddress, parseBtcAddress } from '$btc/utils/btc-address.utils';
 import type { BtcAddress } from '$declarations/backend/backend.did';
 import { AddressSchema } from '$lib/schema/address.schema';
-import { isBtcAddress } from '$lib/utils/address.utils';
 import { nonNullish } from '@dfinity/utils';
 import { z } from 'zod';
 

--- a/src/frontend/src/btc/utils/btc-address.utils.ts
+++ b/src/frontend/src/btc/utils/btc-address.utils.ts
@@ -1,9 +1,10 @@
 import type { BtcAddress } from '$declarations/backend/backend.did';
-import { assertNever } from '@dfinity/utils';
+import { assertNever, isNullish } from '@dfinity/utils';
 import {
 	BtcAddressType,
 	parseBtcAddress as parseBtcAddressCkbtc,
-	type BtcAddressInfo
+	type BtcAddressInfo,
+	type BtcAddress as BtcAddressTypeObjType
 } from '@icp-sdk/canisters/ckbtc';
 
 const createBtcAddressFromAddressInfo = ({ info }: { info: BtcAddressInfo }): BtcAddress => {
@@ -52,3 +53,19 @@ export const getBtcAddressString = (address: BtcAddress): string => {
 
 	assertNever(address, `Unexpected BtcAddress: ${address}`);
 };
+
+export const isBtcAddress = (address: BtcAddressTypeObjType | undefined): boolean => {
+	if (isNullish(address)) {
+		return false;
+	}
+
+	try {
+		parseBtcAddressCkbtc(address);
+		return true;
+	} catch (_: unknown) {
+		return false;
+	}
+};
+
+export const invalidBtcAddress = (address: BtcAddressTypeObjType | undefined): boolean =>
+	!isBtcAddress(address);

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -10,27 +10,10 @@ import type { TokenAccountIdTypes } from '$lib/types/token-account-id';
 import { mapCertifiedData } from '$lib/utils/certified-store.utils';
 import { isNetworkIdICP } from '$lib/utils/network.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import { parseBtcAddress, type BtcAddress } from '@icp-sdk/canisters/ckbtc';
 
 export const mapAddress = <T extends Address>(
 	$addressStore: AddressStoreData<T>
 ): OptionAddress<T> => mapCertifiedData($addressStore);
-
-export const isBtcAddress = (address: BtcAddress | undefined): boolean => {
-	if (isNullish(address)) {
-		return false;
-	}
-
-	try {
-		parseBtcAddress(address);
-		return true;
-	} catch (_: unknown) {
-		return false;
-	}
-};
-
-export const invalidBtcAddress = (address: BtcAddress | undefined): boolean =>
-	!isBtcAddress(address);
 
 export const mapNetworkIdToAddressType = (
 	networkId: NetworkId | undefined

--- a/src/frontend/src/lib/utils/send.utils.ts
+++ b/src/frontend/src/lib/utils/send.utils.ts
@@ -1,5 +1,5 @@
+import { invalidBtcAddress } from '$btc/utils/btc-address.utils';
 import type { NetworkId } from '$lib/types/network';
-import { invalidBtcAddress } from '$lib/utils/address.utils';
 import { isNullishOrEmpty } from '$lib/utils/input.utils';
 import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$lib/utils/network.utils';
 import { BtcNetwork } from '@icp-sdk/canisters/ckbtc';


### PR DESCRIPTION
# Motivation

Util `isBtcAddress` was causing an import loop, so we move it to a specific file.
