### PR TITLE
refactor(frontend): Better key readability in TokensList

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -164,7 +164,7 @@
 <TokensDisplayHandler {animating} bind:tokens>
 	<TokensSkeletons {loading}>
 		<div class="flex flex-col gap-3" class:mb-12={filteredTokens?.length > 0}>
-						{#key firstListRerenderTick}
+			{#key firstListRerenderTick}
 				{#each tokensWithKey as { tokenOrGroup, key } (key)}
 					<div
 						class="overflow-hidden rounded-xl"


### PR DESCRIPTION
# Motivation

To have better readability, we refactor `TokensList` to understand better the keys associated to the tokens items.
