### PR TITLE
feat(frontend): stores instead of context in BTC send/convert

### DIFF
--- a/src/frontend/src/btc/components/fee/AllUtxosLoader.svelte
+++ b/src/frontend/src/btc/components/fee/AllUtxosLoader.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
-	import { getContext, type Snippet, untrack } from 'svelte';
+	import { type Snippet, untrack } from 'svelte';
 	import { CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS } from '$btc/constants/btc.constants';
-	import { ALL_UTXOS_CONTEXT_KEY, type AllUtxosContext } from '$btc/stores/all-utxos.store';
+	import { allUtxosStore } from '$btc/stores/all-utxos.store';
 	import {
 		BITCOIN_CANISTER_IDS,
 		IC_CKBTC_MINTER_CANISTER_ID
@@ -19,8 +19,6 @@
 	}
 
 	let { source, networkId, children }: Props = $props();
-
-	const { store } = getContext<AllUtxosContext>(ALL_UTXOS_CONTEXT_KEY);
 
 	const loadAllUtxos = async () => {
 		if (isNullish(networkId)) {
@@ -41,13 +39,13 @@
 			minConfirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 		});
 
-		store.setAllUtxos({ allUtxos });
+		allUtxosStore.setAllUtxos({ allUtxos });
 	};
 
 	$effect(() => {
 		[source, networkId];
 
-		untrack(() => loadAllUtxos());
+		untrack(() => isNullish($allUtxosStore?.allUtxos) && loadAllUtxos());
 	});
 </script>
 

--- a/src/frontend/src/btc/components/fee/FeeRatePercentilesLoader.svelte
+++ b/src/frontend/src/btc/components/fee/FeeRatePercentilesLoader.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
-	import { getContext, type Snippet, untrack } from 'svelte';
+	import { type Snippet, untrack } from 'svelte';
 	import { getFeeRateFromPercentiles } from '$btc/services/btc-utxos.service';
-	import {
-		FEE_RATE_PERCENTILES_CONTEXT_KEY,
-		type FeeRatePercentilesContext
-	} from '$btc/stores/fee-rate-percentiles.store';
+	import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import type { NetworkId } from '$lib/types/network';
 	import { mapNetworkIdToBitcoinNetwork } from '$lib/utils/network.utils';
@@ -16,8 +13,6 @@
 	}
 
 	let { networkId, children }: Props = $props();
-
-	const { store } = getContext<FeeRatePercentilesContext>(FEE_RATE_PERCENTILES_CONTEXT_KEY);
 
 	const loadFeeRateFromPercentiles = async () => {
 		if (isNullish(networkId)) {
@@ -35,13 +30,16 @@
 			network
 		});
 
-		store.setFeeRateFromPercentiles({ feeRateFromPercentiles });
+		feeRatePercentilesStore.setFeeRateFromPercentiles({ feeRateFromPercentiles });
 	};
 
 	$effect(() => {
 		[networkId];
 
-		untrack(() => loadFeeRateFromPercentiles());
+		untrack(
+			() =>
+				isNullish($feeRatePercentilesStore?.feeRateFromPercentiles) && loadFeeRateFromPercentiles()
+		);
 	});
 </script>
 

--- a/src/frontend/src/btc/components/fee/UtxosFeeContexts.svelte
+++ b/src/frontend/src/btc/components/fee/UtxosFeeContexts.svelte
@@ -1,16 +1,6 @@
 <script lang="ts">
 	import { setContext, type Snippet } from 'svelte';
 	import {
-		ALL_UTXOS_CONTEXT_KEY,
-		type AllUtxosContext as AllUtxosContextType,
-		initAllUtxosStore
-	} from '$btc/stores/all-utxos.store';
-	import {
-		FEE_RATE_PERCENTILES_CONTEXT_KEY,
-		type FeeRatePercentilesContext as FeeRatePercentilesContextType,
-		initFeeRatePercentilesStore
-	} from '$btc/stores/fee-rate-percentiles.store';
-	import {
 		UTXOS_FEE_CONTEXT_KEY,
 		type UtxosFeeContext as UtxosFeeContextType,
 		initUtxosFeeStore
@@ -21,14 +11,6 @@
 	}
 
 	let { children }: Props = $props();
