### PR TITLE
feat(frontend): Show spender in ETH WalletConnect send flow

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
@@ -6,7 +6,7 @@
 	import { decodeErc20AbiData } from '$eth/utils/transactions.utils';
 	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
 	import SendData from '$lib/components/send/SendData.svelte';
-	import SendDataDestination from '$lib/components/send/SendDataDestination.svelte';
+	import SendDataSpender from '$lib/components/send/SendDataSpender.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
 	import WalletConnectData from '$lib/components/wallet-connect/WalletConnectData.svelte';
@@ -91,7 +91,7 @@
 		{/snippet}
 
 		{#if erc20Approve && nonNullish(spender)}
-			<SendDataDestination destination={spender} label={$i18n.wallet_connect.text.spender} />
+			<SendDataSpender {spender} />
 		{/if}
 
 		<WalletConnectData {data} label={$i18n.wallet_connect.text.hex_data} />

--- a/src/frontend/src/lib/components/send/SendDataSpender.svelte
+++ b/src/frontend/src/lib/components/send/SendDataSpender.svelte
@@ -4,15 +4,15 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
-		destination: string;
+		spender: string;
 	}
 
-	let { destination }: Props = $props();
+	let { spender }: Props = $props();
 </script>
 
-<WalletConnectModalValue label={$i18n.send.text.destination} ref="destination">
+<WalletConnectModalValue label={$i18n.wallet_connect.text.spender} ref="spender">
 	<div class="flex flex-col gap-1">
-		{destination}
-		<ContactOrToken identifier={destination} />
+		{spender}
+		<ContactOrToken identifier={spender} />
 	</div>
 </WalletConnectModalValue>


### PR DESCRIPTION
# Motivation

For approvals in the ETH WalletConnect flow, we want to show the spender.

### Before

<img width="749" height="760" alt="Screenshot 2026-03-10 at 20 57 57" src="https://github.com/user-attachments/assets/b24aa381-c9fa-40cc-8ab9-76560c4306cb" />

### After

<img width="747" height="752" alt="Screenshot 2026-03-10 at 20 55 38" src="https://github.com/user-attachments/assets/cc19c76b-bd5b-4d27-8e41-73eac506adca" />



