### PR TITLE
feat(frontend): Remove unnecessary filter from store `tokensToPin`

### DIFF
--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -9,7 +9,6 @@ import { erc721Tokens } from '$eth/derived/erc721.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import type { Erc20Token } from '$eth/types/erc20';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
-import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { extTokens } from '$icp/derived/ext.derived';
 import { icPunksTokens } from '$icp/derived/icpunks.derived';
@@ -75,10 +74,6 @@ export const nonFungibleTokens: Readable<CustomToken<NonFungibleToken>[]> = deri
 export const tokens: Readable<Token[]> = derived(
 	[fungibleTokens, nonFungibleTokens],
 	([$fungibleTokens, $nonFungibleTokens]) => [...$fungibleTokens, ...$nonFungibleTokens]
-);
-
-export const defaultEthereumTokens: Readable<Token[]> = derived([tokens], ([$tokens]) =>
-	$tokens.filter((token) => isDefaultEthereumToken(token))
 );
 
 export const tokensToPin: Readable<TokenToPin[]> = derived(


### PR DESCRIPTION
# Motivation

In derived store `tokensToPin` we are wrongly using the total list of native EVMs networks, since we filter them using object comparison, while we can simply use the existing derived store `enabledEvmTokens`.