-
-	setContext<AllUtxosContextType>(ALL_UTXOS_CONTEXT_KEY, {
-		store: initAllUtxosStore()
-	});
-
-	setContext<FeeRatePercentilesContextType>(FEE_RATE_PERCENTILES_CONTEXT_KEY, {
-		store: initFeeRatePercentilesStore()
-	});
 
 	setContext<UtxosFeeContextType>(UTXOS_FEE_CONTEXT_KEY, {
 		store: initUtxosFeeStore()

--- a/src/frontend/src/btc/components/fee/UtxosFeeLoader.svelte
+++ b/src/frontend/src/btc/components/fee/UtxosFeeLoader.svelte
@@ -2,19 +2,13 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext, type Snippet, untrack } from 'svelte';
 	import AllUtxosLoader from '$btc/components/fee/AllUtxosLoader.svelte';
+	import BtcPendingSentTransactionsLoader from '$btc/components/fee/BtcPendingSentTransactionsLoader.svelte';
 	import FeeRatePercentilesLoader from '$btc/components/fee/FeeRatePercentilesLoader.svelte';
 	import { DEFAULT_BTC_AMOUNT_FOR_UTXOS_FEE } from '$btc/constants/btc.constants';
-	import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
 	import { prepareBtcSend } from '$btc/services/btc-utxos.service';
-	import {
-		ALL_UTXOS_CONTEXT_KEY,
-		type AllUtxosContext as AllUtxosContextType
-	} from '$btc/stores/all-utxos.store';
+	import { allUtxosStore } from '$btc/stores/all-utxos.store';
 	import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
-	import {
-		FEE_RATE_PERCENTILES_CONTEXT_KEY,
-		type FeeRatePercentilesContext as FeeRatePercentilesContextType
-	} from '$btc/stores/fee-rate-percentiles.store';
+	import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 	import {
 		UTXOS_FEE_CONTEXT_KEY,
 		type UtxosFeeContext as UtxosFeeContextType
@@ -35,12 +29,6 @@
 	let { source, amount, networkId, amountError = false, children }: Props = $props();
 
 	const { store } = getContext<UtxosFeeContextType>(UTXOS_FEE_CONTEXT_KEY);
-
-	const { store: allUtxosStore } = getContext<AllUtxosContextType>(ALL_UTXOS_CONTEXT_KEY);
-
-	const { store: feeRatePercentilesStore } = getContext<FeeRatePercentilesContextType>(
-		FEE_RATE_PERCENTILES_CONTEXT_KEY
-	);
 
 	let allUtxos = $derived($allUtxosStore?.allUtxos);
 	let feeRateFromPercentiles = $derived($feeRatePercentilesStore?.feeRateFromPercentiles);
@@ -92,18 +80,6 @@
 	};
 
 	$effect(() => {
-		[networkId, source];
-
-		untrack(() =>
-			loadBtcPendingSentTransactions({
-				identity: $authIdentity,
-				networkId,
-				address: source
-			})
-		);
-	});
-
-	$effect(() => {
 		[amount, networkId, source];
 
 		if (
@@ -116,8 +92,10 @@
 	});
 </script>
 
-<AllUtxosLoader {networkId} {source}>
-	<FeeRatePercentilesLoader {networkId}>
-		{@render children()}
-	</FeeRatePercentilesLoader>
-</AllUtxosLoader>
+<BtcPendingSentTransactionsLoader {networkId} {source}>
+	<AllUtxosLoader {networkId} {source}>
+		<FeeRatePercentilesLoader {networkId}>
+			{@render children()}
+		</FeeRatePercentilesLoader>
+	</AllUtxosLoader>
+</BtcPendingSentTransactionsLoader>

--- a/src/frontend/src/btc/stores/all-utxos.store.ts
+++ b/src/frontend/src/btc/stores/all-utxos.store.ts
@@ -27,8 +27,4 @@ export const initAllUtxosStore = (): AllUtxosStore => {
 	};
 };
 
-export interface AllUtxosContext {
-	store: AllUtxosStore;
-}
-
-export const ALL_UTXOS_CONTEXT_KEY = Symbol('all-utxos');
+export const allUtxosStore = initAllUtxosStore();

--- a/src/frontend/src/btc/stores/fee-rate-percentiles.store.ts
+++ b/src/frontend/src/btc/stores/fee-rate-percentiles.store.ts
@@ -26,8 +26,4 @@ export const initFeeRatePercentilesStore = (): FeeRatePercentilesStore => {
 	};
 };
 
