### PR TITLE
feat(backend)!: Remove unused `supported_credentials` param from arguments

### DIFF
--- a/scripts/build.backend.args.ic.did
+++ b/scripts/build.backend.args.ic.did
@@ -5,15 +5,6 @@
 			allowed_callers = vec { principal "nynz6-haaaa-aaaan-qzqda-cai" };
 			cfs_canister_id = opt principal "grghe-syaaa-aaaar-qabyq-cai";
 			derivation_origin = opt "https://oisy.com";
-			supported_credentials = opt vec {
-				record {
-					credential_type = variant { ProofOfUniqueness };
-					ii_origin = "https://identity.internetcomputer.org";
-					ii_canister_id = principal "rdmx6-jaaaa-aaaaa-aaadq-cai";
-					issuer_origin = "https://id.decideai.xyz/";
-					issuer_canister_id = principal "qgxyr-pyaaa-aaaah-qdcwq-cai"
-				}
-			};
 			ii_canister_id = opt principal "rdmx6-jaaaa-aaaaa-aaadq-cai";
 			ic_root_key_der = null
 		}

--- a/scripts/build.backend.args.sh
+++ b/scripts/build.backend.args.sh
@@ -29,18 +29,12 @@ case "$DFX_NETWORK" in
   ECDSA_KEY_NAME="test_key_1"
   # For security reasons, mainnet root key will be hardcoded in the backend canister.
   ic_root_key_der="null"
-  # URL used by issuer in the issued verifiable credentials (typically hard-coded)
-  # Represents more an ID than a URL
-  POUH_ISSUER_VC_URL="https://${CANISTER_ID_POUH_ISSUER}.icp0.io/"
   DERIVATION_ORIGIN="https://tewsx-xaaaa-aaaad-aadia-cai.icp0.io"
   ;;
 "ic" | "beta")
   ECDSA_KEY_NAME="key_1"
   # For security reasons, mainnet root key will be hardcoded in the backend canister.
   ic_root_key_der="null"
-  # URL used by issuer in the issued verifiable credentials (typically hard-coded)
-  # Represents more an ID than a URL
-  POUH_ISSUER_VC_URL="https://id.decideai.xyz/"
   DERIVATION_ORIGIN="https://oisy.com"
   ;;
 *)
@@ -53,9 +47,6 @@ case "$DFX_NETWORK" in
     jq -r '.root_key | reduce .[] as $item ("{ "; "\(.) \($item):nat8;") + " }"')
   echo "Parsed rootkey: ${rootkey_did:0:20}..." >&2
   ic_root_key_der="opt vec $rootkey_did"
-  # URL used by issuer in the issued verifiable credentials (typically hard-coded)
-  # We use the dummy issuer canister for local development
-  POUH_ISSUER_VC_URL="https://dummy-issuer.vc/"
   DERIVATION_ORIGIN="http://${CANISTER_ID_BACKEND}.localhost:4943"
   ;;
 esac
@@ -67,27 +58,12 @@ else
   ALLOWED_CALLERS="vec{ principal \"$CANISTER_ID_REWARDS\" }"
 fi
 
-# URL used by II-issuer in the id_alias-verifiable credentials (hard-coded in II)
-# Represents more an ID than a URL
-II_VC_URL="https://identity.internetcomputer.org"
-
-echo "Deploying backend with the following arguments: ${POUH_ISSUER_VC_URL}"
-
 echo "(variant {
     Init = record {
          ecdsa_key_name = \"$ECDSA_KEY_NAME\";
          allowed_callers = $ALLOWED_CALLERS;
          cfs_canister_id = opt principal \"$CANISTER_ID_SIGNER\";
          derivation_origin = opt \"$DERIVATION_ORIGIN\";
-         supported_credentials = opt vec {
-            record {
-              credential_type = variant { ProofOfUniqueness };
-              ii_origin = \"$II_VC_URL\";
-              ii_canister_id = principal \"$CANISTER_ID_INTERNET_IDENTITY\";
-              issuer_origin = \"$POUH_ISSUER_VC_URL\";
-              issuer_canister_id = principal \"$CANISTER_ID_POUH_ISSUER\";
-            }
-         };
          ii_canister_id = opt principal \"$CANISTER_ID_INTERNET_IDENTITY\";
          ic_root_key_der = $ic_root_key_der;
      }

