### PR TITLE
feat(build): Extend Docker build to signer domains

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -32,6 +32,9 @@ ARG network="staging"
 ENV ENV=$network
 ENV DFX_NETWORK=$network
 
+ARG signer_target=""
+ENV OISY_SIGNER_TARGET=$signer_target
+
 RUN echo $ENV
 RUN echo $DFX_NETWORK
 

--- a/scripts/dfx-orbit.validate.legacy-signer-frontend.sh
+++ b/scripts/dfx-orbit.validate.legacy-signer-frontend.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ -z "${RELEASE_COMMIT}" ]; then
+  echo "RELEASE_COMMIT is unset or set to the empty string"
+  exit 1
+fi
+
+if [ -z "${ENV_SHA}" ]; then
+  echo "ENV_SHA is unset or set to the empty string"
+  exit 1
+fi
+
+# Checkout
+git fetch
+git checkout "$RELEASE_COMMIT" || exit 1
+
+# Make sure target directory exists but no prior artifacts are there
+mkdir -p target
+rm -fr target/frontend target/legacy_signer_frontend
+
+# Check that the frontend ENV file matches the hash and build the legacy signer frontend
+echo "$ENV_SHA .env.production" | sha256sum -c || exit 1
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.frontend --progress=plain --build-arg network=ic --build-arg signer_target=legacy_signer -o target/ .
+mv target/frontend target/legacy_signer_frontend
+
+# Check that the artifacts match the commit args
+dfx-orbit verify "$LEGACY_SIGNER_FRONTEND_REQUEST_ID" asset upload legacy_signer_frontend --batch-id "$LEGACY_SIGNER_FRONTEND_BATCH_ID" --files target/legacy_signer_frontend

--- a/scripts/dfx-orbit.validate.signer-frontend.sh
+++ b/scripts/dfx-orbit.validate.signer-frontend.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ -z "${RELEASE_COMMIT}" ]; then
+  echo "RELEASE_COMMIT is unset or set to the empty string"
+  exit 1
+fi
+
+if [ -z "${ENV_SHA}" ]; then
+  echo "ENV_SHA is unset or set to the empty string"
+  exit 1
+fi
+
+# Checkout
+git fetch
+git checkout "$RELEASE_COMMIT" || exit 1
+
+# Make sure target directory exists but no prior artifacts are there
+mkdir -p target
+rm -fr target/frontend target/signer_frontend
+
+# Check that the frontend ENV file matches the hash and build the signer frontend
+echo "$ENV_SHA .env.production" | sha256sum -c || exit 1
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.frontend --progress=plain --build-arg network=ic --build-arg signer_target=signer -o target/ .
+mv target/frontend target/signer_frontend
+
+# Check that the artifacts match the commit args
+dfx-orbit verify "$SIGNER_FRONTEND_REQUEST_ID" asset upload signer_frontend --batch-id "$SIGNER_FRONTEND_BATCH_ID" --files target/signer_frontend

--- a/scripts/docker-build.legacy-signer-frontend
+++ b/scripts/docker-build.legacy-signer-frontend
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+OUTDIR="target"
+
+print_help() {
+  cat <<-EOF
+
+	Build the Oisy legacy signer frontend inside docker. This creates:
+	- A "$OUTDIR/legacy_signer_frontend" directory in the project directory containing all build artefacts.
+	  Note: If the "$OUTDIR" directory already exists, it will be deleted and replaced.
+
+	EOF
+}
+
+print_docker_help() {
+  cat <<-"EOF"
+	Note: If the docker build fails, it may help to build from a clean cache:
+
+	  ./scripts/docker-build.legacy-signer-frontend --no-cache
+
+	EOF
+}
+
+if [[ "${1:-}" == "--help" ]]; then
+  print_help
+
+  print_docker_help
+  exit 0
+fi
+
+rm -fr "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.frontend --progress=plain --build-arg network=ic --build-arg signer_target=legacy_signer -o "$OUTDIR/" . "${@}" || print_docker_help
+mv "$OUTDIR/frontend" "$OUTDIR/legacy_signer_frontend"
+echo "BUILD REPORT:"
+cat "$OUTDIR/legacy_signer_frontend/build-report.txt"

--- a/scripts/docker-build.signer-frontend
+++ b/scripts/docker-build.signer-frontend
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+OUTDIR="target"
+
+print_help() {
+  cat <<-EOF
+
+	Build the Oisy signer frontend inside docker. This creates:
+	- A "$OUTDIR/signer_frontend" directory in the project directory containing all build artefacts.
+	  Note: If the "$OUTDIR" directory already exists, it will be deleted and replaced.
+
+	EOF
+}
+
+print_docker_help() {
+  cat <<-"EOF"
+	Note: If the docker build fails, it may help to build from a clean cache:
+
+	  ./scripts/docker-build.signer-frontend --no-cache
+
+	EOF
+}
+
+if [[ "${1:-}" == "--help" ]]; then
+  print_help
+
+  print_docker_help
+  exit 0
+fi
+
+rm -fr "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.frontend --progress=plain --build-arg network=ic --build-arg signer_target=signer -o "$OUTDIR/" . "${@}" || print_docker_help
+mv "$OUTDIR/frontend" "$OUTDIR/signer_frontend"
+echo "BUILD REPORT:"
+cat "$OUTDIR/signer_frontend/build-report.txt"


### PR DESCRIPTION
# Motivation

Similar to what we do for frontend and backend, we will deploy the signer domains via Orbit. To do so, we duplicate the frontend scripts for each domain (with proper adjustments) and we extend the Docker file to accept a signer argument.