### PR TITLE
feat(backend): Hourly housekeeping timer guard

### DIFF
--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -178,15 +178,13 @@ const HOUSEKEEPING_TIMEOUT_NS: u64 = 2 * 60 * 60 * 1_000_000_000;
 
 pub(crate) const MAX_CONCURRENT_ALLOW_SIGNING: u32 = 50;
 
-/// Spawns housekeeping only if no previous run is still in flight.
-/// If a previous run appears stuck (older than `HOUSEKEEPING_TIMEOUT_NS`),
-/// the stale lock is cleared and a new run is allowed to proceed.
-fn spawn_housekeeping_if_idle() {
-    let now = time();
-
-    let in_progress = HOUSEKEEPING_STARTED_AT.with(|cell| {
+/// Returns `true` if a housekeeping run is currently in flight and has not
+/// timed out.  If the lock has been held longer than `HOUSEKEEPING_TIMEOUT_NS`,
+/// logs a warning and returns `false` so the caller can force a new run.
+pub(crate) fn is_housekeeping_in_progress(now_ns: u64) -> bool {
+    HOUSEKEEPING_STARTED_AT.with(|cell| {
         if let Some(started) = *cell.borrow() {
-            let elapsed = now.saturating_sub(started);
+            let elapsed = now_ns.saturating_sub(started);
             if elapsed > HOUSEKEEPING_TIMEOUT_NS {
                 eprintln!(
                     "Housekeeping appears stuck (started {}s ago), forcing unlock",
@@ -199,9 +197,16 @@ fn spawn_housekeeping_if_idle() {
         } else {
             false
         }
-    });
+    })
+}
 
-    if in_progress {
+/// Spawns housekeeping only if no previous run is still in flight.
+/// If a previous run appears stuck (older than `HOUSEKEEPING_TIMEOUT_NS`),
+/// the stale lock is cleared and a new run is allowed to proceed.
+fn spawn_housekeeping_if_idle() {
+    let now = time();
+
+    if is_housekeeping_in_progress(now) {
         return;
     }
 
@@ -213,22 +218,33 @@ fn spawn_housekeeping_if_idle() {
     });
 }
 
-/// Spawns an `allow_signing` task only if the number of in-flight tasks is
-/// below `MAX_CONCURRENT_ALLOW_SIGNING`.  The counter is decremented when the
-/// task finishes normally; on IC traps the counter stays elevated, but the
-/// cap prevents unbounded accumulation and slots are reclaimed as other tasks
-/// complete.
-fn spawn_allow_signing_if_below_limit(stored_principal: StoredPrincipal) {
-    let acquired = ALLOW_SIGNING_IN_PROGRESS.with(|cell| {
+/// Atomically increments the in-flight `allow_signing` counter if below
+/// `MAX_CONCURRENT_ALLOW_SIGNING`.  Returns `true` on success.
+///
+/// The caller is responsible for decrementing after the task finishes.
+/// On IC traps the counter stays elevated, but the cap prevents unbounded
+/// accumulation.  In practice the `allow_signing` code path contains no
+/// panic sites, so leaked slots are unlikely.
+pub(crate) fn try_acquire_allow_signing_slot() -> bool {
+    ALLOW_SIGNING_IN_PROGRESS.with(|cell| {
         let mut count = cell.borrow_mut();
         if *count >= MAX_CONCURRENT_ALLOW_SIGNING {
             return false;
         }
         *count += 1;
         true
-    });
+    })
+}
 
-    if !acquired {
+/// Decrements the in-flight `allow_signing` counter.
+pub(crate) fn release_allow_signing_slot() {
+    ALLOW_SIGNING_IN_PROGRESS.with(|cell| *cell.borrow_mut() -= 1);
+}
+
+/// Spawns an `allow_signing` task only if the number of in-flight tasks is
+/// below `MAX_CONCURRENT_ALLOW_SIGNING`.
+fn spawn_allow_signing_if_below_limit(stored_principal: StoredPrincipal) {
+    if !try_acquire_allow_signing_slot() {
         eprintln!(
             "Skipped allow_signing for user {}: too many concurrent tasks",
             stored_principal.0,
@@ -244,7 +260,7 @@ fn spawn_allow_signing_if_below_limit(stored_principal: StoredPrincipal) {
                 e
             );
         }
-        ALLOW_SIGNING_IN_PROGRESS.with(|cell| *cell.borrow_mut() -= 1);
+        release_allow_signing_slot();
     });
 }
 

--- a/src/backend/src/tests.rs
+++ b/src/backend/src/tests.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 use candid_parser::utils::{service_compatible, CandidSource};
 
 use crate::{
-    __export_service, ALLOW_SIGNING_IN_PROGRESS, HOUSEKEEPING_STARTED_AT,
-    MAX_CONCURRENT_ALLOW_SIGNING,
+    __export_service, is_housekeeping_in_progress, release_allow_signing_slot,
+    try_acquire_allow_signing_slot, ALLOW_SIGNING_IN_PROGRESS, HOUSEKEEPING_STARTED_AT,
+    HOUSEKEEPING_TIMEOUT_NS, MAX_CONCURRENT_ALLOW_SIGNING,
 };
 
 /// Checks candid interface type compatibility with production.
@@ -34,86 +35,121 @@ fn workspace_dir() -> PathBuf {
     cargo_path.parent().unwrap().to_path_buf()
 }
 
-fn reset_housekeeping_started_at() {
+fn reset_housekeeping() {
     HOUSEKEEPING_STARTED_AT.with(|cell| *cell.borrow_mut() = None);
 }
 
-fn set_housekeeping_started_at(ns: u64) {
+fn lock_housekeeping_at(ns: u64) {
     HOUSEKEEPING_STARTED_AT.with(|cell| *cell.borrow_mut() = Some(ns));
 }
 
-fn get_housekeeping_started_at() -> Option<u64> {
-    HOUSEKEEPING_STARTED_AT.with(|cell| *cell.borrow())
-}
-
-fn reset_allow_signing_counter() {
+fn reset_allow_signing() {
     ALLOW_SIGNING_IN_PROGRESS.with(|cell| *cell.borrow_mut() = 0);
 }
 
-fn get_allow_signing_count() -> u32 {
-    ALLOW_SIGNING_IN_PROGRESS.with(|cell| *cell.borrow())
-}
-
 // ---------------------------------------------------------------------------
-// Housekeeping timestamp lock tests
+// Housekeeping timestamp-lock tests
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_housekeeping_lock_starts_idle() {
-    reset_housekeeping_started_at();
-    assert_eq!(get_housekeeping_started_at(), None);
-}
-
-#[test]
-fn test_housekeeping_lock_and_unlock() {
-    reset_housekeeping_started_at();
-
-    set_housekeeping_started_at(1_000_000_000);
-    assert_eq!(get_housekeeping_started_at(), Some(1_000_000_000));
-
-    reset_housekeeping_started_at();
-    assert_eq!(get_housekeeping_started_at(), None);
-}
-
-// ---------------------------------------------------------------------------
-// AllowSigning counter tests
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_allow_signing_counter_increment_and_decrement() {
-    reset_allow_signing_counter();
-    assert_eq!(get_allow_signing_count(), 0);
-
-    ALLOW_SIGNING_IN_PROGRESS.with(|cell| *cell.borrow_mut() += 1);
-    assert_eq!(get_allow_signing_count(), 1);
-
-    ALLOW_SIGNING_IN_PROGRESS.with(|cell| *cell.borrow_mut() -= 1);
-    assert_eq!(get_allow_signing_count(), 0);
-}
-
-#[test]
-fn test_allow_signing_counter_respects_limit() {
-    reset_allow_signing_counter();
-
-    ALLOW_SIGNING_IN_PROGRESS.with(|cell| *cell.borrow_mut() = MAX_CONCURRENT_ALLOW_SIGNING);
-    assert_eq!(get_allow_signing_count(), MAX_CONCURRENT_ALLOW_SIGNING);
-
-    let can_acquire = ALLOW_SIGNING_IN_PROGRESS.with(|cell| {
-        let count = cell.borrow();
-        *count < MAX_CONCURRENT_ALLOW_SIGNING
-    });
-    assert!(!can_acquire, "should not be able to acquire beyond limit");
-
-    ALLOW_SIGNING_IN_PROGRESS.with(|cell| *cell.borrow_mut() -= 1);
-
-    let can_acquire = ALLOW_SIGNING_IN_PROGRESS.with(|cell| {
-        let count = cell.borrow();
-        *count < MAX_CONCURRENT_ALLOW_SIGNING
-    });
+fn test_housekeeping_idle_when_no_lock() {
+    reset_housekeeping();
     assert!(
-        can_acquire,
-        "should be able to acquire after one slot freed"
+        !is_housekeeping_in_progress(1_000_000_000),
+        "should report idle when no lock is held"
+    );
+}
+
+#[test]
+fn test_housekeeping_in_progress_within_timeout() {
+    reset_housekeeping();
+    let start = 1_000_000_000u64;
+    lock_housekeeping_at(start);
+
+    let within_timeout = start + HOUSEKEEPING_TIMEOUT_NS - 1;
+    assert!(
+        is_housekeeping_in_progress(within_timeout),
+        "should report in-progress when elapsed < timeout"
+    );
+}
+
+#[test]
+fn test_housekeeping_force_unlocks_after_timeout() {
+    reset_housekeeping();
+    let start = 1_000_000_000u64;
+    lock_housekeeping_at(start);
+
+    let past_timeout = start + HOUSEKEEPING_TIMEOUT_NS + 1;
+    assert!(
+        !is_housekeeping_in_progress(past_timeout),
+        "should force-unlock when elapsed > timeout"
+    );
+}
+
+#[test]
+fn test_housekeeping_handles_time_at_exact_boundary() {
+    reset_housekeeping();
+    let start = 1_000_000_000u64;
+    lock_housekeeping_at(start);
+
+    let at_boundary = start + HOUSEKEEPING_TIMEOUT_NS;
+    assert!(
+        is_housekeeping_in_progress(at_boundary),
+        "should still be in-progress at exactly the timeout (> not >=)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AllowSigning slot tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_allow_signing_acquire_and_release() {
+    reset_allow_signing();
+
+    assert!(try_acquire_allow_signing_slot());
+    assert_eq!(ALLOW_SIGNING_IN_PROGRESS.with(|c| *c.borrow()), 1);
+
+    release_allow_signing_slot();
+    assert_eq!(ALLOW_SIGNING_IN_PROGRESS.with(|c| *c.borrow()), 0);
+}
+
+#[test]
+fn test_allow_signing_rejects_beyond_limit() {
+    reset_allow_signing();
+
+    for _ in 0..MAX_CONCURRENT_ALLOW_SIGNING {
+        assert!(try_acquire_allow_signing_slot());
+    }
+
+    assert!(
+        !try_acquire_allow_signing_slot(),
+        "should reject when all slots are taken"
     );
 
-    reset_allow_signing_counter();
+    release_allow_signing_slot();
+
+    assert!(
+        try_acquire_allow_signing_slot(),
+        "should succeed after one slot is freed"
+    );
+
+    reset_allow_signing();
+}
+
+#[test]
+fn test_allow_signing_multiple_concurrent() {
+    reset_allow_signing();
+
+    assert!(try_acquire_allow_signing_slot());
+    assert!(try_acquire_allow_signing_slot());
+    assert!(try_acquire_allow_signing_slot());
+    assert_eq!(ALLOW_SIGNING_IN_PROGRESS.with(|c| *c.borrow()), 3);
+
+    release_allow_signing_slot();
+    release_allow_signing_slot();
+    assert_eq!(ALLOW_SIGNING_IN_PROGRESS.with(|c| *c.borrow()), 1);
+
+    release_allow_signing_slot();
+    assert_eq!(ALLOW_SIGNING_IN_PROGRESS.with(|c| *c.borrow()), 0);
 }

--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -157,15 +157,15 @@ fn test_get_allowed_cycles_returns_correct_error_when_cycles_ledger_unavailable(
 }
 
 // -------------------------------------------------------------------------------------------------
-// - Housekeeping guard integration tests
+// - Housekeeping / allow_signing concurrency integration tests
 // -------------------------------------------------------------------------------------------------
 
 /// Verify the canister remains responsive after multiple housekeeping timer
 /// ticks, even when the cycles ledger is unavailable (every top-up attempt
-/// fails). If the guard were not properly released on error, housekeeping
-/// would be permanently stuck and subsequent ticks would silently pile up.
+/// fails). If the timestamp lock were not properly released on error,
+/// housekeeping would be permanently stuck until the timeout expires.
 #[test]
-fn test_housekeeping_guard_resets_after_failed_topup() {
+fn test_housekeeping_lock_resets_after_failed_topup() {
     let pic_setup = setup();
     let caller = controller();
 
@@ -225,7 +225,7 @@ fn test_allow_signing_backpressure_under_burst() {
 }
 
 /// After the cycles ledger becomes available, housekeeping should resume
-/// successfully (guard was not permanently stuck from prior failures).
+/// successfully (lock was not permanently stuck from prior failures).
 #[test]
 fn test_housekeeping_resumes_after_cycles_ledger_becomes_available() {
     let pic_setup = BackendBuilder::default().with_cycles_ledger(true).deploy();


### PR DESCRIPTION
# Motivation

The backend uses fire-and-forget `ic_cdk::spawn` in two places:

1. **Hourly housekeeping timer** -- spawns a task that calls `top_up_cycles_ledger`. If the cycles ledger is slow to respond, subsequent timer ticks spawn additional futures that pile up on the heap.
2. **`create_user_profile`** -- every call spawns a detached `allow_signing` task. Under a burst of user creations with a slow cycles ledger, these futures also accumulate.

On IC, if a spawned future traps, `Drop` destructors do not run (no unwinding), so a simple boolean flag would get permanently stuck. The guards need a recovery mechanism.

# Changes

- **Housekeeping**: replaced the bare boolean flag with a timestamp-based lock (`HOUSEKEEPING_STARTED_AT`). Each timer tick checks whether a previous run is still in flight. If it has been running longer than `HOUSEKEEPING_TIMEOUT_NS` (2 hours), the stale lock is force-cleared with a warning log, allowing the next tick to proceed. This matches the `spawn_fee_update_if_idle` pattern used in `bitcoin_api`.
- **Allow signing**: added a counter-based concurrency cap (`ALLOW_SIGNING_IN_PROGRESS`, limited to `MAX_CONCURRENT_ALLOW_SIGNING = 50`). `spawn_allow_signing_if_below_limit()` increments the counter before spawning and decrements it on completion. When the cap is reached, additional tasks are skipped with a log message. The `allow_signing` code path has no panic sites, so counter leaks from traps are unlikely.
- Extracted `is_housekeeping_in_progress()`, `try_acquire_allow_signing_slot()`, and `release_allow_signing_slot()` as testable `pub(crate)` functions.

# Tests

- **Unit tests** (`src/backend/src/tests.rs`):
  - Housekeeping: idle detection, in-progress within timeout, force-unlock after timeout, exact boundary behavior.
  - Allow signing: acquire/release, concurrent slots up to limit, rejection beyond limit.
- **Integration tests** (`src/backend/tests/it/signer.rs`):
  - Canister remains responsive after repeated failed housekeeping ticks (no cycles ledger).
  - Burst of 60 user profile creations does not degrade the canister.
  - Housekeeping resumes successfully once the cycles ledger becomes available.