### PR TITLE
fix(frontend): Persist value of custom nonce in ETH send flow

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendForm.svelte
+++ b/src/frontend/src/eth/components/send/EthSendForm.svelte
@@ -17,7 +17,6 @@
 	interface Props {
 		amount: OptionAmount;
 		destination?: string;
-		customNonce?: number;
 		nativeEthereumToken: Token;
 		selectedContact?: ContactUi;
 		onBack: () => void;
@@ -29,7 +28,6 @@
 	let {
 		amount = $bindable(),
 		destination = $bindable(''),
-		customNonce = $bindable(),
 		nativeEthereumToken,
 		selectedContact,
 		onBack,

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -49,7 +49,8 @@
 	 * Send context store
 	 */
 
-	const { sendTokenDecimals, sendTokenId, sendToken } = getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendTokenDecimals, sendTokenId, sendToken, sendEthCustomNonce } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	/**
 	 * Props
@@ -99,7 +100,7 @@
 		})
 	);
 
-	let customNonce = $state<number | undefined>();
+	let customNonce = $derived($sendEthCustomNonce);
 
 	/**
 	 * Fee context store
@@ -373,7 +374,6 @@
 				{onTokensList}
 				{selectedContact}
 				bind:destination
-				bind:customNonce
 				bind:amount
 			>
 				{#snippet cancel()}

--- a/src/frontend/src/lib/stores/send.store.ts
+++ b/src/frontend/src/lib/stores/send.store.ts
@@ -64,6 +64,11 @@ export const initSendContext = ({
 			$sendDestination === encodeIcrcAccount($sendToken.mintingAccount)
 	);
 
+	// WizardModal re-renders content on step change (e.g. when switching between SendForm to SendReview steps)
+	// So, the `customNonce` property cannot be passed between components because it is reset even if is `$bindable`
+	// To persist the value between components, we need to put it in a context outside the WizardModal
+	const sendEthCustomNonce = writable<number | undefined>();
+
 	return {
 		sendToken,
 		sendTokenDecimals,
@@ -74,7 +79,8 @@ export const initSendContext = ({
 		sendTokenNetworkId,
 		sendBalance,
 		sendDestination,
-		isIcBurning
+		isIcBurning,
+		sendEthCustomNonce
 	};
 };
 
@@ -89,6 +95,7 @@ export interface SendContext {
 	sendBalance: Readable<OptionBalance>;
 	sendDestination: Writable<Address>;
 	isIcBurning: Readable<boolean>;
+	sendEthCustomNonce: Writable<number | undefined>;
 }
 
 export const SEND_CONTEXT_KEY = Symbol('send');


### PR DESCRIPTION
# Motivation

Credits to @DenysKarmazynDFINITY 

The `WizardModal` re-renders content on step change (e.g. when switching between SendForm to SendReview steps).

So, the `customNonce` property cannot be passed between components because it is reset even if is `$bindable`.

To persist the value between components, we need to put it in a context outside the `WizardModal`.

NOTE: we are still not actively using this feature, but it is to get ready for the usage.