### PR TITLE
feat(frontend): Create specific context store for `List`

### DIFF
--- a/src/frontend/src/lib/components/common/List.svelte
+++ b/src/frontend/src/lib/components/common/List.svelte
@@ -27,8 +27,6 @@
 		testId
 	}: Props = $props();
 
-
-
 	setContext<ListContext>(LIST_CONTEXT_KEY, {
 		store: initListStore()
 	});

--- a/src/frontend/src/lib/components/common/ListItem.svelte
+++ b/src/frontend/src/lib/components/common/ListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext, type Snippet } from 'svelte';
-	import type { ListContext } from '$lib/components/common/List.svelte';
+	import { LIST_CONTEXT_KEY, type ListContext } from '$lib/stores/list-store.store';
 	import type { ListVariant } from '$lib/types/style';
 
 	interface Props {
@@ -11,8 +11,9 @@
 
 	const { children, styleClass }: Props = $props();
 
-	const { variant, condensed, noPadding, noBorder, itemStyleClass } =
-		getContext<ListContext>('list-context');
+	const { store } = getContext<ListContext>(LIST_CONTEXT_KEY);
+
+	const { variant, condensed, noPadding, noBorder, itemStyleClass } = $derived($store);
 
 	const classes: { [key in ListVariant]: string } = $derived({
 		none: `ml-3 ${condensed || noPadding ? 'py-0' : 'py-1'} ${styleClass ?? ''}`,

--- a/src/frontend/src/lib/stores/list-store.store.ts
+++ b/src/frontend/src/lib/stores/list-store.store.ts
@@ -1,21 +1,20 @@
 import type { ListVariant } from '$lib/types/style';
-import type { Option } from '$lib/types/utils';
 import { writable, type Readable } from 'svelte/store';
 
-export type ListStoreData = Option<{
+export interface ListStoreData {
 	variant: ListVariant;
 	condensed?: boolean;
 	noPadding?: boolean;
 	noBorder?: boolean;
 	itemStyleClass?: string;
-}>;
+}
 
 export interface ListStore extends Readable<ListStoreData> {
 	setList: (data: ListStoreData) => void;
 }
 
 export const initListStore = (): ListStore => {
-	const { subscribe, set } = writable<ListStoreData>(undefined);
+	const { subscribe, set } = writable<ListStoreData>({ variant: 'styled' });
 
 	return {
 		subscribe,


### PR DESCRIPTION
# Motivation

To be coherent and for manageability, we create a context store for `List` component.