### PR TITLE
feat(frontend): implement OCP BTC utils

### DIFF
--- a/src/frontend/src/btc/utils/btc-open-crypto-pay.utils.ts
+++ b/src/frontend/src/btc/utils/btc-open-crypto-pay.utils.ts
@@ -1,0 +1,118 @@
+import type { UtxosFee } from '$btc/types/btc-send';
+import { isBtcAddress } from '$btc/utils/btc-address.utils';
+import { isBitcoinToken } from '$btc/utils/token.utils';
+import { ZERO } from '$lib/constants/app.constants';
+import type { BalancesData } from '$lib/stores/balances.store';
+import type { CertifiedStoreData } from '$lib/stores/certified.store';
+import { i18n } from '$lib/stores/i18n.store';
+import type { ExchangesData } from '$lib/types/exchange';
+import type {
+	PayableTokenWithConvertedAmount,
+	PayableTokenWithFees,
+	ValidatedBtcPaymentData
+} from '$lib/types/open-crypto-pay';
+import type { DecodedUrn } from '$lib/types/qr-code';
+import { formatToken } from '$lib/utils/format.utils';
+import { parseToken } from '$lib/utils/parse.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+export const enrichBtcPayableToken = ({
+	token,
+	exchanges,
+	balances
+}: {
+	token: PayableTokenWithFees;
+	exchanges: ExchangesData;
+	balances: CertifiedStoreData<BalancesData>;
+}): PayableTokenWithConvertedAmount | undefined => {
+	const utxosFee = token.fee as UtxosFee;
+
+	if (isNullish(utxosFee) || nonNullish(utxosFee.error)) {
+		return;
+	}
+
+	const exchangeRate = exchanges?.[token.id]?.usd;
+	const balance = balances?.[token.id]?.data ?? ZERO;
+	if (isNullish(exchangeRate) || isNullish(balance)) {
+		return;
+	}
+
+	const amountToPay = parseToken({
+		value: token.amount,
+		unitName: token.decimals
+	});
+
+	if (balance < amountToPay + utxosFee.feeSatoshis) {
+		return;
+	}
+
+	const formattedFee = Number(
+		formatToken({
+			value: utxosFee.feeSatoshis,
+			unitName: token.decimals,
+			displayDecimals: token.decimals
+		})
+	);
+
+	const amountInUSD = Number(token.amount) * exchangeRate;
+	const feeInUSD = formattedFee * exchangeRate;
+
+	return {
+		...token,
+		amountInUSD,
+		feeInUSD,
+		sumInUSD: amountInUSD + feeInUSD
+	};
+};
+
+export const validateBtcTransfer = ({
+	decodedData,
+	amount,
+	token
+}: {
+	decodedData: DecodedUrn;
+	token: PayableTokenWithConvertedAmount;
+	amount: bigint;
+}): ValidatedBtcPaymentData => {
+	const btcFee = token.fee as UtxosFee | undefined;
+	const { destination, amount: amountParam } = decodedData;
+
+	const {
+		pay: {
+			error: { data_is_incompleted, amount_does_not_match, recipient_address_is_not_valid }
+		}
+	} = get(i18n);
+
+	if (
+		!isBitcoinToken(token) ||
+		isNullish(btcFee) ||
+		nonNullish(btcFee.error) ||
+		isNullish(destination) ||
+		isNullish(amountParam)
+	) {
+		throw new Error(data_is_incompleted);
+	}
+
+	if (!isBtcAddress({ address: destination })) {
+		throw new Error(recipient_address_is_not_valid);
+	}
+
+	const dfxAmount = parseToken({
+		value: amountParam.toString(),
+		unitName: token.decimals
+	});
+
+	if (amount !== dfxAmount) {
+		throw new Error(amount_does_not_match);
+	}
+
+	return {
+		destination,
+		satoshisAmount: amount,
+		utxosFee: {
+			utxos: btcFee.utxos,
+			feeSatoshis: btcFee.feeSatoshis
+		}
+	};
+};

--- a/src/frontend/src/lib/types/open-crypto-pay.ts
+++ b/src/frontend/src/lib/types/open-crypto-pay.ts
@@ -1,3 +1,5 @@
+import type { BtcAddress } from '$btc/types/address';
+import type { UtxosFee } from '$btc/types/btc-send';
 import type { EthAddress } from '$eth/types/address';
 import type { EthFeeResult } from '$eth/types/pay';
 import type { ProgressStepsPayment } from '$lib/enums/progress-steps';
