### PR TITLE
fix(frontend): Missing `$derived` rune in `ListItem`

### DIFF
--- a/src/frontend/src/lib/components/common/ListItem.svelte
+++ b/src/frontend/src/lib/components/common/ListItem.svelte
@@ -14,10 +14,10 @@
 	const { variant, condensed, noPadding, noBorder, itemStyleClass } =
 		getContext<ListContext>('list-context');
 
-	const classes: { [key in ListVariant]: string } = {
+	const classes: { [key in ListVariant]: string } = $derived({
 		none: `ml-3 ${condensed || noPadding ? 'py-0' : 'py-1'} ${styleClass ?? ''}`,
 		styled: `flex justify-between ${!noPadding ? (condensed ? 'py-1.5 px-1' : 'py-2.5 px-1') : ''} ${!noBorder ? 'border-b-1 last-of-type:border-b-0 border-brand-subtle-10' : ''} ${styleClass ?? ''} ${itemStyleClass}`
-	};
+	});
 </script>
 
 {#if nonNullish(children)}


### PR DESCRIPTION
# Motivation

There was a missing `$derived` rune in component `ListItem`.
