### PR TITLE
refactor(frontend): Avoid loop import for type `GetFeeData`

### DIFF
--- a/src/frontend/src/eth/providers/infura.providers.ts
+++ b/src/frontend/src/eth/providers/infura.providers.ts
@@ -1,8 +1,8 @@
 import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
 import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 import { INFURA_API_KEY } from '$env/rest/infura.env';
-import type { GetFeeData } from '$eth/services/fee.services';
 import type { EthAddress } from '$eth/types/address';
+import type { GetFeeData } from '$eth/types/infura';
 import { TRACK_ETH_ESTIMATE_GAS_ERROR } from '$lib/constants/analytics.constants';
 import { trackEvent } from '$lib/services/analytics.services';
 import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -8,6 +8,7 @@ import { infuraProviders, type InfuraProvider } from '$eth/providers/infura.prov
 import { InfuraGasRest } from '$eth/rest/infura.rest';
 import type { EthAddress, OptionEthAddress } from '$eth/types/address';
 import type { Erc20Token } from '$eth/types/erc20';
+import type { GetFeeData } from '$eth/types/infura';
 import type { EthereumNetwork } from '$eth/types/network';
 import { isDestinationContractAddress } from '$eth/utils/send.utils';
 import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
@@ -15,13 +16,6 @@ import type { Network, NetworkId } from '$lib/types/network';
 import type { TransactionFeeData } from '$lib/types/transaction';
 import { maxBigInt } from '$lib/utils/bigint.utils';
 import { isNetworkIdICP } from '$lib/utils/network.utils';
-
-export interface GetFeeData {
-	from: EthAddress;
-	to: EthAddress;
-	value?: bigint;
-	data?: string;
-}
 
 export const getEthFeeData = ({
 	to,

--- a/src/frontend/src/eth/services/pay.services.ts
+++ b/src/frontend/src/eth/services/pay.services.ts
@@ -1,11 +1,8 @@
 import { ETH_BASE_FEE } from '$eth/constants/eth.constants';
 import type { InfuraProvider } from '$eth/providers/infura.providers';
-import {
-	getErc20FeeData,
-	getEthFeeDataWithProvider,
-	type GetFeeData
-} from '$eth/services/fee.services';
+import { getErc20FeeData, getEthFeeDataWithProvider } from '$eth/services/fee.services';
 import type { OptionEthAddress } from '$eth/types/address';
+import type { GetFeeData } from '$eth/types/infura';
 import type { EthFeeResult } from '$eth/types/pay';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';

--- a/src/frontend/src/eth/types/infura.ts
+++ b/src/frontend/src/eth/types/infura.ts
@@ -1,3 +1,5 @@
+import type { EthAddress } from '$eth/types/address';
+
 interface FeeEstimateLevel {
 	suggestedMaxPriorityFeePerGas: string;
 	suggestedMaxFeePerGas: string;
@@ -17,4 +19,11 @@ export interface GasFeeEstimate {
 	priorityFeeTrend: 'up' | 'down' | 'stable';
 	baseFeeTrend: 'up' | 'down' | 'stable';
 	version: string;
+}
+
+export interface GetFeeData {
+	from: EthAddress;
+	to: EthAddress;
+	value?: bigint;
+	data?: string;
 }

--- a/src/frontend/src/tests/eth/components/fee/EthFeeContext.spec.ts
+++ b/src/frontend/src/tests/eth/components/fee/EthFeeContext.spec.ts
@@ -11,6 +11,7 @@ import {
 	type EthFeeStore,
 	type FeeStoreData
 } from '$eth/stores/eth-fee.store';
+import type { GetFeeData } from '$eth/types/infura';
 import type { EthereumNetwork } from '$eth/types/network';
 import * as ethUtils from '$eth/utils/eth.utils';
 import * as tokenUtils from '$eth/utils/token.utils';
@@ -141,7 +142,7 @@ describe('EthFeeContext', () => {
 
 		const provider = infuraMod.infuraProviders(network.id) as unknown as {
 			getFeeData: () => Promise<unknown>;
-			safeEstimateGas: (p: feeServices.GetFeeData) => Promise<bigint>;
+			safeEstimateGas: (p: GetFeeData) => Promise<bigint>;
 		};
 		vi.spyOn(provider, 'safeEstimateGas').mockResolvedValue(25n);
 
@@ -181,7 +182,7 @@ describe('EthFeeContext', () => {
 		const nft = mockValidErc721Nft;
 
 		const provider = infuraMod.infuraProviders(network.id) as unknown as {
-			estimateGas: (p: feeServices.GetFeeData & { data?: string }) => Promise<bigint>;
+			estimateGas: (p: GetFeeData & { data?: string }) => Promise<bigint>;
 		};
 		vi.spyOn(provider, 'estimateGas').mockResolvedValue(90n);
 


### PR DESCRIPTION
# Motivation

Type `GetFeeData` was causing an import loop, so we move it to a specific file.
