### PR TITLE
fix(frontend): Set idempotent URL params

### DIFF
--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -303,8 +303,8 @@ const appendMsgToUrl = ({ msg, deleteIdbCache }: { msg?: ToastMsg; deleteIdbCach
 	if (nonNullish(msg)) {
 		const { text, level } = msg;
 
-		url.searchParams.append(PARAM_MSG, encodeURI(text));
-		url.searchParams.append(PARAM_LEVEL, level);
+		url.searchParams.set(PARAM_MSG, encodeURI(text));
+		url.searchParams.set(PARAM_LEVEL, level);
 	}
 
 	if (deleteIdbCache) {


### PR DESCRIPTION
# Motivation

To be sure not to attach the wrong parameters to the URL, we should use the idempotent method `set` instead of `append`, se we can guarantee that any existing value is overwritten.
