### PR TITLE
refactor(frontend): Add optional `certified` param to NFT loading flow

### DIFF
--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -10,7 +10,7 @@ import type { Nft, NftCollection } from '$lib/types/nft';
 import { mapNftAttributes } from '$lib/utils/nft.utils';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
-import { notEmptyString } from '@dfinity/utils';
+import { notEmptyString, type QueryParams } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 
@@ -22,12 +22,13 @@ const mapExtCollection = ({ canisterId, ...rest }: ExtToken): NftCollection => (
 export const mapExtNft = async ({
 	index,
 	token,
-	identity
+	identity,
+	certified
 }: {
 	index: TokenIndex;
 	token: ExtToken;
 	identity: Identity;
-}): Promise<Nft> => {
+} & QueryParams): Promise<Nft> => {
 	const { canisterId } = token;
 
 	const identifier = extIndexToIdentifier({ collectionId: Principal.fromText(canisterId), index });
@@ -41,7 +42,8 @@ export const mapExtNft = async ({
 	} = (await getExtMetadata({
 		canisterId,
 		tokenIdentifier: identifier,
-		identity
+		identity,
+		certified
 	})) ?? {};
 
 	const imageUrl = fetchedImageUrl ?? defaultImageUrl;
@@ -69,7 +71,10 @@ const mapDip721Collection = ({ canisterId, ...rest }: Dip721Token): NftCollectio
 });
 
 // TODO: Fetch metadata of the NFT
-export const mapDip721Nft = ({ index, token }: { index: bigint; token: Dip721Token }): Nft => {
+export const mapDip721Nft = ({
+	index,
+	token
+}: { index: bigint; token: Dip721Token } & QueryParams): Nft => {
 	const mediaStatus = {
 		image: NftMediaStatusEnum.INVALID_DATA,
 		thumbnail: NftMediaStatusEnum.INVALID_DATA
@@ -90,12 +95,13 @@ const mapIcPunksCollection = ({ canisterId, ...rest }: IcPunksToken): NftCollect
 export const mapIcPunksNft = async ({
 	index: tokenIdentifier,
 	token,
-	identity
+	identity,
+	certified
 }: {
 	index: bigint;
 	token: IcPunksToken;
 	identity: Identity;
-}): Promise<Nft> => {
+} & QueryParams): Promise<Nft> => {
 	const { canisterId } = token;
 
 	const {
@@ -106,7 +112,8 @@ export const mapIcPunksNft = async ({
 	} = await getIcPunksMetadata({
 		canisterId,
 		tokenIdentifier,
-		identity
+		identity,
+		certified
 	});
 
 	const imageUrl = `https://${canisterId}.raw.icp0.io${rawUrl}`;

--- a/src/frontend/src/lib/services/nft.services.ts
+++ b/src/frontend/src/lib/services/nft.services.ts
@@ -17,19 +17,20 @@ import type { NetworkId } from '$lib/types/network';
 import type { Nft, NonFungibleToken } from '$lib/types/nft';
 import { isNetworkIdEthereum, isNetworkIdEvm, isNetworkIdICP } from '$lib/utils/network.utils';
 import { getTokensByNetwork } from '$lib/utils/nft.utils';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, type QueryParams } from '@dfinity/utils';
 
 export const loadNftsByNetwork = async ({
 	networkId,
 	tokens,
 	identity,
-	ethAddress
+	ethAddress,
+	certified
 }: {
 	networkId: NetworkId;
 	tokens: NonFungibleToken[];
 	identity: OptionIdentity;
 	ethAddress: OptionEthAddress;
-}): Promise<Nft[]> => {
+} & QueryParams): Promise<Nft[]> => {
 	if (tokens.length === 0) {
 		return [];
 	}
@@ -47,7 +48,8 @@ export const loadNftsByNetwork = async ({
 		return await loadIcNfts({
 			// For now, it is acceptable to cast it since we checked before if the network is ICP.
 			tokens: tokens as IcNonFungibleToken[],
-			identity
+			identity,
+			certified
 		});
 	}
 
@@ -57,12 +59,13 @@ export const loadNftsByNetwork = async ({
 export const loadNfts = async ({
 	tokens,
 	identity,
+	certified,
 	ethAddress
 }: {
 	tokens: NonFungibleToken[];
 	identity: OptionIdentity;
 	ethAddress: OptionEthAddress;
-}) => {
+} & QueryParams) => {
 	const tokensByNetwork = getTokensByNetwork(tokens);
 
 	const promises = Array.from(tokensByNetwork).map(async ([networkId, tokens]) => {
@@ -74,6 +77,7 @@ export const loadNfts = async ({
 			networkId,
 			tokens,
 			identity,
+			certified,
 			ethAddress
 		});
 


### PR DESCRIPTION
# Motivation

The NFT loading flow includes calls to IC network, meaning that they could be `query` and/or `update`. By default they are all `update` calls. However, it could be useful to have a parameter to decide which one we prefer.

In this PR, we add such parameter to the entire flow.

NOTE: for now, we are not actively using it. We will use it in follow-up PRs.