### PR TITLE
chore(backend): Remove deprecated field in validation tests

### DIFF
--- a/src/shared/src/types/tests.rs
+++ b/src/shared/src/types/tests.rs
@@ -21,7 +21,6 @@ mod bitcoin {
                 input: BtcAddPendingTransactionRequest {
                     txid: vec![0; MAX_TXID_BYTES],
                     utxos: vec![],
-                    address: "".to_string(),
                     network: BitcoinNetwork::Mainnet,
                 },
                 valid: true,
@@ -31,7 +30,6 @@ mod bitcoin {
                 input: BtcAddPendingTransactionRequest {
                     txid: vec![0; MAX_TXID_BYTES + 1],
                     utxos: vec![],
-                    address: "".to_string(),
                     network: BitcoinNetwork::Mainnet,
                 },
                 valid: false,
@@ -48,7 +46,6 @@ mod bitcoin {
                         value: 0,
                         height: 0,
                     }],
-                    address: "".to_string(),
                     network: BitcoinNetwork::Mainnet,
                 },
                 valid: true,
@@ -65,7 +62,6 @@ mod bitcoin {
                         value: 0,
                         height: 0,
                     }],
-                    address: "".to_string(),
                     network: BitcoinNetwork::Mainnet,
                 },
                 valid: false,
@@ -85,7 +81,6 @@ mod bitcoin {
                         };
                         MAX_UTXOS_LEN + 1
                     ],
-                    address: "".to_string(),
                     network: BitcoinNetwork::Mainnet,
                 },
                 valid: false,


### PR DESCRIPTION
# Motivation

There is no `address` field anymore in the validation tests/
