### PR TITLE
refactor(frontend): Type `CustomTokenState` is agnostic to the other types

### DIFF
--- a/src/frontend/src/lib/types/token-toggleable.ts
+++ b/src/frontend/src/lib/types/token-toggleable.ts
@@ -1,14 +1,16 @@
 import type { CustomToken } from '$declarations/backend/backend.did';
-import type { NonFungibleTokenAppearance } from '$lib/types/nft-ui';
+import type { CustomTokenSection } from '$lib/enums/custom-token-section';
 import type { Token } from '$lib/types/token';
 
-// Type pick and omit fields to make the reader aware that we are redefining the two fields we are interested in.
+// Type pick and omit fields to make the reader aware that we are redefining the fields we are interested in.
 export type CustomTokenState = Omit<
-	Pick<CustomToken, 'version' | 'enabled'>,
-	'version' | 'enabled' | 'section' | 'allowExternalContentSource'
+	Pick<CustomToken, 'version' | 'enabled' | 'section' | 'allow_external_content_source'>,
+	'version' | 'enabled' | 'section' | 'allow_external_content_source'
 > & {
 	version?: bigint;
 	enabled: boolean;
-} & NonFungibleTokenAppearance;
+	section?: CustomTokenSection;
+	allowExternalContentSource?: boolean;
+};
 
 export type TokenToggleable<T extends Token> = T & CustomTokenState;


### PR DESCRIPTION
# Motivation

Type `CustomTokenState` is explicitly defined to clarify that we are re-defining the fields of backend type `CustomToken`.

So, it should be agnostic to what are the current types in the frontend: we replace `NonFungibleTokenAppearance` with its explicit definition.
