### PR TITLE
refactor(frontend): Align Solana fee context to other similar components

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendSolToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendSolToken.svelte
@@ -252,7 +252,7 @@
 </script>
 
 <div class="mt-2 mb-8">
-	<SolFeeContext token={$sendToken} {destination} observe={!loading}>
+	<SolFeeContext {destination} observe={!loading} token={$sendToken}>
 		<SolFeeDisplay />
 
 		<SendFeeInfo

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendSolToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendSolToken.svelte
@@ -252,7 +252,7 @@
 </script>
 
 <div class="mt-2 mb-8">
-	<SolFeeContext {destination} observe={!loading}>
+	<SolFeeContext token={$sendToken} {destination} observe={!loading}>
 		<SolFeeDisplay />
 
 		<SendFeeInfo

--- a/src/frontend/src/sol/components/fee/SolFeeContext.svelte
+++ b/src/frontend/src/sol/components/fee/SolFeeContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext, onDestroy, type Snippet, untrack } from 'svelte';
-	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { Token } from '$lib/types/token';
 	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import {
 		checkIfAccountExists,
@@ -19,27 +19,25 @@
 	import { isTokenSpl } from '$sol/utils/spl.utils';
 
 	interface Props {
+		token: Token;
 		observe: boolean;
 		destination?: string;
 		children: Snippet;
 	}
 
-	let { observe, destination = '', children }: Props = $props();
+	let { token, observe, destination = '', children }: Props = $props();
 
 	const { feeStore, prioritizationFeeStore, ataFeeStore }: FeeContext =
 		getContext<FeeContext>(SOL_FEE_CONTEXT_KEY);
 
-	const { sendToken, sendTokenNetworkId } = getContext<SendContext>(SEND_CONTEXT_KEY);
-
 	const estimateFee = async () => {
-		// In case we are already sending, we don't want to update the fee
-		if (!observe) {
+		if (!observe || isNullish(token)) {
 			return;
 		}
 
-		const solNetwork = safeMapNetworkIdToNetwork($sendTokenNetworkId);
+		const solNetwork = safeMapNetworkIdToNetwork(token.network.id);
 
-		const addresses = isTokenSpl($sendToken) ? [$sendToken.address] : undefined;
+		const addresses = isTokenSpl(token) ? [token.address] : undefined;
 		const priorityFee = await estimatePriorityFee({ network: solNetwork, addresses });
 		const fee = SOLANA_TRANSACTION_FEE_IN_LAMPORTS + priorityFee / MICROLAMPORTS_PER_LAMPORT;
 		feeStore.setFee(fee);
@@ -55,7 +53,7 @@
 	};
 
 	$effect(() => {
-		[$sendTokenNetworkId];
+		token;
 
 		untrack(() => updateFee());
 	});
@@ -67,12 +65,18 @@
 	onDestroy(clearTimer);
 
 	const updateAtaFee = async () => {
-		if (isNullishOrEmpty(destination) || !isTokenSpl($sendToken)) {
+		if (!isTokenSpl(token)) {
 			ataFeeStore.setFee(undefined);
 			return;
 		}
 
-		const solNetwork = safeMapNetworkIdToNetwork($sendTokenNetworkId);
+		const solNetwork = safeMapNetworkIdToNetwork(token.network.id);
+
+		if (isNullishOrEmpty(destination)) {
+			const ataFee = await getSolCreateAccountFee(solNetwork);
+			ataFeeStore.setFee(ataFee);
+			return;
+		}
 
 		// we check if it is an ATA address and if it is not closed, if it isn't an ATA address or has been closed, we need to charge the ATA fee
 		if (
@@ -86,7 +90,7 @@
 		const tokenAccount = await loadTokenAccount({
 			address: destination,
 			network: solNetwork,
-			tokenAddress: $sendToken.address
+			tokenAddress: token.address
 		});
 
 		if (nonNullish(tokenAccount)) {
@@ -100,7 +104,7 @@
 	};
 
 	$effect(() => {
-		[destination, $sendToken];
+		[destination, token];
 
 		untrack(() => updateAtaFee());
 	});

--- a/src/frontend/src/sol/components/fee/SolFeeContext.svelte
+++ b/src/frontend/src/sol/components/fee/SolFeeContext.svelte
@@ -53,7 +53,7 @@
 	};
 
 	$effect(() => {
-		token;
+		[token];
 
 		untrack(() => updateFee());
 	});
@@ -74,7 +74,9 @@
 
 		if (isNullishOrEmpty(destination)) {
 			const ataFee = await getSolCreateAccountFee(solNetwork);
+
 			ataFeeStore.setFee(ataFee);
+
 			return;
 		}
 

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -234,7 +234,7 @@
 	};
 </script>
 
-<SolFeeContext {destination} observe={currentStep?.name !== WizardStepsSend.SENDING}>
+<SolFeeContext token={$sendToken} {destination} observe={currentStep?.name !== WizardStepsSend.SENDING}>
 	{#key currentStep?.name}
 		{#if currentStep?.name === WizardStepsSend.REVIEW}
 			<SolSendReview {amount} {destination} {network} {onBack} onSend={send} {selectedContact} />

--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -234,7 +234,11 @@
 	};
 </script>
 
-<SolFeeContext token={$sendToken} {destination} observe={currentStep?.name !== WizardStepsSend.SENDING}>
+<SolFeeContext
+	{destination}
+	observe={currentStep?.name !== WizardStepsSend.SENDING}
+	token={$sendToken}
+>
 	{#key currentStep?.name}
 		{#if currentStep?.name === WizardStepsSend.REVIEW}
 			<SolSendReview {amount} {destination} {network} {onBack} onSend={send} {selectedContact} />


### PR DESCRIPTION
# Motivation

We want to align the behaviour of SolFeeContext to be the same as the other similar components:

- `IcTokenFeeContext` accepts `token` as a **prop**. No dependency on `SendContext`.
- `EthFeeContext` accepts `sendToken`, `sendTokenId`, etc. as **props**. No dependency on `SendContext`.
- `SolFeeContext` (before this change) was the **odd one out**: it read `sendToken` and `sendTokenNetworkId` from `SendContext` via `getContext`, which hard-coupled it to the send flow and made it impossible to reuse for other flows.

It will allow us to reuse it as a generic fee context in the swap wizards too (see PR https://github.com/dfinity/oisy-wallet/pull/12359).