### PR TITLE
fix(frontend): use price from first priced token in token group header

### DIFF
--- a/src/frontend/src/env/tokens/tokens.sns.json
+++ b/src/frontend/src/env/tokens/tokens.sns.json
@@ -20,6 +20,7 @@
 		"rootCanisterId": "3e3x2-xyaaa-aaaaq-aaalq-cai",
 		"indexCanisterId": "2awyi-oyaaa-aaaaq-aaanq-cai",
 		"governanceCanisterId": "2jvtu-yqaaa-aaaaq-aaama-cai",
+		"groupDataId": "CHAT",
 		"metadata": {
 			"decimals": 8,
 			"name": "CHAT",

--- a/src/frontend/src/env/tokens/tokens.sns.json
+++ b/src/frontend/src/env/tokens/tokens.sns.json
@@ -20,7 +20,6 @@
 		"rootCanisterId": "3e3x2-xyaaa-aaaaq-aaalq-cai",
 		"indexCanisterId": "2awyi-oyaaa-aaaaq-aaanq-cai",
 		"governanceCanisterId": "2jvtu-yqaaa-aaaaq-aaama-cai",
-		"groupDataId": "CHAT",
 		"metadata": {
 			"decimals": 8,
 			"name": "CHAT",

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -101,8 +101,12 @@ export const updateTokenGroup = ({ token, tokenGroup }: UpdateTokenGroupParams):
 		),
 		usdBalance: sumUsdBalances([tokenGroup.usdBalance, token.usdBalance]),
 		...(nonNullish(tokenGroup.usdPrice ?? token.usdPrice) && {
-			usdPrice: tokenGroup.usdPrice ?? token.usdPrice,
-			usdMarketCap: tokenGroup.usdMarketCap ?? token.usdMarketCap,
+			usdPrice: tokenGroup.usdPrice ?? token.usdPrice
+		}),
+		...(nonNullish(tokenGroup.usdMarketCap ?? token.usdMarketCap) && {
+			usdMarketCap: tokenGroup.usdMarketCap ?? token.usdMarketCap
+		}),
+		...(nonNullish(tokenGroup.usdPriceChangePercentage24h ?? token.usdPriceChangePercentage24h) && {
 			usdPriceChangePercentage24h:
 				tokenGroup.usdPriceChangePercentage24h ?? token.usdPriceChangePercentage24h
 		})

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -100,10 +100,12 @@ export const updateTokenGroup = ({ token, tokenGroup }: UpdateTokenGroupParams):
 			)
 		),
 		usdBalance: sumUsdBalances([tokenGroup.usdBalance, token.usdBalance]),
-		usdPrice: tokenGroup.usdPrice ?? token.usdPrice,
-		usdMarketCap: tokenGroup.usdMarketCap ?? token.usdMarketCap,
-		usdPriceChangePercentage24h:
-			tokenGroup.usdPriceChangePercentage24h ?? token.usdPriceChangePercentage24h
+		...(nonNullish(tokenGroup.usdPrice ?? token.usdPrice) && {
+			usdPrice: tokenGroup.usdPrice ?? token.usdPrice,
+			usdMarketCap: tokenGroup.usdMarketCap ?? token.usdMarketCap,
+			usdPriceChangePercentage24h:
+				tokenGroup.usdPriceChangePercentage24h ?? token.usdPriceChangePercentage24h
+		})
 	};
 };
 

--- a/src/frontend/src/lib/utils/token-group.utils.ts
+++ b/src/frontend/src/lib/utils/token-group.utils.ts
@@ -99,7 +99,11 @@ export const updateTokenGroup = ({ token, tokenGroup }: UpdateTokenGroupParams):
 					: balance
 			)
 		),
