### PR TITLE
fix(frontend): rounding issue with OCP minFee value

### DIFF
--- a/src/frontend/src/btc/services/btc-open-crypto-pay.services.ts
+++ b/src/frontend/src/btc/services/btc-open-crypto-pay.services.ts
@@ -23,7 +23,9 @@ export const calculateBtcFee = (token: PayableToken): UtxosFee | undefined => {
 		return;
 	}
 
-	const feeRateMiliSatoshisPerVByteProvider = nonNullish(token.minFee) ? token.minFee * 1000 : 0;
+	const feeRateMiliSatoshisPerVByteProvider = nonNullish(token.minFee)
+		? Math.round(token.minFee * 1000)
+		: 0;
 	const feeRateMiliSatoshisPerVByte = BigInt(
 		Math.max(Number(feeRateMiliSatoshisPerVByteStore), feeRateMiliSatoshisPerVByteProvider)
 	);


### PR DESCRIPTION
# Motivation

Since `minFee` returned by OCP is a float (e.g. `2.026`), we need to use Math.round when converting it to a number that later can be used as BigInt.