### PR TITLE
feat(frontend): Do not await update calls for wallet services

### DIFF
--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -288,8 +288,7 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 				if (FAILURE_THRESHOLD <= this.failedSyncCounter) {
 					this.postMessageWalletError({ error });
 				}
-			},
-			resolution: 'all_settled'
+			}
 		});
 	};
 

--- a/src/frontend/src/icp/schedulers/btc-statuses.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/btc-statuses.scheduler.ts
@@ -49,8 +49,7 @@ export class BtcStatusesScheduler implements Scheduler<PostMessageDataRequestIcC
 				withdrawalStatuses({ minterCanisterId, identity, certified }),
 			onLoad: ({ certified, ...rest }) => this.syncStatusesResults({ certified, ...rest }),
 			onUpdateError: ({ error }) => this.postMessageWalletError(error),
-			identity,
-			resolution: 'all_settled'
+			identity
 		});
 	};
 

--- a/src/frontend/src/icp/schedulers/ck-minter-info.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ck-minter-info.scheduler.ts
@@ -55,8 +55,7 @@ export class CkMinterInfoScheduler<
 				this.minterInfo({ minterCanisterId, identity, certified }),
 			onLoad: ({ certified, ...rest }) => this.syncMinterInfo({ certified, ...rest }),
 			onUpdateError: ({ error }) => this.postMessageWalletError(error),
-			identity,
-			resolution: 'all_settled'
+			identity
 		});
 	};
 

--- a/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
@@ -81,8 +81,7 @@ export class IcWalletBalanceAndTransactionsScheduler<
 				this.cleanTransactions({ certified });
 			},
 			onUpdateError: ({ error }) => this.postMessageWalletError({ msg: this.msg, error }),
-			identity,
-			resolution: 'all_settled'
+			identity
 		});
 	};
 

--- a/src/frontend/src/icp/schedulers/ic-wallet-balance.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance.scheduler.ts
@@ -41,8 +41,7 @@ export class IcWalletBalanceScheduler<
 			request: ({ identity: _, certified }) => this.getBalance({ ...data, identity, certified }),
 			onLoad: ({ certified, ...rest }) => this.syncBalance({ certified, ...rest }),
 			onUpdateError: ({ error }) => this.postMessageWalletError({ msg: this.msg, error }),
-			identity,
-			resolution: 'all_settled'
+			identity
 		});
 	};
 


### PR DESCRIPTION
# Motivation

There is no need to await both query and update calls in the wallet services, since the default behaviour of `race` is more than enough for UI pointview.
