### PR TITLE
refactor(frontend): Extract sub-service for update error in loading tokens

### DIFF
--- a/src/frontend/src/eth/services/erc1155.services.ts
+++ b/src/frontend/src/eth/services/erc1155.services.ts
@@ -56,14 +56,7 @@ export const loadCustomTokens = ({
 	queryAndUpdate<Erc1155CustomToken[]>({
 		request: (params) => loadCustomTokensWithMetadata({ ...params, useCache }),
 		onLoad: loadCustomTokenData,
-		onUpdateError: ({ error: err }) => {
-			erc1155CustomTokensStore.resetAll();
-
-			toastsError({
-				msg: { text: get(i18n).init.error.erc1155_custom_tokens },
-				err
-			});
-		},
+		onUpdateError,
 		identity
 	});
 
@@ -169,4 +162,13 @@ const loadCustomTokenData = ({
 	response: Erc1155CustomToken[];
 }) => {
 	erc1155CustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
+};
+
+const onUpdateError = ({ error: err }: { error: unknown }) => {
+	erc1155CustomTokensStore.resetAll();
+
+	toastsError({
+		msg: { text: get(i18n).init.error.erc1155_custom_tokens },
+		err
+	});
 };

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -87,14 +87,7 @@ export const loadCustomTokens = ({
 	queryAndUpdate<Erc20CustomToken[]>({
 		request: (params) => loadCustomTokensWithMetadata({ ...params, useCache }),
 		onLoad: loadCustomTokenData,
-		onUpdateError: ({ error: err }) => {
-			erc20CustomTokensStore.resetAll();
-
-			toastsError({
-				msg: { text: get(i18n).init.error.erc20_custom_tokens },
-				err
-			});
-		},
+		onUpdateError,
 		identity
 	});
 
@@ -221,4 +214,13 @@ const loadCustomTokenData = ({
 	response: Erc20CustomToken[];
 }) => {
 	erc20CustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
+};
+
+const onUpdateError = ({ error: err }: { error: unknown }) => {
+	erc20CustomTokensStore.resetAll();
+
+	toastsError({
+		msg: { text: get(i18n).init.error.erc20_custom_tokens },
+		err
+	});
 };

--- a/src/frontend/src/eth/services/erc721.services.ts
+++ b/src/frontend/src/eth/services/erc721.services.ts
@@ -56,14 +56,7 @@ export const loadCustomTokens = ({
 	queryAndUpdate<Erc721CustomToken[]>({
 		request: (params) => loadCustomTokensWithMetadata({ ...params, useCache }),
 		onLoad: loadCustomTokenData,
-		onUpdateError: ({ error: err }) => {
-			erc721CustomTokensStore.resetAll();
-
-			toastsError({
-				msg: { text: get(i18n).init.error.erc721_custom_tokens },
-				err
-			});
-		},
+		onUpdateError,
 		identity
 	});
 
@@ -169,4 +162,13 @@ const loadCustomTokenData = ({
 	response: Erc721CustomToken[];
 }) => {
 	erc721CustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
+};
+
+const onUpdateError = ({ error: err }: { error: unknown }) => {
+	erc721CustomTokensStore.resetAll();
+
+	toastsError({
+		msg: { text: get(i18n).init.error.erc721_custom_tokens },
+		err
+	});
 };

--- a/src/frontend/src/icp/services/ext.services.ts
+++ b/src/frontend/src/icp/services/ext.services.ts
@@ -37,14 +37,7 @@ export const loadCustomTokens = ({
 	queryAndUpdate<ExtCustomToken[]>({
 		request: (params) => loadCustomTokensWithMetadata({ ...params, useCache }),
 		onLoad: loadCustomTokenData,
-		onUpdateError: ({ error: err }) => {
-			extCustomTokensStore.resetAll();
-
-			toastsError({
-				msg: { text: get(i18n).init.error.ext_custom_tokens },
-				err
-			});
-		},
+		onUpdateError,
 		identity
 	});
 
@@ -116,4 +109,13 @@ const loadCustomTokenData = ({
 	response: ExtCustomToken[];
 }) => {
 	extCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
+};
+
+const onUpdateError = ({ error: err }: { error: unknown }) => {
+	extCustomTokensStore.resetAll();
+
+	toastsError({
+		msg: { text: get(i18n).init.error.ext_custom_tokens },
+		err
+	});
 };

--- a/src/frontend/src/icp/services/icpunks.services.ts
+++ b/src/frontend/src/icp/services/icpunks.services.ts
@@ -51,14 +51,7 @@ export const loadCustomTokens = ({
 	queryAndUpdate<IcPunksCustomToken[]>({
 		request: (params) => loadCustomTokensWithMetadata({ ...params, useCache }),
 		onLoad: loadCustomTokenData,
-		onUpdateError: ({ error: err }) => {
-			icPunksCustomTokensStore.resetAll();
-
-			toastsError({
-				msg: { text: get(i18n).init.error.icpunks_custom_tokens },
-				err
-			});
-		},
+		onUpdateError,
 		identity
 	});
 
@@ -134,4 +127,13 @@ const loadCustomTokenData = ({
 	response: IcPunksCustomToken[];
 }) => {
 	icPunksCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
+};
+
+const onUpdateError = ({ error: err }: { error: unknown }) => {
+	icPunksCustomTokensStore.resetAll();
+
+	toastsError({
+		msg: { text: get(i18n).init.error.icpunks_custom_tokens },
+		err
+	});
 };

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -96,14 +96,7 @@ const loadDefaultIcrc = ({
 		request: (params) =>
 			requestIcrcMetadata({ ...params, ...data, ledgerCanisterId, category: 'default' }),
 		onLoad: loadIcrcData,
-		onUpdateError: ({ error: err }) => {
-			icrcDefaultTokensStore.reset(ledgerCanisterId);
-
-			trackEvent({
-				name: TRACK_COUNT_IC_LOADING_ICRC_CANISTER_ERROR,
-				metadata: { ...mapIcErrorMetadata(err), ledgerCanisterId }
-			});
-		},
+		onUpdateError: (params) => onUpdateError({ ...params, ledgerCanisterId }),
 		identity: new AnonymousIdentity()
 	});
 
@@ -266,6 +259,21 @@ const loadIcrcCustomData = ({
 	onSuccess?.();
 
 	icrcCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
+};
+
+const onUpdateError = ({
+	error: err,
+	ledgerCanisterId
+}: {
+	error: unknown;
+	ledgerCanisterId: LedgerCanisterIdText;
+}) => {
+	icrcDefaultTokensStore.reset(ledgerCanisterId);
+
+	trackEvent({
+		name: TRACK_COUNT_IC_LOADING_ICRC_CANISTER_ERROR,
+		metadata: { ...mapIcErrorMetadata(err), ledgerCanisterId }
+	});
 };
 
 // TODO: Refactor to use queryAndUpdate

--- a/src/frontend/src/sol/services/spl.services.ts
+++ b/src/frontend/src/sol/services/spl.services.ts
@@ -51,14 +51,7 @@ export const loadCustomTokens = ({
 	queryAndUpdate<SplCustomToken[]>({
 		request: (params) => loadCustomTokensWithMetadata({ ...params, useCache }),
 		onLoad: loadCustomTokenData,
-		onUpdateError: ({ error: err }) => {
-			splCustomTokensStore.resetAll();
-
-			toastsError({
-				msg: { text: get(i18n).init.error.spl_custom_tokens },
-				err
-			});
-		},
+		onUpdateError,
 		identity
 	});
 
@@ -182,6 +175,15 @@ const loadCustomTokenData = ({
 	response: SplCustomToken[];
 }) => {
 	splCustomTokensStore.setAll(tokens.map((token) => ({ data: token, certified })));
+};
+
+const onUpdateError = ({ error: err }: { error: unknown }) => {
+	splCustomTokensStore.resetAll();
+
+	toastsError({
+		msg: { text: get(i18n).init.error.spl_custom_tokens },
+		err
+	});
 };
 
 export const getSplMetadata = async ({


### PR DESCRIPTION
# Motivation

For re-usability, we can put the onUpdateError sub-service in a separate function when loading custom tokens.
