### PR TITLE
fix(frontend): Missing `$derived` rune in component `InProgress`

### DIFF
--- a/src/frontend/src/lib/components/ui/InProgress.svelte
+++ b/src/frontend/src/lib/components/ui/InProgress.svelte
@@ -17,10 +17,7 @@
 
 	let Cmp = $derived(type === 'static' ? StaticSteps : ProgressStepsCmp);
 
-	let dynamicSteps = $derived<ProgressSteps>([
-		// TODO: have a look if there is a better solution than casting
-		...(steps as ProgressSteps)
-	]);
+	let dynamicSteps = $derived(steps as ProgressSteps);
 
 	const updateSteps = () => {
 		const progressIndex = dynamicSteps.findIndex(({ step }) => step === progressStep);


### PR DESCRIPTION
# Motivation

In component `InProgress`, it makes more sense that the `dynamicSteps ` variable uses `$derived` instead of `$state`, since it will not change its value on-demand, but by its dependencies.
