### PR TITLE
fix(frontend): Do not save ERC custom tokens with unrecognized standard

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
@@ -2,6 +2,7 @@
 	import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 	import { get } from 'svelte/store';
 	import EthAddTokenReview from '$eth/components/tokens/EthAddTokenReview.svelte';
+	import { infuraErc20Providers } from '$eth/providers/infura-erc20.providers';
 	import { isInterfaceErc1155 } from '$eth/services/erc1155.services';
 	import { isInterfaceErc721 } from '$eth/services/erc721.services';
 	import type { Erc20Metadata } from '$eth/types/erc20';
@@ -33,7 +34,6 @@
 		isNetworkIdSOLDevnet
 	} from '$lib/utils/network.utils';
 	import SolAddTokenReview from '$sol/components/tokens/SolAddTokenReview.svelte';
-	import {infuraErc20Providers} from "$eth/providers/infura-erc20.providers";
 
 	interface Props {
 		network?: Network;
@@ -157,10 +157,9 @@
 			return;
 		}
 
-			const {  isErc20 } = infuraErc20Providers(network.id);
+		const { isErc20 } = infuraErc20Providers(network.id);
 
-
-		if (await isErc20({ contractAddress:ethContractAddress })) {
+		if (await isErc20({ contractAddress: ethContractAddress })) {
 			await saveTokens([{ ...newToken, networkKey: 'Erc20' }]);
 
 			return;


### PR DESCRIPTION
# Motivation

In component AddTokenReviewByNetwork, we are considering a token ERC20 if the metadata have decimals. That is not effective, since other standard may have decimals (null or positive) and not being ERC20. Since we have a method for it, better to use that directly.