### PR TITLE
feat(frontend): Debounce `BalanceIdbSetter`

### DIFF
--- a/src/frontend/src/lib/components/balances/BalancesIdbSetter.svelte
+++ b/src/frontend/src/lib/components/balances/BalancesIdbSetter.svelte
@@ -2,8 +2,6 @@
 	import { debounce } from '@dfinity/utils';
 	import { type Snippet, untrack } from 'svelte';
 	import { setIdbBalancesStore } from '$lib/api/idb-balances.api';
-	import { setIdbBtcTransactions } from '$lib/api/idb-transactions.api';
-	import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledTokens } from '$lib/derived/tokens.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
@@ -23,7 +21,7 @@
 			tokens: untrack(() => $enabledTokens),
 			balancesStoreData: $balancesStore
 		});
-	}, WALLET_TIMER_INTERVAL_MILLIS);
+	});
 
 	$effect(() => {
 		[$balancesStore];


### PR DESCRIPTION
# Motivation

To avoid high-frequency actions on initialization, we debounce the component `BalanceIdbSetter` (similar to `TransactionsIdbSetter`).