### PR TITLE
feat(frontend): update earning stores

### DIFF
--- a/src/frontend/src/lib/derived/earning.derived.ts
+++ b/src/frontend/src/lib/derived/earning.derived.ts
@@ -1,21 +1,18 @@
 import { goto } from '$app/navigation';
 import { EarningCardFields } from '$env/types/env.earning-cards';
-import { isGLDTToken } from '$icp-eth/utils/token.utils';
-import { gldtStakeStore } from '$icp/stores/gldt-stake.store';
-import { ZERO } from '$lib/constants/app.constants';
-import { AppPath } from '$lib/constants/routes.constants';
-import { exchanges } from '$lib/derived/exchange.derived';
 import {
-	enabledFungibleTokensUi,
-	enabledMainnetFungibleTokensUsdBalance
-} from '$lib/derived/tokens-ui.derived';
-import { i18n } from '$lib/stores/i18n.store';
-import { formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
-import { calculateTokenUsdAmount } from '$lib/utils/token.utils';
+	enabledHarvestAutopilotsUsdBalance,
+	harvestAutopilots,
+	harvestAutopilotsCurrentEarning,
+	harvestAutopilotsMaxApy,
+	harvestAutopilotsUsdBalance
+} from '$eth/derived/harvest-autopilots.derived';
+import { AppPath } from '$lib/constants/routes.constants';
+import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
-type EarningDataRecord = { [key in EarningCardFields]?: string | number } & {
+type EarningDataRecord = { [key in EarningCardFields]?: string | number | string[] } & {
 	action: () => Promise<void>;
 };
 
@@ -23,46 +20,45 @@ type EarningData = Record<string, EarningDataRecord>;
 
 export const earningData: Readable<EarningData> = derived(
 	[
-		i18n,
-		exchanges,
-		enabledFungibleTokensUi,
 		enabledMainnetFungibleTokensUsdBalance,
-		gldtStakeStore
+		harvestAutopilotsUsdBalance,
+		enabledHarvestAutopilotsUsdBalance,
+		harvestAutopilotsCurrentEarning,
+		harvestAutopilots,
+		harvestAutopilotsMaxApy
 	],
 	([
-		$i18n,
-		$exchanges,
-		$enabledFungibleTokensUi,
 		$enabledMainnetFungibleTokensUsdBalance,
-		$gldtStakeStore
-	]) => {
-		const gldtToken = $enabledFungibleTokensUi.find(isGLDTToken);
-		return {
-			'gldt-staking': {
-				[EarningCardFields.APY]: nonNullish($gldtStakeStore?.apy)
-					? formatStakeApyNumber($gldtStakeStore.apy)
-					: undefined,
-				[EarningCardFields.CURRENT_STAKED]: nonNullish(gldtToken)
-					? `${formatToken({
-							value: $gldtStakeStore?.position?.staked ?? ZERO,
-							unitName: gldtToken.decimals
-						})} ${gldtToken.symbol}`
-					: undefined,
-				[EarningCardFields.EARNING_POTENTIAL]: nonNullish($gldtStakeStore?.apy)
-					? ($enabledMainnetFungibleTokensUsdBalance * $gldtStakeStore.apy) / 100
-					: undefined,
-				[EarningCardFields.CURRENT_EARNING]: nonNullish(gldtToken)
-					? calculateTokenUsdAmount({
-							amount: $gldtStakeStore?.position?.staked,
-							token: gldtToken,
-							$exchanges
-						})
-					: undefined,
-				[EarningCardFields.TERMS]: $i18n.earning.terms.flexible,
-				action: () => goto(AppPath.EarnGold)
-			}
-		};
-	}
+		$harvestAutopilotsUsdBalance,
+		$enabledHarvestAutopilotsUsdBalance,
+		$harvestAutopilotsCurrentEarning,
+		$harvestAutopilots,
+		$harvestAutopilotsMaxApy
+	]) => ({
+		'harvest-autopilot': {
+			[EarningCardFields.APY]: $harvestAutopilotsMaxApy,
+			[EarningCardFields.CURRENT_EARNING]: $harvestAutopilotsCurrentEarning,
+			[EarningCardFields.CURRENT_STAKED]: $harvestAutopilotsUsdBalance,
+			[EarningCardFields.NETWORKS]: [
+				...$harvestAutopilots.reduce<Set<string>>(
+					(acc, { token: { network } }) => (nonNullish(network.icon) ? acc.add(network.icon) : acc),
+					new Set()
+				)
+			],
+			[EarningCardFields.ASSETS]: [
+				...$harvestAutopilots.reduce<Set<string>>(
+					(acc, { token: { assetIcon } }) => (nonNullish(assetIcon) ? acc.add(assetIcon) : acc),
+					new Set()
+				)
+			],
+			[EarningCardFields.EARNING_POTENTIAL]: nonNullish($enabledMainnetFungibleTokensUsdBalance)
+				? (($enabledMainnetFungibleTokensUsdBalance - $enabledHarvestAutopilotsUsdBalance) *
+						Number($harvestAutopilotsMaxApy)) /
+					100
+				: undefined,
+			action: () => goto(AppPath.EarnAutopilot)
+		}
+	})
 );
 
 export const highestApyEarningData: Readable<EarningDataRecord | undefined> = derived(
@@ -96,16 +92,34 @@ export const highestApyEarningData: Readable<EarningDataRecord | undefined> = de
 export const highestApyEarning: Readable<number> = derived(
 	[highestApyEarningData],
 	([$highestApyEarningData]) =>
-		!isNaN(Number($highestApyEarningData?.apy)) ? Number($highestApyEarningData?.apy) : 0
+		!isNaN(Number($highestApyEarningData?.[EarningCardFields.APY]))
+			? Number($highestApyEarningData?.[EarningCardFields.APY])
+			: 0
 );
 
 export const highestEarningPotentialUsd: Readable<number> = derived(
-	[highestApyEarning, enabledMainnetFungibleTokensUsdBalance],
-	([$highestApyEarning, $enabledMainnetFungibleTokensUsdBalance]) =>
-		($enabledMainnetFungibleTokensUsdBalance * $highestApyEarning) / 100
+	[highestApyEarning, enabledMainnetFungibleTokensUsdBalance, enabledHarvestAutopilotsUsdBalance],
+	([
+		$highestApyEarning,
+		$enabledMainnetFungibleTokensUsdBalance,
+		$enabledHarvestAutopilotsUsdBalance
+	]) =>
+		(($enabledMainnetFungibleTokensUsdBalance - $enabledHarvestAutopilotsUsdBalance) *
+			$highestApyEarning) /
+		100
 );
 
 export const allEarningPositionsUsd: Readable<number> = derived([earningData], ([$earningData]) =>
+	Object.values($earningData).reduce<number>(
+		(acc, record) =>
+			isNaN(Number(record[EarningCardFields.CURRENT_STAKED]))
+				? acc
+				: acc + Number(record[EarningCardFields.CURRENT_STAKED]),
+		0
+	)
+);
+
+export const allEarningYearlyAmountUsd = derived([earningData], ([$earningData]) =>
 	Object.values($earningData).reduce<number>(
 		(acc, record) =>
 			isNaN(Number(record[EarningCardFields.CURRENT_EARNING]))
@@ -113,13 +127,4 @@ export const allEarningPositionsUsd: Readable<number> = derived([earningData], (
 				: acc + Number(record[EarningCardFields.CURRENT_EARNING]),
 		0
 	)
-);
-
-export const allEarningYearlyAmountUsd = derived([earningData], ([$earningData]) =>
-	Object.values($earningData).reduce((acc, record) => {
-		const earning = Number(record[EarningCardFields.CURRENT_EARNING] ?? 0);
-		const apy = Number(record[EarningCardFields.APY] ?? 0);
-
-		return isNaN(earning) || isNaN(apy) ? acc : acc + earning * (apy / 100);
-	}, 0)
 );

--- a/src/frontend/src/tests/lib/components/earning/AllEarningOpportunityCardList.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/AllEarningOpportunityCardList.spec.ts
@@ -2,33 +2,12 @@ import * as navModule from '$app/navigation';
 import * as earningCardsEnv from '$env/earning-cards.env';
 import * as rewardCampaignsEnv from '$env/reward-campaigns.env';
 import { EarningCardFields } from '$env/types/env.earning-cards';
-import * as tokenFilter from '$icp-eth/utils/token.utils';
-import { GLDT_STAKE_CONTEXT_KEY } from '$icp/stores/gldt-stake.store';
 import AllEarningOpportunityCardList from '$lib/components/earning/AllEarningOpportunityCardList.svelte';
-import * as exchangeDerived from '$lib/derived/exchange.derived';
-import * as tokensUiDerived from '$lib/derived/tokens-ui.derived';
+import * as earningDerived from '$lib/derived/earning.derived';
 import { REWARD_ELIGIBILITY_CONTEXT_KEY } from '$lib/stores/reward.store';
-import type { Token } from '$lib/types/token';
-import * as formatUtils from '$lib/utils/format.utils';
-import * as tokenUtils from '$lib/utils/token.utils';
 import { mockRewardCampaigns } from '$tests/mocks/reward-campaigns.mock';
 import { render, screen } from '@testing-library/svelte';
 import { readable, writable } from 'svelte/store';
-
-// mock contexts
-const mockGldtStakeStore = {
-	subscribe: (fn: (v: unknown) => void) => {
-		fn({ apy: 5, position: { staked: 10 } });
-		return () => {};
-	},
-	setApy: vi.fn(),
-	resetApy: vi.fn(),
-	setPosition: vi.fn(),
-	resetPosition: vi.fn(),
-	reset: vi.fn()
-};
-
-const mockGldtStakeContext = { store: mockGldtStakeStore };
 
 const mockRewardEligibilityStore = writable({
 	campaignEligibilities: [
@@ -58,13 +37,12 @@ const mockRewardEligibilityContext = {
 };
 
 const mockContexts = new Map<symbol, unknown>([
-	[GLDT_STAKE_CONTEXT_KEY, mockGldtStakeContext],
 	[REWARD_ELIGIBILITY_CONTEXT_KEY, mockRewardEligibilityContext]
 ]);
 
 describe('AllEarningOpportunityCardList', () => {
 	beforeEach(() => {
-		vi.restoreAllMocks();
+		vi.resetAllMocks();
 
 		vi.spyOn(earningCardsEnv, 'earningCards', 'get').mockReturnValue([
 			{
@@ -76,51 +54,35 @@ describe('AllEarningOpportunityCardList', () => {
 				actionText: 'mock.rewards.action'
 			},
 			{
-				id: 'gldt-staking',
-				titles: ['mock.gldt.title'],
-				description: 'mock.gldt.description',
+				id: 'harvest-autopilot',
+				titles: ['mock.harvest.title'],
+				description: 'mock.harvest.description',
 				logo: '/mock/logo.svg',
 				fields: [
-					EarningCardFields.APY,
-					EarningCardFields.CURRENT_STAKED,
+					EarningCardFields.NETWORKS,
+					EarningCardFields.ASSETS,
 					EarningCardFields.CURRENT_EARNING,
-					EarningCardFields.EARNING_POTENTIAL,
-					EarningCardFields.TERMS
+					EarningCardFields.EARNING_POTENTIAL
 				],
-				actionText: 'mock.gldt.action'
+				actionText: 'mock.harvest.action'
 			}
 		]);
 
 		vi.spyOn(rewardCampaignsEnv, 'rewardCampaigns', 'get').mockReturnValue(mockRewardCampaigns);
 
-		const mockGldtToken = {
-			id: 'mock-gldt',
-			symbol: 'GLDT',
-			name: 'Gold DAO Token',
-			decimals: 8,
-			network: { id: 'mock-network', env: 'mainnet' },
-			address: '0xmock',
-			enabled: true
-		} as unknown as Token;
-
-		// mock derived stores
-		const enabledFungibleTokensUi = writable([mockGldtToken]);
-		const enabledMainnetFungibleTokensUsdBalance = readable(1000);
-
-		vi.spyOn(tokensUiDerived, 'enabledFungibleTokensUi', 'get').mockReturnValue(
-			enabledFungibleTokensUi
+		vi.spyOn(earningDerived, 'earningData', 'get').mockReturnValue(
+			readable({
+				'harvest-autopilot': {
+					[EarningCardFields.APY]: '5.5',
+					[EarningCardFields.CURRENT_STAKED]: 100,
+					[EarningCardFields.CURRENT_EARNING]: 5.5,
+					[EarningCardFields.NETWORKS]: ['eth-icon'],
+					[EarningCardFields.ASSETS]: ['usdc-icon'],
+					[EarningCardFields.EARNING_POTENTIAL]: 49.5,
+					action: () => navModule.goto('/earn/autopilot/')
+				}
+			})
 		);
-		vi.spyOn(tokensUiDerived, 'enabledMainnetFungibleTokensUsdBalance', 'get').mockReturnValue(
-			enabledMainnetFungibleTokensUsdBalance
-		);
-
-		vi.spyOn(exchangeDerived, 'exchanges', 'get').mockReturnValue(readable({}));
-
-		// mock utils
-		vi.spyOn(tokenFilter, 'isGLDTToken').mockReturnValue(true);
-		vi.spyOn(tokenUtils, 'calculateTokenUsdAmount').mockReturnValue(123.45);
-		vi.spyOn(formatUtils, 'formatToken').mockReturnValue('10.00');
-		vi.spyOn(formatUtils, 'formatToShortDateString').mockReturnValue('Dec 31, 2024');
 
 		// mock navigation
 		vi.spyOn(navModule, 'goto').mockResolvedValue();
@@ -131,8 +93,8 @@ describe('AllEarningOpportunityCardList', () => {
 
 		expect(screen.getByText('mock.rewards.title')).toBeInTheDocument();
 		expect(screen.getByText('mock.rewards.description')).toBeInTheDocument();
-		expect(screen.getByText('mock.gldt.title')).toBeInTheDocument();
-		expect(screen.getByText('mock.gldt.description')).toBeInTheDocument();
+		expect(screen.getByText('mock.harvest.title')).toBeInTheDocument();
+		expect(screen.getByText('mock.harvest.description')).toBeInTheDocument();
 	});
 
 	it('renders all card buttons with correct text', () => {
@@ -144,7 +106,7 @@ describe('AllEarningOpportunityCardList', () => {
 
 		expect(buttons).toHaveLength(2);
 		expect(buttons[0]).toHaveTextContent('mock.rewards.action');
-		expect(buttons[1]).toHaveTextContent('mock.gldt.action');
+		expect(buttons[1]).toHaveTextContent('mock.harvest.action');
 	});
 
 	it('calls goto when a card action button is clicked', async () => {

--- a/src/frontend/src/tests/lib/components/earning/Earning.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/Earning.spec.ts
@@ -1,25 +1,14 @@
+import * as navModule from '$app/navigation';
 import * as earningCardsEnv from '$env/earning-cards.env';
 import * as rewardCampaignsEnv from '$env/reward-campaigns.env';
 import { EarningCardFields } from '$env/types/env.earning-cards';
-import { GLDT_STAKE_CONTEXT_KEY } from '$icp/stores/gldt-stake.store';
 import EarningOpportunitiesPage from '$lib/components/earning/Earning.svelte';
+import * as earningDerived from '$lib/derived/earning.derived';
 import { i18n } from '$lib/stores/i18n.store';
 import { REWARD_ELIGIBILITY_CONTEXT_KEY } from '$lib/stores/reward.store';
 import { mockRewardCampaigns } from '$tests/mocks/reward-campaigns.mock';
 import { render, screen } from '@testing-library/svelte';
-import { get, writable } from 'svelte/store';
-
-const mockGldtStakeStore = {
-	subscribe: (fn: (v: unknown) => void) => {
-		fn({ apy: 5, position: { staked: 10 } });
-		return () => {};
-	},
-	setApy: vi.fn(),
-	resetApy: vi.fn(),
-	setPosition: vi.fn(),
-	resetPosition: vi.fn(),
-	reset: vi.fn()
-};
+import { get, readable, writable } from 'svelte/store';
 
 const mockRewardEligibilityStore = writable({
 	campaignEligibilities: [
@@ -62,20 +51,35 @@ describe('EarningOpportunitiesPage', () => {
 				actionText: 'mock.rewards.action'
 			},
 			{
-				id: 'gldt-staking',
-				titles: ['mock.gldt.title'],
-				description: 'mock.gldt.description',
+				id: 'harvest-autopilot',
+				titles: ['mock.harvest.title'],
+				description: 'mock.harvest.description',
 				logo: '/mock/logo.svg',
-				fields: [EarningCardFields.APY, EarningCardFields.CURRENT_STAKED],
-				actionText: 'mock.gldt.action'
+				fields: [EarningCardFields.NETWORKS, EarningCardFields.CURRENT_EARNING],
+				actionText: 'mock.harvest.action'
 			}
 		]);
+
+		vi.spyOn(navModule, 'goto').mockResolvedValue();
+
+		vi.spyOn(earningDerived, 'earningData', 'get').mockReturnValue(
+			readable({
+				'harvest-autopilot': {
+					[EarningCardFields.APY]: '5.5',
+					[EarningCardFields.CURRENT_STAKED]: 100,
+					[EarningCardFields.CURRENT_EARNING]: 5.5,
+					[EarningCardFields.NETWORKS]: ['eth-icon'],
+					[EarningCardFields.ASSETS]: ['usdc-icon'],
+					[EarningCardFields.EARNING_POTENTIAL]: 49.5,
+					action: () => navModule.goto('/earn/autopilot/')
+				}
+			})
+		);
 	});
 
 	it('renders PageTitle and nested earning components', () => {
 		render(EarningOpportunitiesPage, {
 			context: new Map<symbol, unknown>([
-				[GLDT_STAKE_CONTEXT_KEY, { store: mockGldtStakeStore }],
 				[REWARD_ELIGIBILITY_CONTEXT_KEY, mockRewardEligibilityContext]
 			])
 		});
@@ -85,6 +89,6 @@ describe('EarningOpportunitiesPage', () => {
 
 		// Child components should show content from earning cards
 		expect(screen.getByText('mock.rewards.title')).toBeInTheDocument();
-		expect(screen.getByText('mock.gldt.title')).toBeInTheDocument();
+		expect(screen.getByText('mock.harvest.title')).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
@@ -1,11 +1,11 @@
-import type { StakePositionResponse } from '$declarations/gldt_stake/gldt_stake.did';
-import { ICP_NETWORK } from '$env/networks/networks.icp.env';
-import { GLDT_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.additional.env';
-import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { EarningCardFields } from '$env/types/env.earning-cards';
-import { gldtStakeStore } from '$icp/stores/gldt-stake.store';
-import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
-import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
+import {
+	enabledHarvestAutopilotsUsdBalance,
+	harvestAutopilots,
+	harvestAutopilotsCurrentEarning,
+	harvestAutopilotsMaxApy,
+	harvestAutopilotsUsdBalance
+} from '$eth/derived/harvest-autopilots.derived';
 import {
 	allEarningPositionsUsd,
 	allEarningYearlyAmountUsd,
@@ -14,96 +14,138 @@ import {
 	highestApyEarningData,
 	highestEarningPotentialUsd
 } from '$lib/derived/earning.derived';
-import { balancesStore } from '$lib/stores/balances.store';
-import { exchangeStore } from '$lib/stores/exchange.store';
-import { i18n } from '$lib/stores/i18n.store';
-import { parseTokenId } from '$lib/validation/token.validation';
-import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
-import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
-import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
+import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
 import { get } from 'svelte/store';
-
-const mockGldtToken: IcrcCustomToken = {
-	...mockValidIcrcToken,
-	id: parseTokenId('GOLDAO'),
-	symbol: 'GLDT',
-	name: 'Gold DAO Token',
-	decimals: 8,
-	network: ICP_NETWORK,
-	enabled: true,
-	standard: { code: 'icrc' },
-	ledgerCanisterId: GLDT_LEDGER_CANISTER_ID
-};
 
 describe('earning.derived', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-
-		setupTestnetsStore('reset');
-		setupUserNetworksStore('allEnabled');
-
-		gldtStakeStore.reset();
-
-		icrcCustomTokensStore.resetAll();
-		icrcCustomTokensStore.setAll([{ data: mockGldtToken, certified: true }]);
-
-		balancesStore.reset(ICP_TOKEN.id);
-		balancesStore.set({
-			id: ICP_TOKEN.id,
-			data: { data: 100_000_000_000n, certified: true }
-		});
-
-		exchangeStore.reset();
-		exchangeStore.set([
-			{ 'internet-computer': { usd: 1 } },
-			{ [mockGldtToken.ledgerCanisterId]: { usd: 1 } }
-		]);
 	});
 
 	describe('earningData', () => {
-		it('correctly formatted values for GLDT', () => {
-			gldtStakeStore.setApy(10);
-			gldtStakeStore.setPosition({ staked: 1000000000n } as unknown as StakePositionResponse);
+		const setupStores = ({
+			enabledMainnetUsdBalance = 1000,
+			harvestUsdBalance = 100,
+			enabledHarvestUsdBalance = 100,
+			currentEarning = 5,
+			vaults = [{ token: { network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' } }],
+			maxApy = '5.5'
+		}: {
+			enabledMainnetUsdBalance?: number | null;
+			harvestUsdBalance?: number;
+			enabledHarvestUsdBalance?: number;
+			currentEarning?: number;
+			vaults?: { token: { network: { icon?: string }; assetIcon?: string } }[];
+			maxApy?: string;
+		} = {}) => {
+			vi.spyOn(enabledMainnetFungibleTokensUsdBalance, 'subscribe').mockImplementation((fn) => {
+				fn(enabledMainnetUsdBalance as number);
+				return () => {};
+			});
+			vi.spyOn(harvestAutopilotsUsdBalance, 'subscribe').mockImplementation((fn) => {
+				fn(harvestUsdBalance);
+				return () => {};
+			});
+			vi.spyOn(enabledHarvestAutopilotsUsdBalance, 'subscribe').mockImplementation((fn) => {
+				fn(enabledHarvestUsdBalance);
+				return () => {};
+			});
+			vi.spyOn(harvestAutopilotsCurrentEarning, 'subscribe').mockImplementation((fn) => {
+				fn(currentEarning);
+				return () => {};
+			});
+			vi.spyOn(harvestAutopilots, 'subscribe').mockImplementation((fn) => {
+				fn(vaults as never);
+				return () => {};
+			});
+			vi.spyOn(harvestAutopilotsMaxApy, 'subscribe').mockImplementation((fn) => {
+				fn(maxApy);
+				return () => {};
+			});
+		};
+
+		it('returns correctly structured harvest-autopilot record', () => {
+			setupStores();
 
 			const result = get(earningData);
+			const record = result['harvest-autopilot'];
 
-			const record = result['gldt-staking'];
-
-			expect(record[EarningCardFields.APY]).toBe('10.0');
-			expect(record[EarningCardFields.CURRENT_STAKED]).toBe('10 GLDT');
-			expect(record[EarningCardFields.CURRENT_EARNING]).toBe(10);
-			expect(record[EarningCardFields.EARNING_POTENTIAL]).toBe(100);
-			expect(record[EarningCardFields.TERMS]).toBe(get(i18n).earning.terms.flexible);
-
-			expect(typeof record.action).toBe('function');
+			expect(record[EarningCardFields.APY]).toBe('5.5');
+			expect(record[EarningCardFields.CURRENT_STAKED]).toBe(100);
+			expect(record[EarningCardFields.CURRENT_EARNING]).toBe(5);
+			expect(record[EarningCardFields.NETWORKS]).toEqual(['eth-icon']);
+			expect(record[EarningCardFields.ASSETS]).toEqual(['usdc-icon']);
 		});
 
-		it('handles missing GLDT APY', () => {
-			gldtStakeStore.setApy(undefined as unknown as number);
-			gldtStakeStore.setPosition({ staked: 1000000000n } as unknown as StakePositionResponse);
+		it('calculates earning potential correctly', () => {
+			setupStores({
+				enabledMainnetUsdBalance: 10000,
+				enabledHarvestUsdBalance: 2000,
+				maxApy: '10.0'
+			});
 
 			const result = get(earningData);
-			const rec = result['gldt-staking'];
+			const record = result['harvest-autopilot'];
 
-			expect(rec[EarningCardFields.APY]).toBeUndefined();
-			expect(rec[EarningCardFields.EARNING_POTENTIAL]).toBeUndefined();
+			// (10000 - 2000) * 10.0 / 100 = 800
+			expect(record[EarningCardFields.EARNING_POTENTIAL]).toBe(800);
 		});
 
-		it('handles missing GLDT token gracefully', () => {
-			icrcCustomTokensStore.resetAll();
+		it('returns undefined earning potential when mainnet balance is nullish', () => {
+			setupStores({
+				enabledMainnetUsdBalance: null
+			});
 
 			const result = get(earningData);
-			const rec = result['gldt-staking'];
+			const record = result['harvest-autopilot'];
 
-			expect(rec[EarningCardFields.CURRENT_STAKED]).toBeUndefined();
-			expect(rec[EarningCardFields.CURRENT_EARNING]).toBeUndefined();
+			expect(record[EarningCardFields.EARNING_POTENTIAL]).toBeUndefined();
+		});
+
+		it('deduplicates network and asset icons', () => {
+			setupStores({
+				vaults: [
+					{ token: { network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' } },
+					{ token: { network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' } },
+					{ token: { network: { icon: 'base-icon' }, assetIcon: 'usdt-icon' } }
+				]
+			});
+
+			const result = get(earningData);
+			const record = result['harvest-autopilot'];
+
+			expect(record[EarningCardFields.NETWORKS]).toEqual(['eth-icon', 'base-icon']);
+			expect(record[EarningCardFields.ASSETS]).toEqual(['usdc-icon', 'usdt-icon']);
+		});
+
+		it('excludes nullish icons from networks and assets', () => {
+			setupStores({
+				vaults: [
+					{ token: { network: { icon: 'eth-icon' }, assetIcon: undefined } },
+					{ token: { network: { icon: undefined }, assetIcon: 'usdc-icon' } }
+				]
+			});
+
+			const result = get(earningData);
+			const record = result['harvest-autopilot'];
+
+			expect(record[EarningCardFields.NETWORKS]).toEqual(['eth-icon']);
+			expect(record[EarningCardFields.ASSETS]).toEqual(['usdc-icon']);
 		});
 	});
 
 	describe('highestApyEarningData', () => {
 		it('returns the record with the highest APY', () => {
-			gldtStakeStore.setApy(10);
-			gldtStakeStore.setPosition({ staked: 1000000000n } as unknown as StakePositionResponse);
+			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
+				fn({
+					'harvest-autopilot': {
+						[EarningCardFields.APY]: '10.0',
+						[EarningCardFields.CURRENT_STAKED]: 100,
+						action: vi.fn()
+					}
+				});
+				return () => {};
+			});
 
 			const highest = get(highestApyEarningData);
 
@@ -112,35 +154,38 @@ describe('earning.derived', () => {
 		});
 
 		it('returns undefined if no earning records exist', () => {
-			icrcCustomTokensStore.resetAll();
-			gldtStakeStore.reset();
+			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
+				fn({});
+				return () => {};
+			});
 
-			const highest = get(highestApyEarningData);
-
-			expect(highest).toBeUndefined();
+			expect(get(highestApyEarningData)).toBeUndefined();
 		});
 
 		it('ignores records with invalid APY values', () => {
-			gldtStakeStore.setApy(undefined as unknown as number);
-			gldtStakeStore.setPosition({ staked: 1000000000n } as unknown as StakePositionResponse);
+			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
+				fn({
+					'harvest-autopilot': {
+						[EarningCardFields.APY]: undefined,
+						action: vi.fn()
+					}
+				});
+				return () => {};
+			});
 
-			const highest = get(highestApyEarningData);
-
-			expect(highest).toBeUndefined();
+			expect(get(highestApyEarningData)).toBeUndefined();
 		});
 
 		it('correctly compares numeric APY values across multiple records', () => {
 			const mockSecondRecord = {
 				[EarningCardFields.APY]: '25.0',
-				[EarningCardFields.CURRENT_STAKED]: '999 GLDT',
+				[EarningCardFields.CURRENT_STAKED]: 999,
 				action: vi.fn()
 			};
 
-			const originalEarningData = earningData.subscribe;
-
 			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
 				fn({
-					'gldt-staking': {
+					'harvest-autopilot': {
 						[EarningCardFields.APY]: '10.0',
 						action: vi.fn()
 					},
@@ -152,88 +197,97 @@ describe('earning.derived', () => {
 			const highest = get(highestApyEarningData);
 
 			expect(highest).toEqual(mockSecondRecord);
-
-			vi.spyOn(earningData, 'subscribe').mockImplementation(originalEarningData);
 		});
 	});
 
 	describe('highestApyEarning', () => {
-		const mockApy = 10;
+		it('returns the highest APY as a number', () => {
+			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
+				fn({
+					'harvest-autopilot': {
+						[EarningCardFields.APY]: '10.0',
+						action: vi.fn()
+					}
+				});
+				return () => {};
+			});
 
-		beforeEach(() => {
-			vi.clearAllMocks();
-
-			gldtStakeStore.reset();
-		});
-
-		it('returns the highest APY', () => {
-			gldtStakeStore.setApy(mockApy);
-			gldtStakeStore.setPosition({ staked: 1000000000n } as unknown as StakePositionResponse);
-
-			expect(get(highestApyEarning)).toBe(mockApy);
+			expect(get(highestApyEarning)).toBe(10);
 		});
 
 		it('handles missing APY values gracefully', () => {
-			gldtStakeStore.setApy(undefined as unknown as number);
-			gldtStakeStore.setPosition({ staked: 1000000000n } as unknown as StakePositionResponse);
+			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
+				fn({
+					'harvest-autopilot': {
+						[EarningCardFields.APY]: undefined,
+						action: vi.fn()
+					}
+				});
+				return () => {};
+			});
 
 			expect(get(highestApyEarning)).toBe(0);
 		});
 
-		it('handles missing earning records', () => {
-			gldtStakeStore.reset();
+		it('returns 0 when no earning records exist', () => {
+			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
+				fn({});
+				return () => {};
+			});
 
 			expect(get(highestApyEarning)).toBe(0);
 		});
 	});
 
 	describe('highestEarningPotentialUsd', () => {
-		const mockTotalBalance = 12_345_600_000_000n;
-		const mockApy = 10;
-		const expectedEarningPotential = (123_456 * mockApy) / 100;
-
-		beforeEach(() => {
-			vi.clearAllMocks();
-
-			gldtStakeStore.reset();
-
-			gldtStakeStore.setApy(mockApy);
-			gldtStakeStore.setPosition({ staked: 123n } as unknown as StakePositionResponse);
-
-			balancesStore.set({
-				id: ICP_TOKEN.id,
-				data: { data: mockTotalBalance, certified: true }
+		const setupStores = ({ apy = 10, mainnetBalance = 1000, harvestBalance = 0 } = {}) => {
+			vi.spyOn(highestApyEarning, 'subscribe').mockImplementation((fn) => {
+				fn(apy);
+				return () => {};
 			});
-		});
+			vi.spyOn(enabledMainnetFungibleTokensUsdBalance, 'subscribe').mockImplementation((fn) => {
+				fn(mainnetBalance);
+				return () => {};
+			});
+			vi.spyOn(enabledHarvestAutopilotsUsdBalance, 'subscribe').mockImplementation((fn) => {
+				fn(harvestBalance);
+				return () => {};
+			});
+		};
 
 		it('returns the highest earning potential in USD', () => {
-			balancesStore.set({
-				id: ICP_TOKEN.id,
-				data: { data: mockTotalBalance, certified: true }
-			});
+			setupStores({ mainnetBalance: 123456 });
 
-			expect(get(highestEarningPotentialUsd)).toBe(expectedEarningPotential);
+			// (123456 - 0) * 10 / 100 = 12345.6
+			expect(get(highestEarningPotentialUsd)).toBe(12345.6);
 		});
 
-		it('handles a null APY', () => {
-			gldtStakeStore.setApy(0);
+		it('subtracts enabled harvest autopilot balance', () => {
+			setupStores({ mainnetBalance: 1000, harvestBalance: 200 });
+
+			// (1000 - 200) * 10 / 100 = 80
+			expect(get(highestEarningPotentialUsd)).toBe(80);
+		});
+
+		it('handles a zero APY', () => {
+			setupStores({ apy: 0 });
 
 			expect(get(highestEarningPotentialUsd)).toBe(0);
 		});
 
-		it('handles a null balance', () => {
-			balancesStore.reset(ICP_TOKEN.id);
+		it('handles a zero balance', () => {
+			setupStores({ mainnetBalance: 0 });
 
 			expect(get(highestEarningPotentialUsd)).toBe(0);
 		});
 	});
 
 	describe('allEarningPositionsUsd', () => {
-		it('sums all valid CURRENT_EARNING values', () => {
+		it('sums all valid CURRENT_STAKED values', () => {
 			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
 				fn({
-					a: { [EarningCardFields.CURRENT_EARNING]: 10, action: async () => {} },
-					b: { [EarningCardFields.CURRENT_EARNING]: 20, action: async () => {} }
+					a: { [EarningCardFields.CURRENT_STAKED]: 10, action: async () => {} },
+					b: { [EarningCardFields.CURRENT_STAKED]: 20, action: async () => {} }
 				});
 				return () => {};
 			});
@@ -241,11 +295,11 @@ describe('earning.derived', () => {
 			expect(get(allEarningPositionsUsd)).toBe(30);
 		});
 
-		it('ignores undefined CURRENT_EARNING', () => {
+		it('ignores undefined CURRENT_STAKED', () => {
 			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
 				fn({
 					a: { action: async () => {} },
-					b: { [EarningCardFields.CURRENT_EARNING]: 20, action: async () => {} }
+					b: { [EarningCardFields.CURRENT_STAKED]: 20, action: async () => {} }
 				});
 				return () => {};
 			});
@@ -256,8 +310,8 @@ describe('earning.derived', () => {
 		it('ignores invalid numeric values', () => {
 			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
 				fn({
-					a: { [EarningCardFields.CURRENT_EARNING]: 'abc', action: async () => {} },
-					b: { [EarningCardFields.CURRENT_EARNING]: 10, action: async () => {} }
+					a: { [EarningCardFields.CURRENT_STAKED]: 'abc', action: async () => {} },
+					b: { [EarningCardFields.CURRENT_STAKED]: 10, action: async () => {} }
 				});
 				return () => {};
 			});
@@ -275,24 +329,40 @@ describe('earning.derived', () => {
 		});
 	});
 
-	describe('allEarningYearlyAmountUsd (mocked subscribe)', () => {
+	describe('allEarningYearlyAmountUsd', () => {
 		beforeEach(() => {
 			vi.restoreAllMocks();
 		});
 
-		it('computes yearly earning correctly from valid entries', () => {
+		it('sums all valid CURRENT_EARNING values', () => {
 			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
 				fn({
-					a: {
-						[EarningCardFields.CURRENT_EARNING]: 100,
-						[EarningCardFields.APY]: 10,
-						action: async () => {}
-					},
-					b: {
-						[EarningCardFields.CURRENT_EARNING]: 200,
-						[EarningCardFields.APY]: 5,
-						action: async () => {}
-					}
+					a: { [EarningCardFields.CURRENT_EARNING]: 100, action: async () => {} },
+					b: { [EarningCardFields.CURRENT_EARNING]: 200, action: async () => {} }
+				});
+				return () => {};
+			});
+
+			expect(get(allEarningYearlyAmountUsd)).toBe(300);
+		});
+
+		it('ignores invalid CURRENT_EARNING values', () => {
+			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
+				fn({
+					a: { [EarningCardFields.CURRENT_EARNING]: 'abc', action: async () => {} },
+					b: { [EarningCardFields.CURRENT_EARNING]: 50, action: async () => {} }
+				});
+				return () => {};
+			});
+
+			expect(get(allEarningYearlyAmountUsd)).toBe(50);
+		});
+
+		it('ignores entries with undefined CURRENT_EARNING', () => {
+			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
+				fn({
+					a: { action: async () => {} },
+					b: { [EarningCardFields.CURRENT_EARNING]: 20, action: async () => {} }
 				});
 				return () => {};
 			});
@@ -300,58 +370,11 @@ describe('earning.derived', () => {
 			expect(get(allEarningYearlyAmountUsd)).toBe(20);
 		});
 
-		it('ignores invalid CURRENT_EARNING values', () => {
-			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
-				fn({
-					a: {
-						[EarningCardFields.CURRENT_EARNING]: 'abc', // invalid
-						[EarningCardFields.APY]: 10,
-						action: async () => {}
-					},
-					b: {
-						[EarningCardFields.CURRENT_EARNING]: 50,
-						[EarningCardFields.APY]: 20,
-						action: async () => {}
-					}
-				});
-				return () => {};
-			});
-
-			expect(get(allEarningYearlyAmountUsd)).toBe(10);
-		});
-
-		it('ignores entries with missing APY', () => {
-			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
-				fn({
-					a: {
-						[EarningCardFields.CURRENT_EARNING]: 100,
-						action: async () => {}
-					},
-					b: {
-						[EarningCardFields.CURRENT_EARNING]: 20,
-						[EarningCardFields.APY]: 10,
-						action: async () => {}
-					}
-				});
-				return () => {};
-			});
-
-			expect(get(allEarningYearlyAmountUsd)).toBe(2);
-		});
-
 		it('returns 0 when all records are invalid', () => {
 			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
 				fn({
-					a: {
-						[EarningCardFields.CURRENT_EARNING]: 'nope',
-						[EarningCardFields.APY]: 'bad',
-						action: async () => {}
-					},
-					b: {
-						[EarningCardFields.CURRENT_EARNING]: undefined,
-						[EarningCardFields.APY]: undefined,
-						action: async () => {}
-					}
+					a: { [EarningCardFields.CURRENT_EARNING]: 'nope', action: async () => {} },
+					b: { [EarningCardFields.CURRENT_EARNING]: undefined, action: async () => {} }
 				});
 				return () => {};
 			});
@@ -359,34 +382,18 @@ describe('earning.derived', () => {
 			expect(get(allEarningYearlyAmountUsd)).toBe(0);
 		});
 
-		it('handles mixed valid + invalid entries', () => {
+		it('handles mixed valid and invalid entries', () => {
 			vi.spyOn(earningData, 'subscribe').mockImplementation((fn) => {
 				fn({
-					a: {
-						[EarningCardFields.CURRENT_EARNING]: 100,
-						[EarningCardFields.APY]: 10,
-						action: async () => {}
-					},
-					b: {
-						[EarningCardFields.CURRENT_EARNING]: NaN,
-						[EarningCardFields.APY]: 20,
-						action: async () => {}
-					},
-					c: {
-						[EarningCardFields.CURRENT_EARNING]: 50,
-						[EarningCardFields.APY]: undefined,
-						action: async () => {}
-					},
-					d: {
-						[EarningCardFields.CURRENT_EARNING]: 20,
-						[EarningCardFields.APY]: 20,
-						action: async () => {}
-					}
+					a: { [EarningCardFields.CURRENT_EARNING]: 100, action: async () => {} },
+					b: { [EarningCardFields.CURRENT_EARNING]: NaN, action: async () => {} },
+					c: { [EarningCardFields.CURRENT_EARNING]: undefined, action: async () => {} },
+					d: { [EarningCardFields.CURRENT_EARNING]: 20, action: async () => {} }
 				});
 				return () => {};
 			});
 
-			expect(get(allEarningYearlyAmountUsd)).toBe(14);
+			expect(get(allEarningYearlyAmountUsd)).toBe(120);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The next step is to update `earning.derived` with Harvest autopilot data. At the same time, the GLDT stuff can be removed from there.
