### PR TITLE
feat(frontend): Resolve possible contact in IC transactions

### DIFF
--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -1,4 +1,5 @@
 import type { Contact } from '$declarations/backend/backend.did';
+import { tryToParseIcrcAccountStringToAccountIdentifierText } from '$icp/utils/icp-account.utils';
 import { TokenAccountIdSchema } from '$lib/schema/token-account-id.schema';
 import type { Address, OptionAddress } from '$lib/types/address';
 import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
@@ -9,7 +10,15 @@ import {
 	getDiscriminatorForTokenAccountId,
 	getTokenAccountIdAddressString
 } from '$lib/utils/token-account-id.utils';
-import { fromNullable, isEmptyString, isNullish, notEmptyString, toNullable } from '@dfinity/utils';
+import {
+	fromNullable,
+	isEmptyString,
+	isNullish,
+	nonNullish,
+	notEmptyString,
+	toNullable
+} from '@dfinity/utils';
+import { isIcpAccountIdentifier } from '@icp-sdk/canisters/ledger/icp';
 
 export const selectColorForName = <T>({
 	colors,
@@ -111,20 +120,56 @@ export const isContactMatchingFilter = ({
 				}) && label?.toLowerCase().includes(filterValue.toLowerCase())
 		));
 
+/**
+ * Normalises an ICP address (hex account identifier or ICRC principal) to its
+ * canonical hex account identifier form. Returns undefined for non-ICP addresses.
+ */
+const normalizeToIcpAccountIdentifierHex = (address: string): string | undefined => {
+	const derived = tryToParseIcrcAccountStringToAccountIdentifierText(address);
+
+	if (nonNullish(derived)) {
+		return derived.toLowerCase();
+	}
+
+	if (isIcpAccountIdentifier(address)) {
+		return address.toLowerCase();
+	}
+};
+
 export const filterAddressFromContact = <T extends Address>({
 	contact,
 	address: filterAddress
 }: {
 	contact: ContactUi | undefined;
 	address: OptionAddress<T>;
-}): ContactAddressUi | undefined =>
-	contact?.addresses.find(({ address, addressType }) =>
+}): ContactAddressUi | undefined => {
+	if (isNullish(contact) || isNullish(filterAddress)) {
+		return;
+	}
+
+	const directMatch = contact.addresses.find(({ address, addressType }) =>
 		areAddressesEqual({
 			address1: address,
 			address2: filterAddress,
 			addressType
 		})
 	);
+
+	if (nonNullish(directMatch)) {
+		return directMatch;
+	}
+
+	const normalizedInput = normalizeToIcpAccountIdentifierHex(filterAddress);
+
+	if (isNullish(normalizedInput)) {
+		return;
+	}
+
+	return contact.addresses.find(
+		({ addressType, address }) =>
+			addressType === 'Icrcv2' && normalizeToIcpAccountIdentifierHex(address) === normalizedInput
+	);
+};
 
 export const getNetworkContactKey = ({
 	contact,

--- a/src/frontend/src/lib/utils/contact.utils.ts
+++ b/src/frontend/src/lib/utils/contact.utils.ts
@@ -121,18 +121,19 @@ export const isContactMatchingFilter = ({
 		));
 
 /**
- * Normalises an ICP address (hex account identifier or ICRC principal) to its
- * canonical hex account identifier form. Returns undefined for non-ICP addresses.
+ * Normalises an ICP address (hex account identifier or ICRC-1 account string,
+ * i.e. principal text with an optional subaccount) to its canonical lowercase
+ * hex account identifier form. Returns undefined for non-ICP addresses.
  */
 const normalizeToIcpAccountIdentifierHex = (address: string): string | undefined => {
+	if (isIcpAccountIdentifier(address)) {
+		return address.toLowerCase();
+	}
+
 	const derived = tryToParseIcrcAccountStringToAccountIdentifierText(address);
 
 	if (nonNullish(derived)) {
 		return derived.toLowerCase();
-	}
-
-	if (isIcpAccountIdentifier(address)) {
-		return address.toLowerCase();
 	}
 };
 

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -1,4 +1,5 @@
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ZERO } from '$lib/constants/app.constants';
 import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
 import type { NonEmptyArray } from '$lib/types/utils';
 import {
@@ -26,7 +27,6 @@ import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { fromNullable } from '@dfinity/utils';
 import { AccountIdentifier } from '@icp-sdk/canisters/ledger/icp';
 import { Principal } from '@icp-sdk/core/principal';
-import { ZERO } from '$lib/constants/app.constants';
 
 const mockPrincipal = Principal.fromText(mockPrincipalText);
 const mockDerivedAccountIdentifierHex = AccountIdentifier.fromPrincipal({

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -24,6 +24,14 @@ import { mockEthAddress, mockEthAddress3 } from '$tests/mocks/eth.mock';
 import { mockPrincipalText } from '$tests/mocks/identity.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { fromNullable } from '@dfinity/utils';
+import { AccountIdentifier } from '@icp-sdk/canisters/ledger/icp';
+import { Principal } from '@icp-sdk/core/principal';
+
+const mockPrincipal = Principal.fromText(mockPrincipalText);
+const mockDerivedAccountIdentifierHex = AccountIdentifier.fromPrincipal({
+	principal: mockPrincipal,
+	subAccount: undefined
+}).toHex();
 
 describe('contact.utils', () => {
 	describe('selectColorForName', () => {
@@ -195,6 +203,110 @@ describe('contact.utils', () => {
 			});
 
 			expect(result?.addresses?.[0]?.address).not.toEqual(mockEthAddress3);
+		});
+
+		describe('ICP account derivation fallback', () => {
+			const principalAddress: ContactAddressUi = {
+				address: mockPrincipalText,
+				addressType: 'Icrcv2'
+			};
+
+			const hexAccountAddress: ContactAddressUi = {
+				address: mockDerivedAccountIdentifierHex,
+				addressType: 'Icrcv2'
+			};
+
+			it('should find contact by hex account ID when contact has only a principal', () => {
+				const contactWithPrincipal: ContactUi = {
+					name: 'Principal Only',
+					id: BigInt(10),
+					updateTimestampNs: 0n,
+					addresses: [principalAddress]
+				};
+
+				const result = getContactForAddress({
+					addressString: mockDerivedAccountIdentifierHex,
+					contactList: [contactWithPrincipal]
+				});
+
+				expect(result?.name).toBe('Principal Only');
+			});
+
+			it('should find contact by principal when contact has only a hex account ID', () => {
+				const contactWithHex: ContactUi = {
+					name: 'Hex Only',
+					id: BigInt(11),
+					updateTimestampNs: 0n,
+					addresses: [hexAccountAddress]
+				};
+
+				const result = getContactForAddress({
+					addressString: mockPrincipalText,
+					contactList: [contactWithHex]
+				});
+
+				expect(result?.name).toBe('Hex Only');
+			});
+
+			it('should prefer direct match over derivation fallback', () => {
+				const contactWithExactHex: ContactUi = {
+					name: 'Exact Match',
+					id: BigInt(12),
+					updateTimestampNs: 0n,
+					addresses: [hexAccountAddress]
+				};
+
+				const contactWithPrincipal: ContactUi = {
+					name: 'Derived Match',
+					id: BigInt(13),
+					updateTimestampNs: 0n,
+					addresses: [principalAddress]
+				};
+
+				const result = getContactForAddress({
+					addressString: mockDerivedAccountIdentifierHex,
+					contactList: [contactWithExactHex, contactWithPrincipal]
+				});
+
+				expect(result?.name).toBe('Exact Match');
+			});
+
+			it('should not match non-ICP addresses through derivation', () => {
+				const contactWithBtc: ContactUi = {
+					name: 'BTC Contact',
+					id: BigInt(14),
+					updateTimestampNs: 0n,
+					addresses: [
+						{
+							address: mockBtcAddress,
+							addressType: 'Btc'
+						}
+					]
+				};
+
+				const result = getContactForAddress({
+					addressString: mockDerivedAccountIdentifierHex,
+					contactList: [contactWithBtc]
+				});
+
+				expect(result).toBeUndefined();
+			});
+
+			it('should handle case-insensitive hex comparison in derivation', () => {
+				const contactWithPrincipal: ContactUi = {
+					name: 'Case Test',
+					id: BigInt(15),
+					updateTimestampNs: 0n,
+					addresses: [principalAddress]
+				};
+
+				const result = getContactForAddress({
+					addressString: mockDerivedAccountIdentifierHex.toUpperCase(),
+					contactList: [contactWithPrincipal]
+				});
+
+				expect(result?.name).toBe('Case Test');
+			});
 		});
 	});
 
@@ -379,6 +491,87 @@ describe('contact.utils', () => {
 			expect(
 				filterAddressFromContact({ contact: mockContact, address: mockSolAddress.toUpperCase() })
 			).toBeUndefined();
+		});
+
+		describe('ICP account derivation fallback', () => {
+			const principalAddress: ContactAddressUi = {
+				address: mockPrincipalText,
+				addressType: 'Icrcv2'
+			};
+
+			const hexAccountAddress: ContactAddressUi = {
+				address: mockDerivedAccountIdentifierHex,
+				addressType: 'Icrcv2'
+			};
+
+			it('should match hex input to principal contact address via derivation', () => {
+				const contact: ContactUi = {
+					name: 'Test',
+					id: BigInt(20),
+					updateTimestampNs: 0n,
+					addresses: [principalAddress]
+				};
+
+				const result = filterAddressFromContact({
+					contact,
+					address: mockDerivedAccountIdentifierHex
+				});
+
+				expect(result).toStrictEqual(principalAddress);
+			});
+
+			it('should match principal input to hex contact address via derivation', () => {
+				const contact: ContactUi = {
+					name: 'Test',
+					id: BigInt(21),
+					updateTimestampNs: 0n,
+					addresses: [hexAccountAddress]
+				};
+
+				const result = filterAddressFromContact({
+					contact,
+					address: mockPrincipalText
+				});
+
+				expect(result).toStrictEqual(hexAccountAddress);
+			});
+
+			it('should prefer direct match over derivation', () => {
+				const contact: ContactUi = {
+					name: 'Test',
+					id: BigInt(22),
+					updateTimestampNs: 0n,
+					addresses: [hexAccountAddress, principalAddress]
+				};
+
+				const result = filterAddressFromContact({
+					contact,
+					address: mockDerivedAccountIdentifierHex
+				});
+
+				expect(result).toStrictEqual(hexAccountAddress);
+			});
+
+			it('should not apply derivation to non-Icrcv2 addresses', () => {
+				const contact: ContactUi = {
+					name: 'Test',
+					id: BigInt(23),
+					updateTimestampNs: 0n,
+					addresses: [
+						{
+							address: mockBtcAddress,
+							addressType: 'Btc'
+						}
+					]
+				};
+
+				const result = filterAddressFromContact({
+					contact,
+					address: mockDerivedAccountIdentifierHex
+				});
+
+				expect(result).toBeUndefined();
+			});
 		});
 	});
 

--- a/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/contact.utils.spec.ts
@@ -26,6 +26,7 @@ import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { fromNullable } from '@dfinity/utils';
 import { AccountIdentifier } from '@icp-sdk/canisters/ledger/icp';
 import { Principal } from '@icp-sdk/core/principal';
+import { ZERO } from '$lib/constants/app.constants';
 
 const mockPrincipal = Principal.fromText(mockPrincipalText);
 const mockDerivedAccountIdentifierHex = AccountIdentifier.fromPrincipal({
@@ -220,7 +221,7 @@ describe('contact.utils', () => {
 				const contactWithPrincipal: ContactUi = {
 					name: 'Principal Only',
 					id: BigInt(10),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [principalAddress]
 				};
 
@@ -236,7 +237,7 @@ describe('contact.utils', () => {
 				const contactWithHex: ContactUi = {
 					name: 'Hex Only',
 					id: BigInt(11),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [hexAccountAddress]
 				};
 
@@ -252,14 +253,14 @@ describe('contact.utils', () => {
 				const contactWithExactHex: ContactUi = {
 					name: 'Exact Match',
 					id: BigInt(12),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [hexAccountAddress]
 				};
 
 				const contactWithPrincipal: ContactUi = {
 					name: 'Derived Match',
 					id: BigInt(13),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [principalAddress]
 				};
 
@@ -275,7 +276,7 @@ describe('contact.utils', () => {
 				const contactWithBtc: ContactUi = {
 					name: 'BTC Contact',
 					id: BigInt(14),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [
 						{
 							address: mockBtcAddress,
@@ -296,7 +297,7 @@ describe('contact.utils', () => {
 				const contactWithPrincipal: ContactUi = {
 					name: 'Case Test',
 					id: BigInt(15),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [principalAddress]
 				};
 
@@ -508,7 +509,7 @@ describe('contact.utils', () => {
 				const contact: ContactUi = {
 					name: 'Test',
 					id: BigInt(20),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [principalAddress]
 				};
 
@@ -524,7 +525,7 @@ describe('contact.utils', () => {
 				const contact: ContactUi = {
 					name: 'Test',
 					id: BigInt(21),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [hexAccountAddress]
 				};
 
@@ -540,7 +541,7 @@ describe('contact.utils', () => {
 				const contact: ContactUi = {
 					name: 'Test',
 					id: BigInt(22),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [hexAccountAddress, principalAddress]
 				};
 
@@ -556,7 +557,7 @@ describe('contact.utils', () => {
 				const contact: ContactUi = {
 					name: 'Test',
 					id: BigInt(23),
-					updateTimestampNs: 0n,
+					updateTimestampNs: ZERO,
 					addresses: [
 						{
 							address: mockBtcAddress,


### PR DESCRIPTION
# Motivation

In the IC transactions we should always try to resolve in account against a saved principal, and viceversa.

So, if a user only saves the principal of a contact, it still sees such contact in the IC transactions that provide them as account ID.

# Changes

- We just reuse the existing `tryToParseIcrcAccountStringToAccountIdentifierText` util to normalize the IC addresses.

# Tests

Added tests and a practical one:

### Before

<img width="645" height="264" alt="Screenshot 2026-04-13 at 16 15 35" src="https://github.com/user-attachments/assets/1d489c20-2344-4ec7-be03-c4a07186f6be" />

### After

<img width="661" height="267" alt="Screenshot 2026-04-13 at 16 15 38" src="https://github.com/user-attachments/assets/e2687c5d-c237-40dc-9497-5668dfc77b4b" />

