### PR TITLE
feat(frontend): implement OverlappedLogos component

### DIFF
--- a/src/frontend/src/lib/components/ui/OverlappedLogos.svelte
+++ b/src/frontend/src/lib/components/ui/OverlappedLogos.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
+	import { logoSizes } from '$lib/constants/components.constants';
+	import type { LogoSize } from '$lib/types/components';
+
+	interface Props {
+		icons: string[];
+		size?: LogoSize;
+		color?: 'off-white' | 'white';
+		invertColor?: boolean;
+	}
+
+	let { icons, size = 'xxs', invertColor, color = 'off-white' }: Props = $props();
+</script>
+
+<div class="flex items-center">
+	{#if icons.length > 0}
+		{#each icons as icon, i (icon)}
+			<div
+				style={`max-height: ${logoSizes[size]}; margin-right: calc(-${logoSizes[size]} / 3); z-index: ${i + 1};`}
+				class="relative rounded-full bg-primary ring ring-disabled last:mr-0"
+				in:fade
+			>
+				<span class="inline-flex" class:invert-on-dark-theme={invertColor}>
+					<Logo alt={`${icon}-${i}`} {color} {size} src={icon} />
+				</span>
+			</div>
+		{/each}
+	{:else}
+		<div class="w-12">
+			<SkeletonText />
+		</div>
+	{/if}
+</div>

--- a/src/frontend/src/tests/lib/components/ui/OverlappedLogos.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/OverlappedLogos.spec.ts
@@ -1,0 +1,41 @@
+import OverlappedLogos from '$lib/components/ui/OverlappedLogos.svelte';
+import { render } from '@testing-library/svelte';
+
+describe('OverlappedLogos.svelte', () => {
+	const mockIcons = ['/icon1.svg', '/icon2.svg', '/icon3.svg'];
+
+	const getIconWrappers = (container: HTMLElement) =>
+		container.querySelectorAll<HTMLElement>('[style*="z-index"]');
+
+	it('renders a Logo for each icon', () => {
+		const { container } = render(OverlappedLogos, { props: { icons: mockIcons } });
+
+		const images = container.querySelectorAll('img');
+
+		expect(images).toHaveLength(mockIcons.length);
+	});
+
+	it('renders a skeleton when icons array is empty', () => {
+		const { container } = render(OverlappedLogos, { props: { icons: [] } });
+
+		const images = container.querySelectorAll('img');
+
+		expect(images).toHaveLength(0);
+
+		const skeleton = container.querySelector('.w-12');
+
+		expect(skeleton).toBeInTheDocument();
+	});
+
+	it('applies z-index to each icon wrapper', () => {
+		const { container } = render(OverlappedLogos, { props: { icons: mockIcons } });
+
+		const wrappers = getIconWrappers(container);
+
+		expect(wrappers).toHaveLength(mockIcons.length);
+
+		wrappers.forEach((wrapper, i) => {
+			expect(wrapper.style.zIndex).toBe(`${i + 1}`);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

We need to implement a new UI component for displaying multiple logos.

<img width="92" height="70" alt="Screenshot 2026-03-03 at 11 04 22" src="https://github.com/user-attachments/assets/1ea549f2-d3b7-4d6b-8ba1-62c1134069bd" />
