### PR TITLE
feat(frontend): New derived for notification settings

### DIFF
--- a/src/frontend/src/lib/derived/user-profile.derived.ts
+++ b/src/frontend/src/lib/derived/user-profile.derived.ts
@@ -1,7 +1,9 @@
 import type {
 	Agreements,
+	DismissedNotification,
 	ExperimentalFeaturesSettings,
 	NetworksSettings,
+	NotificationSettings,
 	Settings,
 	UserProfile
 } from '$declarations/backend/backend.did';
@@ -39,4 +41,14 @@ export const userExperimentalFeaturesSettings: Readable<ExperimentalFeaturesSett
 export const userAgreementsData: Readable<Agreements | undefined> = derived(
 	[userProfile],
 	([$userProfile]) => fromNullishNullable($userProfile?.agreements)
+);
+
+export const userNotificationSettings: Readable<NotificationSettings | undefined> = derived(
+	[userSettings],
+	([$userSettings]) => fromNullishNullable($userSettings?.notifications)
+);
+
+export const userDismissedNotifications: Readable<DismissedNotification[]> = derived(
+	[userNotificationSettings],
+	([$userNotificationSettings]) => $userNotificationSettings?.dismissed_notifications ?? []
 );

--- a/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/user-profile.derived.spec.ts
@@ -1,6 +1,8 @@
 import {
 	userAgreementsData,
+	userDismissedNotifications,
 	userExperimentalFeaturesSettings,
+	userNotificationSettings,
 	userProfile,
 	userProfileLoaded,
 	userProfileVersion,
@@ -16,6 +18,7 @@ import {
 	mockUserProfileVersion,
 	mockUserSettings
 } from '$tests/mocks/user-profile.mock';
+import { toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 describe('user-profile.derived', () => {
@@ -128,6 +131,78 @@ describe('user-profile.derived', () => {
 			userProfileStore.set({ certified, profile: mockUserProfile });
 
 			expect(get(userAgreementsData)).toEqual(mockUserAgreements);
+		});
+	});
+
+	describe('userNotificationSettings', () => {
+		it('should return undefined when user profile is not set', () => {
+			userProfileStore.reset();
+
+			expect(get(userNotificationSettings)).toBeUndefined();
+		});
+
+		it('should return undefined when settings have no notifications', () => {
+			userProfileStore.set({ certified, profile: mockUserProfile });
+
+			expect(get(userNotificationSettings)).toBeUndefined();
+		});
+
+		it('should return notification settings if they are set', () => {
+			const mockNotificationSettings = {
+				dismissed_notifications: [
+					{ Simple: { kind: { BtcActivityInfo: null }, version: 1 } },
+					{ Qualified: { kind: { NoIndexCanister: null }, qualifier: 'ETH', version: 1 } }
+				]
+			};
+
+			userProfileStore.set({
+				certified,
+				profile: {
+					...mockUserProfile,
+					settings: toNullable({
+						...mockUserSettings,
+						notifications: toNullable(mockNotificationSettings)
+					})
+				}
+			});
+
+			expect(get(userNotificationSettings)).toEqual(mockNotificationSettings);
+		});
+	});
+
+	describe('userDismissedNotifications', () => {
+		it('should return empty array when user profile is not set', () => {
+			userProfileStore.reset();
+
+			expect(get(userDismissedNotifications)).toEqual([]);
+		});
+
+		it('should return empty array when settings have no notifications', () => {
+			userProfileStore.set({ certified, profile: mockUserProfile });
+
+			expect(get(userDismissedNotifications)).toEqual([]);
+		});
+
+		it('should return dismissed notifications when set', () => {
+			const dismissed = [
+				{ Simple: { kind: { BtcActivityInfo: null }, version: 1 } },
+				{ Qualified: { kind: { NoIndexCanister: null }, qualifier: 'ETH', version: 1 } }
+			];
+
+			userProfileStore.set({
+				certified,
+				profile: {
+					...mockUserProfile,
+					settings: toNullable({
+						...mockUserSettings,
+						notifications: toNullable({
+							dismissed_notifications: dismissed
+						})
+					})
+				}
+			});
+
+			expect(get(userDismissedNotifications)).toEqual(dismissed);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

We expose the new notification settings through a derive store of the user's profile.
