### PR TITLE
fix(frontend): Do not reconnect WalletConnect if there is URI

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -104,6 +104,9 @@
 
 		await connectListener({ uri: $walletConnectUri, onSessionDeleteCallback: goToFirstStep });
 
+		// Remove the URI query parameter after a successful deep-link connection
+		// to prevent stale URIs from forcing a cleanSlate reconnect on refresh,
+		// which would otherwise wipe persisted WalletConnect sessions.
 		removeSearchParam({ url: page.url, searchParam: URI_PARAM });
 	};
 


### PR DESCRIPTION
# Motivation

When a WalletConnect URI is present (deep link), `uriConnect()` handles the connection. Running `reconnect()` concurrently would race and potentially disconnect the session.
