### PR TITLE
refactor(frontend): Use WalletConnect `proposal` store instead of passing it down

### DIFF
--- a/src/frontend/src/lib/components/transactions/Transactions.svelte
+++ b/src/frontend/src/lib/components/transactions/Transactions.svelte
@@ -23,14 +23,13 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsShow } from '$lib/stores/toasts.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { getPageTokenIdentifier } from '$lib/utils/nav.utils';
 	import SolTransactions from '$sol/components/transactions/SolTransactions.svelte';
 
 	let token = $derived(
 		$allTokens.find(
 			(token) =>
-				getPageTokenIdentifier(token) === $routeToken &&
-				nonNullish($routeNetwork) &&
+				token.name === $routeToken &&
+				$routeNetwork &&
 				token.network.id.description === $routeNetwork
 		)
 	);

--- a/src/frontend/src/lib/derived/page-token.derived.ts
+++ b/src/frontend/src/lib/derived/page-token.derived.ts
@@ -10,7 +10,6 @@ import { defaultFallbackToken } from '$lib/derived/token.derived';
 import { nativeTokens, nonFungibleTokens } from '$lib/derived/tokens.derived';
 import type { NonFungibleToken } from '$lib/types/nft';
 import type { OptionToken, OptionTokenStandardCode, Token } from '$lib/types/token';
-import { getPageTokenIdentifier } from '$lib/utils/nav.utils';
 import { findNonFungibleToken } from '$lib/utils/nfts.utils';
 import { enabledSplTokens } from '$sol/derived/spl.derived';
 import { isTokenSpl, isTokenSplCustomToken } from '$sol/utils/spl.utils';
