### PR TITLE
feat(frontend): Persist dismissed message box in AllTransactions

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { notEmptyString } from '@dfinity/utils';
+	import type { DismissedNotification } from '$declarations/backend/backend.did';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import type { IcToken } from '$icp/types/ic-token';
 	import { hasNoIndexCanister } from '$icp/validation/ic-token.validation';
@@ -7,12 +7,60 @@
 	import AllTransactionsList from '$lib/components/transactions/AllTransactionsList.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import PageTitle from '$lib/components/ui/PageTitle.svelte';
+	import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
+	import {
+		userDismissedNotifications,
+		userProfileVersion
+	} from '$lib/derived/user-profile.derived';
+	import { dismissNotifications } from '$lib/services/notification.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { TokenUi } from '$lib/types/token-ui';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import {
+		filterUndismissedNotificationQualifiers,
+		isSimpleNotificationDismissed
+	} from '$lib/utils/notification.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+
+	// The backend call is an update call that takes some time to complete.
+	// If the user profile is reactively refreshed before the call completes, the store would
+	// temporarily lose the dismissal, causing the banner to flicker back into view.
+	// To prevent this, we keep an optimistic local copy, merged with the store.
+	let temporaryDismissedNotifications = $state<DismissedNotification[]>([]);
+
+	let allDismissedNotifications = $derived([
+		...$userDismissedNotifications,
+		...temporaryDismissedNotifications
+	]);
+
+	let btcBannerDismissed = $derived(
+		isSimpleNotificationDismissed({
+			kind: 'BtcActivityInfo',
+			dismissedNotifications: allDismissedNotifications
+		})
+	);
+
+	const dismissBtcBanner = () => {
+		const notifications: DismissedNotification[] = [
+			{
+				Simple: {
+					kind: { BtcActivityInfo: null },
+					version: NOTIFICATION_VERSIONS.BtcActivityInfo
+				}
+			}
+		];
+
+		temporaryDismissedNotifications = [...temporaryDismissedNotifications, ...notifications];
+
+		dismissNotifications({
+			notifications,
+			identity: $authIdentity,
+			currentUserVersion: $userProfileVersion
+		});
+	};
 
 	let enabledTokensWithoutTransaction = $derived(
 		$enabledFungibleNetworkTokens
@@ -20,32 +68,81 @@
 			.map((token: TokenUi) => token as IcToken)
 	);
 
