### PR TITLE
refactor(frontend): Optional token filter in service `loadNetworkCustomTokens`

### DIFF
--- a/src/frontend/src/lib/services/custom-tokens.services.ts
+++ b/src/frontend/src/lib/services/custom-tokens.services.ts
@@ -140,7 +140,7 @@ export const loadNetworkCustomTokens = async ({
 			return cachedTokens.reduce<CustomToken[]>((acc, token) => {
 				const parsed = parsePrincipal(token);
 
-				return nonNullish(filterTokens) && filterTokens(parsed) ? [...acc, parsed] : acc;
+				return isNullish(filterTokens) || filterTokens(parsed) ? [...acc, parsed] : acc;
 			}, []);
 		}
 	}


### PR DESCRIPTION
# Motivation

Sometimes we don't need to filter the tokens in service `loadNetworkCustomTokens`. So we can make the param optional.
