### PR TITLE
chore(backend): Remove unnecessary Verifiable Credentials mock

### DIFF
--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -18,13 +18,12 @@ use shared::types::{
 };
 
 use crate::utils::{
-    mock::{CALLER},
+    mock::{CALLER, USER_1},
     pocketic::{
         controller, pic_canister::PicCanisterTrait, setup, setup_with_ii,
         setup_with_production_config, BackendBuilder, PicBackend,
     },
 };
-use crate::utils::mock::USER_1;
 
 pub fn call_create_user_profile(
     pic_setup: &PicBackend,

--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -18,12 +18,13 @@ use shared::types::{
 };
 
 use crate::utils::{
-    mock::{CALLER, VC_HOLDER},
+    mock::{CALLER},
     pocketic::{
         controller, pic_canister::PicCanisterTrait, setup, setup_with_ii,
         setup_with_production_config, BackendBuilder, PicBackend,
     },
 };
+use crate::utils::mock::USER_1;
 
 pub fn call_create_user_profile(
     pic_setup: &PicBackend,
@@ -83,7 +84,7 @@ fn register_ii_caller(
 fn test_topup_cannot_be_called_if_not_controller() {
     let pic_setup = setup();
     // A random unauthorized user.
-    let caller = Principal::from_text(VC_HOLDER).unwrap();
+    let caller = Principal::from_text(USER_1).unwrap();
 
     let response = pic_setup.update::<TopUpCyclesLedgerResult>(caller, "top_up_cycles_ledger", ());
 
@@ -168,7 +169,7 @@ fn test_get_allowed_cycles_requires_authenticated_user() {
 #[test]
 fn test_get_allowed_cycles_returns_correct_amount() {
     let pic_setup = setup_with_cycles_ledger();
-    let caller = Principal::from_text(VC_HOLDER).unwrap();
+    let caller = Principal::from_text(USER_1).unwrap();
 
     // Create a user profile so the allow_signing function is called.
     // `create_user_profile` spawns an async `allow_signing` task; give
@@ -191,7 +192,7 @@ fn test_get_allowed_cycles_returns_correct_amount() {
 #[test]
 fn test_get_allowed_cycles_returns_zero_when_no_allowance() {
     let pic_setup = setup_with_cycles_ledger();
-    let caller = Principal::from_text(VC_HOLDER).unwrap();
+    let caller = Principal::from_text(USER_1).unwrap();
 
     // Call get_allowed_cycles
     let result = call_get_allowed_cycles(&pic_setup, caller);
@@ -205,7 +206,7 @@ fn test_get_allowed_cycles_returns_zero_when_no_allowance() {
 fn test_get_allowed_cycles_returns_correct_error_when_cycles_ledger_unavailable() {
     // Regular setup without cycles ledger
     let pic_setup = setup();
-    let caller = Principal::from_text(VC_HOLDER).unwrap();
+    let caller = Principal::from_text(USER_1).unwrap();
 
     // Call get_allowed_cycles - should fail since cycles ledger is not available
     let result = call_get_allowed_cycles(&pic_setup, caller);
@@ -403,7 +404,7 @@ fn test_allow_signing_rate_limit_is_per_caller() {
 #[test]
 fn test_allow_signing_skips_rate_limit_when_allowance_sufficient() {
     let pic_setup = setup_with_cycles_ledger();
-    let caller = Principal::from_text(VC_HOLDER).unwrap();
+    let caller = Principal::from_text(USER_1).unwrap();
 
     // Create profile → housekeeping spawns allow_signing which sets up the
     // allowance above SUFFICIENT_CYCLES_THRESHOLD (~1.458 T cycles).

--- a/src/backend/tests/it/utils/mock.rs
+++ b/src/backend/tests/it/utils/mock.rs
@@ -5,7 +5,6 @@ pub const CONTROLLER: &str = "l3lfs-gak7g-xrbil-j4v4h-aztjn-4jyki-wprso-m27h3-ib
 /// A normal user, without any special permissions.
 pub const USER_1: &str = "7blps-itamd-lzszp-7lbda-4nngn-fev5u-2jvpn-6y3ap-eunp7-kz57e-fqe";
 
-pub const VC_HOLDER: &str = "7eboi-tyuys-aqm4c-w2l7i-vgucm-xvawx-lemzx-6kq2g-f53u7-yvfh2-nae";
 pub const ISSUER_CANISTER_ID: &str = "qdiif-2iaaa-aaaap-ahjaq-cai";
 pub const ISSUER_ORIGIN: &str = "https://dummy-issuer.vc/";
 pub const VC_DERIVATION_ORIGIN: &str = "https://l7rua-raaaa-aaaap-ahh6a-cai.ic0.app";


### PR DESCRIPTION
# Motivation

Mock `VC_HOLDER` is not really necessary since we can use a normal user mock to test the signer.
