### PR TITLE
refactor(frontend): Fix setContext reactivity in ManageTokens

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -2,6 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext, onMount, setContext, type Snippet } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
+	import { writable } from 'svelte/store';
 	import IconPlus from '$lib/components/icons/lucide/IconPlus.svelte';
 	import EnableTokenToggle from '$lib/components/tokens/EnableTokenToggle.svelte';
 	import ModalNetworksFilter from '$lib/components/tokens/ModalNetworksFilter.svelte';
@@ -24,7 +25,6 @@
 	import type { Token, TokenId } from '$lib/types/token';
 	import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
 	import { pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
-	import {writable} from "svelte/store";
 
 	interface Props {
 		initialSearch?: string;
@@ -57,17 +57,17 @@
 			: []
 	);
 
-	const filterQuery = writable<string>()
+	const filterQuery = writable<string>();
 
 	$effect(() => {
-		filterQuery.set(nonNullish(initialSearch) ? initialSearch : '')
-	})
+		filterQuery.set(nonNullish(initialSearch) ? initialSearch : '');
+	});
 
-	const filterNfts = writable<boolean>()
+	const filterNfts = writable<boolean>();
 
 	$effect(() => {
-		filterNfts.set(!!isNftsPage)
-	})
+		filterNfts.set(!!isNftsPage);
+	});
 
 	setContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY,


### PR DESCRIPTION
# Motivation

With svelte check [`state_referenced_locally`](https://svelte.dev/docs/svelte/compiler-warnings#state_referenced_locally) we have quite a few **warnings** about `setContext` and reading state variables.

That is because the context will not update the values since the reference to the object changes.

A way to solve this is to use a getter or a derived store.
