### PR TITLE
feat(frontend): add ERC4626 tokens in icrc-erc20.derived

### DIFF
--- a/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
+++ b/src/frontend/src/icp-eth/derived/icrc-erc20.derived.ts
@@ -1,4 +1,5 @@
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
+import { enabledErc4626AssetAddresses } from '$eth/derived/erc4626.derived';
 import type { Erc20Token } from '$eth/types/erc20';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
@@ -45,13 +46,18 @@ const enabledIcrcTwinTokensAddresses: Readable<Erc20ContractAddressWithNetwork[]
 
 export const enabledMergedErc20TokensAddresses: Readable<Erc20ContractAddressWithNetwork[]> =
 	derived(
-		[enabledIcrcTwinTokensAddresses, enabledErc20TokensAddresses],
-		([$enabledIcrcTwinTokensAddresses, $enabledErc20TokensAddresses]) => [
+		[enabledIcrcTwinTokensAddresses, enabledErc20TokensAddresses, enabledErc4626AssetAddresses],
+		([
+			$enabledIcrcTwinTokensAddresses,
+			$enabledErc20TokensAddresses,
+			$enabledErc4626AssetAddresses
+		]) => [
 			...new Map(
-				[...$enabledErc20TokensAddresses, ...$enabledIcrcTwinTokensAddresses].map((item) => [
-					`${item.address}|${item.coingeckoId}`,
-					item
-				])
+				[
+					...$enabledErc20TokensAddresses,
+					...$enabledIcrcTwinTokensAddresses,
+					...$enabledErc4626AssetAddresses
+				].map((item) => [`${item.address}|${item.coingeckoId}`, item])
 			).values()
 		]
 	);


### PR DESCRIPTION
# Motivation

We need to extend icrc-erc20.derived with ERC4626 tokens.

Note: potentially, this store can be moved outside of `icp-eth` folder, but for now we re-use the same structure.
