### PR TITLE
refactor(frontend): move pay method up to wizard

### DIFF
--- a/src/frontend/src/lib/components/open-crypto-pay/OpenCryptoPay.svelte
+++ b/src/frontend/src/lib/components/open-crypto-pay/OpenCryptoPay.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import SelectedTokenToPay from '$lib/components/open-crypto-pay/SelectedTokenToPay.svelte';
 	import PayHero from '$lib/components/scanner/PayHero.svelte';
 	import ReceiptData from '$lib/components/scanner/PayReceiptData.svelte';
@@ -9,45 +8,23 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
-	import { ethAddress } from '$lib/derived/address.derived';
-	import { authIdentity } from '$lib/derived/auth.derived';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import {
-		PLAUSIBLE_EVENT_CONTEXTS,
-		PLAUSIBLE_EVENT_EVENTS_KEYS,
-		PLAUSIBLE_EVENTS
-	} from '$lib/enums/plausible';
-	import type { ProgressStepsPayment } from '$lib/enums/progress-steps';
-	import { trackEvent } from '$lib/services/analytics.services';
-	import { pay } from '$lib/services/open-crypto-pay.services';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { PAY_CONTEXT_KEY, type PayContext } from '$lib/stores/open-crypto-pay.store';
-	import { errorDetailToString } from '$lib/utils/error.utils';
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { parseToken } from '$lib/utils/parse.utils';
 
 	interface Props {
 		onSelectToken: () => void;
 		isTokenSelecting: boolean;
-		payProgressStep: ProgressStepsPayment;
-		onPay: () => void;
-		onPaySucceeded: () => void;
-		onPayFailed: () => void;
+		onPayClick: () => void;
 	}
 
-	let {
-		onSelectToken,
-		onPay,
-		onPaySucceeded,
-		onPayFailed,
-		isTokenSelecting = $bindable(),
-		payProgressStep = $bindable()
-	}: Props = $props();
+	let { onSelectToken, onPayClick, isTokenSelecting = $bindable() }: Props = $props();
 
-	const { data, selectedToken, failedPaymentError } = getContext<PayContext>(PAY_CONTEXT_KEY);
+	const { data, selectedToken } = getContext<PayContext>(PAY_CONTEXT_KEY);
 
 	let exchangeFeeBalance = $derived(
 		nonNullish($selectedToken)
@@ -79,87 +56,6 @@
 				})
 			: $i18n.scanner.text.pay
 	);
-
-	const progress = (step: ProgressStepsPayment) => (payProgressStep = step);
-
-	const fetchPay = async () => {
-		if (
-			isNullish($selectedToken) ||
-			isNullish($data) ||
-			isNullish($ethAddress) ||
-			isNullish($authIdentity)
-		) {
-			return;
-		}
-
-		onPay();
-
-		const trackEventBaseParams = {
-			event_context: PLAUSIBLE_EVENT_CONTEXTS.OPEN_CRYPTOPAY,
-			event_subcontext: PLAUSIBLE_EVENT_CONTEXTS.DFX,
-			event_key: PLAUSIBLE_EVENT_EVENTS_KEYS.PRICE,
-			event_value: `${$data.requestedAmount.amount} ${$data.requestedAmount.asset}`,
-			token_symbol: $selectedToken.symbol,
-			token_network: $selectedToken.network.name,
-			token_name: $selectedToken.name,
-			token_standard: $selectedToken.standard.code,
-			token_id: `${$selectedToken.id.toString()}`,
-			token_usd_value: `${$selectedToken.amountInUSD}`,
-			...(isTokenErc20($selectedToken) && {
-				token_address: $selectedToken.address
-			})
-		};
-
-		const startTime = performance.now();
-
-		const amount = parseToken({
-			value: `${$selectedToken.amount}`,
-			unitName: $selectedToken.decimals
-		});
-
-		try {
-			await pay({
-				token: $selectedToken,
-				data: $data,
-				from: $ethAddress,
-				identity: $authIdentity,
-				progress,
-				amount
-			});
-
-			const duration = performance.now() - startTime;
-			const durationInSeconds = Math.round(duration / 1000);
-
-			trackEvent({
-				name: PLAUSIBLE_EVENTS.PAY,
-				metadata: {
-					...trackEventBaseParams,
-					result_status: 'success',
-					result_duration_in_seconds: `${durationInSeconds}`
-				}
-			});
-
-			onPaySucceeded();
-		} catch (error: unknown) {
-			const duration = performance.now() - startTime;
-			const durationInSeconds = Math.round(duration / 1000);
-			const errorMessage = errorDetailToString(error) ?? $i18n.send.error.unexpected;
-
-			trackEvent({
-				name: PLAUSIBLE_EVENTS.PAY,
-				metadata: {
-					...trackEventBaseParams,
-					result_status: 'error',
-					result_error: errorMessage,
-					result_duration_in_seconds: `${durationInSeconds}`
-				}
-			});
-
-			failedPaymentError.set(errorMessage);
-
-			onPayFailed();
-		}
-	};
 </script>
 
 <ContentWithToolbar>
