### PR TITLE
style(frontend): update FactBox styling

### DIFF
--- a/src/frontend/src/lib/components/ui/FactBox.svelte
+++ b/src/frontend/src/lib/components/ui/FactBox.svelte
@@ -13,12 +13,14 @@
 
 <div class="flex w-full flex-col items-center">
 	{@render icon?.()}
+
 	{#if nonNullish(title)}
-		<span class="my-3 text-lg font-bold">
+		<span class="my-3 text-sm font-bold">
 			{@render title()}
 		</span>
 	{/if}
+
 	{#if nonNullish(description)}
-		<p class="text-tertiary">{@render description()}</p>
+		<p class="text-xs text-tertiary">{@render description()}</p>
 	{/if}
 </div>


### PR DESCRIPTION
# Motivation

We need to make some minor styling changes in FactBox.

<img width="185" height="188" alt="Screenshot 2026-02-25 at 16 47 47" src="https://github.com/user-attachments/assets/ab1b3b32-e4fd-49ad-a6b7-99e14295f577" />