-		usdBalance: sumUsdBalances([tokenGroup.usdBalance, token.usdBalance])
+		usdBalance: sumUsdBalances([tokenGroup.usdBalance, token.usdBalance]),
+		usdPrice: tokenGroup.usdPrice ?? token.usdPrice,
+		usdMarketCap: tokenGroup.usdMarketCap ?? token.usdMarketCap,
+		usdPriceChangePercentage24h:
+			tokenGroup.usdPriceChangePercentage24h ?? token.usdPriceChangePercentage24h
 	};
 };
 

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -153,6 +153,11 @@ describe('token-group.utils', () => {
 	});
 
 	describe('updateTokenGroup', () => {
+		const noPriceFields = {
+			usdPrice: undefined,
+			usdMarketCap: undefined,
+			usdPriceChangePercentage24h: undefined
+		} as const;
 		const token = {
 			...ETHEREUM_TOKEN,
 			groupData: ETH_TOKEN_GROUP,
@@ -194,10 +199,7 @@ describe('token-group.utils', () => {
 			decimals: expectedDecimals,
 			tokens: [anotherToken, token],
 			balance: expectedBalance,
-			usdBalance: anotherToken.usdBalance + token.usdBalance,
-			usdPrice: undefined,
-			usdMarketCap: undefined,
-			usdPriceChangePercentage24h: undefined
+			usdBalance: anotherToken.usdBalance + token.usdBalance
 		};
 
 		it('should add a token to a token group successfully', () => {
@@ -221,10 +223,7 @@ describe('token-group.utils', () => {
 				...tokenGroup,
 				tokens: [anotherToken, thirdToken, token],
 				balance: expectedBalance + thirdToken.balance,
-				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance,
-				usdPrice: undefined,
-				usdMarketCap: undefined,
-				usdPriceChangePercentage24h: undefined
+				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
 			});
 		});
 
@@ -310,10 +309,7 @@ describe('token-group.utils', () => {
 				decimals: newDecimals,
 				tokens: [...tokenGroup.tokens, newToken],
 				balance: expectedBalance,
-				usdBalance: tokenGroup.usdBalance + newToken.usdBalance,
-				usdPrice: undefined,
-				usdMarketCap: undefined,
-				usdPriceChangePercentage24h: undefined
+				usdBalance: tokenGroup.usdBalance + newToken.usdBalance
 			});
 
 			const thirdToken = {

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -357,7 +357,9 @@ describe('token-group.utils', () => {
 				id: ETH_TOKEN_GROUP.id,
 				decimals: BASE_ETH_TOKEN.decimals,
 				groupData: ETH_TOKEN_GROUP,
-				tokens: [{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn2Bi, usdBalance: 200 }],
+				tokens: [
+					{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn2Bi, usdBalance: 200 }
+				],
 				balance: bn2Bi,
 				usdBalance: 200,
 				usdPrice: undefined,
@@ -377,7 +379,9 @@ describe('token-group.utils', () => {
 				id: ETH_TOKEN_GROUP.id,
 				decimals: BASE_ETH_TOKEN.decimals,
 				groupData: ETH_TOKEN_GROUP,
-				tokens: [{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn1Bi, usdBalance: 100 }],
+				tokens: [
+					{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn1Bi, usdBalance: 100 }
+				],
 				balance: bn1Bi,
 				usdBalance: 100,
 				usdPrice: 1500,
@@ -395,7 +399,10 @@ describe('token-group.utils', () => {
 				usdPriceChangePercentage24h: -0.5
 			};
 
-			const result = updateTokenGroup({ token: tokenWithDifferentPrice, tokenGroup: groupWithPrice });
+			const result = updateTokenGroup({
+				token: tokenWithDifferentPrice,
+				tokenGroup: groupWithPrice
+			});
 
 			expect(result.usdPrice).toBe(groupWithPrice.usdPrice);
 			expect(result.usdMarketCap).toBe(groupWithPrice.usdMarketCap);

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -153,11 +153,6 @@ describe('token-group.utils', () => {
 	});
 
 	describe('updateTokenGroup', () => {
-		const noPriceFields = {
-			usdPrice: undefined,
-			usdMarketCap: undefined,
-			usdPriceChangePercentage24h: undefined
-		} as const;
 		const token = {
 			...ETHEREUM_TOKEN,
 			groupData: ETH_TOKEN_GROUP,

--- a/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-group.utils.spec.ts
@@ -194,7 +194,10 @@ describe('token-group.utils', () => {
 			decimals: expectedDecimals,
 			tokens: [anotherToken, token],
 			balance: expectedBalance,
-			usdBalance: anotherToken.usdBalance + token.usdBalance
+			usdBalance: anotherToken.usdBalance + token.usdBalance,
+			usdPrice: undefined,
+			usdMarketCap: undefined,
+			usdPriceChangePercentage24h: undefined
 		};
 
 		it('should add a token to a token group successfully', () => {
@@ -218,7 +221,10 @@ describe('token-group.utils', () => {
 				...tokenGroup,
 				tokens: [anotherToken, thirdToken, token],
 				balance: expectedBalance + thirdToken.balance,
-				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
+				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance,
+				usdPrice: undefined,
+				usdMarketCap: undefined,
+				usdPriceChangePercentage24h: undefined
 			});
 		});
 
@@ -304,7 +310,10 @@ describe('token-group.utils', () => {
 				decimals: newDecimals,
 				tokens: [...tokenGroup.tokens, newToken],
 				balance: expectedBalance,
-				usdBalance: tokenGroup.usdBalance + newToken.usdBalance
+				usdBalance: tokenGroup.usdBalance + newToken.usdBalance,
+				usdPrice: undefined,
+				usdMarketCap: undefined,
+				usdPriceChangePercentage24h: undefined
 			});
 
 			const thirdToken = {
@@ -331,6 +340,66 @@ describe('token-group.utils', () => {
 					}) + thirdToken.balance,
 				usdBalance: anotherToken.usdBalance + thirdToken.usdBalance + token.usdBalance
 			});
+		});
+
+		it('should use price from the first token that has one when group has no price', () => {
+			const tokenWithPrice = {
+				...ETHEREUM_TOKEN,
+				groupData: ETH_TOKEN_GROUP,
+				balance: bn1Bi,
+				usdBalance: 100,
+				usdPrice: 2000,
+				usdMarketCap: 240000000000,
+				usdPriceChangePercentage24h: -0.5
+			};
+
+			const groupWithoutPrice: TokenUiGroup = {
+				id: ETH_TOKEN_GROUP.id,
+				decimals: BASE_ETH_TOKEN.decimals,
+				groupData: ETH_TOKEN_GROUP,
+				tokens: [{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn2Bi, usdBalance: 200 }],
+				balance: bn2Bi,
+				usdBalance: 200,
+				usdPrice: undefined,
+				usdMarketCap: undefined,
+				usdPriceChangePercentage24h: undefined
+			};
+
+			const result = updateTokenGroup({ token: tokenWithPrice, tokenGroup: groupWithoutPrice });
+
+			expect(result.usdPrice).toBe(tokenWithPrice.usdPrice);
+			expect(result.usdMarketCap).toBe(tokenWithPrice.usdMarketCap);
+			expect(result.usdPriceChangePercentage24h).toBe(tokenWithPrice.usdPriceChangePercentage24h);
+		});
+
+		it('should keep existing group price when it already has one', () => {
+			const groupWithPrice: TokenUiGroup = {
+				id: ETH_TOKEN_GROUP.id,
+				decimals: BASE_ETH_TOKEN.decimals,
+				groupData: ETH_TOKEN_GROUP,
+				tokens: [{ ...BASE_ETH_TOKEN, groupData: ETH_TOKEN_GROUP, balance: bn1Bi, usdBalance: 100 }],
+				balance: bn1Bi,
+				usdBalance: 100,
+				usdPrice: 1500,
+				usdMarketCap: 180000000000,
+				usdPriceChangePercentage24h: 1.0
+			};
+
+			const tokenWithDifferentPrice = {
+				...ETHEREUM_TOKEN,
+				groupData: ETH_TOKEN_GROUP,
+				balance: bn2Bi,
+				usdBalance: 200,
+				usdPrice: 2000,
+				usdMarketCap: 240000000000,
+				usdPriceChangePercentage24h: -0.5
+			};
+
+			const result = updateTokenGroup({ token: tokenWithDifferentPrice, tokenGroup: groupWithPrice });
+
+			expect(result.usdPrice).toBe(groupWithPrice.usdPrice);
+			expect(result.usdMarketCap).toBe(groupWithPrice.usdMarketCap);
+			expect(result.usdPriceChangePercentage24h).toBe(groupWithPrice.usdPriceChangePercentage24h);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

When the first token(s) in a group have no price data (e.g. the Ethereum, Base, and Arbitrum CHAT tokens), the group header shows no price or performance — even though a later token in the group (the ICP CHAT token) does have a price.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bab363e0-5a7d-49a0-aeb6-b1a40e9bf7e4" />

The root cause was in `updateTokenGroup`: it spread `...tokenGroup`, which preserved `usdPrice: undefined` from the initial group and never fell back to a price from tokens added later.

# Changes

- In `updateTokenGroup`, after summing balances, each of `usdPrice`, `usdMarketCap`, and `usdPriceChangePercentage24h` is now conditionally spread using `??` — only when the resolved value is non-nullish, preserving the original `TokenUiGroup` shape when no price data is available.

# Tests

Updated existing `updateTokenGroup` test expectations to align with the new behaviour, and added two new unit tests:
- Verifies the price is taken from the first token that has one when the group has no price.
- Verifies the existing group price is preserved when it is already set.