### PR TITLE
feat(frontend): load pay BTC data only if feature flag is on

### DIFF
--- a/src/frontend/src/lib/components/scanner/ScannerModalPayDataLoader.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerModalPayDataLoader.svelte
@@ -6,6 +6,7 @@
 	import FeeRatePercentilesLoader from '$btc/components/fee/FeeRatePercentilesLoader.svelte';
 	import { enabledMainnetBitcoinToken } from '$btc/derived/tokens.derived';
 	import { resetUtxosDataStores } from '$btc/utils/btc-utxos.utils';
+	import { OCP_PAY_WITH_BTC_ENABLED } from '$env/open-crypto-pay.env';
 	import { btcAddressMainnet } from '$lib/derived/address.derived';
 
 	interface Props {
@@ -15,13 +16,17 @@
 	let { children }: Props = $props();
 
 	onDestroy(() => {
-		if (nonNullish($enabledMainnetBitcoinToken) && nonNullish($btcAddressMainnet)) {
+		if (
+			OCP_PAY_WITH_BTC_ENABLED &&
+			nonNullish($enabledMainnetBitcoinToken) &&
+			nonNullish($btcAddressMainnet)
+		) {
 			resetUtxosDataStores();
 		}
 	});
 </script>
 
-{#if nonNullish($enabledMainnetBitcoinToken) && nonNullish($btcAddressMainnet)}
+{#if OCP_PAY_WITH_BTC_ENABLED && nonNullish($enabledMainnetBitcoinToken) && nonNullish($btcAddressMainnet)}
 	<BtcPendingSentTransactionsLoader
 		networkId={$enabledMainnetBitcoinToken.network.id}
 		source={$btcAddressMainnet}

--- a/src/frontend/src/tests/lib/components/scanner/ScannerModalPayDataLoader.spec.ts
+++ b/src/frontend/src/tests/lib/components/scanner/ScannerModalPayDataLoader.spec.ts
@@ -2,6 +2,7 @@ import * as btcTokensDerived from '$btc/derived/tokens.derived';
 import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import * as btcUtxosUtils from '$btc/utils/btc-utxos.utils';
+import * as openCryptoPayEnv from '$env/open-crypto-pay.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import * as bitcoinApi from '$icp/api/bitcoin.api';
 import ScannerModalPayDataLoader from '$lib/components/scanner/ScannerModalPayDataLoader.svelte';
@@ -14,6 +15,8 @@ import { render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
 describe('ScannerModalPayDataLoader', () => {
+	vi.spyOn(openCryptoPayEnv, 'OCP_PAY_WITH_BTC_ENABLED', 'get').mockImplementation(() => true);
+
 	const mockEnabledMainnetBitcoinToken = (token?: Token) =>
 		vi
 			.spyOn(btcTokensDerived, 'enabledMainnetBitcoinToken', 'get')


### PR DESCRIPTION
# Motivation

We can skip loading BTC data in the Pay modal if the related feature flag is not on.