@@ -193,7 +89,7 @@
 
 	{#snippet toolbar()}
 		<ButtonGroup>
-			<Button disabled={isNullish($selectedToken)} onclick={fetchPay}>{payAmount}</Button>
+			<Button disabled={isNullish($selectedToken)} onclick={onPayClick}>{payAmount}</Button>
 		</ButtonGroup>
 	{/snippet}
 </ContentWithToolbar>

--- a/src/frontend/src/lib/components/open-crypto-pay/OpenCryptoPayWizard.svelte
+++ b/src/frontend/src/lib/components/open-crypto-pay/OpenCryptoPayWizard.svelte
@@ -7,10 +7,19 @@
 	import OpenCryptoPayTokensList from '$lib/components/open-crypto-pay/OpenCryptoPayTokensList.svelte';
 	import PaymentFailed from '$lib/components/open-crypto-pay/PaymentFailed.svelte';
 	import PaymentSucceeded from '$lib/components/open-crypto-pay/PaymentSucceeded.svelte';
+	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { PLAUSIBLE_EVENTS } from '$lib/enums/plausible';
 	import type { ProgressStepsPayment } from '$lib/enums/progress-steps';
 	import { WizardStepsScanner } from '$lib/enums/wizard-steps';
+	import { trackEvent } from '$lib/services/analytics.services';
+	import { pay as payApi } from '$lib/services/open-crypto-pay.services';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { PAY_CONTEXT_KEY, type PayContext } from '$lib/stores/open-crypto-pay.store';
+	import { errorDetailToString } from '$lib/utils/error.utils';
+	import { getOpenCryptoPayBaseTrackingParams } from '$lib/utils/open-crypto-pay.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	interface Props {
@@ -24,7 +33,8 @@
 
 	const onClose = () => modalStore.close();
 
-	const { reset } = getContext<PayContext>(PAY_CONTEXT_KEY);
+	const { data, selectedToken, failedPaymentError, reset } =
+		getContext<PayContext>(PAY_CONTEXT_KEY);
 
 	const goToStep = (stepName: WizardStepsScanner) => {
 		if (isNullish(modal)) {
@@ -38,18 +48,85 @@
 		});
 	};
 
