### PR TITLE
feat(backend)!: Transactions settings with filter in user's profile

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -411,7 +411,8 @@ type Settings = record {
 	networks : NetworksSettings;
 	notifications : opt NotificationSettings;
 	dapp : DappSettings;
-	experimental_features : ExperimentalFeaturesSettings
+	experimental_features : ExperimentalFeaturesSettings;
+	transactions : opt TransactionSettings
 };
 type SignedDelegation = record { signature : blob; delegation : Delegation };
 type SimpleNotificationKind = variant { BtcActivityInfo };
@@ -495,6 +496,8 @@ type TopUpCyclesLedgerResult = variant {
 	Ok : TopUpCyclesLedgerResponse;
 	Err : TopUpCyclesLedgerError
 };
+type TransactionFilterSettings = record { hide_micro_transactions : bool };
+type TransactionSettings = record { filter : opt TransactionFilterSettings };
 type TransformArgs = record { context : blob; response : HttpRequestResult };
 type UpdateAgreementsError = variant { VersionMismatch; UserNotFound };
 type UpdateExperimentalFeaturesSettingsRequest = record {

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -443,6 +443,7 @@ export interface Settings {
 	notifications: [] | [NotificationSettings];
 	dapp: DappSettings;
 	experimental_features: ExperimentalFeaturesSettings;
+	transactions: [] | [TransactionSettings];
 }
 export interface SignedDelegation {
 	signature: Uint8Array;
@@ -533,6 +534,12 @@ export interface TopUpCyclesLedgerResponse {
 export type TopUpCyclesLedgerResult =
 	| { Ok: TopUpCyclesLedgerResponse }
 	| { Err: TopUpCyclesLedgerError };
+export interface TransactionFilterSettings {
+	hide_micro_transactions: boolean;
+}
+export interface TransactionSettings {
+	filter: [] | [TransactionFilterSettings];
+}
 export interface TransformArgs {
 	context: Uint8Array;
 	response: HttpRequestResult;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -333,11 +333,18 @@ export const idlFactory = ({ IDL }) => {
 			IDL.Tuple(ExperimentalFeatureSettingsFor, ExperimentalFeatureSettings)
 		)
 	});
+	const TransactionFilterSettings = IDL.Record({
+		hide_micro_transactions: IDL.Bool
+	});
+	const TransactionSettings = IDL.Record({
+		filter: IDL.Opt(TransactionFilterSettings)
+	});
 	const Settings = IDL.Record({
 		networks: NetworksSettings,
 		notifications: IDL.Opt(NotificationSettings),
 		dapp: DappSettings,
-		experimental_features: ExperimentalFeaturesSettings
+		experimental_features: ExperimentalFeaturesSettings,
+		transactions: IDL.Opt(TransactionSettings)
 	});
 	const UserProfile = IDL.Record({
 		agreements: IDL.Opt(Agreements),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -333,11 +333,18 @@ export const idlFactory = ({ IDL }) => {
 			IDL.Tuple(ExperimentalFeatureSettingsFor, ExperimentalFeatureSettings)
 		)
 	});
+	const TransactionFilterSettings = IDL.Record({
+		hide_micro_transactions: IDL.Bool
+	});
+	const TransactionSettings = IDL.Record({
+		filter: IDL.Opt(TransactionFilterSettings)
+	});
 	const Settings = IDL.Record({
 		networks: NetworksSettings,
 		notifications: IDL.Opt(NotificationSettings),
 		dapp: DappSettings,
-		experimental_features: ExperimentalFeaturesSettings
+		experimental_features: ExperimentalFeaturesSettings,
+		transactions: IDL.Opt(TransactionSettings)
 	});
 	const UserProfile = IDL.Record({
 		agreements: IDL.Opt(Agreements),

--- a/src/frontend/src/tests/mocks/user-profile.mock.ts
+++ b/src/frontend/src/tests/mocks/user-profile.mock.ts
@@ -39,7 +39,8 @@ export const mockUserSettings: Settings = {
 	networks: mockNetworksSettings,
 	dapp: mockDappSettings,
 	experimental_features: mockExperimentalFeaturesSettings,
-	notifications: []
+	notifications: [],
+	transactions: [{ filter: [{ hide_micro_transactions: true }] }]
 };
 
 const mockUserAgreement: UserAgreement = {

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -582,9 +582,9 @@ impl StoredUserProfile {
         let mut new_profile = self.with_incremented_version();
         new_profile.settings = {
             let mut settings = new_profile.settings.unwrap_or_default();
-            settings.transactions = Some(TransactionSettings {
-                filter: Some(filter),
-            });
+            let mut transactions = settings.transactions.unwrap_or_default();
+            transactions.filter = Some(filter);
+            settings.transactions = Some(transactions);
             Some(settings)
         };
         new_profile.updated_timestamp = now;

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -584,7 +584,6 @@ impl StoredUserProfile {
             let mut settings = new_profile.settings.unwrap_or_default();
             settings.transactions = Some(TransactionSettings {
                 filter: Some(filter),
-                ..settings.transactions.unwrap_or_default()
             });
             Some(settings)
         };

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -32,6 +32,10 @@ use crate::{
             MAX_DISMISSED_NOTIFICATIONS_LIST_LENGTH,
         },
         settings::Settings,
+        transaction_settings::{
+            TransactionFilterSettings, TransactionSettings,
+            UpdateTransactionFilterSettingsError,
+        },
         token::{UserToken, EVM_CONTRACT_ADDRESS_LENGTH},
         user_profile::{OisyUser, StoredUserProfile, UserProfile},
         Timestamp, TokenVersion, Version, MAX_SYMBOL_LENGTH,
@@ -234,6 +238,9 @@ impl StoredUserProfile {
             },
             experimental_features: ExperimentalFeaturesSettings::default(),
             notifications: None,
+            transactions: Some(TransactionSettings {
+                filter: Some(TransactionFilterSettings::default()),
+            }),
         };
         let agreements = Agreements::default();
         StoredUserProfile {
@@ -541,6 +548,45 @@ impl StoredUserProfile {
         new_profile.settings = {
             let mut settings = new_profile.settings.unwrap_or_default();
             settings.experimental_features.experimental_features = new_experimental_features;
+            Some(settings)
+        };
+        new_profile.updated_timestamp = now;
+        Ok(new_profile)
+    }
+
+    /// Returns a copy with the transaction filter settings updated.
+    ///
+    /// # Errors
+    ///
+    /// Will return Err if there is a version mismatch.
+    pub fn with_transaction_filter_settings(
+        &self,
+        profile_version: Option<Version>,
+        now: Timestamp,
+        filter: TransactionFilterSettings,
+    ) -> Result<StoredUserProfile, UpdateTransactionFilterSettingsError> {
+        if profile_version != self.version {
+            return Err(UpdateTransactionFilterSettingsError::VersionMismatch);
+        }
+
+        let transactions = self
+            .settings
+            .clone()
+            .unwrap_or_default()
+            .transactions
+            .unwrap_or_default();
+
+        if transactions.filter.as_ref() == Some(&filter) {
+            return Ok(self.clone());
+        }
+
+        let mut new_profile = self.with_incremented_version();
+        new_profile.settings = {
+            let mut settings = new_profile.settings.unwrap_or_default();
+            settings.transactions = Some(TransactionSettings {
+                filter: Some(filter),
+                ..settings.transactions.unwrap_or_default()
+            });
             Some(settings)
         };
         new_profile.updated_timestamp = now;

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -32,11 +32,10 @@ use crate::{
             MAX_DISMISSED_NOTIFICATIONS_LIST_LENGTH,
         },
         settings::Settings,
-        transaction_settings::{
-            TransactionFilterSettings, TransactionSettings,
-            UpdateTransactionFilterSettingsError,
-        },
         token::{UserToken, EVM_CONTRACT_ADDRESS_LENGTH},
+        transaction_settings::{
+            TransactionFilterSettings, TransactionSettings, UpdateTransactionFilterSettingsError,
+        },
         user_profile::{OisyUser, StoredUserProfile, UserProfile},
         Timestamp, TokenVersion, Version, MAX_SYMBOL_LENGTH,
     },

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -22,6 +22,7 @@ pub mod pow;
 pub mod result_types;
 pub mod settings;
 pub mod signer;
+pub mod transaction_settings;
 pub mod token;
 pub mod token_id;
 pub mod token_standard;

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -22,11 +22,11 @@ pub mod pow;
 pub mod result_types;
 pub mod settings;
 pub mod signer;
-pub mod transaction_settings;
 pub mod token;
 pub mod token_id;
 pub mod token_standard;
 pub mod transaction;
+pub mod transaction_settings;
 pub mod user_profile;
 pub mod user_transaction;
 

--- a/src/shared/src/types/settings.rs
+++ b/src/shared/src/types/settings.rs
@@ -3,6 +3,7 @@ use candid::{CandidType, Deserialize};
 use crate::types::{
     dapp::DappSettings, experimental_feature::ExperimentalFeaturesSettings,
     network::NetworksSettings, notification::NotificationSettings,
+    transaction_settings::TransactionSettings,
 };
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
@@ -11,4 +12,5 @@ pub struct Settings {
     pub dapp: DappSettings,
     pub experimental_features: ExperimentalFeaturesSettings,
     pub notifications: Option<NotificationSettings>,
+    pub transactions: Option<TransactionSettings>,
 }

--- a/src/shared/src/types/transaction_settings.rs
+++ b/src/shared/src/types/transaction_settings.rs
@@ -1,0 +1,33 @@
+use candid::{CandidType, Deserialize};
+
+use crate::types::Version;
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct TransactionFilterSettings {
+    pub hide_micro_transactions: bool,
+}
+
+impl Default for TransactionFilterSettings {
+    fn default() -> Self {
+        Self {
+            hide_micro_transactions: true,
+        }
+    }
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub struct TransactionSettings {
+    pub filter: Option<TransactionFilterSettings>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum UpdateTransactionFilterSettingsError {
+    UserNotFound,
+    VersionMismatch,
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct UpdateTransactionFilterSettingsRequest {
+    pub filter: TransactionFilterSettings,
+    pub current_user_version: Option<Version>,
+}


### PR DESCRIPTION
# Motivation

We want to start persisting some settings about transactions. Specifically the enabling or disabling of filters.

In this PR, we first create the transactions settings with the sub-settings for filters.

BREAKING CHANGE: Expansion of the user profile type with new settings.
