### PR TITLE
feat(frontend): Sort tokens inside group by value first

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -60,7 +60,7 @@
 			return usdBalanceDiff;
 		}
 
-		// If same balance order by Native > CK > others
+		// If same balance, order by showTokenInGroup (neverCollapseInTokenGroup) > CK > others
 		if (showTokenInGroup(a) !== showTokenInGroup(b)) {
 			return showTokenInGroup(a) ? -1 : 1;
 		}


### PR DESCRIPTION
# Motivation

In the dropdown of a token group, we would like to prioritize ALWAYS the value, before the rest (existing sorting, deprecated, CK-tokens, etc).

Furthermore, we want to persist such order when showing the networks in the card description.

# Changes

- Add a comparator in component `TokenGroupCard` to sort the tokens before any other check (hiding zero for example).
- Pass the sorted array to the children `TokenCard`.

# Tests

Current tests should work as expected.
