### PR TITLE
feat(frontend): Ignore stale ICPSwap token prices

### DIFF
--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -31,6 +31,8 @@ export const usdValue = ({
 			) * exchangeRate
 		: Number(ZERO);
 
+const ICPSWAP_MIN_TVL_USD = 10;
+
 export const formatIcpSwapToCoingeckoPrices = (
 	tokens: IcpSwapToken[]
 ): CoingeckoSimpleTokenPriceResponse =>
@@ -38,6 +40,12 @@ export const formatIcpSwapToCoingeckoPrices = (
 		const price = Number(token.price);
 
 		if (isNullish(token) || isNaN(price) || price === 0) {
+			return acc;
+		}
+
+		const tvl = Number(token.tvlUSD);
+
+		if (isNaN(tvl) || tvl <= ICPSWAP_MIN_TVL_USD) {
 			return acc;
 		}
 

--- a/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
@@ -49,6 +49,91 @@ describe('exchange.utils', () => {
 			expect(result).toEqual({});
 		});
 
+		it('skips token where tvlUSD is below threshold', () => {
+			const mock = createMockIcpSwapToken({
+				price: '1.230000000000000000',
+				tvlUSD: '1.780000000000000000'
+			});
+			const result = formatIcpSwapToCoingeckoPrices([mock]);
+
+			expect(result).toEqual({});
+		});
+
+		it('skips token where tvlUSD is zero', () => {
+			const mock = createMockIcpSwapToken({
+				price: '1.230000000000000000',
+				tvlUSD: '0.000000000000000000'
+			});
+			const result = formatIcpSwapToCoingeckoPrices([mock]);
+
+			expect(result).toEqual({});
+		});
+
+		it('skips token where tvlUSD is exactly at the threshold', () => {
+			const mock = createMockIcpSwapToken({
+				price: '1.230000000000000000',
+				tvlUSD: '10.000000000000000000'
+			});
+			const result = formatIcpSwapToCoingeckoPrices([mock]);
+
+			expect(result).toEqual({});
+		});
+
+		it('accepts token where tvlUSD is just above threshold', () => {
+			const mock = createMockIcpSwapToken({
+				tokenLedgerId: MOCK_CANISTER_ID_1,
+				price: '1.230000000000000000',
+				tvlUSD: '10.010000000000000000'
+			});
+			const result = formatIcpSwapToCoingeckoPrices([mock]);
+
+			expect(result[MOCK_CANISTER_ID_1.toLowerCase()]).toEqual({
+				usd: 1.23,
+				usd_market_cap: 0,
+				usd_24h_vol: 50_000,
+				usd_24h_change: 2.5
+			});
+		});
+
+		it('skips token where tvlUSD is negative', () => {
+			const mock = createMockIcpSwapToken({
+				price: '1.230000000000000000',
+				tvlUSD: '-500.000000000000000000'
+			});
+			const result = formatIcpSwapToCoingeckoPrices([mock]);
+
+			expect(result).toEqual({});
+		});
+
+		it('skips token where tvlUSD is NaN', () => {
+			const mock = createMockIcpSwapToken({
+				price: '1.230000000000000000',
+				tvlUSD: 'NaN' as unknown as string
+			});
+			const result = formatIcpSwapToCoingeckoPrices([mock]);
+
+			expect(result).toEqual({});
+		});
+
+		it('filters stale tokens but keeps healthy ones in a batch', () => {
+			const stale = createMockIcpSwapToken({
+				tokenLedgerId: MOCK_CANISTER_ID_1,
+				price: '99000.000000000000000000',
+				tvlUSD: '1.780000000000000000'
+			});
+			const healthy = createMockIcpSwapToken({
+				tokenLedgerId: MOCK_CANISTER_ID_2,
+				price: '2.500000000000000000',
+				tvlUSD: '500000.000000000000000000'
+			});
+
+			const result = formatIcpSwapToCoingeckoPrices([stale, healthy]);
+
+			expect(result[MOCK_CANISTER_ID_1.toLowerCase()]).toBeUndefined();
+			expect(result[MOCK_CANISTER_ID_2.toLowerCase()]).toBeDefined();
+			expect(result[MOCK_CANISTER_ID_2.toLowerCase()].usd).toBe(2.5);
+		});
+
 		it('lowercases canister IDs in output keys', () => {
 			const mock = createMockIcpSwapToken({
 				tokenLedgerId: MOCK_CANISTER_ID_1,


### PR DESCRIPTION
# Motivation

Some tokens in ICPSwap show a massively different price than others.

<img width="655" height="190" alt="Screenshot 2026-04-15 at 11 04 09" src="https://github.com/user-attachments/assets/c479a98d-4313-4dcc-96af-184eae7d2f08" />

That is because some pools are stale.

To avoid feeding "old" prices to the users, we create some logic to exclude stale pools.

# Changes

- Create a limit of TVL to define a stale pool (minimum 10 USD).
- Add logic in ICPSwap price service to exclude stale pools, as per above logic

# Tests

Added tests.
