### PR TITLE
style(frontend): Truncate token name instead of symbol

### DIFF
--- a/src/frontend/src/lib/components/ui/LogoButton.svelte
+++ b/src/frontend/src/lib/components/ui/LogoButton.svelte
@@ -78,7 +78,11 @@
 				<span class="flex min-w-0 flex-col text-left">
 					<span class="flex min-w-0 items-center truncate text-nowrap">
 						{#if nonNullish(title)}
-							<span class="text-lg font-bold text-nowrap text-primary" class:truncate={isNullish(subtitle)} class:min-w-0={isNullish(subtitle)}>
+							<span
+								class="text-lg font-bold text-nowrap text-primary"
+								class:min-w-0={isNullish(subtitle)}
+								class:truncate={isNullish(subtitle)}
+							>
 								{@render title()}
 							</span>
 						{/if}


### PR DESCRIPTION
# Motivation

We prefer to truncate the token name instead of the token symbol.

### Before

<img width="628" height="797" alt="Screenshot 2026-03-05 at 11 36 28" src="https://github.com/user-attachments/assets/4e3d3cdd-1ce5-4220-94b5-5ce7971ec804" />

### After

<img width="618" height="797" alt="Screenshot 2026-03-05 at 11 34 35" src="https://github.com/user-attachments/assets/a0764df7-cf63-4955-b27b-132c01051c66" />

