### PR TITLE
style(frontend): Avoid wrapping Token card amount

### DIFF
--- a/src/frontend/src/lib/components/ui/LogoButton.svelte
+++ b/src/frontend/src/lib/components/ui/LogoButton.svelte
@@ -111,7 +111,7 @@
 						</span>
 					{/if}
 					{#if nonNullish(descriptionEnd)}
-						<span class="text-sm text-tertiary text-nowrap">
+						<span class="text-sm text-nowrap text-tertiary">
 							{@render descriptionEnd()}
 						</span>
 					{/if}


### PR DESCRIPTION
# Motivation

We should always show the token amount in a readable form.

### Before

<img width="590" height="1278" alt="IMG_5259" src="https://github.com/user-attachments/assets/0ee91b9c-da0b-47da-a650-3993fe007dd8" />
<img width="590" height="1278" alt="IMG_5260" src="https://github.com/user-attachments/assets/bfa92a32-2ac1-4f3b-8ffb-adf97b8cdb39" />


### After

![WhatsApp Image 2026-03-05 at 15 21 08 (1)](https://github.com/user-attachments/assets/b3bbeb6c-8b35-4715-a292-7a0a92312067)
![WhatsApp Image 2026-03-05 at 15 21 08](https://github.com/user-attachments/assets/f0b40db0-88e9-4f1b-81d7-2f9e0a1a6115)
