### PR TITLE
feat(frontend): Type-safe mapping of backend errors

### DIFF
--- a/src/frontend/src/lib/canisters/backend.errors.ts
+++ b/src/frontend/src/lib/canisters/backend.errors.ts
@@ -6,7 +6,20 @@ import type {
 } from '$declarations/backend/backend.did';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { NANO_SECONDS_IN_SECOND } from '$lib/constants/app.constants';
+import { assertNever } from '@dfinity/utils';
 import { mapIcrc2ApproveError, type ApproveError } from '@icp-sdk/canisters/ledger/icp';
+
+// eslint-disable-next-line local-rules/prefer-object-params -- this util is more meaningful with separate parameters instead of an object
+const assertNeverOr = <T>(value: never, fallback: T): T => {
+	try {
+		assertNever(value);
+	} catch {
+		// If a new/untracked variant arrives at runtime, assertNever will throw.
+		// We deliberately return the fallback instead of crashing.
+	}
+
+	return fallback;
+};
 
 export const mapBtcPendingTransactionError = (
 	err: BtcAddPendingTransactionError
@@ -15,7 +28,23 @@ export const mapBtcPendingTransactionError = (
 		return new CanisterInternalError(err.InternalError.msg);
 	}
 
-	return new CanisterInternalError('Unknown BtcAddPendingTransactionError');
+	if ('InvalidUtxos' in err) {
+		return new CanisterInternalError('The provided UTXOs are invalid.');
+	}
+
+	if ('EmptyUtxos' in err) {
+		return new CanisterInternalError('No UTXOs provided.');
+	}
+
+	if ('DuplicateUtxos' in err) {
+		return new CanisterInternalError('Duplicate UTXOs provided.');
+	}
+
+	if ('UtxosAlreadyReserved' in err) {
+		return new CanisterInternalError('Some of the provided UTXOs are already reserved.');
+	}
+
+	return assertNeverOr(err, new CanisterInternalError('Unknown BtcAddPendingTransactionError'));
 };
 
 export const mapBtcSelectUserUtxosFeeError = (
@@ -31,7 +60,7 @@ export const mapBtcSelectUserUtxosFeeError = (
 		);
 	}
 
-	return new CanisterInternalError('Unknown BtcSelectUserUtxosFeeError');
+	return assertNeverOr(err, new CanisterInternalError('Unknown BtcSelectUserUtxosFeeError'));
 };
 
 export const mapGetAllowedCyclesError = (err: GetAllowedCyclesError): CanisterInternalError => {
@@ -43,7 +72,7 @@ export const mapGetAllowedCyclesError = (err: GetAllowedCyclesError): CanisterIn
 		return new CanisterInternalError(err.Other);
 	}
 
-	return new CanisterInternalError('Unknown GetAllowedCyclesError');
+	return assertNeverOr(err, new CanisterInternalError('Unknown GetAllowedCyclesError'));
 };
 
 export const mapAllowSigningError = (
@@ -71,5 +100,5 @@ export const mapAllowSigningError = (
 		return new CanisterInternalError(err.Other);
 	}
 
-	return new CanisterInternalError('An unknown error occurred while allowing signing.');
+	return assertNeverOr(err, new CanisterInternalError('Unknown AllowSigningError'));
 };

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -748,7 +748,7 @@ describe('backend.canister', () => {
 			});
 
 			await expect(allowSigning()).rejects.toThrowError(
-				new CanisterInternalError('An unknown error occurred while allowing signing.')
+				new CanisterInternalError('Unknown AllowSigningError')
 			);
 		});
 

--- a/src/frontend/src/tests/lib/canisters/backend.errors.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.errors.spec.ts
@@ -19,6 +19,42 @@ describe('backend.errors', () => {
 			expect(err.message).toBe('pending tx error');
 		});
 
+		it('should map InvalidUtxos', () => {
+			const err = mapBtcPendingTransactionError({
+				InvalidUtxos: null
+			});
+
+			expect(err).toBeInstanceOf(CanisterInternalError);
+			expect(err.message).toBe('The provided UTXOs are invalid.');
+		});
+
+		it('should map EmptyUtxos', () => {
+			const err = mapBtcPendingTransactionError({
+				EmptyUtxos: null
+			});
+
+			expect(err).toBeInstanceOf(CanisterInternalError);
+			expect(err.message).toBe('No UTXOs provided.');
+		});
+
+		it('should map DuplicateUtxos', () => {
+			const err = mapBtcPendingTransactionError({
+				DuplicateUtxos: null
+			});
+
+			expect(err).toBeInstanceOf(CanisterInternalError);
+			expect(err.message).toBe('Duplicate UTXOs provided.');
+		});
+
+		it('should map UtxosAlreadyReserved', () => {
+			const err = mapBtcPendingTransactionError({
+				UtxosAlreadyReserved: null
+			});
+
+			expect(err).toBeInstanceOf(CanisterInternalError);
+			expect(err.message).toBe('Some of the provided UTXOs are already reserved.');
+		});
+
 		it('should return unknown error for unrecognized variant', () => {
 			// @ts-expect-error testing unknown error variant
 			const err = mapBtcPendingTransactionError({ SomeOther: null });
@@ -126,7 +162,7 @@ describe('backend.errors', () => {
 			const err = mapAllowSigningError({ SomeOther: null });
 
 			expect(err).toBeInstanceOf(CanisterInternalError);
-			expect(err.message).toBe('An unknown error occurred while allowing signing.');
+			expect(err.message).toBe('Unknown AllowSigningError');
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We should always exhaust and map all the backend errors, all the variants.

To help us guarantee such task, we can use assertNever to check that no variant is being left unmapped.

In fact, with this PR, we found some unmapped errors for util `mapBtcPendingTransactionError`.

# Changes

- Create assertion util that raises a specific error type.
- Apply the assertion in all the backend error mapping utils.
- Add unmapped variants cases.

# Tests

Added more tests.