--- a/scripts/deploy.args.sh
+++ b/scripts/deploy.args.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 II_CANISTER_ID="$(dfx canister id internet_identity --network "${ENV:-local}")"
-POUH_ISSUER_CANISTER_ID="$(dfx canister id pouh_issuer --network "${ENV:-local}")"
 SIGNER_CANISTER_ID="$(dfx canister id signer --network "${ENV:-local}")"
 
 case $ENV in
@@ -9,38 +8,19 @@ case $ENV in
   ECDSA_KEY_NAME="test_key_1"
   # For security reasons, mainnet root key will be hardcoded in the backend canister.
   ic_root_key_der="null"
-  # URL used by issuer in the issued verifiable credentials (typically hard-coded)
-  # Represents more an ID than a URL
-  POUH_ISSUER_VC_URL="https://${POUH_ISSUER_CANISTER_ID}.icp0.io/"
   ;;
 "ic" | "beta")
   ECDSA_KEY_NAME="key_1"
   # For security reasons, mainnet root key will be hardcoded in the backend canister.
   ic_root_key_der="null"
-  # URL used by issuer in the issued verifiable credentials (typically hard-coded)
-  # Represents more an ID than a URL
-  POUH_ISSUER_VC_URL="https://id.decideai.xyz/"
   ;;
 esac
