### PR TITLE
fix(frontend): use dvh instead of vh for height in QrCodeScanner

### DIFF
--- a/src/frontend/src/lib/components/qr/QrCodeScanner.svelte
+++ b/src/frontend/src/lib/components/qr/QrCodeScanner.svelte
@@ -68,9 +68,9 @@
 <div
 	class="qr-code-wrapper relative flex w-full items-start justify-center"
 	class:h-[60vh]={!universalScanner}
-	class:h-[calc(100vh-128px)]={universalScanner}
+	class:h-[calc(100dvh-128px)]={universalScanner}
 	class:min-h-[300px]={!universalScanner}
-	class:sm:h-[calc(100vh-148px)]={universalScanner}
+	class:sm:h-[calc(100dvh-148px)]={universalScanner}
 	class:sm:max-h-[700px]={universalScanner}
 	class:sm:min-h-[500px]={universalScanner}
 	data-tid={ADDRESS_BOOK_QR_CODE_SCAN}

--- a/src/frontend/src/tests/lib/components/qr/QrCodeScanner.spec.ts
+++ b/src/frontend/src/tests/lib/components/qr/QrCodeScanner.spec.ts
@@ -46,7 +46,7 @@ describe('QrCodeScanner', () => {
 
 		const wrapper = getByTestId(ADDRESS_BOOK_QR_CODE_SCAN);
 
-		expect(wrapper.classList.contains('h-[calc(100vh-128px)]')).toBeTruthy();
+		expect(wrapper.classList.contains('h-[calc(100dvh-128px)]')).toBeTruthy();
 	});
 
 	it('should show camera permission denied message on NotAllowedError', async () => {


### PR DESCRIPTION
# Motivation

- Fix unwanted scrollbar in the Scanner modal on mobile devices by replacing 100vh with 100dvh in QrCodeScanner                                                               
 - On mobile browsers, 100vh includes the area behind the browser's address bar and bottom navigation bar, making the scanner taller than the visible viewport. 100dvh (dynamic
   viewport height) accounts for the browser chrome and matches the actual visible area.                                                                                        
                                                                                                                                                                              
  Notes                                                                                                                                                                         
                                                                                                                                                                              
  - Only the universalScanner height classes are affected (100vh-128px and sm:100vh-148px). The non-universal 60vh is unchanged since at that scale the vh/dvh difference is    
  negligible and doesn't cause overflow.
  - Not reproducible in Chrome's "toggle device toolbar" since it doesn't emulate browser chrome — must be tested on a real mobile device.    
