### PR TITLE
refactor(frontend): Improve checks in derived store `enabledIcrcTwinTokensAddresses`

### DIFF
--- a/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
+++ b/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
@@ -1,9 +1,10 @@
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import type { Erc20Token } from '$eth/types/erc20';
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import { enabledIcrcTokens } from '$icp/derived/icrc.derived';
 import type { IcCkToken, IcToken } from '$icp/types/ic-token';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 const enabledErc20TokensAddresses: Readable<Erc20ContractAddressWithNetwork[]> = derived(
@@ -19,9 +20,19 @@ const enabledIcrcTwinTokensAddresses: Readable<Erc20ContractAddressWithNetwork[]
 	[enabledIcrcTokens],
 	([$enabledIcrcTokens]) =>
 		$enabledIcrcTokens
-			.filter((token: IcToken) =>
-				nonNullish(((token as Partial<IcCkToken>).twinToken as Erc20Token | undefined)?.address)
-			)
+			.filter((token: IcToken) => {
+				if (isNullish((token as Partial<IcCkToken>).twinToken)) {
+					return false;
+				}
+
+				const { twinToken } = token as Partial<IcCkToken>;
+
+				if (isNullish(twinToken)) {
+					return false;
+				}
+
+				return isTokenErc20(twinToken) && nonNullish(twinToken.address);
+			})
 			.map((token) => {
 				const {
 					address,


### PR DESCRIPTION
# Motivation

We make derived store `enabledIcrcTwinTokensAddresses` more readable and check-safe.