### PR TITLE
feat(frontend): Use query-only warm-up in BTC status scheduler

### DIFF
--- a/src/frontend/src/icp/schedulers/btc-statuses.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/btc-statuses.scheduler.ts
@@ -9,7 +9,7 @@ import type {
 	PostMessageJsonDataResponse
 } from '$lib/types/post-message';
 import type { CertifiedData } from '$lib/types/store';
-import { assertNonNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
+import { assertNonNullish, isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
 import type { RetrieveBtcStatusV2WithId } from '@icp-sdk/canisters/ckbtc';
 
 export class BtcStatusesScheduler implements Scheduler<PostMessageDataRequestIcCk> {


### PR DESCRIPTION
# Motivation

During login/initialization, we ran a huge amount of calls using the service `queryAndUpdate`: it basically fires both type of calls and works them according to parameters (race, strategy, etc).

However, for the first part, the update calls are really not that relevant. We are more interested in having the UI loaded, and to diminish the weight of calls that we fire/manage.

In PR #11221, we created a service that for the first 10 seconds will lunch only query calls, and then will do both query and update (a wrapper around service `queryAndUpdate`).

In this PR, we apply this service to the BTC status schedulers.
