### PR TITLE
feat(frontend): Delete data on logout only once

### DIFF
--- a/src/frontend/src/lib/components/auth/LockPage.svelte
+++ b/src/frontend/src/lib/components/auth/LockPage.svelte
@@ -8,7 +8,7 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
-	import { signOut, signIn } from '$lib/services/auth.services';
+	import { signOut, signIn, PrincipalsStorage } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { authLocked } from '$lib/stores/locked.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -34,7 +34,11 @@
 
 	const handleLogout = async () => {
 		authLocked.unlock({ source: 'logout from lock page' });
-		await signOut({ resetUrl: true, clearPrincipalStorages: 'all', source: 'lock-page' });
+		await signOut({
+			resetUrl: true,
+			clearPrincipalStorages: PrincipalsStorage.ALL,
+			source: 'lock-page'
+		});
 	};
 </script>
 

--- a/src/frontend/src/lib/components/core/LockOrSignOut.svelte
+++ b/src/frontend/src/lib/components/core/LockOrSignOut.svelte
@@ -4,7 +4,7 @@
 	import IconLogout from '$lib/components/icons/IconLogout.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import { LOCK_BUTTON, LOGOUT_BUTTON } from '$lib/constants/test-ids.constants';
-	import { lockSession, signOut } from '$lib/services/auth.services';
+	import { lockSession, PrincipalsStorage, signOut } from '$lib/services/auth.services';
 	import { authRemainingTimeStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { authLocked } from '$lib/stores/locked.store';
@@ -28,7 +28,11 @@
 
 	const handleLogoutTriggered = async () => {
 		onHidePopover?.();
-		await signOut({ resetUrl: true, clearPrincipalStorages: 'all', source: 'menu-button' });
+		await signOut({
+			resetUrl: true,
+			clearPrincipalStorages: PrincipalsStorage.ALL,
+			source: 'menu-button'
+		});
 	};
 
 	const handleLock = async () => {

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -57,6 +57,12 @@ import { isNullish } from '@dfinity/utils';
 import type { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
 
+export enum PrincipalsStorage {
+	CURRENT = 'current',
+	ALL = 'all',
+	NONE = 'none'
+}
+
 export const signIn = async (
 	params: AuthSignInParams
 ): Promise<{ success: 'ok' | 'cancelled' | 'error'; err?: unknown }> => {
@@ -128,11 +134,11 @@ export const signIn = async (
 
 export const signOut = ({
 	resetUrl = false,
-	clearPrincipalStorages = 'current',
+	clearPrincipalStorages = PrincipalsStorage.CURRENT,
 	source = ''
 }: {
 	resetUrl?: boolean;
-	clearPrincipalStorages?: 'current' | 'all' | 'none';
+	clearPrincipalStorages?: PrincipalsStorage;
 	source?: string;
 }): Promise<void> => {
 	trackSignOut({
@@ -192,14 +198,14 @@ export const idleSignOut = (): Promise<void> => {
 			text,
 			level
 		},
-		clearPrincipalStorages: 'none'
+		clearPrincipalStorages: PrincipalsStorage.NONE
 	});
 };
 
 export const lockSession = ({ resetUrl = false }: { resetUrl?: boolean }): Promise<void> =>
 	logout({
 		resetUrl,
-		clearPrincipalStorages: 'none'
+		clearPrincipalStorages: PrincipalsStorage.NONE
 	});
 
 const emptyPrincipalIdbStore = async (deleteIdbStore: (principal: Principal) => Promise<void>) => {
@@ -284,11 +290,11 @@ const disconnectWalletConnect = async () => {
 
 const logout = async ({
 	msg = undefined,
-	clearPrincipalStorages = 'current',
+	clearPrincipalStorages = PrincipalsStorage.CURRENT,
 	resetUrl = false
 }: {
 	msg?: ToastMsg;
-	clearPrincipalStorages?: 'current' | 'all' | 'none';
+	clearPrincipalStorages?: PrincipalsStorage;
 	resetUrl?: boolean;
 }) => {
 	// To mask not operational UI (a side effect of sometimes slow JS loading after window.reload because of service worker and no cache).
@@ -296,9 +302,9 @@ const logout = async ({
 
 	await disconnectWalletConnect();
 
-	if (clearPrincipalStorages === 'current') {
+	if (clearPrincipalStorages === PrincipalsStorage.CURRENT) {
 		await Promise.all(deleteIdbStoreList.map(emptyPrincipalIdbStore));
-	} else if (clearPrincipalStorages === 'all') {
+	} else if (clearPrincipalStorages === PrincipalsStorage.ALL) {
 		await Promise.all(clearIdbStoreList.map(clearIdbStore));
 	}
 

--- a/src/frontend/src/tests/lib/services/auth.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/auth.services.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '$lib/constants/analytics.constants';
 import { trackEvent } from '$lib/services/analytics.services';
 import {
+	PrincipalsStorage,
 	errorSignOut,
 	idleSignOut,
 	lockSession,
@@ -127,7 +128,7 @@ describe('auth.services', () => {
 		});
 
 		it('should clean the IDB storage for all principals', async () => {
-			await signOut({ clearPrincipalStorages: 'all' });
+			await signOut({ clearPrincipalStorages: PrincipalsStorage.ALL });
 
 			// 6 addresses (mainnet and testnet) + 1 tokens + 4 txs + 1 balance
 			expect(idbKeyval.clear).toHaveBeenCalledTimes(12);


### PR DESCRIPTION
# Motivation

In the logout service it makes more sense to either delete all principals data or just the current one.

So, we adjust the parameters to this respect.
