### PR TITLE
feat(frontend): Cache finalized SOL parsed transactions

### DIFF
--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -37,6 +37,7 @@ import {
 	mockSplAddress
 } from '$tests/mocks/sol.mock';
 import * as solProgramToken from '@solana-program/token';
+import { SvelteMap } from 'svelte/reactivity';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 
@@ -67,6 +68,8 @@ describe('sol-transactions.services', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+
+		vi.spyOn(SvelteMap.prototype, 'get').mockReturnValue(undefined); // invalidate cache
 
 		solTransactionsStore.reset(SOLANA_TOKEN_ID);
 		spyGetTransactions = vi.spyOn(solSignaturesServices, 'getSolTransactions');


### PR DESCRIPTION
# Motivation

If a Solana signature is finalized, it is quite definitive (unless forced changes in the chain). So we can safely cache those values, to reduce calls.
