### PR TITLE
feat(frontend): Persist network choice between steps of `ManageTokensModal`

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -21,11 +21,13 @@
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { ExchangesData } from '$lib/types/exchange';
+	import type { Network } from '$lib/types/network';
 	import type { Token, TokenId } from '$lib/types/token';
 	import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
 	import { pinEnabledTokensAtTop, sortTokens } from '$lib/utils/tokens.utils';
 
 	interface Props {
+		network?: Network;
 		initialSearch?: string;
 		infoElement?: Snippet;
 		isNftsPage?: boolean;
@@ -33,7 +35,14 @@
 		onAddToken: () => void;
 	}
 
-	let { initialSearch, infoElement, isNftsPage, onSave, onAddToken }: Props = $props();
+	let {
+		network = $bindable(),
+		initialSearch,
+		infoElement,
+		isNftsPage,
+		onSave,
+		onAddToken
+	}: Props = $props();
 
 	// To avoid strange behaviour when the exchange data changes (for example, the tokens may shift
 	// since some of them are sorted by market cap), we store the exchange data in a variable during
@@ -69,7 +78,7 @@
 		initModalTokensListContext({
 			tokens: [],
 			filterZeroBalance: false,
-			filterNetwork: $selectedNetwork,
+			filterNetwork: network ?? $selectedNetwork,
 			// TODO: This statement is not reactive. Check if it is intentional or not.
 			// eslint-disable-next-line svelte/no-unused-svelte-ignore
 			// svelte-ignore state_referenced_locally
@@ -82,7 +91,9 @@
 		})
 	);
 
-	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
+	const { setTokens, filterNetwork } = getContext<ModalTokensListContext>(
+		MODAL_TOKENS_LIST_CONTEXT_KEY
+	);
 
 	const updateContextTokens = () => {
 		// Keep the context list in sync only until the user starts editing.
@@ -97,6 +108,12 @@
 		[userHasEdited, allTokensSorted];
 
 		untrack(() => updateContextTokens());
+	});
+
+	$effect(() => {
+		if (nonNullish($filterNetwork)) {
+			network = $filterNetwork;
+		}
 	});
 
 	let showNetworks = $state(false);

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -122,6 +122,7 @@
 				{isNftsPage}
 				onAddToken={modal.next}
 				onSave={saveTokens}
+				bind:network
 			/>
 		{/if}
 	{/key}


### PR DESCRIPTION
# Motivation

When we move from the token list to the manual import of tokens in the Manage Tokens Modal, we would like to persist any choice of network (if the user had ever chosen one).

So, for example:

1. User opens manage tokens modal.
2. User selects network A.
3. User click "Import token"
4. User already has the network A selected.

# Changes

- Bind the `network` prop in component `ManageTokens`.
- Set an effect to set the `network` based on `filterNetwork` of modal context: this allows to persist a choice from `ManageTokens` component.
- Initialize the modal context with the network if existing: this allows to persist a choice from the `AddTokenByNetwork` component.

# Tests

A manual test:


https://github.com/user-attachments/assets/1daab3e1-f23c-436e-9f25-9fafe44128a2


