### PR TITLE
fix(frontend): Set user selected network on loading

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { isIOS, Spinner, SystemThemeListener, Toasts } from '@dfinity/gix-components';
-	import { userSelectedNetworkStore } from '$lib/stores/user-selected-network.store';
 	import { nonNullish } from '@dfinity/utils';
 	import { onDestroy, onMount, type Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -26,6 +25,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError } from '$lib/stores/toasts.store';
+	import { userSelectedNetworkStore } from '$lib/stores/user-selected-network.store';
 
 	interface Props {
 		children: Snippet;


### PR DESCRIPTION
# Motivation

Currently, if the user opens the NFT page from a deep link that already has `?network=...`, the breadcrumb back-link will omit the `network` param and effectively clear the filter.

This is not the intended behaviour, since ideally, the user would like to persist the network filter that started the page.

At the same time, we need to persist the current behaviour too: if no network is selected, we cannot enforce the network of any chosen NFT. That means that we cannot use the route network as point of truth.

The `userSelectedNetworkStore` is a good compromise, but it requires an additional step: we need to set it on loading with the route network value.

# Changes

- Add an `onMount` condition in the main layout, to set the `userSelectedNetworkStore` with the derived store `networkId` (derived from the URL network param).

# Tests

### Before

https://github.com/user-attachments/assets/ef336a94-7264-4cf5-bc7b-96c527261018

### After

https://github.com/user-attachments/assets/ddd62732-aa5e-46b2-ad4b-555d4a1426fe

### No changes for the rest

https://github.com/user-attachments/assets/3ad8c479-35b7-454a-8ac9-68bcc9eaf1ff


