### PR TITLE
feat(frontend): Auto-enable tokens when swapping new ones

### DIFF
--- a/src/frontend/src/eth/types/eip2612-permit.ts
+++ b/src/frontend/src/eth/types/eip2612-permit.ts
@@ -1,10 +1,10 @@
 import type { EthAddress } from '$eth/types/address';
-import type { Erc20Token } from '$eth/types/erc20';
+import type { ErcFungibleToken } from '$eth/types/erc-fungible';
 import type { Identity } from '@icp-sdk/core/agent';
 import type { Contract } from 'ethers/contract';
 
 export interface PermitParams {
-	token: Erc20Token;
+	token: ErcFungibleToken;
 	userAddress: EthAddress;
 	spender: string;
 	value: string;
@@ -48,7 +48,7 @@ export interface FetchPermitMetadataParams {
 }
 
 export interface CreateEIP2612TypedDataParams {
-	token: Erc20Token;
+	token: ErcFungibleToken;
 	userAddress: EthAddress;
 	spender: string;
 	value: string;

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -140,7 +140,7 @@ const enableSwapDestinationToken = async ({
 	destinationToken: Token;
 	identity: Identity;
 }): Promise<void> => {
-	if (isTokenToggleable(destinationToken) && destinationToken.enabled) {
+	if (!isTokenToggleable(destinationToken) || destinationToken.enabled) {
 		return;
 	}
 

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -1,10 +1,12 @@
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
 import { approve as approveToken, erc20ContractAllowance } from '$eth/services/approve.services';
 import { createPermit } from '$eth/services/eip2612-permit.services';
+import { loadCustomTokens as loadCustomErc20Tokens } from '$eth/services/erc20.services';
 import { send as sendEvm } from '$eth/services/send.services';
 import { swap } from '$eth/services/swap.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import { getCompactSignature, getSignParamsEIP712 } from '$eth/utils/eip712.utils';
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { setCustomToken as setCustomIcrcToken } from '$icp-eth/services/icrc-token.services';
 import { approve } from '$icp/api/icrc-ledger.api';
@@ -56,6 +58,7 @@ import {
 	kongSwapTokensStore,
 	type KongSwapTokensStoreData
 } from '$lib/stores/kong-swap-tokens.store';
+import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
 import type { NearIntentsQuoteResponse } from '$lib/types/near-intents';
 import type { Amount } from '$lib/types/send';
 import {
@@ -79,7 +82,7 @@ import type { Token } from '$lib/types/token';
 import { consoleError } from '$lib/utils/console.utils';
 import { toCustomToken } from '$lib/utils/custom-token.utils';
 import { formatToken } from '$lib/utils/format.utils';
-import { isNetworkIdICP, isNetworkIdSolana } from '$lib/utils/network.utils';
+import { isNetworkIdICP, isNetworkIdSOLDevnet, isNetworkIdSolana } from '$lib/utils/network.utils';
 import { parseToken } from '$lib/utils/parse.utils';
 import {
 	calculateSlippage,
@@ -87,8 +90,11 @@ import {
 	getWithdrawableToken,
 	isKongSupportedIcToken
 } from '$lib/utils/swap.utils';
+import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import { sendSol } from '$sol/services/sol-send.services';
+import { loadCustomTokens as loadCustomSplTokens } from '$sol/services/spl.services';
+import { isTokenSpl } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
@@ -124,6 +130,50 @@ const checkNeedsApproval = async ({
 		return !isAllowanceSufficient;
 	} catch (_: unknown) {
 		return true;
+	}
+};
+
+const enableSwapDestinationToken = async ({
+	destinationToken,
+	identity
+}: {
+	destinationToken: Token;
+	identity: Identity;
+}): Promise<void> => {
+	if (isTokenToggleable(destinationToken) && destinationToken.enabled) {
+		return;
+	}
+
+	try {
+		if (isTokenErc20(destinationToken)) {
+			await setCustomToken({
+				token: toCustomToken({
+					...destinationToken,
+					enabled: true,
+					chainId: destinationToken.network.chainId,
+					networkKey: 'Erc20'
+				} as SaveCustomTokenWithKey),
+				identity,
+				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+			});
+			await loadCustomErc20Tokens({ identity });
+			return;
+		}
+
+		if (isTokenSpl(destinationToken)) {
+			await setCustomToken({
+				token: toCustomToken({
+					...destinationToken,
+					enabled: true,
+					networkKey: isNetworkIdSOLDevnet(destinationToken.network.id) ? 'SplDevnet' : 'SplMainnet'
+				} as SaveCustomTokenWithKey),
+				identity,
+				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+			});
+			await loadCustomSplTokens({ identity });
+		}
+	} catch (_: unknown) {
+		// Auto-enabling the token is just a good-to-have extra, not necessary for the continuity of the user flow
 	}
 };
 
@@ -639,13 +689,15 @@ const executeNearIntentsSwap = async ({
 	sourceToken,
 	swapAmount,
 	swapDetails,
-	sendTransaction
+	sendTransaction,
+	enableDestinationToken
 }: {
 	progress: (step: ProgressStepsSwap) => void;
 	sourceToken: Token;
 	swapAmount: Amount;
 	swapDetails: NearIntentsQuoteResponse;
 	sendTransaction: (params: { amount: bigint; depositAddress: string }) => Promise<string>;
+	enableDestinationToken?: () => Promise<void>;
 }): Promise<void> => {
 	const parsedSwapAmount = parseToken({
 		value: `${swapAmount}`,
@@ -673,6 +725,8 @@ const executeNearIntentsSwap = async ({
 
 	progress(ProgressStepsSwap.UPDATE_UI);
 
+	await enableDestinationToken?.();
+
 	await waitAndTriggerWallet();
 };
 
@@ -680,6 +734,7 @@ export const fetchNearIntentsEvmSwap = async ({
 	identity,
 	progress,
 	sourceToken,
+	destinationToken,
 	swapAmount,
 	sourceNetwork,
 	userAddress,
@@ -706,7 +761,8 @@ export const fetchNearIntentsEvmSwap = async ({
 				maxPriorityFeePerGas
 			});
 			return hash;
-		}
+		},
+		enableDestinationToken: () => enableSwapDestinationToken({ destinationToken, identity })
 	});
 };
 
@@ -714,6 +770,7 @@ export const fetchNearIntentsSolSwap = async ({
 	identity,
 	progress,
 	sourceToken,
+	destinationToken,
 	swapAmount,
 	userAddress,
 	swapDetails
@@ -731,7 +788,8 @@ export const fetchNearIntentsSolSwap = async ({
 				destination: depositAddress,
 				source: userAddress,
 				prioritizationFee: ZERO
-			})
+			}),
+		enableDestinationToken: () => enableSwapDestinationToken({ destinationToken, identity })
 	});
 };
 
@@ -1076,6 +1134,8 @@ export const fetchVeloraDeltaSwap = async ({
 
 	progress(ProgressStepsSwap.UPDATE_UI);
 
+	await enableSwapDestinationToken({ destinationToken, identity });
+
 	await waitAndTriggerWallet();
 };
 
@@ -1199,6 +1259,8 @@ export const fetchVeloraMarketSwap = async ({
 	});
 
 	progress(ProgressStepsSwap.UPDATE_UI);
+
+	await enableSwapDestinationToken({ destinationToken, identity });
 
 	await waitAndTriggerWallet();
 };

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -6,7 +6,7 @@ import { send as sendEvm } from '$eth/services/send.services';
 import { swap } from '$eth/services/swap.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import { getCompactSignature, getSignParamsEIP712 } from '$eth/utils/eip712.utils';
-import { isTokenErc20 } from '$eth/utils/erc20.utils';
+import { isTokenErc } from '$eth/utils/erc.utils';
 import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { setCustomToken as setCustomIcrcToken } from '$icp-eth/services/icrc-token.services';
 import { approve } from '$icp/api/icrc-ledger.api';
@@ -145,7 +145,7 @@ const enableSwapDestinationToken = async ({
 	}
 
 	try {
-		if (isTokenErc20(destinationToken)) {
+		if (isTokenErc(destinationToken)) {
 			await setCustomToken({
 				token: toCustomToken({
 					...destinationToken,

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -156,7 +156,9 @@ const enableSwapDestinationToken = async ({
 				identity,
 				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 			});
+
 			await loadCustomErc20Tokens({ identity });
+
 			return;
 		}
 
@@ -170,7 +172,10 @@ const enableSwapDestinationToken = async ({
 				identity,
 				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 			});
+
 			await loadCustomSplTokens({ identity });
+
+			return;
 		}
 	} catch (_: unknown) {
 		// Auto-enabling the token is just a good-to-have extra, not necessary for the continuity of the user flow

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -174,8 +174,6 @@ const enableSwapDestinationToken = async ({
 			});
 
 			await loadCustomSplTokens({ identity });
-
-			return;
 		}
 	} catch (_: unknown) {
 		// Auto-enabling the token is just a good-to-have extra, not necessary for the continuity of the user flow

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -265,6 +265,7 @@ export interface SwapNearIntentsEvmParams
 }
 
 export interface SwapNearIntentsSolParams extends SwapNearIntentsParams {
+	destinationToken: Token;
 	userAddress: SolAddress;
 }
 

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -1,5 +1,6 @@
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
 import type { EthAddress, OptionEthAddress } from '$eth/types/address';
+import type { ErcFungibleToken } from '$eth/types/erc-fungible';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import type { ProgressStep } from '$eth/types/send';
@@ -235,7 +236,7 @@ export interface SwapVeloraParams extends RequiredTransactionFeeData {
 	identity: Identity;
 	progress: (step: ProgressStep) => void;
 	sourceToken: Erc20Token;
-	destinationToken: Erc20Token;
+	destinationToken: ErcFungibleToken;
 	swapAmount: Amount;
 	receiveAmount: bigint;
 	slippageValue: Amount;
@@ -256,8 +257,8 @@ interface SwapNearIntentsParams {
 
 export interface SwapNearIntentsEvmParams
 	extends SwapNearIntentsParams, RequiredTransactionFeeData {
-	sourceToken: Erc20Token;
-	destinationToken: Erc20Token;
+	sourceToken: ErcFungibleToken;
+	destinationToken: ErcFungibleToken;
 	receiveAmount: bigint;
 	slippageValue: Amount;
 	sourceNetwork: EthereumNetwork;

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -235,7 +235,7 @@ export interface SwapProvidersConfig {
 export interface SwapVeloraParams extends RequiredTransactionFeeData {
 	identity: Identity;
 	progress: (step: ProgressStep) => void;
-	sourceToken: Erc20Token;
+	sourceToken: ErcFungibleToken;
 	destinationToken: ErcFungibleToken;
 	swapAmount: Amount;
 	receiveAmount: bigint;

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -5,7 +5,7 @@ import type {
 	TokenReply
 } from '$declarations/kong_backend/kong_backend.did';
 import { dAppDescriptions } from '$env/dapp-descriptions.env';
-import type { Erc20Token } from '$eth/types/erc20';
+import type { ErcFungibleToken } from '$eth/types/erc-fungible';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 import type { IcToken } from '$icp/types/ic-token';
@@ -314,7 +314,7 @@ export const buildNearIntentsQuoteRequest = ({
 	deadline: new Date(Date.now() + deadlineMs).toISOString()
 });
 
-export const geSwapEthTokenAddress = (token: Erc20Token) => {
+export const geSwapEthTokenAddress = (token: ErcFungibleToken) => {
 	if (isDefaultEthereumToken(token)) {
 		return SWAP_ETH_TOKEN_PLACEHOLDER;
 	}

--- a/src/frontend/src/sol/components/swap/SwapSolWizard.svelte
+++ b/src/frontend/src/sol/components/swap/SwapSolWizard.svelte
@@ -217,6 +217,7 @@
 				identity: $authIdentity,
 				progress: (step: ProgressStep) => (swapProgressStep = step),
 				sourceToken: $sourceToken,
+				destinationToken: $destinationToken,
 				swapAmount,
 				userAddress: $solAddressMainnet,
 				swapDetails: selectedProvider.swapDetails as NearIntentsQuoteResponse

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -716,7 +716,8 @@ describe('swap.services', () => {
 		const mockDestinationToken = {
 			...mockValidErc20Token,
 			address: '0xDestinationToken',
-			decimals: 6
+			decimals: 6,
+			enabled: true
 		};
 
 		const mockSwapAmount = '1000000000000000000'; // 1 ETH
@@ -903,7 +904,8 @@ describe('swap.services', () => {
 		const mockDestinationToken = {
 			...mockValidErc20Token,
 			address: '0xDestinationToken',
-			decimals: 6
+			decimals: 6,
+			enabled: true
 		};
 
 		const mockSwapAmount = '1000000000000000000';
@@ -1712,7 +1714,8 @@ describe('swap.services', () => {
 		const destinationToken = {
 			...mockValidErc20Token,
 			decimals: 6,
-			address: '0xARB_USDC'
+			address: '0xARB_USDC',
+			enabled: true
 		};
 
 		const mockProgress = vi.fn();
@@ -1817,6 +1820,7 @@ describe('swap.services', () => {
 
 	describe('fetchNearIntentsSolSwap', () => {
 		const sourceToken = mockValidSplToken;
+		const destinationToken = { ...mockValidSplToken, symbol: 'DEST', enabled: true };
 		const mockProgress = vi.fn();
 		const solTxSignature = mockSolSignature();
 		const { depositAddress } = mockNearIntentsQuoteResponse.quote;
@@ -1834,6 +1838,7 @@ describe('swap.services', () => {
 				identity: mockIdentity,
 				progress: mockProgress,
 				sourceToken,
+				destinationToken,
 				swapAmount: '1',
 				userAddress: mockSolAddress,
 				swapDetails: mockNearIntentsQuoteResponse
@@ -1861,6 +1866,7 @@ describe('swap.services', () => {
 				identity: mockIdentity,
 				progress: mockProgress,
 				sourceToken,
+				destinationToken,
 				swapAmount: '1',
 				userAddress: mockSolAddress,
 				swapDetails: mockNearIntentsQuoteResponse
@@ -1882,6 +1888,7 @@ describe('swap.services', () => {
 				identity: mockIdentity,
 				progress: mockProgress,
 				sourceToken,
+				destinationToken,
 				swapAmount: '1',
 				userAddress: mockSolAddress,
 				swapDetails: quoteWithMemo

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -41,6 +41,7 @@ import { parseTokenId } from '$lib/validation/token.validation';
 import { sendSol } from '$sol/services/sol-send.services';
 import { loadCustomTokens as loadCustomSplTokens } from '$sol/services/spl.services';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockValidIcToken, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
@@ -1806,6 +1807,37 @@ describe('swap.services', () => {
 				fetchNearIntentsEvmSwap({ ...baseParams, destinationToken })
 			).resolves.not.toThrow();
 		});
+
+		it('should call setCustomToken and loadCustomErc20Tokens when ERC4626 destination token is toggleable and disabled', async () => {
+			const destinationToken = {
+				...mockValidErc4626Token,
+				enabled: false
+			};
+
+			await fetchNearIntentsEvmSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).toHaveBeenCalledOnce();
+			expect(loadCustomErc20Tokens).toHaveBeenCalledOnce();
+		});
+
+		it('should not call setCustomToken when ERC4626 destination token is toggleable and already enabled', async () => {
+			const destinationToken = {
+				...mockValidErc4626Token,
+				enabled: true
+			};
+
+			await fetchNearIntentsEvmSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomErc20Tokens).not.toHaveBeenCalled();
+		});
+
+		it('should not call setCustomToken when ERC4626 destination token is not toggleable', async () => {
+			await fetchNearIntentsEvmSwap({ ...baseParams, destinationToken: mockValidErc4626Token });
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomErc20Tokens).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('enableSwapDestinationToken via fetchNearIntentsSolSwap', () => {
@@ -1854,6 +1886,31 @@ describe('swap.services', () => {
 
 			expect(setCustomToken).toHaveBeenCalledOnce();
 			expect(loadCustomSplTokens).toHaveBeenCalledOnce();
+		});
+
+		it('should call setCustomToken and loadCustomErc20Tokens when ERC4626 destination token is toggleable and disabled', async () => {
+			const destinationToken = {
+				...mockValidErc4626Token,
+				enabled: false
+			};
+
+			await fetchNearIntentsSolSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).toHaveBeenCalledOnce();
+			expect(loadCustomErc20Tokens).toHaveBeenCalledOnce();
+			expect(loadCustomSplTokens).not.toHaveBeenCalled();
+		});
+
+		it('should not call setCustomToken when ERC4626 destination token is toggleable and already enabled', async () => {
+			const destinationToken = {
+				...mockValidErc4626Token,
+				enabled: true
+			};
+
+			await fetchNearIntentsSolSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomErc20Tokens).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -2,12 +2,14 @@ import type { PoolMetadata } from '$declarations/icp_swap_pool/icp_swap_pool.did
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
 import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import { createPermit } from '$eth/services/eip2612-permit.services';
+import { loadCustomTokens as loadCustomErc20Tokens } from '$eth/services/erc20.services';
 import { send as sendEvm } from '$eth/services/send.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import * as ethUtils from '$eth/utils/eth.utils';
 import * as icrcLedgerApi from '$icp/api/icrc-ledger.api';
 import type { IcToken } from '$icp/types/ic-token';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
+import { setCustomToken } from '$lib/api/backend.api';
 import * as icpSwapPool from '$lib/api/icp-swap-pool.api';
 import * as kongBackendApi from '$lib/api/kong_backend.api';
 import { ZERO } from '$lib/constants/app.constants';
@@ -37,6 +39,7 @@ import type { NearIntentsQuoteResponse } from '$lib/types/near-intents';
 import { SwapErrorCodes, SwapProvider, type VeloraSwapDetails } from '$lib/types/swap';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { sendSol } from '$sol/services/sol-send.services';
+import { loadCustomTokens as loadCustomSplTokens } from '$sol/services/spl.services';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockValidIcToken, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
@@ -149,6 +152,18 @@ vi.mock('$lib/utils/swap.utils', async (importOriginal) => {
 
 vi.mock('$eth/services/eip2612-permit.services', () => ({
 	createPermit: vi.fn()
+}));
+
+vi.mock('$lib/api/backend.api', () => ({
+	setCustomToken: vi.fn()
+}));
+
+vi.mock('$eth/services/erc20.services', () => ({
+	loadCustomTokens: vi.fn()
+}));
+
+vi.mock('$sol/services/spl.services', () => ({
+	loadCustomTokens: vi.fn()
 }));
 
 vi.mock('$env/rest/kongswap.env', () => ({
@@ -1701,6 +1716,144 @@ describe('swap.services', () => {
 					})
 				})
 			);
+		});
+	});
+
+	describe('enableSwapDestinationToken via fetchNearIntentsEvmSwap', () => {
+		const sourceToken = {
+			...mockValidErc20Token,
+			decimals: 6,
+			address: '0xUSDC'
+		};
+
+		const mockProgress = vi.fn();
+
+		const baseParams = {
+			identity: mockIdentity,
+			progress: mockProgress,
+			sourceToken,
+			swapAmount: '1',
+			receiveAmount: 900000n,
+			slippageValue: '1',
+			sourceNetwork: ETHEREUM_NETWORK,
+			userAddress: mockEthAddress,
+			gas: 21000n,
+			maxFeePerGas: 20000000000n,
+			maxPriorityFeePerGas: 2000000000n,
+			swapDetails: mockNearIntentsQuoteResponse
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.mocked(sendEvm).mockResolvedValue({ hash: '0xTxHash123' });
+			vi.mocked(nearIntentsServices.submitNearIntentsDepositTx).mockResolvedValue(undefined);
+			vi.mocked(nearIntentsServices.pollNearIntentsStatus).mockResolvedValue(undefined);
+		});
+
+		it('should not call setCustomToken when ERC20 destination token is toggleable and already enabled', async () => {
+			const destinationToken = {
+				...mockValidErc20Token,
+				decimals: 6,
+				address: '0xARB_USDC',
+				enabled: true
+			};
+
+			await fetchNearIntentsEvmSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomErc20Tokens).not.toHaveBeenCalled();
+		});
+
+		it('should not call setCustomToken when ERC20 destination token is not toggleable', async () => {
+			const destinationToken = {
+				...mockValidErc20Token,
+				decimals: 6,
+				address: '0xARB_USDC'
+			};
+
+			await fetchNearIntentsEvmSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomErc20Tokens).not.toHaveBeenCalled();
+		});
+
+		it('should call setCustomToken and loadCustomErc20Tokens when ERC20 destination token is toggleable and disabled', async () => {
+			const destinationToken = {
+				...mockValidErc20Token,
+				decimals: 6,
+				address: '0xARB_USDC',
+				enabled: false
+			};
+
+			await fetchNearIntentsEvmSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).toHaveBeenCalledOnce();
+			expect(loadCustomErc20Tokens).toHaveBeenCalledOnce();
+		});
+
+		it('should silently catch errors from setCustomToken without breaking the swap flow', async () => {
+			const destinationToken = {
+				...mockValidErc20Token,
+				decimals: 6,
+				address: '0xARB_USDC',
+				enabled: false
+			};
+
+			vi.mocked(setCustomToken).mockRejectedValueOnce(new Error('Backend error'));
+
+			await expect(
+				fetchNearIntentsEvmSwap({ ...baseParams, destinationToken })
+			).resolves.not.toThrow();
+		});
+	});
+
+	describe('enableSwapDestinationToken via fetchNearIntentsSolSwap', () => {
+		const sourceToken = mockValidSplToken;
+		const mockProgress = vi.fn();
+
+		const baseParams = {
+			identity: mockIdentity,
+			progress: mockProgress,
+			sourceToken,
+			swapAmount: '1',
+			userAddress: mockSolAddress,
+			swapDetails: mockNearIntentsQuoteResponse
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.mocked(sendSol).mockResolvedValue(mockSolSignature());
+			vi.mocked(nearIntentsServices.submitNearIntentsDepositTx).mockResolvedValue(undefined);
+			vi.mocked(nearIntentsServices.pollNearIntentsStatus).mockResolvedValue(undefined);
+		});
+
+		it('should not call setCustomToken when SPL destination token is toggleable and already enabled', async () => {
+			const destinationToken = { ...mockValidSplToken, symbol: 'DEST', enabled: true };
+
+			await fetchNearIntentsSolSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomSplTokens).not.toHaveBeenCalled();
+		});
+
+		it('should not call setCustomToken when SPL destination token is not toggleable', async () => {
+			const destinationToken = { ...mockValidSplToken, symbol: 'DEST' };
+
+			await fetchNearIntentsSolSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomSplTokens).not.toHaveBeenCalled();
+		});
+
+		it('should call setCustomToken and loadCustomSplTokens when SPL destination token is toggleable and disabled', async () => {
+			const destinationToken = { ...mockValidSplToken, symbol: 'DEST', enabled: false };
+
+			await fetchNearIntentsSolSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).toHaveBeenCalledOnce();
+			expect(loadCustomSplTokens).toHaveBeenCalledOnce();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

During a swap, if the destination token is not enabled, it is better to enable it, to provide a further service to the user.

Since we already have an "Update UI" step in the swap flow, we include there a simple service.
