### PR TITLE
feat(backend)!: Use explicit II canister params for delegation check

### DIFF
--- a/scripts/build.backend.args.ic.did
+++ b/scripts/build.backend.args.ic.did
@@ -14,6 +14,7 @@
 					issuer_canister_id = principal "qgxyr-pyaaa-aaaah-qdcwq-cai"
 				}
 			};
+			ii_canister_id = opt principal "rdmx6-jaaaa-aaaaa-aaadq-cai";
 			ic_root_key_der = null
 		}
 	}

--- a/scripts/build.backend.args.sh
+++ b/scripts/build.backend.args.sh
@@ -88,6 +88,7 @@ echo "(variant {
               issuer_canister_id = principal \"$CANISTER_ID_POUH_ISSUER\";
             }
          };
+         ii_canister_id = opt principal \"$CANISTER_ID_INTERNET_IDENTITY\";
          ic_root_key_der = $ic_root_key_der;
      }
   })" >"$CANISTER_ARG_PATH_BACKEND_FOR_NETWORK"

--- a/scripts/deploy.args.sh
+++ b/scripts/deploy.args.sh
@@ -41,6 +41,7 @@ echo "(variant {
             issuer_canister_id = principal \"$POUH_ISSUER_CANISTER_ID\";
           }
         };
