### PR TITLE
fix(frontend): move pay progress var to modal

### DIFF
--- a/src/frontend/src/lib/components/open-crypto-pay/OpenCryptoPayWizard.svelte
+++ b/src/frontend/src/lib/components/open-crypto-pay/OpenCryptoPayWizard.svelte
@@ -7,7 +7,7 @@
 	import OpenCryptoPayTokensList from '$lib/components/open-crypto-pay/OpenCryptoPayTokensList.svelte';
 	import PaymentFailed from '$lib/components/open-crypto-pay/PaymentFailed.svelte';
 	import PaymentSucceeded from '$lib/components/open-crypto-pay/PaymentSucceeded.svelte';
-	import { ProgressStepsPayment } from '$lib/enums/progress-steps';
+	import type { ProgressStepsPayment } from '$lib/enums/progress-steps';
 	import { WizardStepsScanner } from '$lib/enums/wizard-steps';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { PAY_CONTEXT_KEY, type PayContext } from '$lib/stores/open-crypto-pay.store';
@@ -17,11 +17,10 @@
 		modal: WizardModal<WizardStepsScanner>;
 		steps: WizardSteps<WizardStepsScanner>;
 		currentStep?: WizardStep<WizardStepsScanner>;
+		payProgressStep: ProgressStepsPayment;
 	}
 
-	let { modal, steps, currentStep }: Props = $props();
-
-	let payProgressStep = $state(ProgressStepsPayment.REQUEST_DETAILS);
+	let { modal, steps, currentStep, payProgressStep = $bindable() }: Props = $props();
 
 	const onClose = () => modalStore.close();
 

--- a/src/frontend/src/lib/components/scanner/ScannerModal.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerModal.svelte
@@ -6,6 +6,7 @@
 	import ScannerCode from '$lib/components/scanner/ScannerCode.svelte';
 	import { scannerWizardSteps } from '$lib/config/scanner.config';
 	import { PLAUSIBLE_EVENTS } from '$lib/enums/plausible';
+	import { ProgressStepsPayment } from '$lib/enums/progress-steps';
 	import { WizardStepsScanner } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -25,7 +26,12 @@
 
 	let modal: WizardModal<WizardStepsScanner> | undefined = $state();
 
-	const { selectedToken, data } = setContext<PayContext>(PAY_CONTEXT_KEY, initPayContext());
+	let payProgressStep = $state(ProgressStepsPayment.REQUEST_DETAILS);
+
+	const { selectedToken, data: payData } = setContext<PayContext>(
+		PAY_CONTEXT_KEY,
+		initPayContext()
+	);
 
 	const onClose = () => {
 		if (currentStep?.name === WizardStepsScanner.PAY) {
@@ -34,7 +40,7 @@
 				metadata: {
 					...getOpenCryptoPayBaseTrackingParams({
 						token: $selectedToken,
-						providerData: $data
+						providerData: $payData
 					}),
 					result_status: 'cancel'
 				}
@@ -81,7 +87,7 @@
 		{#if currentStep?.name === WizardStepsScanner.SCAN}
 			<ScannerCode {onNext} />
 		{:else if currentStep?.name === WizardStepsScanner.PAY || currentStep?.name === WizardStepsScanner.TOKENS_LIST || currentStep?.name === WizardStepsScanner.PAYING || currentStep?.name === WizardStepsScanner.PAYMENT_FAILED || currentStep?.name === WizardStepsScanner.PAYMENT_CONFIRMED}
-			<OpenCryptoPayWizard {currentStep} {modal} {steps} />
+			<OpenCryptoPayWizard {currentStep} {modal} {steps} bind:payProgressStep />
 		{/if}
 	{/key}
 </WizardModal>


### PR DESCRIPTION
# Motivation

Because of the well-known issue with the wizard component (it completely re-renders on step change and therefore all the local stores/vars get reset), we need to move `payProgressStep` outside of it.
