### PR TITLE
refactor(frontend): Use derived store `ercFungibleTokens` when possible

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { erc20Tokens } from '$eth/derived/erc20.derived';
-	import { erc4626Tokens } from '$eth/derived/erc4626.derived';
+	import { ercFungibleTokens } from '$eth/derived/erc-fungible.derived';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { decodeErc20AbiDataValue } from '$eth/utils/transactions.utils';
 	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
@@ -50,7 +49,7 @@
 
 	let token = $derived(
 		erc20Approve
-			? [...$erc20Tokens, ...$erc4626Tokens].find(
+			? $ercFungibleTokens.find(
 					({ address, network: { id: networkId } }) =>
 						areAddressesEqual({ address1: address, address2: destination, networkId }) &&
 						networkId === sourceNetworkProp.id

--- a/src/frontend/src/lib/derived/all-tokens.derived.ts
+++ b/src/frontend/src/lib/derived/all-tokens.derived.ts
@@ -1,6 +1,6 @@
 import { IC_BUILTIN_TOKENS } from '$env/tokens/tokens.ic.env';
+import { ercFungibleTokens } from '$eth/derived/erc-fungible.derived';
 import { erc20Tokens } from '$eth/derived/erc20.derived';
-import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { icrcTokens } from '$icp/derived/icrc.derived';
@@ -50,18 +50,10 @@ export const allKongSwapCompatibleIcrcTokens: Readable<IcTokenToggleable[]> = de
 );
 
 export const allTokens: Readable<CustomToken<Token>[]> = derived(
-	[nativeTokens, erc20Tokens, erc4626Tokens, allIcrcTokens, splTokens, nonFungibleTokens],
-	([
-		$nativeTokens,
-		$erc20Tokens,
-		$erc4626Tokens,
-		$allIcrcTokens,
-		$splTokens,
-		$nonFungibleTokens
-	]) => [
+	[nativeTokens, ercFungibleTokens, allIcrcTokens, splTokens, nonFungibleTokens],
+	([$nativeTokens, $ercFungibleTokens, $allIcrcTokens, $splTokens, $nonFungibleTokens]) => [
 		...$nativeTokens.map((token) => ({ ...token, enabled: true })),
-		...$erc20Tokens,
-		...$erc4626Tokens,
+		...$ercFungibleTokens,
 		...$allIcrcTokens,
 		...$splTokens,
 		...$nonFungibleTokens

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -3,9 +3,8 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN, TESTICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { ercFungibleTokens } from '$eth/derived/erc-fungible.derived';
 import { erc1155Tokens } from '$eth/derived/erc1155.derived';
-import { erc20Tokens } from '$eth/derived/erc20.derived';
-import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import { erc721Tokens } from '$eth/derived/erc721.derived';
 import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import type { Erc20Token } from '$eth/types/erc20';
@@ -55,11 +54,10 @@ export const nativeTokens: Readable<Token[]> = derived(
 );
 
 export const fungibleTokens: Readable<Token[]> = derived(
-	[nativeTokens, erc20Tokens, erc4626Tokens, icrcTokens, splTokens],
-	([$nativeTokens, $erc20Tokens, $erc4626Tokens, $icrcTokens, $splTokens]) => [
+	[nativeTokens, ercFungibleTokens, icrcTokens, splTokens],
+	([$nativeTokens, $ercFungibleTokens, $icrcTokens, $splTokens]) => [
 		...$nativeTokens,
-		...$erc20Tokens,
-		...$erc4626Tokens,
+		...$ercFungibleTokens,
 		...$icrcTokens,
 		...$splTokens
 	]


### PR DESCRIPTION
# Motivation

To avoid repetition of code, we can use `ercFungibleTokens` derived store whenever possible.
