### PR TITLE
fix(frontend): Do not persist unavailable canister dismissed notifications

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -96,14 +96,6 @@
 		})
 	);
 
-	let undismissedUnavailable = $derived(
-		filterUndismissedNotificationQualifiers({
-			kind: 'UnavailableIndexCanister',
-			qualifiers: tokensWithUnavailableCanister,
-			dismissedNotifications: allDismissedNotifications
-		})
-	);
-
 	const dismissNoCanisterWarning = () => {
 		if (undismissedNoCanister.length > 0) {
 			const notifications: DismissedNotification[] = undismissedNoCanister.map((symbol) => ({
@@ -111,26 +103,6 @@
 					kind: { NoIndexCanister: null },
 					qualifier: symbol,
 					version: NOTIFICATION_VERSIONS.NoIndexCanister
-				}
-			}));
-
-			temporaryDismissedNotifications = [...temporaryDismissedNotifications, ...notifications];
-
-			dismissNotifications({
-				notifications,
-				identity: $authIdentity,
-				currentUserVersion: $userProfileVersion
-			});
-		}
-	};
-
-	const dismissUnavailableWarning = () => {
-		if (undismissedUnavailable.length > 0) {
-			const notifications: DismissedNotification[] = undismissedUnavailable.map((symbol) => ({
-				Qualified: {
-					kind: { UnavailableIndexCanister: null },
-					qualifier: symbol,
-					version: NOTIFICATION_VERSIONS.UnavailableIndexCanister
 				}
 			}));
 
@@ -165,10 +137,10 @@
 		</MessageBox>
 	{/if}
 
-	{#if undismissedUnavailable.length > 0}
-		<MessageBox level="warning" onDismiss={dismissUnavailableWarning}>
+	{#if tokensWithUnavailableCanister.length > 0}
+		<MessageBox level="warning">
 			{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
-				$token_list: undismissedUnavailable.map((s) => `$${s}`).join(', ')
+				$token_list: tokensWithUnavailableCanister.map((s) => `$${s}`).join(', ')
 			})}
 		</MessageBox>
 	{/if}

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -138,7 +138,7 @@
 	{/if}
 
 	{#if tokensWithUnavailableCanister.length > 0}
-		<MessageBox level="warning">
+		<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
 			{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
 				$token_list: tokensWithUnavailableCanister.map((s) => `$${s}`).join(', ')
 			})}

--- a/src/frontend/src/lib/components/ui/MessageBox.svelte
+++ b/src/frontend/src/lib/components/ui/MessageBox.svelte
@@ -18,8 +18,15 @@
 		onDismiss?: () => void;
 	}
 
-	let { children, icon, level = 'info', closableKey, styleClass, testId, onDismiss }: Props =
-		$props();
+	let {
+		children,
+		icon,
+		level = 'info',
+		closableKey,
+		styleClass,
+		testId,
+		onDismiss
+	}: Props = $props();
 
 	const closable = $derived(nonNullish(onDismiss) || nonNullish(closableKey));
 

--- a/src/frontend/src/lib/components/ui/MessageBox.svelte
+++ b/src/frontend/src/lib/components/ui/MessageBox.svelte
@@ -1,28 +1,40 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import IconClose from '$lib/components/icons/lucide/IconClose.svelte';
 	import IconInfo from '$lib/components/icons/lucide/IconInfo.svelte';
 	import { SLIDE_EASING } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { type HideInfoKey, saveHideInfo, shouldHideInfo } from '$lib/utils/info.utils';
 
 	interface Props {
 		children: Snippet;
 		icon?: Snippet;
 		level?: 'plain' | 'info' | 'warning' | 'error' | 'success';
+		closableKey?: HideInfoKey;
 		styleClass?: string;
 		testId?: string;
 		onDismiss?: () => void;
 	}
 
-	let { children, icon, level = 'info', styleClass, testId, onDismiss }: Props = $props();
+	let { children, icon, level = 'info', closableKey, styleClass, testId, onDismiss }: Props =
+		$props();
 
