### PR TITLE
feat(frontend): Show Swap button only for swappable tokens

### DIFF
--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { page } from '$app/state';
 	import ConvertToCkBtc from '$btc/components/convert/ConvertToCkBtc.svelte';
 	import BtcReceive from '$btc/components/receive/BtcReceive.svelte';
@@ -47,7 +47,9 @@
 	let isTransactionsPage = $derived(isRouteTransactions(page));
 	let isNftsPage = $derived(isRouteNfts(page));
 
-	let swapAction = $derived((!isTransactionsPage || $isPageTokenSwappable) && !isNftsPage);
+	let swapAction = $derived(
+		(!isTransactionsPage || $isPageTokenSwappable || isNullish($pageToken)) && !isNftsPage
+	);
 
 	let sendAction = $derived(!$allBalancesZero || isTransactionsPage);
 

--- a/src/frontend/src/lib/components/hero/Actions.svelte
+++ b/src/frontend/src/lib/components/hero/Actions.svelte
@@ -29,6 +29,7 @@
 	} from '$lib/derived/network.derived';
 	import { networkBitcoinMainnetEnabled } from '$lib/derived/networks.derived';
 	import { pageToken, pageTokenWithFallback } from '$lib/derived/page-token.derived';
+	import { isPageTokenSwappable } from '$lib/derived/swap.derived';
 	import { isRouteNfts, isRouteTransactions } from '$lib/utils/nav.utils';
 	import { isNetworkIdBTCMainnet } from '$lib/utils/network.utils';
 	import SolReceive from '$sol/components/receive/SolReceive.svelte';
@@ -46,10 +47,7 @@
 	let isTransactionsPage = $derived(isRouteTransactions(page));
 	let isNftsPage = $derived(isRouteNfts(page));
 
-	let swapAction = $derived(
-		(!isTransactionsPage || (isTransactionsPage && !$networkSolana && !$networkBitcoin)) &&
-			!isNftsPage
-	);
+	let swapAction = $derived((!isTransactionsPage || $isPageTokenSwappable) && !isNftsPage);
 
 	let sendAction = $derived(!$allBalancesZero || isTransactionsPage);
 

--- a/src/frontend/src/lib/derived/swap.derived.ts
+++ b/src/frontend/src/lib/derived/swap.derived.ts
@@ -6,8 +6,10 @@ import {
 } from '$lib/derived/all-tokens.derived';
 import { pageToken } from '$lib/derived/page-token.derived';
 import { balancesStore } from '$lib/stores/balances.store';
+import { swapSupportedTokensStore } from '$lib/stores/swap-supported-tokens.store';
 import type { Balance } from '$lib/types/balance';
 import type { Token } from '$lib/types/token';
+import { filterSwapTokens } from '$lib/utils/swap-tokens-filter.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -37,6 +39,22 @@ const selectedSwappableToken: Readable<Token | undefined> = derived(
 		}
 
 		return undefined;
+	}
+);
+
+export const isPageTokenSwappable: Readable<boolean> = derived(
+	[selectedSwappableToken, swapSupportedTokensStore],
+	([$selectedSwappableToken, $swapSupportedTokensStore]) => {
+		if (isNullish($selectedSwappableToken)) {
+			return false;
+		}
+
+		const result = filterSwapTokens({
+			tokens: [{ ...$selectedSwappableToken, enabled: true }],
+			supportedData: $swapSupportedTokensStore
+		});
+
+		return result.length > 0;
 	}
 );
 

