### PR TITLE
feat(frontend): implement all-utxos store

### DIFF
--- a/src/frontend/src/btc/stores/all-utxos.store.ts
+++ b/src/frontend/src/btc/stores/all-utxos.store.ts
@@ -1,0 +1,34 @@
+import type { Option } from '$lib/types/utils';
+import type { BitcoinDid } from '@icp-sdk/canisters/ckbtc';
+import { writable, type Readable } from 'svelte/store';
+
+export type AllUtxosStoreData = Option<{
+	allUtxos?: BitcoinDid.utxo[];
+}>;
+
+export interface AllUtxosStore extends Readable<AllUtxosStoreData> {
+	setAllUtxos: (data: AllUtxosStoreData) => void;
+	reset: () => void;
+}
+
+export const initAllUtxosStore = (): AllUtxosStore => {
+	const { subscribe, set } = writable<AllUtxosStoreData>();
+
+	return {
+		subscribe,
+
+		reset: () => {
+			set(null);
+		},
+
+		setAllUtxos: (data: AllUtxosStoreData) => {
+			set(data);
+		}
+	};
+};
+
+export interface AllUtxosContext {
+	store: AllUtxosStore;
+}
+
+export const ALL_UTXOS_CONTEXT_KEY = Symbol('all-utxos');

--- a/src/frontend/src/tests/btc/stores/all-utxos.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/all-utxos.store.spec.ts
@@ -1,0 +1,61 @@
+import { initAllUtxosStore } from '$btc/stores/all-utxos.store';
+import { mockUtxo } from '$tests/mocks/btc.mock';
+import { mockPage } from '$tests/mocks/page.store.mock';
+import { testDerivedUpdates } from '$tests/utils/derived.test-utils';
+import { get } from 'svelte/store';
+
+describe('allUtxosStore', () => {
+	beforeEach(() => {
+		mockPage.reset();
+	});
+
+	const mockAllUtxos = [mockUtxo];
+
+	it('should ensure derived stores update at most once when the store changes', async () => {
+		const store = initAllUtxosStore();
+
+		await testDerivedUpdates(() =>
+			store.setAllUtxos({
+				allUtxos: mockAllUtxos
+			})
+		);
+	});
+
+	it('should have all expected values', () => {
+		const store = initAllUtxosStore();
+
+		store.setAllUtxos({
+			allUtxos: mockAllUtxos
+		});
+
+		expect(get(store)?.allUtxos).toStrictEqual(mockAllUtxos);
+	});
+
+	it('should reset the value', () => {
+		const store = initAllUtxosStore();
+
+		store.setAllUtxos({
+			allUtxos: mockAllUtxos
+		});
+		store.reset();
+
+		expect(get(store)?.allUtxos).toBeUndefined();
+	});
+
+	it('should start with undefined value', () => {
+		const store = initAllUtxosStore();
+
+		expect(get(store)).toBeUndefined();
+	});
+
+	it('should set null after reset', () => {
+		const store = initAllUtxosStore();
+
+		store.setAllUtxos({
+			allUtxos: mockAllUtxos
+		});
+		store.reset();
+
+		expect(get(store)).toBeNull();
+	});
+});


### PR DESCRIPTION
# Motivation

We need to implement a new store for saving the data returned by `getUtxosQuery`.
