### PR TITLE
refactor(frontend): Remove deprecated filter param in load custom tokens

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
@@ -129,7 +129,6 @@
 			// no need to raise the error, but we should reload the custom tokens, just to avoid that it is caused by outdated tokens
 			await loadNetworkCustomTokens({
 				identity: $authIdentity,
-				filterTokens: () => true,
 				certified: true
 			});
 		}

--- a/src/frontend/src/lib/services/custom-tokens.services.ts
+++ b/src/frontend/src/lib/services/custom-tokens.services.ts
@@ -19,8 +19,7 @@ type LoadCustomTokensParams = LoadCustomTokensFromBackendParams & {
 
 const loadCustomTokensFromBackend = async ({
 	identity,
-	certified,
-	filterTokens
+	certified
 }: LoadCustomTokensFromBackendParams): Promise<CustomToken[]> => {
 	const tokens = await listCustomTokens({
 		identity,
@@ -35,18 +34,12 @@ const loadCustomTokensFromBackend = async ({
 		await setIdbAllCustomTokens({ identity, tokens });
 	}
 
-	if (isNullish(filterTokens)) {
-		return tokens;
-	}
-
-	// We filter the custom tokens, since the backend "Custom Token" potentially supports other types
-	return tokens.filter(filterTokens);
+	return tokens;
 };
 
 export const loadNetworkCustomTokens = async ({
 	identity,
 	certified,
-	filterTokens,
 	useCache = false
 }: LoadCustomTokensParams): Promise<CustomToken[]> => {
 	if (isNullish(identity)) {
@@ -136,17 +129,12 @@ export const loadNetworkCustomTokens = async ({
 				assertNever(token.token, `Unexpected token type: ${token.token}`);
 			};
 
-			return cachedTokens.reduce<CustomToken[]>((acc, token) => {
-				const parsed = parsePrincipal(token);
-
-				return isNullish(filterTokens) || filterTokens(parsed) ? [...acc, parsed] : acc;
-			}, []);
+			return cachedTokens.map(parsePrincipal);
 		}
 	}
 
 	return await loadCustomTokensFromBackend({
 		identity,
-		certified,
-		filterTokens
+		certified
 	});
 };

--- a/src/frontend/src/tests/lib/services/custom-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/custom-tokens.services.spec.ts
@@ -24,8 +24,7 @@ describe('custom-tokens.services', () => {
 
 		const mockParams = {
 			identity: mockIdentity,
-			certified: true,
-			filterTokens: () => true
+			certified: true
 		};
 
 		beforeEach(() => {
@@ -57,28 +56,10 @@ describe('custom-tokens.services', () => {
 			expect(get(backendCustomTokens)).toStrictEqual(mockCustomTokens);
 		});
 
-		it('should filter the custom tokens based on the provided filter function', async () => {
-			const result = await loadNetworkCustomTokens({
-				...mockParams,
-				filterTokens: ({ token }) => 'Icrc' in token
-			});
-
-			expect(result).toStrictEqual(mockCustomTokens.slice(0, 2));
-		});
-
 		it('should handle empty token list from the backend', async () => {
 			vi.mocked(listCustomTokens).mockResolvedValue([]);
 
 			const result = await loadNetworkCustomTokens(mockParams);
-
-			expect(result).toStrictEqual([]);
-		});
-
-		it('should handle empty list of filtered tokens', async () => {
-			const result = await loadNetworkCustomTokens({
-				...mockParams,
-				filterTokens: () => false
-			});
 
 			expect(result).toStrictEqual([]);
 		});
@@ -107,18 +88,6 @@ describe('custom-tokens.services', () => {
 			await loadNetworkCustomTokens(mockParams);
 
 			expect(mockSetIdbTokens).not.toHaveBeenCalled();
-		});
-
-		it('should always set the IDB tokens even if the filtered tokens are empty', async () => {
-			await loadNetworkCustomTokens({
-				...mockParams,
-				filterTokens: () => false
-			});
-
-			expect(mockSetIdbTokens).toHaveBeenCalledExactlyOnceWith({
-				identity: mockIdentity,
-				tokens: mockCustomTokens
-			});
 		});
 
 		it('should throw if listCustomTokens fails', async () => {


### PR DESCRIPTION
# Motivation

The param `filterTokens` of service `loadNetworkCustomTokens` is not used anymore.