### PR TITLE
style(frontend): Align token details to left in `Hero`

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -183,7 +183,7 @@
 						<div class="flex min-w-0 items-center justify-start gap-1 sm:gap-2" in:fade>
 							<TokenLogo data={pageTokenUi} logoSize="sm" ring />
 
-							<div class="flex flex-col text-left truncate">
+							<div class="flex flex-col truncate text-left">
 								<span class="truncate font-semibold">
 									{getTokenDisplayName(pageTokenUi)}
 								</span>


### PR DESCRIPTION
# Motivation

Fixing the alignment of token name and network in the `Hero`.

### Before

<img width="366" height="265" alt="Screenshot 2026-02-26 at 10 39 04" src="https://github.com/user-attachments/assets/27b39428-677f-415c-9f3b-deddc379ebb8" />

### After

<img width="368" height="265" alt="Screenshot 2026-02-26 at 10 39 34" src="https://github.com/user-attachments/assets/cd2b4907-0f4a-422e-b48f-da2e7d83e499" />
