### PR TITLE
chore(signer): Decouple signer and legacy signer versioning

### DIFF
--- a/.github/workflows/bump-legacy-signer-version.yml
+++ b/.github/workflows/bump-legacy-signer-version.yml
@@ -3,10 +3,15 @@ name: Legacy Signer Version Bump
 on:
   workflow_dispatch:
     inputs:
-      new_version:
-        description: 'New version for legacy_signer_frontend (e.g. 1.0.1)'
+      version_bump:
+        description: 'Version bump type (major, minor, patch)'
         required: true
-        type: string
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 
 permissions: {}
 
@@ -38,15 +43,22 @@ jobs:
         run: |
           node -e "
             const fs = require('fs');
+            const semver = require('semver');
             const path = 'signer-versions.json';
             const data = JSON.parse(fs.readFileSync(path, 'utf8'));
-            data.legacy_signer_frontend = process.env.NEW_VERSION;
+            const bumped = semver.inc(data.legacy_signer_frontend, process.env.VERSION_BUMP);
+            if (!bumped) {
+              console.error('Failed to bump version');
+              process.exit(1);
+            }
+            data.legacy_signer_frontend = bumped;
             fs.writeFileSync(path, JSON.stringify(data, null, '\t') + '\n');
+            console.log('Bumped legacy signer to version: ' + bumped);
           "
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Bumped legacy signer to version: $NEW_VERSION"
+          new_version=$(node -p "require('./signer-versions.json').legacy_signer_frontend")
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
         env:
-          NEW_VERSION: ${{ github.event.inputs.new_version }}
+          VERSION_BUMP: ${{ github.event.inputs.version_bump }}
 
       - name: Create Pull Request
         uses: ./.github/actions/create-pr

--- a/.github/workflows/bump-legacy-signer-version.yml
+++ b/.github/workflows/bump-legacy-signer-version.yml
@@ -1,0 +1,58 @@
+name: Legacy Signer Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_version:
+        description: 'New version for legacy_signer_frontend (e.g. 1.0.1)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  bump_legacy_signer_version:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Prepare
+        uses: ./.github/actions/prepare
+
+      - name: Bump legacy signer version
+        id: bump_version
+        run: |
+          node -e "
+            const fs = require('fs');
+            const path = 'signer-versions.json';
+            const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+            data.legacy_signer_frontend = process.env.NEW_VERSION;
+            fs.writeFileSync(path, JSON.stringify(data, null, '\t') + '\n');
+          "
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Bumped legacy signer to version: $NEW_VERSION"
+        env:
+          NEW_VERSION: ${{ github.event.inputs.new_version }}
+
+      - name: Create Pull Request
+        uses: ./.github/actions/create-pr
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: 'chore(release)/legacy-signer-v${{ steps.bump_version.outputs.new_version }}'
+          title: 'chore(release): legacy signer v${{ steps.bump_version.outputs.new_version }}'
+          body: |
+            This PR bumps the legacy signer frontend version to v${{ steps.bump_version.outputs.new_version }}.

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - v*
+      - legacy-signer/v*
   workflow_dispatch:
     inputs:
       network:
@@ -128,6 +129,7 @@ on:
 run-name: >-
   ${{
     github.event_name == 'push' && github.ref_type == 'branch' && 'Deploying Frontend / Backend to Staging'
+    || github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/legacy-signer/') && format('Deploying Legacy Signer Frontend to Beta ({0})', github.ref_name)
     || github.event_name == 'push' && github.ref_type == 'tag' && 'Deploying Frontend / Backend to Beta'
     || github.event.inputs.canister == 'backend' && github.event.inputs.force-backend == 'true' && format('Deploying {0} to {1} and force backend = {2}', inputs.canister, inputs.network, inputs.force-backend)
     || format('Deploying {0} to {1}', inputs.canister, inputs.network) }}
@@ -169,16 +171,25 @@ jobs:
           elif [ "${{ github.event_name }}" == "push" ]; then
             if [ "$REF_TYPE" == "branch" ]; then
               echo "NETWORK=staging" >> $GITHUB_ENV
