### PR TITLE
chore(dependabot): Add cooldown for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       interval: weekly
     commit-message:
       prefix: 'chore(github-actions): '
+    cooldown:
+      default-days: 30
 
   - package-ecosystem: cargo
     directory: '/'


### PR DESCRIPTION
# Motivation

For coherence, we add the cooldown in dependabot for github actions too.
