### PR TITLE
feat(frontend): Remove same-network restriction for EVM native token swaps

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -2,7 +2,6 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext, type Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
-	import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import SwapCrossChainInfo from '$lib/components/swap/SwapCrossChainInfo.svelte';
 	import SwapSlippage from '$lib/components/swap/SwapSlippage.svelte';
@@ -102,10 +101,7 @@
 		const condition2 = !SUPPORTED_CROSS_SWAP_NETWORKS[$destinationToken.network.id]?.includes(
 			$sourceToken.network.id
 		);
-		const condition3 =
-			isDefaultEthereumToken($destinationToken) &&
-			$destinationToken.network.id !== $sourceToken.network.id;
-		return condition1 || condition2 || condition3;
+		return condition1 || condition2;
 	});
 
 	let invalid = $derived(

--- a/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
@@ -2,7 +2,6 @@
 	import type { WizardModal, WizardStep, WizardSteps } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 	import SwapProviderListModal from '$lib/components/swap/SwapProviderListModal.svelte';
 	import SwapTokenWizard from '$lib/components/swap/SwapTokenWizard.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
@@ -151,9 +150,7 @@
 		}
 
 		// source selected (constraints apply)
-		const allowedIds = isDefaultEthereumToken($sourceToken)
-			? [$sourceToken.network.id]
-			: SUPPORTED_CROSS_SWAP_NETWORKS[$sourceToken.network.id];
+		const allowedIds = SUPPORTED_CROSS_SWAP_NETWORKS[$sourceToken.network.id];
 
 		setNetworksMode({ enabled: false, allowedIds });
 
@@ -191,10 +188,6 @@
 		source: Token;
 		destination: Token;
 	}): boolean => {
-		if (isDefaultEthereumToken(source)) {
-			return source.network.id === destination.network.id;
-		}
-
 		const allowed = SUPPORTED_CROSS_SWAP_NETWORKS[source.network.id];
 
 		return isNullish(allowed) ? true : allowed.includes(destination.network.id);


### PR DESCRIPTION
# Motivation

EVM native tokens (e.g. ETH) were restricted to same-network swaps only in the UI. This was added for Velora, which requires it, but it unnecessarily blocks other providers like NEAR Intents from offering cross-chain quotes.

This PR removes the blanket `isDefaultEthereumToken` checks from the token picker and switch button, letting `SUPPORTED_CROSS_SWAP_NETWORKS` handle network filtering uniformly. Velora is unaffected: it gracefully returns no quote for unsupported pairs, and the execution guard in `SwapEthWizard` remains in place.