### PR TITLE
feat(frontend): add ERC4626 tokens to tokens.utils

### DIFF
--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -1,5 +1,6 @@
 import { isTokenErc1155, isTokenErc1155CustomToken } from '$eth/utils/erc1155.utils';
 import { isTokenErc20, isTokenErc20CustomToken } from '$eth/utils/erc20.utils';
+import { isTokenErc4626CustomToken } from '$eth/utils/erc4626.utils';
 import { isTokenErc721, isTokenErc721CustomToken } from '$eth/utils/erc721.utils';
 import { isTokenDip721CustomToken } from '$icp/utils/dip721.utils';
 import { isTokenExtCustomToken } from '$icp/utils/ext.utils';
@@ -364,6 +365,10 @@ const normaliseTokenForSave = (token: Token): SaveCustomTokenWithKey | undefined
 
 	if (isTokenErc721CustomToken(token)) {
 		return { ...token, chainId: token.network.chainId, networkKey: 'Erc721' };
+	}
+
+	if (isTokenErc4626CustomToken(token)) {
+		return { ...token, chainId: token.network.chainId, networkKey: 'Erc4626' };
 	}
 
 	if (isTokenErc1155CustomToken(token)) {

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -48,6 +48,7 @@ import { bn1Bi, bn2Bi, bn3Bi, certified, mockBalances } from '$tests/mocks/balan
 import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidErc1155Token } from '$tests/mocks/erc1155-tokens.mock';
 import { createMockErc20Tokens, mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
 import { mockValidErc721Token } from '$tests/mocks/erc721-tokens.mock';
 import { mockExchanges, mockOneUsd } from '$tests/mocks/exchanges.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
@@ -1065,6 +1066,25 @@ describe('tokens.utils', () => {
 			expect(saveCustomTokensWithKey).toHaveBeenCalledWith(
 				expect.objectContaining({
 					tokens: expect.arrayContaining([expect.objectContaining(token)]),
+					identity: mockIdentity
+				})
+			);
+		});
+
+		it('should call saveCustomTokensWithKey when ERC4626 tokens are present', async () => {
+			const token = { ...mockValidErc4626Token, enabled: true } as unknown as TokenUi;
+
+			await saveAllCustomTokens({
+				tokens: [token],
+				$authIdentity: mockIdentity,
+				$i18n: i18nMock
+			});
+
+			expect(saveCustomTokensWithKey).toHaveBeenCalledWith(
+				expect.objectContaining({
+					tokens: expect.arrayContaining([
+						expect.objectContaining({ ...token, networkKey: 'Erc4626' })
+					]),
 					identity: mockIdentity
 				})
 			);


### PR DESCRIPTION
# Motivation

We can now extend tokens.utils with ERC4626 token.