@@ -25,9 +24,8 @@ export const pageToken: Readable<OptionToken> = derived(
 	([$routeToken, $routeNetwork, $nativeTokens, $erc20Tokens, $icrcTokens, $splTokens]) =>
 		nonNullish($routeToken)
 			? [...$nativeTokens, ...$erc20Tokens, ...$icrcTokens, ...$splTokens].find(
-					(token) =>
-						getPageTokenIdentifier(token) === $routeToken &&
-						token.network.id.description === $routeNetwork
+					({ name, network: { id: networkId } }) =>
+						name === $routeToken && networkId.description === $routeNetwork
 				)
 			: undefined
 );

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -3,14 +3,6 @@ import * as appNavigation from '$app/navigation';
 import { goto } from '$app/navigation';
 import { ETHEREUM_NETWORK, ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
-import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
-import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
-import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
-import { ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
-import { ETHEREUM_TOKEN, SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
-import { ICP_TOKEN, TESTICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import { SUPPORTED_SOLANA_TOKENS } from '$env/tokens/tokens.sol.env';
-import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
 import {
 	AppPath,
 	COLLECTION_PARAM,
@@ -22,10 +14,8 @@ import {
 	URI_PARAM
 } from '$lib/constants/routes.constants';
 import { userSelectedNetworkStore } from '$lib/stores/settings.store';
-import type { Token } from '$lib/types/token';
 import {
 	back,
-	getPageTokenIdentifier,
 	gotoReplaceRoot,
 	isActivityPath,
 	isDappExplorerPath,
@@ -57,19 +47,8 @@ import {
 	type RouteParams
 } from '$lib/utils/nav.utils';
 import { mapTokenToCollection } from '$lib/utils/nfts.utils';
-import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidErc1155Token } from '$tests/mocks/erc1155-tokens.mock';
-import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
-import { mockValidErc721Token } from '$tests/mocks/erc721-tokens.mock';
-import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
-import {
-	mockValidDip20Token,
-	mockValidIcCkToken,
-	mockValidIcrcToken
-} from '$tests/mocks/ic-tokens.mock';
-import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 import { mockValidErc1155Nft } from '$tests/mocks/nfts.mock';
-import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import type { LoadEvent, NavigationTarget, Page } from '@sveltejs/kit';
 import { get } from 'svelte/store';
@@ -831,80 +810,6 @@ describe('nav.utils', () => {
 			expect(url.searchParams.get(NETWORK_PARAM)).toBe(ETHEREUM_NETWORK.id.description);
 			expect(url.searchParams.get(COLLECTION_PARAM)).toBeNull();
 			expect(url.searchParams.get(NFT_PARAM)).toBeNull();
-		});
-	});
-
-	describe('getPageTokenIdentifier', () => {
-		it('should return the address for ERC tokens', () => {
-			const tokens = [
-				...ERC20_TWIN_TOKENS,
-				...EVM_ERC20_TOKENS,
-				mockValidErc20Token,
-				mockValidErc721Token,
-				mockValidErc1155Token
-			];
-
-			tokens.forEach((token) => {
-				expect(getPageTokenIdentifier(token)).toBe(token.address);
-			});
-		});
-
-		it('should return the address for SPL tokens', () => {
-			const tokens = [...SPL_TOKENS, mockValidSplToken];
-
-			tokens.forEach((token) => {
-				expect(getPageTokenIdentifier(token)).toBe(token.address);
-			});
-		});
-
-		it('should return the Ledger canister ID for IC tokens', () => {
-			const tokens = [
-				ICP_TOKEN,
-				TESTICP_TOKEN,
-				mockValidIcrcToken,
-				mockValidDip20Token,
-				mockValidIcCkToken
-			];
-
-			tokens.forEach((token) => {
-				expect(getPageTokenIdentifier(token)).toBe(token.ledgerCanisterId);
-			});
-		});
-
-		it('should return the canister ID for IC NFTs', () => {
-			const tokens = [mockValidExtV2Token, mockValidDip721Token, mockValidIcPunksToken];
-
-			tokens.forEach((token) => {
-				expect(getPageTokenIdentifier(token)).toBe(token.canisterId);
-			});
-		});
-
-		it('should return the symbol for native tokens', () => {
-			const tokens = [
-				...SUPPORTED_BITCOIN_TOKENS,
-				...SUPPORTED_ETHEREUM_TOKENS,
-				...SUPPORTED_EVM_TOKENS,
-				...SUPPORTED_SOLANA_TOKENS
-			];
-
-			tokens.forEach((token) => {
-				expect(getPageTokenIdentifier(token)).toBe(token.symbol);
-			});
-		});
-
-		it('should return the symbol for all other tokens', () => {
-			// @ts-expect-error we test this in purposes
-			const mockToken1: Token = { ...ICP_TOKEN, standard: { code: 'UNKNOWN_STANDARD' } };
-			const mockToken2: Token = {
-				...ETHEREUM_TOKEN,
-				// @ts-expect-error we test this in purposes
-				standard: { code: 'ANOTHER_UNKNOWN_STANDARD' }
-			};
-			const tokens = [mockToken1, mockToken2];
-
-			tokens.forEach((token) => {
-				expect(getPageTokenIdentifier(token)).toBe(token.symbol);
-			});
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/page.store.mock.ts
+++ b/src/frontend/src/tests/mocks/page.store.mock.ts
@@ -2,7 +2,7 @@ import { page } from '$app/state';
 import type { NetworkId } from '$lib/types/network';
 import type { Nft, NftCollection } from '$lib/types/nft';
 import type { Token } from '$lib/types/token';
-import { getPageTokenIdentifier, resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
+import { resetRouteParams, type RouteParams } from '$lib/utils/nav.utils';
 import type { Page } from '@sveltejs/kit';
 import { writable } from 'svelte/store';
 
@@ -39,11 +39,8 @@ const initPageStoreMock = () => {
 			set({ ...page, url });
 			page.url = url;
 		},
-		mockToken: (token: Token) => {
-			const {
-				network: { id: networkId }
-			} = token;
-			const data = { token: getPageTokenIdentifier(token), network: networkId.description };
+		mockToken: ({ name, network: { id: networkId } }: Token) => {
+			const data = { token: name, network: networkId.description };
 			set({ ...page, data });
 			page.data = data;
 		},


### PR DESCRIPTION
# Motivation

In component `WalletConnectReview` we can really use the WalletConnect `proposal` store, instead of passing the prop down.

That also allows us to reuse the entire WalletConnect wizard.
