### PR TITLE
chore(bots): Allow bots to save images for icp-eth tokens

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -14,6 +14,7 @@ src/frontend/static/icons/dip20/*.png
 src/frontend/static/icons/icrc/*.png
 src/frontend/static/icons/sns/*.png
 src/frontend/src/icp/assets/*.svg
+src/frontend/src/icp-eth/assets/*.svg
 src/frontend/src/**/*.svelte
 src/frontend/src/tests/**/*.spec.ts
 src/frontend/src/tests/**/*.mock.ts


### PR DESCRIPTION
# Motivation

To allow PRs like https://github.com/dfinity/oisy-wallet/pull/11594, we need to expand our BOT policy and let them save assets for icp-eth tokens.
