### PR TITLE
feat(backend): Add WASM memory size to metrics

### DIFF
--- a/src/shared/src/metrics.rs
+++ b/src/shared/src/metrics.rs
@@ -62,7 +62,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     w.encode_gauge(
         "ic_eth_wallet_wasm_memory_size_bytes",
         wasm_memory_size_bytes() as f64,
-        "Wasm heap size in bytes, useful for alerting on growth towards the 4 GiB limit",
+        "Wasm memory size in bytes, useful for alerting on growth towards the 4 GiB limit",
     )?;
     Ok(())
 }


### PR DESCRIPTION
# Motivation

We want to improve our monitoring of the Backend memory.

In this PR, we add the WASM heap size to the `/metrics` endpoint so we can observe growth between upgrades, in bytes.

The existing GiB metric can be hard to alert on at small values; a raw byte count makes it straightforward to set a threshold alert (e.g., warn at 3 GiB = ~3,221,225,472 bytes).
