### PR TITLE
fix(frontend): Adjust the logic to select the Swap network

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
@@ -102,12 +102,13 @@
 	// 3) Secondary token network
 	// If allowedIds is provided, returns the first candidate whose id is allowed.
 	// If none match (or none exist), returns undefined.
-	const getPreferredNetworkForSide = (
-		{side, allowedIds}: {
-			side: TokenSide,
-			allowedIds?: readonly NetworkId[]
-		}
-	): Network | undefined => {
+	const getPreferredNetworkForSide = ({
+		side,
+		allowedIds
+	}: {
+		side: TokenSide;
+		allowedIds?: readonly NetworkId[];
+	}): Network | undefined => {
 		const primary = side === 'source' ? $sourceToken?.network : $destinationToken?.network;
 
 		const secondary = side === 'source' ? $destinationToken?.network : $sourceToken?.network;
@@ -134,7 +135,7 @@
 		if (side === 'source') {
 			setNetworksMode({ enabled: true });
 
-			setFilterNetwork(getPreferredNetworkForSide({side}));
+			setFilterNetwork(getPreferredNetworkForSide({ side }));
 
 			return;
 		}
@@ -144,7 +145,7 @@
 			// no source yet: no constraints
 			setNetworksMode({ enabled: false });
 
-			setFilterNetwork(getPreferredNetworkForSide({side}));
+			setFilterNetwork(getPreferredNetworkForSide({ side }));
 
 			return;
 		}
@@ -156,7 +157,7 @@
 
 		setNetworksMode({ enabled: false, allowedIds });
 
-		setFilterNetwork(getPreferredNetworkForSide({side, allowedIds}));
+		setFilterNetwork(getPreferredNetworkForSide({ side, allowedIds }));
 	};
 
 	const enterTokenList = (side: TokenSide) => {


### PR DESCRIPTION
# Motivation

The logic to choose the initial selected network in the token list of the Swap modal should follow the following criteria:

### If no network is selected at top-level

- The source token is selected --> the destination token list has the same network.
- The destination token is selected --> the source token list has the same network.
- No token selected --> no network in both lists.

### If a network is selected at top-level

- The source token is selected --> the destination token list has the top-level network IF swappable, otherwise the source token network.
- The destination tokens is selected --> the source token list has the top-level network IF swappable, otherwise the destination token network.
- No token selected --> both lists have the top-level network.

### Practical test cases


Uploading Screen Recording 2026-03-02 at 18.20.44.mov…