+        ii_canister_id = opt principal \"$II_CANISTER_ID\";
         ic_root_key_der = $ic_root_key_der;
     }
 })"

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -133,6 +133,7 @@ type CanisterStatusResultV2 = record {
 type CanisterStatusType = variant { stopped; stopping; running };
 type Config = record {
 	derivation_origin : opt text;
+	ii_canister_id : opt principal;
 	ecdsa_key_name : text;
 	cfs_canister_id : opt principal;
 	allowed_callers : vec principal;
@@ -298,6 +299,7 @@ type ImageMimeType = variant {
 };
 type InitArg = record {
 	derivation_origin : opt text;
+	ii_canister_id : opt principal;
 	ecdsa_key_name : text;
 	cfs_canister_id : opt principal;
 	allowed_callers : vec principal;

--- a/src/backend/src/delegation.rs
+++ b/src/backend/src/delegation.rs
@@ -16,11 +16,7 @@ const PRODUCTION_ECDSA_KEY_NAME: &str = "key_1";
 /// (`ecdsa_key_name == "key_1"`).
 pub(crate) fn read_ii_verification_config() -> (Vec<Principal>, Vec<u8>, bool) {
     read_config(|config| {
-        let ii_ids = config
-            .supported_credentials
-            .as_ref()
-            .map(|creds| creds.iter().map(|c| c.ii_canister_id).collect::<Vec<_>>())
-            .unwrap_or_default();
+        let ii_ids = config.ii_canister_id.map(|id| vec![id]).unwrap_or_default();
         let root_key = config
             .ic_root_key_raw
             .clone()

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -424,6 +424,7 @@ pub fn setup_with_ii() -> (PicBackend, super::ii::IICanister) {
             Principal::from_text(SIGNER_CANISTER_ID).expect("wrong cfs canister id"),
         ),
         derivation_origin: Some(VC_DERIVATION_ORIGIN.to_string()),
+        ii_canister_id: Some(ii_canister_id),
     });
 
     let mut builder = BackendBuilder::default().with_arg(encode_one(backend_init).unwrap());
@@ -503,6 +504,7 @@ fn init_arg_with_ecdsa_key(ecdsa_key_name: &str) -> Arg {
             Principal::from_text(SIGNER_CANISTER_ID).expect("wrong cfs canister id"),
         ),
         derivation_origin: Some(VC_DERIVATION_ORIGIN.to_string()),
+        ii_canister_id: Some(Principal::from_text(II_CANISTER_ID).expect("wrong ii canister id")),
     })
 }
 

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -143,6 +143,7 @@ export interface CanisterStatusResultV2 {
 export type CanisterStatusType = { stopped: null } | { stopping: null } | { running: null };
 export interface Config {
 	derivation_origin: [] | [string];
+	ii_canister_id: [] | [Principal];
 	ecdsa_key_name: string;
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
@@ -325,6 +326,7 @@ export type ImageMimeType =
 	| { 'image/webp': null };
 export interface InitArg {
 	derivation_origin: [] | [string];
+	ii_canister_id: [] | [Principal];
 	ecdsa_key_name: string;
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -17,6 +17,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
+		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -178,6 +179,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const Config = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
+		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -713,6 +715,7 @@ export const init = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
+		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -17,6 +17,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
+		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -178,6 +179,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const Config = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
+		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
@@ -723,6 +725,7 @@ export const init = ({ IDL }) => {
 	});
 	const InitArg = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
+		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -165,6 +165,7 @@ impl From<InitArg> for Config {
             ic_root_key_der,
             cfs_canister_id,
             derivation_origin,
+            ii_canister_id,
         } = arg;
         let ic_root_key_raw = match extract_raw_root_pk_from_der(
             &ic_root_key_der.unwrap_or_else(|| IC_ROOT_PK_DER.to_vec()),
@@ -179,6 +180,7 @@ impl From<InitArg> for Config {
             supported_credentials,
             ic_root_key_raw: Some(ic_root_key_raw),
             derivation_origin,
+            ii_canister_id,
         }
     }
 }

--- a/src/shared/src/types/backend_config.rs
+++ b/src/shared/src/types/backend_config.rs
@@ -7,6 +7,8 @@ use crate::types::verifiable_credential::SupportedCredential;
 #[derive(CandidType, Deserialize)]
 pub struct InitArg {
     pub ecdsa_key_name: String,
+    /// A list of allowed callers to restrict access to endpoints that do not particularly check or
+    /// use the `msg_caller()`
     pub allowed_callers: Vec<Principal>,
     pub supported_credentials: Option<Vec<SupportedCredential>>,
     /// Root of trust for checking canister signatures.
@@ -14,10 +16,11 @@ pub struct InitArg {
     /// Chain Fusion Signer canister id. Used to derive the bitcoin address in
     /// `btc_select_user_utxos_fee`
     pub cfs_canister_id: Option<Principal>,
-    /// Derivation origins when logging in the dapp with Internet Identity.
-    /// Used to validate the id alias credential which includes the derivation origin of the id
-    /// alias.
+    /// The derivation origin used for II authentication, ensuring users get a
+    /// consistent identity across different domains.
     pub derivation_origin: Option<String>,
+    /// The Internet Identity canister used for delegation verification.
+    pub ii_canister_id: Option<Principal>,
 }
 
 #[derive(CandidType, Deserialize)]
@@ -29,8 +32,8 @@ pub enum Arg {
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Config {
     pub ecdsa_key_name: String,
-    // A list of allowed callers to restrict access to endpoints that do not particularly check or
-    // use the msg_caller()
+    /// A list of allowed callers to restrict access to endpoints that do not particularly check or
+    /// use the `msg_caller()`
     pub allowed_callers: Vec<Principal>,
     pub supported_credentials: Option<Vec<SupportedCredential>>,
     /// Root of trust for checking canister signatures.
@@ -38,8 +41,9 @@ pub struct Config {
     /// Chain Fusion Signer canister id. Used to derive the bitcoin address in
     /// `btc_select_user_utxos_fee`
     pub cfs_canister_id: Option<Principal>,
-    /// Derivation origins when logging in the dapp with Internet Identity.
-    /// Used to validate the id alias credential which includes the derivation origin of the id
-    /// alias.
+    /// The derivation origin used for II authentication, ensuring users get a
+    /// consistent identity across different domains.
     pub derivation_origin: Option<String>,
+    /// The Internet Identity canister used for delegation verification.
+    pub ii_canister_id: Option<Principal>,
 }


### PR DESCRIPTION
# Motivation

When we check the Internet Identity delegation check in the backend, we extract the II canister from the supported_credentials configuration.

However, we are going to deprecate such field, and moreover, we should rely on an explicit param for an important data such as that.

BREAKING CHANGE: New `ii_canister_id` field in the arguments of the backend canister.

# Changes

- Add `ii_canister_id` to configuration arguments of backend canister.
- Use the new param in the delegation check.
- Adapt the build and deploy scripts.

# Tests

Current tests must work.
