### PR TITLE
feat(backend): Ignore stale ICPSwap token prices

### DIFF
--- a/src/backend/src/exchange/providers/icpswap/mod.rs
+++ b/src/backend/src/exchange/providers/icpswap/mod.rs
@@ -12,6 +12,8 @@ use crate::{
 const DEFAULT_BASE_URL: &str = "https://api.icpswap.com";
 /// `ICPSwap` token info responses are small JSON objects; keep the cap tight for cycle costs.
 const MAX_RESPONSE_BYTES: u64 = 8_192;
+/// Pools with TVL at or below this threshold are considered stale and their prices are discarded.
+const MIN_TVL_USD: f64 = 10.0;
 
 #[derive(Debug, Deserialize)]
 struct IcpSwapEnvelope {
@@ -27,6 +29,8 @@ struct IcpSwapTokenBody {
     price: String,
     #[serde(rename = "priceChange24H")]
     price_change_24h: String,
+    #[serde(rename = "tvlUSD")]
+    tvl_usd: String,
 }
 
 fn exchange_data_from_icpswap_envelope(
@@ -39,6 +43,10 @@ fn exchange_data_from_icpswap_envelope(
     let token = parsed.data?;
     let price: f64 = token.price.parse().ok()?;
     if !price.is_finite() || price <= 0.0 {
+        return None;
+    }
+    let tvl: f64 = token.tvl_usd.parse().ok()?;
+    if !tvl.is_finite() || tvl <= MIN_TVL_USD {
         return None;
     }
     let price_24h_change_pct = token
@@ -138,7 +146,7 @@ mod tests {
 
     #[test]
     fn parse_icpswap_body_success() {
-        let json = br#"{"code":0,"message":null,"data":{"tokenLedgerId":"ryjl3-tyaaa-aaaaa-aaaba-cai","tokenName":"x","tokenSymbol":"X","price":"1.25","priceChange24H":"-2.5","tvlUSD":"0","tvlUSDChange24H":"0","txCount24H":"0","volumeUSD24H":"0","volumeUSD7D":"0","totalVolumeUSD":"0","priceLow24H":"0","priceHigh24H":"0","priceLow7D":"0","priceHigh7D":"0","priceLow30D":"0","priceHigh30D":"0"}}"#;
+        let json = br#"{"code":0,"message":null,"data":{"tokenLedgerId":"ryjl3-tyaaa-aaaaa-aaaba-cai","tokenName":"x","tokenSymbol":"X","price":"1.25","priceChange24H":"-2.5","tvlUSD":"50000","tvlUSDChange24H":"0","txCount24H":"0","volumeUSD24H":"0","volumeUSD7D":"0","totalVolumeUSD":"0","priceLow24H":"0","priceHigh24H":"0","priceLow7D":"0","priceHigh7D":"0","priceLow30D":"0","priceHigh30D":"0"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         let d = exchange_data_from_icpswap_envelope(parsed, 99).unwrap();
         assert_eq!(d.timestamp_ns, 99);
@@ -156,7 +164,7 @@ mod tests {
     #[test]
     fn parse_icpswap_body_filters_non_finite_price_change() {
         let json =
-            br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.0","priceChange24H":"NaN"}}"#;
+            br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.0","priceChange24H":"NaN","tvlUSD":"100"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         let d = exchange_data_from_icpswap_envelope(parsed, 0).unwrap();
         assert_eq!(d.price, Some(1.0));
@@ -165,8 +173,61 @@ mod tests {
 
     #[test]
     fn parse_icpswap_body_rejects_bad_price() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"0","priceChange24H":"0"}}"#;
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"0","priceChange24H":"0","tvlUSD":"100"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
+    }
+
+    #[test]
+    fn parse_icpswap_body_rejects_stale_pool() {
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"1.78"}}"#;
+        let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
+        assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
+    }
+
+    #[test]
+    fn parse_icpswap_body_rejects_zero_tvl() {
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"0"}}"#;
+        let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
+        assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
+    }
+
+    #[test]
+    fn parse_icpswap_body_rejects_tvl_at_threshold() {
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"10"}}"#;
+        let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
+        assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
+    }
+
+    #[test]
+    fn parse_icpswap_body_accepts_tvl_above_threshold() {
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"10.01"}}"#;
+        let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
+        let d = exchange_data_from_icpswap_envelope(parsed, 0).unwrap();
+        assert_eq!(d.price, Some(1.25));
+    }
+
+    #[test]
+    fn parse_icpswap_body_rejects_nan_tvl() {
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"NaN"}}"#;
+        let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
+        assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
+    }
+
+    #[test]
+    fn parse_icpswap_body_rejects_negative_tvl() {
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"-500"}}"#;
+        let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
+        assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
+    }
+
+    #[test]
+    fn parse_icpswap_body_rejects_missing_tvl() {
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5"}}"#;
+        let parsed: Result<IcpSwapEnvelope, _> = serde_json::from_slice(json);
+        assert!(parsed
+            .ok()
+            .and_then(|e| exchange_data_from_icpswap_envelope(e, 0))
+            .is_none());
     }
 }

--- a/src/backend/src/exchange/providers/icpswap/mod.rs
+++ b/src/backend/src/exchange/providers/icpswap/mod.rs
@@ -223,7 +223,8 @@ mod tests {
 
     #[test]
     fn parse_icpswap_body_rejects_missing_tvl() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5"}}"#;
+        let json =
+            br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5"}}"#;
         let parsed: Result<IcpSwapEnvelope, _> = serde_json::from_slice(json);
         assert!(parsed
             .ok()


### PR DESCRIPTION
# Motivation

Similar to what we are doing in the frontend with PR https://github.com/dfinity/oisy-wallet/pull/12431, we will ignore the stale ICPSwap prices according to a minimum threshold of TVL. 