### PR TITLE
refactor(frontend): Move ck-ERC20 env variables to separate module

### DIFF
--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -1,53 +1,28 @@
-import { CKETH_EXPLORER_URL, CKETH_SEPOLIA_EXPLORER_URL } from '$env/explorers.env';
-import { EURC_TOKEN_GROUP } from '$env/tokens/groups/groups.eurc.env';
-import { LINK_TOKEN_GROUP } from '$env/tokens/groups/groups.link.env';
-import { OCT_TOKEN_GROUP } from '$env/tokens/groups/groups.oct.env';
-import { PEPE_TOKEN_GROUP } from '$env/tokens/groups/groups.pepe.env';
-import { SHIB_TOKEN_GROUP } from '$env/tokens/groups/groups.shib.env';
-import { UNI_TOKEN_GROUP } from '$env/tokens/groups/groups.uni.env';
-import { USDC_TOKEN_GROUP } from '$env/tokens/groups/groups.usdc.env';
-import { USDT_TOKEN_GROUP } from '$env/tokens/groups/groups.usdt.env';
-import { WBTC_TOKEN_GROUP } from '$env/tokens/groups/groups.wbtc.env';
-import { WSTETH_TOKEN_GROUP } from '$env/tokens/groups/groups.wsteth.env';
-import { XAUT_TOKEN_GROUP } from '$env/tokens/groups/groups.xaut.env';
-import { EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
-import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
-import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';
-import { PEPE_TOKEN, SEPOLIA_PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
-import { SHIB_TOKEN } from '$env/tokens/tokens-erc20/tokens.shib.env';
-import { UNI_TOKEN } from '$env/tokens/tokens-erc20/tokens.uni.env';
-import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
-import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
-import { WBTC_TOKEN } from '$env/tokens/tokens-erc20/tokens.wbtc.env';
-import { WSTETH_TOKEN } from '$env/tokens/tokens-erc20/tokens.wsteth.env';
-import { XAUT_TOKEN } from '$env/tokens/tokens-erc20/tokens.xaut.env';
 import {
 	CKBTC_IC_DATA,
 	CKBTC_LEDGER_CANISTER_TESTNET_IDS,
-	ICRC_CK_BTC_TOKENS,
-	IC_CKBTC_LEDGER_CANISTER_ID
+	IC_CKBTC_LEDGER_CANISTER_ID,
+	ICRC_CK_BTC_TOKENS
 } from '$env/tokens/tokens-icp/tokens.icp.ck.btc.env';
+import {
+	CKERC20_LEDGER_CANISTER_TESTNET_IDS,
+	CKUSDC_IC_DATA,
+	IC_CKUSDC_LEDGER_CANISTER_ID,
+	IC_CKUSDT_LEDGER_CANISTER_ID,
+	ICRC_CK_ERC20_TOKENS
+} from '$env/tokens/tokens-icp/tokens.icp.ck.erc20.env';
 import {
 	CKETH_IC_DATA,
 	CKETH_LEDGER_CANISTER_TESTNET_IDS,
-	ICRC_CK_ETH_TOKENS,
 	IC_CKETH_LEDGER_CANISTER_ID,
-	IC_CKETH_MINTER_CANISTER_ID,
-	LOCAL_CKETH_LEDGER_CANISTER_ID,
-	LOCAL_CKETH_MINTER_CANISTER_ID,
-	STAGING_CKETH_LEDGER_CANISTER_ID,
-	STAGING_CKETH_MINTER_CANISTER_ID
+	ICRC_CK_ETH_TOKENS
 } from '$env/tokens/tokens-icp/tokens.icp.ck.eth.env';
-import { ckErc20Production, ckErc20Staging } from '$env/tokens/tokens.ckerc20.env';
 import { additionalIcrcTokens } from '$env/tokens/tokens.icrc.env';
-import type { EnvCkErc20Tokens } from '$env/types/env-token-ckerc20';
-import type { EnvTokenSymbol } from '$env/types/env-token-common';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
-import type { IcCkInterface, IcInterface } from '$icp/types/ic-token';
+import type { IcInterface } from '$icp/types/ic-token';
 import { mapIcrcData } from '$icp/utils/map-icrc-data';
 import { BETA, LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
 import type { CanisterIdText, OptionCanisterIdText } from '$lib/types/canister';
-import type { NetworkEnvironment } from '$lib/types/network';
 import { nonNullish } from '@dfinity/utils';
 
 export const IC_CYCLES_LEDGER_CANISTER_ID =
@@ -66,192 +41,6 @@ export const CYCLES_LEDGER_CANISTER_ID: CanisterIdText =
 		: (STAGING || BETA || PROD) && nonNullish(STAGING_CYCLES_LEDGER_CANISTER_ID)
 			? STAGING_CYCLES_LEDGER_CANISTER_ID
 			: IC_CYCLES_LEDGER_CANISTER_ID;
-
-/**
- * ckERC20
- */
-
-export const LOCAL_CKUSDC_LEDGER_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKUSDC_LEDGER_CANISTER_ID as OptionCanisterIdText;
-export const LOCAL_CKUSDC_INDEX_CANISTER_ID = import.meta.env
-	.VITE_LOCAL_CKUSDC_INDEX_CANISTER_ID as OptionCanisterIdText;
-
-const CKUSDC_LOCAL_DATA: IcCkInterface | undefined =
-	LOCAL &&
-	nonNullish(LOCAL_CKUSDC_LEDGER_CANISTER_ID) &&
-	nonNullish(LOCAL_CKUSDC_INDEX_CANISTER_ID) &&
-	nonNullish(LOCAL_CKETH_MINTER_CANISTER_ID)
-		? {
-				ledgerCanisterId: LOCAL_CKUSDC_LEDGER_CANISTER_ID,
-				indexCanisterId: LOCAL_CKUSDC_INDEX_CANISTER_ID,
-				minterCanisterId: LOCAL_CKETH_MINTER_CANISTER_ID,
-				exchangeCoinId: 'ethereum',
-				twinToken: SEPOLIA_USDC_TOKEN,
-				...(nonNullish(LOCAL_CKETH_LEDGER_CANISTER_ID) && {
-					feeLedgerCanisterId: LOCAL_CKETH_LEDGER_CANISTER_ID
-				})
-			}
-		: undefined;
-
-const mapCkErc20Data = ({
-	ckErc20Tokens,
-	minterCanisterId,
-	ledgerCanisterId,
-	env
-}: {
-	ckErc20Tokens: EnvCkErc20Tokens;
-	minterCanisterId: OptionCanisterIdText;
-	ledgerCanisterId: OptionCanisterIdText;
-	env: NetworkEnvironment;
-}): Record<EnvTokenSymbol, Omit<IcCkInterface, 'twinToken' | 'position'>> =>
-	Object.entries(ckErc20Tokens).reduce(
-		(acc, [key, value]) => ({
-			...acc,
-			...((STAGING || BETA || PROD) &&
-				nonNullish(value) &&
-				nonNullish(minterCanisterId) && {
-					[key]: {
-						...value,
-						minterCanisterId,
-						exchangeCoinId: 'ethereum',
-						explorerUrl: `${env === 'testnet' ? CKETH_SEPOLIA_EXPLORER_URL : CKETH_EXPLORER_URL}/${value.ledgerCanisterId}`,
-						...(nonNullish(ledgerCanisterId) && {
-							feeLedgerCanisterId: ledgerCanisterId
-						})
-					}
-				})
-		}),
-		{}
-	);
-
-const CKERC20_STAGING_DATA = mapCkErc20Data({
-	ckErc20Tokens: ckErc20Staging,
-	minterCanisterId: STAGING_CKETH_MINTER_CANISTER_ID,
-	ledgerCanisterId: STAGING_CKETH_LEDGER_CANISTER_ID,
-	env: 'testnet'
-});
-
-const CKERC20_PRODUCTION_DATA = mapCkErc20Data({
-	ckErc20Tokens: ckErc20Production,
-	minterCanisterId: IC_CKETH_MINTER_CANISTER_ID,
-	ledgerCanisterId: IC_CKETH_LEDGER_CANISTER_ID,
-	env: 'mainnet'
-});
-
-const CKUSDC_STAGING_DATA: IcCkInterface | undefined = nonNullish(
-	CKERC20_STAGING_DATA?.ckSepoliaUSDC
-)
-	? {
-			...CKERC20_STAGING_DATA.ckSepoliaUSDC,
-			twinToken: SEPOLIA_USDC_TOKEN
-		}
-	: undefined;
-
-const CKLINK_STAGING_DATA: IcCkInterface | undefined = nonNullish(
-	CKERC20_STAGING_DATA?.ckSepoliaLINK
-)
-	? {
-			...CKERC20_STAGING_DATA.ckSepoliaLINK,
-			twinToken: SEPOLIA_LINK_TOKEN
-		}
-	: undefined;
-
-const CKPEPE_STAGING_DATA: IcCkInterface | undefined = nonNullish(
-	CKERC20_STAGING_DATA?.ckSepoliaPEPE
-)
-	? {
-			...CKERC20_STAGING_DATA.ckSepoliaPEPE,
-			twinToken: SEPOLIA_PEPE_TOKEN
-		}
-	: undefined;
-
-const CKUSDC_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckUSDC)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckUSDC,
-			twinToken: USDC_TOKEN,
-			groupData: USDC_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKLINK_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckLINK)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckLINK,
-			twinToken: LINK_TOKEN,
-			groupData: LINK_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKPEPE_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckPEPE)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckPEPE,
-			twinToken: PEPE_TOKEN,
-			groupData: PEPE_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKOCT_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckOCT)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckOCT,
-			twinToken: OCT_TOKEN,
-			groupData: OCT_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKSHIB_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckSHIB)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckSHIB,
-			twinToken: SHIB_TOKEN,
-			groupData: SHIB_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKWBTC_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckWBTC)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckWBTC,
-			twinToken: WBTC_TOKEN,
-			groupData: WBTC_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKUSDT_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckUSDT)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckUSDT,
-			twinToken: USDT_TOKEN,
-			groupData: USDT_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKWSTETH_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckWSTETH)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckWSTETH,
-			twinToken: WSTETH_TOKEN,
-			groupData: WSTETH_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKUNI_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckUNI)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckUNI,
-			twinToken: UNI_TOKEN,
-			groupData: UNI_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKEURC_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckEURC)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckEURC,
-			twinToken: EURC_TOKEN,
-			groupData: EURC_TOKEN_GROUP
-		}
-	: undefined;
-
-const CKXAUT_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckXAUT)
-	? {
-			...CKERC20_PRODUCTION_DATA.ckXAUT,
-			twinToken: XAUT_TOKEN,
-			groupData: XAUT_TOKEN_GROUP
-		}
-	: undefined;
 
 const ADDITIONAL_ICRC_PRODUCTION_DATA = mapIcrcData(additionalIcrcTokens);
 
