### PR TITLE
refactor(frontend): Reduce loops in util `pinTokensWithBalanceAtTop`

### DIFF
--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -129,9 +129,13 @@ export const pinTokensWithBalanceAtTop = <T extends Token>({
 				$exchanges
 			});
 
-			return (tokenUI.usdBalance ?? 0) > 0 || (tokenUI.balance ?? ZERO) > 0
-				? [[...acc[0], tokenUI], acc[1]]
-				: [acc[0], [...acc[1], tokenUI]];
+			if ((tokenUI.usdBalance ?? 0) > 0 || (tokenUI.balance ?? ZERO) > 0) {
+				acc[0].push(tokenUI);
+			} else {
+				acc[1].push(tokenUI);
+			}
+
+			return acc;
 		},
 		[[], []]
 	);


### PR DESCRIPTION
# Motivation

The previous implementation of `pinTokensWithBalanceAtTop` used array spreading inside a `reduce`, which caused repeated array copying on every iteration.

This resulted in quadratic time complexity (`O(n²)`) and unnecessary memory allocations as the number of tokens grows.

This refactor replaces those copies with in-place mutations, reducing the operation to linear time (`O(n)`) while preserving the exact same behaviour and ordering.
