### PR TITLE
feat(frontend): update Scanner logic on desktop

### DIFF
--- a/src/frontend/src/lib/components/qr/QrCodeScanner.svelte
+++ b/src/frontend/src/lib/components/qr/QrCodeScanner.svelte
@@ -7,14 +7,15 @@
 	import { ADDRESS_BOOK_QR_CODE_SCAN } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { QrStatus } from '$lib/types/qr-code';
+	import { isMobile } from '$lib/utils/device.utils';
 
 	interface Props {
 		onScan: ({ status, code }: { status: QrStatus; code?: string }) => void;
-		expandedLayout?: boolean;
+		universalScanner?: boolean;
 		onBack?: () => void;
 	}
 
-	let { onScan, onBack, expandedLayout = false }: Props = $props();
+	let { onScan, onBack, universalScanner = false }: Props = $props();
 
 	let resolveQrCodePromise:
 		| (({ status, code }: { status: QrStatus; code?: string }) => void)
@@ -23,7 +24,9 @@
 	let cameraPermissionDenied = $state(false);
 
 	onMount(async () => {
-		await scanQrCode();
+		if (isMobile() || !universalScanner) {
+			await scanQrCode();
+		}
 	});
 
 	const scanQrCode = async () => {
@@ -63,33 +66,41 @@
 </script>
 
 <div
-	class="qr-code-wrapper relative flex w-full items-center justify-center"
-	class:h-[60vh]={!expandedLayout}
-	class:h-[calc(100vh-128px)]={expandedLayout}
-	class:min-h-[300px]={!expandedLayout}
-	class:sm:h-[calc(100vh-148px)]={expandedLayout}
-	class:sm:max-h-[700px]={expandedLayout}
-	class:sm:min-h-[500px]={expandedLayout}
+	class="qr-code-wrapper relative flex w-full items-start justify-center"
+	class:h-[60vh]={!universalScanner}
+	class:h-[calc(100vh-128px)]={universalScanner}
+	class:min-h-[300px]={!universalScanner}
+	class:sm:h-[calc(100vh-148px)]={universalScanner}
+	class:sm:max-h-[700px]={universalScanner}
+	class:sm:min-h-[500px]={universalScanner}
 	data-tid={ADDRESS_BOOK_QR_CODE_SCAN}
 >
 	{#if nonNullish(resolveQrCodePromise)}
 		<QrCodeReader
-			{expandedLayout}
+			{universalScanner}
 			on:nnsCancel={onCancel}
 			on:nnsQRCode={onQRCode}
 			on:nnsQRCodeError={onError}
 		/>
-	{:else if cameraPermissionDenied}
-		<div class="text-center text-sm text-tertiary">
-			{$i18n.scanner.text.no_camera_permission}
-		</div>
 	{:else}
-		<div class="absolute inset-0 flex h-full w-full items-center justify-center">
-			<Button onclick={scanQrCode} paddingSmall styleClass="max-w-[16rem]">
-				<span>{$i18n.scanner.text.scan_qr_code}</span>
+		<div
+			class="flex w-[90%] items-center justify-center rounded-lg border border-dashed border-secondary"
+			class:h-[60%]={universalScanner}
+			class:h-full={!universalScanner}
+			class:my-10={universalScanner}
+			class:sm:h-[calc(100%-280px)]={universalScanner}
+		>
+			{#if cameraPermissionDenied}
+				<div class="text-center text-sm text-tertiary">
+					{$i18n.scanner.text.no_camera_permission}
+				</div>
+			{:else}
+				<Button onclick={scanQrCode} paddingSmall styleClass="max-w-[16rem]">
+					<span>{$i18n.scanner.text.scan_qr_code}</span>
 
-				<IconScanLine />
-			</Button>
+					<IconScanLine />
+				</Button>
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/src/frontend/src/lib/components/scanner/ScannerCode.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerCode.svelte
@@ -111,7 +111,7 @@
 </script>
 
 <div class="relative flex w-full flex-col bg-tertiary">
-	<QrCodeScanner expandedLayout onScan={handleScan} />
+	<QrCodeScanner onScan={handleScan} universalScanner />
 
 	<Responsive up="md">
 		<ScannerCodeInput

--- a/src/frontend/src/lib/components/ui/QrCodeReader.svelte
+++ b/src/frontend/src/lib/components/ui/QrCodeReader.svelte
@@ -5,10 +5,10 @@
 	import { nextElementId } from '$lib/utils/html.utils';
 
 	interface Props {
-		expandedLayout?: boolean;
+		universalScanner?: boolean;
 	}
 
-	let { expandedLayout = false }: Props = $props();
+	let { universalScanner = false }: Props = $props();
 
 	const id = nextElementId('qrcode-reader-');
 
@@ -131,7 +131,7 @@
 
 	<div
 		class="[container-type:size] pointer-events-none absolute inset-0 flex h-full items-center justify-center"
-		class:sm:h-[70%]={expandedLayout}
+		class:sm:h-[70%]={universalScanner}
 	>
 		<div class="relative aspect-square w-[min(60cqw,60cqh)]">
 			<span class="{cornerBase} top-0 left-0 rounded-tl-xl border-t-[5px] border-l-[5px]"></span>

--- a/src/frontend/src/tests/lib/components/qr/QrCodeScanner.spec.ts
+++ b/src/frontend/src/tests/lib/components/qr/QrCodeScanner.spec.ts
@@ -28,9 +28,9 @@ describe('QrCodeScanner', () => {
 		expect(getByTestId(ADDRESS_BOOK_QR_CODE_SCAN)).toBeInTheDocument();
 	});
 
-	it('should apply default height classes when expandedLayout is false', () => {
+	it('should apply default height classes when universalScanner is false', () => {
 		const { getByTestId } = render(QrCodeScanner, {
-			props: { onScan: mockOnScan, expandedLayout: false }
+			props: { onScan: mockOnScan, universalScanner: false }
 		});
 
 		const wrapper = getByTestId(ADDRESS_BOOK_QR_CODE_SCAN);
@@ -39,9 +39,9 @@ describe('QrCodeScanner', () => {
 		expect(wrapper.classList.contains('min-h-[300px]')).toBeTruthy();
 	});
 
-	it('should apply expanded height classes when expandedLayout is true', () => {
+	it('should apply expanded height classes when universalScanner is true', () => {
 		const { getByTestId } = render(QrCodeScanner, {
-			props: { onScan: mockOnScan, expandedLayout: true }
+			props: { onScan: mockOnScan, universalScanner: true }
 		});
 
 		const wrapper = getByTestId(ADDRESS_BOOK_QR_CODE_SCAN);


### PR DESCRIPTION
# Motivation

We need to make the following changes in the scanner component:
  - Rename expandedLayout prop to universalScanner across QrCodeScanner, QrCodeReader, and ScannerCode components for clearer intent                                            
  - Skip auto-starting the QR camera scan on desktop when in universal scanner mode (isMobile() || !universalScanner), showing a manual "Scan QR code" button instead           
  - Restructure the scanner fallback UI: wrap the permission-denied message and scan button in a dashed-border placeholder container with responsive sizing                     
  - Update alignment from items-center to items-start in the scanner wrapper        