@@ -279,38 +68,6 @@ export const FORSETISCN_LEDGER_CANISTER_ID: LedgerCanisterIdText =
 const TICRC1_LEDGER_CANISTER_ID: LedgerCanisterIdText =
 	ADDITIONAL_ICRC_PRODUCTION_DATA?.TICRC1?.ledgerCanisterId ?? '3jkp5-oyaaa-aaaaj-azwqa-cai';
 
-export const CKERC20_LEDGER_CANISTER_TESTNET_IDS: CanisterIdText[] = [
-	...(nonNullish(LOCAL_CKUSDC_LEDGER_CANISTER_ID) ? [LOCAL_CKUSDC_LEDGER_CANISTER_ID] : []),
-	...(nonNullish(CKUSDC_STAGING_DATA?.ledgerCanisterId)
-		? [CKUSDC_STAGING_DATA.ledgerCanisterId]
-		: []),
-	...(nonNullish(CKLINK_STAGING_DATA?.ledgerCanisterId)
-		? [CKLINK_STAGING_DATA.ledgerCanisterId]
-		: []),
-	...(nonNullish(CKPEPE_STAGING_DATA?.ledgerCanisterId)
-		? [CKPEPE_STAGING_DATA.ledgerCanisterId]
-		: [])
-];
-
-export const CKERC20_LEDGER_CANISTER_IC_IDS: CanisterIdText[] = [
-	...(nonNullish(CKUSDC_IC_DATA?.ledgerCanisterId) ? [CKUSDC_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKLINK_IC_DATA?.ledgerCanisterId) ? [CKLINK_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKPEPE_IC_DATA?.ledgerCanisterId) ? [CKPEPE_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKOCT_IC_DATA?.ledgerCanisterId) ? [CKOCT_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKSHIB_IC_DATA?.ledgerCanisterId) ? [CKSHIB_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKWBTC_IC_DATA?.ledgerCanisterId) ? [CKWBTC_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKUSDT_IC_DATA?.ledgerCanisterId) ? [CKUSDT_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKWSTETH_IC_DATA?.ledgerCanisterId) ? [CKWSTETH_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKUNI_IC_DATA?.ledgerCanisterId) ? [CKUNI_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKEURC_IC_DATA?.ledgerCanisterId) ? [CKEURC_IC_DATA.ledgerCanisterId] : []),
-	...(nonNullish(CKXAUT_IC_DATA?.ledgerCanisterId) ? [CKXAUT_IC_DATA.ledgerCanisterId] : [])
-];
-
-export const CKERC20_LEDGER_CANISTER_IDS: CanisterIdText[] = [
-	...CKERC20_LEDGER_CANISTER_IC_IDS,
-	...CKERC20_LEDGER_CANISTER_TESTNET_IDS
-];
-
 /**
  * All ICRC tokens data
  */
