### PR TITLE
style(frontend): Increase margin between title and subtitle in `TokenCard`

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -109,7 +109,12 @@
 		{/snippet}
 
 		{#snippet subtitle()}
-			<span class="flex items-center gap-1 sm:gap-2" class:ml-2={!asNetwork} class:sm:ml-4={!asNetwork} class:text-sm={asNetwork}>
+			<span
+				class="flex items-center gap-1 sm:gap-2"
+				class:ml-2={!asNetwork}
+				class:sm:ml-4={!asNetwork}
+				class:text-sm={asNetwork}
+			>
 				{#if !asNetwork}
 					{formattedExchangeRate}
 					<span


### PR DESCRIPTION
# Motivation

More spacing between the token symbol and its price change. Furthermore, we align the text to center.

### Before

<img width="620" height="785" alt="Screenshot 2026-02-18 at 10 31 12" src="https://github.com/user-attachments/assets/b8f70129-486c-4209-bdb5-70f2604f8106" />

### After

<img width="625" height="796" alt="Screenshot 2026-02-18 at 10 35 13" src="https://github.com/user-attachments/assets/9840cc58-a3e9-45b5-a4e0-4e2ef4d3c76b" />


