### PR TITLE
feat(backend): Fee percentiles timer guard

### DIFF
--- a/src/backend/src/bitcoin_api.rs
+++ b/src/backend/src/bitcoin_api.rs
@@ -6,16 +6,12 @@ use ic_cdk::api::management_canister::bitcoin::{
     UtxoFilter,
 };
 use ic_cdk_timers::{set_timer, set_timer_interval};
-use shared::types::bitcoin::FEE_PERCENTILES_UPDATE_INTERVAL;
+use shared::types::bitcoin::{FEE_PERCENTILES_UPDATE_INTERVAL, FEE_UPDATE_TIMEOUT_NS};
 
 // Default fee values for different networks when API fails
 const DEFAULT_MAINNET_FEE: u64 = 10_000; // 10 sat/byte (10,000 msat/byte)
 const DEFAULT_TESTNET_FEE: u64 = 5_000; // 5 sat/byte (5,000 msat/byte)
 const DEFAULT_REGTEST_FEE: u64 = 2_000; // 2 sat/byte (2,000 msat/byte)
-
-/// Safety timeout: if an update has been "in progress" for longer than this,
-/// assume it was lost to a trap and allow a new one. Set to 5× the update interval.
-const FEE_UPDATE_TIMEOUT_NS: u64 = 5 * 60 * 1_000_000_000;
 
 thread_local! {
     // We use thread_local! + RefCell for fee percentiles cache since the data is refreshed

--- a/src/shared/src/types/bitcoin.rs
+++ b/src/shared/src/types/bitcoin.rs
@@ -27,6 +27,11 @@ pub const MAX_UTXOS_LEN: usize = 128;
 /// Timer interval for updating fee percentiles cache (1 minute)
 pub const FEE_PERCENTILES_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Safety timeout: if an update has been "in progress" for longer than this,
+/// assume it was lost to a trap and allow a new one. Set to 5× the update interval.
+pub const FEE_UPDATE_TIMEOUT_NS: u64 =
+    5 * FEE_PERCENTILES_UPDATE_INTERVAL.as_secs() * 1_000_000_000;
+
 #[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct BtcGetFeePercentilesRequest {
     pub network: BitcoinNetwork,


### PR DESCRIPTION
# Motivation

There is a fire-and-forget `ic_cdk::spawn` pattern in the fee percentiles timer.

The timer fires every 60 seconds and spawns a future that makes 3 parallel Bitcoin API calls. If the Bitcoin management canister is slow (>60s), a new future is spawned before the previous one completes, causing unbounded heap accumulation. Additionally, if a spawned task traps after an `await` point, the in-progress flag would be committed to state and never cleared — permanently disabling fee-cache refreshes.

# Changes

- Replaced the `bool` guard with a timestamp-based lock (`FEE_UPDATE_STARTED_AT`). Records the IC time when an update starts and clears it on completion.
- If a previous update is still running within the timeout window, the timer tick is skipped.
- Added a safety timeout (`FEE_UPDATE_TIMEOUT_NS`, 5 minutes): if an update appears stuck (e.g. the task trapped after committing the timestamp at an `await` boundary), subsequent timer ticks will force-unlock and retry. This is necessary because wasm traps don't unwind the stack, so RAII/`Drop` guards won't run.

# Tests

Current tests must work.