@@ -325,20 +82,7 @@ export const PUBLIC_ICRC_TOKENS: IcInterface[] = [
 const ICRC_CK_TOKENS: IcInterface[] = [
 	...ICRC_CK_BTC_TOKENS,
 	...ICRC_CK_ETH_TOKENS,
-	...(nonNullish(CKUSDC_LOCAL_DATA) ? [CKUSDC_LOCAL_DATA] : []),
-	...(nonNullish(CKUSDC_STAGING_DATA) ? [CKUSDC_STAGING_DATA] : []),
-	...(nonNullish(CKLINK_STAGING_DATA) ? [CKLINK_STAGING_DATA] : []),
-	...(nonNullish(CKLINK_IC_DATA) ? [CKLINK_IC_DATA] : []),
-	...(nonNullish(CKPEPE_IC_DATA) ? [CKPEPE_IC_DATA] : []),
-	...(nonNullish(CKPEPE_STAGING_DATA) ? [CKPEPE_STAGING_DATA] : []),
-	...(nonNullish(CKOCT_IC_DATA) ? [CKOCT_IC_DATA] : []),
-	...(nonNullish(CKSHIB_IC_DATA) ? [CKSHIB_IC_DATA] : []),
-	...(nonNullish(CKWBTC_IC_DATA) ? [CKWBTC_IC_DATA] : []),
-	...(nonNullish(CKUSDT_IC_DATA) ? [CKUSDT_IC_DATA] : []),
-	...(nonNullish(CKWSTETH_IC_DATA) ? [CKWSTETH_IC_DATA] : []),
-	...(nonNullish(CKUNI_IC_DATA) ? [CKUNI_IC_DATA] : []),
-	...(nonNullish(CKEURC_IC_DATA) ? [CKEURC_IC_DATA] : []),
-	...(nonNullish(CKXAUT_IC_DATA) ? [CKXAUT_IC_DATA] : [])
+	...ICRC_CK_ERC20_TOKENS
 ];
 
 const ADDITIONAL_ICRC_TOKENS: IcInterface[] = Object.values(
@@ -367,14 +111,10 @@ export const ICRC_LEDGER_CANISTER_TESTNET_IDS = [
 export const ICRC_CHAIN_FUSION_DEFAULT_LEDGER_CANISTER_IDS = [
 	IC_CKBTC_LEDGER_CANISTER_ID,
 	IC_CKETH_LEDGER_CANISTER_ID,
-	...(nonNullish(CKERC20_PRODUCTION_DATA?.ckUSDC)
-		? [CKERC20_PRODUCTION_DATA.ckUSDC.ledgerCanisterId]
-		: [])
+	...(nonNullish(IC_CKUSDC_LEDGER_CANISTER_ID) ? [IC_CKUSDC_LEDGER_CANISTER_ID] : [])
 ];
 
 // Additional suggested canisters to be enabled by default if the user set no preference
 export const ICRC_CHAIN_FUSION_SUGGESTED_LEDGER_CANISTER_IDS = [
-	...(nonNullish(CKERC20_PRODUCTION_DATA?.ckUSDT)
-		? [CKERC20_PRODUCTION_DATA.ckUSDT.ledgerCanisterId]
-		: [])
+	...(nonNullish(IC_CKUSDT_LEDGER_CANISTER_ID) ? [IC_CKUSDT_LEDGER_CANISTER_ID] : [])
 ];

--- a/src/frontend/src/env/tokens/tokens-icp/tokens.icp.ck.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens-icp/tokens.icp.ck.erc20.env.ts
@@ -1,0 +1,279 @@
+import { CKETH_EXPLORER_URL, CKETH_SEPOLIA_EXPLORER_URL } from '$env/explorers.env';
+import { EURC_TOKEN_GROUP } from '$env/tokens/groups/groups.eurc.env';
+import { LINK_TOKEN_GROUP } from '$env/tokens/groups/groups.link.env';
+import { OCT_TOKEN_GROUP } from '$env/tokens/groups/groups.oct.env';
+import { PEPE_TOKEN_GROUP } from '$env/tokens/groups/groups.pepe.env';
+import { SHIB_TOKEN_GROUP } from '$env/tokens/groups/groups.shib.env';
+import { UNI_TOKEN_GROUP } from '$env/tokens/groups/groups.uni.env';
+import { USDC_TOKEN_GROUP } from '$env/tokens/groups/groups.usdc.env';
+import { USDT_TOKEN_GROUP } from '$env/tokens/groups/groups.usdt.env';
+import { WBTC_TOKEN_GROUP } from '$env/tokens/groups/groups.wbtc.env';
+import { WSTETH_TOKEN_GROUP } from '$env/tokens/groups/groups.wsteth.env';
+import { XAUT_TOKEN_GROUP } from '$env/tokens/groups/groups.xaut.env';
+import { EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.eurc.env';
+import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
+import { OCT_TOKEN } from '$env/tokens/tokens-erc20/tokens.oct.env';
+import { PEPE_TOKEN, SEPOLIA_PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
+import { SHIB_TOKEN } from '$env/tokens/tokens-erc20/tokens.shib.env';
+import { UNI_TOKEN } from '$env/tokens/tokens-erc20/tokens.uni.env';
+import { SEPOLIA_USDC_TOKEN, USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
+import { WBTC_TOKEN } from '$env/tokens/tokens-erc20/tokens.wbtc.env';
+import { WSTETH_TOKEN } from '$env/tokens/tokens-erc20/tokens.wsteth.env';
+import { XAUT_TOKEN } from '$env/tokens/tokens-erc20/tokens.xaut.env';
+import {
+	IC_CKETH_LEDGER_CANISTER_ID,
+	IC_CKETH_MINTER_CANISTER_ID,
+	LOCAL_CKETH_LEDGER_CANISTER_ID,
+	LOCAL_CKETH_MINTER_CANISTER_ID,
+	STAGING_CKETH_LEDGER_CANISTER_ID,
+	STAGING_CKETH_MINTER_CANISTER_ID
+} from '$env/tokens/tokens-icp/tokens.icp.ck.eth.env';
+import { ckErc20Production, ckErc20Staging } from '$env/tokens/tokens.ckerc20.env';
+import type { EnvCkErc20Tokens } from '$env/types/env-token-ckerc20';
+import type { EnvTokenSymbol } from '$env/types/env-token-common';
+import type { IcCkInterface, IcInterface } from '$icp/types/ic-token';
+import { BETA, LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
+import type { CanisterIdText, OptionCanisterIdText } from '$lib/types/canister';
+import type { NetworkEnvironment } from '$lib/types/network';
+import { nonNullish } from '@dfinity/utils';
+
+export const LOCAL_CKUSDC_LEDGER_CANISTER_ID = import.meta.env
+	.VITE_LOCAL_CKUSDC_LEDGER_CANISTER_ID as OptionCanisterIdText;
+
+export const LOCAL_CKUSDC_INDEX_CANISTER_ID = import.meta.env
+	.VITE_LOCAL_CKUSDC_INDEX_CANISTER_ID as OptionCanisterIdText;
+
+const CKUSDC_LOCAL_DATA: IcCkInterface | undefined =
+	LOCAL &&
+	nonNullish(LOCAL_CKUSDC_LEDGER_CANISTER_ID) &&
+	nonNullish(LOCAL_CKUSDC_INDEX_CANISTER_ID) &&
+	nonNullish(LOCAL_CKETH_MINTER_CANISTER_ID)
+		? {
+				ledgerCanisterId: LOCAL_CKUSDC_LEDGER_CANISTER_ID,
+				indexCanisterId: LOCAL_CKUSDC_INDEX_CANISTER_ID,
+				minterCanisterId: LOCAL_CKETH_MINTER_CANISTER_ID,
+				exchangeCoinId: 'ethereum',
+				twinToken: SEPOLIA_USDC_TOKEN,
+				...(nonNullish(LOCAL_CKETH_LEDGER_CANISTER_ID) && {
+					feeLedgerCanisterId: LOCAL_CKETH_LEDGER_CANISTER_ID
+				})
+			}
+		: undefined;
+
+const mapCkErc20Data = ({
+	ckErc20Tokens,
+	minterCanisterId,
+	ledgerCanisterId,
+	env
+}: {
+	ckErc20Tokens: EnvCkErc20Tokens;
+	minterCanisterId: OptionCanisterIdText;
+	ledgerCanisterId: OptionCanisterIdText;
+	env: NetworkEnvironment;
+}): Record<EnvTokenSymbol, Omit<IcCkInterface, 'twinToken' | 'position'>> =>
+	Object.entries(ckErc20Tokens).reduce(
+		(acc, [key, value]) => ({
+			...acc,
+			...((STAGING || BETA || PROD) &&
+				nonNullish(value) &&
+				nonNullish(minterCanisterId) && {
+					[key]: {
+						...value,
+						minterCanisterId,
+						exchangeCoinId: 'ethereum',
+						explorerUrl: `${env === 'testnet' ? CKETH_SEPOLIA_EXPLORER_URL : CKETH_EXPLORER_URL}/${value.ledgerCanisterId}`,
+						...(nonNullish(ledgerCanisterId) && {
+							feeLedgerCanisterId: ledgerCanisterId
+						})
+					}
+				})
+		}),
+		{}
+	);
+
+const CKERC20_STAGING_DATA = mapCkErc20Data({
+	ckErc20Tokens: ckErc20Staging,
+	minterCanisterId: STAGING_CKETH_MINTER_CANISTER_ID,
+	ledgerCanisterId: STAGING_CKETH_LEDGER_CANISTER_ID,
+	env: 'testnet'
+});
+
+const CKERC20_PRODUCTION_DATA = mapCkErc20Data({
+	ckErc20Tokens: ckErc20Production,
+	minterCanisterId: IC_CKETH_MINTER_CANISTER_ID,
+	ledgerCanisterId: IC_CKETH_LEDGER_CANISTER_ID,
+	env: 'mainnet'
+});
+
+const CKUSDC_STAGING_DATA: IcCkInterface | undefined = nonNullish(
+	CKERC20_STAGING_DATA?.ckSepoliaUSDC
+)
+	? {
+			...CKERC20_STAGING_DATA.ckSepoliaUSDC,
+			twinToken: SEPOLIA_USDC_TOKEN
+		}
+	: undefined;
+
+const CKLINK_STAGING_DATA: IcCkInterface | undefined = nonNullish(
+	CKERC20_STAGING_DATA?.ckSepoliaLINK
+)
+	? {
+			...CKERC20_STAGING_DATA.ckSepoliaLINK,
+			twinToken: SEPOLIA_LINK_TOKEN
+		}
+	: undefined;
+
+const CKPEPE_STAGING_DATA: IcCkInterface | undefined = nonNullish(
+	CKERC20_STAGING_DATA?.ckSepoliaPEPE
+)
+	? {
+			...CKERC20_STAGING_DATA.ckSepoliaPEPE,
+			twinToken: SEPOLIA_PEPE_TOKEN
+		}
+	: undefined;
+
+export const CKUSDC_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckUSDC)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckUSDC,
+			twinToken: USDC_TOKEN,
+			groupData: USDC_TOKEN_GROUP
+		}
+	: undefined;
+
+export const IC_CKUSDC_LEDGER_CANISTER_ID = nonNullish(CKUSDC_IC_DATA)
+	? CKUSDC_IC_DATA.ledgerCanisterId
+	: undefined;
+
+const CKLINK_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckLINK)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckLINK,
+			twinToken: LINK_TOKEN,
+			groupData: LINK_TOKEN_GROUP
+		}
+	: undefined;
+
+const CKPEPE_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckPEPE)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckPEPE,
+			twinToken: PEPE_TOKEN,
+			groupData: PEPE_TOKEN_GROUP
+		}
+	: undefined;
+
+const CKOCT_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckOCT)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckOCT,
+			twinToken: OCT_TOKEN,
+			groupData: OCT_TOKEN_GROUP
+		}
+	: undefined;
+
+const CKSHIB_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckSHIB)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckSHIB,
+			twinToken: SHIB_TOKEN,
+			groupData: SHIB_TOKEN_GROUP
+		}
+	: undefined;
+
+const CKWBTC_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckWBTC)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckWBTC,
+			twinToken: WBTC_TOKEN,
+			groupData: WBTC_TOKEN_GROUP
+		}
+	: undefined;
+
+const CKUSDT_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckUSDT)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckUSDT,
+			twinToken: USDT_TOKEN,
+			groupData: USDT_TOKEN_GROUP
+		}
+	: undefined;
+
+export const IC_CKUSDT_LEDGER_CANISTER_ID = nonNullish(CKUSDT_IC_DATA)
+	? CKUSDT_IC_DATA.ledgerCanisterId
+	: undefined;
+
+const CKWSTETH_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckWSTETH)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckWSTETH,
+			twinToken: WSTETH_TOKEN,
+			groupData: WSTETH_TOKEN_GROUP
+		}
+	: undefined;
+
+const CKUNI_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckUNI)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckUNI,
+			twinToken: UNI_TOKEN,
+			groupData: UNI_TOKEN_GROUP
+		}
+	: undefined;
+
+const CKEURC_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckEURC)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckEURC,
+			twinToken: EURC_TOKEN,
+			groupData: EURC_TOKEN_GROUP
+		}
+	: undefined;
+
+const CKXAUT_IC_DATA: IcCkInterface | undefined = nonNullish(CKERC20_PRODUCTION_DATA?.ckXAUT)
+	? {
+			...CKERC20_PRODUCTION_DATA.ckXAUT,
+			twinToken: XAUT_TOKEN,
+			groupData: XAUT_TOKEN_GROUP
+		}
+	: undefined;
+
+export const CKERC20_LEDGER_CANISTER_TESTNET_IDS: CanisterIdText[] = [
+	...(nonNullish(LOCAL_CKUSDC_LEDGER_CANISTER_ID) ? [LOCAL_CKUSDC_LEDGER_CANISTER_ID] : []),
+	...(nonNullish(CKUSDC_STAGING_DATA?.ledgerCanisterId)
+		? [CKUSDC_STAGING_DATA.ledgerCanisterId]
+		: []),
+	...(nonNullish(CKLINK_STAGING_DATA?.ledgerCanisterId)
+		? [CKLINK_STAGING_DATA.ledgerCanisterId]
+		: []),
+	...(nonNullish(CKPEPE_STAGING_DATA?.ledgerCanisterId)
+		? [CKPEPE_STAGING_DATA.ledgerCanisterId]
+		: [])
+];
+
+export const CKERC20_LEDGER_CANISTER_IC_IDS: CanisterIdText[] = [
+	...(nonNullish(CKUSDC_IC_DATA?.ledgerCanisterId) ? [CKUSDC_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKLINK_IC_DATA?.ledgerCanisterId) ? [CKLINK_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKPEPE_IC_DATA?.ledgerCanisterId) ? [CKPEPE_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKOCT_IC_DATA?.ledgerCanisterId) ? [CKOCT_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKSHIB_IC_DATA?.ledgerCanisterId) ? [CKSHIB_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKWBTC_IC_DATA?.ledgerCanisterId) ? [CKWBTC_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKUSDT_IC_DATA?.ledgerCanisterId) ? [CKUSDT_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKWSTETH_IC_DATA?.ledgerCanisterId) ? [CKWSTETH_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKUNI_IC_DATA?.ledgerCanisterId) ? [CKUNI_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKEURC_IC_DATA?.ledgerCanisterId) ? [CKEURC_IC_DATA.ledgerCanisterId] : []),
+	...(nonNullish(CKXAUT_IC_DATA?.ledgerCanisterId) ? [CKXAUT_IC_DATA.ledgerCanisterId] : [])
+];
+
+export const CKERC20_LEDGER_CANISTER_IDS: CanisterIdText[] = [
+	...CKERC20_LEDGER_CANISTER_IC_IDS,
+	...CKERC20_LEDGER_CANISTER_TESTNET_IDS
+];
+
+export const ICRC_CK_ERC20_TOKENS: IcInterface[] = [
+	...(nonNullish(CKUSDC_LOCAL_DATA) ? [CKUSDC_LOCAL_DATA] : []),
+	...(nonNullish(CKUSDC_STAGING_DATA) ? [CKUSDC_STAGING_DATA] : []),
+	...(nonNullish(CKLINK_STAGING_DATA) ? [CKLINK_STAGING_DATA] : []),
+	...(nonNullish(CKLINK_IC_DATA) ? [CKLINK_IC_DATA] : []),
+	...(nonNullish(CKPEPE_IC_DATA) ? [CKPEPE_IC_DATA] : []),
+	...(nonNullish(CKPEPE_STAGING_DATA) ? [CKPEPE_STAGING_DATA] : []),
+	...(nonNullish(CKOCT_IC_DATA) ? [CKOCT_IC_DATA] : []),
+	...(nonNullish(CKSHIB_IC_DATA) ? [CKSHIB_IC_DATA] : []),
+	...(nonNullish(CKWBTC_IC_DATA) ? [CKWBTC_IC_DATA] : []),
+	...(nonNullish(CKUSDT_IC_DATA) ? [CKUSDT_IC_DATA] : []),
+	...(nonNullish(CKWSTETH_IC_DATA) ? [CKWSTETH_IC_DATA] : []),
+	...(nonNullish(CKUNI_IC_DATA) ? [CKUNI_IC_DATA] : []),
+	...(nonNullish(CKEURC_IC_DATA) ? [CKEURC_IC_DATA] : []),
+	...(nonNullish(CKXAUT_IC_DATA) ? [CKXAUT_IC_DATA] : [])
+];

