### PR TITLE
fix(frontend): Enable Swap button for null balances

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapButton.svelte
+++ b/src/frontend/src/lib/components/swap/SwapButton.svelte
@@ -13,13 +13,12 @@
 
 	let { onclick }: Props = $props();
 
-	const { outflowActionsDisabled, inflowActionsDisabled } =
-		getContext<HeroContext>(HERO_CONTEXT_KEY);
+	const { inflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 </script>
 
 <ButtonHero
 	ariaLabel={$i18n.swap.text.swap}
-	disabled={$isBusy || $outflowActionsDisabled || $inflowActionsDisabled}
+	disabled={$isBusy || $inflowActionsDisabled}
 	{onclick}
 	testId={SWAP_TOKENS_MODAL_OPEN_BUTTON}
 >


### PR DESCRIPTION
# Motivation

For tokens with no balance, we want to allow a swap: the user may want to convert some other token to it.
