### PR TITLE
feat(frontend): temporary hide AUTOPILOT_USDC_TOKEN

### DIFF
--- a/src/frontend/src/env/tokens/tokens.erc4626.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc4626.env.ts
@@ -1,9 +1,7 @@
-import { AUTOPILOT_USDC_TOKEN } from '$env/tokens/tokens-erc4626/tokens.autopilot_usdc.env';
 import { EVM_ERC4626_TOKENS } from '$env/tokens/tokens-evm/tokens.erc4626.env';
 import type { RequiredErc4626Token } from '$eth/types/erc4626';
 import type { RequiredEvmErc4626Token } from '$evm/types/erc4626';
 
 export const ERC4626_TOKENS: (RequiredErc4626Token | RequiredEvmErc4626Token)[] = [
-	...EVM_ERC4626_TOKENS,
-	AUTOPILOT_USDC_TOKEN
+	...EVM_ERC4626_TOKENS
 ];

--- a/src/frontend/src/eth/constants/harvest-autopilots.constants.ts
+++ b/src/frontend/src/eth/constants/harvest-autopilots.constants.ts
@@ -1,4 +1,3 @@
-import { AUTOPILOT_USDC_TOKEN } from '$env/tokens/tokens-erc4626/tokens.autopilot_usdc.env';
 import { AAUTOPILOT_USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_usdc.env';
 import { AAUTOPILOT_WBTC_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_wbtc.env';
 import { AAUTOPILOT_WETH_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc4626/tokens.aautopilot_weth.env';
@@ -14,7 +13,6 @@ export const HARVEST_AUTOPILOT_ADDRESSES = [
 	BAUTOPILOT_CBBTC_TOKEN.address.toLowerCase(),
 	BAUTOPILOT_WETH_TOKEN.address.toLowerCase(),
 	MORPHOAUTOPILOT_USDC_TOKEN.address.toLowerCase(),
-	AUTOPILOT_USDC_TOKEN.address.toLowerCase(),
 	AAUTOPILOT_USDC_TOKEN.address.toLowerCase(),
 	AAUTOPILOT_WBTC_TOKEN.address.toLowerCase(),
 	AAUTOPILOT_WETH_TOKEN.address.toLowerCase()

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -16,7 +16,7 @@ import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
 import { get } from 'svelte/store';
 
 describe('harvest-autopilots.derived', () => {
-	const mockHarvestAddress = '0x3151cee0cdb517c0e7db2b55ff5085e7d1809d90';
+	const mockHarvestAddress = '0x0d877dc7c8fa3ad980dfdb18b48ec9f8768359c4';
 
 	const mockHarvestToken: Erc4626CustomToken = {
 		...mockValidErc4626Token,


### PR DESCRIPTION
# Motivation

We need to temporary hide AUTOPILOT_USDC_TOKEN as per request from the Harvest team.
