### PR TITLE
feat(frontend): handle WC connect and Pay in ScannerCode

### DIFF
--- a/src/frontend/src/lib/components/scanner/ScannerCode.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerCode.svelte
@@ -7,12 +7,11 @@
 	import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 	import { OCP_PAY_WITH_BTC_ENABLED } from '$env/open-crypto-pay.env';
 	import IconChain from '$lib/components/icons/IconChain.svelte';
+	import IconHelpCircle from '$lib/components/icons/IconHelpCircle.svelte';
 	import QrCodeScanner from '$lib/components/qr/QrCodeScanner.svelte';
 	import ScannerCodeInput from '$lib/components/scanner/ScannerCodeInput.svelte';
 	import BottomSheet from '$lib/components/ui/BottomSheet.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
-	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { OPEN_CRYPTO_PAY_ENTER_MANUALLY_BUTTON } from '$lib/constants/test-ids.constants';
 	import { btcAddressMainnet } from '$lib/derived/address.derived';
@@ -27,14 +26,18 @@
 	import { PAY_CONTEXT_KEY, type PayContext } from '$lib/stores/open-crypto-pay.store';
 	import type { QrStatus } from '$lib/types/qr-code';
 	import { ScannerResults } from '$lib/types/scanner';
+	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 	import { prepareBasePayableTokens } from '$lib/utils/open-crypto-pay.utils';
 	import { waitReady } from '$lib/utils/timeout.utils';
 
 	interface Props {
-		onNext: (results: ScannerResults) => void;
+		onNext: (params: { results: ScannerResults; code?: string }) => void;
+		onOpenInfo?: () => void;
 	}
 
-	let { onNext }: Props = $props();
+	let { onNext, onOpenInfo }: Props = $props();
+
+	const WALLET_CONNECT_URI_PREFIX = 'wc:';
 
 	let openBottomSheet = $state(false);
 	let uri = $state('');
@@ -44,6 +47,11 @@
 	const { setData, setAvailableTokens } = getContext<PayContext>(PAY_CONTEXT_KEY);
 
 	const processCode = async (code: string) => {
+		if (code.startsWith(WALLET_CONNECT_URI_PREFIX)) {
+			onNext({ results: ScannerResults.WALLET_CONNECT, code });
+			return;
+		}
+
 		busy.start();
 
 		error = '';
@@ -74,7 +82,7 @@
 
 			setAvailableTokens(tokensWithFees);
 
-			onNext(ScannerResults.PAY);
+			onNext({ results: ScannerResults.PAY });
 		} catch (_: unknown) {
 			error = $i18n.scanner.error.code_link_is_not_valid;
 		} finally {
@@ -101,8 +109,8 @@
 	});
 </script>
 
-<ContentWithToolbar styleClass="flex flex-col gap-3 md:gap-4 w-full">
-	<QrCodeScanner onScan={handleScan} />
+<div class="relative flex w-full flex-col bg-tertiary">
+	<QrCodeScanner expandedLayout onScan={handleScan} />
 
 	<Responsive up="md">
 		<ScannerCodeInput
@@ -110,58 +118,58 @@
 			{error}
 			label={$i18n.scanner.text.url_or_code}
 			placeholder={$i18n.scanner.text.enter_or_paste_code}
+			styleClass="absolute right-0 bottom-[90px] left-0 mx-auto w-[90%] rounded-lg bg-surface"
 			bind:value={uri}
