### PR TITLE
feat(frontend): Add background and timeframe to exchange rate change

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeRateChange.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeRateChange.svelte
@@ -3,13 +3,16 @@
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { format24hChangeInCurrency } from '$lib/utils/format.utils';
 
 	interface Props {
 		usdPriceChangePercentage24h: number | undefined;
+		withBackground?: boolean;
+		timeFrame?: '24h';
 	}
 
-	let { usdPriceChangePercentage24h }: Props = $props();
+	let { usdPriceChangePercentage24h, withBackground = false, timeFrame }: Props = $props();
 
 	let parsedExchangeRateChange = $derived(
 		nonNullish(usdPriceChangePercentage24h)
@@ -31,18 +34,31 @@
 	let exchangeRateChangeSymbol = $derived(
 		nonNullish(exchangeRateChangeSign) ? (exchangeRateChangeSign === 'zero' ? '▸' : '▾') : undefined
 	);
+
+	let parsedTimeFrame = $derived(
+		nonNullish(timeFrame) ? $i18n.temporal.time_frame[`t_${timeFrame}`] : undefined
+	);
 </script>
 
 {#if nonNullish(parsedExchangeRateChange)}
 	<span
-		class="text-sm"
+		class="px-1 text-sm"
+		class:bg-error-subtle-30={withBackground && exchangeRateChangeSign === 'negative'}
+		class:bg-success-subtle-30={withBackground && exchangeRateChangeSign === 'positive'}
+		class:rounded={withBackground}
 		class:text-error-primary={exchangeRateChangeSign === 'negative'}
 		class:text-success-primary={exchangeRateChangeSign === 'positive'}
 		class:text-tertiary={exchangeRateChangeSign === 'zero'}
 	>
-		<span class="inline-block transform" class:rotate-180={exchangeRateChangeSign === 'positive'}>
+		<span
+			class="inline-block transform text-lg leading-none"
+			class:rotate-180={exchangeRateChangeSign === 'positive'}
+		>
 			{exchangeRateChangeSymbol}
 		</span>
 		{formattedExchangeRateChange}
+		{#if nonNullish(parsedTimeFrame)}
+			<span class="text-[11px]">{`(${parsedTimeFrame})`}</span>
+		{/if}
 	</span>
 {/if}

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "دقائق",
 			"second": "ثانية",
 			"second_plural": "ثواني"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "minuty",
 			"second": "sekunda",
 			"second_plural": "sekundy"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "Minuten",
 			"second": "Sekunde",
 			"second_plural": "Sekunden"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "minutes",
 			"second": "second",
 			"second_plural": "seconds"
+		},
+		"time_frame": {
+			"t_24h": "24h"
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "",
 			"second": "",
 			"second_plural": ""
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "minutes",
 			"second": "seconde",
 			"second_plural": "secondes"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "मिनट",
 			"second": "सेकंड",
 			"second_plural": "सेकंड"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "minuti",
 			"second": "secondo",
 			"second_plural": "secondi"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "分",
 			"second": "秒",
 			"second_plural": "秒"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "minuty",
 			"second": "sekunda",
 			"second_plural": "sekundy"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "minutos",
 			"second": "segundo",
 			"second_plural": "segundos"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "минут",
 			"second": "секунда",
 			"second_plural": "секунд"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "phút",
 			"second": "giây",
 			"second_plural": "giây"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2023,6 +2023,9 @@
 			"minute_plural": "分钟（复数）",
 			"second": "秒（单数）",
 			"second_plural": "秒（复数）"
+		},
+		"time_frame": {
+			"t_24h": ""
 		}
 	},
 	"ai_assistant": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1613,6 +1613,7 @@ interface I18nTemporal {
 		second: string;
 		second_plural: string;
 	};
+	time_frame: { t_24h: string };
 }
 
 interface I18nAi_assistant {

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeRateChange.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeRateChange.spec.ts
@@ -66,4 +66,33 @@ describe('ExchangeRateChange', () => {
 
 		expect(getByText('▸')).toBeInTheDocument();
 	});
+
+	it('should render the proper background', async () => {
+		const { getByText, rerender } = render(ExchangeRateChange, {
+			props: {
+				usdPriceChangePercentage24h: 1.23456,
+				withBackground: true
+			}
+		});
+
+		expect(getByText('1.23%')).toHaveClass('bg-success-subtle-30');
+
+		await rerender({
+			usdPriceChangePercentage24h: -123.456,
+			withBackground: true
+		});
+
+		expect(getByText('123%')).toHaveClass('bg-error-subtle-30');
+	});
+
+	it('should render the time-frame', () => {
+		const { getByText } = render(ExchangeRateChange, {
+			props: {
+				usdPriceChangePercentage24h: 1.23456,
+				timeFrame: '24h'
+			}
+		});
+
+		expect(getByText('(24h)')).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
# Motivation

We want to re-use the `ExchangeRateChange` component but with a few more optional props. Specifically, a background to increase the contrast, and a time-frame indicator to specify the time-range of reference (for example 24-hour).

# Changes

- Add property for an optional background in the same pallet of positive/negative values.
- Add property to use a localized timeframe if needed. 
- Adapted size of the indicator symbol.

# Tests

Adapted tests, but a practical MOCKED one to show a possible result:

<img width="663" height="428" alt="Screenshot 2026-02-18 at 21 41 44" src="https://github.com/user-attachments/assets/d6d7806a-f99e-460b-8b58-adeddecdee68" />
 