### PR TITLE
chore(frontend): set the correct how to convert URL

### DIFF
--- a/src/frontend/src/env/oisy.metadata.json
+++ b/src/frontend/src/env/oisy.metadata.json
@@ -19,7 +19,7 @@
 	"OISY_INTERNET_IDENTITY_HELP_CENTER_URL": "https://identitysupport.dfinity.org/hc/en-us/articles/39593373981588-Internet-Identity-2-0",
 	"OISY_ACCESS_CONTROL_URL": "https://docs.oisy.com/security/asset-control-recovery-and-governance-in-oisy-wallet",
 	"OISY_NFT_DOCS_URL": "https://docs.oisy.com/using-oisy-wallet/how-tos/nfts",
-	"OISY_HOW_TO_CONVERT_DOCS_URL": "https://docs.oisy.com/using-oisy-wallet/how-tos/",
+	"OISY_HOW_TO_CONVERT_DOCS_URL": "https://docs.oisy.com/using-oisy-wallet/how-tos/swapping-tokens#convert-assets-from-to-the-icp-network",
 	"OISY_INTERNET_IDENTITY_VERSION_2_0_DOCS_URL": "https://docs.oisy.com/using-oisy-wallet/support/oisy-wallet-switches-to-internet-identity-2.0",
 	"OISY_LOGGING_INTO_OISY_URL": "https://docs.oisy.com/using-oisy-wallet/how-tos/logging-into-oisy",
 	"OISY_CREATING_A_WALLET_URL": "https://docs.oisy.com/using-oisy-wallet/how-tos/creating-a-wallet"


### PR DESCRIPTION
# Motivation

We finally made the "How to convert" page/anchor in our docs.

# Changes

- adjust the URL

# Tests
<img width="838" alt="image" src="https://github.com/user-attachments/assets/ac519b50-2b73-480a-9dce-e73505e799db" />

