### PR TITLE
feat(frontend): update EarningHeader components

### DIFF
--- a/src/frontend/src/lib/components/earning/EarningHeader.svelte
+++ b/src/frontend/src/lib/components/earning/EarningHeader.svelte
@@ -4,6 +4,11 @@
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import { OISY_DOCS_URL } from '$lib/constants/oisy.constants';
+	import {
+		allEarningPositionsUsd,
+		allEarningYearlyAmountUsd,
+		highestEarningPotentialUsd
+	} from '$lib/derived/earning.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>
 
@@ -22,8 +27,11 @@
 		</p>
 
 		<div class="mt-4 flex w-full flex-col gap-3 sm:flex-row">
-			<EarningPositionCard />
-			<EarningPotentialCard />
+			<EarningPotentialCard highestEarningPotentialUsd={$highestEarningPotentialUsd} />
+			<EarningPositionCard
+				earningPositionsUsd={$allEarningYearlyAmountUsd}
+				earningYearlyAmountUsd={$allEarningPositionsUsd}
+			/>
 		</div>
 	{/snippet}
 </StakeContentSection>

--- a/src/frontend/src/lib/components/earning/EarningPositionCard.svelte
+++ b/src/frontend/src/lib/components/earning/EarningPositionCard.svelte
@@ -2,11 +2,17 @@
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
-	import { allEarningPositionsUsd, allEarningYearlyAmountUsd } from '$lib/derived/earning.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { formatCurrency } from '$lib/utils/format.utils';
+
+	interface Props {
+		earningYearlyAmountUsd: number;
+		earningPositionsUsd: number;
+	}
+
+	let { earningPositionsUsd, earningYearlyAmountUsd }: Props = $props();
 </script>
 
 <StakeContentCard>
@@ -14,13 +20,12 @@
 		<div class="text-sm font-bold">{$i18n.stake.text.active_earning}</div>
 
 		<div class="my-1 text-lg font-bold sm:text-xl">
-			<EarningYearlyAmount showAsSuccess value={$allEarningYearlyAmountUsd} />
+			<EarningYearlyAmount showAsSuccess value={earningPositionsUsd} />
 		</div>
 
