### PR TITLE
feat(frontend): add signBtc signer canister method

### DIFF
--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -22,6 +22,7 @@ import {
 import type {
 	GetSchnorrPublicKeyParams,
 	SendBtcParams,
+	SignBtcResponse,
 	SignWithSchnorrParams
 } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
@@ -180,6 +181,35 @@ export class SignerCanister extends Canister<SignerService> {
 		utxosToSpend,
 		...rest
 	}: SendBtcParams): Promise<SendBtcResponse> => {
+		const { btc_caller_send } = this.caller({
+			certified: true
+		});
+
+		const response = await btc_caller_send(
+			{
+				address_type: P2WPKH,
+				utxos_to_spend: utxosToSpend,
+				fee_satoshis: feeSatoshis,
+				...rest
+			},
+			[SIGNER_PAYMENT_TYPE]
+		);
+
+		if ('Ok' in response) {
+			const { Ok } = response;
+			return Ok;
+		}
+
+		throw mapSignerCanisterSendBtcError(response.Err);
+	};
+
+	signBtc = async ({
+		feeSatoshis,
+		utxosToSpend,
+		...rest
+	}: SendBtcParams): Promise<SignBtcResponse> => {
+		// TODO: replace with signer's btc_caller_sign when the respective method is available
+		// Note: btc_caller_sign will accept the same params as btc_caller_send so only the function name should be changed
 		const { btc_caller_send } = this.caller({
 			certified: true
 		});

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -12,6 +12,7 @@ import type { TxId } from '$declarations/kong_backend/kong_backend.did';
 import type {
 	BtcTxOutput,
 	SchnorrKeyId,
+	SendBtcResponse,
 	BitcoinNetwork as SignerBitcoinNetwork,
 	Utxo as SignerUtxo
 } from '$declarations/signer/signer.did';
@@ -59,6 +60,9 @@ export interface SendBtcParams {
 	utxosToSpend: SignerUtxo[];
 	outputs: BtcTxOutput[];
 }
+
+// TODO: replace with signer's SignBtcResponse when the respective type is available
+export type SignBtcResponse = SendBtcResponse;
 
 export interface GetSchnorrPublicKeyParams {
 	derivationPath: string[];


### PR DESCRIPTION
# Motivation

Even though the `btc_caller_sign` signer's method is not available yet (pending release), we can already prepare the canister code. Since all the params are 1:1 with what `btc_caller_send` accepts, we can use it for now and then replace all the places when the proposal went through. 