### PR TITLE
fix(frontend): missing +page.ts file for autopilot route

### DIFF
--- a/src/frontend/src/routes/(app)/earn/autopilot/+page.ts
+++ b/src/frontend/src/routes/(app)/earn/autopilot/+page.ts
@@ -1,0 +1,6 @@
+import { loadRouteParams, type RouteParams } from '$lib/utils/nav.utils';
+import type { LoadEvent } from '@sveltejs/kit';
+// eslint-disable-next-line local-rules/no-relative-imports
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ($event: LoadEvent): RouteParams => loadRouteParams($event);


### PR DESCRIPTION
# Motivation

There is one file missing in the autopilot route folder.