-		/>
+		>
+			<Button disabled={isEmptyUri} fullWidth onclick={handleManualConnect} paddingSmall>
+				{$i18n.core.text.continue}
+			</Button>
+		</ScannerCodeInput>
 	</Responsive>
 
 	<Responsive down="sm">
 		<BottomSheet contentClass="min-h-[10vh]" bind:visible={openBottomSheet}>
 			{#snippet content()}
-				<div class="mb-4">
-					<ScannerCodeInput
-						name="uri"
-						{error}
-						label={$i18n.scanner.text.url_or_code}
-						placeholder={$i18n.scanner.text.enter_or_paste_code}
-						bind:value={uri}
-					/>
-				</div>
-			{/snippet}
-
-			{#snippet footer()}
-				<Button disabled={isEmptyUri} fullWidth onclick={handleManualConnect}>
-					{$i18n.core.text.continue}
-				</Button>
+				<ScannerCodeInput
+					name="uri"
+					{error}
+					label={$i18n.scanner.text.url_or_code}
+					placeholder={$i18n.scanner.text.enter_or_paste_code}
+					bind:value={uri}
+				>
+					<Button disabled={isEmptyUri} fullWidth onclick={handleManualConnect} paddingSmall>
+						{$i18n.core.text.continue}
+					</Button>
+				</ScannerCodeInput>
 			{/snippet}
 		</BottomSheet>
+
+		<div class="absolute right-0 bottom-[90px] left-0 mx-auto flex w-[200px] justify-center">
+			<Button
+				colorStyle="tertiary"
+				innerStyleClass="flex items-center justify-center"
+				onclick={() => {
+					uri = '';
+					error = '';
+					openBottomSheet = true;
+				}}
+				testId={OPEN_CRYPTO_PAY_ENTER_MANUALLY_BUTTON}
+			>
+				{$i18n.scanner.text.enter_manually}
+
+				<IconChain />
+			</Button>
+		</div>
 	</Responsive>
 
-	{#snippet toolbar()}
-		<Responsive up="md">
-			<ButtonGroup>
-				<Button disabled={isEmptyUri} onclick={handleManualConnect}>
-					{$i18n.core.text.continue}
-				</Button>
-			</ButtonGroup>
-		</Responsive>
+	<Button
+		fullWidth
+		link
+		onclick={onOpenInfo}
+		styleClass="text-secondary bg-surface py-4 rounded-none"
+	>
+		<span>{replaceOisyPlaceholders($i18n.scanner.text.what_is_scan)}</span>
 
-		<Responsive down="sm">
-			<div class="mb-4 flex flex-0">
-				<Button
-					colorStyle="primary"
-					innerStyleClass="flex items-center justify-center"
-					link
-					onclick={() => {
-						uri = '';
-						error = '';
-						openBottomSheet = true;
-					}}
-					testId={OPEN_CRYPTO_PAY_ENTER_MANUALLY_BUTTON}
-				>
-					{$i18n.scanner.text.enter_manually}
-					<IconChain />
-				</Button>
-			</div>
-		</Responsive>
-	{/snippet}
-</ContentWithToolbar>
+		<IconHelpCircle />
+	</Button>
+</div>

--- a/src/frontend/src/lib/components/scanner/ScannerModal.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerModal.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { assertNever, isNullish } from '@dfinity/utils';
-	import { setContext } from 'svelte';
+	import { assertNever, isNullish, nonNullish } from '@dfinity/utils';
+	import { setContext, untrack } from 'svelte';
 	import OpenCryptoPayWizard from '$lib/components/open-crypto-pay/OpenCryptoPayWizard.svelte';
 	import ScannerCode from '$lib/components/scanner/ScannerCode.svelte';
+	import ScannerInfo from '$lib/components/scanner/ScannerInfo.svelte';
 	import ScannerModalPayDataLoader from '$lib/components/scanner/ScannerModalPayDataLoader.svelte';
 	import WalletConnectSessionWizard from '$lib/components/wallet-connect/WalletConnectSessionWizard.svelte';
 	import { scannerWizardSteps } from '$lib/config/scanner.config';
+	import { modalUniversalScannerData } from '$lib/derived/modal.derived';
 	import { PLAUSIBLE_EVENTS } from '$lib/enums/plausible';
 	import { ProgressStepsPayment } from '$lib/enums/progress-steps';
 	import { WizardStepsScanner } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
+	import { connectListener } from '$lib/services/wallet-connect.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import {
@@ -63,11 +66,25 @@
 		});
 	};
 
