### PR TITLE
style(frontend): Change arrow of `Back` component

### DIFF
--- a/src/frontend/src/lib/components/core/Back.svelte
+++ b/src/frontend/src/lib/components/core/Back.svelte
@@ -3,7 +3,6 @@
 	import { nonNullish } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { afterNavigate } from '$app/navigation';
-	import IconBackArrow from '$lib/components/icons/lucide/IconBackArrow.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { back } from '$lib/utils/nav.utils';
 
@@ -29,11 +28,6 @@
 	aria-label={$i18n.core.alt.back}
 	onclick={() => back({ pop: nonNullish(fromRoute) })}
 >
-	{#if onlyArrow}
-		<IconBackArrow />
-		<span class="visually-hidden">{$i18n.core.text.back}</span>
-	{:else}
-		<IconBack />
-		{$i18n.core.text.back}
-	{/if}
+	<IconBack />
+	<span class:visually-hidden={onlyArrow}>{$i18n.core.text.back}</span>
 </button>


### PR DESCRIPTION
# Motivation

To decrease the visual pollution of the `Hero` component, we can use a smaller arrow in the `Back` component.

### Before

<img width="632" height="319" alt="Screenshot 2026-02-19 at 10 34 29" src="https://github.com/user-attachments/assets/91971dee-bf3e-4960-87b7-bb76919c48df" />
<img width="370" height="271" alt="Screenshot 2026-02-19 at 10 34 36" src="https://github.com/user-attachments/assets/a9508429-33ac-4e2f-9912-a72cf55b8ccb" />

### After

<img width="626" height="323" alt="Screenshot 2026-02-19 at 10 34 22" src="https://github.com/user-attachments/assets/3f64b735-5010-4693-a1af-4766181f9d24" />
<img width="371" height="271" alt="Screenshot 2026-02-19 at 10 34 16" src="https://github.com/user-attachments/assets/58e89147-613b-4392-a8e3-168b2946584a" />
