### PR TITLE
docs(signer): Include signer domains flow in the deployment documentation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -67,18 +67,28 @@ dfx-orbit station show
 
 > To perform production development, you'll need a `.env.production` file for the frontend. Then:
 
-```bash
-DOCKER_BUILDKIT=1 docker build -f Dockerfile.frontend --progress=plain --build-arg network=ic -o target/ .
+#### Frontend
 
-dfx-oisy request deploy frontend --network ic --wallet yit3i-lyaaa-aaaan-qeavq-cai
+```bash
+./scripts/docker-build.frontend
 ```
 
-For the backend:
+```bash
+dfx-orbit request asset upload frontend --files target/frontend
+```
+
+#### Backend
 
 ```bash
-scripts/docker-build
+./scripts/docker-build
+```
 
-dfx-orbit request canister install backend --mode upgrade --wasm out/backend.wasm.gz --arg-file out/backend.args.did
+```bash
+dfx-orbit --station oisy-prod \
+  request canister install backend \
+  --mode upgrade \
+  --wasm out/backend.wasm.gz \
+  --arg-file out/backend.args.did
 ```
 
 ### Signer Domains

--- a/HACKING.md
+++ b/HACKING.md
@@ -77,6 +77,26 @@ dfx-orbit station show
 dfx-orbit request asset upload frontend --files target/frontend
 ```
 
+#### Signer frontend
+
+```bash
+./scripts/docker-build.signer-frontend
+```
+
+```bash
+dfx-orbit request asset upload signer_frontend --files target/signer_frontend
+```
+
+#### Legacy signer frontend
+
+```bash
+./scripts/docker-build.legacy-signer-frontend
+```
+
+```bash
+dfx-orbit request asset upload legacy_signer_frontend --files target/legacy_signer_frontend
+```
+
 #### Backend
 
 ```bash
@@ -93,7 +113,7 @@ dfx-orbit --station oisy-prod \
 
 ### Signer Domains
 
-The OISY signer is deployed to dedicated production subdomains (`signer.oisy.com`, `legacy-signer.oisy.com`) with their own canisters and versioning. Production IC deploys for those asset canisters use the **same Orbit-controlled process** as the main wallet `frontend` (see [IC](#ic) above: Docker image build, then `dfx-oisy request deploy`, with verification via `dfx-orbit` where applicable). For architecture, build targets, identity derivation, and the migration plan, see [SIGNER_DOMAINS.md](SIGNER_DOMAINS.md).
+The OISY signer is deployed to dedicated production subdomains (`signer.oisy.com`, `legacy-signer.oisy.com`) with their own canisters and versioning. Production IC deploys for those asset canisters use the **same Orbit-controlled process** as the main wallet `frontend` -- each has its own Docker build script and `dfx-orbit` request (see [IC](#ic) above). For architecture, build targets, identity derivation, and the migration plan, see [SIGNER_DOMAINS.md](SIGNER_DOMAINS.md).
 
 ## Internationalization
 

--- a/SIGNER_DOMAINS.md
+++ b/SIGNER_DOMAINS.md
@@ -141,19 +141,19 @@ Each signer domain reports to Plausible under its own domain name. This means yo
 
 ## Key Files
 
-| File                                              | Purpose                                                |
-| ------------------------------------------------- | ------------------------------------------------------ |
-| `signer-versions.json`                            | Independent version numbers for signer frontends       |
-| `scripts/domains.json`                            | Domain-to-URL mapping per canister + network           |
-| `dfx.json`                                        | Canister definitions and network config                |
-| `canister_ids.json`                               | Canister IDs per network                               |
-| `vite.utils.ts`                                   | Build-time domain resolution + globals                 |
-| `scripts/build.utils.mjs`                         | Post-process domain resolution                         |
-| `scripts/docker-build.signer-frontend`            | Reproducible Docker build for signer frontend          |
-| `scripts/docker-build.legacy-signer-frontend`     | Reproducible Docker build for legacy signer frontend   |
-| `scripts/dfx-orbit.validate.signer-frontend.sh`   | Orbit verification for signer frontend proposals       |
+| File                                                   | Purpose                                                 |
+| ------------------------------------------------------ | ------------------------------------------------------- |
+| `signer-versions.json`                                 | Independent version numbers for signer frontends        |
+| `scripts/domains.json`                                 | Domain-to-URL mapping per canister + network            |
+| `dfx.json`                                             | Canister definitions and network config                 |
+| `canister_ids.json`                                    | Canister IDs per network                                |
+| `vite.utils.ts`                                        | Build-time domain resolution + globals                  |
+| `scripts/build.utils.mjs`                              | Post-process domain resolution                          |
+| `scripts/docker-build.signer-frontend`                 | Reproducible Docker build for signer frontend           |
+| `scripts/docker-build.legacy-signer-frontend`          | Reproducible Docker build for legacy signer frontend    |
+| `scripts/dfx-orbit.validate.signer-frontend.sh`        | Orbit verification for signer frontend proposals        |
 | `scripts/dfx-orbit.validate.legacy-signer-frontend.sh` | Orbit verification for legacy signer frontend proposals |
-| `src/frontend/src/hooks.ts`                       | SvelteKit reroute hook (signer -> `/sign`)             |
-| `src/frontend/src/lib/constants/app.constants.ts` | `SIGNER_TARGET`, `IS_SIGNER_DOMAIN`, derivation origin |
-| `src/frontend/src/env/plausible.env.ts`           | Plausible domain per signer target                     |
-| `.env.production` / `.env.staging` / `.env.beta`  | `VITE_AUTH_ALTERNATIVE_ORIGINS` with signer domains    |
+| `src/frontend/src/hooks.ts`                            | SvelteKit reroute hook (signer -> `/sign`)              |
+| `src/frontend/src/lib/constants/app.constants.ts`      | `SIGNER_TARGET`, `IS_SIGNER_DOMAIN`, derivation origin  |
+| `src/frontend/src/env/plausible.env.ts`                | Plausible domain per signer target                      |
+| `.env.production` / `.env.staging` / `.env.beta`       | `VITE_AUTH_ALTERNATIVE_ORIGINS` with signer domains     |

--- a/SIGNER_DOMAINS.md
+++ b/SIGNER_DOMAINS.md
@@ -57,7 +57,19 @@ dfx deploy signer_frontend --network <network>
 dfx deploy legacy_signer_frontend --network <network>
 ```
 
