### PR TITLE
feat(frontend): make WC and Scanner modals global

### DIFF
--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -5,9 +5,11 @@
 	import AddressBookModal from '$lib/components/address-book/AddressBookModal.svelte';
 	import DappModalDetails from '$lib/components/dapps/DappModalDetails.svelte';
 	import NftImageConsentModal from '$lib/components/nfts/NftImageConsentModal.svelte';
+	import PayDialog from '$lib/components/pay/PayDialog.svelte';
 	import ReceiveAddressModal from '$lib/components/receive/ReceiveAddressModal.svelte';
 	import ReceiveAddresses from '$lib/components/receive/ReceiveAddresses.svelte';
 	import ReferralCodeModal from '$lib/components/referral/ReferralCodeModal.svelte';
+	import ScannerModal from '$lib/components/scanner/ScannerModal.svelte';
 	import SettingsModal from '$lib/components/settings/SettingsModal.svelte';
 	import FullscreenMediaModal from '$lib/components/ui/FullscreenMediaModal.svelte';
 	import VipQrCodeModal from '$lib/components/vip/VipQrCodeModal.svelte';
@@ -30,7 +32,9 @@
 		modalNftFullscreenDisplayData,
 		modalNftFullscreenDisplayOpen,
 		modalReceive,
-		modalReceiveId
+		modalReceiveId,
+		modalPayDialogOpen,
+		modalUniversalScannerOpen
 	} from '$lib/derived/modal.derived';
 	import { getSymbol } from '$lib/utils/modal.utils';
 	import SolHideTokenModal from '$sol/components/tokens/SolHideTokenModal.svelte';
@@ -63,5 +67,9 @@
 		<FullscreenMediaModal mediaSrc={$modalNftFullscreenDisplayData.imageUrl} />
 	{:else if $modalReceive && $modalReceiveId === getSymbol('menu-addresses')}
 		<ReceiveAddressModal infoCmp={ReceiveAddresses} />
+	{:else if $modalPayDialogOpen}
+		<PayDialog />
+	{:else if $modalUniversalScannerOpen}
+		<ScannerModal />
 	{/if}
 {/if}

--- a/src/frontend/src/lib/components/pay/Pay.svelte
+++ b/src/frontend/src/lib/components/pay/Pay.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 	import IconPay from '$lib/components/icons/IconPay.svelte';
-	import PayDialog from '$lib/components/pay/PayDialog.svelte';
-	import ScannerModal from '$lib/components/scanner/ScannerModal.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
-	import { modalPayDialogOpen, modalUniversalScannerOpen } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 
@@ -22,10 +19,3 @@
 	{/snippet}
 	{$i18n.pay.text.pay}
 </ButtonIcon>
