### PR TITLE
feat(frontend): sns tokens also need to read out the groupDataId from the json

### DIFF
--- a/src/frontend/src/icp/utils/icrc.utils.ts
+++ b/src/frontend/src/icp/utils/icrc.utils.ts
@@ -115,6 +115,7 @@ export const mapIcrcToken = ({
 			deprecated: customTokenSymbol.deprecated
 		}),
 		tags: customTokenSymbol?.tags ?? twinTokenTags ?? DEFAULT_TOKEN_TAGS,
+		...(nonNullish(customTokenSymbol?.groupData) && { groupData: customTokenSymbol.groupData }),
 		ledgerCanisterId,
 		...metadataToken,
 		...rest,

--- a/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
@@ -3,7 +3,6 @@ import { IC_CKBTC_MINTER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import type { IcCkInterface, IcInterface } from '$icp/types/ic-token';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
-import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 import {
 	CUSTOM_SYMBOLS_BY_LEDGER_CANISTER_ID,
 	isTokenDip20,
@@ -19,6 +18,7 @@ import {
 } from '$icp/utils/icrc.utils';
 import { TokenCategoryTagValue, TokenRiskTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenStandard, TokenStandardCode } from '$lib/types/token';
+import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 import { mockLedgerCanisterId, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIcrcCustomToken } from '$tests/mocks/icrc-custom-tokens.mock';
 import { mockIcrcAccount } from '$tests/mocks/identity.mock';

--- a/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc.utils.spec.ts
@@ -3,6 +3,7 @@ import { IC_CKBTC_MINTER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import type { IcCkInterface, IcInterface } from '$icp/types/ic-token';
 import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
+import { parseTokenGroupId } from '$lib/validation/token-group.validation';
 import {
 	CUSTOM_SYMBOLS_BY_LEDGER_CANISTER_ID,
 	isTokenDip20,
@@ -416,6 +417,58 @@ describe('icrc.utils', () => {
 						{ type: TokenTagType.CATEGORY, value: TokenCategoryTagValue.CRYPTO }
 					]);
 				});
+			});
+		});
+
+		describe('groupData', () => {
+			const mockGroupData = {
+				id: parseTokenGroupId('TEST'),
+				name: 'Test Group',
+				symbol: 'TEST'
+			};
+
+			it('should propagate groupData from icrcCustomTokens when present', () => {
+				const token = mapIcrcToken({
+					...mockParams,
+					icrcCustomTokens: {
+						[mockToken.ledgerCanisterId]: { ...mockToken, groupData: mockGroupData }
+					}
+				});
+
+				expect(token?.groupData).toStrictEqual(mockGroupData);
+			});
+
+			it('should not set groupData when the token in icrcCustomTokens has no groupData', () => {
+				const { groupData: _, ...mockTokenWithoutGroupData } = mockToken;
+
+				const token = mapIcrcToken({
+					...mockParams,
+					icrcCustomTokens: {
+						[mockToken.ledgerCanisterId]: mockTokenWithoutGroupData
+					}
+				});
+
+				expect(token?.groupData).toBeUndefined();
+			});
+
+			it('should not set groupData when icrcCustomTokens is not provided', () => {
+				const token = mapIcrcToken({
+					...mockParams,
+					icrcCustomTokens: undefined
+				});
+
+				expect(token?.groupData).toBeUndefined();
+			});
+
+			it('should not set groupData when the token is not found in icrcCustomTokens', () => {
+				const token = mapIcrcToken({
+					...mockParams,
+					icrcCustomTokens: {
+						['other-canister-id']: { ...mockToken, groupData: mockGroupData }
+					}
+				});
+
+				expect(token?.groupData).toBeUndefined();
 			});
 		});
 


### PR DESCRIPTION
# Motivation

SNS tokens are loaded as custom tokens, meaning their token data is built from scratch in `requestIcrcCustomTokenMetadata` rather than flowing through as `...rest` like default ICRC tokens do. As a result, `groupData` was silently dropped during loading even when it was correctly set on the indexed token entry.

The `mapIcrcToken` function already reads `icon`, `explorerUrl`, `alternativeName`, `deprecated`, `tags`, and `standard` from `icrcCustomTokens?.[ledgerCanisterId]` — but `groupData` was never included, so SNS tokens would never appear in a token group regardless of their `groupDataId` configuration.

# Changes

- In `mapIcrcToken`, propagate `groupData` from `icrcCustomTokens?.[ledgerCanisterId]` into the returned token, consistent with how other fields from that source are already handled

# Verification

- Add `groupDataId` to an SNS token in `tokens.sns.json` (e.g. CHAT) and enable it in the wallet — confirm it appears inside the correct token group alongside its EVM counterparts
- Confirm tokens from `tokens.icrc.json` with `groupDataId` are unaffected
- Confirm SNS tokens without `groupDataId` are unaffected and still appear standalone

# Tests

- Propagates `groupData` from `icrcCustomTokens` to the mapped token when present
- Does not set `groupData` when the token entry in `icrcCustomTokens` has no `groupData`
- Does not set `groupData` when `icrcCustomTokens` is not provided
- Does not set `groupData` when the token's canister ID is not found in `icrcCustomTokens`

**Verified with CHAT in #12480**

<img width="615" height="433" alt="image" src="https://github.com/user-attachments/assets/773c5012-fb5b-4670-9ba9-eee2bfc3d455" />