+              echo "CANISTER=frontend" >> $GITHUB_ENV
+              echo "deploy_frontend=true" >> $GITHUB_ENV
+              echo "deploy_backend=true" >> $GITHUB_ENV
+              echo "deploy_all_signers=true" >> $GITHUB_ENV
             elif [ "$REF_TYPE" == "tag" ]; then
               echo "NETWORK=beta" >> $GITHUB_ENV
+              if [[ "${{ github.ref }}" == refs/tags/legacy-signer/* ]]; then
+                echo "CANISTER=legacy_signer_frontend" >> $GITHUB_ENV
+                echo "deploy_signer=true" >> $GITHUB_ENV
+              else
+                echo "CANISTER=frontend" >> $GITHUB_ENV
+                echo "deploy_frontend=true" >> $GITHUB_ENV
+                echo "deploy_backend=true" >> $GITHUB_ENV
+                echo "deploy_all_signers=true" >> $GITHUB_ENV
+              fi
             else
               echo "Error: Unsupported ref type."
               exit 1
             fi
-            echo "CANISTER=frontend" >> $GITHUB_ENV
-            echo "deploy_frontend=true" >> $GITHUB_ENV
-            echo "deploy_backend=true" >> $GITHUB_ENV
-            echo "deploy_all_signers=true" >> $GITHUB_ENV
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "NETWORK=$NETWORK" >> $GITHUB_ENV
             echo "CANISTER=$CANISTER" >> $GITHUB_ENV

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -177,7 +177,7 @@ jobs:
               echo "deploy_all_signers=true" >> $GITHUB_ENV
             elif [ "$REF_TYPE" == "tag" ]; then
               echo "NETWORK=beta" >> $GITHUB_ENV
-              if [[ "${{ github.ref }}" == refs/tags/legacy-signer/* ]]; then
+              if [[ "$GIT_REF" == refs/tags/legacy-signer/* ]]; then
                 echo "CANISTER=legacy_signer_frontend" >> $GITHUB_ENV
                 echo "deploy_signer=true" >> $GITHUB_ENV
               else
@@ -207,6 +207,7 @@ jobs:
             exit 1
           fi
         env:
+          GIT_REF: ${{ github.ref }}
           REF_TYPE: ${{ github.ref_type }}
           NETWORK: ${{ github.event.inputs.network }}
           CANISTER: ${{ github.event.inputs.canister }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,7 +6,6 @@ on:
   push:
     tags:
       - v*
-      - legacy-signer/v*
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - v*
+      - legacy-signer/v*
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/tag-legacy-signer-release.yml
+++ b/.github/workflows/tag-legacy-signer-release.yml
@@ -1,0 +1,113 @@
+name: Tag on Merge from Legacy Signer Release Branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore(release)/legacy-signer-v')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Prepare
+        uses: ./.github/actions/prepare
+
+      - name: Get version from signer-versions.json
+        id: get_version
+        run: |
+          version=$(node -p "require('./signer-versions.json').legacy_signer_frontend")
+          echo "Version from signer-versions.json: $version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Set git remote silently and locally
+        shell: bash
+        run: |
+          git config url."https://github-actions:$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Create Git tag
+        run: |
+          git tag "legacy-signer/v$VERSION"
+          git push origin "legacy-signer/v$VERSION"
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+
+      - name: Unset local git remote config
+        shell: bash
+        run: |
+          git config --unset-all url."https://github-actions:${GITHUB_TOKEN}@github.com/".insteadOf || true
+          git config --unset-all url."https://github.com/".insteadOf || true
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Publish Release Notes
+        uses: ./.github/actions/release-notes
+        with:
+          tag: 'legacy-signer/v${{ steps.get_version.outputs.version }}'
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+  call-deploy:
+    needs: release
+    if: needs.release.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/deploy-to-environment.yml
+    with:
+      network: beta
+      canister: legacy_signer_frontend
+    secrets:
+      VITE_ETHERSCAN_API_KEY_STAGING: ${{ secrets.VITE_ETHERSCAN_API_KEY_STAGING }}
+      VITE_INFURA_API_KEY_STAGING: ${{ secrets.VITE_INFURA_API_KEY_STAGING }}
+      VITE_ALCHEMY_API_KEY_STAGING: ${{ secrets.VITE_ALCHEMY_API_KEY_STAGING }}
+      VITE_ALCHEMY_API_KEY_TEST_FE: ${{ secrets.VITE_ALCHEMY_API_KEY_TEST_FE }}
+      VITE_QUICKNODE_API_KEY_STAGING: ${{ secrets.VITE_QUICKNODE_API_KEY_STAGING }}
+      VITE_WALLET_CONNECT_PROJECT_ID_STAGING: ${{ secrets.VITE_WALLET_CONNECT_PROJECT_ID_STAGING }}
+      VITE_COINGECKO_API_KEY_STAGING: ${{ secrets.VITE_COINGECKO_API_KEY_STAGING }}
+      VITE_POUH_ENABLED_STAGING: ${{ secrets.VITE_POUH_ENABLED_STAGING }}
+      VITE_PLAUSIBLE_ENABLED_STAGING: ${{ secrets.VITE_PLAUSIBLE_ENABLED_STAGING }}
+      VITE_EARNING_ENABLED_STAGING: ${{ secrets.VITE_EARNING_ENABLED_STAGING }}
+      VITE_AI_ASSISTANT_CONSOLE_ENABLED_STAGING: ${{ secrets.VITE_AI_ASSISTANT_CONSOLE_ENABLED_STAGING }}
+      VITE_UNIVERSAL_SCANNER_ENABLED_STAGING: ${{ secrets.VITE_UNIVERSAL_SCANNER_ENABLED_STAGING }}
+      VITE_OCP_PAY_WITH_BTC_ENABLED_STAGING: ${{ secrets.VITE_OCP_PAY_WITH_BTC_ENABLED_STAGING }}
+      VITE_ONRAMPER_API_KEY_DEV_STAGING: ${{ secrets.VITE_ONRAMPER_API_KEY_DEV_STAGING }}
+      VITE_ONRAMPER_API_KEY_PROD_STAGING: ${{ secrets.VITE_ONRAMPER_API_KEY_PROD_STAGING }}
+      VITE_AUTH_ALTERNATIVE_ORIGINS_STAGING: ${{ secrets.VITE_AUTH_ALTERNATIVE_ORIGINS_STAGING }}
+      DFX_DEPLOY_KEY_STAGING: ${{ secrets.DFX_DEPLOY_KEY_STAGING }}
+
+      VITE_ETHERSCAN_API_KEY_BETA: ${{ secrets.VITE_ETHERSCAN_API_KEY_BETA }}
+      VITE_INFURA_API_KEY_BETA: ${{ secrets.VITE_INFURA_API_KEY_BETA }}
+      VITE_ALCHEMY_API_KEY_BETA: ${{ secrets.VITE_ALCHEMY_API_KEY_BETA }}
+      VITE_QUICKNODE_API_KEY_BETA: ${{ secrets.VITE_QUICKNODE_API_KEY_BETA }}
+      VITE_WALLET_CONNECT_PROJECT_ID_BETA: ${{ secrets.VITE_WALLET_CONNECT_PROJECT_ID_BETA }}
+      VITE_COINGECKO_API_KEY_BETA: ${{ secrets.VITE_COINGECKO_API_KEY_BETA }}
+      VITE_POUH_ENABLED_BETA: ${{ secrets.VITE_POUH_ENABLED_BETA }}
+      VITE_AUTH_ALTERNATIVE_ORIGINS_BETA: ${{ secrets.VITE_AUTH_ALTERNATIVE_ORIGINS_BETA }}
+      VITE_ONRAMPER_API_KEY_DEV_BETA: ${{ secrets.VITE_ONRAMPER_API_KEY_DEV_BETA }}
+      VITE_PLAUSIBLE_ENABLED_BETA: ${{ secrets.VITE_PLAUSIBLE_ENABLED_BETA }}
+      VITE_EARNING_ENABLED_BETA: ${{ secrets.VITE_EARNING_ENABLED_BETA }}
+      VITE_AI_ASSISTANT_CONSOLE_ENABLED_BETA: ${{ secrets.VITE_AI_ASSISTANT_CONSOLE_ENABLED_BETA }}
+      VITE_UNIVERSAL_SCANNER_ENABLED_BETA: ${{ secrets.VITE_UNIVERSAL_SCANNER_ENABLED_BETA }}
+      VITE_OCP_PAY_WITH_BTC_ENABLED_BETA: ${{ secrets.VITE_OCP_PAY_WITH_BTC_ENABLED_BETA }}
+      VITE_ONRAMPER_API_KEY_PROD_BETA: ${{ secrets.VITE_ONRAMPER_API_KEY_PROD_BETA }}
+      DFX_DEPLOY_KEY_BETA: ${{ secrets.DFX_DEPLOY_KEY_BETA }}

--- a/.github/workflows/tag-legacy-signer-release.yml
+++ b/.github/workflows/tag-legacy-signer-release.yml
@@ -60,13 +60,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Publish Release Notes
-        uses: ./.github/actions/release-notes
-        with:
-          tag: 'legacy-signer/v${{ steps.get_version.outputs.version }}'
-          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-
   call-deploy:
     needs: release
     if: needs.release.result == 'success'

--- a/SIGNER_DOMAINS.md
+++ b/SIGNER_DOMAINS.md
@@ -97,7 +97,7 @@ The **legacy signer** (`legacy_signer_frontend`) has its own independent version
 
 ```json
 {
-	"legacy_signer_frontend": "1.0.0"
+	"legacy_signer_frontend": "1.2.3"
 }
 ```
 
@@ -127,7 +127,7 @@ The slash-scoped format keeps tags filterable (`git tag -l 'legacy-signer/*'`) a
 | PR branch         | `chore(release)/v2.0.3`                                         | `chore(release)/legacy-signer-v1.0.1`                           |
 | Auto-tag on merge | `tag-release.yml` → `v2.0.3`                                    | `tag-legacy-signer-release.yml` → `legacy-signer/v1.0.1`        |
 | Beta deploy       | `deploy-to-environment.yml` (all canisters)                     | `deploy-to-environment.yml` (`legacy_signer_frontend` only)     |
-| Release notes     | `release-notes.yml` on `v*` push                                | `release-notes.yml` on `legacy-signer/v*` push                  |
+| Release notes     | `release-notes.yml` on `v*` push                                | N/A                                                             |
 | Production (IC)   | Orbit workflow                                                  | Orbit workflow                                                  |
 
 ### Canister definitions

--- a/SIGNER_DOMAINS.md
+++ b/SIGNER_DOMAINS.md
@@ -112,23 +112,23 @@ This means:
 
 Git tags use a scoped prefix to distinguish releases:
 
-| Target                    | Tag format              | Example                 |
-| ------------------------- | ----------------------- | ----------------------- |
-| Main OISY + Signer        | `v<semver>`             | `v2.0.3`                |
-| Legacy Signer              | `legacy-signer/v<semver>` | `legacy-signer/v1.0.1` |
+| Target             | Tag format                | Example                |
+| ------------------ | ------------------------- | ---------------------- |
+| Main OISY + Signer | `v<semver>`               | `v2.0.3`               |
+| Legacy Signer      | `legacy-signer/v<semver>` | `legacy-signer/v1.0.1` |
 
 The slash-scoped format keeps tags filterable (`git tag -l 'legacy-signer/*'`) and avoids collisions with the main `v*` tags.
 
 **Release pipelines:**
 
-| Step | Main OISY + Signer | Legacy Signer |
-| ---- | ------------------- | ------------- |
-| Version bump | _Version Bump and Release Branch Creation_ (`bump-version.yml`) | _Legacy Signer Version Bump_ (`bump-legacy-signer-version.yml`) |
-| PR branch | `chore(release)/v2.0.3` | `chore(release)/legacy-signer-v1.0.1` |
-| Auto-tag on merge | `tag-release.yml` → `v2.0.3` | `tag-legacy-signer-release.yml` → `legacy-signer/v1.0.1` |
-| Beta deploy | `deploy-to-environment.yml` (all canisters) | `deploy-to-environment.yml` (`legacy_signer_frontend` only) |
-| Release notes | `release-notes.yml` on `v*` push | `release-notes.yml` on `legacy-signer/v*` push |
-| Production (IC) | Orbit workflow | Orbit workflow |
+| Step              | Main OISY + Signer                                              | Legacy Signer                                                   |
+| ----------------- | --------------------------------------------------------------- | --------------------------------------------------------------- |
+| Version bump      | _Version Bump and Release Branch Creation_ (`bump-version.yml`) | _Legacy Signer Version Bump_ (`bump-legacy-signer-version.yml`) |
+| PR branch         | `chore(release)/v2.0.3`                                         | `chore(release)/legacy-signer-v1.0.1`                           |
+| Auto-tag on merge | `tag-release.yml` → `v2.0.3`                                    | `tag-legacy-signer-release.yml` → `legacy-signer/v1.0.1`        |
+| Beta deploy       | `deploy-to-environment.yml` (all canisters)                     | `deploy-to-environment.yml` (`legacy_signer_frontend` only)     |
+| Release notes     | `release-notes.yml` on `v*` push                                | `release-notes.yml` on `legacy-signer/v*` push                  |
+| Production (IC)   | Orbit workflow                                                  | Orbit workflow                                                  |
 
 ### Canister definitions
 
@@ -185,4 +185,4 @@ Each signer domain reports to Plausible under its own domain name. This means yo
 | `src/frontend/src/lib/constants/app.constants.ts`      | `SIGNER_TARGET`, `IS_SIGNER_DOMAIN`, derivation origin  |
 | `src/frontend/src/env/plausible.env.ts`                | Plausible domain per signer target                      |
 | `.env.production` / `.env.staging` / `.env.beta`       | `VITE_AUTH_ALTERNATIVE_ORIGINS` with signer domains     |
-| `.github/workflows/bump-legacy-signer-version.yml`    | Workflow to independently bump legacy signer version    |
+| `.github/workflows/bump-legacy-signer-version.yml`     | Workflow to independently bump legacy signer version    |

--- a/SIGNER_DOMAINS.md
+++ b/SIGNER_DOMAINS.md
@@ -93,13 +93,7 @@ When set, this env var affects the build in several ways:
 
 The **signer** (`signer_frontend`) shares the same version as the main OISY wallet, read from `package.json`. It is released, deployed, and versioned hand-in-hand with OISY.
 
-The **legacy signer** (`legacy_signer_frontend`) has its own independent version, stored in `signer-versions.json`:
-
-```json
-{
-	"legacy_signer_frontend": "1.2.3"
-}
-```
+The **legacy signer** (`legacy_signer_frontend`) has its own independent version, stored in `signer-versions.json`.
 
 When `OISY_SIGNER_TARGET=legacy_signer` is set, both `vite.utils.ts` and `svelte.config.js` read the version from `signer-versions.json`. For all other targets (including `signer`), the version falls through to `package.json`.
 

--- a/SIGNER_DOMAINS.md
+++ b/SIGNER_DOMAINS.md
@@ -80,7 +80,7 @@ When set, this env var affects the build in several ways:
 | Aspect                   | Default (unset)     | `signer`                     | `legacy_signer`                  |
 | ------------------------ | ------------------- | ---------------------------- | -------------------------------- |
 | `VITE_OISY_DOMAIN`       | `https://oisy.com`  | `https://signer.oisy.com`    | `https://legacy-signer.oisy.com` |
-| `VITE_APP_VERSION`       | from `package.json` | from `signer-versions.json`  | from `signer-versions.json`      |
+| `VITE_APP_VERSION`       | from `package.json` | from `package.json`          | from `signer-versions.json`      |
 | `.well-known/ic-domains` | `oisy.com`          | `signer.oisy.com`            | `legacy-signer.oisy.com`         |
 | `AUTH_DERIVATION_ORIGIN` | (varies)            | Canonical origin \*          | Canonical origin \*              |
 | Plausible domain         | `oisy.com`          | `signer.oisy.com`            | `legacy-signer.oisy.com`         |
@@ -91,16 +91,44 @@ When set, this env var affects the build in several ways:
 
 ### Versioning
 
-The signer frontends have their own version numbers, independent of the main wallet's `package.json` version. These are stored in `signer-versions.json`:
+The **signer** (`signer_frontend`) shares the same version as the main OISY wallet, read from `package.json`. It is released, deployed, and versioned hand-in-hand with OISY.
+
+The **legacy signer** (`legacy_signer_frontend`) has its own independent version, stored in `signer-versions.json`:
 
 ```json
 {
-	"signer_frontend": "1.0.0",
 	"legacy_signer_frontend": "1.0.0"
 }
 ```
 
-When `OISY_SIGNER_TARGET` is set, both `vite.utils.ts` and `svelte.config.js` read the version from this file instead of `package.json`. This allows each signer to be released independently -- particularly important when `legacy-signer` is frozen at v4 while `signer` advances with v5.
+When `OISY_SIGNER_TARGET=legacy_signer` is set, both `vite.utils.ts` and `svelte.config.js` read the version from `signer-versions.json`. For all other targets (including `signer`), the version falls through to `package.json`.
+
+This means:
+
+- **Signer** version advances automatically whenever the OISY wallet version is bumped (via the existing _Version Bump and Release Branch Creation_ workflow).
+- **Legacy signer** version is bumped independently via the _Legacy Signer Version Bump_ workflow. At some point the legacy signer will be frozen to a snapshot of `main` and only receive hotfixes.
+
+### Tagging convention
+
+Git tags use a scoped prefix to distinguish releases:
+
+| Target                    | Tag format              | Example                 |
+| ------------------------- | ----------------------- | ----------------------- |
+| Main OISY + Signer        | `v<semver>`             | `v2.0.3`                |
+| Legacy Signer              | `legacy-signer/v<semver>` | `legacy-signer/v1.0.1` |
+
+The slash-scoped format keeps tags filterable (`git tag -l 'legacy-signer/*'`) and avoids collisions with the main `v*` tags.
+
+**Release pipelines:**
+
+| Step | Main OISY + Signer | Legacy Signer |
+| ---- | ------------------- | ------------- |
+| Version bump | _Version Bump and Release Branch Creation_ (`bump-version.yml`) | _Legacy Signer Version Bump_ (`bump-legacy-signer-version.yml`) |
+| PR branch | `chore(release)/v2.0.3` | `chore(release)/legacy-signer-v1.0.1` |
+| Auto-tag on merge | `tag-release.yml` → `v2.0.3` | `tag-legacy-signer-release.yml` → `legacy-signer/v1.0.1` |
+| Beta deploy | `deploy-to-environment.yml` (all canisters) | `deploy-to-environment.yml` (`legacy_signer_frontend` only) |
+| Release notes | `release-notes.yml` on `v*` push | `release-notes.yml` on `legacy-signer/v*` push |
+| Production (IC) | Orbit workflow | Orbit workflow |
 
 ### Canister definitions
 
@@ -143,7 +171,7 @@ Each signer domain reports to Plausible under its own domain name. This means yo
 
 | File                                                   | Purpose                                                 |
 | ------------------------------------------------------ | ------------------------------------------------------- |
-| `signer-versions.json`                                 | Independent version numbers for signer frontends        |
+| `signer-versions.json`                                 | Independent version number for legacy signer frontend   |
 | `scripts/domains.json`                                 | Domain-to-URL mapping per canister + network            |
 | `dfx.json`                                             | Canister definitions and network config                 |
 | `canister_ids.json`                                    | Canister IDs per network                                |
@@ -157,3 +185,4 @@ Each signer domain reports to Plausible under its own domain name. This means yo
 | `src/frontend/src/lib/constants/app.constants.ts`      | `SIGNER_TARGET`, `IS_SIGNER_DOMAIN`, derivation origin  |
 | `src/frontend/src/env/plausible.env.ts`                | Plausible domain per signer target                      |
 | `.env.production` / `.env.staging` / `.env.beta`       | `VITE_AUTH_ALTERNATIVE_ORIGINS` with signer domains     |
+| `.github/workflows/bump-legacy-signer-version.yml`    | Workflow to independently bump legacy signer version    |

--- a/signer-versions.json
+++ b/signer-versions.json
@@ -1,4 +1,3 @@
 {
-	"signer_frontend": "1.0.0",
 	"legacy_signer_frontend": "1.0.0"
 }

--- a/signer-versions.json
+++ b/signer-versions.json
@@ -1,3 +1,3 @@
 {
-	"legacy_signer_frontend": "1.0.0"
+	"legacy_signer_frontend": "2.0.2"
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,17 +12,11 @@ const signerVersionsFile = fileURLToPath(new URL('signer-versions.json', import.
 
 const signerVersions = JSON.parse(readFileSync(signerVersionsFile, 'utf8'));
 
-const SIGNER_TARGET_TO_KEY = {
-	signer: 'signer_frontend',
-	legacy_signer: 'legacy_signer_frontend'
-};
-
 const signerTarget = process.env.OISY_SIGNER_TARGET;
 
-const signerKey = notEmptyString(signerTarget) ? SIGNER_TARGET_TO_KEY[signerTarget] : undefined;
-
 const version =
-	(notEmptyString(signerKey) ? signerVersions[signerKey] : undefined) ?? packageVersion;
+	(signerTarget === 'legacy_signer' ? signerVersions['legacy_signer_frontend'] : undefined) ??
+	packageVersion;
 
 const filesPath = (/** @type {string} */ path) => `src/frontend/${path}`;
 

--- a/vite.utils.ts
+++ b/vite.utils.ts
@@ -138,11 +138,9 @@ export const defineViteReplacements = (): {
 	const network = process.env.DFX_NETWORK ?? 'local';
 
 	const signerTarget = process.env.OISY_SIGNER_TARGET;
-	const signerCanisterKey =
-		signerTarget && signerTarget in SIGNER_TARGET_MAP ? SIGNER_TARGET_MAP[signerTarget] : undefined;
 
 	const version =
-		(signerCanisterKey && (SIGNER_VERSIONS as Record<string, string>)[signerCanisterKey]) ??
+		(signerTarget === 'legacy_signer' ? SIGNER_VERSIONS['legacy_signer_frontend'] : undefined) ??
 		packageVersion;
 
 	const isTestFe = network.startsWith('test_fe_');


### PR DESCRIPTION
# Motivation

The signer and legacy signer frontends currently share the same versioning mechanism (`signer-versions.json`), but their lifecycles are diverging. The signer (`signer_frontend`) should be released, deployed, and versioned hand-in-hand with the main OISY wallet, while the legacy signer (`legacy_signer_frontend`) needs its own independent version (it will eventually be frozen to a snapshot and only receive hotfixes).

# Changes

- Removed the `signer_frontend` key from `signer-versions.json`. Only `legacy_signer_frontend` remains with its own independent version.
- Version resolution now explicitly checks for `legacy_signer` target. Only `OISY_SIGNER_TARGET=legacy_signer` reads from `signer-versions.json`; all other targets (including `signer`) fall through to `package.json`.
- Added `legacy-signer/v*` tag trigger. A `legacy-signer/v*` tag push deploys only `legacy_signer_frontend` to beta (instead of the full stack). Updated `run-name` for clarity.
- Added `legacy-signer/v*` tag trigger so release notes are generated for legacy signer releases.
- New `bump-legacy-signer-version.yml`: `workflow_dispatch` workflow to independently bump the legacy signer version in `signer-versions.json` and create a release PR.
- New `tag-legacy-signer-release.yml`: auto-tags `legacy-signer/v<version>` when a legacy signer release PR is merged, publishes release notes, and triggers a beta deploy of `legacy_signer_frontend`.
- Updated versioning section in documentation, added tagging convention documentation, and a release pipeline comparison table.

# Tests

Current tests and checks must work. Plus the new workflows run smoothly.
