### PR TITLE
feat(frontend): Remove unnecessary sorting in `TokenGroupCard`

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -64,9 +64,9 @@
 
 	// Show all if hideZeros = false and sort
 	const tokensToShow: TokenUi[] = $derived(
-		(hideZeros ? truncatedTokens : filteredTokens).sort((a, b) => 
+		(hideZeros ? truncatedTokens : filteredTokens).sort((a, b) =>
 			// if same balance order by Native > CK > others
-			 showTokenInGroup(a) ? -1 : isCkToken(a) && !showTokenInGroup(b) ? -1 : 1
+			showTokenInGroup(a) ? -1 : isCkToken(a) && !showTokenInGroup(b) ? -1 : 1
 		)
 	);
 


### PR DESCRIPTION
# Motivation

The list of tokens for the group already arrives sorted by USD balance. So there is no need for re-sorting.

Furthermore, the sorting priority (before USD balance) is deprecation, and we want to persist that and not overwrite.
