### PR TITLE
fix(frontend): handle no-networks state on Harvest Autopilot earn card

### DIFF
--- a/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
+++ b/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
@@ -1,3 +1,4 @@
+import { ERC4626_TOKENS } from '$env/tokens/tokens.erc4626.env';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
 import type { Erc4626Token } from '$eth/types/erc4626';
@@ -15,7 +16,7 @@ import { derived, type Readable } from 'svelte/store';
 export const allHarvestAutopilotTokens: Readable<Erc4626Token[]> = derived(
 	[erc4626DefaultTokensStore],
 	([$erc4626DefaultTokensStore]) =>
-		($erc4626DefaultTokensStore ?? []).filter(isTokenHarvestAutopilot)
+		($erc4626DefaultTokensStore ?? ERC4626_TOKENS).filter(isTokenHarvestAutopilot)
 );
 
 export const allHarvestAutopilotsMaxApy: Readable<string> = derived(

--- a/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
+++ b/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
@@ -1,7 +1,7 @@
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
-import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import type { Erc4626Token } from '$eth/types/erc4626';
+import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { stakeBalances } from '$lib/derived/stake.derived';
@@ -14,7 +14,8 @@ import { derived, type Readable } from 'svelte/store';
 
 export const allHarvestAutopilotTokens: Readable<Erc4626Token[]> = derived(
 	[erc4626DefaultTokensStore],
-	([$erc4626DefaultTokensStore]) => ($erc4626DefaultTokensStore ?? []).filter(isTokenHarvestAutopilot)
+	([$erc4626DefaultTokensStore]) =>
+		($erc4626DefaultTokensStore ?? []).filter(isTokenHarvestAutopilot)
 );
 
 export const harvestAutopilotTokens: Readable<Erc4626CustomToken[]> = derived(

--- a/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
+++ b/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
@@ -18,6 +18,18 @@ export const allHarvestAutopilotTokens: Readable<Erc4626Token[]> = derived(
 		($erc4626DefaultTokensStore ?? []).filter(isTokenHarvestAutopilot)
 );
 
+export const allHarvestAutopilotsMaxApy: Readable<string> = derived(
+	[allHarvestAutopilotTokens, harvestVaultsStore],
+	([$allHarvestAutopilotTokens, $harvestVaultsStore]) =>
+		$allHarvestAutopilotTokens.reduce<string>(
+			(acc, { address }) => {
+				const apy = $harvestVaultsStore[address.toLowerCase()]?.estimatedApy;
+				return nonNullish(apy) ? `${Math.max(Number(acc), Number(apy))}` : acc;
+			},
+			'0'
+		)
+);
+
 export const harvestAutopilotTokens: Readable<Erc4626CustomToken[]> = derived(
 	[erc4626Tokens],
 	([$erc4626Tokens]) => $erc4626Tokens.filter((token) => isTokenHarvestAutopilot(token))

--- a/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
+++ b/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
@@ -21,13 +21,10 @@ export const allHarvestAutopilotTokens: Readable<Erc4626Token[]> = derived(
 export const allHarvestAutopilotsMaxApy: Readable<string> = derived(
 	[allHarvestAutopilotTokens, harvestVaultsStore],
 	([$allHarvestAutopilotTokens, $harvestVaultsStore]) =>
-		$allHarvestAutopilotTokens.reduce<string>(
-			(acc, { address }) => {
-				const apy = $harvestVaultsStore[address.toLowerCase()]?.estimatedApy;
-				return nonNullish(apy) ? `${Math.max(Number(acc), Number(apy))}` : acc;
-			},
-			'0'
-		)
+		$allHarvestAutopilotTokens.reduce<string>((acc, { address }) => {
+			const apy = $harvestVaultsStore[address.toLowerCase()]?.estimatedApy;
+			return nonNullish(apy) ? `${Math.max(Number(acc), Number(apy))}` : acc;
+		}, '0')
 );
 
 export const harvestAutopilotTokens: Readable<Erc4626CustomToken[]> = derived(

--- a/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
+++ b/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
@@ -1,5 +1,7 @@
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
+import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
+import type { Erc4626Token } from '$eth/types/erc4626';
 import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { stakeBalances } from '$lib/derived/stake.derived';
@@ -9,6 +11,11 @@ import type { Vault } from '$lib/types/vaults';
 import { mapTokenUi } from '$lib/utils/token.utils';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
+
+export const allHarvestAutopilotTokens: Readable<Erc4626Token[]> = derived(
+	[erc4626DefaultTokensStore],
+	([$erc4626DefaultTokensStore]) => ($erc4626DefaultTokensStore ?? []).filter(isTokenHarvestAutopilot)
+);
 
 export const harvestAutopilotTokens: Readable<Erc4626CustomToken[]> = derived(
 	[erc4626Tokens],

--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -59,9 +59,9 @@
 								{/snippet}
 							</EarningYearlyAmount>
 						{:else if (cardField === EarningCardFields.NETWORKS || cardField === EarningCardFields.ASSETS) && Array.isArray(cardFields[cardField])}
-							{#if (cardFields[cardField] as string[]).length > 0}
+							{#if (cardFields[cardField]).length > 0}
 								<OverlappedLogos
-									icons={cardFields[cardField] as string[]}
+									icons={cardFields[cardField]}
 									invertColor={cardField === EarningCardFields.NETWORKS}
 								/>
 							{:else}
@@ -96,9 +96,16 @@
 	{/snippet}
 	{#snippet button()}
 		{#if nonNullish(cardFields.disabledNotice)}
-			<p class="mb-2 text-xs text-tertiary">{resolveText({ i18n: $i18n, path: cardFields.disabledNotice })}</p>
+			<p class="mb-2 text-xs text-tertiary"
+				>{resolveText({ i18n: $i18n, path: cardFields.disabledNotice })}</p
+			>
 		{/if}
-		<Button colorStyle="success" fullWidth onclick={cardFields.action} paddingSmall disabled={cardFields.disabled}
+		<Button
+			colorStyle="success"
+			disabled={cardFields.disabled}
+			fullWidth
+			onclick={cardFields.action}
+			paddingSmall
 			>{resolveText({ i18n: $i18n, path: cardData.actionText })}</Button
 		>
 	{/snippet}

--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -59,7 +59,7 @@
 								{/snippet}
 							</EarningYearlyAmount>
 						{:else if (cardField === EarningCardFields.NETWORKS || cardField === EarningCardFields.ASSETS) && Array.isArray(cardFields[cardField])}
-							{#if (cardFields[cardField]).length > 0}
+							{#if cardFields[cardField].length > 0}
 								<OverlappedLogos
 									icons={cardFields[cardField]}
 									invertColor={cardField === EarningCardFields.NETWORKS}
@@ -105,8 +105,7 @@
 			disabled={cardFields.disabled}
 			fullWidth
 			onclick={cardFields.action}
-			paddingSmall
-			>{resolveText({ i18n: $i18n, path: cardData.actionText })}</Button
+			paddingSmall>{resolveText({ i18n: $i18n, path: cardData.actionText })}</Button
 		>
 	{/snippet}
 </EarningOpportunityCard>

--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -93,13 +93,14 @@
 				</ListItem>
 			{/each}
 		</List>
-	{/snippet}
-	{#snippet button()}
+
 		{#if nonNullish(cardFields.disabledNotice)}
-			<p class="mb-2 text-xs text-tertiary"
+			<p class="text-center text-xs text-tertiary"
 				>{resolveText({ i18n: $i18n, path: cardFields.disabledNotice })}</p
 			>
 		{/if}
+	{/snippet}
+	{#snippet button()}
 		<Button
 			colorStyle="success"
 			disabled={cardFields.disabled}

--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -15,6 +15,8 @@
 		cardData: EarningCards;
 		cardFields: { [key in EarningCardFields]?: string | number | string[] } & {
 			action: () => Promise<void>;
+			disabled?: boolean;
+			disabledNotice?: string;
 		};
 	}
 
@@ -57,10 +59,14 @@
 								{/snippet}
 							</EarningYearlyAmount>
 						{:else if (cardField === EarningCardFields.NETWORKS || cardField === EarningCardFields.ASSETS) && Array.isArray(cardFields[cardField])}
-							<OverlappedLogos
-								icons={cardFields[cardField]}
-								invertColor={cardField === EarningCardFields.NETWORKS}
-							/>
+							{#if (cardFields[cardField] as string[]).length > 0}
+								<OverlappedLogos
+									icons={cardFields[cardField] as string[]}
+									invertColor={cardField === EarningCardFields.NETWORKS}
+								/>
+							{:else}
+								-
+							{/if}
 						{:else if cardField === EarningCardFields.CURRENT_EARNING}
 							<EarningYearlyAmount
 								showAsSuccess
@@ -89,7 +95,10 @@
 		</List>
 	{/snippet}
 	{#snippet button()}
-		<Button colorStyle="success" fullWidth onclick={cardFields.action} paddingSmall
+		{#if nonNullish(cardFields.disabledNotice)}
+			<p class="mb-2 text-xs text-tertiary">{resolveText({ i18n: $i18n, path: cardFields.disabledNotice })}</p>
+		{/if}
+		<Button colorStyle="success" fullWidth onclick={cardFields.action} paddingSmall disabled={cardFields.disabled}
 			>{resolveText({ i18n: $i18n, path: cardData.actionText })}</Button
 		>
 	{/snippet}

--- a/src/frontend/src/lib/derived/earning.derived.ts
+++ b/src/frontend/src/lib/derived/earning.derived.ts
@@ -14,6 +14,8 @@ import { derived, type Readable } from 'svelte/store';
 
 type EarningDataRecord = { [key in EarningCardFields]?: string | number | string[] } & {
 	action: () => Promise<void>;
+	disabled?: boolean;
+	disabledNotice?: string;
 };
 
 type EarningData = Record<string, EarningDataRecord>;
@@ -56,6 +58,11 @@ export const earningData: Readable<EarningData> = derived(
 						Number($harvestAutopilotsMaxApy)) /
 					100
 				: undefined,
+			disabled: $harvestAutopilots.length === 0,
+			disabledNotice:
+				$harvestAutopilots.length === 0
+					? 'earning.cards.harvest_autopilot.no_networks_enabled'
+					: undefined,
 			action: () => goto(AppPath.EarnAutopilot)
 		}
 	})

--- a/src/frontend/src/lib/derived/earning.derived.ts
+++ b/src/frontend/src/lib/derived/earning.derived.ts
@@ -1,6 +1,7 @@
 import { goto } from '$app/navigation';
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import {
+	allHarvestAutopilotTokens,
 	enabledHarvestAutopilotsUsdBalance,
 	harvestAutopilots,
 	harvestAutopilotsCurrentEarning,
@@ -27,7 +28,8 @@ export const earningData: Readable<EarningData> = derived(
 		enabledHarvestAutopilotsUsdBalance,
 		harvestAutopilotsCurrentEarning,
 		harvestAutopilots,
-		harvestAutopilotsMaxApy
+		harvestAutopilotsMaxApy,
+		allHarvestAutopilotTokens
 	],
 	([
 		$enabledMainnetFungibleTokensUsdBalance,
@@ -35,21 +37,22 @@ export const earningData: Readable<EarningData> = derived(
 		$enabledHarvestAutopilotsUsdBalance,
 		$harvestAutopilotsCurrentEarning,
 		$harvestAutopilots,
-		$harvestAutopilotsMaxApy
+		$harvestAutopilotsMaxApy,
+		$allHarvestAutopilotTokens
 	]) => ({
 		'harvest-autopilot': {
 			[EarningCardFields.APY]: $harvestAutopilotsMaxApy,
 			[EarningCardFields.CURRENT_EARNING]: $harvestAutopilotsCurrentEarning,
 			[EarningCardFields.CURRENT_STAKED]: $harvestAutopilotsUsdBalance,
 			[EarningCardFields.NETWORKS]: [
-				...$harvestAutopilots.reduce<Set<string>>(
-					(acc, { token: { network } }) => (nonNullish(network.icon) ? acc.add(network.icon) : acc),
+				...$allHarvestAutopilotTokens.reduce<Set<string>>(
+					(acc, { network }) => (nonNullish(network.icon) ? acc.add(network.icon) : acc),
 					new Set()
 				)
 			],
 			[EarningCardFields.ASSETS]: [
-				...$harvestAutopilots.reduce<Set<string>>(
-					(acc, { token: { assetIcon } }) => (nonNullish(assetIcon) ? acc.add(assetIcon) : acc),
+				...$allHarvestAutopilotTokens.reduce<Set<string>>(
+					(acc, { assetIcon }) => (nonNullish(assetIcon) ? acc.add(assetIcon) : acc),
 					new Set()
 				)
 			],

--- a/src/frontend/src/lib/derived/earning.derived.ts
+++ b/src/frontend/src/lib/derived/earning.derived.ts
@@ -2,6 +2,7 @@ import { goto } from '$app/navigation';
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import {
 	allHarvestAutopilotTokens,
+	allHarvestAutopilotsMaxApy,
 	enabledHarvestAutopilotsUsdBalance,
 	harvestAutopilots,
 	harvestAutopilotsCurrentEarning,
@@ -29,7 +30,8 @@ export const earningData: Readable<EarningData> = derived(
 		harvestAutopilotsCurrentEarning,
 		harvestAutopilots,
 		harvestAutopilotsMaxApy,
-		allHarvestAutopilotTokens
+		allHarvestAutopilotTokens,
+		allHarvestAutopilotsMaxApy
 	],
 	([
 		$enabledMainnetFungibleTokensUsdBalance,
@@ -38,10 +40,11 @@ export const earningData: Readable<EarningData> = derived(
 		$harvestAutopilotsCurrentEarning,
 		$harvestAutopilots,
 		$harvestAutopilotsMaxApy,
-		$allHarvestAutopilotTokens
+		$allHarvestAutopilotTokens,
+		$allHarvestAutopilotsMaxApy
 	]) => ({
 		'harvest-autopilot': {
-			[EarningCardFields.APY]: $harvestAutopilotsMaxApy,
+			[EarningCardFields.APY]: $allHarvestAutopilotsMaxApy,
 			[EarningCardFields.CURRENT_EARNING]: $harvestAutopilotsCurrentEarning,
 			[EarningCardFields.CURRENT_STAKED]: $harvestAutopilotsUsdBalance,
 			[EarningCardFields.NETWORKS]: [

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "",
 				"description": "",
-				"action": ""
+				"action": "",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Maximální výnosová efektivita s automatickými trezory na jeden klik.",
-				"action": "Přejít na Autopilot"
+				"action": "Přejít na Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Maximale Ertragseffizienz mit Autopilot-Vaults per Mausklick.",
-				"action": "Zum Autopilot"
+				"action": "Zum Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest - Autopilot",
 				"description": "Maximized yield efficiency with 1-click autopilot vaults.",
-				"action": "Go to Autopilot"
+				"action": "Go to Autopilot",
+				"no_networks_enabled": "None of the supported networks are currently enabled."
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Máxima eficiencia de rendimiento con vaults en Autopilot con un solo clic.",
-				"action": "Ir al Autopilot"
+				"action": "Ir al Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Efficacité de rendement maximale avec des vaults en Autopilot en un seul clic.",
-				"action": "Aller à l'Autopilot"
+				"action": "Aller à l'Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "एक क्लिक के Autopilot vaults के साथ अधिकतम यील्ड दक्षता।",
-				"action": "Autopilot पर जाएं"
+				"action": "Autopilot पर जाएं",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Massima efficienza di rendimento con vault in Autopilot con un solo clic.",
-				"action": "Vai all'Autopilot"
+				"action": "Vai all'Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "ワンクリックのAutopilot vaultで最大限のイールド効率を実現。",
-				"action": "Autopilotへ移動"
+				"action": "Autopilotへ移動",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "원클릭 Autopilot vault로 최대 수익 효율을 실현하세요.",
-				"action": "Autopilot으로 이동"
+				"action": "Autopilot으로 이동",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Maksymalna wydajność zysku dzięki automatycznym vaultom jednym kliknięciem.",
-				"action": "Przejdź do Autopilot"
+				"action": "Przejdź do Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Máxima eficiência de rendimento com vaults no Autopilot com um único clique.",
-				"action": "Ir para o Autopilot"
+				"action": "Ir para o Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Максимальная эффективность доходности с автопилотными хранилищами в один клик.",
-				"action": "Перейти к Autopilot"
+				"action": "Перейти к Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Hiệu quả sinh lời tối đa với các vault Autopilot chỉ một cú nhấp chuột.",
-				"action": "Đi đến Autopilot"
+				"action": "Đi đến Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "一键Autopilot金库，实现最大收益效率。",
-				"action": "前往Autopilot"
+				"action": "前往Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1521,7 +1521,12 @@ interface I18nEarning {
 		go_to_earn: string;
 	};
 	cards: {
-		harvest_autopilot: { title: string; description: string; action: string };
+		harvest_autopilot: {
+			title: string;
+			description: string;
+			action: string;
+			no_networks_enabled: string;
+		};
 		sprinkles: { title: string; description: string; action: string };
 	};
 	card_fields: {

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '$eth/derived/harvest-autopilots.derived';
 import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
+import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 import { harvestVaultsStore } from '$lib/stores/harvest.store';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
@@ -73,10 +74,13 @@ describe('harvest-autopilots.derived', () => {
 			expect(result[0].address).toBe(mockHarvestAddress);
 		});
 
-		it('should return empty array when store is undefined', () => {
+		it('should fall back to ERC4626_TOKENS when store is undefined', () => {
 			mockErc4626DefaultTokensStore(undefined);
 
-			expect(get(allHarvestAutopilotTokens)).toEqual([]);
+			const result = get(allHarvestAutopilotTokens);
+
+			expect(result.length).toBeGreaterThan(0);
+			expect(result.every(isTokenHarvestAutopilot)).toBe(true);
 		});
 
 		it('should return empty array when no harvest autopilot tokens exist', () => {

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -1,8 +1,8 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import {
-	allHarvestAutopilotTokens,
 	allHarvestAutopilotsMaxApy,
+	allHarvestAutopilotTokens,
 	disabledHarvestAutopilotTokens,
 	enabledHarvestAutopilotsUsdBalance,
 	harvestAutopilots,
@@ -11,8 +11,8 @@ import {
 	harvestAutopilotsUsdBalance,
 	harvestAutopilotTokens
 } from '$eth/derived/harvest-autopilots.derived';
-import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
+import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import { harvestVaultsStore } from '$lib/stores/harvest.store';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -80,7 +80,7 @@ describe('harvest-autopilots.derived', () => {
 			const result = get(allHarvestAutopilotTokens);
 
 			expect(result.length).toBeGreaterThan(0);
-			expect(result.every(isTokenHarvestAutopilot)).toBe(true);
+			expect(result.every(isTokenHarvestAutopilot)).toBeTruthy();
 		});
 
 		it('should return empty array when no harvest autopilot tokens exist', () => {

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -1,6 +1,8 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import {
+	allHarvestAutopilotTokens,
+	allHarvestAutopilotsMaxApy,
 	disabledHarvestAutopilotTokens,
 	enabledHarvestAutopilotsUsdBalance,
 	harvestAutopilots,
@@ -10,6 +12,7 @@ import {
 	harvestAutopilotTokens
 } from '$eth/derived/harvest-autopilots.derived';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
+import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
 import { harvestVaultsStore } from '$lib/stores/harvest.store';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
@@ -51,6 +54,73 @@ describe('harvest-autopilots.derived', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
 		harvestVaultsStore.reset();
+	});
+
+	const mockErc4626DefaultTokensStore = (tokens: Erc4626CustomToken[] | undefined) => {
+		vi.spyOn(erc4626DefaultTokensStore, 'subscribe').mockImplementation((fn) => {
+			fn(tokens as never);
+			return () => {};
+		});
+	};
+
+	describe('allHarvestAutopilotTokens', () => {
+		it('should filter only harvest autopilot tokens from the default tokens store', () => {
+			mockErc4626DefaultTokensStore([mockHarvestToken, mockNonHarvestToken]);
+
+			const result = get(allHarvestAutopilotTokens);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].address).toBe(mockHarvestAddress);
+		});
+
+		it('should return empty array when store is undefined', () => {
+			mockErc4626DefaultTokensStore(undefined);
+
+			expect(get(allHarvestAutopilotTokens)).toEqual([]);
+		});
+
+		it('should return empty array when no harvest autopilot tokens exist', () => {
+			mockErc4626DefaultTokensStore([mockNonHarvestToken]);
+
+			expect(get(allHarvestAutopilotTokens)).toEqual([]);
+		});
+	});
+
+	describe('allHarvestAutopilotsMaxApy', () => {
+		it('should return max APY from vault store regardless of network enablement', () => {
+			mockErc4626DefaultTokensStore([mockHarvestToken]);
+			harvestVaultsStore.set([
+				{ id: 'vault-1', vaultAddress: mockHarvestAddress, estimatedApy: '12.5' }
+			]);
+
+			expect(get(allHarvestAutopilotsMaxApy)).toBe('12.5');
+		});
+
+		it('should return the highest APY across multiple vaults', () => {
+			const secondAddress = '0x31a421271414641cb5063b71594b642d2666db6b';
+			mockErc4626DefaultTokensStore([
+				mockHarvestToken,
+				{ ...mockHarvestToken, address: secondAddress }
+			]);
+			harvestVaultsStore.set([
+				{ id: 'vault-1', vaultAddress: mockHarvestAddress, estimatedApy: '5' },
+				{ id: 'vault-2', vaultAddress: secondAddress, estimatedApy: '18.3' }
+			]);
+
+			expect(get(allHarvestAutopilotsMaxApy)).toBe('18.3');
+		});
+
+		it('should return "0" when vault store has no matching data', () => {
+			mockErc4626DefaultTokensStore([mockHarvestToken]);
+
+			expect(get(allHarvestAutopilotsMaxApy)).toBe('0');
+		});
+
+		it('should return "0" when token list is empty', () => {
+			mockErc4626DefaultTokensStore([]);
+
+			expect(get(allHarvestAutopilotsMaxApy)).toBe('0');
+		});
 	});
 
 	describe('harvestAutopilotTokens', () => {

--- a/src/frontend/src/tests/lib/components/earning/DefaultEarningOpportunityCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/DefaultEarningOpportunityCard.spec.ts
@@ -111,4 +111,83 @@ describe('DefaultEarningOpportunityCard', () => {
 
 		expect(mockAction).toHaveBeenCalledOnce();
 	});
+
+	describe('NETWORKS and ASSETS fields', () => {
+		const cardDataWithIcons = {
+			...mockCardData,
+			fields: [EarningCardFields.NETWORKS, EarningCardFields.ASSETS]
+		};
+
+		it('renders a dash when the icons array is empty', () => {
+			render(DefaultEarningOpportunityCard, {
+				cardData: cardDataWithIcons,
+				cardFields: {
+					...mockCardFields,
+					[EarningCardFields.NETWORKS]: [],
+					[EarningCardFields.ASSETS]: []
+				}
+			});
+
+			expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(2);
+		});
+
+		it('does not render a dash when icons are provided', () => {
+			render(DefaultEarningOpportunityCard, {
+				cardData: cardDataWithIcons,
+				cardFields: {
+					...mockCardFields,
+					[EarningCardFields.NETWORKS]: ['/icon-eth.svg'],
+					[EarningCardFields.ASSETS]: ['/icon-usdc.svg']
+				}
+			});
+
+			expect(screen.queryByText('-')).toBeNull();
+		});
+	});
+
+	describe('disabled state', () => {
+		it('disables the button when disabled is true', () => {
+			render(DefaultEarningOpportunityCard, {
+				cardData: mockCardData,
+				cardFields: { ...mockCardFields, disabled: true }
+			});
+
+			expect(screen.getByRole('button')).toBeDisabled();
+		});
+
+		it('does not disable the button when disabled is false', () => {
+			render(DefaultEarningOpportunityCard, {
+				cardData: mockCardData,
+				cardFields: { ...mockCardFields, disabled: false }
+			});
+
+			expect(screen.getByRole('button')).not.toBeDisabled();
+		});
+
+		it('shows disabledNotice text when set', () => {
+			render(DefaultEarningOpportunityCard, {
+				cardData: mockCardData,
+				cardFields: {
+					...mockCardFields,
+					disabled: true,
+					disabledNotice: 'earning.cards.harvest_autopilot.no_networks_enabled'
+				}
+			});
+
+			expect(
+				screen.getByText(get(i18n).earning.cards.harvest_autopilot.no_networks_enabled)
+			).toBeInTheDocument();
+		});
+
+		it('does not show notice text when disabledNotice is not set', () => {
+			render(DefaultEarningOpportunityCard, {
+				cardData: mockCardData,
+				cardFields: mockCardFields
+			});
+
+			expect(
+				screen.queryByText(get(i18n).earning.cards.harvest_autopilot.no_networks_enabled)
+			).toBeNull();
+		});
+	});
 });

--- a/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
@@ -139,7 +139,7 @@ describe('earning.derived', () => {
 			const result = get(earningData);
 			const record = result['harvest-autopilot'];
 
-			expect(record.disabled).toBe(true);
+			expect(record.disabled).toBeTruthy();
 			expect(record.disabledNotice).toBe('earning.cards.harvest_autopilot.no_networks_enabled');
 		});
 
@@ -149,7 +149,7 @@ describe('earning.derived', () => {
 			const result = get(earningData);
 			const record = result['harvest-autopilot'];
 
-			expect(record.disabled).toBe(false);
+			expect(record.disabled).toBeFalsy();
 			expect(record.disabledNotice).toBeUndefined();
 		});
 	});

--- a/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
@@ -1,5 +1,6 @@
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import {
+	allHarvestAutopilotTokens,
 	enabledHarvestAutopilotsUsdBalance,
 	harvestAutopilots,
 	harvestAutopilotsCurrentEarning,
@@ -23,18 +24,23 @@ describe('earning.derived', () => {
 	});
 
 	describe('earningData', () => {
+		const defaultAllTokens = [{ network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' }];
+		const defaultVaults = [{ token: { network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' } }];
+
 		const setupStores = ({
 			enabledMainnetUsdBalance = 1000,
 			harvestUsdBalance = 100,
 			enabledHarvestUsdBalance = 100,
 			currentEarning = 5,
-			vaults = [{ token: { network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' } }],
+			allTokens = defaultAllTokens,
+			vaults = defaultVaults,
 			maxApy = '5.5'
 		}: {
 			enabledMainnetUsdBalance?: number | null;
 			harvestUsdBalance?: number;
 			enabledHarvestUsdBalance?: number;
 			currentEarning?: number;
+			allTokens?: { network: { icon?: string }; assetIcon?: string }[];
 			vaults?: { token: { network: { icon?: string }; assetIcon?: string } }[];
 			maxApy?: string;
 		} = {}) => {
@@ -52,6 +58,10 @@ describe('earning.derived', () => {
 			});
 			vi.spyOn(harvestAutopilotsCurrentEarning, 'subscribe').mockImplementation((fn) => {
 				fn(currentEarning);
+				return () => {};
+			});
+			vi.spyOn(allHarvestAutopilotTokens, 'subscribe').mockImplementation((fn) => {
+				fn(allTokens as never);
 				return () => {};
 			});
 			vi.spyOn(harvestAutopilots, 'subscribe').mockImplementation((fn) => {
@@ -104,10 +114,10 @@ describe('earning.derived', () => {
 
 		it('deduplicates network and asset icons', () => {
 			setupStores({
-				vaults: [
-					{ token: { network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' } },
-					{ token: { network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' } },
-					{ token: { network: { icon: 'base-icon' }, assetIcon: 'usdt-icon' } }
+				allTokens: [
+					{ network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' },
+					{ network: { icon: 'eth-icon' }, assetIcon: 'usdc-icon' },
+					{ network: { icon: 'base-icon' }, assetIcon: 'usdt-icon' }
 				]
 			});
 
@@ -120,11 +130,21 @@ describe('earning.derived', () => {
 
 		it('excludes nullish icons from networks and assets', () => {
 			setupStores({
-				vaults: [
-					{ token: { network: { icon: 'eth-icon' }, assetIcon: undefined } },
-					{ token: { network: { icon: undefined }, assetIcon: 'usdc-icon' } }
+				allTokens: [
+					{ network: { icon: 'eth-icon' }, assetIcon: undefined },
+					{ network: { icon: undefined }, assetIcon: 'usdc-icon' }
 				]
 			});
+
+			const result = get(earningData);
+			const record = result['harvest-autopilot'];
+
+			expect(record[EarningCardFields.NETWORKS]).toEqual(['eth-icon']);
+			expect(record[EarningCardFields.ASSETS]).toEqual(['usdc-icon']);
+		});
+
+		it('shows all network icons even when no vaults are enabled', () => {
+			setupStores({ vaults: [] });
 
 			const result = get(earningData);
 			const record = result['harvest-autopilot'];

--- a/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
@@ -1,6 +1,7 @@
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import {
 	allHarvestAutopilotTokens,
+	allHarvestAutopilotsMaxApy,
 	enabledHarvestAutopilotsUsdBalance,
 	harvestAutopilots,
 	harvestAutopilotsCurrentEarning,
@@ -34,7 +35,8 @@ describe('earning.derived', () => {
 			currentEarning = 5,
 			allTokens = defaultAllTokens,
 			vaults = defaultVaults,
-			maxApy = '5.5'
+			maxApy = '5.5',
+			allMaxApy = '5.5'
 		}: {
 			enabledMainnetUsdBalance?: number | null;
 			harvestUsdBalance?: number;
@@ -43,6 +45,7 @@ describe('earning.derived', () => {
 			allTokens?: { network: { icon?: string }; assetIcon?: string }[];
 			vaults?: { token: { network: { icon?: string }; assetIcon?: string } }[];
 			maxApy?: string;
+			allMaxApy?: string;
 		} = {}) => {
 			vi.spyOn(enabledMainnetFungibleTokensUsdBalance, 'subscribe').mockImplementation((fn) => {
 				fn(enabledMainnetUsdBalance as number);
@@ -70,6 +73,10 @@ describe('earning.derived', () => {
 			});
 			vi.spyOn(harvestAutopilotsMaxApy, 'subscribe').mockImplementation((fn) => {
 				fn(maxApy);
+				return () => {};
+			});
+			vi.spyOn(allHarvestAutopilotsMaxApy, 'subscribe').mockImplementation((fn) => {
+				fn(allMaxApy);
 				return () => {};
 			});
 		};
@@ -151,6 +158,15 @@ describe('earning.derived', () => {
 
 			expect(record[EarningCardFields.NETWORKS]).toEqual(['eth-icon']);
 			expect(record[EarningCardFields.ASSETS]).toEqual(['usdc-icon']);
+		});
+
+		it('shows allMaxApy as APY even when no vaults are enabled', () => {
+			setupStores({ vaults: [], allMaxApy: '12.5' });
+
+			const result = get(earningData);
+			const record = result['harvest-autopilot'];
+
+			expect(record[EarningCardFields.APY]).toBe('12.5');
 		});
 
 		it('sets disabled and disabledNotice when no vaults are available', () => {

--- a/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
@@ -132,6 +132,26 @@ describe('earning.derived', () => {
 			expect(record[EarningCardFields.NETWORKS]).toEqual(['eth-icon']);
 			expect(record[EarningCardFields.ASSETS]).toEqual(['usdc-icon']);
 		});
+
+		it('sets disabled and disabledNotice when no vaults are available', () => {
+			setupStores({ vaults: [] });
+
+			const result = get(earningData);
+			const record = result['harvest-autopilot'];
+
+			expect(record.disabled).toBe(true);
+			expect(record.disabledNotice).toBe('earning.cards.harvest_autopilot.no_networks_enabled');
+		});
+
+		it('clears disabled and disabledNotice when vaults are available', () => {
+			setupStores();
+
+			const result = get(earningData);
+			const record = result['harvest-autopilot'];
+
+			expect(record.disabled).toBe(false);
+			expect(record.disabledNotice).toBeUndefined();
+		});
 	});
 
 	describe('highestApyEarningData', () => {


### PR DESCRIPTION
# Motivation

When a user has no compatible network enabled (Arbitrum or Base), the Harvest – Autopilot card on the Earn page rendered the **Networks** and **Assets** fields as a loading skeleton indefinitely, showed **0%** for Max APY, and left the "Go to Autopilot" button active even though the feature cannot be used.

<img width="294" alt="image" src="https://github.com/user-attachments/assets/25e0040d-3f3e-4f92-a42a-7580cd90c8ba" />

# Changes

- Add `allHarvestAutopilotTokens` derived from the unfiltered `erc4626DefaultTokensStore` (no network-enablement filter), so Networks and Assets icons always reflect all supported tokens.
- Add `allHarvestAutopilotsMaxApy` derived from `allHarvestAutopilotTokens` + `harvestVaultsStore` (loaded unconditionally from the REST API), so the Max APY badge shows the real highest APY even when no networks are enabled.
- Extend `EarningDataRecord` with `disabled` and `disabledNotice` fields; populate them in `earningData` when `harvestAutopilots` is empty (i.e. no compatible network is currently enabled).
- In `DefaultEarningOpportunityCard`, show `-` for Networks and Assets fields when the icons array is empty, instead of delegating to `OverlappedLogos` which falls back to a loading skeleton.
- Disable the "Go to Autopilot" button when `cardFields.disabled` is `true`.
- Render a horizontally and vertically centred notice above the button when `cardFields.disabledNotice` is set.
- Add i18n string `earning.cards.harvest_autopilot.no_networks_enabled`.

# Tests

- `harvest-autopilots.derived.spec.ts`: 7 new tests covering `allHarvestAutopilotTokens` (filtering, undefined store, no-match) and `allHarvestAutopilotsMaxApy` (correct max, highest across multiple vaults, zero fallbacks).
- `earning.derived.spec.ts`: tests for `disabled`/`disabledNotice` when vaults are empty or present, network icons shown regardless of enabled state, and APY sourced from all-networks store.
- `DefaultEarningOpportunityCard.spec.ts`: 6 new tests covering dash vs icons rendering, disabled button state, and notice text presence/absence.