### PR TITLE
fix(frontend): Missing `$derived` rune in `SwapProgress`

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapProgress.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProgress.svelte
@@ -18,7 +18,7 @@
 		swapWithWithdrawing = false
 	}: Props = $props();
 
-	let steps = $state<ProgressSteps>([
+	let steps = $derived<ProgressSteps>([
 		{
 			step: ProgressStepsSwap.INITIALIZATION,
 			text: $i18n.swap.text.initializing,


### PR DESCRIPTION
# Motivation

In component `SwapProgress`, it makes more sense that the `steps` variable uses `$derived` instead of `$state`, since it will not change its value on-demand, but by its dependencies.
