### PR TITLE
feat(frontend): Hide BTC transactions banner according to user profile

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { DismissedNotification } from '$declarations/backend/backend.did';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import type { IcToken } from '$icp/types/ic-token';
 	import { hasNoIndexCanister } from '$icp/validation/ic-token.validation';
@@ -8,10 +9,30 @@
 	import PageTitle from '$lib/components/ui/PageTitle.svelte';
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
+	import { userDismissedNotifications } from '$lib/derived/user-profile.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { TokenUi } from '$lib/types/token-ui';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { isSimpleNotificationDismissed } from '$lib/utils/notification.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+
+	// The backend call is an update call that takes some time to complete.
+	// If the user profile is reactively refreshed before the call completes, the store would
+	// temporarily lose the dismissal, causing the banner to flicker back into view.
+	// To prevent this, we keep an optimistic local copy, merged with the store.
+	let temporaryDismissedNotifications = $state<DismissedNotification[]>([]);
+
+	let allDismissedNotifications = $derived([
+		...$userDismissedNotifications,
+		...temporaryDismissedNotifications
+	]);
+
+	let btcBannerDismissed = $derived(
+		isSimpleNotificationDismissed({
+			kind: 'BtcActivityInfo',
+			dismissedNotifications: allDismissedNotifications
+		})
+	);
 
 	let enabledTokensWithoutTransaction = $derived(
 		$enabledFungibleNetworkTokens
@@ -39,7 +60,6 @@
 			{ tokensWithoutCanister: [], tokensWithUnavailableCanister: [] }
 		)
 	);
-
 </script>
 
 <div class="flex flex-col gap-5">
@@ -55,7 +75,7 @@
 	{/if}
 
 	{#if tokensWithoutCanister.length > 0}
-<MessageBox closableKey="oisy_ic_hide_transaction_no_canister" level="warning">
+		<MessageBox closableKey="oisy_ic_hide_transaction_no_canister" level="warning">
 			{replacePlaceholders($i18n.activity.warning.no_index_canister, {
 				$token_list: tokensWithoutCanister.map((s) => `$${s}`).join(', ')
 			})}
@@ -63,16 +83,18 @@
 	{/if}
 
 	{#if tokensWithUnavailableCanister.length > 0}
-	<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
+		<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
 			{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
 				$token_list: tokensWithUnavailableCanister.map((s) => `$${s}`).join(', ')
 			})}
 		</MessageBox>
 	{/if}
 
-	<MessageBox closableKey="oisy_ic_hide_bitcoin_activity" level="plain">
-		{$i18n.activity.info.btc_transactions}
-	</MessageBox>
+	{#if !btcBannerDismissed}
+		<MessageBox closableKey="oisy_ic_hide_bitcoin_activity" level="plain">
+			{$i18n.activity.info.btc_transactions}
+		</MessageBox>
+	{/if}
 
 	<AllTransactionsList />
 </div>

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { notEmptyString } from '@dfinity/utils';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import type { IcToken } from '$icp/types/ic-token';
 	import { hasNoIndexCanister } from '$icp/validation/ic-token.validation';
@@ -20,32 +19,27 @@
 			.map((token: TokenUi) => token as IcToken)
 	);
 
-	let { tokenListWithoutCanister, tokenListWithUnavailableCanister } = $derived.by(() => {
-		const { enabledTokensWithoutCanister, enabledTokensWithUnavailableCanister } =
-			enabledTokensWithoutTransaction.reduce(
-				(
-					acc: {
-						enabledTokensWithoutCanister: string[];
-						enabledTokensWithUnavailableCanister: string[];
-					},
-					curr
-				) => {
-					hasNoIndexCanister(curr)
-						? acc.enabledTokensWithoutCanister.push(`$${getTokenDisplaySymbol(curr)}`)
-						: acc.enabledTokensWithUnavailableCanister.push(`$${getTokenDisplaySymbol(curr)}`);
-					return acc;
-				},
-				{
-					enabledTokensWithoutCanister: [],
-					enabledTokensWithUnavailableCanister: []
-				}
-			);
+	let { tokensWithoutCanister, tokensWithUnavailableCanister } = $derived.by(() =>
+		enabledTokensWithoutTransaction.reduce<{
+			tokensWithoutCanister: string[];
+			tokensWithUnavailableCanister: string[];
+		}>(
+			(acc, curr) => {
+				// TODO: use a unique token identifier (e.g. token ID + network) instead of the display symbol to avoid collisions if two tokens share the same symbol
+				const symbol = getTokenDisplaySymbol(curr);
 
-		return {
-			tokenListWithoutCanister: enabledTokensWithoutCanister.join(', '),
-			tokenListWithUnavailableCanister: enabledTokensWithUnavailableCanister.join(', ')
-		};
-	});
+				if (hasNoIndexCanister(curr)) {
+					acc.tokensWithoutCanister.push(symbol);
+				} else {
+					acc.tokensWithUnavailableCanister.push(symbol);
+				}
+
+				return acc;
+			},
+			{ tokensWithoutCanister: [], tokensWithUnavailableCanister: [] }
+		)
+	);
+
 </script>
 
 <div class="flex flex-col gap-5">
@@ -60,18 +54,18 @@
 		</span>
 	{/if}
 
-	{#if notEmptyString(tokenListWithoutCanister)}
-		<MessageBox closableKey="oisy_ic_hide_transaction_no_canister" level="warning">
+	{#if tokensWithoutCanister.length > 0}
+<MessageBox closableKey="oisy_ic_hide_transaction_no_canister" level="warning">
 			{replacePlaceholders($i18n.activity.warning.no_index_canister, {
-				$token_list: tokenListWithoutCanister
+				$token_list: tokensWithoutCanister.map((s) => `$${s}`).join(', ')
 			})}
 		</MessageBox>
 	{/if}
 
-	{#if notEmptyString(tokenListWithUnavailableCanister)}
-		<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
+	{#if tokensWithUnavailableCanister.length > 0}
+	<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
 			{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
-				$token_list: tokenListWithUnavailableCanister
+				$token_list: tokensWithUnavailableCanister.map((s) => `$${s}`).join(', ')
 			})}
 		</MessageBox>
 	{/if}

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -40,7 +40,7 @@
 			.map((token: TokenUi) => token as IcToken)
 	);
 
-	let { tokensWithoutCanister, tokensWithUnavailableCanister } = $derived.by(() =>
+	let { tokensWithoutCanister, tokensWithUnavailableCanister } = $derived(
 		enabledTokensWithoutTransaction.reduce<{
 			tokensWithoutCanister: string[];
 			tokensWithUnavailableCanister: string[];


### PR DESCRIPTION
# Motivation

Using the existing derived and utils, we can check if the BTC banner is already dismissed in the `AllTransactions` component.

Note that we already need to have logic to avoid possible race conditions between the user closing the message box and the backend saving the setting.