### PR TITLE
feat(frontend): Slightly improve `sortTokens` utils performance

### DIFF
--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -219,7 +219,7 @@ export function sortTokens<T extends Token>({
 
 	// We intentionally precompute sort keys once per element before sorting.
 	//
-	// Each token is first normalised via `unwrapTokenSortFields`, so the
+	// Each item is first normalised via `unwrapTokenSortFields`, so the
 	// comparator operates only on plain, precomputed values. This ensures that:
 	//   • expensive field normalisation runs exactly once per element (not per comparison),
 	//   • the comparator remains simple and fast (no repeated unwrapping or branching),


### PR DESCRIPTION
# Motivation

Why this is an improvement over the current decorate/sort/undecorate?

- The current version allocates `n` wrapper objects: `{ token, u }`.

- The index-sort version allocates:
  - one `unwrapped[]` array (already done conceptually)
  - one `indices[]` array of numbers
  - the final output array

So it’s less object allocation, typically less GC pressure, with the same `O(n log n)` comparisons and still only `O(n)` unwrapping.

At 100–150 items every 30s, we won’t need this for performance, but this is the “best” variant without making the code gnarly, this is the sweet spot.
