### PR TITLE
fix(signer): Disable PWA install prompt on signer domains

### DIFF
--- a/scripts/build.metadata.mjs
+++ b/scripts/build.metadata.mjs
@@ -81,16 +81,19 @@ if (!IS_SIGNER_BUILD) {
 	parseMetadata(join(process.cwd(), 'build', 'manifest.webmanifest'));
 } else {
 	const manifestPath = join(process.cwd(), 'build', 'manifest.webmanifest');
+
 	if (existsSync(manifestPath)) {
 		unlinkSync(manifestPath);
 	}
 
 	htmlFiles.forEach((htmlFile) => {
 		const content = readFileSync(htmlFile, 'utf8');
+
 		const updated = content.replace(
 			/\s*<link\s+crossorigin="anonymous"\s+href="\/manifest\.webmanifest"\s+rel="manifest"\s*\/>/,
 			''
 		);
+
 		writeFileSync(htmlFile, updated);
 	});
 }

--- a/scripts/build.metadata.mjs
+++ b/scripts/build.metadata.mjs
@@ -2,7 +2,7 @@
 
 import { notEmptyString } from '@dfinity/utils';
 import { config } from 'dotenv';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { ENV, OISY_IC_DOMAIN, findHtmlFiles, replaceEnv } from './build.utils.mjs';
 
@@ -79,6 +79,20 @@ htmlFiles.forEach((htmlFile) => parseMetadata(htmlFile));
 if (!IS_SIGNER_BUILD) {
 	parseUrl(join(process.cwd(), 'build', 'sitemap.xml'));
 	parseMetadata(join(process.cwd(), 'build', 'manifest.webmanifest'));
+} else {
+	const manifestPath = join(process.cwd(), 'build', 'manifest.webmanifest');
+	if (existsSync(manifestPath)) {
+		unlinkSync(manifestPath);
+	}
+
+	htmlFiles.forEach((htmlFile) => {
+		const content = readFileSync(htmlFile, 'utf8');
+		const updated = content.replace(
+			/\s*<link\s+crossorigin="anonymous"\s+href="\/manifest\.webmanifest"\s+rel="manifest"\s*\/>/,
+			''
+		);
+		writeFileSync(htmlFile, updated);
+	});
 }
 
 // SEO

--- a/scripts/build.metadata.mjs
+++ b/scripts/build.metadata.mjs
@@ -90,9 +90,15 @@ if (!IS_SIGNER_BUILD) {
 		const content = readFileSync(htmlFile, 'utf8');
 
 		const updated = content.replace(
-			/\s*<link\s+crossorigin="anonymous"\s+href="\/manifest\.webmanifest"\s+rel="manifest"\s*\/>/,
+			/\s*<link\b(?=[^>]*\brel\s*=\s*["']manifest["'])(?=[^>]*\bhref\s*=\s*["'][^"']*\/?manifest\.webmanifest["'])[^>]*\/?>/i,
 			''
 		);
+
+		if (updated === content) {
+			console.warn(
+				`Signer build: no manifest link was removed from "${htmlFile}". Check the generated HTML manifest <link> markup.`
+			);
+		}
 
 		writeFileSync(htmlFile, updated);
 	});


### PR DESCRIPTION
# Motivation

We remove `manifest.webmanifest` and its `<link>` tag from signer builds to prevent browsers from showing the PWA install prompt on signer domains.