### PR TITLE
feat(frontend): Scanner handles results per case

### DIFF
--- a/src/frontend/src/lib/components/scanner/ScannerCode.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerCode.svelte
@@ -21,10 +21,11 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { PAY_CONTEXT_KEY, type PayContext } from '$lib/stores/open-crypto-pay.store';
 	import type { QrStatus } from '$lib/types/qr-code';
+	import { ScannerResults } from '$lib/types/scanner';
 	import { prepareBasePayableTokens } from '$lib/utils/open-crypto-pay.utils';
 
 	interface Props {
-		onNext: () => void;
+		onNext: (results: ScannerResults) => void;
 	}
 
 	let { onNext }: Props = $props();
@@ -63,7 +64,7 @@
 
 			setAvailableTokens(tokensWithFees);
 
-			onNext();
+			onNext(ScannerResults.PAY);
 		} catch (_: unknown) {
 			error = $i18n.scanner.error.code_link_is_not_valid;
 		} finally {

--- a/src/frontend/src/lib/types/scanner.ts
+++ b/src/frontend/src/lib/types/scanner.ts
@@ -1,0 +1,3 @@
+export enum ScannerResults {
+	PAY = 'pay'
+}

--- a/src/frontend/src/tests/lib/components/scanner/ScannerCode.spec.ts
+++ b/src/frontend/src/tests/lib/components/scanner/ScannerCode.spec.ts
@@ -6,6 +6,7 @@ import en from '$lib/i18n/en.json';
 import * as openCryptoPayServices from '$lib/services/open-crypto-pay.services';
 import { PAY_CONTEXT_KEY } from '$lib/stores/open-crypto-pay.store';
 import type { OpenCryptoPayResponse, PayableTokenWithFees } from '$lib/types/open-crypto-pay';
+import { ScannerResults } from '$lib/types/scanner';
 import * as openCryptoPayUtils from '$lib/utils/open-crypto-pay.utils';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
@@ -249,8 +250,8 @@ describe('ScannerCode.svelte', () => {
 		await fireEvent.click(button);
 
 		await waitFor(() => {
-			expect(mockSetData).toHaveBeenCalledWith(mockApiResponse);
-			expect(mockOnNext).toHaveBeenCalled();
+			expect(mockSetData).toHaveBeenCalledExactlyOnceWith(mockApiResponse);
+			expect(mockOnNext).toHaveBeenCalledExactlyOnceWith(ScannerResults.PAY);
 		});
 	});
 
@@ -329,7 +330,7 @@ describe('ScannerCode.svelte', () => {
 			const button = screen.getByRole('button', { name: en.core.text.continue });
 			await fireEvent.click(button);
 			await waitFor(() => {
-				expect(openCryptoPayUtils.prepareBasePayableTokens).toHaveBeenCalledWith({
+				expect(openCryptoPayUtils.prepareBasePayableTokens).toHaveBeenCalledExactlyOnceWith({
 					transferAmounts: mockApiResponse.transferAmounts,
 					networks: [ETHEREUM_NETWORK],
 					availableTokens: [ETHEREUM_TOKEN]
@@ -346,7 +347,7 @@ describe('ScannerCode.svelte', () => {
 			const button = screen.getByRole('button', { name: en.core.text.continue });
 			await fireEvent.click(button);
 			await waitFor(() => {
-				expect(openCryptoPayServices.calculateTokensWithFees).toHaveBeenCalledWith({
+				expect(openCryptoPayServices.calculateTokensWithFees).toHaveBeenCalledExactlyOnceWith({
 					tokens: mockBaseTokens,
 					userAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 				});
@@ -362,7 +363,7 @@ describe('ScannerCode.svelte', () => {
 			const button = screen.getByRole('button', { name: en.core.text.continue });
 			await fireEvent.click(button);
 			await waitFor(() => {
-				expect(mockSetsetAvailableTokens).toHaveBeenCalledWith(mockTokensWithFees);
+				expect(mockSetsetAvailableTokens).toHaveBeenCalledExactlyOnceWith(mockTokensWithFees);
 			});
 		});
 
@@ -400,8 +401,8 @@ describe('ScannerCode.svelte', () => {
 			const button = screen.getByRole('button', { name: en.core.text.continue });
 			await fireEvent.click(button);
 			await waitFor(() => {
-				expect(mockSetsetAvailableTokens).toHaveBeenCalledWith([]);
-				expect(mockOnNext).toHaveBeenCalled();
+				expect(mockSetsetAvailableTokens).toHaveBeenCalledExactlyOnceWith([]);
+				expect(mockOnNext).toHaveBeenCalledExactlyOnceWith(ScannerResults.PAY);
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

We want to expand the `Scanner` component to handle different types of URL/URI. For example, we want to add WalletConnect.

However, we first must adapt the component to possibly handle different kind of scan results.

For now, the only handled result is the payment flow.

# Changes

- Create enum for possible scanner results (only Payment).
- Adapt the callback of `Scanner` component.

# Tests

Adapted tests.
