### PR TITLE
refactor(frontend): Reduce loop in util `filterTokenGroups`

### DIFF
--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -52,8 +52,8 @@ export const groupTokensByTwin = (tokens: TokenUi[]): TokenUiOrGroupUi[] => {
 		});
 };
 
-const hasBalance = ({ token, showZeroBalances }: { token: TokenUi; showZeroBalances: boolean }) =>
-	Number(token.balance ?? ZERO) || Number(token.usdBalance ?? ZERO) || showZeroBalances;
+const hasBalance = ({ balance, usdBalance }: TokenUi) =>
+	Number(balance ?? ZERO) || Number(usdBalance ?? ZERO);
 
 /**
  * Function to create a list of TokenUiOrGroupUi, filtering out all groups that do not have at least
@@ -71,11 +71,13 @@ export const filterTokenGroups = ({
 	groupedTokens: TokenUiOrGroupUi[];
 	showZeroBalances: boolean;
 }) =>
-	groupedTokens.filter((tokenOrGroup: TokenUiOrGroupUi) =>
-		isTokenUiGroup(tokenOrGroup)
-			? tokenOrGroup.group.tokens.some((token: TokenUi) => hasBalance({ token, showZeroBalances }))
-			: hasBalance({ token: tokenOrGroup.token, showZeroBalances })
-	);
+	showZeroBalances
+		? groupedTokens
+		: groupedTokens.filter((tokenOrGroup: TokenUiOrGroupUi) =>
+				isTokenUiGroup(tokenOrGroup)
+					? tokenOrGroup.group.tokens.some((token: TokenUi) => hasBalance(token))
+					: hasBalance(tokenOrGroup.token)
+			);
 
 const mapNewTokenGroup = (token: TokenUiGroupable): TokenUiGroup => ({
 	id: token.groupData.id,


### PR DESCRIPTION
# Motivation

In util `filterTokenGroups`, if we want to show the null balances, there is no need to loop the tokens list.