### PR TITLE
feat(frontend): add ERC4626 tokens to token utils

### DIFF
--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -46,7 +46,11 @@ export const getMaxTransactionAmount = ({
 }): string => {
 	const value =
 		(balance ?? ZERO) -
-		(tokenStandard.code !== 'erc20' && tokenStandard.code !== 'spl' ? fee : ZERO);
+		(tokenStandard.code !== 'erc20' &&
+		tokenStandard.code !== 'erc4626' &&
+		tokenStandard.code !== 'spl'
+			? fee
+			: ZERO);
 
 	return value <= ZERO
 		? ZERO.toString()

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -114,6 +114,17 @@ describe('token.utils', () => {
 			expect(result).toBe((Number(balance) / 10 ** tokenDecimals).toString());
 		});
 
+		it('should return the untouched amount if the token is ERC4626', () => {
+			const result = getMaxTransactionAmount({
+				balance,
+				fee,
+				tokenDecimals,
+				tokenStandard: { code: 'erc4626' }
+			});
+
+			expect(result).toBe((Number(balance) / 10 ** tokenDecimals).toString());
+		});
+
 		it('should return the untouched amount if the token is SPL', () => {
 			const result = getMaxTransactionAmount({
 				balance,


### PR DESCRIPTION
# Motivation

We need to add ERC4626 standard to the tokens utils.
