### PR TITLE
feat(frontend): add WalletConnect session modal

### DIFF
--- a/src/frontend/src/lib/components/core/Modals.svelte
+++ b/src/frontend/src/lib/components/core/Modals.svelte
@@ -13,6 +13,7 @@
 	import SettingsModal from '$lib/components/settings/SettingsModal.svelte';
 	import FullscreenMediaModal from '$lib/components/ui/FullscreenMediaModal.svelte';
 	import VipQrCodeModal from '$lib/components/vip/VipQrCodeModal.svelte';
+	import WalletConnectSessionsModal from '$lib/components/wallet-connect/WalletConnectSessionsModal.svelte';
 	import { authSignedIn } from '$lib/derived/auth.derived';
 	import {
 		modalDAppDetails,
@@ -34,7 +35,8 @@
 		modalReceive,
 		modalReceiveId,
 		modalPayDialogOpen,
-		modalUniversalScannerOpen
+		modalUniversalScannerOpen,
+		modalWalletConnectSessions
 	} from '$lib/derived/modal.derived';
 	import { getSymbol } from '$lib/utils/modal.utils';
 	import SolHideTokenModal from '$sol/components/tokens/SolHideTokenModal.svelte';
@@ -71,5 +73,7 @@
 		<PayDialog />
 	{:else if $modalUniversalScannerOpen}
 		<ScannerModal />
+	{:else if $modalWalletConnectSessions}
+		<WalletConnectSessionsModal />
 	{/if}
 {/if}

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnect.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnect.svelte
@@ -1,18 +1,12 @@
 <script lang="ts">
 	import WalletConnectButton from '$lib/components/wallet-connect/WalletConnectButton.svelte';
-	import { disconnectListener } from '$lib/services/wallet-connect.services';
-	import { i18n } from '$lib/stores/i18n.store';
-	import { toastsShow } from '$lib/stores/toasts.store';
+	import { modalStore } from '$lib/stores/modal.store';
 
-	const disconnect = async () => {
-		await disconnectListener();
+	const modalId = Symbol();
 
-		toastsShow({
-			text: $i18n.wallet_connect.info.disconnected,
-			level: 'info',
-			duration: 2000
-		});
+	const openSessions = () => {
+		modalStore.openWalletConnectSessions(modalId);
 	};
 </script>
 
-<WalletConnectButton onclick={disconnect} />
+<WalletConnectButton onclick={openSessions} />

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectButton.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectButton.svelte
@@ -1,30 +1,19 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
-	import type { Snippet } from 'svelte';
-	import { fade } from 'svelte/transition';
 	import IconWalletConnect from '$lib/components/icons/IconWalletConnect.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { ethAddressNotLoaded, solAddressMainnetNotLoaded } from '$lib/derived/address.derived';
 
 	interface Props {
 		loading?: boolean;
 		ariaLabel?: string;
 		onclick: () => void;
-		children?: Snippet;
 	}
 
-	let { loading = false, ariaLabel, onclick, children }: Props = $props();
+	let { loading = false, ariaLabel, onclick }: Props = $props();
 
 	let disabled = $derived(loading || ($ethAddressNotLoaded && $solAddressMainnetNotLoaded));
 </script>
 
-<button
-	class="tertiary-alt h-10"
-	class:icon={isNullish(children)}
-	aria-label={ariaLabel}
-	{disabled}
-	{onclick}
-	in:fade
->
+<Button {ariaLabel} {disabled} {onclick} paddingSmall styleClass="h-10 px-2 rounded-xl">
 	<IconWalletConnect size="24" />
-	{@render children?.()}
-</button>
+</Button>

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -258,10 +258,27 @@ export const modalWelcomeData: Readable<WelcomeData | undefined> = derived(
 		$modalStore?.type === 'welcome' ? ($modalStore?.data as WelcomeData) : undefined
 );
 
+export const modalWalletConnectSessions: Readable<boolean> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'wallet-connect-sessions'
+);
 export const modalWalletConnect: Readable<boolean> = derived(
-	[modalWalletConnectAuth, modalWalletConnectSign, modalWalletConnectSend],
-	([$modalWalletConnectAuth, $modalWalletConnectSign, $modalWalletConnectSend]) =>
-		$modalWalletConnectAuth || $modalWalletConnectSign || $modalWalletConnectSend
+	[
+		modalWalletConnectAuth,
+		modalWalletConnectSign,
+		modalWalletConnectSend,
+		modalWalletConnectSessions
+	],
+	([
+		$modalWalletConnectAuth,
+		$modalWalletConnectSign,
+		$modalWalletConnectSend,
+		$modalWalletConnectSessions
+	]) =>
+		$modalWalletConnectAuth ||
+		$modalWalletConnectSign ||
+		$modalWalletConnectSend ||
+		$modalWalletConnectSessions
 );
 
 export const modalSettingsState: Readable<boolean> = derived(

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -70,7 +70,8 @@ export interface Modal<T> {
 		| 'harvest-stake'
 		| 'harvest-unstake'
 		| 'universal-scanner'
-		| 'pay-dialog';
+		| 'pay-dialog'
+		| 'wallet-connect-sessions';
 	data?: T;
 	id?: symbol;
 }
@@ -142,6 +143,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openUniversalScanner: (params: SetWithOptionalDataParams<UniversalScannerData>) => void;
 	openPayDialog: (id: symbol) => void;
 	openGetToken: (id: symbol) => void;
+	openWalletConnectSessions: (id: symbol) => void;
 	close: () => void;
 }
 
