### PR TITLE
feat(frontend): add bAutopilot_USDC ERC4626 token

### DIFF
--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_usdc.env.ts
@@ -1,0 +1,27 @@
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
+import { USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.usdc.env';
+import usdc from '$eth/assets/usdc.svg';
+import type { RequiredErc4626Token } from '$eth/types/erc4626';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+
+export const BAUTOPILOT_USDC_DECIMALS = 8;
+
+export const BAUTOPILOT_USDC_SYMBOL = 'bAutopilot_USDC';
+
+export const BAUTOPILOT_USDC_TOKEN_ID: TokenId = parseTokenId(BAUTOPILOT_USDC_SYMBOL);
+
+export const BAUTOPILOT_USDC_TOKEN: RequiredErc4626Token = {
+	id: BAUTOPILOT_USDC_TOKEN_ID,
+	network: BASE_NETWORK,
+	standard: { code: 'erc4626' },
+	category: 'default',
+	name: 'Autopilot USDC Base',
+	symbol: BAUTOPILOT_USDC_SYMBOL,
+	decimals: BAUTOPILOT_USDC_DECIMALS,
+	icon: usdc,
+	address: '0x0d877dc7c8fa3ad980dfdb18b48ec9f8768359c4',
+	exchange: 'erc4626',
+	assetAddress: USDC_TOKEN.address,
+	assetDecimals: USDC_TOKEN.decimals
+};

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens.erc4626.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens.erc4626.env.ts
@@ -1,0 +1,11 @@
+import { BASE_MAINNET_ENABLED } from '$env/networks/networks-evm/networks.evm.base.env';
+import { BAUTOPILOT_USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_usdc.env';
+import type { RequiredEvmErc4626Token } from '$evm/types/erc4626';
+import { defineSupportedTokens } from '$lib/utils/env.tokens.utils';
+
+const BASE_ERC4626_TOKENS_MAINNET: RequiredEvmErc4626Token[] = [BAUTOPILOT_USDC_TOKEN];
+
+export const BASE_ERC4626_TOKENS: RequiredEvmErc4626Token[] = defineSupportedTokens({
+	mainnetFlag: BASE_MAINNET_ENABLED,
+	mainnetTokens: BASE_ERC4626_TOKENS_MAINNET
+});

--- a/src/frontend/src/env/tokens/tokens-evm/tokens.erc4626.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens.erc4626.env.ts
@@ -1,0 +1,4 @@
+import { BASE_ERC4626_TOKENS } from '$env/tokens/tokens-evm/tokens-base/tokens.erc4626.env';
+import type { RequiredEvmErc4626Token } from '$evm/types/erc4626';
+
+export const EVM_ERC4626_TOKENS: RequiredEvmErc4626Token[] = [...BASE_ERC4626_TOKENS];

--- a/src/frontend/src/env/tokens/tokens.erc4626.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc4626.env.ts
@@ -1,0 +1,7 @@
+import { EVM_ERC4626_TOKENS } from '$env/tokens/tokens-evm/tokens.erc4626.env';
+import type { RequiredErc4626Token } from '$eth/types/erc4626';
+import type { RequiredEvmErc4626Token } from '$evm/types/erc4626';
+
+export const ERC4626_TOKENS: (RequiredErc4626Token | RequiredEvmErc4626Token)[] = [
+	...EVM_ERC4626_TOKENS
+];


### PR DESCRIPTION
# Motivation

We can now add a curated tokens list for ERC4626. For simplicity, it only contains 1 tokens for now, but it will be extended later.
