### PR TITLE
fix(frontend): Bad responsive scaling for medium screens

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -136,7 +136,7 @@
 </script>
 
 <div
-	class="bg-pos-0 flex h-full w-full flex-col content-center items-center justify-center rounded-[24px] bg-brand-primary p-3 text-center text-primary-inverted transition-all duration-500 ease-in-out md:rounded-[28px] md:p-5"
+	class="bg-pos-0 flex h-full w-full flex-col content-center items-center justify-center rounded-[24px] bg-brand-primary p-3 text-center text-primary-inverted transition-[background-position,background-size] duration-500 ease-in-out md:rounded-[28px] md:p-5"
 	class:bg-center={isVeurToken}
 	class:bg-cover={isTrumpToken || isVchfToken || isVeurToken}
 	class:bg-gradient-to-r={isGradientToRight}

--- a/src/frontend/src/lib/components/ui/SplitPane.svelte
+++ b/src/frontend/src/lib/components/ui/SplitPane.svelte
@@ -20,7 +20,7 @@
 	</Responsive>
 
 	<div
-		class="mx-auto max-w-xl px-3 transition-all duration-500 ease-linear md:ml-64 md:box-content md:w-sm md:max-w-none md:px-4 xl:ml-auto"
+		class="mx-auto max-w-xl px-3 md:ml-64 md:box-content md:w-[calc(100%-18rem)] md:px-4 xl:ml-auto"
 	>
 		{@render children()}
 	</div>


### PR DESCRIPTION
# Motivation

At the `md` breakpoint (768px), the content area overflows the viewport — the sidebar margin (256px) + fixed content width (576px) + padding (32px) = 864px, exceeding the 768px viewport. This causes the hero card and action buttons to be clipped on the right.

The issue is amplified after navigation because broad `transition-all` declarations on both the layout and hero containers create conflicting animations with Svelte's `in:slide` transitions and the View Transitions API, leading to intermittent layout breakage.

# Changes

- Replace the fixed `md:w-sm` (576px) in `SplitPane` with `md:w-[calc(100%-18rem)]` so the content width adapts to the available space, capped at 576px by the existing `max-w-xl`.
- Remove `transition-all` from the `SplitPane` content div — responsive layout changes should snap, not animate over 500ms.
- Scope `transition-all` in `HeroContent` to `transition-[background-position,background-size]` so only the gradient shift animates, preventing double-animation conflicts with Svelte slide transitions on navigation.

# Tests

### Before

<img width="939" height="812" alt="Screenshot 2026-02-25 at 15 47 55" src="https://github.com/user-attachments/assets/4ffd3da5-ff16-4d0c-8b8a-ac532c6f52e9" />

### After

<img width="935" height="815" alt="Screenshot 2026-02-25 at 15 48 03" src="https://github.com/user-attachments/assets/62934ce3-feea-4490-a8f3-cdc2e91dd99c" />
