### PR TITLE
refactor(frontend): Move ICRC ENV tokens to specific file

### DIFF
--- a/src/frontend/src/env/networks/networks.icrc.env.ts
+++ b/src/frontend/src/env/networks/networks.icrc.env.ts
@@ -1,13 +1,3 @@
-import {
-	ADDITIONAL_ICRC_TOKENS,
-	TICRC1_LEDGER_CANISTER_ID
-} from '$env/tokens/tokens-icrc/tokens.icrc.additional.env';
-import {
-	CK_LEDGER_CANISTER_TESTNET_IDS,
-	ICRC_CK_TOKENS,
-	PUBLIC_ICRC_TOKENS
-} from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
-import type { IcInterface } from '$icp/types/ic-token';
 import { BETA, LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
 import type { CanisterIdText, OptionCanisterIdText } from '$lib/types/canister';
 import { nonNullish } from '@dfinity/utils';
@@ -28,18 +18,3 @@ export const CYCLES_LEDGER_CANISTER_ID: CanisterIdText =
 		: (STAGING || BETA || PROD) && nonNullish(STAGING_CYCLES_LEDGER_CANISTER_ID)
 			? STAGING_CYCLES_LEDGER_CANISTER_ID
 			: IC_CYCLES_LEDGER_CANISTER_ID;
-
-/**
- * All ICRC tokens data
- */
-
-export const ICRC_TOKENS: IcInterface[] = [
-	...PUBLIC_ICRC_TOKENS,
-	...ADDITIONAL_ICRC_TOKENS,
-	...ICRC_CK_TOKENS
-];
-
-export const ICRC_LEDGER_CANISTER_TESTNET_IDS = [
-	...CK_LEDGER_CANISTER_TESTNET_IDS,
-	TICRC1_LEDGER_CANISTER_ID
-];

--- a/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.env.ts
@@ -1,0 +1,9 @@
+import { ADDITIONAL_ICRC_TOKENS } from '$env/tokens/tokens-icrc/tokens.icrc.additional.env';
+import { ICRC_CK_TOKENS, PUBLIC_ICRC_TOKENS } from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
+import type { IcInterface } from '$icp/types/ic-token';
+
+export const ICRC_TOKENS: IcInterface[] = [
+	...PUBLIC_ICRC_TOKENS,
+	...ADDITIONAL_ICRC_TOKENS,
+	...ICRC_CK_TOKENS
+];

--- a/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.testnet.env.ts
+++ b/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.testnet.env.ts
@@ -1,0 +1,7 @@
+import { TICRC1_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.additional.env';
+import { CK_LEDGER_CANISTER_TESTNET_IDS } from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
+
+export const ICRC_LEDGER_CANISTER_TESTNET_IDS = [
+	...CK_LEDGER_CANISTER_TESTNET_IDS,
+	TICRC1_LEDGER_CANISTER_ID
+];

--- a/src/frontend/src/icp/services/icrc.services.ts
+++ b/src/frontend/src/icp/services/icrc.services.ts
@@ -1,6 +1,6 @@
 import type { CustomToken, IcrcToken } from '$declarations/backend/backend.did';
-import { ICRC_TOKENS } from '$env/networks/networks.icrc.env';
 import { ICRC_CK_TOKENS_LEDGER_CANISTER_IDS } from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
+import { ICRC_TOKENS } from '$env/tokens/tokens-icrc/tokens.icrc.env';
 import { DIP20_BUILTIN_TOKENS_INDEXED } from '$env/tokens/tokens.dip20.env';
 import { SUPPORTED_ICP_TOKENS_INDEXED } from '$env/tokens/tokens.icp.env';
 import { SNS_BUILTIN_TOKENS_INDEXED } from '$env/tokens/tokens.sns.env';

--- a/src/frontend/src/icp/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/cketh-transactions.utils.ts
@@ -4,8 +4,8 @@ import {
 	ETHEREUM_EXPLORER_URL,
 	SEPOLIA_EXPLORER_URL
 } from '$env/explorers.env';
-import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
 import { STAGING_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.eth.env';
+import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/tokens/tokens-icrc/tokens.icrc.testnet.env';
 import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 import type { IcPendingTransactionsData } from '$icp/stores/ic-pending-transactions.store';
 import type { IcToken } from '$icp/types/ic-token';

--- a/src/frontend/src/icp/utils/icrc-ledger.utils.ts
+++ b/src/frontend/src/icp/utils/icrc-ledger.utils.ts
@@ -1,4 +1,4 @@
-import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
+import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/tokens/tokens-icrc/tokens.icrc.testnet.env';
 import type { IcToken } from '$icp/types/ic-token';
 import { nonNullish } from '@dfinity/utils';
 

--- a/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
@@ -5,9 +5,9 @@ import type {
 } from '$declarations/rewards/rewards.did';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
-import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/networks/networks.icrc.env';
 import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 import { ETH_TOKEN_GROUP_ID } from '$env/tokens/groups/groups.eth.env';
+import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/tokens/tokens-icrc/tokens.icrc.testnet.env';
 import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN, ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN, SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';


### PR DESCRIPTION
# Motivation

Keeping the code more organized, we split the ICRC env tokens into specific files.