### PR TITLE
refactor(frontend): Avoid passing store to `switchNetwork` util

### DIFF
--- a/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
+++ b/src/frontend/src/lib/components/networks/NetworksSwitcher.svelte
@@ -13,7 +13,6 @@
 	import { SettingsModalType } from '$lib/enums/settings-modal-types';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import { userSelectedNetworkStore } from '$lib/stores/user-selected-network.store';
 	import type { OptionNetworkId } from '$lib/types/network';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { gotoReplaceRoot, isRouteTransactions, switchNetwork } from '$lib/utils/nav.utils';
@@ -28,7 +27,7 @@
 	let dropdown = $state<Dropdown | undefined>();
 
 	const onNetworkSelect = async (networkId: OptionNetworkId) => {
-		await switchNetwork({ networkId, userSelectedNetworkStore });
+		await switchNetwork({ networkId });
 
 		if (isRouteTransactions(page)) {
 			await gotoReplaceRoot();

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -10,6 +10,7 @@ import {
 	TOKEN_PARAM,
 	URI_PARAM
 } from '$lib/constants/routes.constants';
+import { userSelectedNetworkStore } from '$lib/stores/user-selected-network.store';
 import type { NetworkId } from '$lib/types/network';
 import type { Nft, NftCollection } from '$lib/types/nft';
 import type { OptionString } from '$lib/types/string';
@@ -18,7 +19,6 @@ import type { Option } from '$lib/types/utils';
 import { getPageTokenIdentifier } from '$lib/utils/page-token.utils';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 import type { LoadEvent, NavigationTarget, Page } from '@sveltejs/kit';
-import type { Writable } from 'svelte/store';
 
 const normalizePath = (s: string | null) =>
 	nonNullish(s) ? (s.endsWith('/') ? s : `${s}/`) : null;
@@ -171,13 +171,7 @@ export const resetRouteParams = (): RouteParams => ({
 	[URI_PARAM]: null
 });
 
-export const switchNetwork = async ({
-	networkId,
-	userSelectedNetworkStore
-}: {
-	networkId: Option<NetworkId>;
-	userSelectedNetworkStore: Writable<NetworkId | undefined>;
-}) => {
+export const switchNetwork = async ({ networkId }: { networkId: Option<NetworkId> }) => {
 	const url = new URL(window.location.href);
 
 	if (isNullish(networkId) || isNullish(networkId.description)) {

--- a/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nav.utils.spec.ts
@@ -733,7 +733,7 @@ describe('nav.utils', () => {
 		it('should handle a nullish network ID', async () => {
 			userSelectedNetworkStore.set(ICP_NETWORK_ID);
 
-			await switchNetwork({ networkId: undefined, userSelectedNetworkStore });
+			await switchNetwork({ networkId: undefined });
 
 			expect(get(userSelectedNetworkStore)).toBeUndefined();
 
@@ -741,7 +741,7 @@ describe('nav.utils', () => {
 		});
 
 		it('should go to the URL with the set network ID', async () => {
-			await switchNetwork({ networkId: ICP_NETWORK_ID, userSelectedNetworkStore });
+			await switchNetwork({ networkId: ICP_NETWORK_ID });
 
 			expect(get(userSelectedNetworkStore)).toBe(ICP_NETWORK_ID);
 


### PR DESCRIPTION
# Motivation

It is not necessary (for now) to pass `userSelectedNetworkStore` to util `switchNetwork`.
