### PR TITLE
feat(frontend): add Harvest Autopilot pages

### DIFF
--- a/src/frontend/src/eth/components/stake/harvest-autopilot/HarvestAutopilot.svelte
+++ b/src/frontend/src/eth/components/stake/harvest-autopilot/HarvestAutopilot.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import HarvestAutopilotDetail from '$eth/components/stake/harvest-autopilot/HarvestAutopilotDetail.svelte';
+	import HarvestAutopilotOverview from '$eth/components/stake/harvest-autopilot/HarvestAutopilotOverview.svelte';
+	import { routeAutopilotVault } from '$lib/derived/nav.derived';
+</script>
+
+{#if nonNullish($routeAutopilotVault)}
+	<HarvestAutopilotDetail />
+{:else}
+	<HarvestAutopilotOverview />
+{/if}

--- a/src/frontend/src/routes/(app)/earn/+layout.svelte
+++ b/src/frontend/src/routes/(app)/earn/+layout.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import LoaderMultipleEthTransactions from '$eth/components/loaders/LoaderMultipleEthTransactions.svelte';
+	import LoadersHarvestAutopilotBalances from '$eth/components/loaders/LoadersHarvestAutopilotBalances.svelte';
+	import { harvestAutopilotTokens } from '$eth/derived/harvest-autopilots.derived';
+	import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
+<LoadersHarvestAutopilotBalances />
+
+<LoaderMultipleEthTransactions
+	interval={WALLET_TIMER_INTERVAL_MILLIS}
+	tokens={$harvestAutopilotTokens}
+/>
+
+{@render children()}

--- a/src/frontend/src/routes/(app)/earn/autopilot/+page.svelte
+++ b/src/frontend/src/routes/(app)/earn/autopilot/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import HarvestAutopilot from '$eth/components/stake/harvest-autopilot/HarvestAutopilot.svelte';
+</script>
+
+<HarvestAutopilot />

--- a/src/frontend/src/tests/eth/components/stake/harvest-autopilot/HarvestAutopilot.spec.ts
+++ b/src/frontend/src/tests/eth/components/stake/harvest-autopilot/HarvestAutopilot.spec.ts
@@ -1,0 +1,53 @@
+import HarvestAutopilot from '$eth/components/stake/harvest-autopilot/HarvestAutopilot.svelte';
+import * as harvestAutopilotsDerived from '$eth/derived/harvest-autopilots.derived';
+import * as navDerived from '$lib/derived/nav.derived';
+import type { Vault } from '$lib/types/vaults';
+import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+
+vi.mock('$env/earning', () => ({
+	get EARNING_ENABLED() {
+		return true;
+	}
+}));
+
+describe('HarvestAutopilot', () => {
+	const mockVault: Vault = {
+		token: {
+			...mockValidErc4626Token,
+			enabled: true,
+			version: 1n,
+			usdBalance: 500,
+			balance: 50000000000n
+		},
+		apy: '5.5'
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.spyOn(harvestAutopilotsDerived, 'harvestAutopilots', 'get').mockReturnValue(
+			readable([mockVault])
+		);
+	});
+
+	it('should render overview when no vault is selected', () => {
+		vi.spyOn(navDerived, 'routeAutopilotVault', 'get').mockReturnValue(readable(undefined));
+
+		const { getByText } = render(HarvestAutopilot);
+
+		expect(getByText(en.earning.cards.harvest_autopilot.title)).toBeInTheDocument();
+	});
+
+	it('should render detail when a vault is selected', () => {
+		vi.spyOn(navDerived, 'routeAutopilotVault', 'get').mockReturnValue(
+			readable(mockVault.token.address)
+		);
+
+		const { getByText } = render(HarvestAutopilot);
+
+		expect(getByText(en.stake.text.vault_info)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

Finally, we can add Harvest Autopilot pages to the routes folder.
