### PR TITLE
fix(frontend): rename i18n key universal_scanner to scanner

### DIFF
--- a/src/frontend/src/lib/config/scanner.config.ts
+++ b/src/frontend/src/lib/config/scanner.config.ts
@@ -11,7 +11,7 @@ export const scannerWizardSteps = ({
 	},
 	{
 		name: WizardStepsScanner.OISY_SCANNER_INFO,
-		title: i18n.scanner.text.universal_scanner
+		title: i18n.scanner.text.scanner
 	},
 	{
 		name: WizardStepsScanner.PAY,

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short يفهم أي رمز QR",
 			"learn_more_about_scan": "معرفة المزيد عن الماسح الضوئي",
 			"learn_more_about_pay": "معرفة المزيد عن $oisy_short Pay",
-			"universal_scanner": "الماسح الضوئي"
+			"scanner": "الماسح الضوئي"
 		},
 		"error": {
 			"code_link_is_not_valid": "الرمز/الرابط غير صالح",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short rozumí jakémukoli QR kódu",
 			"learn_more_about_scan": "Více o skeneru",
 			"learn_more_about_pay": "Více o $oisy_short Pay",
-			"universal_scanner": "Skener"
+			"scanner": "Skener"
 		},
 		"error": {
 			"code_link_is_not_valid": "Kód / odkaz není platný",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short versteht jeden QR-Code",
 			"learn_more_about_scan": "Mehr über den Scanner erfahren",
 			"learn_more_about_pay": "Mehr über $oisy_short Pay erfahren",
-			"universal_scanner": "Scanner"
+			"scanner": "Scanner"
 		},
 		"error": {
 			"code_link_is_not_valid": "Code/URL ist nicht gültig",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short understands any QR code",
 			"learn_more_about_scan": "Learn more about the scanner",
 			"learn_more_about_pay": "Learn more about $oisy_short Pay",
-			"universal_scanner": "Scanner"
+			"scanner": "Scanner"
 		},
 		"error": {
 			"code_link_is_not_valid": "Code/link is not valid",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short entiende cualquier código QR",
 			"learn_more_about_scan": "Más información sobre el escáner",
 			"learn_more_about_pay": "Más información sobre $oisy_short Pay",
-			"universal_scanner": "Escáner"
+			"scanner": "Escáner"
 		},
 		"error": {
 			"code_link_is_not_valid": "El código/enlace no es válido",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short comprend tous les codes QR",
 			"learn_more_about_scan": "En savoir plus sur le scanner",
 			"learn_more_about_pay": "En savoir plus sur $oisy_short Pay",
-			"universal_scanner": "Scanner"
+			"scanner": "Scanner"
 		},
 		"error": {
 			"code_link_is_not_valid": "Le code/lien n'est pas valide",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short किसी भी QR कोड को समझता है",
 			"learn_more_about_scan": "स्कैनर के बारे में और जानें",
 			"learn_more_about_pay": "$oisy_short Pay के बारे में और जानें",
-			"universal_scanner": "स्कैनर"
+			"scanner": "स्कैनर"
 		},
 		"error": {
 			"code_link_is_not_valid": "कोड/लिंक मान्य नहीं है",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short comprende qualsiasi codice QR",
 			"learn_more_about_scan": "Scopri di più sullo scanner",
 			"learn_more_about_pay": "Scopri di più su $oisy_short Pay",
-			"universal_scanner": "Scanner"
+			"scanner": "Scanner"
 		},
 		"error": {
 			"code_link_is_not_valid": "Il codice/link non è valido",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_shortはあらゆるQRコードに対応",
 			"learn_more_about_scan": "スキャナーについて詳しく",
 			"learn_more_about_pay": "$oisy_short Payについて詳しく",
-			"universal_scanner": "スキャナー"
+			"scanner": "スキャナー"
 		},
 		"error": {
 			"code_link_is_not_valid": "コード/リンクが無効です",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short는 모든 QR 코드를 인식합니다",
 			"learn_more_about_scan": "스캐너에 대해 자세히 알아보기",
 			"learn_more_about_pay": "$oisy_short Pay에 대해 자세히 알아보기",
-			"universal_scanner": "스캐너"
+			"scanner": "스캐너"
 		},
 		"error": {
 			"code_link_is_not_valid": "코드/링크가 유효하지 않습니다",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short rozumie każdy kod QR",
 			"learn_more_about_scan": "Dowiedz się więcej o skanerze",
 			"learn_more_about_pay": "Dowiedz się więcej o $oisy_short Pay",
-			"universal_scanner": "Skaner"
+			"scanner": "Skaner"
 		},
 		"error": {
 			"code_link_is_not_valid": "Kod/link jest nieprawidłowy",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short entende qualquer código QR",
 			"learn_more_about_scan": "Saiba mais sobre o scanner",
 			"learn_more_about_pay": "Saiba mais sobre o $oisy_short Pay",
-			"universal_scanner": "Scanner"
+			"scanner": "Scanner"
 		},
 		"error": {
 			"code_link_is_not_valid": "O código/link não é válido",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short распознаёт любой QR-код",
 			"learn_more_about_scan": "Узнать больше о сканере",
 			"learn_more_about_pay": "Узнать больше о $oisy_short Pay",
-			"universal_scanner": "Сканер"
+			"scanner": "Сканер"
 		},
 		"error": {
 			"code_link_is_not_valid": "Код/ссылка недействительна",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short hiểu mọi mã QR",
 			"learn_more_about_scan": "Tìm hiểu thêm về máy quét",
 			"learn_more_about_pay": "Tìm hiểu thêm về $oisy_short Pay",
-			"universal_scanner": "Máy quét"
+			"scanner": "Máy quét"
 		},
 		"error": {
 			"code_link_is_not_valid": "Mã/liên kết không hợp lệ",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1042,7 +1042,7 @@
 			"what_is_scan_title": "$oisy_short 可识别任何二维码",
 			"learn_more_about_scan": "了解更多关于扫描器的信息",
 			"learn_more_about_pay": "了解更多关于 $oisy_short Pay 的信息",
-			"universal_scanner": "扫描器"
+			"scanner": "扫描器"
 		},
 		"error": {
 			"code_link_is_not_valid": "代码 / 链接无效",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -772,7 +772,7 @@ interface I18nScanner {
 		what_is_scan_title: string;
 		learn_more_about_scan: string;
 		learn_more_about_pay: string;
-		universal_scanner: string;
+		scanner: string;
 	};
 	error: { code_link_is_not_valid: string; data_is_incompleted: string };
 }

--- a/src/frontend/src/tests/lib/config/scanner.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/scanner.config.spec.ts
@@ -12,7 +12,7 @@ describe('scanner.config', () => {
 			},
 			{
 				name: WizardStepsScanner.OISY_SCANNER_INFO,
-				title: en.scanner.text.universal_scanner
+				title: en.scanner.text.scanner
 			},
 			{
 				name: WizardStepsScanner.PAY,


### PR DESCRIPTION
# Motivation

The text for the i18n key `universal_scanner` was originally intended to read "Universal scanner". But we changed that to just "Scanner", so it's better to adjust the key.

# Changes

- Renamed `scanner.text.universal_scanner` to `scanner.text.scanner` in all 15 language files
- Updated the `i18n.d.ts` type definition accordingly
- Updated the reference in `scanner.config.ts`
- Updated the reference in `scanner.config.spec.ts`

# Tests

Existing `scanner.config.spec.ts` test updated and passing.