-		<div class="text-sm sm:text-base">
-			{$i18n.stake.text.invested_assets}:
+		<div class="text-sm font-bold sm:text-base">
 			{formatCurrency({
-				value: $allEarningPositionsUsd,
+				value: earningYearlyAmountUsd,
 				currency: $currentCurrency,
 				exchangeRate: $currencyExchangeStore,
 				language: $currentLanguage

--- a/src/frontend/src/lib/components/earning/EarningPotentialCard.svelte
+++ b/src/frontend/src/lib/components/earning/EarningPotentialCard.svelte
@@ -4,12 +4,17 @@
 	import IconHelp from '$lib/components/icons/lucide/IconHelp.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
-	import { highestEarningPotentialUsd } from '$lib/derived/earning.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { formatCurrency } from '$lib/utils/format.utils';
+
+	interface Props {
+		highestEarningPotentialUsd: number;
+	}
+
+	let { highestEarningPotentialUsd }: Props = $props();
 
 	let infoExpanded = $state(false);
 </script>
@@ -33,13 +38,12 @@
 		<div class="my-1 text-lg font-bold sm:text-xl">
 			<EarningYearlyAmount
 				showAsNeutral
-				showPlusSign={$highestEarningPotentialUsd > 0}
-				value={$highestEarningPotentialUsd}
+				showPlusSign={highestEarningPotentialUsd > 0}
+				value={highestEarningPotentialUsd}
 			/>
 		</div>
 
-		<div class="text-sm sm:text-base">
-			{$i18n.stake.text.unproductive_assets}:
+		<div class="text-sm font-bold sm:text-base">
 			{formatCurrency({
 				value: $enabledMainnetFungibleTokensUsdBalance,
 				currency: $currentCurrency,

--- a/src/frontend/src/tests/lib/components/earning/EarningPositionCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningPositionCard.spec.ts
@@ -1,12 +1,10 @@
 import EarningPositionCard from '$lib/components/earning/EarningPositionCard.svelte';
 import * as currencyDerived from '$lib/derived/currency.derived';
-import * as earningDerived from '$lib/derived/earning.derived';
 import * as i18nDerived from '$lib/derived/i18n.derived';
 import { Currency } from '$lib/enums/currency';
 import { Languages } from '$lib/enums/languages';
 import * as currencyStore from '$lib/stores/currency-exchange.store';
 import * as formatUtils from '$lib/utils/format.utils';
-import en from '$tests/mocks/i18n.mock';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
@@ -38,49 +36,39 @@ describe('EarningPositionCard', () => {
 	});
 
 	it('renders yearly earning amount correctly', () => {
-		// yearly amount = 150
-		vi.spyOn(earningDerived, 'allEarningYearlyAmountUsd', 'get').mockReturnValue(staticStore(150));
-
-		// total positions in USD = 2000
-		vi.spyOn(earningDerived, 'allEarningPositionsUsd', 'get').mockReturnValue(staticStore(2000));
-
-		render(EarningPositionCard);
+		render(EarningPositionCard, {
+			props: { earningPositionsUsd: 150, earningYearlyAmountUsd: 2000 }
+		});
 
 		// yearly earning → "$150.00"
 		expect(screen.getByText(/\$150\.00/)).toBeInTheDocument();
 
 		// total positions → "$2000.00"
-		expect(screen.getByText(`${en.stake.text.invested_assets}: $2000.00`)).toBeInTheDocument();
+		expect(screen.getByText('$2000.00')).toBeInTheDocument();
 	});
 
 	it('renders a plus sign for positive yearly earnings', () => {
-		vi.spyOn(earningDerived, 'allEarningYearlyAmountUsd', 'get').mockReturnValue(staticStore(30));
-
-		vi.spyOn(earningDerived, 'allEarningPositionsUsd', 'get').mockReturnValue(staticStore(500));
-
-		render(EarningPositionCard);
+		render(EarningPositionCard, {
+			props: { earningPositionsUsd: 30, earningYearlyAmountUsd: 500 }
+		});
 
 		expect(screen.getByText(/\$30\.00/)).toBeInTheDocument();
 	});
 
 	it('renders $0.00 when yearly earnings are zero', () => {
-		vi.spyOn(earningDerived, 'allEarningYearlyAmountUsd', 'get').mockReturnValue(staticStore(0));
-
-		vi.spyOn(earningDerived, 'allEarningPositionsUsd', 'get').mockReturnValue(staticStore(100));
-
-		render(EarningPositionCard);
+		render(EarningPositionCard, {
+			props: { earningPositionsUsd: 0, earningYearlyAmountUsd: 100 }
+		});
 
 		// Should fallback to $0.00 for yearly earnings
 		expect(screen.getByText(/\$0\.00/)).toBeInTheDocument();
 	});
 
 	it('formats summary currency correctly', () => {
-		vi.spyOn(earningDerived, 'allEarningYearlyAmountUsd', 'get').mockReturnValue(staticStore(0));
+		render(EarningPositionCard, {
+			props: { earningPositionsUsd: 0, earningYearlyAmountUsd: 1234 }
+		});
 
-		vi.spyOn(earningDerived, 'allEarningPositionsUsd', 'get').mockReturnValue(staticStore(1234));
-
-		render(EarningPositionCard);
-
-		expect(screen.getByText(`${en.stake.text.invested_assets}: $1234.00`)).toBeInTheDocument();
+		expect(screen.getByText('$1234.00')).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/earning/EarningPotentialCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningPotentialCard.spec.ts
@@ -1,13 +1,11 @@
 import EarningPotentialCard from '$lib/components/earning/EarningPotentialCard.svelte';
 import * as currencyDerived from '$lib/derived/currency.derived';
-import * as earningDerived from '$lib/derived/earning.derived';
 import * as i18nDerived from '$lib/derived/i18n.derived';
 import * as tokensUiDerived from '$lib/derived/tokens-ui.derived';
 import { Currency } from '$lib/enums/currency';
 import { Languages } from '$lib/enums/languages';
 import * as currencyStore from '$lib/stores/currency-exchange.store';
 import * as formatUtils from '$lib/utils/format.utils';
-import en from '$tests/mocks/i18n.mock';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
@@ -39,53 +37,47 @@ describe('EarningPotentialCard', () => {
 
 	it('renders yearly earning amount with correct values', () => {
 		const mockTotalBalance = 1_000;
-		const mockApy = 10;
 
-		vi.spyOn(earningDerived, 'highestEarningPotentialUsd', 'get').mockReturnValue(
-			staticStore((mockTotalBalance * mockApy) / 100)
-		);
 		vi.spyOn(tokensUiDerived, 'enabledMainnetFungibleTokensUsdBalance', 'get').mockReturnValue(
 			staticStore(mockTotalBalance)
 		);
 
-		render(EarningPotentialCard);
+		render(EarningPotentialCard, {
+			props: { highestEarningPotentialUsd: 100 }
+		});
 
-		// Yearly earnings = 1000 * 10% = 100
+		// Yearly earnings = 100
 		expect(screen.getByText(/\$100\.00/)).toBeInTheDocument();
 
 		// Summary shows "$1000.00"
-		expect(screen.getByText(`${en.stake.text.unproductive_assets}: $1000.00`)).toBeInTheDocument();
+		expect(screen.getByText('$1000.00')).toBeInTheDocument();
 	});
 
 	it('shows a plus sign when balance > 0 and APY > 0', () => {
 		const mockTotalBalance = 200;
-		const mockApy = 15;
 
-		vi.spyOn(earningDerived, 'highestEarningPotentialUsd', 'get').mockReturnValue(
-			staticStore((mockTotalBalance * mockApy) / 100)
-		);
 		vi.spyOn(tokensUiDerived, 'enabledMainnetFungibleTokensUsdBalance', 'get').mockReturnValue(
 			staticStore(mockTotalBalance)
 		);
 
-		render(EarningPotentialCard);
+		render(EarningPotentialCard, {
+			props: { highestEarningPotentialUsd: 30 }
+		});
 
-		// 200 * 15% = 30 -> "+ $30.00"
+		// 30 -> "+ $30.00"
 		expect(screen.getByText('+ $30.00/year')).toBeInTheDocument();
 	});
 
 	it('handles null earning potential gracefully', () => {
 		const mockTotalBalance = 1_000;
-		const mockApy = 0;
 
-		vi.spyOn(earningDerived, 'highestEarningPotentialUsd', 'get').mockReturnValue(
-			staticStore((mockTotalBalance * mockApy) / 100)
-		);
 		vi.spyOn(tokensUiDerived, 'enabledMainnetFungibleTokensUsdBalance', 'get').mockReturnValue(
 			staticStore(mockTotalBalance)
 		);
 
-		render(EarningPotentialCard);
+		render(EarningPotentialCard, {
+			props: { highestEarningPotentialUsd: 0 }
+		});
 
 		expect(screen.getByText(/\$0\.00/)).toBeInTheDocument();
 	});


### PR DESCRIPTION
# Motivation

We need to make EarningHeader components more flexible - instead of using the stores directly, they should be now passed down as props. Also, a few minor appearance changes.