--- a/src/frontend/src/icp/utils/ic-send.utils.ts
+++ b/src/frontend/src/icp/utils/ic-send.utils.ts
@@ -1,6 +1,6 @@
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
-import { CKERC20_LEDGER_CANISTER_IDS } from '$env/networks/networks.icrc.env';
 import { CKBTC_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icp/tokens.icp.ck.btc.env';
+import { CKERC20_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icp/tokens.icp.ck.erc20.env';
 import { CKETH_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icp/tokens.icp.ck.eth.env';
 import type { IcToken } from '$icp/types/ic-token';
 import { isTokenIcNft } from '$icp/utils/ic-nft.utils';

--- a/src/frontend/src/tests/icp/components/info/Info.spec.ts
+++ b/src/frontend/src/tests/icp/components/info/Info.spec.ts
@@ -1,6 +1,6 @@
-import { CKERC20_LEDGER_CANISTER_IDS } from '$env/networks/networks.icrc.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.btc.env';
+import { CKERC20_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icp/tokens.icp.ck.erc20.env';
 import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.eth.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';

--- a/src/frontend/src/tests/icp/services/ic-send.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-send.services.spec.ts
@@ -1,6 +1,6 @@
 import { SUPPORTED_BITCOIN_NETWORK_IDS } from '$env/networks/networks.btc.env';
 import { SUPPORTED_ETHEREUM_NETWORK_IDS } from '$env/networks/networks.eth.env';
-import { CKERC20_LEDGER_CANISTER_IDS } from '$env/networks/networks.icrc.env';
+import { CKERC20_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icp/tokens.icp.ck.erc20.env';
 import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.eth.env';
 import {
 	icrc1Transfer as icrc1TransferIcp,

--- a/src/frontend/src/tests/lib/stores/convert.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/convert.store.spec.ts
@@ -1,5 +1,5 @@
-import { LOCAL_CKUSDC_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
 import { LOCAL_CKBTC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.btc.env';
+import { LOCAL_CKUSDC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.erc20.env';
 import { LOCAL_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.eth.env';
 import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';

--- a/src/frontend/src/tests/lib/utils/listener.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/listener.utils.spec.ts
@@ -1,5 +1,4 @@
 import { ICP_NETWORK } from '$env/networks/networks.icp.env';
-import { CKERC20_LEDGER_CANISTER_IDS } from '$env/networks/networks.icrc.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import {
 	BASE_ETH_TOKEN,
@@ -10,6 +9,7 @@ import {
 	BNB_TESTNET_TOKEN
 } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
 import { CKBTC_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icp/tokens.icp.ck.btc.env';
+import { CKERC20_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icp/tokens.icp.ck.erc20.env';
 import { CKETH_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icp/tokens.icp.ck.eth.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';

--- a/src/frontend/src/tests/lib/utils/user-amount.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/user-amount.utils.spec.ts
@@ -1,5 +1,5 @@
-import { LOCAL_CKUSDC_LEDGER_CANISTER_ID } from '$env/networks/networks.icrc.env';
 import { LOCAL_CKBTC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.btc.env';
+import { LOCAL_CKUSDC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.erc20.env';
 import { LOCAL_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icp/tokens.icp.ck.eth.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';


### PR DESCRIPTION
# Motivation

Env module `networks.icrc.env.ts` includes quite a lot of variables that would be more appropriate to stay in the tokens env module.

Furthermore it is a bit too long, and it is causing loop imports.

To try and organize it a bit better, we will split it in separate submodules.

In this PR, we create a file for ck-ERC20 tokens.
