### PR TITLE
feat(frontend): Prevent duplicate WalletConnect event handler registration

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -273,7 +273,15 @@
 		}
 	};
 
+	const attached = new WeakSet<WalletConnectListener>();
+
 	const attachHandlers = (listener: WalletConnectListener) => {
+		if (attached.has(listener)) {
+			return;
+		}
+
+		attached.add(listener);
+
 		listener.sessionProposal(onSessionProposal);
 
 		listener.sessionDelete(onSessionDelete);
@@ -282,6 +290,12 @@
 	};
 
 	const detachHandlers = (listener: WalletConnectListener) => {
+		if (!attached.has(listener)) {
+			return;
+		}
+
+		attached.delete(listener);
+
 		listener.offSessionProposal(onSessionProposal);
 
 		listener.offSessionDelete(onSessionDelete);


### PR DESCRIPTION
# Motivation

Adds an idempotent guard around WalletConnect listener handler attachment using a `WeakSet`.

This ensures session handlers are attached only once per listener instance and safely detached, preventing duplicate callbacks during reconnects or lifecycle transitions without changing existing behaviour.