-	const closable = $derived(nonNullish(onDismiss));
-	let visible = $state(true);
+	const closable = $derived(nonNullish(onDismiss) || nonNullish(closableKey));
+
+	// TODO: check if there is a better way to handle this svelte-ignore
+	// eslint-disable-next-line svelte/no-unused-svelte-ignore
+	// svelte-ignore state_referenced_locally -- we want to get only the initial value
+	let visible = $state(isNullish(closableKey) || !shouldHideInfo(closableKey));
 
 	const close = () => {
 		visible = false;
+
+		if (nonNullish(closableKey)) {
+			saveHideInfo(closableKey);
+		}
+
 		onDismiss?.();
 	};
 </script>

--- a/src/frontend/src/lib/constants/notification.constants.ts
+++ b/src/frontend/src/lib/constants/notification.constants.ts
@@ -1,5 +1,4 @@
 export const NOTIFICATION_VERSIONS = {
 	BtcActivityInfo: 1,
-	NoIndexCanister: 1,
-	UnavailableIndexCanister: 1
+	NoIndexCanister: 1
 } as const;

--- a/src/frontend/src/lib/utils/info.utils.ts
+++ b/src/frontend/src/lib/utils/info.utils.ts
@@ -4,7 +4,8 @@ import { consoleError } from '$lib/utils/console.utils';
 export type HideInfoKey =
 	| 'oisy_ic_hide_bitcoin_info'
 	| 'oisy_ic_hide_ethereum_info'