-
-# URL used by II-issuer in the id_alias-verifiable credentials (hard-coded in II)
-# Represents more an ID than a URL
-II_VC_URL="https://identity.internetcomputer.org"
 
 echo "(variant {
   Init = record {
         ecdsa_key_name = \"$ECDSA_KEY_NAME\";
         allowed_callers = vec {};
         cfs_canister_id = opt principal \"$SIGNER_CANISTER_ID\";
-        supported_credentials = opt vec {
-          record {
-            credential_type = variant { ProofOfUniqueness };
-            ii_origin = \"$II_VC_URL\";
-            ii_canister_id = principal \"$II_CANISTER_ID\";
-            issuer_origin = \"$POUH_ISSUER_VC_URL\";
-            issuer_canister_id = principal \"$POUH_ISSUER_CANISTER_ID\";
-          }
-        };
         ii_canister_id = opt principal \"$II_CANISTER_ID\";
         ic_root_key_der = $ic_root_key_der;
     }

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -137,7 +137,6 @@ type Config = record {
 	ecdsa_key_name : text;
 	cfs_canister_id : opt principal;
 	allowed_callers : vec principal;
-	supported_credentials : opt vec SupportedCredential;
 	ic_root_key_raw : opt blob
 };
 type Contact = record {
@@ -303,7 +302,6 @@ type InitArg = record {
 	ecdsa_key_name : text;
 	cfs_canister_id : opt principal;
 	allowed_callers : vec principal;
-	supported_credentials : opt vec SupportedCredential;
 	ic_root_key_der : opt blob
 };
 type Network = variant { mainnet; regtest; testnet };
@@ -406,13 +404,6 @@ type Stats = record {
 	agreement_history_count : nat64;
 	user_timestamps_count : nat64;
 	user_token_count : nat64
-};
-type SupportedCredential = record {
-	ii_canister_id : principal;
-	issuer_origin : text;
-	issuer_canister_id : principal;
-	ii_origin : text;
-	credential_type : CredentialType
 };
 type TestnetsSettings = record { show_testnets : bool };
 type Token = variant {

--- a/src/backend/tests/it/utils/mock.rs
+++ b/src/backend/tests/it/utils/mock.rs
@@ -5,9 +5,6 @@ pub const CONTROLLER: &str = "l3lfs-gak7g-xrbil-j4v4h-aztjn-4jyki-wprso-m27h3-ib
 /// A normal user, without any special permissions.
 pub const USER_1: &str = "7blps-itamd-lzszp-7lbda-4nngn-fev5u-2jvpn-6y3ap-eunp7-kz57e-fqe";
 
-pub const ISSUER_CANISTER_ID: &str = "qdiif-2iaaa-aaaap-ahjaq-cai";
-pub const ISSUER_ORIGIN: &str = "https://dummy-issuer.vc/";
 pub const VC_DERIVATION_ORIGIN: &str = "https://l7rua-raaaa-aaaap-ahh6a-cai.ic0.app";
 pub const II_CANISTER_ID: &str = "fgte5-ciaaa-aaaad-aaatq-cai";
 pub const SIGNER_CANISTER_ID: &str = "grghe-syaaa-aaaar-qabyq-cai";
-pub const II_ORIGIN: &str = "https://identity.internetcomputer.org/";

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -412,14 +412,6 @@ pub fn setup_with_ii() -> (PicBackend, super::ii::IICanister) {
         ecdsa_key_name: "test_key_1".to_string(),
         allowed_callers: vec![Principal::from_text(CALLER).unwrap()],
         ic_root_key_der: Some(root_key),
-        supported_credentials: Some(vec![SupportedCredential {
-            ii_canister_id,
-            ii_origin: II_ORIGIN.to_string(),
-            issuer_canister_id: Principal::from_text(ISSUER_CANISTER_ID)
-                .expect("wrong issuer canister id"),
-            issuer_origin: ISSUER_ORIGIN.to_string(),
-            credential_type: CredentialType::ProofOfUniqueness,
-        }]),
         cfs_canister_id: Some(
             Principal::from_text(SIGNER_CANISTER_ID).expect("wrong cfs canister id"),
         ),
@@ -492,14 +484,6 @@ fn init_arg_with_ecdsa_key(ecdsa_key_name: &str) -> Arg {
         ecdsa_key_name: ecdsa_key_name.to_string(),
         allowed_callers: vec![Principal::from_text(CALLER).unwrap()],
         ic_root_key_der: None,
-        supported_credentials: Some(vec![SupportedCredential {
-            ii_canister_id: Principal::from_text(II_CANISTER_ID).expect("wrong ii canister id"),
-            ii_origin: II_ORIGIN.to_string(),
-            issuer_canister_id: Principal::from_text(ISSUER_CANISTER_ID)
-                .expect("wrong issuer canister id"),
-            issuer_origin: ISSUER_ORIGIN.to_string(),
-            credential_type: CredentialType::ProofOfUniqueness,
-        }]),
         cfs_canister_id: Some(
             Principal::from_text(SIGNER_CANISTER_ID).expect("wrong cfs canister id"),
         ),

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -10,13 +10,9 @@ use pocket_ic::{PocketIc, PocketIcBuilder};
 use shared::types::{
     backend_config::{Arg, InitArg},
     user_profile::{OisyUser, UserProfile},
-    verifiable_credential::{CredentialType, SupportedCredential},
 };
 
-use super::mock::{
-    CONTROLLER, II_CANISTER_ID, II_ORIGIN, ISSUER_CANISTER_ID, ISSUER_ORIGIN, SIGNER_CANISTER_ID,
-    VC_DERIVATION_ORIGIN,
-};
+use super::mock::{CONTROLLER, II_CANISTER_ID, SIGNER_CANISTER_ID, VC_DERIVATION_ORIGIN};
 use crate::utils::mock::CALLER;
 
 const BACKEND_WASM: &str = "../../target/wasm32-unknown-unknown/release/backend.wasm";

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -147,7 +147,6 @@ export interface Config {
 	ecdsa_key_name: string;
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
-	supported_credentials: [] | [Array<SupportedCredential>];
 	ic_root_key_raw: [] | [Uint8Array];
 }
 export interface Contact {
@@ -330,7 +329,6 @@ export interface InitArg {
 	ecdsa_key_name: string;
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
-	supported_credentials: [] | [Array<SupportedCredential>];
 	ic_root_key_der: [] | [Uint8Array];
 }
 export type Network = { mainnet: null } | { regtest: null } | { testnet: null };
@@ -442,13 +440,6 @@ export interface Stats {
 	agreement_history_count: bigint;
 	user_timestamps_count: bigint;
 	user_token_count: bigint;
-}
-export interface SupportedCredential {
-	ii_canister_id: Principal;
-	issuer_origin: string;
-	issuer_canister_id: Principal;
-	ii_origin: string;
-	credential_type: CredentialType;
 }
 export interface TestnetsSettings {
 	show_testnets: boolean;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -7,21 +7,12 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 export const idlFactory = ({ IDL }) => {
-	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
-	const SupportedCredential = IDL.Record({
-		ii_canister_id: IDL.Principal,
-		issuer_origin: IDL.Text,
-		issuer_canister_id: IDL.Principal,
-		ii_origin: IDL.Text,
-		credential_type: CredentialType
-	});
 	const InitArg = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
@@ -183,7 +174,6 @@ export const idlFactory = ({ IDL }) => {
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const ImageMimeType = IDL.Variant({
@@ -269,6 +259,7 @@ export const idlFactory = ({ IDL }) => {
 		agreements: UserAgreements,
 		provider_agreements: IDL.Opt(IDL.Vec(IDL.Tuple(ProviderAgreementType, UserAgreement)))
 	});
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
 	const UserCredential = IDL.Record({
 		issuer: IDL.Text,
 		verified_date_timestamp: IDL.Opt(IDL.Nat64),
@@ -705,21 +696,12 @@ export const idlFactory = ({ IDL }) => {
 };
 
 export const init = ({ IDL }) => {
-	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
-	const SupportedCredential = IDL.Record({
-		ii_canister_id: IDL.Principal,
-		issuer_origin: IDL.Text,
-		issuer_canister_id: IDL.Principal,
-		ii_origin: IDL.Text,
-		credential_type: CredentialType
-	});
 	const InitArg = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -7,21 +7,12 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 export const idlFactory = ({ IDL }) => {
-	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
-	const SupportedCredential = IDL.Record({
-		ii_canister_id: IDL.Principal,
-		issuer_origin: IDL.Text,
-		issuer_canister_id: IDL.Principal,
-		ii_origin: IDL.Text,
-		credential_type: CredentialType
-	});
 	const InitArg = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
@@ -183,7 +174,6 @@ export const idlFactory = ({ IDL }) => {
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const ImageMimeType = IDL.Variant({
@@ -269,6 +259,7 @@ export const idlFactory = ({ IDL }) => {
 		agreements: UserAgreements,
 		provider_agreements: IDL.Opt(IDL.Vec(IDL.Tuple(ProviderAgreementType, UserAgreement)))
 	});
+	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
 	const UserCredential = IDL.Record({
 		issuer: IDL.Text,
 		verified_date_timestamp: IDL.Opt(IDL.Nat64),
@@ -715,21 +706,12 @@ export const idlFactory = ({ IDL }) => {
 };
 
 export const init = ({ IDL }) => {
-	const CredentialType = IDL.Variant({ ProofOfUniqueness: IDL.Null });
-	const SupportedCredential = IDL.Record({
-		ii_canister_id: IDL.Principal,
-		issuer_origin: IDL.Text,
-		issuer_canister_id: IDL.Principal,
-		ii_origin: IDL.Text,
-		credential_type: CredentialType
-	});
 	const InitArg = IDL.Record({
 		derivation_origin: IDL.Opt(IDL.Text),
 		ii_canister_id: IDL.Opt(IDL.Principal),
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		supported_credentials: IDL.Opt(IDL.Vec(SupportedCredential)),
 		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -161,7 +161,6 @@ impl From<InitArg> for Config {
         let InitArg {
             ecdsa_key_name,
             allowed_callers,
-            supported_credentials,
             ic_root_key_der,
             cfs_canister_id,
             derivation_origin,
@@ -177,7 +176,6 @@ impl From<InitArg> for Config {
             ecdsa_key_name,
             allowed_callers,
             cfs_canister_id,
-            supported_credentials,
             ic_root_key_raw: Some(ic_root_key_raw),
             derivation_origin,
             ii_canister_id,

--- a/src/shared/src/types/backend_config.rs
+++ b/src/shared/src/types/backend_config.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use candid::{CandidType, Deserialize, Principal};
 
-
 #[derive(CandidType, Deserialize)]
 pub struct InitArg {
     pub ecdsa_key_name: String,

--- a/src/shared/src/types/backend_config.rs
+++ b/src/shared/src/types/backend_config.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use candid::{CandidType, Deserialize, Principal};
 
-use crate::types::verifiable_credential::SupportedCredential;
 
 #[derive(CandidType, Deserialize)]
 pub struct InitArg {
@@ -10,7 +9,6 @@ pub struct InitArg {
     /// A list of allowed callers to restrict access to endpoints that do not particularly check or
     /// use the `msg_caller()`
     pub allowed_callers: Vec<Principal>,
-    pub supported_credentials: Option<Vec<SupportedCredential>>,
     /// Root of trust for checking canister signatures.
     pub ic_root_key_der: Option<Vec<u8>>,
     /// Chain Fusion Signer canister id. Used to derive the bitcoin address in
@@ -35,7 +33,6 @@ pub struct Config {
     /// A list of allowed callers to restrict access to endpoints that do not particularly check or
     /// use the `msg_caller()`
     pub allowed_callers: Vec<Principal>,
-    pub supported_credentials: Option<Vec<SupportedCredential>>,
     /// Root of trust for checking canister signatures.
     pub ic_root_key_raw: Option<Vec<u8>>,
     /// Chain Fusion Signer canister id. Used to derive the bitcoin address in


### PR DESCRIPTION
# Motivation

The configuration param `supported_credentials` is not used anymore, so we can remove it.

BREAKING CHANGE: Removing `supported_credentials` from arguments.
