### PR TITLE
chore(frontend): Extend Episode 5 Sprinkles campaign

### DIFF
--- a/src/frontend/src/env/reward-campaigns.json
+++ b/src/frontend/src/env/reward-campaigns.json
@@ -96,7 +96,7 @@
 		"campaignHref": "rewards.campaigns.sprinkles_s1e5.campaign_href",
 		"learnMoreHref": "https://docs.oisy.com/rewards/oisy-sprinkles",
 		"startDate": "2025-09-24T12:00:00.000Z",
-		"endDate": "2026-02-28T12:00:00.000Z",
+		"endDate": "2026-03-31T12:00:00.000Z",
 		"welcome": {
 			"title": "rewards.campaigns.sprinkles_s1e5.welcome.title",
 			"subtitle": "rewards.campaigns.sprinkles_s1e5.welcome.subtitle",


### PR DESCRIPTION
# Motivation

We keep sprinkles rolling, but the campaign ended on Feb 28, 2026.
<img width="318" alt="image" src="https://github.com/user-attachments/assets/d95d91d2-3958-49da-b364-f469bd4249d8" />


# Changes

* extend to to end of Mar 2026

# Tests
<img width="636" alt="image" src="https://github.com/user-attachments/assets/83ad9958-45d6-4384-8132-39c81fdaaba6" />
