### PR TITLE
feat(frontend): implement UtxosFeeContexts component

### DIFF
--- a/src/frontend/src/btc/components/fee/UtxosFeeContexts.svelte
+++ b/src/frontend/src/btc/components/fee/UtxosFeeContexts.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { setContext, type Snippet } from 'svelte';
+	import {
+		ALL_UTXOS_CONTEXT_KEY,
+		type AllUtxosContext as AllUtxosContextType,
+		initAllUtxosStore
+	} from '$btc/stores/all-utxos.store';
+	import {
+		FEE_RATE_PERCENTILES_CONTEXT_KEY,
+		type FeeRatePercentilesContext as FeeRatePercentilesContextType,
+		initFeeRatePercentilesStore
+	} from '$btc/stores/fee-rate-percentiles.store';
+	import {
+		UTXOS_FEE_CONTEXT_KEY,
+		type UtxosFeeContext as UtxosFeeContextType,
+		initUtxosFeeStore
+	} from '$btc/stores/utxos-fee.store';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+
+	setContext<AllUtxosContextType>(ALL_UTXOS_CONTEXT_KEY, {
+		store: initAllUtxosStore()
+	});
+
+	setContext<FeeRatePercentilesContextType>(FEE_RATE_PERCENTILES_CONTEXT_KEY, {
+		store: initFeeRatePercentilesStore()
+	});
+
+	setContext<UtxosFeeContextType>(UTXOS_FEE_CONTEXT_KEY, {
+		store: initUtxosFeeStore()
+	});
+</script>
+
+{@render children()}

--- a/src/frontend/src/tests/btc/components/fee/UtxosFeeContexts.spec.ts
+++ b/src/frontend/src/tests/btc/components/fee/UtxosFeeContexts.spec.ts
@@ -1,0 +1,13 @@
+import UtxosFeeContexts from '$btc/components/fee/UtxosFeeContexts.svelte';
+import { mockSnippet, mockSnippetTestId } from '$tests/mocks/snippet.mock';
+import { render } from '@testing-library/svelte';
+
+describe('UtxosFeeContexts', () => {
+	it('renders children snippet', () => {
+		const { getByTestId } = render(UtxosFeeContexts, {
+			children: mockSnippet
+		});
+
+		expect(getByTestId(mockSnippetTestId)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

We can finally create a component for initializing all utxos-related contexts.

Note: to avoid confusion, the existing utxos, all utxos and fee rate percentiles "context" components will be renamed to "loaders".
