### PR TITLE
feat(frontend): implement new OCP helper utils

### DIFF
--- a/src/frontend/src/lib/services/open-crypto-pay.services.ts
+++ b/src/frontend/src/lib/services/open-crypto-pay.services.ts
@@ -21,7 +21,7 @@ import type {
 	TransactionBaseParams,
 	ValidatedEthPaymentData
 } from '$lib/types/open-crypto-pay';
-import { decodeLNURL, extractQuoteData } from '$lib/utils/open-crypto-pay.utils';
+import { decodeLNURL, extractQuoteData, getPaymentUri } from '$lib/utils/open-crypto-pay.utils';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { isEmptyString, isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
@@ -149,23 +149,6 @@ const fetchPaymentUri = async ({
 	const { uri } = await fetchOpenCryptoPay<{ uri: string }>(url);
 
 	return uri;
-};
-
-const getPaymentUri = ({
-	callback,
-	quoteId,
-	network,
-	rawTransaction
-}: {
-	callback: string;
-	quoteId: string;
-	network: string;
-	rawTransaction: string;
-}): string => {
-	// By dfx documentation we need to replace 'cb' with 'tx' to get the transaction submission endpoint
-	const apiUrl = callback.replace('cb', 'tx');
-
-	return `${apiUrl}?quote=${quoteId}&method=${network}&hex=${rawTransaction}`;
 };
 
 const preparePaymentTransaction = async ({

--- a/src/frontend/src/tests/lib/services/open-crypto-pay.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/open-crypto-pay.services.spec.ts
@@ -32,17 +32,22 @@ import { extractQuoteData } from '$lib/utils/open-crypto-pay.utils';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 
-vi.mock('$lib/utils/open-crypto-pay.utils', () => ({
-	decodeLNURL: vi.fn((lnurl: string) => {
-		if (lnurl === 'VALID_LNURL') {
-			return 'https://api.dfx.swiss/v1/lnurlp/pl_test123';
-		}
-	}),
-	extractQuoteData: vi.fn(() => ({
-		quoteId: 'mock-quote-id-123',
-		callback: 'https://api.dfx.swiss/v1/lnurlp/cb/pl_test123'
-	}))
-}));
+vi.mock('$lib/utils/open-crypto-pay.utils', async (importOriginal) => {
+	const actual = await importOriginal();
+
+	return {
+		...(actual as Record<string, unknown>),
+		decodeLNURL: vi.fn((lnurl: string) => {
+			if (lnurl === 'VALID_LNURL') {
+				return 'https://api.dfx.swiss/v1/lnurlp/pl_test123';
+			}
+		}),
+		extractQuoteData: vi.fn(() => ({
+			quoteId: 'mock-quote-id-123',
+			callback: 'https://api.dfx.swiss/v1/lnurlp/cb/pl_test123'
+		}))
+	};
+});
 
 vi.mock('$eth/utils/eth-open-crypto-pay.utils', () => ({
 	validateEthEvmTransfer: vi.fn(({ decodedData, fee }) => ({


### PR DESCRIPTION
# Motivation

We need to implement 2 new OCP helper utils that is going to be re-used by both ETH and BTC flows. One of those utils were previously available inside the respective service file.
