### PR TITLE
feat(devops): Add ecosystem to dependabot PR title

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: 'chore(github deps): '
+      prefix: 'chore(github-actions): '
 
   - package-ecosystem: cargo
     directory: '/'


### PR DESCRIPTION
# Motivation

Just to keep it more organized, we add the ecosystem detail in the PR title that dependabot creates.