--- a/src/frontend/src/tests/lib/components/hero/Actions.spec.ts
+++ b/src/frontend/src/tests/lib/components/hero/Actions.spec.ts
@@ -1,0 +1,156 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import Actions from '$lib/components/hero/Actions.svelte';
+import { AppPath, ROUTE_ID_GROUP_APP } from '$lib/constants/routes.constants';
+import {
+	BUY_TOKENS_MODAL_OPEN_BUTTON,
+	SEND_TOKENS_MODAL_OPEN_BUTTON,
+	SWAP_TOKENS_MODAL_OPEN_BUTTON
+} from '$lib/constants/test-ids.constants';
+import * as balancesDerived from '$lib/derived/balances.derived';
+import * as swapDerived from '$lib/derived/swap.derived';
+import { HERO_CONTEXT_KEY, initHeroContext } from '$lib/stores/hero.store';
+import { mockPage } from '$tests/mocks/page.store.mock';
+import { render } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+
+describe('Actions', () => {
+	const swapButtonSelector = `button[data-tid="${SWAP_TOKENS_MODAL_OPEN_BUTTON}"]`;
+	const sendButtonSelector = `button[data-tid="${SEND_TOKENS_MODAL_OPEN_BUTTON}"]`;
+	const buyButtonSelector = `button[data-tid="${BUY_TOKENS_MODAL_OPEN_BUTTON}"]`;
+
+	const heroContext = new Map<symbol, unknown>([[HERO_CONTEXT_KEY, initHeroContext()]]);
+
+	const renderActions = () => render(Actions, { context: heroContext });
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		mockPage.reset();
+
+		vi.spyOn(balancesDerived, 'allBalancesZero', 'get').mockReturnValue(readable(false));
+	});
+
+	const setTokensPage = () => {
+		mockPage.mockRoute({ id: `${ROUTE_ID_GROUP_APP}${AppPath.Tokens}` });
+	};
+
+	const setTransactionsPage = () => {
+		mockPage.mockRoute({ id: `${ROUTE_ID_GROUP_APP}${AppPath.Transactions}` });
+	};
+
+	const setNftsPage = () => {
+		mockPage.mockRoute({ id: `${ROUTE_ID_GROUP_APP}${AppPath.Nfts}` });
+	};
+
+	describe('swap button visibility', () => {
+		it('should show swap button on tokens page', () => {
+			setTokensPage();
+			mockPage.mockToken(ICP_TOKEN);
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(swapButtonSelector)).toBeInTheDocument();
+		});
+
+		it('should show swap button on transactions page when token is swappable', () => {
+			setTransactionsPage();
+			mockPage.mockToken(ICP_TOKEN);
+			vi.spyOn(swapDerived, 'isPageTokenSwappable', 'get').mockReturnValue(readable(true));
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(swapButtonSelector)).toBeInTheDocument();
+		});
+
+		it('should hide swap button on transactions page when token is not swappable', () => {
+			setTransactionsPage();
+			mockPage.mockToken(BTC_MAINNET_TOKEN);
+			vi.spyOn(swapDerived, 'isPageTokenSwappable', 'get').mockReturnValue(readable(false));
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(swapButtonSelector)).not.toBeInTheDocument();
+		});
+
+		it('should hide swap button on NFTs page', () => {
+			setNftsPage();
+			mockPage.mockToken(ICP_TOKEN);
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(swapButtonSelector)).not.toBeInTheDocument();
+		});
+	});
+
+	describe('send button visibility', () => {
+		it('should show send button on tokens page when balances are not all zero', () => {
+			setTokensPage();
+			mockPage.mockToken(ICP_TOKEN);
+			vi.spyOn(balancesDerived, 'allBalancesZero', 'get').mockReturnValue(readable(false));
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(sendButtonSelector)).toBeInTheDocument();
+		});
+
+		it('should hide send button on tokens page when all balances are zero', () => {
+			setTokensPage();
+			mockPage.mockToken(ICP_TOKEN);
+			vi.spyOn(balancesDerived, 'allBalancesZero', 'get').mockReturnValue(readable(true));
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(sendButtonSelector)).not.toBeInTheDocument();
+		});
+
+		it('should show send button on transactions page even when all balances are zero', () => {
+			setTransactionsPage();
+			mockPage.mockToken(ICP_TOKEN);
+			vi.spyOn(balancesDerived, 'allBalancesZero', 'get').mockReturnValue(readable(true));
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(sendButtonSelector)).toBeInTheDocument();
+		});
+	});
+
+	describe('buy button visibility', () => {
+		it('should show buy button on non-ICP network', () => {
+			setTokensPage();
+			mockPage.mockToken(ETHEREUM_TOKEN);
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(buyButtonSelector)).toBeInTheDocument();
+		});
+
+		it('should show buy button on ICP network when token has buy property', () => {
+			setTokensPage();
+			mockPage.mockToken(ICP_TOKEN);
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(buyButtonSelector)).toBeInTheDocument();
+		});
+
+		it('should show buy button on Solana network', () => {
+			setTokensPage();
+			mockPage.mockToken(SOLANA_TOKEN);
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(buyButtonSelector)).toBeInTheDocument();
+		});
+
+		it('should hide buy button on NFTs page', () => {
+			setNftsPage();
+			mockPage.mockToken(ICP_TOKEN);
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(buyButtonSelector)).not.toBeInTheDocument();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/components/hero/Actions.spec.ts
+++ b/src/frontend/src/tests/lib/components/hero/Actions.spec.ts
@@ -74,6 +74,15 @@ describe('Actions', () => {
 			expect(container.querySelector(swapButtonSelector)).not.toBeInTheDocument();
 		});
 
+		it('should show swap button on transactions page when no token is selected', () => {
+			setTransactionsPage();
+			mockPage.mockNetwork(ICP_TOKEN.network.id.description);
+
+			const { container } = renderActions();
+
+			expect(container.querySelector(swapButtonSelector)).toBeInTheDocument();
+		});
+
 		it('should hide swap button on NFTs page', () => {
 			setNftsPage();
 			mockPage.mockToken(ICP_TOKEN);

--- a/src/frontend/src/tests/lib/components/hero/Actions.spec.ts
+++ b/src/frontend/src/tests/lib/components/hero/Actions.spec.ts
@@ -1,7 +1,7 @@
-import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
-import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import Actions from '$lib/components/hero/Actions.svelte';
 import { AppPath, ROUTE_ID_GROUP_APP } from '$lib/constants/routes.constants';
 import {

--- a/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
@@ -1,13 +1,245 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN, ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import type { Erc20CustomToken } from '$eth/types/erc20-custom-token';
 import { ZERO } from '$lib/constants/app.constants';
-import { swappableTokens } from '$lib/derived/swap.derived';
+import {
+	allCrossChainSwapTokens,
+	allSwapCompatibleIcrcTokens
+} from '$lib/derived/all-tokens.derived';
+import { pageToken } from '$lib/derived/page-token.derived';
+import { isPageTokenSwappable, swappableTokens } from '$lib/derived/swap.derived';
 import { balancesStore } from '$lib/stores/balances.store';
+import { swapSupportedTokensStore } from '$lib/stores/swap-supported-tokens.store';
+import type { SplCustomToken } from '$sol/types/spl-custom-token';
 import { bn2Bi } from '$tests/mocks/balances.mock';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { get } from 'svelte/store';
 
 describe('swap.derived', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		swapSupportedTokensStore.reset();
+	});
+
+	describe('isPageTokenSwappable', () => {
+		beforeEach(() => {
+			mockPage.reset();
+		});
+
+		it('should return false when no page token is set', () => {
+			expect(get(isPageTokenSwappable)).toBeFalsy();
+		});
+
+		it('should return true for ICP token', () => {
+			mockPage.mockToken(ICP_TOKEN);
+
+			expect(get(isPageTokenSwappable)).toBeTruthy();
+		});
+
+		it('should return true for Ethereum token', () => {
+			mockPage.mockToken(ETHEREUM_TOKEN);
+
+			expect(get(isPageTokenSwappable)).toBeTruthy();
+		});
+
+		it('should return true for Solana token', () => {
+			mockPage.mockToken(SOLANA_TOKEN);
+
+			expect(get(isPageTokenSwappable)).toBeTruthy();
+		});
+
+		it('should return false for Bitcoin token', () => {
+			mockPage.mockToken(BTC_MAINNET_TOKEN);
+
+			expect(get(isPageTokenSwappable)).toBeFalsy();
+		});
+
+		it('should update reactively when switching between swappable and non-swappable tokens', () => {
+			mockPage.mockToken(SOLANA_TOKEN);
+
+			expect(get(isPageTokenSwappable)).toBeTruthy();
+
+			mockPage.mockToken(BTC_MAINNET_TOKEN);
+
+			expect(get(isPageTokenSwappable)).toBeFalsy();
+		});
+
+		it('should return false after resetting the page', () => {
+			mockPage.mockToken(ETHEREUM_TOKEN);
+
+			expect(get(isPageTokenSwappable)).toBeTruthy();
+
+			mockPage.reset();
+
+			expect(get(isPageTokenSwappable)).toBeFalsy();
+		});
+
+		describe('with custom tokens', () => {
+			it('should return true for an SPL token in the swap universe', () => {
+				const splToken: SplCustomToken = { ...mockValidSplToken, enabled: true };
+
+				vi.spyOn(pageToken, 'subscribe').mockImplementation((fn) => {
+					fn(splToken);
+					return () => {};
+				});
+
+				vi.spyOn(allCrossChainSwapTokens, 'subscribe').mockImplementation((fn) => {
+					fn([splToken]);
+					return () => {};
+				});
+
+				vi.spyOn(allSwapCompatibleIcrcTokens, 'subscribe').mockImplementation((fn) => {
+					fn([]);
+					return () => {};
+				});
+
+				expect(get(isPageTokenSwappable)).toBeTruthy();
+			});
+
+			it('should return true for an ERC20 token in the swap universe', () => {
+				const erc20Token: Erc20CustomToken = { ...mockValidErc20Token, enabled: true };
+
+				vi.spyOn(pageToken, 'subscribe').mockImplementation((fn) => {
+					fn(erc20Token);
+					return () => {};
+				});
+
+				vi.spyOn(allCrossChainSwapTokens, 'subscribe').mockImplementation((fn) => {
+					fn([erc20Token]);
+					return () => {};
+				});
+
+				vi.spyOn(allSwapCompatibleIcrcTokens, 'subscribe').mockImplementation((fn) => {
+					fn([]);
+					return () => {};
+				});
+
+				expect(get(isPageTokenSwappable)).toBeTruthy();
+			});
+
+			it('should return false for a token not in the swap universe', () => {
+				const splToken: SplCustomToken = { ...mockValidSplToken, enabled: true };
+
+				vi.spyOn(pageToken, 'subscribe').mockImplementation((fn) => {
+					fn(splToken);
+					return () => {};
+				});
+
+				vi.spyOn(allCrossChainSwapTokens, 'subscribe').mockImplementation((fn) => {
+					fn([]);
+					return () => {};
+				});
+
+				vi.spyOn(allSwapCompatibleIcrcTokens, 'subscribe').mockImplementation((fn) => {
+					fn([]);
+					return () => {};
+				});
+
+				expect(get(isPageTokenSwappable)).toBeFalsy();
+			});
+		});
+
+		describe('with provider supported data', () => {
+			it('should return false when token is in universe but not supported by providers', () => {
+				mockPage.mockToken(SOLANA_TOKEN);
+
+				swapSupportedTokensStore.set({
+					icp: { coverage: 'none', supportedTokenIds: new Set() },
+					evm: { coverage: 'none', supportedTokenIds: new Set() },
+					sol: { coverage: 'all', supportedTokenIds: new Set(['some-other-token']) }
+				});
+
+				expect(get(isPageTokenSwappable)).toBeFalsy();
+			});
+
+			it('should return true when token is in universe and supported by providers', () => {
+				mockPage.mockToken(SOLANA_TOKEN);
+
+				swapSupportedTokensStore.set({
+					icp: { coverage: 'none', supportedTokenIds: new Set() },
+					evm: { coverage: 'none', supportedTokenIds: new Set() },
+					sol: {
+						coverage: 'all',
+						supportedTokenIds: new Set([SOLANA_TOKEN.symbol.toLowerCase()])
+					}
+				});
+
+				expect(get(isPageTokenSwappable)).toBeTruthy();
+			});
+
+			it('should return true for ETH token when EVM providers have no list', () => {
+				mockPage.mockToken(ETHEREUM_TOKEN);
+
+				swapSupportedTokensStore.set({
+					icp: { coverage: 'none', supportedTokenIds: new Set() },
+					evm: { coverage: 'none', supportedTokenIds: new Set() },
+					sol: { coverage: 'all', supportedTokenIds: new Set() }
+				});
+
+				expect(get(isPageTokenSwappable)).toBeTruthy();
+			});
+
+			it('should return false for SPL token not in provider supported set', () => {
+				const splToken: SplCustomToken = { ...mockValidSplToken, enabled: true };
+
+				vi.spyOn(pageToken, 'subscribe').mockImplementation((fn) => {
+					fn(splToken);
+					return () => {};
+				});
+
+				vi.spyOn(allCrossChainSwapTokens, 'subscribe').mockImplementation((fn) => {
+					fn([splToken]);
+					return () => {};
+				});
+
+				vi.spyOn(allSwapCompatibleIcrcTokens, 'subscribe').mockImplementation((fn) => {
+					fn([]);
+					return () => {};
+				});
+
+				vi.spyOn(swapSupportedTokensStore, 'subscribe').mockImplementation((fn) => {
+					fn({
+						icp: { coverage: 'none', supportedTokenIds: new Set() },
+						evm: { coverage: 'none', supportedTokenIds: new Set() },
+						sol: { coverage: 'all', supportedTokenIds: new Set(['different-address']) }
+					});
+					return () => {};
+				});
+
+				expect(get(isPageTokenSwappable)).toBeFalsy();
+			});
+
+			it('should update reactively when provider data loads', () => {
+				mockPage.mockToken(SOLANA_TOKEN);
+
+				expect(get(isPageTokenSwappable)).toBeTruthy();
+
+				swapSupportedTokensStore.set({
+					icp: { coverage: 'none', supportedTokenIds: new Set() },
+					evm: { coverage: 'none', supportedTokenIds: new Set() },
+					sol: { coverage: 'all', supportedTokenIds: new Set(['not-sol']) }
+				});
+
+				expect(get(isPageTokenSwappable)).toBeFalsy();
+
+				swapSupportedTokensStore.set({
+					icp: { coverage: 'none', supportedTokenIds: new Set() },
+					evm: { coverage: 'none', supportedTokenIds: new Set() },
+					sol: {
+						coverage: 'all',
+						supportedTokenIds: new Set([SOLANA_TOKEN.symbol.toLowerCase()])
+					}
+				});
+
+				expect(get(isPageTokenSwappable)).toBeTruthy();
+			});
+		});
+	});
+
 	describe('swappableTokens', () => {
 		it('should return undefined for sourceToken and destinationToken', () => {
 			const tokens = get(swappableTokens);


### PR DESCRIPTION
# Motivation

When we are in the token-specific page, we would like to show the Swap button only for supported tokens: we follow the same logic used when displaying the token list in the Swap modal.
