### PR TITLE
refactor(frontend): Reduce loops in `TokenGroupCard`

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenGroupCard.svelte
@@ -17,7 +17,7 @@
 	import { transactionsUrl } from '$lib/utils/nav.utils';
 	import { mapHeaderData } from '$lib/utils/token-card.utils';
 	import { getFilteredTokenGroup } from '$lib/utils/token-list.utils.js';
-	import {sumTokensUiUsdBalance} from "$lib/utils/tokens.utils";
+	import { sumTokensUiUsdBalance } from '$lib/utils/tokens.utils';
 
 	interface Props {
 		tokenGroup: TokenUiGroup;
@@ -50,7 +50,7 @@
 		})
 	);
 
-	const totalUsdBalance: number = $derived(sumTokensUiUsdBalance(filteredTokens),);
+	const totalUsdBalance: number = $derived(sumTokensUiUsdBalance(filteredTokens));
 
 	// list of tokens that should display with a "show more" button for not displayed ones
 	const truncatedTokens: TokenUi[] = $derived(


### PR DESCRIPTION
# Motivation

Instead of recalculating the total USD balance each loop of `truncatedTokens` in component `TokenGroupCard`, we can create a `$derived`.