-	const onWalletConnectConnect = async () => {
-		// TODO: implement this function
+	const goToScanStep = () => goToStep(WizardStepsScanner.SCAN);
+
+	const goToInfoStep = () => goToStep(WizardStepsScanner.OISY_SCANNER_INFO);
+
+	const startWalletConnect = async (uri: string) => {
+		goToStep(WizardStepsScanner.WALLET_CONNECT_REVIEW);
+
+		const { result } = await connectListener({ uri, onSessionDeleteCallback: goToScanStep });
+
+		if (result === 'error') {
+			goToStep(WizardStepsScanner.SCAN);
+		}
 	};
 
-	const onNext = (results: ScannerResults) => {
+	const onWalletConnectConnect = async (uri: string) => {
+		await startWalletConnect(uri);
+	};
+
+	const onNext = async ({ results, code }: { results: ScannerResults; code?: string }) => {
 		if (results === ScannerResults.PAY) {
 			goToStep(WizardStepsScanner.PAY);
 
@@ -75,35 +92,67 @@
 		}
 
 		if (results === ScannerResults.WALLET_CONNECT) {
-			// TODO: implement wallet connect flow
+			if (isNullish(code)) {
+				return;
+			}
+
+			await startWalletConnect(code);
 
 			return;
 		}
 
 		assertNever(results, `Unhandled scanner result: ${results}`);
 	};
+
+	// When WalletConnectSession opens the scanner with a WC URI (deep-link), navigate to WC review once the modal renders
+	let walletConnectDeepLinkHandled = $state(false);
+
+	$effect(() => {
+		if (
+			!walletConnectDeepLinkHandled &&
+			nonNullish($modalUniversalScannerData?.walletConnectUri) &&
+			nonNullish(modal)
+		) {
+			walletConnectDeepLinkHandled = true;
+
+			const uri = $modalUniversalScannerData.walletConnectUri;
+
+			untrack(() => startWalletConnect(uri));
+		}
+	});
 </script>
 
 <ScannerModalPayDataLoader>
-	<WizardModal
-		bind:this={modal}
-		disablePointerEvents={currentStep?.name === WizardStepsScanner.TOKENS_LIST}
-		{onClose}
-		{steps}
-		bind:currentStep
-	>
-		{#snippet title()}
-			{currentStep?.title}
-		{/snippet}
+	<div class="scanner-modal">
+		<WizardModal
+			bind:this={modal}
+			disablePointerEvents={currentStep?.name === WizardStepsScanner.TOKENS_LIST}
+			{onClose}
+			{steps}
+			bind:currentStep
+		>
+			{#snippet title()}
+				{currentStep?.title}
+			{/snippet}
 
-		{#key currentStep?.name}
-			{#if currentStep?.name === WizardStepsScanner.SCAN}
-				<ScannerCode {onNext} />
-			{:else if currentStep?.name === WizardStepsScanner.PAY || currentStep?.name === WizardStepsScanner.TOKENS_LIST || currentStep?.name === WizardStepsScanner.PAYING || currentStep?.name === WizardStepsScanner.PAYMENT_FAILED || currentStep?.name === WizardStepsScanner.PAYMENT_CONFIRMED}
-				<OpenCryptoPayWizard {currentStep} {modal} {steps} bind:payProgressStep />
-			{:else if currentStep?.name === WizardStepsScanner.WALLET_CONNECT_CONNECT || currentStep?.name === WizardStepsScanner.WALLET_CONNECT_REVIEW}
-				<WalletConnectSessionWizard {currentStep} onConnect={onWalletConnectConnect} />
-			{/if}
-		{/key}
-	</WizardModal>
+			{#key currentStep?.name}
+				{#if currentStep?.name === WizardStepsScanner.OISY_SCANNER_INFO}
+					<ScannerInfo onButtonClick={goToScanStep} />
+				{:else if currentStep?.name === WizardStepsScanner.SCAN}
+					<ScannerCode {onNext} onOpenInfo={goToInfoStep} />
+				{:else if currentStep?.name === WizardStepsScanner.PAY || currentStep?.name === WizardStepsScanner.TOKENS_LIST || currentStep?.name === WizardStepsScanner.PAYING || currentStep?.name === WizardStepsScanner.PAYMENT_FAILED || currentStep?.name === WizardStepsScanner.PAYMENT_CONFIRMED}
+					<OpenCryptoPayWizard {currentStep} {modal} {steps} bind:payProgressStep />
+				{:else if currentStep?.name === WizardStepsScanner.WALLET_CONNECT_CONNECT || currentStep?.name === WizardStepsScanner.WALLET_CONNECT_REVIEW}
+					<WalletConnectSessionWizard {currentStep} onConnect={onWalletConnectConnect} />
+				{/if}
+			{/key}
+		</WizardModal>
+	</div>
 </ScannerModalPayDataLoader>
+
+<style lang="scss">
+	.scanner-modal :global(.content) {
+		--dialog-padding-x: 0px;
+		--dialog-padding-y: 0px;
+	}
+</style>

--- a/src/frontend/src/lib/config/scanner.config.ts
+++ b/src/frontend/src/lib/config/scanner.config.ts
@@ -10,6 +10,10 @@ export const scannerWizardSteps = ({
 		title: i18n.scanner.text.scan_qr_code
 	},
 	{
+		name: WizardStepsScanner.OISY_SCANNER_INFO,
+		title: i18n.scanner.text.scan_qr_code
+	},
+	{
 		name: WizardStepsScanner.PAY,
 		title: i18n.scanner.text.pay
 	},

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -101,6 +101,7 @@ export const WizardStepsGetToken = {
 } as const;
 
 export enum WizardStepsScanner {
+	OISY_SCANNER_INFO = 'Oisy Scanner Info',
 	SCAN = 'Scan',
 	PAY = 'Pay',
 	TOKENS_LIST = 'Tokens List',

--- a/src/frontend/src/tests/lib/components/scanner/ScannerCode.spec.ts
+++ b/src/frontend/src/tests/lib/components/scanner/ScannerCode.spec.ts
@@ -184,10 +184,13 @@ describe('ScannerCode.svelte', () => {
 		} as PayableTokenWithFees
 	];
 
+	const mockOnOpenInfo = vi.fn();
+
 	const renderWithContext = () =>
 		render(ScannerCode, {
 			props: {
-				onNext: mockOnNext
+				onNext: mockOnNext,
+				onOpenInfo: mockOnOpenInfo
 			},
 			context: new Map([
 				[
@@ -293,7 +296,49 @@ describe('ScannerCode.svelte', () => {
 
 		await waitFor(() => {
 			expect(mockSetData).toHaveBeenCalledExactlyOnceWith(mockApiResponse);
-			expect(mockOnNext).toHaveBeenCalledExactlyOnceWith(ScannerResults.PAY);
+			expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({ results: ScannerResults.PAY });
+		});
+	});
+
+	it('should call onNext with WALLET_CONNECT result for wc: URIs', async () => {
+		renderWithContext();
+
+		await openManualEntry();
+
+		const input = await screen.findByPlaceholderText(en.scanner.text.enter_or_paste_code);
+		await fireEvent.input(input, { target: { value: 'wc:abc123@2?relay-protocol=irn' } });
+
+		const button = screen.getByRole('button', { name: en.core.text.continue });
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({
+				results: ScannerResults.WALLET_CONNECT,
+				code: 'wc:abc123@2?relay-protocol=irn'
+			});
+		});
+
+		expect(openCryptoPayServices.processOpenCryptoPayCode).not.toHaveBeenCalled();
+	});
+
+	it('should not treat non-wc: URIs as WalletConnect', async () => {
+		vi.mocked(openCryptoPayServices.processOpenCryptoPayCode).mockResolvedValue(mockApiResponse);
+
+		renderWithContext();
+
+		await openManualEntry();
+
+		const input = await screen.findByPlaceholderText(en.scanner.text.enter_or_paste_code);
+		await fireEvent.input(input, { target: { value: 'https://example.com/pay' } });
+
+		const button = screen.getByRole('button', { name: en.core.text.continue });
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(openCryptoPayServices.processOpenCryptoPayCode).toHaveBeenCalledExactlyOnceWith(
+				'https://example.com/pay'
+			);
+			expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({ results: ScannerResults.PAY });
 		});
 	});
 
@@ -443,7 +488,7 @@ describe('ScannerCode.svelte', () => {
 			await fireEvent.click(button);
 			await waitFor(() => {
 				expect(mockSetsetAvailableTokens).toHaveBeenCalledExactlyOnceWith([]);
-				expect(mockOnNext).toHaveBeenCalledExactlyOnceWith(ScannerResults.PAY);
+				expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({ results: ScannerResults.PAY });
 			});
 		});
 	});
@@ -486,7 +531,7 @@ describe('ScannerCode.svelte', () => {
 
 			await waitFor(() => {
 				expect(mockSetData).toHaveBeenCalledExactlyOnceWith(mockApiResponse);
-				expect(mockOnNext).toHaveBeenCalledExactlyOnceWith(ScannerResults.PAY);
+				expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({ results: ScannerResults.PAY });
 			});
 		});
 
@@ -505,7 +550,7 @@ describe('ScannerCode.svelte', () => {
 
 			await waitFor(() => {
 				expect(mockSetData).toHaveBeenCalledExactlyOnceWith(mockApiResponse);
-				expect(mockOnNext).toHaveBeenCalledExactlyOnceWith(ScannerResults.PAY);
+				expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({ results: ScannerResults.PAY });
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/config/scanner.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/scanner.config.spec.ts
@@ -11,6 +11,10 @@ describe('scanner.config', () => {
 				title: en.scanner.text.scan_qr_code
 			},
 			{
+				name: WizardStepsScanner.OISY_SCANNER_INFO,
+				title: en.scanner.text.scan_qr_code
+			},
+			{
 				name: WizardStepsScanner.PAY,
 				title: en.scanner.text.pay
 			},


### PR DESCRIPTION
# Motivation

We can now implement the WC connect and Pay logic in ScannerCode component. Additionally, we update the related modal according to the new specs.
