### PR TITLE
feat(frontend): Clean only current user cache on explicit signout

### DIFF
--- a/src/frontend/src/lib/components/core/LockOrSignOut.svelte
+++ b/src/frontend/src/lib/components/core/LockOrSignOut.svelte
@@ -30,7 +30,7 @@
 		onHidePopover?.();
 		await signOut({
 			resetUrl: true,
-			clearPrincipalStorages: PrincipalsStorage.ALL,
+			clearPrincipalStorages: PrincipalsStorage.CURRENT,
 			source: 'menu-button'
 		});
 	};


### PR DESCRIPTION
# Motivation

When the user explicitly sign-out directly (not in lock state), we should delete only the cache of the current user.
