### PR TITLE
feat(frontend): Use clean-cache search param when reloading

### DIFF
--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -26,7 +26,7 @@ import {
 	TRACK_SIGN_OUT_SUCCESS,
 	TRACK_SIGN_OUT_WITH_WARNING
 } from '$lib/constants/analytics.constants';
-import { PARAM_LEVEL, PARAM_MSG } from '$lib/constants/routes.constants';
+import { PARAM_DELETE_IDB_CACHE, PARAM_LEVEL, PARAM_MSG } from '$lib/constants/routes.constants';
 import { trackEvent } from '$lib/services/analytics.services';
 import {
 	authLoggedInAnotherTabStore,
@@ -310,8 +310,18 @@ const appendMsgToUrl = (msg: ToastMsg) => {
 /**
  * If the url contains a msg that has been provided on logout, display it as a toast message. Clean up the url afterwards - we don't want the user to see the message again if reloads the browser
  */
-export const displayAndCleanLogoutMsg = () => {
+export const displayAndCleanLogoutMsg = async () => {
 	const urlParams: URLSearchParams = new URLSearchParams(window.location.search);
+
+	const deleteIdbCache: string | null = urlParams.get(PARAM_DELETE_IDB_CACHE);
+
+	if (deleteIdbCache === 'true') {
+		try {
+			await deleteIdbAllOisyRelated();
+		} catch (err: unknown) {
+			console.error('Error deleting cache after logout', err);
+		}
+	}
 
 	const msg: string | null = urlParams.get(PARAM_MSG);
 
@@ -332,6 +342,7 @@ const cleanUpMsgUrl = () => {
 
 	url.searchParams.delete(PARAM_MSG);
 	url.searchParams.delete(PARAM_LEVEL);
+	url.searchParams.delete(PARAM_DELETE_IDB_CACHE);
 
 	replaceHistory(url);
 };

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -72,7 +72,7 @@
 			});
 		}
 
-		displayAndCleanLogoutMsg();
+		await displayAndCleanLogoutMsg();
 	};
 
 	/**


### PR DESCRIPTION
# Motivation

When loading the page, we analyze if we have specific search params in the URL, that are used for example to display a toast message.

We can add the analysis to check if we should clean the IDB cache.

Note that we do not really care if it fails.
