### PR TITLE
fix(frontend): issue with routing on initial load

### DIFF
--- a/src/frontend/src/lib/utils/route.utils.ts
+++ b/src/frontend/src/lib/utils/route.utils.ts
@@ -7,7 +7,7 @@ export const replaceHistory = (url: URL) => {
 		return;
 	}
 
-	history.replaceState({}, '', url);
+	history.replaceState(history.state ?? {}, '', url);
 };
 
 /**


### PR DESCRIPTION
# Motivation

There was an issue with the back button on initial app load - user opens OISY -> goes to a token page -> clicks "back" button -> the URL changes to "/" but token page content stays on the page. The investigation showed that it was happening because of `cleanUpMsgUrl` - this function is called unconditionally in the main `layout` file (even when there are no `msg`/`level` params to clean). 

The whole issue looks like this:
1. Svelte writes its routing metadata to `history.state` on initial load.
2. `displayAndCleanLogoutMsg` calls `replaceHistory` that deletes the initial state/metadata from p. 1.
3.  User navigates to token page -> Svelte pushes a new history entry with proper state.   
4. User clicks the back button -> history.back() is called, it pops to the initial entry which now has {} as state.
5. Svelte can't recognize the entry -> page component stays the same despite URL being updated correctly.

The fix is to provide the previous history state (if it exists) while calling `history.replaceState`.

