### PR TITLE
feat(frontend): parse negative APY in formatStakeApyNumber

### DIFF
--- a/src/frontend/src/lib/utils/format.utils.ts
+++ b/src/frontend/src/lib/utils/format.utils.ts
@@ -321,19 +321,22 @@ export const formatCurrency = ({
 };
 
 export const formatStakeApyNumber = (apy: number): string => {
-	if (apy >= 100) {
-		return `${Math.round(apy)}`;
+	if (apy === 0) {
+		return '0';
 	}
 
-	if (apy >= 10) {
-		return (Math.round(apy * 10) / 10).toFixed(1);
+	const sign = apy < 0 ? '-' : '';
+	const abs = Math.abs(apy);
+
+	if (abs >= 100) {
+		return `${sign}${Math.round(abs)}`;
 	}
 
-	if (apy > 0) {
-		return (Math.round(apy * 100) / 100).toFixed(2);
+	if (abs >= 10) {
+		return `${sign}${(Math.round(abs * 10) / 10).toFixed(1)}`;
 	}
 
-	return '0';
+	return `${sign}${(Math.round(abs * 100) / 100).toFixed(2)}`;
 };
 
 export const format24hChangeInCurrency = ({

--- a/src/frontend/src/tests/lib/utils/format.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/format.utils.spec.ts
@@ -1453,6 +1453,20 @@ describe('format.utils', () => {
 		it('parses stake apy number correctly if it is zero', () => {
 			expect(formatStakeApyNumber(0)).toEqual('0');
 		});
+
+		it('parses negative stake apy number correctly if it has 3 digits', () => {
+			expect(formatStakeApyNumber(-101.2131231231)).toEqual('-101');
+		});
+
+		it('parses negative stake apy number correctly if it has 2 digits', () => {
+			expect(formatStakeApyNumber(-64.4656)).toEqual('-64.5');
+			expect(formatStakeApyNumber(-64.000001)).toEqual('-64.0');
+		});
+
+		it('parses negative stake apy number correctly if it has 1 digit', () => {
+			expect(formatStakeApyNumber(-6.4656)).toEqual('-6.47');
+			expect(formatStakeApyNumber(-6.0000032)).toEqual('-6.00');
+		});
 	});
 
 	describe('format24hChangeInCurrency', () => {


### PR DESCRIPTION
# Motivation

We need to update `formatStakeApyNumber` so it can parse negative APYs.