### PR TITLE
feat(frontend): Pin token group based on its high-priority member

### DIFF
--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -55,15 +55,16 @@ const unwrapTokenSortFields = <T extends Token>({
 
 	const item = isGroup ? t.group : t.token;
 
+	// For a group we take the minimum pin index of the underlying tokens, so the group is sorted as high as its highest pinned token
 	const tokenPinIndex = isGroup
-		? t.group.tokens.reduce<number | undefined>((maxPin, { id }) => {
+		? t.group.tokens.reduce<number | undefined>((minPin, { id }) => {
 				const pin = tokenPinIndexById.get(id);
 
 				if (isNullish(pin)) {
-					return maxPin;
+					return minPin;
 				}
 
-				return isNullish(maxPin) || pin > maxPin ? pin : maxPin;
+				return isNullish(minPin) || pin < minPin ? pin : minPin;
 			}, undefined)
 		: tokenPinIndexById.get(t.token.id);
 


### PR DESCRIPTION
# Motivation

We want to base the priority of pinned tokens of a group on his highest-priority member.

To do so, we need to refactor the `sortTokens` util to map the highest pinned value for groups.

Performance should not be affected in a relevant way.

# Changes

- Make unwrapper util accept the list of pinned tokens IDs.
- Map the lowest pin for the groups, since it represents the highest (first) priority.
- Use the unwrapped pin in the comparison.
- Clean up the other utils

# Tests

Current tests must work.
