### PR TITLE
chore(frontend): Correct name for USDC token group

### DIFF
--- a/src/frontend/src/env/tokens/groups/groups.usdc.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.usdc.env.ts
@@ -9,6 +9,6 @@ export const USDC_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(USDC_TOKEN_GR
 export const USDC_TOKEN_GROUP: TokenGroupData = {
 	id: USDC_TOKEN_GROUP_ID,
 	icon: usdc,
-	name: 'USDC',
+	name: 'USD Coin',
 	symbol: USDC_TOKEN_GROUP_SYMBOL
 };


### PR DESCRIPTION
# Motivation

It is more detailed to assign the complete name to the USDC token group: USD Coin.