-
-{#if $modalPayDialogOpen}
-	<PayDialog />
-	<!-- TODO: Re-enable the scanner button when it includes WalletConnect and remove the modal from pay button -->
-{:else if $modalUniversalScannerOpen}
-	<ScannerModal />
-{/if}

--- a/src/frontend/src/lib/components/pay/PayDialog.svelte
+++ b/src/frontend/src/lib/components/pay/PayDialog.svelte
@@ -25,7 +25,7 @@
 	const modalId = Symbol();
 
 	const openScanner = () => {
-		modalStore.openUniversalScanner(modalId);
+		modalStore.openUniversalScanner({ id: modalId });
 	};
 </script>
 

--- a/src/frontend/src/lib/components/scanner/Scanner.svelte
+++ b/src/frontend/src/lib/components/scanner/Scanner.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import IconScanLine from '$lib/components/icons/IconScanLine.svelte';
-	import ScannerModal from '$lib/components/scanner/ScannerModal.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
-	import { modalUniversalScannerOpen } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 
@@ -13,14 +11,10 @@
 	ariaLabel={$i18n.scanner.text.scan_qr_code}
 	colorStyle="tertiary-alt"
 	link={false}
-	onclick={() => modalStore.openUniversalScanner(modalId)}
+	onclick={() => modalStore.openUniversalScanner({ id: modalId })}
 >
 	{#snippet icon()}
 		<IconScanLine size="24" />
 	{/snippet}
 	{$i18n.scanner.text.scan_qr_code}
 </ButtonIcon>
-
-{#if $modalUniversalScannerOpen}
-	<ScannerModal />
-{/if}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnect.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnect.svelte
@@ -1,18 +1,8 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
-	import { walletConnectReconnecting } from '$eth/stores/wallet-connect.store';
 	import WalletConnectButton from '$lib/components/wallet-connect/WalletConnectButton.svelte';
-	import { TRACK_COUNT_WALLET_CONNECT_MENU_OPEN } from '$lib/constants/analytics.constants';
-	import { trackEvent } from '$lib/services/analytics.services';
 	import { disconnectListener } from '$lib/services/wallet-connect.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsShow } from '$lib/stores/toasts.store';
-	import { walletConnectListenerStore as listenerStore } from '$lib/stores/wallet-connect.store';
-
-	let listener = $derived($listenerStore);
-
-	const modalId = Symbol();
 
 	const disconnect = async () => {
 		await disconnectListener();
@@ -23,24 +13,6 @@
 			duration: 2000
 		});
 	};
-
-	const openWalletConnectAuth = () => {
-		modalStore.openWalletConnectAuth(modalId);
-
-		trackEvent({
-			name: TRACK_COUNT_WALLET_CONNECT_MENU_OPEN
-		});
-	};
 </script>
 
-{#if nonNullish(listener)}
-	<WalletConnectButton onclick={disconnect}>
-		{$i18n.wallet_connect.text.disconnect}
-	</WalletConnectButton>
-{:else}
-	<WalletConnectButton
-		ariaLabel={$i18n.wallet_connect.text.name}
-		loading={$walletConnectReconnecting}
-		onclick={openWalletConnectAuth}
-	/>
-{/if}
+<WalletConnectButton onclick={disconnect} />

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -1,32 +1,24 @@
 <script lang="ts">
-	import type { WizardModal, WizardSteps } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { WalletKitTypes } from '@reown/walletkit';
 	import { onDestroy, untrack } from 'svelte';
 	import { page } from '$app/state';
 	import { walletConnectUri } from '$eth/derived/wallet-connect.derived';
-	import { walletConnectPaired, walletConnectReconnecting } from '$eth/stores/wallet-connect.store';
-	import WalletConnectSessionModal from '$lib/components/wallet-connect/WalletConnectSessionModal.svelte';
 	import {
-		walletConnectReviewWizardSteps,
-		walletConnectWizardSteps
-	} from '$lib/config/wallet-connect.config';
+		walletConnectPaired,
+		walletConnectReconnecting
+	} from '$eth/stores/wallet-connect.store';
 	import { URI_PARAM } from '$lib/constants/routes.constants';
 	import { ethAddress, solAddressDevnet, solAddressMainnet } from '$lib/derived/address.derived';
 	import { authNotSignedIn } from '$lib/derived/auth.derived';
-	import { modalWalletConnectAuth } from '$lib/derived/modal.derived';
-	import type { WizardStepsWalletConnect } from '$lib/enums/wizard-steps';
+	import { modalUniversalScannerOpen } from '$lib/derived/modal.derived';
 	import { WalletConnectClient } from '$lib/providers/wallet-connect.providers';
 	import {
 		onSessionDelete,
 		onSessionProposal,
 		onSessionRequest
 	} from '$lib/services/wallet-connect-handlers.services';
-	import {
-		connectListener,
-		disconnectListener,
-		resetListener
-	} from '$lib/services/wallet-connect.services';
+	import { disconnectListener, resetListener } from '$lib/services/wallet-connect.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { initialLoading } from '$lib/stores/loader.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -38,26 +30,14 @@
 
 	const modalId = Symbol();
 
-	let onlyReview = $state(false);
-
-	let steps = $derived<WizardSteps<WizardStepsWalletConnect>>(
-		onlyReview
-			? walletConnectReviewWizardSteps({ i18n: $i18n })
-			: walletConnectWizardSteps({ i18n: $i18n })
-	);
-
-	let modal = $state<WizardModal<WizardStepsWalletConnect>>();
-
 	$effect(() => {
 		if ($authNotSignedIn) {
 			untrack(() => disconnectListener());
 		}
 	});
 
-	const goToFirstStep = () => modal?.set?.(0);
-
 	// One try to sign in using the Oisy Wallet listed in the WalletConnect app, and the sign-in occurs through URL
-	const uriConnect = async () => {
+	const uriConnect = () => {
 		if (isNullish($walletConnectUri)) {
 			return;
 		}
@@ -72,9 +52,8 @@
 			return;
 		}
 
-		// For simplicity reason, we just display an error for now if the user has already opened the WalletConnect modal.
-		// Technically, we could potentially check which steps are in progress and eventually jump or not, but let's keep it simple for now.
-		if ($modalWalletConnectAuth) {
+		// For simplicity reason, we just display an error for now if the user has already opened the scanner modal.
+		if ($modalUniversalScannerOpen) {
 			toastsError({
 				msg: {
 					text: $i18n.wallet_connect.error.manual_workflow
@@ -83,15 +62,13 @@
 			return;
 		}
 
-		// No step connect here
-		onlyReview = true;
+		// Open the universal scanner modal with the WC URI — ScannerModal will navigate to the WC review step
+		modalStore.openUniversalScanner({
+			id: modalId,
+			data: { walletConnectUri: $walletConnectUri }
+		});
 
-		// We open the WalletConnect auth modal on the review step
-		modalStore.openWalletConnectAuth(modalId);
-
-		await connectListener({ uri: $walletConnectUri, onSessionDeleteCallback: goToFirstStep });
-
-		// Remove the URI query parameter after a successful deep-link connection
+		// Remove the URI query parameter after capturing it in the store
 		// to prevent stale URIs from forcing a cleanSlate reconnect on refresh,
 		// which would otherwise wipe persisted WalletConnect sessions.
 		removeSearchParam({ url: page.url, searchParam: URI_PARAM });
@@ -150,8 +127,6 @@
 						listener: newListener,
 						callback: () => {
 							resetListener();
-
-							goToFirstStep();
 						}
 					}),
 				onSessionRequest: (sessionRequest: WalletKitTypes.SessionRequest) =>
@@ -190,7 +165,3 @@
 </script>
 
 <svelte:window onoisyDisconnectWalletConnect={disconnectListener} />
-
-{#if $modalWalletConnectAuth}
-	<WalletConnectSessionModal {steps} bind:modal />
-{/if}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -4,10 +4,7 @@
 	import { onDestroy, untrack } from 'svelte';
 	import { page } from '$app/state';
 	import { walletConnectUri } from '$eth/derived/wallet-connect.derived';
-	import {
-		walletConnectPaired,
-		walletConnectReconnecting
-	} from '$eth/stores/wallet-connect.store';
+	import { walletConnectPaired, walletConnectReconnecting } from '$eth/stores/wallet-connect.store';
 	import { URI_PARAM } from '$lib/constants/routes.constants';
 	import { ethAddress, solAddressDevnet, solAddressMainnet } from '$lib/derived/address.derived';
 	import { authNotSignedIn } from '$lib/derived/auth.derived';

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -5,6 +5,7 @@ import { modalStore } from '$lib/stores/modal.store';
 import type { ManageTokensData } from '$lib/types/manage-tokens';
 import type { Nft, NftCollection } from '$lib/types/nft';
 import type { RewardStateData, VipRewardStateData, WelcomeData } from '$lib/types/reward';
+import type { UniversalScannerData } from '$lib/types/scanner';
 import type { NavigationTarget } from '@sveltejs/kit';
 import { derived, type Readable } from 'svelte/store';
 
@@ -304,6 +305,14 @@ export const modalNftFullscreenDisplayData: Readable<Nft | undefined> = derived(
 export const modalUniversalScannerOpen: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'universal-scanner'
+);
+
+export const modalUniversalScannerData: Readable<UniversalScannerData | undefined> = derived(
+	modalStore,
+	($modalStore) =>
+		$modalStore?.type === 'universal-scanner'
+			? ($modalStore?.data as UniversalScannerData)
+			: undefined
 );
 
 export const modalPayDialogOpen: Readable<boolean> = derived(

--- a/src/frontend/src/lib/services/wallet-connect-handlers.services.ts
+++ b/src/frontend/src/lib/services/wallet-connect-handlers.services.ts
@@ -5,7 +5,7 @@ import {
 	SESSION_REQUEST_ETH_SIGN_V4,
 	SESSION_REQUEST_PERSONAL_SIGN
 } from '$eth/constants/wallet-connect.constants';
-import { modalWalletConnect } from '$lib/derived/modal.derived';
+import { modalUniversalScannerOpen, modalWalletConnect } from '$lib/derived/modal.derived';
 import { i18n } from '$lib/stores/i18n.store';
 import { modalStore } from '$lib/stores/modal.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
@@ -59,7 +59,7 @@ export const onSessionRequest = async ({
 	}
 
 	// Another modal, like Send or Receive, is already in progress
-	if (nonNullish(get(modalStore)) && !get(modalWalletConnect)) {
+	if (nonNullish(get(modalStore)) && !get(modalWalletConnect) && !get(modalUniversalScannerOpen)) {
 		toastsError({
 			msg: {
 				text: get(i18n).wallet_connect.error.skipping_request

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -9,6 +9,7 @@ import type { OisyDappDescription } from '$lib/types/dapp-description';
 import type { ManageTokensData } from '$lib/types/manage-tokens';
 import type { Nft, NftCollection } from '$lib/types/nft';
 import type { RewardStateData, VipRewardStateData, WelcomeData } from '$lib/types/reward';
+import type { UniversalScannerData } from '$lib/types/scanner';
 import type { Token } from '$lib/types/token';
 import type { AnyTransactionUi } from '$lib/types/transaction-ui';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
@@ -138,7 +139,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openNftFullscreenDisplay: (params: SetWithDataParams<Nft>) => void;
 	openHarvestStake: (id: symbol) => void;
 	openHarvestUnstake: (id: symbol) => void;
-	openUniversalScanner: (id: symbol) => void;
+	openUniversalScanner: (params: SetWithOptionalDataParams<UniversalScannerData>) => void;
 	openPayDialog: (id: symbol) => void;
 	openGetToken: (id: symbol) => void;
 	close: () => void;
@@ -246,7 +247,9 @@ const initModalStore = <T>(): ModalStore<T> => {
 		),
 		openHarvestStake: setType('harvest-stake'),
 		openHarvestUnstake: setType('harvest-unstake'),
-		openUniversalScanner: setType('universal-scanner'),
+		openUniversalScanner: <(params: SetWithOptionalDataParams<UniversalScannerData>) => void>(
+			setTypeWithData('universal-scanner')
+		),
 		openPayDialog: setType('pay-dialog'),
 		openGetToken: setType('get-token'),
 		close: () => set(null),

--- a/src/frontend/src/lib/types/scanner.ts
+++ b/src/frontend/src/lib/types/scanner.ts
@@ -2,3 +2,7 @@ export enum ScannerResults {
 	PAY = 'pay',
 	WALLET_CONNECT = 'wallet_connect'
 }
+
+export interface UniversalScannerData {
+	walletConnectUri: string;
+}

--- a/src/frontend/src/tests/lib/components/pay/PayDialog.spec.ts
+++ b/src/frontend/src/tests/lib/components/pay/PayDialog.spec.ts
@@ -82,6 +82,8 @@ describe('PayDialog', () => {
 
 		button.click();
 
-		expect(modalStore.openUniversalScanner).toHaveBeenCalledExactlyOnceWith(expect.any(Symbol));
+		expect(modalStore.openUniversalScanner).toHaveBeenCalledExactlyOnceWith({
+			id: expect.any(Symbol)
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/scanner/Scanner.spec.ts
+++ b/src/frontend/src/tests/lib/components/scanner/Scanner.spec.ts
@@ -27,6 +27,7 @@ describe('Scanner', () => {
 		mockModalOpen.set(false);
 		vi.mocked(modalStore).openUniversalScanner = vi.fn();
 		vi.mocked(modalDerived).modalUniversalScannerOpen = mockModalOpen;
+		vi.mocked(modalDerived).modalUniversalScannerData = writable(undefined);
 	});
 
 	it('should render button with correct text', () => {
@@ -57,7 +58,9 @@ describe('Scanner', () => {
 		const button = screen.getByRole('button', { name: en.scanner.text.scan_qr_code });
 		await fireEvent.click(button);
 
-		expect(modalStore.openUniversalScanner).toHaveBeenCalledExactlyOnceWith(expect.any(Symbol));
+		expect(modalStore.openUniversalScanner).toHaveBeenCalledExactlyOnceWith({
+			id: expect.any(Symbol)
+		});
 	});
 
 	it('should pass a unique modalId symbol on click', async () => {
@@ -68,7 +71,7 @@ describe('Scanner', () => {
 
 		const [[callArg]] = vi.mocked(modalStore.openUniversalScanner).mock.calls;
 
-		expect(typeof callArg).toBe('symbol');
+		expect(typeof callArg.id).toBe('symbol');
 	});
 
 	it('should render ButtonIcon with correct props', () => {

--- a/src/frontend/src/tests/lib/stores/modal.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal.store.spec.ts
@@ -1,4 +1,5 @@
 import { modalStore } from '$lib/stores/modal.store';
+import type { UniversalScannerData } from '$lib/types/scanner';
 import type { WalletKitTypes } from '@reown/walletkit';
 import { get } from 'svelte/store';
 
@@ -48,6 +49,21 @@ describe('modal.store', () => {
 		modalStore.openHarvestUnstake(id);
 
 		expect(get(modalStore)).toEqual({ type: 'harvest-unstake', id });
+	});
+
+	it('should open universal-scanner modal without data', () => {
+		const id = Symbol('modalId');
+		modalStore.openUniversalScanner({ id });
+
+		expect(get(modalStore)).toEqual({ type: 'universal-scanner', id });
+	});
+
+	it('should open universal-scanner modal with data', () => {
+		const id = Symbol('modalId');
+		const data: UniversalScannerData = { walletConnectUri: 'wc:abc123@2' };
+		modalStore.openUniversalScanner({ id, data });
+
+		expect(get(modalStore)).toEqual({ type: 'universal-scanner', id, data });
 	});
 
 	it('should close the modal and reset the store', () => {


### PR DESCRIPTION
# Motivation

In this PR, we make WC and Scanner modals global, as well as simplify the wallet connect modals - the "connect" logic will be moved to ScannerCode in the following request.