-**Production (IC):** Upgrades to `frontend`, `signer_frontend`, and `legacy_signer_frontend` on the IC network go through the same **Orbit-controlled** workflow as the main wallet (station approval, `dfx-oisy` / `dfx-orbit` requests), not a one-off `dfx deploy` from a developer laptop. See [Deployment → IC](HACKING.md#ic) in HACKING.md.
+**Production (IC):** Upgrades to `frontend`, `signer_frontend`, and `legacy_signer_frontend` on the IC network go through the **Orbit-controlled** workflow (station approval, `dfx-orbit` requests), not a one-off `dfx deploy` from a developer laptop. Each target has its own reproducible Docker build script and orbit upload command:
+
+```bash
+# Signer frontend
+./scripts/docker-build.signer-frontend
+dfx-orbit request asset upload signer_frontend --files target/signer_frontend
+
+# Legacy signer frontend
+./scripts/docker-build.legacy-signer-frontend
+dfx-orbit request asset upload legacy_signer_frontend --files target/legacy_signer_frontend
+```
+
+Verification scripts for reviewers are at `scripts/dfx-orbit.validate.signer-frontend.sh` and `scripts/dfx-orbit.validate.legacy-signer-frontend.sh`. See [Deployment → IC](HACKING.md#ic) in HACKING.md for the full workflow including the main frontend.
 
 The `OISY_SIGNER_TARGET` env var is baked into each canister's `build` command in `dfx.json`, so deployers never need to set it manually. The canister name determines the build target.
 
@@ -137,6 +149,10 @@ Each signer domain reports to Plausible under its own domain name. This means yo
 | `canister_ids.json`                               | Canister IDs per network                               |
 | `vite.utils.ts`                                   | Build-time domain resolution + globals                 |
 | `scripts/build.utils.mjs`                         | Post-process domain resolution                         |
+| `scripts/docker-build.signer-frontend`            | Reproducible Docker build for signer frontend          |
+| `scripts/docker-build.legacy-signer-frontend`     | Reproducible Docker build for legacy signer frontend   |
+| `scripts/dfx-orbit.validate.signer-frontend.sh`   | Orbit verification for signer frontend proposals       |
+| `scripts/dfx-orbit.validate.legacy-signer-frontend.sh` | Orbit verification for legacy signer frontend proposals |
 | `src/frontend/src/hooks.ts`                       | SvelteKit reroute hook (signer -> `/sign`)             |
 | `src/frontend/src/lib/constants/app.constants.ts` | `SIGNER_TARGET`, `IS_SIGNER_DOMAIN`, derivation origin |
 | `src/frontend/src/env/plausible.env.ts`           | Plausible domain per signer target                     |


### PR DESCRIPTION
# Motivation

After PR https://github.com/dfinity/oisy-wallet/pull/12365, we can include the instructions to deploy the signer domains through Orbit.
