### PR TITLE
feat(frontend): Util to calculate IC fee for OpenCryptoPay

### DIFF
--- a/src/frontend/src/icp/services/ic-open-crypto-pay.services.ts
+++ b/src/frontend/src/icp/services/ic-open-crypto-pay.services.ts
@@ -1,0 +1,21 @@
+import type { IcFeeResult } from '$icp/types/pay';
+import { getTokenFee } from '$icp/utils/token.utils';
+import type { PayableToken } from '$lib/types/open-crypto-pay';
+import { isNullish } from '@dfinity/utils';
+
+/**
+ * Calculates the fee for an ICP/ICRC token payment.
+ * The total fee covers two transactions: one for `icrc2_approve` and one for `icrc2_transfer_from`.
+ */
+export const calculateIcFee = (token: PayableToken): IcFeeResult | undefined => {
+	const fee = getTokenFee(token);
+
+	if (isNullish(fee)) {
+		return;
+	}
+
+	return {
+		feePerTransaction: fee,
+		totalFee: fee * 2n
+	};
+};

--- a/src/frontend/src/icp/types/pay.ts
+++ b/src/frontend/src/icp/types/pay.ts
@@ -1,0 +1,4 @@
+export interface IcFeeResult {
+	feePerTransaction: bigint;
+	totalFee: bigint;
+}

--- a/src/frontend/src/lib/services/open-crypto-pay.services.ts
+++ b/src/frontend/src/lib/services/open-crypto-pay.services.ts
@@ -5,6 +5,9 @@ import { calculateEthFee, payEth } from '$eth/services/eth-open-crypto-pay.servi
 import type { EthFeeResult } from '$eth/types/pay';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
