### PR TITLE
feat(frontend): make Infura provider accessible by child classes

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20.providers.ts
@@ -15,7 +15,7 @@ import { InfuraProvider, type Networkish } from 'ethers/providers';
 import { get } from 'svelte/store';
 
 export class InfuraErc20Provider implements Erc20Provider {
-	private readonly provider: InfuraProvider;
+	protected readonly provider: InfuraProvider;
 
 	constructor(private readonly network: Networkish) {
 		this.provider = new InfuraProvider(this.network, INFURA_API_KEY);


### PR DESCRIPTION
# Motivation

`InfuraErc4626Provider` is going to extend `InfuraErc20Provider` class, therefore it needs access to `provider` field.
