### PR TITLE
feat(frontend): implement fee-rate-percentiles store

### DIFF
--- a/src/frontend/src/btc/stores/fee-rate-percentiles.store.ts
+++ b/src/frontend/src/btc/stores/fee-rate-percentiles.store.ts
@@ -1,0 +1,33 @@
+import type { Option } from '$lib/types/utils';
+import { writable, type Readable } from 'svelte/store';
+
+export type FeeRatePercentilesStoreData = Option<{
+	feeRateFromPercentiles?: bigint;
+}>;
+
+export interface FeeRatePercentilesStore extends Readable<FeeRatePercentilesStoreData> {
+	setFeeRateFromPercentiles: (data: FeeRatePercentilesStoreData) => void;
+	reset: () => void;
+}
+
+export const initFeeRatePercentilesStore = (): FeeRatePercentilesStore => {
+	const { subscribe, set } = writable<FeeRatePercentilesStoreData>();
+
+	return {
+		subscribe,
+
+		reset: () => {
+			set(null);
+		},
+
+		setFeeRateFromPercentiles: (data: FeeRatePercentilesStoreData) => {
+			set(data);
+		}
+	};
+};
+
+export interface FeeRatePercentilesContext {
+	store: FeeRatePercentilesStore;
+}
+
+export const FEE_RATE_PERCENTILES_CONTEXT_KEY = Symbol('fee-rate-percentiles');

--- a/src/frontend/src/tests/btc/stores/fee-rate-percentiles.store.spec.ts
+++ b/src/frontend/src/tests/btc/stores/fee-rate-percentiles.store.spec.ts
@@ -1,0 +1,60 @@
+import { initFeeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
+import { mockPage } from '$tests/mocks/page.store.mock';
+import { testDerivedUpdates } from '$tests/utils/derived.test-utils';
+import { get } from 'svelte/store';
+
+describe('feeRatePercentilesStore', () => {
+	beforeEach(() => {
+		mockPage.reset();
+	});
+
+	const mockFeeRateFromPercentiles = 5000n;
+
+	it('should ensure derived stores update at most once when the store changes', async () => {
+		const store = initFeeRatePercentilesStore();
+
+		await testDerivedUpdates(() =>
+			store.setFeeRateFromPercentiles({
+				feeRateFromPercentiles: mockFeeRateFromPercentiles
+			})
+		);
+	});
+
+	it('should have all expected values', () => {
+		const store = initFeeRatePercentilesStore();
+
+		store.setFeeRateFromPercentiles({
+			feeRateFromPercentiles: mockFeeRateFromPercentiles
+		});
+
+		expect(get(store)?.feeRateFromPercentiles).toStrictEqual(mockFeeRateFromPercentiles);
+	});
+
+	it('should reset the value', () => {
+		const store = initFeeRatePercentilesStore();
+
+		store.setFeeRateFromPercentiles({
+			feeRateFromPercentiles: mockFeeRateFromPercentiles
+		});
+		store.reset();
+
+		expect(get(store)?.feeRateFromPercentiles).toBeUndefined();
+	});
+
+	it('should start with undefined value', () => {
+		const store = initFeeRatePercentilesStore();
+
+		expect(get(store)).toBeUndefined();
+	});
+
+	it('should set null after reset', () => {
+		const store = initFeeRatePercentilesStore();
+
+		store.setFeeRateFromPercentiles({
+			feeRateFromPercentiles: mockFeeRateFromPercentiles
+		});
+		store.reset();
+
+		expect(get(store)).toBeNull();
+	});
+});


### PR DESCRIPTION
# Motivation

We need to implement a new store for saving the data returned by `getFeeRateFromPercentiles`.