-export interface FeeRatePercentilesContext {
-	store: FeeRatePercentilesStore;
-}
-
-export const FEE_RATE_PERCENTILES_CONTEXT_KEY = Symbol('fee-rate-percentiles');
+export const feeRatePercentilesStore = initFeeRatePercentilesStore();

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import UtxosFeeContexts from '$btc/components/fee/UtxosFeeContexts.svelte';
 	import UtxosFeeLoader from '$btc/components/fee/UtxosFeeLoader.svelte';
 	import { selectedEthereumNetwork } from '$eth/derived/network.derived';
 	import { nativeEthereumTokenWithFallback } from '$eth/derived/token.derived';
@@ -92,15 +93,17 @@
 				sourceNetwork={$selectedEvmNetwork ?? $sendToken.network}
 			/>
 		{:else if isNetworkIdBitcoin($sendTokenNetworkId)}
-			<UtxosFeeLoader {amount} networkId={$sendTokenNetworkId} source={destination}>
-				<AiAssistantReviewSendBtcToken
-					{amount}
-					{destination}
-					{onSendCompleted}
-					{sendCompleted}
-					{sendEnabled}
-				/>
-			</UtxosFeeLoader>
+			<UtxosFeeContexts>
+				<UtxosFeeLoader {amount} networkId={$sendTokenNetworkId} source={destination}>
+					<AiAssistantReviewSendBtcToken
+						{amount}
+						{destination}
+						{onSendCompleted}
+						{sendCompleted}
+						{sendEnabled}
+					/>
+				</UtxosFeeLoader>
+			</UtxosFeeContexts>
 		{:else if isNetworkIdSolana($sendToken.network.id)}
 			<AiAssistantReviewSendSolToken
 				{amount}

--- a/src/frontend/src/tests/btc/components/convert/BtcConvertForm.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertForm.spec.ts
@@ -1,10 +1,8 @@
 import BtcConvertForm from '$btc/components/convert/BtcConvertForm.svelte';
 import * as btcPendingSendTransactionsStatusStore from '$btc/derived/btc-pending-sent-transactions-status.derived';
