### PR TITLE
refactor(frontend): Replace `absolute` with `grid` in `TokenCard`

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenLogo.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenLogo.svelte
@@ -50,7 +50,7 @@
 	{#if badge?.type === 'tokenCount' && badge.count > 0}
 		<div class="col-start-1 row-start-1 translate-x-1 place-self-end">
 			<span
-				class="flex h-6 w-6 items-center justify-center rounded-full border-[0.5px] border-tertiary bg-primary text-sm font-semibold text-primary"
+				class="flex size-6 items-center justify-center rounded-full border-[0.5px] border-tertiary bg-primary text-sm font-semibold text-primary"
 				aria-label={replacePlaceholders($i18n.tokens.alt.token_group_number, { $token: name })}
 				data-tid={`token-count-${badgeTestId}`}
 			>


### PR DESCRIPTION
# Motivation

We refactor the logo badge layout in `TokenCard` to use a single-cell CSS Grid overlay instead of `position: relative/absolute`.

By removing `absolute` positioning, we reduce the number of positioned layers created during rendering and rely on normal `grid` layout and alignment (justify-self / align-self) instead.

This simplifies the DOM structure, improves layout predictability, and provides a small but consistent performance improvement during rendering, especially in lists with many logos.

No visual changes:

<img width="657" height="969" alt="Screenshot 2026-01-21 at 10 15 36" src="https://github.com/user-attachments/assets/3e5bb9a6-3c6e-4665-a672-0b39f3124168" />

<img width="688" height="359" alt="Screenshot 2026-01-21 at 10 17 47" src="https://github.com/user-attachments/assets/b7f6850c-a90d-4d95-ba5b-8c5a74c51eb1" />
