### PR TITLE
refactor(frontend): Better naming of params in `sortTokens` util

### DIFF
--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -21,7 +21,6 @@ import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
 import type { OptionIdentity } from '$lib/types/identity';
 import type { Token, TokenId } from '$lib/types/token';
 import type { TokensTotalUsdBalancePerNetwork } from '$lib/types/token-balance';
-import type { TokenGroupId } from '$lib/types/token-group';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { TokenUi } from '$lib/types/token-ui';
 import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
@@ -64,9 +63,9 @@ const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'bas
 
 type TokenSortUnwrapped = ReturnType<typeof unwrapTokenSortFields>;
 
-type SortableId = TokenId | TokenGroupId;
+type SortableTokenId = TokenId;
 
-type Pin = Readonly<{ id: SortableId }>;
+type TokenPin = Readonly<{ id: SortableTokenId }>;
 
 type SortableItem<T extends Token> = TokenUi<T> | TokenUiOrGroupUi;
 
@@ -88,10 +87,10 @@ type SortableItem<T extends Token> = TokenUi<T> | TokenUiOrGroupUi;
  */
 const createTokenComparator =
 	({
-		pinIndexById,
+		tokenPinIndexById,
 		primarySortStrategy
 	}: {
-		pinIndexById: ReadonlyMap<SortableId, number>;
+		tokenPinIndexById: ReadonlyMap<SortableTokenId, number>;
 		primarySortStrategy: TokensSortType;
 	}) =>
 	// eslint-disable-next-line local-rules/prefer-object-params -- This is a sort function.
@@ -149,8 +148,8 @@ const createTokenComparator =
 		}
 
 		// Pinned tokens (pinned first; pinned order = order provided)
-		const aPin = pinIndexById.get(aId);
-		const bPin = pinIndexById.get(bId);
+		const aPin = tokenPinIndexById.get(aId);
+		const bPin = tokenPinIndexById.get(bId);
 		const aPinned = aPin !== undefined;
 		const bPinned = bPin !== undefined;
 		if (aPinned !== bPinned) {
@@ -171,12 +170,12 @@ const createTokenComparator =
 
 export function sortTokens<T extends Token>(args: {
 	$tokens: TokenUi<T>[];
-	$tokensToPin: ReadonlyArray<Pin>;
+	$tokensToPin: ReadonlyArray<TokenPin>;
 	primarySortStrategy?: TokensSortType;
 }): TokenUi<T>[];
 export function sortTokens(args: {
 	$tokens: TokenUiOrGroupUi[];
-	$tokensToPin: ReadonlyArray<Pin>;
+	$tokensToPin: ReadonlyArray<TokenPin>;
 	primarySortStrategy?: TokensSortType;
 }): TokenUiOrGroupUi[];
 /**
@@ -208,14 +207,14 @@ export function sortTokens<T extends Token>({
 	primarySortStrategy = 'value'
 }: {
 	$tokens: SortableItem<T>[];
-	$tokensToPin: ReadonlyArray<Pin>;
+	$tokensToPin: ReadonlyArray<TokenPin>;
 	primarySortStrategy?: TokensSortType;
 }): SortableItem<T>[] {
-	const pinIndexById = new Map<SortableId, number>(
+	const tokenPinIndexById = new Map<SortableTokenId, number>(
 		$tokensToPin.map(({ id }, index) => [id, index])
 	);
 
-	const comparator = createTokenComparator({ pinIndexById, primarySortStrategy });
+	const comparator = createTokenComparator({ tokenPinIndexById, primarySortStrategy });
 
 	// We intentionally precompute sort keys once per element before sorting.
 	//


### PR DESCRIPTION
# Motivation

Small renaming of params and variables in util `sortTokens`.