### PR TITLE
style(frontend): Sort networks in Token Group card

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -122,7 +122,9 @@
 		{#snippet description()}
 			<span class:text-sm={asNetwork}>
 				{#if data?.networks}
-					{@const networks = [...new Set(data.networks.map((n) => n.name))].sort((a, b) => a.localeCompare(b))}
+					{@const networks = [...new Set(data.networks.map((n) => n.name))].sort((a, b) =>
+						a.localeCompare(b)
+					)}
 
 					<span class="text-primary">{data.name}</span>
 					{replacePlaceholders($i18n.tokens.text.on_network, { $network: '' })}


### PR DESCRIPTION
# Motivation

For consistency, we sort the networks list alphabetically in the Token Group card.

### Before

<img width="610" height="717" alt="Screenshot 2026-02-19 at 14 19 52" src="https://github.com/user-attachments/assets/8c53144c-93f6-47a1-b4ee-f972fa8966ae" />

### After

<img width="606" height="726" alt="Screenshot 2026-02-19 at 14 20 04" src="https://github.com/user-attachments/assets/925686ed-ba34-4ee4-bc96-36cdbf08861d" />

