### PR TITLE
feat(frontend): Expose API backend methods for notification settings

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -11,6 +11,7 @@ import { BackendCanister } from '$lib/canisters/backend.canister';
 import { BACKEND_CANISTER_ID } from '$lib/constants/app.constants';
 import type {
 	AddPendingTransactionOutcome,
+	AddUserDismissedNotificationParams,
 	AddUserHiddenDappIdParams,
 	AllowSigningOutcome,
 	AllowSigningParams,
@@ -156,6 +157,15 @@ export const addUserHiddenDappId = async ({
 	const { addUserHiddenDappId } = await backendCanister({ identity });
 
 	return addUserHiddenDappId(params);
+};
+
+export const addUserDismissedNotification = async ({
+	identity,
+	...params
+}: CanisterApiFunctionParams<AddUserDismissedNotificationParams>): Promise<void> => {
+	const { addUserDismissedNotification } = await backendCanister({ identity });
+
+	return addUserDismissedNotification(params);
 };
 
 export const setUserShowTestnets = async ({

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -21,6 +21,7 @@ import {
 import { ZERO } from '$lib/constants/app.constants';
 import type {
 	AddPendingTransactionOutcome,
+	AddUserDismissedNotificationParams,
 	AddUserHiddenDappIdParams,
 	AllowSigningOutcome,
 	AllowSigningParams,
@@ -288,6 +289,18 @@ export class BackendCanister extends Canister<BackendService> {
 
 		await add_user_hidden_dapp_id({
 			dapp_id: dappId,
+			current_user_version: toNullable(currentUserVersion)
+		});
+	};
+
+	addUserDismissedNotification = async ({
+		notifications,
+		currentUserVersion
+	}: AddUserDismissedNotificationParams): Promise<void> => {
+		const { add_user_dismissed_notification } = this.caller({ certified: true });
+
+		await add_user_dismissed_notification({
+			notifications,
 			current_user_version: toNullable(currentUserVersion)
 		});
 	};

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -4,6 +4,7 @@ import type {
 	TokenId as BackendTokenId,
 	Network as BitcoinNetwork,
 	Contact,
+	DismissedNotification,
 	GetUserProfileError,
 	IIDelegationChain,
 	PendingTransaction,
@@ -97,6 +98,11 @@ export interface SignWithSchnorrParams extends GetSchnorrPublicKeyParams {
 
 export interface AddUserHiddenDappIdParams {
 	dappId: string;
+	currentUserVersion?: bigint;
+}
+
+export interface AddUserDismissedNotificationParams {
+	notifications: DismissedNotification[];
 	currentUserVersion?: bigint;
 }
 

--- a/src/frontend/src/tests/lib/api/backend.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/backend.api.spec.ts
@@ -1,6 +1,7 @@
 import type { CustomToken, PendingTransaction, TokenId } from '$declarations/backend/backend.did';
 import {
 	addPendingBtcTransaction,
+	addUserDismissedNotification,
 	allowSigning,
 	createUserProfile,
 	getExchangeRate,
@@ -18,6 +19,7 @@ import {
 import { BackendCanister } from '$lib/canisters/backend.canister';
 import type {
 	AddPendingTransactionOutcome,
+	AddUserDismissedNotificationParams,
 	AllowSigningOutcome,
 	AllowSigningParams,
 	BtcAddPendingTransactionParams,
@@ -490,6 +492,50 @@ describe('backend.api', () => {
 			});
 
 			await expect(saveUserTransactions(mockParams)).rejects.toThrow();
+		});
+	});
+
+	describe('addUserDismissedNotification', () => {
+		const mockParams: CanisterApiFunctionParams<AddUserDismissedNotificationParams> = {
+			...baseParams,
+			notifications: [
+				{ Simple: { kind: { BtcActivityInfo: null }, version: 1 } },
+				{ Qualified: { kind: { NoIndexCanister: null }, qualifier: 'ETH', version: 1 } }
+			],
+			currentUserVersion: 1n
+		};
+
+		beforeEach(() => {
+			backendCanisterMock.addUserDismissedNotification.mockResolvedValue();
+		});
+
+		it('should successfully call addUserDismissedNotification endpoint', async () => {
+			const result = await addUserDismissedNotification(mockParams);
+
+			expect(result).toEqual(undefined);
+			expect(
+				backendCanisterMock.addUserDismissedNotification
+			).toHaveBeenCalledExactlyOnceWith({
+				notifications: [
+					{ Simple: { kind: { BtcActivityInfo: null }, version: 1 } },
+					{ Qualified: { kind: { NoIndexCanister: null }, qualifier: 'ETH', version: 1 } }
+				],
+				currentUserVersion: 1n
+			});
+		});
+
+		it('should throw an error if identity is undefined', async () => {
+			await expect(
+				addUserDismissedNotification({ ...mockParams, identity: undefined })
+			).rejects.toThrow();
+		});
+
+		it('should throw an error if addUserDismissedNotification throws', async () => {
+			backendCanisterMock.addUserDismissedNotification.mockImplementation(() => {
+				throw new Error('mock-error');
+			});
+
+			await expect(addUserDismissedNotification(mockParams)).rejects.toThrow();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/api/backend.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/backend.api.spec.ts
@@ -513,9 +513,7 @@ describe('backend.api', () => {
 			const result = await addUserDismissedNotification(mockParams);
 
 			expect(result).toEqual(undefined);
-			expect(
-				backendCanisterMock.addUserDismissedNotification
-			).toHaveBeenCalledExactlyOnceWith({
+			expect(backendCanisterMock.addUserDismissedNotification).toHaveBeenCalledExactlyOnceWith({
 				notifications: [
 					{ Simple: { kind: { BtcActivityInfo: null }, version: 1 } },
 					{ Qualified: { kind: { NoIndexCanister: null }, qualifier: 'ETH', version: 1 } }

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -962,6 +962,76 @@ describe('backend.canister', () => {
 		});
 	});
 
+	describe('addUserDismissedNotification', () => {
+		it('should add user dismissed notifications', async () => {
+			const response = { Ok: null };
+
+			service.add_user_dismissed_notification.mockResolvedValue(response);
+
+			const { addUserDismissedNotification } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await addUserDismissedNotification({
+				notifications: [
+					{ Simple: { kind: { BtcActivityInfo: null }, version: 1 } },
+					{ Qualified: { kind: { NoIndexCanister: null }, qualifier: 'ETH', version: 1 } }
+				]
+			});
+
+			expect(service.add_user_dismissed_notification).toHaveBeenCalledWith({
+				notifications: [
+					{ Simple: { kind: { BtcActivityInfo: null }, version: 1 } },
+					{ Qualified: { kind: { NoIndexCanister: null }, qualifier: 'ETH', version: 1 } }
+				],
+				current_user_version: []
+			});
+			expect(res).toBeUndefined();
+		});
+
+		it('should pass current_user_version when provided', async () => {
+			const response = { Ok: null };
+
+			service.add_user_dismissed_notification.mockResolvedValue(response);
+
+			const { addUserDismissedNotification } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await addUserDismissedNotification({
+				notifications: [
+					{ Qualified: { kind: { UnavailableIndexCanister: null }, qualifier: 'BTC', version: 1 } }
+				],
+				currentUserVersion: 3n
+			});
+
+			expect(service.add_user_dismissed_notification).toHaveBeenCalledWith({
+				notifications: [
+					{ Qualified: { kind: { UnavailableIndexCanister: null }, qualifier: 'BTC', version: 1 } }
+				],
+				current_user_version: [3n]
+			});
+			expect(res).toBeUndefined();
+		});
+
+		it('should throw an error if add_user_dismissed_notification throws', async () => {
+			service.add_user_dismissed_notification.mockImplementation(async () => {
+				await Promise.resolve();
+				throw mockResponseError;
+			});
+
+			const { addUserDismissedNotification } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = addUserDismissedNotification({
+				notifications: [{ Simple: { kind: { BtcActivityInfo: null }, version: 1 } }]
+			});
+
+			await expect(res).rejects.toThrow(mockResponseError);
+		});
+	});
+
 	describe('setUserShowTestnets', () => {
 		it('should set user show testnets', async () => {
 			const response = { Ok: null };


### PR DESCRIPTION
# Motivation

Like for the other backend methods, we expose API services to direct interact with the notification settings.
