### PR TITLE
refactor(frontend): Split cleaning IDB storage from deleting them

### DIFF
--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -217,10 +217,7 @@ const clearIdbStoreList = [
 	clearIdbIcTransactions,
 	clearIdbSolTransactions,
 	// Balances
-	clearIdbBalances,
-	// Delete all possible OISY-related indexedDB
-	// We should clear them first, since the deletion may not be supported in the current browser
-	deleteIdbAllOisyRelated
+	clearIdbBalances
 ];
 
 // eslint-disable-next-line require-await
@@ -257,6 +254,10 @@ const logout = async ({
 
 	if (clearIdbStorages) {
 		await Promise.all(clearIdbStoreList.map(clearIdbStore));
+
+		// Delete all possible OISY-related indexedDB
+		// We should clear them first, since the deletion may not be supported in the current browser
+		await clearIdbStore(deleteIdbAllOisyRelated);
 	}
 
 	try {


### PR DESCRIPTION
# Motivation

Just to keep split asynchronicity, we split the calls to clean the IDB storage and to delete it.