@@ -252,6 +254,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 		),
 		openPayDialog: setType('pay-dialog'),
 		openGetToken: setType('get-token'),
+		openWalletConnectSessions: setType('wallet-connect-sessions'),
 		close: () => set(null),
 		subscribe
 	};

--- a/src/frontend/src/tests/lib/components/wallet-connect/WalletConnect.spec.ts
+++ b/src/frontend/src/tests/lib/components/wallet-connect/WalletConnect.spec.ts
@@ -1,0 +1,60 @@
+import WalletConnect from '$lib/components/wallet-connect/WalletConnect.svelte';
+import { modalStore } from '$lib/stores/modal.store';
+import { assertNonNullish } from '@dfinity/utils';
+import { fireEvent, render } from '@testing-library/svelte';
+
+vi.mock('$lib/derived/address.derived', async () => {
+	const { writable } = await import('svelte/store');
+	return {
+		ethAddressNotLoaded: writable(false),
+		solAddressMainnetNotLoaded: writable(false)
+	};
+});
+
+describe('WalletConnect', () => {
+	const openSessionsSpy = vi
+		.spyOn(modalStore, 'openWalletConnectSessions')
+		.mockImplementation(() => {});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should render WalletConnect button', () => {
+		const { container } = render(WalletConnect);
+
+		const button = container.querySelector('button');
+
+		expect(button).toBeInTheDocument();
+	});
+
+	it('should render WalletConnect icon', () => {
+		const { container } = render(WalletConnect);
+
+		const svg = container.querySelector('svg');
+
+		expect(svg).toBeInTheDocument();
+	});
+
+	it('should open wallet connect sessions modal on click', async () => {
+		const { container } = render(WalletConnect);
+
+		const button = container.querySelector('button');
+
+		expect(button).not.toBeNull();
+
+		assertNonNullish(button);
+
+		await fireEvent.click(button);
+
+		expect(openSessionsSpy).toHaveBeenCalledExactlyOnceWith(expect.any(Symbol));
+	});
+
+	it('should not be disabled when addresses are loaded', () => {
+		const { container } = render(WalletConnect);
+
+		const button = container.querySelector('button');
+
+		expect(button).not.toBeDisabled();
+	});
+});


### PR DESCRIPTION
# Motivation

We can now add a new modal for WC session overview and show it on WC button click.