### PR TITLE
fix(frontend): reactivity issues in DappsCarousel

### DIFF
--- a/src/frontend/src/lib/components/carousel/Carousel.svelte
+++ b/src/frontend/src/lib/components/carousel/Carousel.svelte
@@ -159,7 +159,7 @@
 	 * Clear slide transform timer
 	 */
 	const clearSlideTransformTimer = () => {
-		clearInterval(slideTransformTimer);
+		clearTimeout(slideTransformTimer);
 		slideTransformTimer = undefined;
 	};
 

--- a/src/frontend/src/lib/components/carousel/Indicator.svelte
+++ b/src/frontend/src/lib/components/carousel/Indicator.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <button
-	class="{`${isActive ? 'w-7 bg-primary-inverted' : 'w-4 bg-disabled'} mr-1 h-1.5 transition-all duration-300 ease-linear last:mr-0`}}"
+	class={`${isActive ? 'w-7 bg-primary-inverted' : 'w-4 bg-disabled'} mr-1 h-1.5 transition-all duration-300 ease-linear last:mr-0`}
 	aria-label={replacePlaceholders($i18n.carousel.text.indicator, { $index: `${index + 1}` })}
 	data-tid={`${CAROUSEL_SLIDE_NAVIGATION}${index + 1}`}
 	onclick={onClick}

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -36,7 +36,7 @@
 	// It may happen that the user's settings are refreshed before having been updated.
 	// But for that small instant of time, we could still show the dApp.
 	// To avoid this glitch, we store the dApp id in a temporary array, and we add it to the hidden dApps ids.
-	let temporaryHiddenDappsIds = $state<OisyDappDescription['id'][]>([]);
+	let temporaryHiddenDappsIds: OisyDappDescription['id'][] = [];
 
 	let hiddenDappsIds = $derived([
 		...($userSettings?.dapp.dapp_carousel.hidden_dapp_ids ?? []),


### PR DESCRIPTION
# Motivation

`DappsCarousel` component had some reactivity issues, because of which the component could have ended up in displaying an empty card after user hides a slide. To fix those, we need to make a few adjustments.
