### PR TITLE
chore(frontend): Extend Episode 5 Sprinkles campaign

### DIFF
--- a/src/frontend/src/env/reward-campaigns.json
+++ b/src/frontend/src/env/reward-campaigns.json
@@ -96,7 +96,7 @@
 		"campaignHref": "rewards.campaigns.sprinkles_s1e5.campaign_href",
 		"learnMoreHref": "https://docs.oisy.com/rewards/oisy-sprinkles",
 		"startDate": "2025-09-24T12:00:00.000Z",
-		"endDate": "2026-01-31T12:00:00.000Z",
+		"endDate": "2026-02-28T12:00:00.000Z",
 		"welcome": {
 			"title": "rewards.campaigns.sprinkles_s1e5.welcome.title",
 			"subtitle": "rewards.campaigns.sprinkles_s1e5.welcome.subtitle",


### PR DESCRIPTION
# Motivation

We keep sprinkles rolling, but the campaign is scheduled to end Jan 31, 2026.

# Changes

- extend to to end of Feb 2026

# Tests
I deployed it to fe3, traveled to the future and properly won sprinkles on Feb 20, 2026.
<img width="400" height="" alt="image" src="https://github.com/user-attachments/assets/e3d11ebb-395c-4a9f-9760-ef26a7b55ba5" />

The card also looks good
<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/ea643ed9-84fd-441f-acad-b561359672cd" />
