### PR TITLE
feat(frontend): Utils to check dismissed notifications

### DIFF
--- a/src/frontend/src/lib/constants/notification.constants.ts
+++ b/src/frontend/src/lib/constants/notification.constants.ts
@@ -1,0 +1,5 @@
+export const NOTIFICATION_VERSIONS = {
+	BtcActivityInfo: 1,
+	NoIndexCanister: 1,
+	UnavailableIndexCanister: 1
+} as const;

--- a/src/frontend/src/lib/utils/notification.utils.ts
+++ b/src/frontend/src/lib/utils/notification.utils.ts
@@ -1,0 +1,36 @@
+import type { DismissedNotification } from '$declarations/backend/backend.did';
+import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
+
+type NotificationKind = keyof typeof NOTIFICATION_VERSIONS;
+
+export const isSimpleNotificationDismissed = ({
+	kind,
+	dismissedNotifications
+}: {
+	kind: NotificationKind;
+	dismissedNotifications: DismissedNotification[];
+}): boolean =>
+	dismissedNotifications.some(
+		(n) =>
+			'Simple' in n && kind in n.Simple.kind && n.Simple.version === NOTIFICATION_VERSIONS[kind]
+	);
+
+export const filterUndismissedNotificationQualifiers = ({
+	kind,
+	qualifiers,
+	dismissedNotifications
+}: {
+	kind: NotificationKind;
+	qualifiers: string[];
+	dismissedNotifications: DismissedNotification[];
+}): string[] =>
+	qualifiers.filter(
+		(qualifier) =>
+			!dismissedNotifications.some(
+				(n) =>
+					'Qualified' in n &&
+					kind in n.Qualified.kind &&
+					n.Qualified.qualifier === qualifier &&
+					n.Qualified.version === NOTIFICATION_VERSIONS[kind]
+			)
+	);

