### PR TITLE
chore(frontend): Correct OpenCryptoPay network for IC

### DIFF
--- a/src/frontend/src/env/networks/networks.icp.env.ts
+++ b/src/frontend/src/env/networks/networks.icp.env.ts
@@ -43,7 +43,7 @@ export const ICP_NETWORK: Network = {
 	explorerUrl: ICP_EXPLORER_URL,
 	supportsNft: true,
 	buy: { onramperId: 'icp' },
-	pay: { openCryptoPay: 'Internet Computer' }
+	pay: { openCryptoPay: 'InternetComputer' }
 };
 
 /**

--- a/src/frontend/src/tests/lib/schema/network.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/network.schema.spec.ts
@@ -52,7 +52,7 @@ describe('network.schema', () => {
 			...validNetworkWithRequiredFields,
 			icon: 'https://example.com/icon.svg',
 			buy: { onramperId: 'icp' },
-			pay: { openCryptoPay: 'Internet Computer' }
+			pay: { openCryptoPay: 'InternetComputer' }
 		};
 
 		it('should validate a complete network', () => {


### PR DESCRIPTION
# Motivation

According to [OpenCryptoPay documentation](https://github.com/openCryptoPay/landingPage?tab=readme-ov-file#open-cryptopay), the final network identifier for IC does not have whitespaces.