### PR TITLE
feat(frontend): Service to dismiss user notifications

### DIFF
--- a/src/frontend/src/lib/services/notification.services.ts
+++ b/src/frontend/src/lib/services/notification.services.ts
@@ -26,6 +26,6 @@ export const dismissNotifications = async ({
 
 		emit({ message: 'oisyRefreshUserProfile' });
 	} catch (_: unknown) {
-		// We can ignore the issue created by this service since it is not disruptive of the user flow
+		// We can ignore the issue created by this service since it is not disruptive to the user flow
 	}
 };

--- a/src/frontend/src/lib/services/notification.services.ts
+++ b/src/frontend/src/lib/services/notification.services.ts
@@ -1,0 +1,31 @@
+import type { DismissedNotification } from '$declarations/backend/backend.did';
+import { addUserDismissedNotification } from '$lib/api/backend.api';
+import type { NullishIdentity } from '$lib/types/identity';
+import { emit } from '$lib/utils/events.utils';
+import { isNullish } from '@dfinity/utils';
+
+export const dismissNotifications = async ({
+	notifications,
+	identity,
+	currentUserVersion
+}: {
+	notifications: DismissedNotification[];
+	identity: NullishIdentity;
+	currentUserVersion: bigint | undefined;
+}): Promise<void> => {
+	if (isNullish(identity) || notifications.length === 0) {
+		return;
+	}
+
+	try {
+		await addUserDismissedNotification({
+			notifications,
+			identity,
+			currentUserVersion
+		});
+
+		emit({ message: 'oisyRefreshUserProfile' });
+	} catch (_: unknown) {
+		// We can ignore the issue created by this service since it is not disruptive of the user flow
+	}
+};

--- a/src/frontend/src/tests/lib/services/notification.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/notification.services.spec.ts
@@ -1,0 +1,91 @@
+import type { DismissedNotification } from '$declarations/backend/backend.did';
+import { addUserDismissedNotification } from '$lib/api/backend.api';
+import { dismissNotifications } from '$lib/services/notification.services';
+import * as eventsUtils from '$lib/utils/events.utils';
+import { emit } from '$lib/utils/events.utils';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+
+vi.mock('$lib/api/backend.api', () => ({
+	addUserDismissedNotification: vi.fn()
+}));
+
+describe('notification.services', () => {
+	describe('dismissNotifications', () => {
+		const mockNotifications: DismissedNotification[] = [
+			{
+				Qualified: {
+					kind: { NoIndexCanister: null },
+					qualifier: 'BTC',
+					version: 1
+				}
+			},
+			{
+				Qualified: {
+					kind: { NoIndexCanister: null },
+					qualifier: 'ETH',
+					version: 1
+				}
+			}
+		];
+		const mockUserVersion = 5n;
+
+		const params = {
+			notifications: mockNotifications,
+			identity: mockIdentity,
+			currentUserVersion: mockUserVersion
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(eventsUtils, 'emit');
+		});
+
+		it('should return early if identity is nullish', async () => {
+			await dismissNotifications({ ...params, identity: null });
+
+			expect(addUserDismissedNotification).not.toHaveBeenCalled();
+			expect(emit).not.toHaveBeenCalled();
+		});
+
+		it('should return early if identity is undefined', async () => {
+			await dismissNotifications({ ...params, identity: undefined });
+
+			expect(addUserDismissedNotification).not.toHaveBeenCalled();
+			expect(emit).not.toHaveBeenCalled();
+		});
+
+		it('should return early if notifications is empty', async () => {
+			await dismissNotifications({ ...params, notifications: [] });
+
+			expect(addUserDismissedNotification).not.toHaveBeenCalled();
+			expect(emit).not.toHaveBeenCalled();
+		});
+
+		it('should call addUserDismissedNotification with the correct params', async () => {
+			await dismissNotifications(params);
+
+			expect(addUserDismissedNotification).toHaveBeenCalledExactlyOnceWith({
+				notifications: mockNotifications,
+				identity: mockIdentity,
+				currentUserVersion: mockUserVersion
+			});
+		});
+
+		it('should emit oisyRefreshUserProfile event on success', async () => {
+			await dismissNotifications(params);
+
+			expect(emit).toHaveBeenCalledExactlyOnceWith({
+				message: 'oisyRefreshUserProfile'
+			});
+		});
+
+		it('should silently catch errors without emitting', async () => {
+			vi.mocked(addUserDismissedNotification).mockRejectedValueOnce(new Error('API failure'));
+
+			await dismissNotifications(params);
+
+			expect(emit).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

For the new flow of persisting a close message box in the user's profile, we require a service to trigger both the call to the backend AND the refresh of the user profile.

Note that we can safely ignore any errors since this particular service is not disruptive for the user experience.