--- a/src/frontend/src/tests/lib/utils/notification.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/notification.utils.spec.ts
@@ -133,7 +133,9 @@ describe('notification.utils', () => {
 				const result = filterUndismissedNotificationQualifiers({
 					kind: 'NoIndexCanister',
 					qualifiers: ['BTC'],
-					dismissedNotifications: [qualified({ kind: 'NoIndexCanister', qualifier: 'BTC', version: 0 })]
+					dismissedNotifications: [
+						qualified({ kind: 'NoIndexCanister', qualifier: 'BTC', version: 0 })
+					]
 				});
 
 				expect(result).toEqual(['BTC']);
@@ -145,7 +147,9 @@ describe('notification.utils', () => {
 				const result = filterUndismissedNotificationQualifiers({
 					kind: 'UnavailableIndexCanister',
 					qualifiers: ['BTC', 'ETH', 'ICP'],
-					dismissedNotifications: [qualified({ kind: 'UnavailableIndexCanister', qualifier: 'ETH' })]
+					dismissedNotifications: [
+						qualified({ kind: 'UnavailableIndexCanister', qualifier: 'ETH' })
+					]
 				});
 
 				expect(result).toEqual(['BTC', 'ICP']);

--- a/src/frontend/src/tests/lib/utils/notification.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/notification.utils.spec.ts
@@ -6,18 +6,25 @@ import {
 } from '$lib/utils/notification.utils';
 
 describe('notification.utils', () => {
-	const simple = (
-		kind: 'BtcActivityInfo',
+	const simple = ({
+		kind,
 		version = NOTIFICATION_VERSIONS[kind]
-	): DismissedNotification => ({
+	}: {
+		kind: 'BtcActivityInfo';
+		version?: number;
+	}): DismissedNotification => ({
 		Simple: { kind: { [kind]: null } as { BtcActivityInfo: null }, version }
 	});
 
-	const qualified = (
-		kind: 'NoIndexCanister' | 'UnavailableIndexCanister',
-		qualifier: string,
+	const qualified = ({
+		kind,
+		qualifier,
 		version = NOTIFICATION_VERSIONS[kind]
-	): DismissedNotification => ({
+	}: {
+		kind: 'NoIndexCanister' | 'UnavailableIndexCanister';
+		qualifier: string;
+		version?: number;
+	}): DismissedNotification => ({
 		Qualified: {
 			kind: { [kind]: null } as { NoIndexCanister: null } | { UnavailableIndexCanister: null },
 			qualifier,
@@ -28,8 +35,8 @@ describe('notification.utils', () => {
 	describe('isSimpleNotificationDismissed', () => {
 		it('should return true when the kind is in the list with current version', () => {
 			const dismissed: DismissedNotification[] = [
-				simple('BtcActivityInfo'),
-				qualified('NoIndexCanister', 'ETH')
+				simple({ kind: 'BtcActivityInfo' }),
+				qualified({ kind: 'NoIndexCanister', qualifier: 'ETH' })
 			];
 
 			expect(
@@ -41,8 +48,7 @@ describe('notification.utils', () => {
 		});
 
 		it('should return false when the kind has an old version', () => {
-			// @ts-expect-error we test this on purpose
-			const dismissed: DismissedNotification[] = [simple('BtcActivityInfo', 0)];
+			const dismissed: DismissedNotification[] = [simple({ kind: 'BtcActivityInfo', version: 0 })];
 
 			expect(
 				isSimpleNotificationDismissed({
@@ -53,7 +59,9 @@ describe('notification.utils', () => {
 		});
 
 		it('should return false when the kind is not in the list', () => {
-			const dismissed: DismissedNotification[] = [qualified('NoIndexCanister', 'ETH')];
+			const dismissed: DismissedNotification[] = [
+				qualified({ kind: 'NoIndexCanister', qualifier: 'ETH' })
+			];
 
 			expect(
 				isSimpleNotificationDismissed({
@@ -87,8 +95,8 @@ describe('notification.utils', () => {
 					kind: 'NoIndexCanister',
 					qualifiers: ['BTC', 'ETH', 'ICP'],
 					dismissedNotifications: [
-						qualified('NoIndexCanister', 'BTC'),
-						qualified('NoIndexCanister', 'ICP')
+						qualified({ kind: 'NoIndexCanister', qualifier: 'BTC' }),
+						qualified({ kind: 'NoIndexCanister', qualifier: 'ICP' })
 					]
 				});
 
@@ -100,8 +108,8 @@ describe('notification.utils', () => {
 					kind: 'NoIndexCanister',
 					qualifiers: ['BTC', 'ETH'],
 					dismissedNotifications: [
-						qualified('NoIndexCanister', 'BTC'),
-						qualified('NoIndexCanister', 'ETH')
+						qualified({ kind: 'NoIndexCanister', qualifier: 'BTC' }),
+						qualified({ kind: 'NoIndexCanister', qualifier: 'ETH' })
 					]
 				});
 
@@ -113,8 +121,8 @@ describe('notification.utils', () => {
 					kind: 'NoIndexCanister',
 					qualifiers: ['BTC', 'ETH'],
 					dismissedNotifications: [
-						qualified('UnavailableIndexCanister', 'BTC'),
-						simple('BtcActivityInfo')
+						qualified({ kind: 'UnavailableIndexCanister', qualifier: 'BTC' }),
+						simple({ kind: 'BtcActivityInfo' })
 					]
 				});
 
@@ -125,8 +133,7 @@ describe('notification.utils', () => {
 				const result = filterUndismissedNotificationQualifiers({
 					kind: 'NoIndexCanister',
 					qualifiers: ['BTC'],
-					// @ts-expect-error we test this on purpose
-					dismissedNotifications: [qualified('NoIndexCanister', 'BTC', 0)]
+					dismissedNotifications: [qualified({ kind: 'NoIndexCanister', qualifier: 'BTC', version: 0 })]
 				});
 
 				expect(result).toEqual(['BTC']);
@@ -138,7 +145,7 @@ describe('notification.utils', () => {
 				const result = filterUndismissedNotificationQualifiers({
 					kind: 'UnavailableIndexCanister',
 					qualifiers: ['BTC', 'ETH', 'ICP'],
-					dismissedNotifications: [qualified('UnavailableIndexCanister', 'ETH')]
+					dismissedNotifications: [qualified({ kind: 'UnavailableIndexCanister', qualifier: 'ETH' })]
 				});
 
 				expect(result).toEqual(['BTC', 'ICP']);
@@ -148,7 +155,7 @@ describe('notification.utils', () => {
 				const result = filterUndismissedNotificationQualifiers({
 					kind: 'UnavailableIndexCanister',
 					qualifiers: ['BTC'],
-					dismissedNotifications: [qualified('NoIndexCanister', 'BTC')]
+					dismissedNotifications: [qualified({ kind: 'NoIndexCanister', qualifier: 'BTC' })]
 				});
 
 				expect(result).toEqual(['BTC']);
@@ -159,7 +166,7 @@ describe('notification.utils', () => {
 			const result = filterUndismissedNotificationQualifiers({
 				kind: 'NoIndexCanister',
 				qualifiers: [],
-				dismissedNotifications: [qualified('NoIndexCanister', 'BTC')]
+				dismissedNotifications: [qualified({ kind: 'NoIndexCanister', qualifier: 'BTC' })]
 			});
 
 			expect(result).toEqual([]);

--- a/src/frontend/src/tests/lib/utils/notification.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/notification.utils.spec.ts
@@ -1,0 +1,168 @@
+import type { DismissedNotification } from '$declarations/backend/backend.did';
+import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
+import {
+	filterUndismissedNotificationQualifiers,
+	isSimpleNotificationDismissed
+} from '$lib/utils/notification.utils';
+
+describe('notification.utils', () => {
+	const simple = (
+		kind: 'BtcActivityInfo',
+		version = NOTIFICATION_VERSIONS[kind]
+	): DismissedNotification => ({
+		Simple: { kind: { [kind]: null } as { BtcActivityInfo: null }, version }
+	});
+
+	const qualified = (
+		kind: 'NoIndexCanister' | 'UnavailableIndexCanister',
+		qualifier: string,
+		version = NOTIFICATION_VERSIONS[kind]
+	): DismissedNotification => ({
+		Qualified: {
+			kind: { [kind]: null } as { NoIndexCanister: null } | { UnavailableIndexCanister: null },
+			qualifier,
+			version
+		}
+	});
+
+	describe('isSimpleNotificationDismissed', () => {
+		it('should return true when the kind is in the list with current version', () => {
+			const dismissed: DismissedNotification[] = [
+				simple('BtcActivityInfo'),
+				qualified('NoIndexCanister', 'ETH')
+			];
+
+			expect(
+				isSimpleNotificationDismissed({
+					kind: 'BtcActivityInfo',
+					dismissedNotifications: dismissed
+				})
+			).toBeTruthy();
+		});
+
+		it('should return false when the kind has an old version', () => {
+			// @ts-expect-error we test this on purpose
+			const dismissed: DismissedNotification[] = [simple('BtcActivityInfo', 0)];
+
+			expect(
+				isSimpleNotificationDismissed({
+					kind: 'BtcActivityInfo',
+					dismissedNotifications: dismissed
+				})
+			).toBeFalsy();
+		});
+
+		it('should return false when the kind is not in the list', () => {
+			const dismissed: DismissedNotification[] = [qualified('NoIndexCanister', 'ETH')];
+
+			expect(
+				isSimpleNotificationDismissed({
+					kind: 'BtcActivityInfo',
+					dismissedNotifications: dismissed
+				})
+			).toBeFalsy();
+		});
+
+		it('should return false for empty list', () => {
+			expect(
+				isSimpleNotificationDismissed({ kind: 'BtcActivityInfo', dismissedNotifications: [] })
+			).toBeFalsy();
+		});
+	});
+
+	describe('filterUndismissedNotificationQualifiers', () => {
+		describe('NoIndexCanister kind', () => {
+			it('should return all qualifiers when none are dismissed', () => {
+				const result = filterUndismissedNotificationQualifiers({
+					kind: 'NoIndexCanister',
+					qualifiers: ['BTC', 'ETH', 'ICP'],
+					dismissedNotifications: []
+				});
+
+				expect(result).toEqual(['BTC', 'ETH', 'ICP']);
+			});
+
+			it('should filter out dismissed qualifiers', () => {
+				const result = filterUndismissedNotificationQualifiers({
+					kind: 'NoIndexCanister',
+					qualifiers: ['BTC', 'ETH', 'ICP'],
+					dismissedNotifications: [
+						qualified('NoIndexCanister', 'BTC'),
+						qualified('NoIndexCanister', 'ICP')
+					]
+				});
+
+				expect(result).toEqual(['ETH']);
+			});
+
+			it('should return empty array when all qualifiers are dismissed', () => {
+				const result = filterUndismissedNotificationQualifiers({
+					kind: 'NoIndexCanister',
+					qualifiers: ['BTC', 'ETH'],
+					dismissedNotifications: [
+						qualified('NoIndexCanister', 'BTC'),
+						qualified('NoIndexCanister', 'ETH')
+					]
+				});
+
+				expect(result).toEqual([]);
+			});
+
+			it('should not filter qualifiers dismissed under a different kind', () => {
+				const result = filterUndismissedNotificationQualifiers({
+					kind: 'NoIndexCanister',
+					qualifiers: ['BTC', 'ETH'],
+					dismissedNotifications: [
+						qualified('UnavailableIndexCanister', 'BTC'),
+						simple('BtcActivityInfo')
+					]
+				});
+
+				expect(result).toEqual(['BTC', 'ETH']);
+			});
+
+			it('should not filter qualifiers dismissed with an old version', () => {
+				const result = filterUndismissedNotificationQualifiers({
+					kind: 'NoIndexCanister',
+					qualifiers: ['BTC'],
+					// @ts-expect-error we test this on purpose
+					dismissedNotifications: [qualified('NoIndexCanister', 'BTC', 0)]
+				});
+
+				expect(result).toEqual(['BTC']);
+			});
+		});
+
+		describe('UnavailableIndexCanister kind', () => {
+			it('should filter dismissed UnavailableIndexCanister qualifiers', () => {
+				const result = filterUndismissedNotificationQualifiers({
+					kind: 'UnavailableIndexCanister',
+					qualifiers: ['BTC', 'ETH', 'ICP'],
+					dismissedNotifications: [qualified('UnavailableIndexCanister', 'ETH')]
+				});
+
+				expect(result).toEqual(['BTC', 'ICP']);
+			});
+
+			it('should not filter qualifiers dismissed under NoIndexCanister', () => {
+				const result = filterUndismissedNotificationQualifiers({
+					kind: 'UnavailableIndexCanister',
+					qualifiers: ['BTC'],
+					dismissedNotifications: [qualified('NoIndexCanister', 'BTC')]
+				});
+
+				expect(result).toEqual(['BTC']);
+			});
+		});
+
+		it('should return empty array when qualifiers is empty', () => {
+			const result = filterUndismissedNotificationQualifiers({
+				kind: 'NoIndexCanister',
+				qualifiers: [],
+				dismissedNotifications: [qualified('NoIndexCanister', 'BTC')]
+			});
+
+			expect(result).toEqual([]);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Two utils that are useful for checking if a type of notification has been dismissed or not: one to check for simple notifications and one for qualified notifications.

Both of them are based on an additional versioning, that for now we hard-code as sequential number.
