### PR TITLE
feat(frontend): Cache finalized SOL transactions

### DIFF
--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -155,7 +155,7 @@ export const fetchTransactionDetailForSignature = async ({
 		signature: signature.signature
 	};
 
-	if (confirmationStatus === 'finalized' && nonNullish(transaction)) {
+	if (confirmationStatus === 'finalized') {
 		networkCache.set(signature.signature, transaction);
 	}
 


### PR DESCRIPTION
# Motivation

If a Solana signature is finalized, it is quite definitive (unless forced changes in the chain). So we can safely cache those values, to reduce calls.
