### PR TITLE
fix(frontend): Do not raise an error when mapping ICRC custom tokens

### DIFF
--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -153,7 +153,7 @@ const loadCustomIcrcTokensData = async ({
 		const { enabled, version: v, token } = custom_token;
 
 		if (!('Icrc' in token)) {
-			throw new Error('Token is not Icrc');
+			return;
 		}
 
 		const {


### PR DESCRIPTION
# Motivation

Since we do not provide filtered custom tokens anymore to the loading-tokens services, we really don't need to raise an error for non ICRC tokens, in the ICRC custom tokens services.