### PR TITLE
style(frontend): Earning placeholder must show the button on mobile

### DIFF
--- a/src/frontend/src/lib/components/stake/NoStakePlaceholder.svelte
+++ b/src/frontend/src/lib/components/stake/NoStakePlaceholder.svelte
@@ -19,8 +19,15 @@
 	const USD_AMOUNT_THRESHOLD = 20;
 </script>
 
-<div class="flex flex-col items-center gap-5 px-6 py-10" data-tid={EARNING_NO_POSITION_PLACEHOLDER}>
-	<Img alt={$i18n.stake.alt.placeholder_image} src={noEarningBanner} />
+<div
+	class="flex flex-col items-center gap-3 px-6 py-4 sm:gap-5 sm:py-10"
+	data-tid={EARNING_NO_POSITION_PLACEHOLDER}
+>
+	<Img
+		alt={$i18n.stake.alt.placeholder_image}
+		src={noEarningBanner}
+		styleClass="h-16 w-16 sm:h-auto sm:w-auto"
+	/>
 
 	<div class="flex flex-col items-center gap-2">
 		{#if notEmptyString($i18n.stake.text.title_empty_1)}
@@ -28,7 +35,7 @@
 		{/if}
 		<h5 class="text-brand-primary">
 			{#if $highestEarningPotentialUsd >= USD_AMOUNT_THRESHOLD}
-				<span class="text-4xl font-bold">
+				<span class="text-2xl font-bold sm:text-4xl">
 					{formatCurrency({
 						value: $highestEarningPotentialUsd,
 						currency: $currentCurrency,
@@ -38,7 +45,7 @@
 				</span>
 				{$i18n.stake.text.title_empty_2_usd}
 			{:else}
-				<span class="text-4xl font-bold">{$highestApyEarning}%</span>
+				<span class="text-2xl font-bold sm:text-4xl">{$highestApyEarning}%</span>
 				{$i18n.stake.text.title_empty_2_apy}
 			{/if}
 		</h5>

--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -122,7 +122,7 @@
 			{/if}
 		</StickyHeader>
 
-		<div class="mt-12 mb-4 flex w-full justify-center sm:w-auto" in:fade>
+		<div class="mt-4 mb-4 flex w-full justify-center sm:mt-12 sm:w-auto" in:fade>
 			{#if activeTab === TokenTypes.TOKENS || activeTab === TokenTypes.NFTS}
 				<ManageTokensButton>
 					{#snippet label()}


### PR DESCRIPTION
# Motivation

We reduce a bit padding and margins for smaller screens to make the Earning placeholder fit better.

### Before

<img width="307" height="659" alt="Screenshot 2026-04-13 at 18 08 10" src="https://github.com/user-attachments/assets/35e9d0c1-fc9e-4a8a-a91f-d2d4fce0e054" />

### After

<img width="306" height="660" alt="Screenshot 2026-04-13 at 18 08 02" src="https://github.com/user-attachments/assets/2795317a-1398-4775-9031-b099a33f52b7" />