+	const progress = (step: ProgressStepsPayment) => (payProgressStep = step);
+
+	const pay = async () => {
+		if (
+			isNullish($selectedToken) ||
+			isNullish($data) ||
+			isNullish($ethAddress) ||
+			isNullish($authIdentity)
+		) {
+			return;
+		}
+
+		goToStep(WizardStepsScanner.PAYING);
+
+		const trackEventBaseParams = getOpenCryptoPayBaseTrackingParams({
+			token: $selectedToken,
+			providerData: $data
+		});
+
+		const startTime = performance.now();
+
+		const amount = parseToken({
+			value: `${$selectedToken.amount}`,
+			unitName: $selectedToken.decimals
+		});
+
+		try {
+			await payApi({
+				token: $selectedToken,
+				data: $data,
+				from: $ethAddress,
+				identity: $authIdentity,
+				progress,
+				amount
+			});
+
+			const duration = performance.now() - startTime;
+			const durationInSeconds = Math.round(duration / 1000);
+
+			trackEvent({
+				name: PLAUSIBLE_EVENTS.PAY,
+				metadata: {
+					...trackEventBaseParams,
+					result_status: 'success',
+					result_duration_in_seconds: `${durationInSeconds}`
+				}
+			});
+
+			goToStep(WizardStepsScanner.PAYMENT_CONFIRMED);
+		} catch (error: unknown) {
+			const duration = performance.now() - startTime;
+			const durationInSeconds = Math.round(duration / 1000);
+			const errorMessage = errorDetailToString(error) ?? $i18n.send.error.unexpected;
+
+			trackEvent({
+				name: PLAUSIBLE_EVENTS.PAY,
+				metadata: {
+					...trackEventBaseParams,
+					result_status: 'error',
+					result_error: errorMessage,
+					result_duration_in_seconds: `${durationInSeconds}`
+				}
+			});
+
+			failedPaymentError.set(errorMessage);
+
+			goToStep(WizardStepsScanner.PAYMENT_FAILED);
+		}
+	};
+
 	let isTokenSelecting = $state<boolean>(false);
 </script>
 
 {#key currentStep?.name}
 	{#if currentStep?.name === WizardStepsScanner.PAY}
 		<OpenCryptoPay
-			onPay={() => goToStep(WizardStepsScanner.PAYING)}
-			onPayFailed={() => goToStep(WizardStepsScanner.PAYMENT_FAILED)}
-			onPaySucceeded={() => goToStep(WizardStepsScanner.PAYMENT_CONFIRMED)}
+			onPayClick={pay}
 			onSelectToken={() => goToStep(WizardStepsScanner.TOKENS_LIST)}
 			bind:isTokenSelecting
-			bind:payProgressStep
 		/>
 	{:else if currentStep?.name === WizardStepsScanner.TOKENS_LIST && !isTokenSelecting}
 		<OpenCryptoPayTokensList onClose={() => goToStep(WizardStepsScanner.PAY)} />

--- a/src/frontend/src/tests/lib/components/open-crypto-pay/OpenCryptoPay.spec.ts
+++ b/src/frontend/src/tests/lib/components/open-crypto-pay/OpenCryptoPay.spec.ts
@@ -1,6 +1,5 @@
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import OpenCryptoPay from '$lib/components/open-crypto-pay/OpenCryptoPay.svelte';
-import { ProgressStepsPayment } from '$lib/enums/progress-steps';
 import en from '$lib/i18n/en.json';
 import { PAY_CONTEXT_KEY } from '$lib/stores/open-crypto-pay.store';
 import type {
@@ -131,33 +130,28 @@ describe('OpenCryptoPay', () => {
 		availableTokens: writable(availableTokens)
 	});
 
-	const props = {
-		payProgressStep: ProgressStepsPayment.REQUEST_DETAILS,
-		onPay: vi.fn(),
-		onPaySucceeded: vi.fn(),
-		onPayFailed: vi.fn()
-	};
-
 	const renderWithContext = ({
 		data = undefined,
 		selectedToken = undefined,
 		onSelectToken = vi.fn(),
 		isTokenSelecting = false,
+		onPayClick = vi.fn(),
 		availableTokens = []
 	}: {
 		data?: OpenCryptoPayResponse | undefined;
 		selectedToken?: PayableTokenWithConvertedAmount | undefined;
 		onSelectToken?: () => void;
 		isTokenSelecting?: boolean;
+		onPayClick?: () => void;
 		availableTokens?: PayableTokenWithConvertedAmount[];
 	} = {}) => {
 		const mockContext = createMockContext({ data, selectedToken, availableTokens });
 
 		return render(OpenCryptoPay, {
 			props: {
-				...props,
 				onSelectToken,
-				isTokenSelecting
+				isTokenSelecting,
+				onPayClick
 			},
 			context: new Map([[PAY_CONTEXT_KEY, mockContext]])
 		});


### PR DESCRIPTION
# Motivation

Currently, the `pay` service is called from one of the wizard step, which is not aligned with the other modal flows. Instead, we need to move it to the respective wizard.
