### PR TITLE
feat(frontend): add ERC4626 tokens to EthTokenModal

### DIFF
--- a/src/frontend/src/eth/components/tokens/EthTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/EthTokenModal.svelte
@@ -2,8 +2,11 @@
 	import { nonNullish } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { erc20DefaultTokens } from '$eth/derived/erc20.derived';
+	import { erc4626DefaultTokens } from '$eth/derived/erc4626.derived';
 	import type { Erc20Token } from '$eth/types/erc20';
+	import type { Erc4626Token } from '$eth/types/erc4626';
 	import { isTokenErc20 } from '$eth/utils/erc20.utils.js';
+	import { isTokenErc4626 } from '$eth/utils/erc4626.utils';
 	import { getExplorerUrl } from '$eth/utils/eth.utils';
 	import ModalListItem from '$lib/components/common/ModalListItem.svelte';
 	import TokenModal from '$lib/components/tokens/TokenModal.svelte';
@@ -21,11 +24,15 @@
 
 	let isErc20 = $derived(nonNullish($pageToken) && isTokenErc20($pageToken));
 
-	let contractAddress = $derived(isErc20 ? ($pageToken as Erc20Token).address : undefined);
+	let isErc4626 = $derived(nonNullish($pageToken) && isTokenErc4626($pageToken));
+
+	let contractAddress = $derived(
+		isErc20 || isErc4626 ? ($pageToken as Erc20Token | Erc4626Token).address : undefined
+	);
 
 	let undeletableToken = $derived(
-		nonNullish($pageToken) && isErc20
-			? $erc20DefaultTokens.some(
+		nonNullish($pageToken) && (isErc20 || isErc4626)
+			? [...$erc20DefaultTokens, ...$erc4626DefaultTokens].some(
 					({ id, network: { id: networkId } }) =>
 						$pageToken.id === id && $pageToken.network.id === networkId
 				)

--- a/src/frontend/src/tests/eth/components/tokens/EthTokenModal.spec.ts
+++ b/src/frontend/src/tests/eth/components/tokens/EthTokenModal.spec.ts
@@ -1,8 +1,10 @@
 import EthTokenModal from '$eth/components/tokens/EthTokenModal.svelte';
 import { enabledErc20Tokens, erc20DefaultTokens } from '$eth/derived/erc20.derived';
+import { enabledErc4626Tokens, erc4626DefaultTokens } from '$eth/derived/erc4626.derived';
 import { modalStore } from '$lib/stores/modal.store';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { mockSplCustomToken } from '$tests/mocks/spl-tokens.mock';
@@ -56,5 +58,54 @@ describe('EthTokenModal', () => {
 		expect(container).toHaveTextContent(`${mockSplCustomToken.decimals}`);
 
 		expect(container).not.toHaveTextContent(en.tokens.text.delete_token);
+	});
+
+	describe('ERC4626 token', () => {
+		beforeEach(() => {
+			vi.resetAllMocks();
+			mockPage.reset();
+
+			vi.spyOn(enabledErc4626Tokens, 'subscribe').mockImplementation((fn) => {
+				fn([{ ...mockValidErc4626Token, enabled: true }]);
+				return () => {};
+			});
+
+			mockPage.mockToken(mockValidErc4626Token);
+		});
+
+		it('displays all required values including the delete button for an ERC4626 token', () => {
+			const { container } = render(EthTokenModal);
+
+			modalStore.openBtcToken({ id: mockValidErc4626Token.id, data: undefined });
+
+			expect(container).toHaveTextContent(mockValidErc4626Token.network.name);
+			expect(container).toHaveTextContent(mockValidErc4626Token.name);
+			expect(container).toHaveTextContent(mockValidErc4626Token.symbol);
+			expect(container).toHaveTextContent(
+				shortenWithMiddleEllipsis({ text: mockValidErc4626Token.address })
+			);
+
+			expect(container).toHaveTextContent(en.tokens.text.delete_token);
+		});
+
+		it('displays all required values without the delete button for a default ERC4626 token', () => {
+			vi.spyOn(erc4626DefaultTokens, 'subscribe').mockImplementation((fn) => {
+				fn([mockValidErc4626Token]);
+				return () => {};
+			});
+
+			const { container } = render(EthTokenModal);
+
+			modalStore.openBtcToken({ id: mockValidErc4626Token.id, data: undefined });
+
+			expect(container).toHaveTextContent(mockValidErc4626Token.network.name);
+			expect(container).toHaveTextContent(mockValidErc4626Token.name);
+			expect(container).toHaveTextContent(mockValidErc4626Token.symbol);
+			expect(container).toHaveTextContent(
+				shortenWithMiddleEllipsis({ text: mockValidErc4626Token.address })
+			);
+
+			expect(container).not.toHaveTextContent(en.tokens.text.delete_token);
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

We can now extend Token details modal with ERC4626 standard.