### PR TITLE
feat(build): Use staging Chain Fusion Signer for staging env

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -13,16 +13,16 @@
 				"id": {
 					"ic": "grghe-syaaa-aaaar-qabyq-cai",
 					"beta": "grghe-syaaa-aaaar-qabyq-cai",
-					"test_be_1": "grghe-syaaa-aaaar-qabyq-cai",
-					"test_fe_1": "grghe-syaaa-aaaar-qabyq-cai",
-					"test_fe_2": "grghe-syaaa-aaaar-qabyq-cai",
-					"test_fe_3": "grghe-syaaa-aaaar-qabyq-cai",
-					"test_fe_4": "grghe-syaaa-aaaar-qabyq-cai",
-					"test_fe_5": "grghe-syaaa-aaaar-qabyq-cai",
-					"test_fe_6": "grghe-syaaa-aaaar-qabyq-cai",
-					"audit": "grghe-syaaa-aaaar-qabyq-cai",
-					"staging": "grghe-syaaa-aaaar-qabyq-cai",
-					"e2e": "grghe-syaaa-aaaar-qabyq-cai"
+					"test_be_1": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_1": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_2": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_3": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_4": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_5": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"test_fe_6": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"audit": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"staging": "tdxud-2yaaa-aaaad-aadiq-cai",
+					"e2e": "tdxud-2yaaa-aaaad-aadiq-cai"
 				}
 			}
 		},


### PR DESCRIPTION
# Motivation

In PR https://github.com/dfinity/oisy-wallet/pull/11316, we said that we should always use the production Chain Fusion Signer, because it is external to OISY codebase.

However, we found out that this does not work for **OISY Staging**.

After switching OISY Staging from staging CFS to prod CFS, BTC balances broke: the initial (query) balance is correct, but the certified balance returned by CFS is `0n`.

We verified other combinations:

- OISY Prod + prod CFS ✅
- OISY Beta (main) + prod CFS ✅
- OISY Staging + staging CFS ✅
- OISY Staging + prod CFS ❌

So the issue is specific to OISY Staging when using prod CFS, not BTC in general.

Since we need a working Staging for the release, we’re reverting the change and keeping: OISY Staging → staging CFS

We’ll investigate the prod-CFS incompatibility and BTC signer refactor after the release.
