### PR TITLE
style(frontend): Change the width for the login legal disclaimer from 80 to 85

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -68,7 +68,7 @@
 
 	<span
 		class="mt-4 flex flex-col text-sm text-tertiary"
-		class:sm:w-80={!fullWidth}
+		class:sm:w-85={!fullWidth}
 		class:text-center={helpAlignment === 'center'}
 		class:w-full={fullWidth}
 	>


### PR DESCRIPTION
# Motivation

This line break bothers me
<img width="613" height="331" alt="image" src="https://github.com/user-attachments/assets/ef5113b0-3c21-40e7-a048-81f79df3d9bf" />

# Changes

- extend the allowed with from 80 to 85

# Tests
<img width="613" height="331" alt="image" src="https://github.com/user-attachments/assets/938eaff1-47bd-4f71-98f0-9c116993ae40" />

