### PR TITLE
feat(frontend): implement VaultCard component

### DIFF
--- a/src/frontend/src/lib/components/vaults/VaultCard.svelte
+++ b/src/frontend/src/lib/components/vaults/VaultCard.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
+	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
+	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
+	import TokenExchangeValueSkeleton from '$lib/components/tokens/TokenExchangeValueSkeleton.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { Vault } from '$lib/types/vaults';
+	import { isMobile } from '$lib/utils/device.utils';
+	import { formatToken } from '$lib/utils/format.utils';
+	import { getTokenDisplayName } from '$lib/utils/token.utils';
+
+	interface Props {
+		data: Vault;
+		onClick?: () => void;
+	}
+
+	let { data, onClick }: Props = $props();
+
+	let { token, apy } = $derived(data);
+
+	let name = $derived(getTokenDisplayName(token));
+
+	let exchange = $derived($exchanges?.[token.id]);
+
+	let assetsPerShare = $derived(
+		nonNullish(exchange) && 'assets_per_share' in exchange ? exchange.assets_per_share : undefined
+	);
+
+	let underlyingAssets = $derived(
+		nonNullish(token.balance) && nonNullish(assetsPerShare)
+			? BigInt(Math.round(Number(token.balance) * assetsPerShare))
+			: ZERO
+	);
+
+	let isHarvestAutopilot = $derived(isTokenHarvestAutopilot(token));
+
+	let currentlyEarning = $derived(
+		nonNullish(token?.usdBalance) && nonNullish(apy) ? (token.usdBalance * Number(apy)) / 100 : 0
+	);
+</script>
+
+<div class="flex w-full flex-col">
+	<LogoButton {onClick}>
+		{#snippet logo()}
+			<span class="mr-2 flex">
+				<TokenLogo
+					badge={{ type: 'network' }}
+					color="white"
+					data={{ ...token, icon: token.assetIcon ?? token.icon }}
+					logoSize={isMobile() ? 'sm' : 'lg'}
+				/>
+			</span>
+		{/snippet}
+
+		{#snippet title()}
+			<span class="text-sm sm:text-lg">{name}</span>
+		{/snippet}
+
+		{#snippet subtitle()}
+			{#if isHarvestAutopilot}
+				<span class="hidden sm:inline-block">
+					<Badge styleClass="ml-2 mb-1" variant="transparent" width="w-fit">
+						{$i18n.vaults.text.autopilot}
+					</Badge>
+				</span>
+			{/if}
+		{/snippet}
+
+		{#snippet description()}
+			{#if nonNullish(apy)}
+				<Badge variant={Number(apy) > 0 ? 'success' : 'default'} width="w-fit">
+					{`${$i18n.vaults.text.live_apy} ${apy}%`}
+				</Badge>
+			{/if}
+		{/snippet}
+
+		{#snippet titleEnd()}
+			<span
+				class="flex min-w-12 items-center justify-end gap-1 text-sm text-nowrap sm:gap-2 sm:text-base"
+			>
+				{#if (token?.usdBalance ?? 0) > 0}
+					<EarningYearlyAmount
+						showAsSuccess
+						showPlusSign
+						showWithShortenedLabel
+						value={currentlyEarning}
+					/>
+				{/if}
+
+				<ExchangeTokenValue data={token} />
+			</span>
+		{/snippet}
+
+		{#snippet descriptionEnd()}
+			<TokenExchangeValueSkeleton data={token}>
+				<span class="block min-w-12 text-nowrap">
+					{formatToken({ value: underlyingAssets, unitName: token.decimals })}
+					{token.assetSymbol}
+				</span>
+			</TokenExchangeValueSkeleton>
+		{/snippet}
+	</LogoButton>
+</div>

--- a/src/frontend/src/tests/lib/components/vaults/VaultCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/vaults/VaultCard.spec.ts
@@ -1,0 +1,79 @@
+import { BAUTOPILOT_USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_usdc.env';
+import VaultCard from '$lib/components/vaults/VaultCard.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { exchangeStore } from '$lib/stores/exchange.store';
+import type { Vault } from '$lib/types/vaults';
+import { formatToken } from '$lib/utils/format.utils';
+import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('VaultCard', () => {
+	const mockVault: Vault = {
+		token: {
+			...mockValidErc4626Token,
+			enabled: true,
+			version: 1n,
+			usdBalance: 0,
+			balance: ZERO
+		},
+		apy: '5.5'
+	};
+
+	beforeEach(() => {
+		exchangeStore.reset();
+	});
+
+	it('should render the token display name', () => {
+		const { getByText } = render(VaultCard, { props: { data: mockVault } });
+
+		expect(getByText(mockVault.token.name)).toBeInTheDocument();
+	});
+
+	it('should render the live APY badge when apy is provided', () => {
+		const { getByText } = render(VaultCard, { props: { data: mockVault } });
+
+		expect(getByText(`${en.vaults.text.live_apy} ${mockVault.apy}%`)).toBeInTheDocument();
+	});
+
+	it('should not render the live APY badge when apy is undefined', () => {
+		const vaultWithoutApy: Vault = { ...mockVault, apy: undefined };
+
+		const { queryByText } = render(VaultCard, { props: { data: vaultWithoutApy } });
+
+		expect(queryByText(en.vaults.text.live_apy, { exact: false })).not.toBeInTheDocument();
+	});
+
+	it('should render the asset symbol when exchange is initialized', () => {
+		exchangeStore.set([{ [mockVault.token.id]: { usd: 1 } }]);
+
+		const { getByText } = render(VaultCard, { props: { data: mockVault } });
+
+		const expectedText = `${formatToken({ value: ZERO, unitName: mockVault.token.decimals })} ${mockVault.token.assetSymbol}`;
+
+		expect(getByText(expectedText)).toBeInTheDocument();
+	});
+
+	it('should not render the autopilot badge for non-harvest tokens', () => {
+		const { queryByText } = render(VaultCard, { props: { data: mockVault } });
+
+		expect(queryByText(en.vaults.text.autopilot)).not.toBeInTheDocument();
+	});
+
+	it('should render the autopilot badge for harvest autopilot tokens', () => {
+		const harvestVault: Vault = {
+			...mockVault,
+			token: {
+				...BAUTOPILOT_USDC_TOKEN,
+				enabled: true,
+				version: 1n,
+				usdBalance: 0,
+				balance: ZERO
+			}
+		};
+
+		const { getByText } = render(VaultCard, { props: { data: harvestVault } });
+
+		expect(getByText(en.vaults.text.autopilot)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

We can now implement the VaultCard component - it's gonna be used both on Earning and Assets page (Earning tab).
