### PR TITLE
fix(frontend): missing Badge style variant

### DIFF
--- a/src/frontend/src/lib/types/style.ts
+++ b/src/frontend/src/lib/types/style.ts
@@ -20,7 +20,8 @@ export type BadgeVariant =
 	| 'nft-trait'
 	| 'nft-spam'
 	| 'eligible'
-	| 'not-eligible';
+	| 'not-eligible'
+	| 'transparent';
 
 export type TagVariant =
 	| 'default'


### PR DESCRIPTION
# Motivation

`style.ts` did not contain the newly added `transparent` option for Badge styling.