-import { ALL_UTXOS_CONTEXT_KEY, initAllUtxosStore } from '$btc/stores/all-utxos.store';
-import {
-	FEE_RATE_PERCENTILES_CONTEXT_KEY,
-	initFeeRatePercentilesStore
-} from '$btc/stores/fee-rate-percentiles.store';
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import {
 	UTXOS_FEE_CONTEXT_KEY,
 	initUtxosFeeStore,
@@ -32,8 +30,6 @@ describe('BtcConvertForm', () => {
 	}) =>
 		new Map([
 			[UTXOS_FEE_CONTEXT_KEY, { store: utxosFeeStore }],
-			[ALL_UTXOS_CONTEXT_KEY, { store: initAllUtxosStore() }],
-			[FEE_RATE_PERCENTILES_CONTEXT_KEY, { store: initFeeRatePercentilesStore() }],
 			[
 				CONVERT_CONTEXT_KEY,
 				{
@@ -72,6 +68,10 @@ describe('BtcConvertForm', () => {
 		mockPage.reset();
 		store = initUtxosFeeStore();
 		store.reset();
+
+		allUtxosStore.reset();
+		feeRatePercentilesStore.reset();
+		btcPendingSentTransactionsStore.reset();
 	});
 
 	it('should keep the next button clickable if all requirements are met', () => {

--- a/src/frontend/src/tests/btc/components/fee/FeeRatePercentilesLoader.spec.ts
+++ b/src/frontend/src/tests/btc/components/fee/FeeRatePercentilesLoader.spec.ts
@@ -1,10 +1,6 @@
 import FeeRatePercentilesLoader from '$btc/components/fee/FeeRatePercentilesLoader.svelte';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
-import {
-	FEE_RATE_PERCENTILES_CONTEXT_KEY,
-	initFeeRatePercentilesStore,
-	type FeeRatePercentilesStore
-} from '$btc/stores/fee-rate-percentiles.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
@@ -12,20 +8,16 @@ import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 
 describe('FeeRatePercentilesLoader', () => {
 	const networkId = BTC_MAINNET_NETWORK_ID;
 	const mockFeeRateFromPercentiles = 5000n;
 
-	const mockContext = (store: FeeRatePercentilesStore) =>
-		new Map([[FEE_RATE_PERCENTILES_CONTEXT_KEY, { store }]]);
-
 	const mockGetFeeRateFromPercentiles = () =>
 		vi
 			.spyOn(btcUtxosService, 'getFeeRateFromPercentiles')
 			.mockResolvedValue(mockFeeRateFromPercentiles);
-
-	let store: FeeRatePercentilesStore;
 
 	const props = {
 		networkId,
@@ -36,28 +28,24 @@ describe('FeeRatePercentilesLoader', () => {
 		vi.clearAllMocks();
 
 		mockPage.reset();
-		store = initFeeRatePercentilesStore();
+		feeRatePercentilesStore.reset();
 	});
 
 	it('should call getFeeRateFromPercentiles and set store with proper params', async () => {
-		const setFeeRateFromPercentilesSpy = vi.spyOn(store, 'setFeeRateFromPercentiles');
 		const getFeeRateFromPercentilesSpy = mockGetFeeRateFromPercentiles();
 
 		mockAuthStore();
 
-		render(FeeRatePercentilesLoader, {
-			props,
-			context: mockContext(store)
-		});
+		render(FeeRatePercentilesLoader, { props });
 
 		await waitFor(() => {
 			expect(getFeeRateFromPercentilesSpy).toHaveBeenCalledExactlyOnceWith({
 				identity: mockIdentity,
 				network: 'mainnet'
 			});
-			expect(setFeeRateFromPercentilesSpy).toHaveBeenCalledExactlyOnceWith({
-				feeRateFromPercentiles: mockFeeRateFromPercentiles
-			});
+			expect(get(feeRatePercentilesStore)?.feeRateFromPercentiles).toEqual(
+				mockFeeRateFromPercentiles
+			);
 		});
 	});
 
@@ -67,10 +55,7 @@ describe('FeeRatePercentilesLoader', () => {
 
 		mockAuthStore();
 
-		render(FeeRatePercentilesLoader, {
-			props: newProps,
-			context: mockContext(store)
-		});
+		render(FeeRatePercentilesLoader, { props: newProps });
 
 		await waitFor(() => {
 			expect(getFeeRateFromPercentilesSpy).not.toHaveBeenCalled();
@@ -83,8 +68,7 @@ describe('FeeRatePercentilesLoader', () => {
 		mockAuthStore();
 
 		render(FeeRatePercentilesLoader, {
-			props: { ...props, networkId: ICP_NETWORK_ID },
-			context: mockContext(store)
+			props: { ...props, networkId: ICP_NETWORK_ID }
 		});
 
 		await waitFor(() => {
@@ -97,10 +81,23 @@ describe('FeeRatePercentilesLoader', () => {
 
 		mockAuthStore(null);
 
-		render(FeeRatePercentilesLoader, {
-			props,
-			context: mockContext(store)
+		render(FeeRatePercentilesLoader, { props });
+
+		await waitFor(() => {
+			expect(getFeeRateFromPercentilesSpy).not.toHaveBeenCalled();
 		});
+	});
+
+	it('should not call getFeeRateFromPercentiles if store already has data', async () => {
+		feeRatePercentilesStore.setFeeRateFromPercentiles({
+			feeRateFromPercentiles: mockFeeRateFromPercentiles
+		});
+
+		const getFeeRateFromPercentilesSpy = mockGetFeeRateFromPercentiles();
+
+		mockAuthStore();
+
+		render(FeeRatePercentilesLoader, { props });
 
 		await waitFor(() => {
 			expect(getFeeRateFromPercentilesSpy).not.toHaveBeenCalled();

--- a/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
@@ -1,16 +1,9 @@
 import BtcSendTokenWizard from '$btc/components/send/BtcSendTokenWizard.svelte';
-import * as btcPendingSentTransactionsStore from '$btc/services/btc-pending-sent-transactions.services';
+import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
-import {
-	ALL_UTXOS_CONTEXT_KEY,
-	initAllUtxosStore,
-	type AllUtxosContext
-} from '$btc/stores/all-utxos.store';
-import {
-	FEE_RATE_PERCENTILES_CONTEXT_KEY,
-	initFeeRatePercentilesStore,
-	type FeeRatePercentilesContext
-} from '$btc/stores/fee-rate-percentiles.store';
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import * as utxosFeeStore from '$btc/stores/utxos-fee.store';
 import {
 	UTXOS_FEE_CONTEXT_KEY,
@@ -51,10 +44,8 @@ describe('BtcSendTokenWizard', () => {
 		token?: Token;
 		mockUtxosFeeStore: UtxosFeeStore;
 	}) =>
-		new Map<symbol, SendContext | UtxosFeeContext | AllUtxosContext | FeeRatePercentilesContext>([
+		new Map<symbol, SendContext | UtxosFeeContext>([
 			[UTXOS_FEE_CONTEXT_KEY, { store: mockUtxosFeeStore }],
-			[ALL_UTXOS_CONTEXT_KEY, { store: initAllUtxosStore() }],
-			[FEE_RATE_PERCENTILES_CONTEXT_KEY, { store: initFeeRatePercentilesStore() }],
 			[SEND_CONTEXT_KEY, initSendContext({ token })]
 		]);
 
@@ -92,9 +83,9 @@ describe('BtcSendTokenWizard', () => {
 			.spyOn(addressesStore, 'btcAddressMainnet', 'get')
 			.mockImplementation(() => readable(mockBtcAddress));
 
-	const mockBtcPendingSentTransactionsStore = () =>
+	const mockLoadBtcPendingSentTransactions = () =>
 		vi
-			.spyOn(btcPendingSentTransactionsStore, 'loadBtcPendingSentTransactions')
+			.spyOn(btcPendingSentTransactionsServices, 'loadBtcPendingSentTransactions')
 			.mockResolvedValue({ success: true });
 
 	const mockUtxosFeeStoreWithValue = (utxosFee?: UtxosFee) => {
@@ -114,7 +105,11 @@ describe('BtcSendTokenWizard', () => {
 		vi.clearAllMocks();
 
 		mockPage.reset();
-		mockBtcPendingSentTransactionsStore();
+		mockLoadBtcPendingSentTransactions();
+
+		allUtxosStore.reset();
+		feeRatePercentilesStore.reset();
+		btcPendingSentTransactionsStore.reset();
 
 		vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
 			feeSatoshis: mockUtxosFee.feeSatoshis,

--- a/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.spec.ts
+++ b/src/frontend/src/tests/lib/components/ai-assistant/AiAssistantReviewSendTokenTool.spec.ts
@@ -1,14 +1,8 @@
+import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
-import {
-	ALL_UTXOS_CONTEXT_KEY,
-	initAllUtxosStore,
-	type AllUtxosContext
-} from '$btc/stores/all-utxos.store';
-import {
-	FEE_RATE_PERCENTILES_CONTEXT_KEY,
-	initFeeRatePercentilesStore,
-	type FeeRatePercentilesContext
-} from '$btc/stores/fee-rate-percentiles.store';
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import {
 	UTXOS_FEE_CONTEXT_KEY,
 	initUtxosFeeStore,
@@ -31,11 +25,9 @@ import { render } from '@testing-library/svelte';
 
 describe('AiAssistantReviewSendTokenTool', () => {
 	const mockContext = (token: Token) =>
-		new Map<symbol, SendContext | UtxosFeeContext | AllUtxosContext | FeeRatePercentilesContext>([
+		new Map<symbol, SendContext | UtxosFeeContext>([
 			[SEND_CONTEXT_KEY, initSendContext({ token })],
-			[UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() }],
-			[ALL_UTXOS_CONTEXT_KEY, { store: initAllUtxosStore() }],
-			[FEE_RATE_PERCENTILES_CONTEXT_KEY, { store: initFeeRatePercentilesStore() }]
+			[UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() }]
 		]);
 
 	const props = {
@@ -49,6 +41,10 @@ describe('AiAssistantReviewSendTokenTool', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
+		allUtxosStore.reset();
+		feeRatePercentilesStore.reset();
+		btcPendingSentTransactionsStore.reset();
+
 		vi.spyOn(solanaApi, 'estimatePriorityFee').mockResolvedValue(ZERO);
 		vi.spyOn(bitcoinApi, 'getUtxosQuery').mockResolvedValue({
 			utxos: [],
@@ -57,6 +53,10 @@ describe('AiAssistantReviewSendTokenTool', () => {
 			next_page: []
 		});
 		vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
+		vi.spyOn(
+			btcPendingSentTransactionsServices,
+			'loadBtcPendingSentTransactions'
+		).mockResolvedValue({ success: true });
 	});
 
 	it('renders correctly for a BTC token', () => {

--- a/src/frontend/src/tests/lib/components/convert/ConvertModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertModal.spec.ts
@@ -1,9 +1,8 @@
+import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
-import { ALL_UTXOS_CONTEXT_KEY, initAllUtxosStore } from '$btc/stores/all-utxos.store';
-import {
-	FEE_RATE_PERCENTILES_CONTEXT_KEY,
-	initFeeRatePercentilesStore
-} from '$btc/stores/fee-rate-percentiles.store';
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import { UTXOS_FEE_CONTEXT_KEY, initUtxosFeeStore } from '$btc/stores/utxos-fee.store';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
@@ -21,6 +20,10 @@ describe('ConvertModal', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
+		allUtxosStore.reset();
+		feeRatePercentilesStore.reset();
+		btcPendingSentTransactionsStore.reset();
+
 		vi.spyOn(bitcoinApi, 'getUtxosQuery').mockResolvedValue({
 			utxos: [],
 			tip_block_hash: new Uint8Array(),
@@ -28,16 +31,16 @@ describe('ConvertModal', () => {
 			next_page: []
 		});
 		vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
+		vi.spyOn(
+			btcPendingSentTransactionsServices,
+			'loadBtcPendingSentTransactions'
+		).mockResolvedValue({ success: true });
 	});
 
 	it('should display correct modal title after navigating between steps', async () => {
 		const { container, getByText, getByTestId } = render(ConvertModal, {
 			props,
-			context: new Map([
-				[UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() }],
-				[ALL_UTXOS_CONTEXT_KEY, { store: initAllUtxosStore() }],
-				[FEE_RATE_PERCENTILES_CONTEXT_KEY, { store: initFeeRatePercentilesStore() }]
-			])
+			context: new Map([[UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() }]])
 		});
 
 		const firstStepTitle = 'Convert BTC → ICP';

--- a/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/convert/ConvertWizard.spec.ts
@@ -1,14 +1,8 @@
+import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
-import {
-	ALL_UTXOS_CONTEXT_KEY,
-	initAllUtxosStore,
-	type AllUtxosContext
-} from '$btc/stores/all-utxos.store';
-import {
-	FEE_RATE_PERCENTILES_CONTEXT_KEY,
-	initFeeRatePercentilesStore,
-	type FeeRatePercentilesContext
-} from '$btc/stores/fee-rate-percentiles.store';
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import {
 	UTXOS_FEE_CONTEXT_KEY,
 	initUtxosFeeStore,
@@ -82,16 +76,9 @@ describe('ConvertWizard', () => {
 	const mockContext = (sourceToken: Token) =>
 		new Map<
 			symbol,
-			| UtxosFeeContext
-			| AllUtxosContext
-			| FeeRatePercentilesContext
-			| EthFeeContext
-			| ConvertContext
-			| TokenActionValidationErrorsContext
+			UtxosFeeContext | EthFeeContext | ConvertContext | TokenActionValidationErrorsContext
 		>([
 			[UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() }],
-			[ALL_UTXOS_CONTEXT_KEY, { store: initAllUtxosStore() }],
-			[FEE_RATE_PERCENTILES_CONTEXT_KEY, { store: initFeeRatePercentilesStore() }],
 			[
 				ETH_FEE_CONTEXT_KEY,
 				initEthFeeContext({
@@ -109,6 +96,10 @@ describe('ConvertWizard', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
+		allUtxosStore.reset();
+		feeRatePercentilesStore.reset();
+		btcPendingSentTransactionsStore.reset();
+
 		vi.spyOn(bitcoinApi, 'getUtxosQuery').mockResolvedValue({
 			utxos: [],
 			tip_block_hash: new Uint8Array(),
@@ -116,6 +107,10 @@ describe('ConvertWizard', () => {
 			next_page: []
 		});
 		vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
+		vi.spyOn(
+			btcPendingSentTransactionsServices,
+			'loadBtcPendingSentTransactions'
+		).mockResolvedValue({ success: true });
 
 		mockPage.reset();
 	});


### PR DESCRIPTION
# Motivation

To prevent utxos data being lost on Wizard steps change, we need to switch from contexts to global stores in BTC send/convert flows.
