### PR TITLE
feat(frontend): extend OCP store with BTC mainnet token

### DIFF
--- a/src/frontend/src/lib/stores/open-crypto-pay.store.ts
+++ b/src/frontend/src/lib/stores/open-crypto-pay.store.ts
@@ -1,3 +1,4 @@
+import { enabledMainnetBitcoinToken } from '$btc/derived/tokens.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { exchanges } from '$lib/derived/exchange.derived';
@@ -29,15 +30,33 @@ export const initPayContext = (): PayContext => {
 	const { set: setData } = data;
 
 	const sufficientTokens = derived(
-		[availableTokens, enabledEvmTokens, enabledEthereumTokens, exchanges, balancesStore],
-		([$availableTokens, $enabledEvmTokens, $enabledEthereumTokens, $exchanges, $balances]) => {
+		[
+			availableTokens,
+			enabledMainnetBitcoinToken,
+			enabledEvmTokens,
+			enabledEthereumTokens,
+			exchanges,
+			balancesStore
+		],
+		([
+			$availableTokens,
+			$enabledMainnetBitcoinToken,
+			$enabledEvmTokens,
+			$enabledEthereumTokens,
+			$exchanges,
+			$balances
+		]) => {
 			if ($availableTokens.length === 0 || isNullish($exchanges)) {
 				return [];
 			}
 
 			return enrichTokensWithUsdAndBalance({
 				tokens: $availableTokens,
-				nativeTokens: [...$enabledEvmTokens, ...$enabledEthereumTokens],
+				nativeTokens: [
+					...$enabledEvmTokens,
+					...$enabledEthereumTokens,
+					...(nonNullish($enabledMainnetBitcoinToken) ? [$enabledMainnetBitcoinToken] : [])
+				],
 				exchanges: $exchanges,
 				balances: $balances
 			});

--- a/src/frontend/src/tests/lib/stores/open-crypto-pay.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/open-crypto-pay.store.spec.ts
@@ -1,3 +1,4 @@
+import { enabledMainnetBitcoinToken } from '$btc/derived/tokens.derived';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
@@ -9,6 +10,15 @@ import type {
 	PayableTokenWithFees
 } from '$lib/types/open-crypto-pay';
 import { get } from 'svelte/store';
+
+vi.mock('$btc/derived/tokens.derived', () => ({
+	enabledMainnetBitcoinToken: {
+		subscribe: vi.fn((callback) => {
+			callback(undefined);
+			return () => {};
+		})
+	}
+}));
 
 vi.mock('$eth/derived/tokens.derived', () => ({
 	enabledEthereumTokens: {
@@ -328,6 +338,11 @@ describe('OpenCryptoPayStore', () => {
 	describe('combined operations', () => {
 		beforeEach(() => {
 			vi.resetAllMocks();
+
+			vi.spyOn(enabledMainnetBitcoinToken, 'subscribe').mockImplementation((fn) => {
+				fn(undefined);
+				return () => {};
+			});
 
 			vi.spyOn(enabledEthereumTokens, 'subscribe').mockImplementation((fn) => {
 				fn([]);


### PR DESCRIPTION
# Motivation

We need to add BTC mainnet token (if enabled) to the OCP store.
