### PR TITLE
feat(frontend): Use Sveltekit `replaceState`

### DIFF
--- a/src/frontend/src/lib/utils/route.utils.ts
+++ b/src/frontend/src/lib/utils/route.utils.ts
@@ -1,3 +1,5 @@
+import { replaceState } from '$app/navigation';
+
 /**
  * Update browser URL. To be use only for really particular use case that do not include navigation and loading data.
  */
@@ -7,7 +9,7 @@ export const replaceHistory = (url: URL) => {
 		return;
 	}
 
-	history.replaceState(history.state ?? {}, '', url);
+	replaceState(url, history.state ?? {});
 };
 
 /**


### PR DESCRIPTION
# Motivation

We receive a warning locally:

> Avoid using `history.pushState(...)` and `history.replaceState(...)` as these will conflict with SvelteKit's router. Use the `pushState` and `replaceState` imports from `$app/navigation` instead.

So, in this PR, we use the suggested method, when possible.
