### PR TITLE
fix(frontend): remove icons from default ERC4626 tokens

### DIFF
--- a/src/frontend/src/env/tokens/tokens-erc4626/tokens.autopilot_usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc4626/tokens.autopilot_usdc.env.ts
@@ -1,6 +1,5 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
-import usdc from '$eth/assets/usdc.svg';
 import type { RequiredErc4626Token } from '$eth/types/erc4626';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,7 +18,8 @@ export const AUTOPILOT_USDC_TOKEN: RequiredErc4626Token = {
 	name: 'Autopilot USDC Ethereum',
 	symbol: AUTOPILOT_USDC_SYMBOL,
 	decimals: AUTOPILOT_USDC_DECIMALS,
-	icon: usdc,
+	// TODO: add custom icon
+	icon: '',
 	address: '0x3151cee0cdb517c0e7db2b55ff5085e7d1809d90',
 	assetAddress: USDC_TOKEN.address,
 	assetDecimals: USDC_TOKEN.decimals

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_usdc.env.ts
@@ -1,6 +1,5 @@
 import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdc.env';
-import usdc from '$eth/assets/usdc.svg';
 import type { RequiredErc4626Token } from '$eth/types/erc4626';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,7 +18,8 @@ export const AAUTOPILOT_USDC_TOKEN: RequiredErc4626Token = {
 	name: 'Autopilot USDC Arbitrum',
 	symbol: AAUTOPILOT_USDC_SYMBOL,
 	decimals: AAUTOPILOT_USDC_DECIMALS,
-	icon: usdc,
+	// TODO: add custom icon
+	icon: '',
 	address: '0x407d3d942d0911a2fea7e22417f81e27c02d6c6f',
 	assetAddress: USDC_TOKEN.address,
 	assetDecimals: USDC_TOKEN.decimals

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_wbtc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_wbtc.env.ts
@@ -1,7 +1,6 @@
 import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { WBTC_TOKEN } from '$env/tokens/tokens-erc20/tokens.wbtc.env';
 import type { RequiredErc4626Token } from '$eth/types/erc4626';
-import wbtc from '$icp-eth/assets/wbtc.svg';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
 
@@ -19,7 +18,8 @@ export const AAUTOPILOT_WBTC_TOKEN: RequiredErc4626Token = {
 	name: 'Autopilot WBTC Arbitrum',
 	symbol: AAUTOPILOT_WBTC_SYMBOL,
 	decimals: AAUTOPILOT_WBTC_DECIMALS,
-	icon: wbtc,
+	// TODO: add custom icon
+	icon: '',
 	address: '0x49b2248f7a7a703731852db0b2217f40da75b8ab',
 	assetAddress: WBTC_TOKEN.address,
 	assetDecimals: WBTC_TOKEN.decimals

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_weth.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_weth.env.ts
@@ -1,6 +1,5 @@
 import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { WETH_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.weth.env';
-import weth from '$eth/assets/weth.svg';
 import type { RequiredErc4626Token } from '$eth/types/erc4626';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,7 +18,8 @@ export const AAUTOPILOT_WETH_TOKEN: RequiredErc4626Token = {
 	name: 'Autopilot WETH Arbitrum',
 	symbol: AAUTOPILOT_WETH_SYMBOL,
 	decimals: AAUTOPILOT_WETH_DECIMALS,
-	icon: weth,
+	// TODO: add custom icon
+	icon: '',
 	address: '0xce4d997a3b404f9eaa796f89deae40747d3647b7',
 	assetAddress: WETH_TOKEN.address,
 	assetDecimals: WETH_TOKEN.decimals

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_cbbtc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_cbbtc.env.ts
@@ -18,8 +18,9 @@ export const BAUTOPILOT_CBBTC_TOKEN: RequiredErc4626Token = {
 	symbol: BAUTOPILOT_CBBTC_SYMBOL,
 	decimals: BAUTOPILOT_CBBTC_DECIMALS,
 	address: '0x31a421271414641cb5063b71594b642d2666db6b',
-	// TODO: add cbBTC (ERC20) token to the list and use its data below
+	// TODO: add custom icon
 	icon: '',
+	// TODO: add cbBTC (ERC20) token to the list and use its data below
 	assetAddress: '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf',
 	assetDecimals: 8
 };

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_usdc.env.ts
@@ -1,6 +1,5 @@
 import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.usdc.env';
-import usdc from '$eth/assets/usdc.svg';
 import type { RequiredErc4626Token } from '$eth/types/erc4626';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,7 +18,8 @@ export const BAUTOPILOT_USDC_TOKEN: RequiredErc4626Token = {
 	name: 'Autopilot USDC Base',
 	symbol: BAUTOPILOT_USDC_SYMBOL,
 	decimals: BAUTOPILOT_USDC_DECIMALS,
-	icon: usdc,
+	// TODO: add custom icon
+	icon: '',
 	address: '0x0d877dc7c8fa3ad980dfdb18b48ec9f8768359c4',
 	assetAddress: USDC_TOKEN.address,
 	assetDecimals: USDC_TOKEN.decimals

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_weth.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_weth.env.ts
@@ -1,6 +1,5 @@
 import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { WETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.weth.env';
-import weth from '$eth/assets/weth.svg';
 import type { RequiredErc4626Token } from '$eth/types/erc4626';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,7 +18,8 @@ export const BAUTOPILOT_WETH_TOKEN: RequiredErc4626Token = {
 	name: 'Autopilot wETH Base',
 	symbol: BAUTOPILOT_WETH_SYMBOL,
 	decimals: BAUTOPILOT_WETH_DECIMALS,
-	icon: weth,
+	// TODO: add custom icon
+	icon: '',
 	address: '0x7872893e528Fe2c0829e405960db5B742112aa97',
 	assetAddress: WETH_TOKEN.address,
 	assetDecimals: WETH_TOKEN.decimals

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.morphoautopilot_usdc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.morphoautopilot_usdc.env.ts
@@ -1,6 +1,5 @@
 import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.usdc.env';
-import usdc from '$eth/assets/usdc.svg';
 import type { RequiredErc4626Token } from '$eth/types/erc4626';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -19,7 +18,8 @@ export const MORPHOAUTOPILOT_USDC_TOKEN: RequiredErc4626Token = {
 	name: 'Autopilot USDC Morpho (Base)',
 	symbol: MORPHOAUTOPILOT_USDC_SYMBOL,
 	decimals: MORPHOAUTOPILOT_USDC_DECIMALS,
-	icon: usdc,
+	// TODO: add custom icon
+	icon: '',
 	address: '0xd6701905c59EE618dc36DC747506BCE0a4AC760A',
 	assetAddress: USDC_TOKEN.address,
 	assetDecimals: USDC_TOKEN.decimals


### PR DESCRIPTION
# Motivation

We need to remove the current icons from the default ERC4626 tokens - we will later add custom icons for them.
