### PR TITLE
fix(frontend): use price from first priced token in token group header

### DIFF
--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -59,9 +59,9 @@
 								{/snippet}
 							</EarningYearlyAmount>
 						{:else if (cardField === EarningCardFields.NETWORKS || cardField === EarningCardFields.ASSETS) && Array.isArray(cardFields[cardField])}
-							{#if (cardFields[cardField] as string[]).length > 0}
+							{#if (cardFields[cardField]).length > 0}
 								<OverlappedLogos
-									icons={cardFields[cardField] as string[]}
+									icons={cardFields[cardField]}
 									invertColor={cardField === EarningCardFields.NETWORKS}
 								/>
 							{:else}
@@ -96,9 +96,16 @@
 	{/snippet}
 	{#snippet button()}
 		{#if nonNullish(cardFields.disabledNotice)}
-			<p class="mb-2 text-xs text-tertiary">{resolveText({ i18n: $i18n, path: cardFields.disabledNotice })}</p>
+			<p class="mb-2 text-xs text-tertiary"
+				>{resolveText({ i18n: $i18n, path: cardFields.disabledNotice })}</p
+			>
 		{/if}
-		<Button colorStyle="success" fullWidth onclick={cardFields.action} paddingSmall disabled={cardFields.disabled}
+		<Button
+			colorStyle="success"
+			disabled={cardFields.disabled}
+			fullWidth
+			onclick={cardFields.action}
+			paddingSmall
 			>{resolveText({ i18n: $i18n, path: cardData.actionText })}</Button
 		>
 	{/snippet}

--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -59,7 +59,7 @@
 								{/snippet}
 							</EarningYearlyAmount>
 						{:else if (cardField === EarningCardFields.NETWORKS || cardField === EarningCardFields.ASSETS) && Array.isArray(cardFields[cardField])}
-							{#if (cardFields[cardField]).length > 0}
+							{#if cardFields[cardField].length > 0}
 								<OverlappedLogos
 									icons={cardFields[cardField]}
 									invertColor={cardField === EarningCardFields.NETWORKS}
@@ -105,8 +105,7 @@
 			disabled={cardFields.disabled}
 			fullWidth
 			onclick={cardFields.action}
-			paddingSmall
-			>{resolveText({ i18n: $i18n, path: cardData.actionText })}</Button
+			paddingSmall>{resolveText({ i18n: $i18n, path: cardData.actionText })}</Button
 		>
 	{/snippet}
 </EarningOpportunityCard>

--- a/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
+++ b/src/frontend/src/lib/components/earning/DefaultEarningOpportunityCard.svelte
@@ -15,6 +15,8 @@
 		cardData: EarningCards;
 		cardFields: { [key in EarningCardFields]?: string | number | string[] } & {
 			action: () => Promise<void>;
+			disabled?: boolean;
+			disabledNotice?: string;
 		};
 	}
 
@@ -57,10 +59,14 @@
 								{/snippet}
 							</EarningYearlyAmount>
 						{:else if (cardField === EarningCardFields.NETWORKS || cardField === EarningCardFields.ASSETS) && Array.isArray(cardFields[cardField])}
-							<OverlappedLogos
-								icons={cardFields[cardField]}
-								invertColor={cardField === EarningCardFields.NETWORKS}
-							/>
+							{#if (cardFields[cardField] as string[]).length > 0}
+								<OverlappedLogos
+									icons={cardFields[cardField] as string[]}
+									invertColor={cardField === EarningCardFields.NETWORKS}
+								/>
+							{:else}
+								-
+							{/if}
 						{:else if cardField === EarningCardFields.CURRENT_EARNING}
 							<EarningYearlyAmount
 								showAsSuccess
@@ -89,7 +95,10 @@
 		</List>
 	{/snippet}
 	{#snippet button()}
-		<Button colorStyle="success" fullWidth onclick={cardFields.action} paddingSmall
+		{#if nonNullish(cardFields.disabledNotice)}
+			<p class="mb-2 text-xs text-tertiary">{resolveText({ i18n: $i18n, path: cardFields.disabledNotice })}</p>
+		{/if}
+		<Button colorStyle="success" fullWidth onclick={cardFields.action} paddingSmall disabled={cardFields.disabled}
 			>{resolveText({ i18n: $i18n, path: cardData.actionText })}</Button
 		>
 	{/snippet}

--- a/src/frontend/src/lib/derived/earning.derived.ts
+++ b/src/frontend/src/lib/derived/earning.derived.ts
@@ -14,6 +14,8 @@ import { derived, type Readable } from 'svelte/store';
 
 type EarningDataRecord = { [key in EarningCardFields]?: string | number | string[] } & {
 	action: () => Promise<void>;
+	disabled?: boolean;
+	disabledNotice?: string;
 };
 
 type EarningData = Record<string, EarningDataRecord>;
@@ -56,6 +58,11 @@ export const earningData: Readable<EarningData> = derived(
 						Number($harvestAutopilotsMaxApy)) /
 					100
 				: undefined,
+			disabled: $harvestAutopilots.length === 0,
+			disabledNotice:
+				$harvestAutopilots.length === 0
+					? 'earning.cards.harvest_autopilot.no_networks_enabled'
+					: undefined,
 			action: () => goto(AppPath.EarnAutopilot)
 		}
 	})

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "",
 				"description": "",
-				"action": ""
+				"action": "",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Maximální výnosová efektivita s automatickými trezory na jeden klik.",
-				"action": "Přejít na Autopilot"
+				"action": "Přejít na Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Maximale Ertragseffizienz mit Autopilot-Vaults per Mausklick.",
-				"action": "Zum Autopilot"
+				"action": "Zum Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest - Autopilot",
 				"description": "Maximized yield efficiency with 1-click autopilot vaults.",
-				"action": "Go to Autopilot"
+				"action": "Go to Autopilot",
+				"no_networks_enabled": "None of the supported networks are currently enabled."
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Máxima eficiencia de rendimiento con vaults en Autopilot con un solo clic.",
-				"action": "Ir al Autopilot"
+				"action": "Ir al Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Efficacité de rendement maximale avec des vaults en Autopilot en un seul clic.",
-				"action": "Aller à l'Autopilot"
+				"action": "Aller à l'Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "एक क्लिक के Autopilot vaults के साथ अधिकतम यील्ड दक्षता।",
-				"action": "Autopilot पर जाएं"
+				"action": "Autopilot पर जाएं",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Massima efficienza di rendimento con vault in Autopilot con un solo clic.",
-				"action": "Vai all'Autopilot"
+				"action": "Vai all'Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "ワンクリックのAutopilot vaultで最大限のイールド効率を実現。",
-				"action": "Autopilotへ移動"
+				"action": "Autopilotへ移動",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "원클릭 Autopilot vault로 최대 수익 효율을 실현하세요.",
-				"action": "Autopilot으로 이동"
+				"action": "Autopilot으로 이동",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Maksymalna wydajność zysku dzięki automatycznym vaultom jednym kliknięciem.",
-				"action": "Przejdź do Autopilot"
+				"action": "Przejdź do Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Máxima eficiência de rendimento com vaults no Autopilot com um único clique.",
-				"action": "Ir para o Autopilot"
+				"action": "Ir para o Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Максимальная эффективность доходности с автопилотными хранилищами в один клик.",
-				"action": "Перейти к Autopilot"
+				"action": "Перейти к Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "Hiệu quả sinh lời tối đa với các vault Autopilot chỉ một cú nhấp chuột.",
-				"action": "Đi đến Autopilot"
+				"action": "Đi đến Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1970,7 +1970,8 @@
 			"harvest_autopilot": {
 				"title": "Harvest – Autopilot",
 				"description": "一键Autopilot金库，实现最大收益效率。",
-				"action": "前往Autopilot"
+				"action": "前往Autopilot",
+				"no_networks_enabled": ""
 			},
 			"sprinkles": {
 				"title": "OISY Sprinkles",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1521,7 +1521,12 @@ interface I18nEarning {
 		go_to_earn: string;
 	};
 	cards: {
-		harvest_autopilot: { title: string; description: string; action: string };
+		harvest_autopilot: {
+			title: string;
+			description: string;
+			action: string;
+			no_networks_enabled: string;
+		};
 		sprinkles: { title: string; description: string; action: string };
 	};
 	card_fields: {

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -99,7 +99,11 @@ export const updateTokenGroup = ({ token, tokenGroup }: UpdateTokenGroupParams):
 					: balance
 			)
 		),
-		usdBalance: sumUsdBalances([tokenGroup.usdBalance, token.usdBalance])
+		usdBalance: sumUsdBalances([tokenGroup.usdBalance, token.usdBalance]),
+		usdPrice: tokenGroup.usdPrice ?? token.usdPrice,
+		usdMarketCap: tokenGroup.usdMarketCap ?? token.usdMarketCap,
+		usdPriceChangePercentage24h:
+			tokenGroup.usdPriceChangePercentage24h ?? token.usdPriceChangePercentage24h
 	};
 };
 

--- a/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
@@ -139,7 +139,7 @@ describe('earning.derived', () => {
 			const result = get(earningData);
 			const record = result['harvest-autopilot'];
 
-			expect(record.disabled).toBe(true);
+			expect(record.disabled).toBeTruthy();
 			expect(record.disabledNotice).toBe('earning.cards.harvest_autopilot.no_networks_enabled');
 		});
 
@@ -149,7 +149,7 @@ describe('earning.derived', () => {
 			const result = get(earningData);
 			const record = result['harvest-autopilot'];
 
-			expect(record.disabled).toBe(false);
+			expect(record.disabled).toBeFalsy();
 			expect(record.disabledNotice).toBeUndefined();
 		});
 	});

--- a/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
@@ -132,6 +132,26 @@ describe('earning.derived', () => {
 			expect(record[EarningCardFields.NETWORKS]).toEqual(['eth-icon']);
 			expect(record[EarningCardFields.ASSETS]).toEqual(['usdc-icon']);
 		});
+
+		it('sets disabled and disabledNotice when no vaults are available', () => {
+			setupStores({ vaults: [] });
+
+			const result = get(earningData);
+			const record = result['harvest-autopilot'];
+
+			expect(record.disabled).toBe(true);
+			expect(record.disabledNotice).toBe('earning.cards.harvest_autopilot.no_networks_enabled');
+		});
+
+		it('clears disabled and disabledNotice when vaults are available', () => {
+			setupStores();
+
+			const result = get(earningData);
+			const record = result['harvest-autopilot'];
+
+			expect(record.disabled).toBe(false);
+			expect(record.disabledNotice).toBeUndefined();
+		});
 	});
 
 	describe('highestApyEarningData', () => {

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -357,7 +357,9 @@ describe('token-group.utils', () => {
 				id: ETH_TOKEN_GROUP.id,
 				decimals: BASE_ETH_TOKEN.decimals,
 				groupData: ETH_TOKEN_GROUP,
-				tokens: [{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn2Bi, usdBalance: 200 }],
+				tokens: [
+					{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn2Bi, usdBalance: 200 }
+				],
 				balance: bn2Bi,
 				usdBalance: 200,
 				usdPrice: undefined,
@@ -377,7 +379,9 @@ describe('token-group.utils', () => {
 				id: ETH_TOKEN_GROUP.id,
 				decimals: BASE_ETH_TOKEN.decimals,
 				groupData: ETH_TOKEN_GROUP,
-				tokens: [{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn1Bi, usdBalance: 100 }],
+				tokens: [
+					{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn1Bi, usdBalance: 100 }
+				],
 				balance: bn1Bi,
 				usdBalance: 100,
 				usdPrice: 1500,
@@ -395,7 +399,10 @@ describe('token-group.utils', () => {
 				usdPriceChangePercentage24h: -0.5
 			};
 
-			const result = updateTokenGroup({ token: tokenWithDifferentPrice, tokenGroup: groupWithPrice });
+			const result = updateTokenGroup({
+				token: tokenWithDifferentPrice,
+				tokenGroup: groupWithPrice
+			});
 
 			expect(result.usdPrice).toBe(groupWithPrice.usdPrice);
 			expect(result.usdMarketCap).toBe(groupWithPrice.usdMarketCap);

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -194,7 +194,10 @@ describe('token-group.utils', () => {
 			decimals: expectedDecimals,
 			tokens: [anotherToken, token],
 			balance: expectedBalance,
-			usdBalance: anotherToken.usdBalance + token.usdBalance
+			usdBalance: anotherToken.usdBalance + token.usdBalance,
+			usdPrice: undefined,
+			usdMarketCap: undefined,
+			usdPriceChangePercentage24h: undefined
 		};
 
 		it('should add a token to a token group successfully', () => {
@@ -218,7 +221,10 @@ describe('token-group.utils', () => {
 				...tokenGroup,
 				tokens: [anotherToken, thirdToken, token],
 				balance: expectedBalance + thirdToken.balance,
-				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
+				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance,
+				usdPrice: undefined,
+				usdMarketCap: undefined,
+				usdPriceChangePercentage24h: undefined
 			});
 		});
 
@@ -304,7 +310,10 @@ describe('token-group.utils', () => {
 				decimals: newDecimals,
 				tokens: [...tokenGroup.tokens, newToken],
 				balance: expectedBalance,
-				usdBalance: tokenGroup.usdBalance + newToken.usdBalance
+				usdBalance: tokenGroup.usdBalance + newToken.usdBalance,
+				usdPrice: undefined,
+				usdMarketCap: undefined,
+				usdPriceChangePercentage24h: undefined
 			});
 
 			const thirdToken = {
@@ -331,6 +340,66 @@ describe('token-group.utils', () => {
 					}) + thirdToken.balance,
 				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
 			});
+		});
+
+		it('should use price from the first token that has one when group has no price', () => {
+			const tokenWithPrice = {
+				...ETHEREUM_TOKEN,
+				groupData: ETH_TOKEN_GROUP,
+				balance: bn1Bi,
+				usdBalance: 100,
+				usdPrice: 2000,
+				usdMarketCap: 240000000000,
+				usdPriceChangePercentage24h: -0.5
+			};
+
+			const groupWithoutPrice: TokenUiGroup = {
+				id: ETH_TOKEN_GROUP.id,
+				decimals: BASE_ETH_TOKEN.decimals,
+				groupData: ETH_TOKEN_GROUP,
+				tokens: [{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn2Bi, usdBalance: 200 }],
+				balance: bn2Bi,
+				usdBalance: 200,
+				usdPrice: undefined,
+				usdMarketCap: undefined,
+				usdPriceChangePercentage24h: undefined
+			};
+
+			const result = updateTokenGroup({ token: tokenWithPrice, tokenGroup: groupWithoutPrice });
+
+			expect(result.usdPrice).toBe(tokenWithPrice.usdPrice);
+			expect(result.usdMarketCap).toBe(tokenWithPrice.usdMarketCap);
+			expect(result.usdPriceChangePercentage24h).toBe(tokenWithPrice.usdPriceChangePercentage24h);
+		});
+
+		it('should keep existing group price when it already has one', () => {
+			const groupWithPrice: TokenUiGroup = {
+				id: ETH_TOKEN_GROUP.id,
+				decimals: BASE_ETH_TOKEN.decimals,
+				groupData: ETH_TOKEN_GROUP,
+				tokens: [{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn1Bi, usdBalance: 100 }],
+				balance: bn1Bi,
+				usdBalance: 100,
+				usdPrice: 1500,
+				usdMarketCap: 180000000000,
+				usdPriceChangePercentage24h: 1.0
+			};
+
+			const tokenWithDifferentPrice = {
+				...ETHEREUM_TOKEN,
+				groupData: ETH_TOKEN_GROUP,
+				balance: bn2Bi,
+				usdBalance: 200,
+				usdPrice: 2000,
+				usdMarketCap: 240000000000,
+				usdPriceChangePercentage24h: -0.5
+			};
+
+			const result = updateTokenGroup({ token: tokenWithDifferentPrice, tokenGroup: groupWithPrice });
+
+			expect(result.usdPrice).toBe(groupWithPrice.usdPrice);
+			expect(result.usdMarketCap).toBe(groupWithPrice.usdMarketCap);
+			expect(result.usdPriceChangePercentage24h).toBe(groupWithPrice.usdPriceChangePercentage24h);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

When the first token(s) in a group have no price data (e.g. the Ethereum, Base, and Arbitrum CHAT tokens), the group header shows no price or performance — even though a later token in the group (the ICP CHAT token) does have a price.

<img width="302" alt="image" src="https://github.com/user-attachments/assets/f27f4d07-20f1-48c1-8dbf-bff756df3cc2" />


The root cause was in `updateTokenGroup`: it spread `...tokenGroup`, which preserved `usdPrice: undefined` from the initial group and never fell back to a price from tokens added later.

# Changes

- In `updateTokenGroup`, after summing balances, explicitly pick `usdPrice`, `usdMarketCap`, and `usdPriceChangePercentage24h` using `??` — keeping the group's existing values if set, or falling back to the incoming token's values if the group has none.

# Tests

Updated existing `updateTokenGroup` test expectations to reflect the now-explicit price fields, and added two new unit tests:
- Verifies the price is taken from the first token that has one when the group has no price.
- Verifies the existing group price is preserved when it is already set.