### PR TITLE
fix(frontend): remove fallback in OpenCryptoPayProgress

### DIFF
--- a/src/frontend/src/lib/components/open-crypto-pay/OpenCryptoPayProgress.svelte
+++ b/src/frontend/src/lib/components/open-crypto-pay/OpenCryptoPayProgress.svelte
@@ -8,9 +8,9 @@
 		payProgressStep?: string;
 	}
 
-	let { payProgressStep = ProgressStepsPayment.REQUEST_DETAILS }: Props = $props();
+	let { payProgressStep }: Props = $props();
 
-	let steps = $state<ProgressSteps>([
+	let steps = $derived<ProgressSteps>([
 		{
 			step: ProgressStepsPayment.REQUEST_DETAILS,
 			text: $i18n.pay.text.request_payment_details,


### PR DESCRIPTION
# Motivation

To align the pay progress component, we need to replace $state with $derived and remove the fallback.