-	| 'oisy_ic_hide_erc20_info';
+	| 'oisy_ic_hide_erc20_info'
+	| 'oisy_ic_hide_transaction_unavailable_canister';
 
 export const saveHideInfo = (key: HideInfoKey) => {
 	try {

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -100,6 +100,31 @@ describe('AllTransactions', () => {
 		expect(getByText(exceptedText)).toBeInTheDocument();
 	});
 
+	it('renders the unavailable Index canister warning box without a close button', () => {
+		const tokenWithUnavailableIndexCanister: IcrcCustomToken = {
+			...customIcrcToken,
+			symbol: 'UTC',
+			indexCanisterId: 'mxzaz-hqaaa-aaaar-qaada-cai'
+		};
+
+		icrcCustomTokensStore.setAll([{ data: tokenWithUnavailableIndexCanister, certified: true }]);
+
+		const store = get(icrcCustomTokensStore);
+		const tokenId = store?.at(0)?.data.id;
+		assertNonNullish(tokenId);
+		icTransactionsStore.nullify(tokenId);
+
+		const { container } = render(AllTransactions);
+
+		const warningBoxes = container.querySelectorAll('.bg-warning-light');
+		expect(warningBoxes.length).toBeGreaterThan(0);
+
+		const unavailableWarning = warningBoxes[0];
+		const closeButton = unavailableWarning.querySelector('button');
+
+		expect(closeButton).toBeNull();
+	});
+
 	it('renders the info box list', () => {
 		const { getByText } = render(AllTransactions);
 
@@ -128,12 +153,6 @@ describe('AllTransactions', () => {
 		const tokenWithoutIndexCanister: IcrcCustomToken = {
 			...customIcrcToken,
 			symbol: 'NIC'
-		};
-
-		const tokenWithUnavailableIndexCanister: IcrcCustomToken = {
-			...customIcrcToken,
-			symbol: 'UIC',
-			indexCanisterId: 'mxzaz-hqaaa-aaaar-qaada-cai'
 		};
 
 		const setUserProfileWithDismissals = (dismissed: DismissedNotification[]) => {
@@ -227,33 +246,6 @@ describe('AllTransactions', () => {
 
 			const expectedText = replacePlaceholders(en.activity.warning.no_index_canister, {
 				$token_list: '$NIC'
-			});
-
-			expect(queryByText(expectedText)).not.toBeInTheDocument();
-		});
-
-		it('should not render the unavailable-index-canister warning when dismissed in user profile', () => {
-			icrcCustomTokensStore.setAll([{ data: tokenWithUnavailableIndexCanister, certified: true }]);
-
-			const store = get(icrcCustomTokensStore);
-			const tokenId = store?.at(0)?.data.id;
-			assertNonNullish(tokenId);
-			icTransactionsStore.nullify(tokenId);
-
-			setUserProfileWithDismissals([
-				{
-					Qualified: {
-						kind: { UnavailableIndexCanister: null },
-						qualifier: 'UIC',
-						version: NOTIFICATION_VERSIONS.UnavailableIndexCanister
-					}
-				}
-			]);
-
-			const { queryByText } = render(AllTransactions);
-
-			const expectedText = replacePlaceholders(en.activity.warning.unavailable_index_canister, {
-				$token_list: '$UIC'
 			});
 
 			expect(queryByText(expectedText)).not.toBeInTheDocument();

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -115,9 +115,7 @@ describe('AllTransactions', () => {
 		icTransactionsStore.nullify(tokenId);
 
 		const spySessionStorage = vi.spyOn(Storage.prototype, 'setItem');
-		const spyDismiss = vi
-			.spyOn(notificationServices, 'dismissNotifications')
-			.mockResolvedValue();
+		const spyDismiss = vi.spyOn(notificationServices, 'dismissNotifications').mockResolvedValue();
 
 		const { container } = render(AllTransactions);
 

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -100,7 +100,7 @@ describe('AllTransactions', () => {
 		expect(getByText(exceptedText)).toBeInTheDocument();
 	});
 
-	it('renders the unavailable Index canister warning box without a close button', () => {
+	it('closes the unavailable Index canister warning via sessionStorage, not backend persistence', async () => {
 		const tokenWithUnavailableIndexCanister: IcrcCustomToken = {
 			...customIcrcToken,
 			symbol: 'UTC',
@@ -114,15 +114,29 @@ describe('AllTransactions', () => {
 		assertNonNullish(tokenId);
 		icTransactionsStore.nullify(tokenId);
 
+		const spySessionStorage = vi.spyOn(Storage.prototype, 'setItem');
+		const spyDismiss = vi
+			.spyOn(notificationServices, 'dismissNotifications')
+			.mockResolvedValue();
+
 		const { container } = render(AllTransactions);
 
-		const warningBoxes = container.querySelectorAll('.bg-warning-light');
-		expect(warningBoxes.length).toBeGreaterThan(0);
+		const warningBox = container.querySelector('.bg-warning-light');
+		assertNonNullish(warningBox);
 
-		const unavailableWarning = warningBoxes[0];
-		const closeButton = unavailableWarning.querySelector('button');
+		const closeButton = warningBox.querySelector('button');
+		assertNonNullish(closeButton);
 
-		expect(closeButton).toBeNull();
+		await fireEvent.click(closeButton);
+
+		expect(spySessionStorage).toHaveBeenCalledWith(
+			'oisy_ic_hide_transaction_unavailable_canister',
+			'true'
+		);
+		expect(spyDismiss).not.toHaveBeenCalled();
+
+		spySessionStorage.mockRestore();
+		spyDismiss.mockRestore();
 	});
 
 	it('renders the info box list', () => {

--- a/src/frontend/src/tests/lib/components/ui/MessageBox.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MessageBox.spec.ts
@@ -81,7 +81,7 @@ describe('MessageBox', () => {
 	});
 
 	describe('close button', () => {
-		it('should not render a close button when onDismiss is not provided', () => {
+		it('should not render a close button when neither onDismiss nor closableKey is provided', () => {
 			const { queryByRole } = render(MessageBox, {
 				props: { children: childrenSnippet }
 			});
@@ -92,6 +92,14 @@ describe('MessageBox', () => {
 		it('should render a close button when onDismiss is provided', () => {
 			const { getByRole } = render(MessageBox, {
 				props: { children: childrenSnippet, onDismiss: vi.fn() }
+			});
+
+			expect(getByRole('button', { name: en.core.text.close })).toBeInTheDocument();
+		});
+
+		it('should render a close button when closableKey is provided', () => {
+			const { getByRole } = render(MessageBox, {
+				props: { children: childrenSnippet, closableKey: 'oisy_ic_hide_bitcoin_info' }
 			});
 
 			expect(getByRole('button', { name: en.core.text.close })).toBeInTheDocument();
@@ -127,6 +135,44 @@ describe('MessageBox', () => {
 			await fireEvent.click(closeButton);
 
 			expect(onDismiss).toHaveBeenCalledOnce();
+		});
+
+		it('should save to sessionStorage when closableKey is provided and close is clicked', async () => {
+			const spySetItem = vi.spyOn(Storage.prototype, 'setItem');
+
+			const { getByRole } = render(MessageBox, {
+				props: {
+					children: childrenSnippet,
+					closableKey: 'oisy_ic_hide_transaction_unavailable_canister'
+				}
+			});
+
+			const closeButton = getByRole('button', { name: en.core.text.close });
+
+			await fireEvent.click(closeButton);
+
+			expect(spySetItem).toHaveBeenCalledWith(
+				'oisy_ic_hide_transaction_unavailable_canister',
+				'true'
+			);
+
+			spySetItem.mockRestore();
+		});
+
+		it('should not be visible when closableKey was previously saved in sessionStorage', () => {
+			vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('true');
+
+			const { queryByTestId } = render(MessageBox, {
+				props: {
+					children: childrenSnippet,
+					closableKey: 'oisy_ic_hide_transaction_unavailable_canister',
+					testId: 'msg-box'
+				}
+			});
+
+			expect(queryByTestId('msg-box')).not.toBeInTheDocument();
+
+			vi.restoreAllMocks();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/utils/notification.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/notification.utils.spec.ts
@@ -21,12 +21,12 @@ describe('notification.utils', () => {
 		qualifier,
 		version = NOTIFICATION_VERSIONS[kind]
 	}: {
-		kind: 'NoIndexCanister' | 'UnavailableIndexCanister';
+		kind: 'NoIndexCanister';
 		qualifier: string;
 		version?: number;
 	}): DismissedNotification => ({
 		Qualified: {
-			kind: { [kind]: null } as { NoIndexCanister: null } | { UnavailableIndexCanister: null },
+			kind: { [kind]: null } as { NoIndexCanister: null },
 			qualifier,
 			version
 		}
@@ -120,10 +120,7 @@ describe('notification.utils', () => {
 				const result = filterUndismissedNotificationQualifiers({
 					kind: 'NoIndexCanister',
 					qualifiers: ['BTC', 'ETH'],
-					dismissedNotifications: [
-						qualified({ kind: 'UnavailableIndexCanister', qualifier: 'BTC' }),
-						simple({ kind: 'BtcActivityInfo' })
-					]
+					dismissedNotifications: [simple({ kind: 'BtcActivityInfo' })]
 				});
 
 				expect(result).toEqual(['BTC', 'ETH']);
@@ -136,30 +133,6 @@ describe('notification.utils', () => {
 					dismissedNotifications: [
 						qualified({ kind: 'NoIndexCanister', qualifier: 'BTC', version: 0 })
 					]
-				});
-
-				expect(result).toEqual(['BTC']);
-			});
-		});
-
-		describe('UnavailableIndexCanister kind', () => {
-			it('should filter dismissed UnavailableIndexCanister qualifiers', () => {
-				const result = filterUndismissedNotificationQualifiers({
-					kind: 'UnavailableIndexCanister',
-					qualifiers: ['BTC', 'ETH', 'ICP'],
-					dismissedNotifications: [
-						qualified({ kind: 'UnavailableIndexCanister', qualifier: 'ETH' })
-					]
-				});
-
-				expect(result).toEqual(['BTC', 'ICP']);
-			});
-
-			it('should not filter qualifiers dismissed under NoIndexCanister', () => {
-				const result = filterUndismissedNotificationQualifiers({
-					kind: 'UnavailableIndexCanister',
-					qualifiers: ['BTC'],
-					dismissedNotifications: [qualified({ kind: 'NoIndexCanister', qualifier: 'BTC' })]
 				});
 
 				expect(result).toEqual(['BTC']);


### PR DESCRIPTION
# Motivation

For the tokens that have index canister but not available, we do not want to persist the dismissing of the message warning in the backend.

So we revert to what it was the code before, only for those.