-	let { tokenListWithoutCanister, tokenListWithUnavailableCanister } = $derived.by(() => {
-		const { enabledTokensWithoutCanister, enabledTokensWithUnavailableCanister } =
-			enabledTokensWithoutTransaction.reduce(
-				(
-					acc: {
-						enabledTokensWithoutCanister: string[];
-						enabledTokensWithUnavailableCanister: string[];
-					},
-					curr
-				) => {
-					hasNoIndexCanister(curr)
-						? acc.enabledTokensWithoutCanister.push(`$${getTokenDisplaySymbol(curr)}`)
-						: acc.enabledTokensWithUnavailableCanister.push(`$${getTokenDisplaySymbol(curr)}`);
-					return acc;
-				},
-				{
-					enabledTokensWithoutCanister: [],
-					enabledTokensWithUnavailableCanister: []
+	let { tokensWithoutCanister, tokensWithUnavailableCanister } = $derived.by(() =>
+		enabledTokensWithoutTransaction.reduce<{
+			tokensWithoutCanister: string[];
+			tokensWithUnavailableCanister: string[];
+		}>(
+			(acc, curr) => {
+				// TODO: use a unique token identifier (e.g. token ID + network) instead of the display symbol
+				// to avoid collisions if two tokens share the same symbol.
+				const symbol = getTokenDisplaySymbol(curr);
+				if (hasNoIndexCanister(curr)) {
+					acc.tokensWithoutCanister.push(symbol);
+				} else {
+					acc.tokensWithUnavailableCanister.push(symbol);
 				}
-			);
+				return acc;
+			},
+			{ tokensWithoutCanister: [], tokensWithUnavailableCanister: [] }
+		)
+	);
 
-		return {
-			tokenListWithoutCanister: enabledTokensWithoutCanister.join(', '),
-			tokenListWithUnavailableCanister: enabledTokensWithUnavailableCanister.join(', ')
-		};
-	});
+	let undismissedNoCanister = $derived(
+		filterUndismissedNotificationQualifiers({
+			kind: 'NoIndexCanister',
+			qualifiers: tokensWithoutCanister,
+			dismissedNotifications: allDismissedNotifications
+		})
+	);
+
+	let undismissedUnavailable = $derived(
+		filterUndismissedNotificationQualifiers({
+			kind: 'UnavailableIndexCanister',
+			qualifiers: tokensWithUnavailableCanister,
+			dismissedNotifications: allDismissedNotifications
+		})
+	);
+
+	const dismissNoCanisterWarning = () => {
+		if (undismissedNoCanister.length > 0) {
+			const notifications: DismissedNotification[] = undismissedNoCanister.map((symbol) => ({
+				Qualified: {
+					kind: { NoIndexCanister: null },
+					qualifier: symbol,
+					version: NOTIFICATION_VERSIONS.NoIndexCanister
+				}
+			}));
+
+			temporaryDismissedNotifications = [...temporaryDismissedNotifications, ...notifications];
+
+			dismissNotifications({
+				notifications,
+				identity: $authIdentity,
+				currentUserVersion: $userProfileVersion
+			});
+		}
+	};
+
+	const dismissUnavailableWarning = () => {
+		if (undismissedUnavailable.length > 0) {
+			const notifications: DismissedNotification[] = undismissedUnavailable.map((symbol) => ({
+				Qualified: {
+					kind: { UnavailableIndexCanister: null },
+					qualifier: symbol,
+					version: NOTIFICATION_VERSIONS.UnavailableIndexCanister
+				}
+			}));
+
+			temporaryDismissedNotifications = [...temporaryDismissedNotifications, ...notifications];
+
+			dismissNotifications({
+				notifications,
+				identity: $authIdentity,
+				currentUserVersion: $userProfileVersion
+			});
+		}
+	};
 </script>
 
 <div class="flex flex-col gap-5">
@@ -60,25 +157,27 @@
 		</span>
 	{/if}
 
-	{#if notEmptyString(tokenListWithoutCanister)}
-		<MessageBox closableKey="oisy_ic_hide_transaction_no_canister" level="warning">
+	{#if undismissedNoCanister.length > 0}
+		<MessageBox level="warning" onDismiss={dismissNoCanisterWarning}>
 			{replacePlaceholders($i18n.activity.warning.no_index_canister, {
-				$token_list: tokenListWithoutCanister
+				$token_list: undismissedNoCanister.map((s) => `$${s}`).join(', ')
 			})}
 		</MessageBox>
 	{/if}
 
-	{#if notEmptyString(tokenListWithUnavailableCanister)}
-		<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
+	{#if undismissedUnavailable.length > 0}
+		<MessageBox level="warning" onDismiss={dismissUnavailableWarning}>
 			{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
-				$token_list: tokenListWithUnavailableCanister
+				$token_list: undismissedUnavailable.map((s) => `$${s}`).join(', ')
 			})}
 		</MessageBox>
 	{/if}
 
-	<MessageBox closableKey="oisy_ic_hide_bitcoin_activity" level="plain">
-		{$i18n.activity.info.btc_transactions}
-	</MessageBox>
+	{#if !btcBannerDismissed}
+		<MessageBox level="plain" onDismiss={dismissBtcBanner}>
+			{$i18n.activity.info.btc_transactions}
+		</MessageBox>
+	{/if}
 
 	<AllTransactionsList />
 </div>

--- a/src/frontend/src/lib/components/ui/MessageBox.svelte
+++ b/src/frontend/src/lib/components/ui/MessageBox.svelte
@@ -1,38 +1,29 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import IconClose from '$lib/components/icons/lucide/IconClose.svelte';
 	import IconInfo from '$lib/components/icons/lucide/IconInfo.svelte';
 	import { SLIDE_EASING } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { type HideInfoKey, saveHideInfo, shouldHideInfo } from '$lib/utils/info.utils';
 
 	interface Props {
 		children: Snippet;
 		icon?: Snippet;
 		level?: 'plain' | 'info' | 'warning' | 'error' | 'success';
-		closableKey?: HideInfoKey;
 		styleClass?: string;
 		testId?: string;
+		onDismiss?: () => void;
 	}
 
-	let { children, icon, level = 'info', closableKey, styleClass, testId }: Props = $props();
+	let { children, icon, level = 'info', styleClass, testId, onDismiss }: Props = $props();
 
-	const closable = $derived(nonNullish(closableKey));
-	// TODO: check if there is a better way to handle this svelte-ignore
-	// eslint-disable-next-line svelte/no-unused-svelte-ignore
-	// svelte-ignore state_referenced_locally -- we want to get only the initial value
-	let visible = $state(isNullish(closableKey) || !shouldHideInfo(closableKey));
+	const closable = $derived(nonNullish(onDismiss));
+	let visible = $state(true);
 
 	const close = () => {
 		visible = false;
-
-		if (isNullish(closableKey)) {
-			return;
-		}
-
-		saveHideInfo(closableKey);
+		onDismiss?.();
 	};
 </script>
 

--- a/src/frontend/src/lib/utils/info.utils.ts
+++ b/src/frontend/src/lib/utils/info.utils.ts
@@ -4,10 +4,7 @@ import { consoleError } from '$lib/utils/console.utils';
 export type HideInfoKey =
 	| 'oisy_ic_hide_bitcoin_info'
 	| 'oisy_ic_hide_ethereum_info'
-	| 'oisy_ic_hide_erc20_info'
-	| 'oisy_ic_hide_bitcoin_activity'
-	| 'oisy_ic_hide_transaction_no_canister'
-	| 'oisy_ic_hide_transaction_unavailable_canister';
+	| 'oisy_ic_hide_erc20_info';
 
 export const saveHideInfo = (key: HideInfoKey) => {
 	try {

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -191,7 +191,8 @@ describe('AllTransactions', () => {
 
 			await fireEvent.click(closeButton);
 
-			expect(notificationServices.dismissNotifications).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+			expect(notificationServices.dismissNotifications).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
 					notifications: [
 						{
 							Simple: {
@@ -200,7 +201,8 @@ describe('AllTransactions', () => {
 							}
 						}
 					]
-				}));
+				})
+			);
 		});
 
 		it('should not render the no-index-canister warning when dismissed in user profile', () => {
@@ -275,7 +277,8 @@ describe('AllTransactions', () => {
 
 			await fireEvent.click(closeButton);
 
-			expect(notificationServices.dismissNotifications).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+			expect(notificationServices.dismissNotifications).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
 					notifications: [
 						{
 							Qualified: {
@@ -285,7 +288,8 @@ describe('AllTransactions', () => {
 							}
 						}
 					]
-				}));
+				})
+			);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -1,5 +1,5 @@
-import type { DismissedNotification } from '$declarations/backend/backend.did';
 import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
+import type { DismissedNotification } from '$declarations/backend/backend.did';
 import { BTC_MAINNET_TOKEN_ID } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
@@ -191,9 +191,7 @@ describe('AllTransactions', () => {
 
 			await fireEvent.click(closeButton);
 
-			expect(notificationServices.dismissNotifications).toHaveBeenCalledOnce();
-			expect(notificationServices.dismissNotifications).toHaveBeenCalledWith(
-				expect.objectContaining({
+			expect(notificationServices.dismissNotifications).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
 					notifications: [
 						{
 							Simple: {
@@ -202,8 +200,7 @@ describe('AllTransactions', () => {
 							}
 						}
 					]
-				})
-			);
+				}));
 		});
 
 		it('should not render the no-index-canister warning when dismissed in user profile', () => {
@@ -234,9 +231,7 @@ describe('AllTransactions', () => {
 		});
 
 		it('should not render the unavailable-index-canister warning when dismissed in user profile', () => {
-			icrcCustomTokensStore.setAll([
-				{ data: tokenWithUnavailableIndexCanister, certified: true }
-			]);
+			icrcCustomTokensStore.setAll([{ data: tokenWithUnavailableIndexCanister, certified: true }]);
 
 			const store = get(icrcCustomTokensStore);
 			const tokenId = store?.at(0)?.data.id;
@@ -255,12 +250,9 @@ describe('AllTransactions', () => {
 
 			const { queryByText } = render(AllTransactions);
 
-			const expectedText = replacePlaceholders(
-				en.activity.warning.unavailable_index_canister,
-				{
-					$token_list: '$UIC'
-				}
-			);
+			const expectedText = replacePlaceholders(en.activity.warning.unavailable_index_canister, {
+				$token_list: '$UIC'
+			});
 
 			expect(queryByText(expectedText)).not.toBeInTheDocument();
 		});
@@ -283,9 +275,7 @@ describe('AllTransactions', () => {
 
 			await fireEvent.click(closeButton);
 
-			expect(notificationServices.dismissNotifications).toHaveBeenCalledOnce();
-			expect(notificationServices.dismissNotifications).toHaveBeenCalledWith(
-				expect.objectContaining({
+			expect(notificationServices.dismissNotifications).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
 					notifications: [
 						{
 							Qualified: {
@@ -295,8 +285,7 @@ describe('AllTransactions', () => {
 							}
 						}
 					]
-				})
-			);
+				}));
 		});
 	});
 

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -1,3 +1,4 @@
+import type { DismissedNotification } from '$declarations/backend/backend.did';
 import { btcTransactionsStore } from '$btc/stores/btc-transactions.store';
 import { BTC_MAINNET_TOKEN_ID } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
@@ -8,6 +9,9 @@ import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import AllTransactions from '$lib/components/transactions/AllTransactions.svelte';
+import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
+import * as notificationServices from '$lib/services/notification.services';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
 import en from '$tests/mocks/i18n.mock';
@@ -16,8 +20,9 @@ import {
 	IntersectionObserverActive,
 	IntersectionObserverPassive
 } from '$tests/mocks/infinite-scroll.mock';
-import { assertNonNullish } from '@dfinity/utils';
-import { render } from '@testing-library/svelte';
+import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
+import { assertNonNullish, toNullable } from '@dfinity/utils';
+import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
 describe('AllTransactions', () => {
@@ -110,6 +115,189 @@ describe('AllTransactions', () => {
 		const { getByText } = render(AllTransactions);
 
 		expect(getByText(en.transactions.text.transaction_history)).toBeInTheDocument();
+	});
+
+	describe('banner dismissal', () => {
+		const dismissedBtc: DismissedNotification = {
+			Simple: {
+				kind: { BtcActivityInfo: null },
+				version: NOTIFICATION_VERSIONS.BtcActivityInfo
+			}
+		};
+
+		const tokenWithoutIndexCanister: IcrcCustomToken = {
+			...customIcrcToken,
+			symbol: 'NIC'
+		};
+
+		const tokenWithUnavailableIndexCanister: IcrcCustomToken = {
+			...customIcrcToken,
+			symbol: 'UIC',
+			indexCanisterId: 'mxzaz-hqaaa-aaaar-qaada-cai'
+		};
+
+		const setUserProfileWithDismissals = (dismissed: DismissedNotification[]) => {
+			userProfileStore.set({
+				certified: true,
+				profile: {
+					...mockUserProfile,
+					settings: toNullable({
+						...mockUserSettings,
+						notifications: toNullable({
+							dismissed_notifications: dismissed
+						})
+					})
+				}
+			});
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			vi.spyOn(notificationServices, 'dismissNotifications').mockResolvedValue();
+			userProfileStore.set({ certified: true, profile: mockUserProfile });
+		});
+
+		it('should not render the BTC banner when it is dismissed in user profile', () => {
+			setUserProfileWithDismissals([dismissedBtc]);
+
+			const { queryByText } = render(AllTransactions);
+
+			expect(queryByText(en.activity.info.btc_transactions)).not.toBeInTheDocument();
+		});
+
+		it('should render the BTC banner when it is dismissed with an old version', () => {
+			setUserProfileWithDismissals([
+				{
+					Simple: {
+						kind: { BtcActivityInfo: null },
+						version: 0
+					}
+				}
+			]);
+
+			const { getByText } = render(AllTransactions);
+
+			expect(getByText(en.activity.info.btc_transactions)).toBeInTheDocument();
+		});
+
+		it('should call dismissNotifications when BTC banner is closed', async () => {
+			const { container } = render(AllTransactions);
+
+			const btcBannerText = container.querySelector('.bg-primary');
+			assertNonNullish(btcBannerText);
+
+			const closeButton = btcBannerText.querySelector('button');
+			assertNonNullish(closeButton);
+
+			await fireEvent.click(closeButton);
+
+			expect(notificationServices.dismissNotifications).toHaveBeenCalledOnce();
+			expect(notificationServices.dismissNotifications).toHaveBeenCalledWith(
+				expect.objectContaining({
+					notifications: [
+						{
+							Simple: {
+								kind: { BtcActivityInfo: null },
+								version: NOTIFICATION_VERSIONS.BtcActivityInfo
+							}
+						}
+					]
+				})
+			);
+		});
+
+		it('should not render the no-index-canister warning when dismissed in user profile', () => {
+			icrcCustomTokensStore.setAll([{ data: tokenWithoutIndexCanister, certified: true }]);
+
+			const store = get(icrcCustomTokensStore);
+			const tokenId = store?.at(0)?.data.id;
+			assertNonNullish(tokenId);
+			icTransactionsStore.nullify(tokenId);
+
+			setUserProfileWithDismissals([
+				{
+					Qualified: {
+						kind: { NoIndexCanister: null },
+						qualifier: 'NIC',
+						version: NOTIFICATION_VERSIONS.NoIndexCanister
+					}
+				}
+			]);
+
+			const { queryByText } = render(AllTransactions);
+
+			const expectedText = replacePlaceholders(en.activity.warning.no_index_canister, {
+				$token_list: '$NIC'
+			});
+
+			expect(queryByText(expectedText)).not.toBeInTheDocument();
+		});
+
+		it('should not render the unavailable-index-canister warning when dismissed in user profile', () => {
+			icrcCustomTokensStore.setAll([
+				{ data: tokenWithUnavailableIndexCanister, certified: true }
+			]);
+
+			const store = get(icrcCustomTokensStore);
+			const tokenId = store?.at(0)?.data.id;
+			assertNonNullish(tokenId);
+			icTransactionsStore.nullify(tokenId);
+
+			setUserProfileWithDismissals([
+				{
+					Qualified: {
+						kind: { UnavailableIndexCanister: null },
+						qualifier: 'UIC',
+						version: NOTIFICATION_VERSIONS.UnavailableIndexCanister
+					}
+				}
+			]);
+
+			const { queryByText } = render(AllTransactions);
+
+			const expectedText = replacePlaceholders(
+				en.activity.warning.unavailable_index_canister,
+				{
+					$token_list: '$UIC'
+				}
+			);
+
+			expect(queryByText(expectedText)).not.toBeInTheDocument();
+		});
+
+		it('should call dismissNotifications when no-index-canister warning is closed', async () => {
+			icrcCustomTokensStore.setAll([{ data: tokenWithoutIndexCanister, certified: true }]);
+
+			const store = get(icrcCustomTokensStore);
+			const tokenId = store?.at(0)?.data.id;
+			assertNonNullish(tokenId);
+			icTransactionsStore.nullify(tokenId);
+
+			const { container } = render(AllTransactions);
+
+			const warningBox = container.querySelector('.bg-warning-light');
+			assertNonNullish(warningBox);
+
+			const closeButton = warningBox.querySelector('button');
+			assertNonNullish(closeButton);
+
+			await fireEvent.click(closeButton);
+
+			expect(notificationServices.dismissNotifications).toHaveBeenCalledOnce();
+			expect(notificationServices.dismissNotifications).toHaveBeenCalledWith(
+				expect.objectContaining({
+					notifications: [
+						{
+							Qualified: {
+								kind: { NoIndexCanister: null },
+								qualifier: 'NIC',
+								version: NOTIFICATION_VERSIONS.NoIndexCanister
+							}
+						}
+					]
+				})
+			);
+		});
 	});
 
 	describe('Privacy Mode', () => {

--- a/src/frontend/src/tests/lib/components/ui/MessageBox.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MessageBox.spec.ts
@@ -1,0 +1,165 @@
+import MessageBox from '$lib/components/ui/MessageBox.svelte';
+import { createMockSnippet } from '$tests/mocks/snippet.mock';
+import en from '$tests/mocks/i18n.mock';
+import { assertNonNullish } from '@dfinity/utils';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+
+describe('MessageBox', () => {
+	const childrenSnippet = createRawSnippet(() => ({
+		render: () => `<span data-tid="children">Hello World</span>`
+	}));
+
+	it('should render children content', () => {
+		const { getByText } = render(MessageBox, {
+			props: { children: childrenSnippet }
+		});
+
+		expect(getByText('Hello World')).toBeInTheDocument();
+	});
+
+	it('should render the default info icon when no custom icon is provided', () => {
+		const { container } = render(MessageBox, {
+			props: { children: childrenSnippet }
+		});
+
+		const iconWrapper = container.querySelector('div.min-w-5');
+
+		expect(iconWrapper).toBeInTheDocument();
+	});
+
+	it('should render a custom icon snippet when provided', () => {
+		const { queryByTestId } = render(MessageBox, {
+			props: {
+				children: childrenSnippet,
+				icon: createMockSnippet('custom-icon')
+			}
+		});
+
+		expect(queryByTestId('custom-icon')).toBeInTheDocument();
+	});
+
+	it('should not render the default icon when a custom icon is provided', () => {
+		const { container } = render(MessageBox, {
+			props: {
+				children: childrenSnippet,
+				icon: createMockSnippet('custom-icon')
+			}
+		});
+
+		const defaultIconWrapper = container.querySelector('div.min-w-5');
+
+		expect(defaultIconWrapper).not.toBeInTheDocument();
+	});
+
+	describe('level styling', () => {
+		it('should apply info background by default', () => {
+			const { container } = render(MessageBox, {
+				props: { children: childrenSnippet }
+			});
+
+			const box = container.querySelector('.bg-brand-light');
+
+			expect(box).toBeInTheDocument();
+		});
+
+		it.each([
+			{ level: 'info', expectedClass: 'bg-brand-light' },
+			{ level: 'warning', expectedClass: 'bg-warning-light' },
+			{ level: 'error', expectedClass: 'bg-error-light' },
+			{ level: 'success', expectedClass: 'bg-success-light' },
+			{ level: 'plain', expectedClass: 'bg-primary' }
+		] as const)('should apply $expectedClass for level "$level"', ({ level, expectedClass }) => {
+			const { container } = render(MessageBox, {
+				props: { children: childrenSnippet, level }
+			});
+
+			const box = container.querySelector(`.${expectedClass}`);
+
+			expect(box).toBeInTheDocument();
+		});
+	});
+
+	describe('close button', () => {
+		it('should not render a close button when onDismiss is not provided', () => {
+			const { queryByRole } = render(MessageBox, {
+				props: { children: childrenSnippet }
+			});
+
+			expect(queryByRole('button', { name: en.core.text.close })).not.toBeInTheDocument();
+		});
+
+		it('should render a close button when onDismiss is provided', () => {
+			const { getByRole } = render(MessageBox, {
+				props: { children: childrenSnippet, onDismiss: vi.fn() }
+			});
+
+			expect(getByRole('button', { name: en.core.text.close })).toBeInTheDocument();
+		});
+
+		it('should hide the message box when the close button is clicked', async () => {
+			const onDismiss = vi.fn();
+
+			const { getByRole, queryByTestId } = render(MessageBox, {
+				props: { children: childrenSnippet, testId: 'msg-box', onDismiss }
+			});
+
+			expect(queryByTestId('msg-box')).toBeInTheDocument();
+
+			const closeButton = getByRole('button', { name: en.core.text.close });
+
+			await fireEvent.click(closeButton);
+
+			await waitFor(() => {
+				expect(queryByTestId('msg-box')).not.toBeInTheDocument();
+			});
+		});
+
+		it('should call onDismiss when the close button is clicked', async () => {
+			const onDismiss = vi.fn();
+
+			const { getByRole } = render(MessageBox, {
+				props: { children: childrenSnippet, onDismiss }
+			});
+
+			const closeButton = getByRole('button', { name: en.core.text.close });
+
+			await fireEvent.click(closeButton);
+
+			expect(onDismiss).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('testId', () => {
+		it('should set data-tid attribute when testId is provided', () => {
+			const { queryByTestId } = render(MessageBox, {
+				props: { children: childrenSnippet, testId: 'my-message' }
+			});
+
+			expect(queryByTestId('my-message')).toBeInTheDocument();
+		});
+
+		it('should not set data-tid attribute when testId is not provided', () => {
+			const { container } = render(MessageBox, {
+				props: { children: childrenSnippet }
+			});
+
+			const box = container.querySelector('.mb-4');
+
+			assertNonNullish(box);
+			expect(box.getAttribute('data-tid')).toBeNull();
+		});
+	});
+
+	describe('styleClass', () => {
+		it('should apply custom style class when provided', () => {
+			const { container } = render(MessageBox, {
+				props: { children: childrenSnippet, styleClass: 'my-custom-class' }
+			});
+
+			const box = container.querySelector('.my-custom-class');
+
+			expect(box).toBeInTheDocument();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/components/ui/MessageBox.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MessageBox.spec.ts
@@ -1,6 +1,6 @@
 import MessageBox from '$lib/components/ui/MessageBox.svelte';
-import { createMockSnippet } from '$tests/mocks/snippet.mock';
 import en from '$tests/mocks/i18n.mock';
+import { createMockSnippet } from '$tests/mocks/snippet.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { createRawSnippet } from 'svelte';
@@ -147,6 +147,7 @@ describe('MessageBox', () => {
 			const box = container.querySelector('.mb-4');
 
 			assertNonNullish(box);
+
 			expect(box.getAttribute('data-tid')).toBeNull();
 		});
 	});


### PR DESCRIPTION
# Motivation

The dismissed state of message banners in the `AllTransactions` page (BTC activity info, no-index-canister warning, unavailable-index-canister warning) was previously stored in `sessionStorage`, meaning dismissals were lost on every new session or device. This PR persists dismissals in the user profile backend so they survive across sessions and devices.

# Changes

- **Refactored `MessageBox`**: replaced the `closableKey` / `sessionStorage` coupling with a callback-based `onDismiss` prop, so the component no longer knows *how* dismissals are persisted.
- **Removed `sessionStorage` keys** from `info.utils.ts`: the three `AllTransactions`-specific `HideInfoKey` values (`oisy_ic_hide_bitcoin_activity`, `oisy_ic_hide_transaction_no_canister`, `oisy_ic_hide_transaction_unavailable_canister`) are no longer needed.
- **New `notification.constants.ts`**: defines `NOTIFICATION_VERSIONS` per notification kind, enabling version-gated dismissals — bumping a version "un-dismisses" the notification for all users.
- **New `notification.utils.ts`**: provides `isSimpleNotificationDismissed` and `filterUndismissedNotificationQualifiers` to check dismissal state from the user profile.
- **New `notification.services.ts`**: exposes `dismissNotifications`, which calls `addUserDismissedNotification` on the backend and emits `oisyRefreshUserProfile` on success. Errors are silently caught since this is a non-critical UX preference.
- **Rewrote `AllTransactions.svelte`**: reads dismissed notifications from the `userDismissedNotifications` derived store, keeps an optimistic local copy (`temporaryDismissedNotifications`) to prevent flicker while the backend round-trip completes, and wires each banner's close action to the new dismiss service.
- **Simplified token list logic**: the `reduce` in `AllTransactions` was cleaned up and the `$` prefix is now added at display time only, not stored in the qualifier.

### Future considerations

> **TODO**: The qualified notifications currently use the token display symbol (e.g. `"BTC"`) as qualifier. This matches the existing logic, but could lead to collisions if two tokens on different networks share the same symbol. A future improvement should use a unique token identifier (e.g. token ID + network) instead. This is tracked with a TODO in `AllTransactions.svelte`.

# Tests

- **New `MessageBox.spec.ts`** (17 tests): covers rendering (children, icons, levels), close button visibility, dismiss callback, hide-on-close animation, `testId` and `styleClass` props.
- **New `notification.services.spec.ts`** (6 tests): covers early returns for nullish identity / empty notifications, correct API call, event emission on success, silent error handling.
- **New `notification.utils.spec.ts`** (12 tests): covers `isSimpleNotificationDismissed` (current version, old version, missing kind, empty list) and `filterUndismissedNotificationQualifiers` (no dismissals, partial, full, cross-kind, old version).
- **Extended `AllTransactions.spec.ts`** (+6 tests): covers BTC banner hidden when dismissed, still shown with old version, dismiss callback triggered; no-index-canister and unavailable-index-canister warnings hidden when dismissed, dismiss callback triggered.