### PR TITLE
feat(frontend): implement resetUtxosDataStores util

### DIFF
--- a/src/frontend/src/btc/utils/btc-utxos.utils.ts
+++ b/src/frontend/src/btc/utils/btc-utxos.utils.ts
@@ -1,3 +1,6 @@
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import { utxoTxIdToString } from '$icp/utils/btc.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { CkBtcMinterDid } from '@icp-sdk/canisters/ckbtc';
@@ -160,4 +163,10 @@ export const filterAvailableUtxos = ({
 		utxos: confirmedUtxos,
 		pendingUtxoTxIds
 	});
+};
+
+export const resetUtxosDataStores = (): void => {
+	btcPendingSentTransactionsStore.reset();
+	allUtxosStore.reset();
+	feeRatePercentilesStore.reset();
 };

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -1,14 +1,19 @@
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import {
 	calculateUtxoSelection,
 	estimateTransactionSize,
 	extractUtxoTxIds,
 	filterAvailableUtxos,
 	filterLockedUtxos,
+	resetUtxosDataStores,
 	type UtxoSelectionResult
 } from '$btc/utils/btc-utxos.utils';
 import { utxoTxIdToString } from '$icp/utils/btc.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { CkBtcMinterDid } from '@icp-sdk/canisters/ckbtc';
+import { get } from 'svelte/store';
 
 describe('btc-utxos.utils', () => {
 	const createMockUtxo = ({
@@ -407,6 +412,37 @@ describe('btc-utxos.utils', () => {
 
 			expect(calculatedFee).toBe(ZERO);
 			expect(selection.feeSatoshis).toBe(ZERO);
+		});
+	});
+
+	describe('resetUtxosDataStores', () => {
+		beforeEach(() => {
+			allUtxosStore.reset();
+			feeRatePercentilesStore.reset();
+			btcPendingSentTransactionsStore.reset();
+		});
+
+		it('should reset all UTXO-related stores', () => {
+			allUtxosStore.setAllUtxos({
+				allUtxos: [createMockUtxo({ value: 100_000 })]
+			});
+			feeRatePercentilesStore.setFeeRateFromPercentiles({
+				feeRateFromPercentiles: 5000n
+			});
+			btcPendingSentTransactionsStore.setPendingTransactions({
+				address: 'test-address',
+				pendingTransactions: []
+			});
+
+			expect(get(allUtxosStore)?.allUtxos).toBeDefined();
+			expect(get(feeRatePercentilesStore)?.feeRateFromPercentiles).toBeDefined();
+			expect(get(btcPendingSentTransactionsStore)['test-address']).toBeDefined();
+
+			resetUtxosDataStores();
+
+			expect(get(allUtxosStore)).toBeNull();
+			expect(get(feeRatePercentilesStore)).toBeNull();
+			expect(get(btcPendingSentTransactionsStore)).toEqual({});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We need to create a util that is going to reset all utxos-related stores. 
