### PR TITLE
fix(frontend): WORKAROUND: re-render the token list

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 	import { isIOS } from '@dfinity/gix-components';
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
-	import { onMount, tick, untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { flip } from 'svelte/animate';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { goto } from '$app/navigation';
-	import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 	import NoTokensPlaceholder from '$lib/components/tokens/NoTokensPlaceholder.svelte';
 	import NothingFoundPlaceholder from '$lib/components/tokens/NothingFoundPlaceholder.svelte';
 	import TokenCard from '$lib/components/tokens/TokenCard.svelte';


### PR DESCRIPTION
# Motivation

For newly logged-in users, the token list occasionally fails to render correctly on the initial load. It breaks down the components and stops showing the data.

<img width="1278" height="1376" alt="Screenshot 2026-01-16 at 15 30 13" src="https://github.com/user-attachments/assets/3d994282-a27a-434f-bf6f-d4ff0e10fcf4" />

The underlying data eventually becomes consistent, but the first render can break due to a timing issue in the tokens list pipeline.

As workaround, we force the re-rendering for the first 10 seconds every 3 seconds.