@@ -81,7 +83,7 @@ export interface PayableToken extends Token {
 }
 
 export interface PayableTokenWithFees extends PayableToken {
-	fee?: EthFeeResult;
+	fee?: EthFeeResult | UtxosFee;
 }
 
 export interface PrepareTokensParams {
@@ -94,6 +96,12 @@ export interface PayableTokenWithConvertedAmount extends PayableTokenWithFees {
 	amountInUSD: number;
 	feeInUSD: number;
 	sumInUSD: number;
+}
+
+export interface ValidatedBtcPaymentData {
+	destination: BtcAddress;
+	satoshisAmount: bigint;
+	utxosFee: UtxosFee;
 }
 
 export interface ValidatedPaymentData {

--- a/src/frontend/src/tests/btc/utils/btc-open-crypto-pay.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-open-crypto-pay.utils.spec.ts
@@ -1,0 +1,262 @@
+import { BtcPrepareSendError } from '$btc/types/btc-send';
+import { enrichBtcPayableToken, validateBtcTransfer } from '$btc/utils/btc-open-crypto-pay.utils';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ZERO } from '$lib/constants/app.constants';
+import type { BalancesData } from '$lib/stores/balances.store';
+import type { CertifiedStoreData } from '$lib/stores/certified.store';
+import type { ExchangesData } from '$lib/types/exchange';
+import type {
+	PayableTokenWithConvertedAmount,
+	PayableTokenWithFees
+} from '$lib/types/open-crypto-pay';
+import type { DecodedUrn } from '$lib/types/qr-code';
+import { mockBtcAddress, mockUtxosFee } from '$tests/mocks/btc.mock';
+import en from '$tests/mocks/i18n.mock';
+
+describe('btc-open-crypto-pay.utils', () => {
+	describe('enrichBtcPayableToken', () => {
+		const mockExchangeRate = 50000;
+		const mockBalance = 100000000n;
+
+		const createMockToken = (overrides?: Partial<PayableTokenWithFees>): PayableTokenWithFees => ({
+			...BTC_MAINNET_TOKEN,
+			amount: '0.001',
+			minFee: 0.00001,
+			fee: mockUtxosFee,
+			tokenNetwork: 'bitcoin',
+			...overrides
+		});
+
+		const createMockExchanges = (rate?: number): ExchangesData => ({
+			[BTC_MAINNET_TOKEN.id]: { usd: rate ?? mockExchangeRate }
+		});
+
+		const createMockBalances = (balance?: bigint): CertifiedStoreData<BalancesData> => ({
+			[BTC_MAINNET_TOKEN.id]: { data: balance ?? mockBalance, certified: true }
+		});
+
+		it('should return undefined when fee is nullish', () => {
+			const token = createMockToken({ fee: undefined });
+
+			const result = enrichBtcPayableToken({
+				token,
+				exchanges: createMockExchanges(),
+				balances: createMockBalances()
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return undefined when fee has error', () => {
+			const token = createMockToken({
+				fee: { ...mockUtxosFee, error: BtcPrepareSendError.InsufficientBalance }
+			});
+
+			const result = enrichBtcPayableToken({
+				token,
+				exchanges: createMockExchanges(),
+				balances: createMockBalances()
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return undefined when exchange rate is nullish', () => {
+			const token = createMockToken();
+
+			const result = enrichBtcPayableToken({
+				token,
+				exchanges: {},
+				balances: createMockBalances()
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return undefined when balance is nullish', () => {
+			const token = createMockToken();
+
+			const result = enrichBtcPayableToken({
+				token,
+				exchanges: createMockExchanges(),
+				balances: {}
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return undefined when balance is insufficient', () => {
+			const token = createMockToken({ amount: '1' });
+			const insufficientBalance = 1000n;
+
+			const result = enrichBtcPayableToken({
+				token,
+				exchanges: createMockExchanges(),
+				balances: createMockBalances(insufficientBalance)
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return undefined when balance equals zero', () => {
+			const token = createMockToken();
+
+			const result = enrichBtcPayableToken({
+				token,
+				exchanges: createMockExchanges(),
+				balances: createMockBalances(ZERO)
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return enriched token with correct USD values', () => {
+			const amount = 0.001;
+			const token = createMockToken({ amount: `${amount}` });
+
+			const result = enrichBtcPayableToken({
+				token,
+				exchanges: createMockExchanges(),
+				balances: createMockBalances()
+			});
+
+			expect(result?.amountInUSD).toBe(amount * mockExchangeRate);
+			expect(result?.feeInUSD).toBe(0.5);
+			expect(result?.sumInUSD).toBe((result?.amountInUSD ?? 0) + (result?.feeInUSD ?? 0));
+		});
+	});
+
+	describe('validateBtcTransfer', () => {
+		const mockAmount = 100000n;
+
+		const createMockToken = (
+			overrides?: Partial<PayableTokenWithConvertedAmount>
+		): PayableTokenWithConvertedAmount => ({
+			...BTC_MAINNET_TOKEN,
+			amount: '0.001',
+			minFee: 0.00001,
+			fee: mockUtxosFee,
+			amountInUSD: 50,
+			feeInUSD: 0.5,
+			sumInUSD: 50.5,
+			tokenNetwork: 'bitcoin',
+			...overrides
+		});
+
+		const createMockDecodedData = (overrides?: Partial<DecodedUrn>): DecodedUrn => ({
+			destination: mockBtcAddress,
+			amount: 0.001,
+			prefix: 'bitcoin',
+			...overrides
+		});
+
+		it('should throw error when token is not Bitcoin token', () => {
+			const token = createMockToken({
+				...ETHEREUM_TOKEN
+			});
+
+			expect(() =>
+				validateBtcTransfer({
+					decodedData: createMockDecodedData(),
+					amount: mockAmount,
+					token
+				})
+			).toThrowError(en.pay.error.data_is_incompleted);
+		});
+
+		it('should throw error when fee is undefined', () => {
+			const token = createMockToken({ fee: undefined });
+
+			expect(() =>
+				validateBtcTransfer({
+					decodedData: createMockDecodedData(),
+					amount: mockAmount,
+					token
+				})
+			).toThrowError(en.pay.error.data_is_incompleted);
+		});
+
+		it('should throw error when fee has error', () => {
+			const token = createMockToken({
+				fee: { ...mockUtxosFee, error: BtcPrepareSendError.InsufficientBalance }
+			});
+
+			expect(() =>
+				validateBtcTransfer({
+					decodedData: createMockDecodedData(),
+					amount: mockAmount,
+					token
+				})
+			).toThrowError(en.pay.error.data_is_incompleted);
+		});
+
+		it('should throw error when destination is undefined', () => {
+			const token = createMockToken();
+
+			expect(() =>
+				validateBtcTransfer({
+					decodedData: createMockDecodedData({ destination: undefined }),
+					amount: mockAmount,
+					token
+				})
+			).toThrowError(en.pay.error.data_is_incompleted);
+		});
+
+		it('should throw error when amount param is undefined', () => {
+			const token = createMockToken();
+
+			expect(() =>
+				validateBtcTransfer({
+					decodedData: createMockDecodedData({ amount: undefined }),
+					amount: mockAmount,
+					token
+				})
+			).toThrowError(en.pay.error.data_is_incompleted);
+		});
+
+		it('should throw error when destination is not a valid BTC address', () => {
+			const token = createMockToken();
+
+			expect(() =>
+				validateBtcTransfer({
+					decodedData: createMockDecodedData({ destination: 'invalid-address' }),
+					amount: mockAmount,
+					token
+				})
+			).toThrowError(en.pay.error.recipient_address_is_not_valid);
+		});
+
+		it('should throw error when amounts do not match', () => {
+			const token = createMockToken();
+			const differentAmount = 200000n;
+
+			expect(() =>
+				validateBtcTransfer({
+					decodedData: createMockDecodedData({ amount: 0.001 }),
+					amount: differentAmount,
+					token
+				})
+			).toThrowError(en.pay.error.amount_does_not_match);
+		});
+
+		it('should return validated data when all conditions are met', () => {
+			const token = createMockToken();
+
+			const result = validateBtcTransfer({
+				decodedData: createMockDecodedData(),
+				amount: mockAmount,
+				token
+			});
+
+			expect(result).toEqual({
+				destination: mockBtcAddress,
+				satoshisAmount: mockAmount,
+				utxosFee: {
+					utxos: mockUtxosFee.utxos,
+					feeSatoshis: mockUtxosFee.feeSatoshis
+				}
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We need to implement to helper utils for the OCP BTC feature:
* `enrichBtcPayableToken` - util for extending the token data with fees and total amount values
* `validateBtcTransfer` - util for parsing OCP decoded data and formatting it in the needed object