### PR TITLE
fix(frontend): Missing `$derived` rune in `EditAddressStep`

### DIFF
--- a/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
+++ b/src/frontend/src/lib/components/address-book/EditAddressStep.svelte
@@ -79,7 +79,7 @@
 
 	let isFormValid = $state(false);
 
-	let focusField = $derived((isNewAddress ? 'address' as const : 'label' as const));
+	let focusField = $derived(isNewAddress ? ('address' as const) : ('label' as const));
 
 	let originalLabel = $derived(!isNewAddress && nonNullish(address?.label) ? address.label : '');
 	let labelChanged = $derived(isNewAddress ? true : editingAddress.label !== originalLabel);


### PR DESCRIPTION
# Motivation

There was a missing `$derived` rune in component `EditAddressStep`.
