### PR TITLE
fix(frontend): Missing `$derived` rune in `SwapEthFeeInfo`

### DIFF
--- a/src/frontend/src/eth/components/swap/SwapEthFeeInfo.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthFeeInfo.svelte
@@ -18,11 +18,14 @@
 		feeTokenId?: OptionTokenId;
 		feeSymbol?: OptionString;
 	}
+
 	let { decimals, feeSymbol, feeTokenId }: Props = $props();
+
 	const { sourceToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
-	const balanceForFee = nonNullish(feeTokenId)
-		? ($balancesStore?.[feeTokenId]?.data ?? ZERO)
-		: ZERO;
+
+	const balanceForFee = $derived(
+		nonNullish(feeTokenId) ? ($balancesStore?.[feeTokenId]?.data ?? ZERO) : ZERO
+	);
 </script>
 
 {#if nonNullish(feeSymbol) && $sourceToken?.symbol !== feeSymbol}


### PR DESCRIPTION
# Motivation

There was a missing `$derived` rune in component `SwapEthFeeInfo`.
