### PR TITLE
fix(frontend): Missing `$derived` rune in component `EditAddressStep`

### DIFF
--- a/src/frontend/src/lib/components/tokens/ModalTokensListItem.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensListItem.svelte
@@ -17,7 +17,7 @@
 
 	let { token, logoSize = 'lg', onClick, showDividers = true }: Props = $props();
 
-	const { oisyName, oisySymbol, symbol, name, network } = $derived(token);
+	const { oisyName, oisySymbol, symbol, name, network } = token;
 </script>
 
 <LogoButton dividers={showDividers} fullWidth {onClick}>


### PR DESCRIPTION
# Motivation

There was a missing `$derived` rune in component `EditAddressStep`.