+import { calculateIcFee } from '$icp/services/ic-open-crypto-pay.services';
+import type { IcFeeResult } from '$icp/types/pay';
+import { isIcToken } from '$icp/validation/ic-token.validation';
 import { ProgressStepsPayment } from '$lib/enums/progress-steps';
 import { fetchOpenCryptoPay } from '$lib/rest/open-crypto-pay.rest';
 import type {
@@ -56,13 +59,17 @@ export const processOpenCryptoPayCode = async (code: string): Promise<OpenCrypto
 
 const calculateTokenFee = async (
 	token: PayableToken
-): Promise<EthFeeResult | UtxosFee | undefined> => {
+): Promise<EthFeeResult | UtxosFee | IcFeeResult | undefined> => {
 	if (isBitcoinToken(token)) {
 		return calculateBtcFee(token);
 	}
 
 	if (isDefaultEthereumToken(token) || isTokenErc20(token)) {
 		return await calculateEthFee(token);
+	}
+
+	if (isIcToken(token)) {
+		return calculateIcFee(token);
 	}
 };
 

--- a/src/frontend/src/lib/types/open-crypto-pay.ts
+++ b/src/frontend/src/lib/types/open-crypto-pay.ts
@@ -1,6 +1,7 @@
 import type { BtcAddress, OptionBtcAddress } from '$btc/types/address';
 import type { UtxosFee } from '$btc/types/btc-send';
 import type { EthFeeResult } from '$eth/types/pay';
+import type { IcFeeResult } from '$icp/types/pay';
 import type { ProgressStepsPayment } from '$lib/enums/progress-steps';
 import type { Network } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
@@ -85,7 +86,7 @@ export type PayableToken = Omit<Token, 'network'> & {
 };
 
 export interface PayableTokenWithFees extends PayableToken {
-	fee?: EthFeeResult | UtxosFee;
+	fee?: EthFeeResult | UtxosFee | IcFeeResult;
 }
 
 export interface PrepareTokensParams {

--- a/src/frontend/src/tests/icp/services/ic-open-crypto-pay.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-open-crypto-pay.service.spec.ts
@@ -1,0 +1,45 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-spl/tokens.usdc.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { calculateIcFee } from '$icp/services/ic-open-crypto-pay.services';
+import type { PayableToken } from '$lib/types/open-crypto-pay';
+import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+
+describe('ic-open-crypto-pay.service', () => {
+	describe('calculateIcFee', () => {
+		it('should return correct fee for a valid ICP token', () => {
+			const mockToken: PayableToken = {
+				...ICP_TOKEN,
+				amount: '1.0',
+				tokenNetwork: 'InternetComputer'
+			} as PayableToken;
+
+			expect(calculateIcFee(mockToken)).toEqual({
+				feePerTransaction: ICP_TOKEN.fee,
+				totalFee: ICP_TOKEN.fee * 2n
+			});
+		});
+
+		it('should return correct fee for a valid ICRC token', () => {
+			const mockToken: PayableToken = {
+				...mockValidIcrcToken,
+				amount: '1.0',
+				tokenNetwork: 'InternetComputer'
+			} as PayableToken;
+
+			expect(calculateIcFee(mockToken)).toEqual({
+				feePerTransaction: mockValidIcrcToken.fee,
+				totalFee: mockValidIcrcToken.fee * 2n
+			});
+		});
+
+		it('should return undefined for non-IC tokens', () => {
+			const mockToken: PayableToken = {
+				...USDC_TOKEN,
+				amount: '1.0',
+				tokenNetwork: 'Solana'
+			} as PayableToken;
+
+			expect(calculateIcFee(mockToken)).toBeUndefined();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/open-crypto-pay.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/open-crypto-pay.services.spec.ts
@@ -1,6 +1,7 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import * as ethPayServices from '$eth/services/eth-open-crypto-pay.services';
 import { buildTransactionBaseParams } from '$eth/services/eth-open-crypto-pay.services';
 import { getNonce } from '$eth/services/nonce.services';
@@ -25,6 +26,7 @@ import type {
 } from '$lib/types/open-crypto-pay';
 import { extractQuoteData } from '$lib/utils/open-crypto-pay.utils';
 import { decodeQrCodeUrn } from '$lib/utils/qr-code.utils';
+import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { readable } from 'svelte/store';
 
@@ -253,6 +255,20 @@ describe('open-crypto-pay.service', () => {
 			tokenNetwork: 'Bitcoin'
 		} as PayableToken;
 
+		const mockIcpToken: PayableToken = {
+			...ICP_TOKEN,
+			amount: '10',
+			minFee: 0.01,
+			tokenNetwork: 'InternetComputer'
+		} as PayableToken;
+
+		const mockIcrcToken: PayableToken = {
+			...mockValidIcrcToken,
+			amount: '20',
+			minFee: 0.02,
+			tokenNetwork: 'InternetComputer'
+		} as PayableToken;
+
 		const mockFeeResult: EthFeeResult = {
 			feeInWei: 300000n,
 			feeData: {
@@ -293,7 +309,7 @@ describe('open-crypto-pay.service', () => {
 			expect(ethPayServices.calculateEthFee).toHaveBeenCalledWith(mockErc20Token);
 		});
 
-		it('should skip non-Ethereum tokens', async () => {
+		it('should skip Bitcoin tokens', async () => {
 			const result = await calculateTokensWithFees([mockBtcToken]);
 
 			expect(result).toHaveLength(1);
@@ -301,15 +317,25 @@ describe('open-crypto-pay.service', () => {
 			expect(ethPayServices.calculateEthFee).not.toHaveBeenCalled();
 		});
 
-		it('should handle mixed tokens (ETH, ERC20, Bitcoin)', async () => {
-			const tokens = [mockPayableToken, mockErc20Token, mockBtcToken];
+		it('should handle mixed tokens', async () => {
+			const tokens = [mockPayableToken, mockErc20Token, mockBtcToken, mockIcpToken, mockIcrcToken];
 
 			const result = await calculateTokensWithFees(tokens);
 
-			expect(result).toHaveLength(3);
-			expect(result[0].fee).toBeDefined();
-			expect(result[1].fee).toBeDefined();
-			expect(result[2].fee).toBeUndefined();
+			expect(result.map(({ fee }) => fee)).toStrictEqual([
+				mockFeeResult,
+				mockFeeResult,
+				undefined,
+				{
+					feePerTransaction: ICP_TOKEN.fee,
+					totalFee: ICP_TOKEN.fee * 2n
+				},
+				{
+					feePerTransaction: mockValidIcrcToken.fee,
+					totalFee: mockValidIcrcToken.fee * 2n
+				}
+			]);
+
 			expect(ethPayServices.calculateEthFee).toHaveBeenCalledTimes(2);
 		});
 


### PR DESCRIPTION
# Motivation

As first step to integrate ICP in the OpenCryptoPay flow, we calculate the fee to return a structured response to the pay service.

NOTE: this util can be applied both to ICP and to ICRC tokens.