### PR TITLE
fix(frontend): Missing `$derived` rune in component `Logo`

### DIFF
--- a/src/frontend/src/lib/components/ui/Logo.svelte
+++ b/src/frontend/src/lib/components/ui/Logo.svelte
@@ -26,7 +26,7 @@
 		testId
 	}: Props = $props();
 
-	let sizePx = $state(logoSizes[size]);
+	let sizePx = $derived(logoSizes[size]);
 
 	let loadingError: boolean | undefined = $state();
 	let isReady = $derived((nonNullish(src) && nonNullish(loadingError)) || isNullish(src));


### PR DESCRIPTION
# Motivation

In component `Logo`, it makes more sense that the `sizePx ` variable uses `$derived` instead of `$state`, since it will not change its value on-demand, but by its dependencies.
