### PR TITLE
fix(frontend): Remove looped effect in `LoaderCollections`

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import {  isNullish } from '@dfinity/utils';
+	import { isNullish } from '@dfinity/utils';
 	import type { Identity } from '@icp-sdk/core/agent';
 	import type { CustomToken } from '$declarations/backend/backend.did';
 	import { EXT_BUILTIN_TOKENS } from '$env/tokens/tokens-ext/tokens.ext.env';
@@ -139,8 +139,6 @@
 
 		event?.detail.callback?.();
 	};
-
-
 </script>
 
 <svelte:window onoisyReloadCollections={reload} />


### PR DESCRIPTION
# Motivation

There is a looped $effect in `LoaderCollections`:

- The backend custom tokens store is updated.
- We reload the collections.
- In case of failure, we re-lad the custom tokens.
- And so the backend custom tokens store is re-updated, etc etc.

We don't really need reactivity here, since we have a timer to update the collections.
