### PR TITLE
refactor(frontend): Move network tokens UI derived store to specific folder

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -8,7 +8,7 @@
 	import { allBalancesZero } from '$lib/derived/balances.derived';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import { sortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
+	import { sortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens-ui.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { HERO_CONTEXT_KEY, type HeroContext } from '$lib/stores/hero.store';

--- a/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensDisplayHandler.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { type Snippet, untrack } from 'svelte';
-	import { sortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
+	import { sortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens-ui.derived';
 	import { showZeroBalances } from '$lib/derived/settings.derived';
 	import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 	import { filterTokenGroups, groupTokensByTwin } from '$lib/utils/token-group.utils';

--- a/src/frontend/src/lib/derived/network-tokens-ui.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens-ui.derived.ts
@@ -1,0 +1,29 @@
+import { exchanges } from '$lib/derived/exchange.derived';
+import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
+import { tokensSortType } from '$lib/derived/settings.derived';
+import { stakeBalances } from '$lib/derived/stake.derived';
+import { tokensToPin } from '$lib/derived/tokens.derived';
+import { balancesStore } from '$lib/stores/balances.store';
+import type { TokenUi } from '$lib/types/token-ui';
+import { sortTokens } from '$lib/utils/tokens.utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const sortedFungibleNetworkTokensUi: Readable<TokenUi[]> = derived(
+	[
+		enabledFungibleNetworkTokens,
+		tokensToPin,
+		balancesStore,
+		stakeBalances,
+		exchanges,
+		tokensSortType
+	],
+	([$tokens, $tokensToPin, $balances, $stakeBalances, $exchanges, $tokensSortType]) =>
+		sortTokens({
+			$tokens,
+			$balances,
+			$stakeBalances,
+			$exchanges,
+			$tokensToPin,
+			primarySortStrategy: $tokensSortType
+		})
+);

--- a/src/frontend/src/lib/derived/network-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/network-tokens.derived.ts
@@ -1,19 +1,9 @@
-import { exchanges } from '$lib/derived/exchange.derived';
 import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
-import { tokensSortType } from '$lib/derived/settings.derived';
-import { stakeBalances } from '$lib/derived/stake.derived';
-import {
-	enabledFungibleTokens,
-	enabledNonFungibleTokens,
-	tokensToPin
-} from '$lib/derived/tokens.derived';
+import { enabledFungibleTokens, enabledNonFungibleTokens } from '$lib/derived/tokens.derived';
 import { CustomTokenSection } from '$lib/enums/custom-token-section';
-import { balancesStore } from '$lib/stores/balances.store';
 import type { NonFungibleToken } from '$lib/types/nft';
 import type { Token } from '$lib/types/token';
-import type { TokenUi } from '$lib/types/token-ui';
 import { filterTokensForSelectedNetwork } from '$lib/utils/network.utils';
-import { sortTokens } from '$lib/utils/tokens.utils';
 import { derived, type Readable } from 'svelte/store';
 
 /**
@@ -36,27 +26,4 @@ export const enabledNonFungibleNetworkTokensWithoutSpam: Readable<NonFungibleTok
 	[enabledNonFungibleNetworkTokens],
 	([$enabledNonFungibleNetworkTokens]) =>
 		$enabledNonFungibleNetworkTokens.filter(({ section }) => section != CustomTokenSection.SPAM)
-);
-
-/**
- * All fungible tokens matching the selected network or Chain Fusion, with the ones with non-null balance at the top of the list.
- */
-export const sortedFungibleNetworkTokensUi: Readable<TokenUi[]> = derived(
-	[
-		enabledFungibleNetworkTokens,
-		tokensToPin,
-		balancesStore,
-		stakeBalances,
-		exchanges,
-		tokensSortType
-	],
-	([$enabledNetworkTokens, $tokensToPin, $balances, $stakeBalances, $exchanges, $tokensSortType]) =>
-		sortTokens({
-			$tokens: $enabledNetworkTokens,
-			$balances,
-			$stakeBalances,
-			$exchanges,
-			$tokensToPin,
-			primarySortStrategy: $tokensSortType
-		})
 );

--- a/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandler.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensDisplayHandler.spec.ts
@@ -1,4 +1,4 @@
-import { sortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens.derived';
+import { sortedFungibleNetworkTokensUi } from '$lib/derived/network-tokens-ui.derived';
 import { showZeroBalances } from '$lib/derived/settings.derived';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';


### PR DESCRIPTION
# Motivation

Just to keep it more organized, we move derived store `sortedFungibleNetworkTokensUi` to a specific file.
