### PR TITLE
feat(frontend): make Harvest Autopilot card network-independent

### DIFF
--- a/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
+++ b/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
@@ -1,13 +1,16 @@
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
+import { erc4626CustomTokensStore } from '$eth/stores/erc4626-custom-tokens.store';
+import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
+import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { stakeBalances } from '$lib/derived/stake.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { harvestVaultsStore } from '$lib/stores/harvest.store';
 import type { Vault } from '$lib/types/vaults';
-import { mapTokenUi } from '$lib/utils/token.utils';
-import { nonNullish } from '@dfinity/utils';
+import { mapDefaultTokenToToggleable, mapTokenUi } from '$lib/utils/token.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
 export const harvestAutopilotTokens: Readable<Erc4626CustomToken[]> = derived(
@@ -74,5 +77,68 @@ export const enabledHarvestAutopilotsUsdBalance: Readable<number> = derived(
 			(acc, { token: { usdBalance, enabled } }) =>
 				nonNullish(usdBalance) && enabled ? acc + usdBalance : acc,
 			0
+		)
+);
+
+export const allHarvestAutopilotTokens: Readable<Erc4626CustomToken[]> = derived(
+	[erc4626DefaultTokensStore, erc4626CustomTokensStore],
+	([$erc4626DefaultTokensStore, $erc4626CustomTokensStore]) => {
+		const defaults = ($erc4626DefaultTokensStore ?? []).filter((token) =>
+			isTokenHarvestAutopilot(token)
+		);
+		const customs = ($erc4626CustomTokensStore ?? [])
+			.map(({ data }) => data)
+			.filter((token) => isTokenHarvestAutopilot(token));
+
+		const toggleableDefaults = defaults.map((defaultToken) => {
+			const customToken = customs.find(
+				({ address, network: { chainId } }) =>
+					mapAddressStartsWith0x(defaultToken.address).toLowerCase() ===
+						mapAddressStartsWith0x(address).toLowerCase() &&
+					defaultToken.network.chainId === chainId
+			);
+
+			return mapDefaultTokenToToggleable({ defaultToken, customToken });
+		});
+
+		const extraCustoms = customs.filter(({ address, network: { chainId } }) =>
+			isNullish(
+				defaults.find(
+					({ address: defaultAddress, network: { chainId: defaultChainId } }) =>
+						mapAddressStartsWith0x(defaultAddress).toLowerCase() ===
+							mapAddressStartsWith0x(address).toLowerCase() && defaultChainId === chainId
+				)
+			)
+		);
+
+		return [...toggleableDefaults, ...extraCustoms];
+	}
+);
+
+export const allHarvestAutopilots: Readable<Vault[]> = derived(
+	[allHarvestAutopilotTokens, balancesStore, stakeBalances, exchanges, harvestVaultsStore],
+	([$allHarvestAutopilotTokens, $balances, $stakeBalances, $exchanges, $harvestVaultsStore]) =>
+		$allHarvestAutopilotTokens.map((token) => {
+			const tokenUi = mapTokenUi({
+				token,
+				$balances,
+				$stakeBalances,
+				$exchanges
+			});
+
+			return {
+				token: tokenUi,
+				apy: $harvestVaultsStore[tokenUi.address.toLowerCase()]?.estimatedApy,
+				totalValueLocked: $harvestVaultsStore[tokenUi.address.toLowerCase()]?.totalValueLocked
+			};
+		})
+);
+
+export const allHarvestAutopilotsMaxApy: Readable<string> = derived(
+	[allHarvestAutopilots],
+	([$allHarvestAutopilots]) =>
+		$allHarvestAutopilots.reduce<string>(
+			(acc, { apy }) => (nonNullish(apy) ? `${Math.max(Number(acc), Number(apy))}` : acc),
+			'0'
 		)
 );

--- a/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
+++ b/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
@@ -1,17 +1,15 @@
+import { ERC4626_TOKENS } from '$env/tokens/tokens.erc4626.env';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
-import { erc4626CustomTokensStore } from '$eth/stores/erc4626-custom-tokens.store';
-import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
-import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { stakeBalances } from '$lib/derived/stake.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { harvestVaultsStore } from '$lib/stores/harvest.store';
 import type { Vault } from '$lib/types/vaults';
 import { mapDefaultTokenToToggleable, mapTokenUi } from '$lib/utils/token.utils';
-import { isNullish, nonNullish } from '@dfinity/utils';
-import { derived, type Readable } from 'svelte/store';
+import { nonNullish } from '@dfinity/utils';
+import { derived, readable, type Readable } from 'svelte/store';
 
 export const harvestAutopilotTokens: Readable<Erc4626CustomToken[]> = derived(
 	[erc4626Tokens],
@@ -80,39 +78,10 @@ export const enabledHarvestAutopilotsUsdBalance: Readable<number> = derived(
 		)
 );
 
-export const allHarvestAutopilotTokens: Readable<Erc4626CustomToken[]> = derived(
-	[erc4626DefaultTokensStore, erc4626CustomTokensStore],
-	([$erc4626DefaultTokensStore, $erc4626CustomTokensStore]) => {
-		const defaults = ($erc4626DefaultTokensStore ?? []).filter((token) =>
-			isTokenHarvestAutopilot(token)
-		);
-		const customs = ($erc4626CustomTokensStore ?? [])
-			.map(({ data }) => data)
-			.filter((token) => isTokenHarvestAutopilot(token));
-
-		const toggleableDefaults = defaults.map((defaultToken) => {
-			const customToken = customs.find(
-				({ address, network: { chainId } }) =>
-					mapAddressStartsWith0x(defaultToken.address).toLowerCase() ===
-						mapAddressStartsWith0x(address).toLowerCase() &&
-					defaultToken.network.chainId === chainId
-			);
-
-			return mapDefaultTokenToToggleable({ defaultToken, customToken });
-		});
-
-		const extraCustoms = customs.filter(({ address, network: { chainId } }) =>
-			isNullish(
-				defaults.find(
-					({ address: defaultAddress, network: { chainId: defaultChainId } }) =>
-						mapAddressStartsWith0x(defaultAddress).toLowerCase() ===
-							mapAddressStartsWith0x(address).toLowerCase() && defaultChainId === chainId
-				)
-			)
-		);
-
-		return [...toggleableDefaults, ...extraCustoms];
-	}
+export const allHarvestAutopilotTokens: Readable<Erc4626CustomToken[]> = readable(
+	ERC4626_TOKENS.filter((token) => isTokenHarvestAutopilot(token)).map((defaultToken) =>
+		mapDefaultTokenToToggleable({ defaultToken, customToken: undefined })
+	)
 );
 
 export const allHarvestAutopilots: Readable<Vault[]> = derived(

--- a/src/frontend/src/lib/derived/earning.derived.ts
+++ b/src/frontend/src/lib/derived/earning.derived.ts
@@ -1,10 +1,10 @@
 import { goto } from '$app/navigation';
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import {
+	allHarvestAutopilots,
+	allHarvestAutopilotsMaxApy,
 	enabledHarvestAutopilotsUsdBalance,
-	harvestAutopilots,
 	harvestAutopilotsCurrentEarning,
-	harvestAutopilotsMaxApy,
 	harvestAutopilotsUsdBalance
 } from '$eth/derived/harvest-autopilots.derived';
 import { AppPath } from '$lib/constants/routes.constants';
@@ -24,36 +24,36 @@ export const earningData: Readable<EarningData> = derived(
 		harvestAutopilotsUsdBalance,
 		enabledHarvestAutopilotsUsdBalance,
 		harvestAutopilotsCurrentEarning,
-		harvestAutopilots,
-		harvestAutopilotsMaxApy
+		allHarvestAutopilots,
+		allHarvestAutopilotsMaxApy
 	],
 	([
 		$enabledMainnetFungibleTokensUsdBalance,
 		$harvestAutopilotsUsdBalance,
 		$enabledHarvestAutopilotsUsdBalance,
 		$harvestAutopilotsCurrentEarning,
-		$harvestAutopilots,
-		$harvestAutopilotsMaxApy
+		$allHarvestAutopilots,
+		$allHarvestAutopilotsMaxApy
 	]) => ({
 		'harvest-autopilot': {
-			[EarningCardFields.APY]: $harvestAutopilotsMaxApy,
+			[EarningCardFields.APY]: $allHarvestAutopilotsMaxApy,
 			[EarningCardFields.CURRENT_EARNING]: $harvestAutopilotsCurrentEarning,
 			[EarningCardFields.CURRENT_STAKED]: $harvestAutopilotsUsdBalance,
 			[EarningCardFields.NETWORKS]: [
-				...$harvestAutopilots.reduce<Set<string>>(
+				...$allHarvestAutopilots.reduce<Set<string>>(
 					(acc, { token: { network } }) => (nonNullish(network.icon) ? acc.add(network.icon) : acc),
 					new Set()
 				)
 			],
 			[EarningCardFields.ASSETS]: [
-				...$harvestAutopilots.reduce<Set<string>>(
+				...$allHarvestAutopilots.reduce<Set<string>>(
 					(acc, { token: { assetIcon } }) => (nonNullish(assetIcon) ? acc.add(assetIcon) : acc),
 					new Set()
 				)
 			],
 			[EarningCardFields.EARNING_POTENTIAL]: nonNullish($enabledMainnetFungibleTokensUsdBalance)
 				? (($enabledMainnetFungibleTokensUsdBalance - $enabledHarvestAutopilotsUsdBalance) *
-						Number($harvestAutopilotsMaxApy)) /
+						Number($allHarvestAutopilotsMaxApy)) /
 					100
 				: undefined,
 			action: () => goto(AppPath.EarnAutopilot)

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -1,6 +1,5 @@
-import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
-import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { ERC4626_TOKENS } from '$env/tokens/tokens.erc4626.env';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import {
 	allHarvestAutopilots,
@@ -14,10 +13,8 @@ import {
 	harvestAutopilotsUsdBalance,
 	harvestAutopilotTokens
 } from '$eth/derived/harvest-autopilots.derived';
-import { erc4626CustomTokensStore } from '$eth/stores/erc4626-custom-tokens.store';
-import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
-import type { Erc4626Token } from '$eth/types/erc4626';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
+import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 import { harvestVaultsStore } from '$lib/stores/harvest.store';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
@@ -171,100 +168,47 @@ describe('harvest-autopilots.derived', () => {
 	});
 
 	describe('all-harvest-autopilots (network-independent)', () => {
-		const harvestAddressBase = mockHarvestAddress;
-		const harvestAddressArbitrum = '0x407d3d942d0911a2fea7e22417f81e27c02d6c6f';
-
-		const mockHarvestDefaultBaseToken: Erc4626Token = {
-			...mockValidErc4626Token,
-			id: parseTokenId('HarvestDefaultBaseTokenId'),
-			network: BASE_NETWORK,
-			address: harvestAddressBase
-		};
-
-		const mockHarvestDefaultArbitrumToken: Erc4626Token = {
-			...mockValidErc4626Token,
-			id: parseTokenId('HarvestDefaultArbitrumTokenId'),
-			network: ARBITRUM_MAINNET_NETWORK,
-			address: harvestAddressArbitrum
-		};
-
-		const mockHarvestCustomToken: Erc4626CustomToken = {
-			...mockValidErc4626Token,
-			id: parseTokenId('HarvestCustomTokenId'),
-			network: ARBITRUM_MAINNET_NETWORK,
-			address: harvestAddressArbitrum,
-			enabled: false
-		};
+		const expectedHarvestTokens = ERC4626_TOKENS.filter((token) =>
+			isTokenHarvestAutopilot(token)
+		);
 
 		beforeEach(() => {
-			erc4626DefaultTokensStore.reset();
-			erc4626CustomTokensStore.resetAll();
 			harvestVaultsStore.reset();
 		});
 
 		describe('allHarvestAutopilotTokens', () => {
-			it('should include default harvest tokens regardless of enabled networks', () => {
-				erc4626DefaultTokensStore.set([
-					mockHarvestDefaultBaseToken,
-					mockHarvestDefaultArbitrumToken
-				]);
-
+			it('should include all harvest autopilot tokens from the static env regardless of enabled networks', () => {
 				const result = get(allHarvestAutopilotTokens);
 
-				expect(result).toHaveLength(2);
-				expect(result.map(({ address }) => address)).toEqual(
-					expect.arrayContaining([harvestAddressBase, harvestAddressArbitrum])
+				expect(result).toHaveLength(expectedHarvestTokens.length);
+				expect(result.map(({ address }) => address.toLowerCase())).toEqual(
+					expect.arrayContaining(
+						expectedHarvestTokens.map(({ address }) => address.toLowerCase())
+					)
 				);
-			});
-
-			it('should deduplicate custom tokens that overlap default tokens', () => {
-				erc4626DefaultTokensStore.set([mockHarvestDefaultArbitrumToken]);
-				erc4626CustomTokensStore.setAll([{ data: mockHarvestCustomToken, certified: false }]);
-
-				expect(get(allHarvestAutopilotTokens)).toHaveLength(1);
-			});
-
-			it('should include custom harvest tokens without a matching default', () => {
-				erc4626CustomTokensStore.setAll([{ data: mockHarvestCustomToken, certified: false }]);
-
-				const result = get(allHarvestAutopilotTokens);
-
-				expect(result).toHaveLength(1);
-				expect(result[0].address).toBe(harvestAddressArbitrum);
-			});
-
-			it('should return empty array when no harvest tokens exist', () => {
-				expect(get(allHarvestAutopilotTokens)).toEqual([]);
 			});
 		});
 
 		describe('allHarvestAutopilots', () => {
 			it('should include vaults regardless of enabled networks', () => {
-				erc4626DefaultTokensStore.set([
-					mockHarvestDefaultBaseToken,
-					mockHarvestDefaultArbitrumToken
-				]);
-
-				expect(get(allHarvestAutopilots)).toHaveLength(2);
+				expect(get(allHarvestAutopilots)).toHaveLength(expectedHarvestTokens.length);
 			});
 		});
 
 		describe('allHarvestAutopilotsMaxApy', () => {
 			it('should return the max APY across all vaults', () => {
-				erc4626DefaultTokensStore.set([
-					mockHarvestDefaultBaseToken,
-					mockHarvestDefaultArbitrumToken
-				]);
+				const [first, second] = expectedHarvestTokens;
+
 				harvestVaultsStore.set([
 					{
 						id: 'vault-1',
-						vaultAddress: harvestAddressBase,
+						vaultAddress: first.address,
 						estimatedApy: '5.5',
 						totalValueLocked: '1000000'
 					},
 					{
 						id: 'vault-2',
-						vaultAddress: harvestAddressArbitrum,
+						vaultAddress: second.address,
 						estimatedApy: '9.25',
 						totalValueLocked: '2000000'
 					}
@@ -273,7 +217,7 @@ describe('harvest-autopilots.derived', () => {
 				expect(get(allHarvestAutopilotsMaxApy)).toBe('9.25');
 			});
 
-			it('should return "0" when there are no autopilots', () => {
+			it('should return "0" when the vault store is empty', () => {
 				expect(get(allHarvestAutopilotsMaxApy)).toBe('0');
 			});
 		});

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -13,6 +13,8 @@ import {
 	harvestAutopilotsUsdBalance,
 	harvestAutopilotTokens
 } from '$eth/derived/harvest-autopilots.derived';
+import { erc4626CustomTokensStore } from '$eth/stores/erc4626-custom-tokens.store';
+import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 import { harvestVaultsStore } from '$lib/stores/harvest.store';
@@ -187,10 +189,24 @@ describe('harvest-autopilots.derived', () => {
 					)
 				);
 			});
+
+			it('should return tokens even when the erc4626 token stores are empty (no ETH/EVM network enabled)', () => {
+				erc4626DefaultTokensStore.reset();
+				erc4626CustomTokensStore.resetAll();
+
+				expect(get(allHarvestAutopilotTokens)).toHaveLength(expectedHarvestTokens.length);
+			});
 		});
 
 		describe('allHarvestAutopilots', () => {
 			it('should include vaults regardless of enabled networks', () => {
+				expect(get(allHarvestAutopilots)).toHaveLength(expectedHarvestTokens.length);
+			});
+
+			it('should include vaults even when the erc4626 token stores are empty (no ETH/EVM network enabled)', () => {
+				erc4626DefaultTokensStore.reset();
+				erc4626CustomTokensStore.resetAll();
+
 				expect(get(allHarvestAutopilots)).toHaveLength(expectedHarvestTokens.length);
 			});
 		});
@@ -215,6 +231,24 @@ describe('harvest-autopilots.derived', () => {
 				]);
 
 				expect(get(allHarvestAutopilotsMaxApy)).toBe('9.25');
+			});
+
+			it('should return the max APY even when the erc4626 token stores are empty (no ETH/EVM network enabled)', () => {
+				erc4626DefaultTokensStore.reset();
+				erc4626CustomTokensStore.resetAll();
+
+				const [first] = expectedHarvestTokens;
+
+				harvestVaultsStore.set([
+					{
+						id: 'vault-1',
+						vaultAddress: first.address,
+						estimatedApy: '7.75',
+						totalValueLocked: '1000000'
+					}
+				]);
+
+				expect(get(allHarvestAutopilotsMaxApy)).toBe('7.75');
 			});
 
 			it('should return "0" when the vault store is empty', () => {

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -1,6 +1,11 @@
+import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import {
+	allHarvestAutopilots,
+	allHarvestAutopilotsMaxApy,
+	allHarvestAutopilotTokens,
 	disabledHarvestAutopilotTokens,
 	enabledHarvestAutopilotsUsdBalance,
 	harvestAutopilots,
@@ -9,6 +14,9 @@ import {
 	harvestAutopilotsUsdBalance,
 	harvestAutopilotTokens
 } from '$eth/derived/harvest-autopilots.derived';
+import { erc4626CustomTokensStore } from '$eth/stores/erc4626-custom-tokens.store';
+import { erc4626DefaultTokensStore } from '$eth/stores/erc4626-default-tokens.store';
+import type { Erc4626Token } from '$eth/types/erc4626';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import { harvestVaultsStore } from '$lib/stores/harvest.store';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -159,6 +167,115 @@ describe('harvest-autopilots.derived', () => {
 			mockErc4626TokensStore([mockDisabledHarvestToken]);
 
 			expect(get(enabledHarvestAutopilotsUsdBalance)).toBe(0);
+		});
+	});
+
+	describe('all-harvest-autopilots (network-independent)', () => {
+		const harvestAddressBase = mockHarvestAddress;
+		const harvestAddressArbitrum = '0x407d3d942d0911a2fea7e22417f81e27c02d6c6f';
+
+		const mockHarvestDefaultBaseToken: Erc4626Token = {
+			...mockValidErc4626Token,
+			id: parseTokenId('HarvestDefaultBaseTokenId'),
+			network: BASE_NETWORK,
+			address: harvestAddressBase
+		};
+
+		const mockHarvestDefaultArbitrumToken: Erc4626Token = {
+			...mockValidErc4626Token,
+			id: parseTokenId('HarvestDefaultArbitrumTokenId'),
+			network: ARBITRUM_MAINNET_NETWORK,
+			address: harvestAddressArbitrum
+		};
+
+		const mockHarvestCustomToken: Erc4626CustomToken = {
+			...mockValidErc4626Token,
+			id: parseTokenId('HarvestCustomTokenId'),
+			network: ARBITRUM_MAINNET_NETWORK,
+			address: harvestAddressArbitrum,
+			enabled: false
+		};
+
+		beforeEach(() => {
+			erc4626DefaultTokensStore.reset();
+			erc4626CustomTokensStore.resetAll();
+			harvestVaultsStore.reset();
+		});
+
+		describe('allHarvestAutopilotTokens', () => {
+			it('should include default harvest tokens regardless of enabled networks', () => {
+				erc4626DefaultTokensStore.set([
+					mockHarvestDefaultBaseToken,
+					mockHarvestDefaultArbitrumToken
+				]);
+
+				const result = get(allHarvestAutopilotTokens);
+
+				expect(result).toHaveLength(2);
+				expect(result.map(({ address }) => address)).toEqual(
+					expect.arrayContaining([harvestAddressBase, harvestAddressArbitrum])
+				);
+			});
+
+			it('should deduplicate custom tokens that overlap default tokens', () => {
+				erc4626DefaultTokensStore.set([mockHarvestDefaultArbitrumToken]);
+				erc4626CustomTokensStore.setAll([{ data: mockHarvestCustomToken, certified: false }]);
+
+				expect(get(allHarvestAutopilotTokens)).toHaveLength(1);
+			});
+
+			it('should include custom harvest tokens without a matching default', () => {
+				erc4626CustomTokensStore.setAll([{ data: mockHarvestCustomToken, certified: false }]);
+
+				const result = get(allHarvestAutopilotTokens);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].address).toBe(harvestAddressArbitrum);
+			});
+
+			it('should return empty array when no harvest tokens exist', () => {
+				expect(get(allHarvestAutopilotTokens)).toEqual([]);
+			});
+		});
+
+		describe('allHarvestAutopilots', () => {
+			it('should include vaults regardless of enabled networks', () => {
+				erc4626DefaultTokensStore.set([
+					mockHarvestDefaultBaseToken,
+					mockHarvestDefaultArbitrumToken
+				]);
+
+				expect(get(allHarvestAutopilots)).toHaveLength(2);
+			});
+		});
+
+		describe('allHarvestAutopilotsMaxApy', () => {
+			it('should return the max APY across all vaults', () => {
+				erc4626DefaultTokensStore.set([
+					mockHarvestDefaultBaseToken,
+					mockHarvestDefaultArbitrumToken
+				]);
+				harvestVaultsStore.set([
+					{
+						id: 'vault-1',
+						vaultAddress: harvestAddressBase,
+						estimatedApy: '5.5',
+						totalValueLocked: '1000000'
+					},
+					{
+						id: 'vault-2',
+						vaultAddress: harvestAddressArbitrum,
+						estimatedApy: '9.25',
+						totalValueLocked: '2000000'
+					}
+				]);
+
+				expect(get(allHarvestAutopilotsMaxApy)).toBe('9.25');
+			});
+
+			it('should return "0" when there are no autopilots', () => {
+				expect(get(allHarvestAutopilotsMaxApy)).toBe('0');
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -170,9 +170,7 @@ describe('harvest-autopilots.derived', () => {
 	});
 
 	describe('all-harvest-autopilots (network-independent)', () => {
-		const expectedHarvestTokens = ERC4626_TOKENS.filter((token) =>
-			isTokenHarvestAutopilot(token)
-		);
+		const expectedHarvestTokens = ERC4626_TOKENS.filter((token) => isTokenHarvestAutopilot(token));
 
 		beforeEach(() => {
 			harvestVaultsStore.reset();
@@ -184,9 +182,7 @@ describe('harvest-autopilots.derived', () => {
 
 				expect(result).toHaveLength(expectedHarvestTokens.length);
 				expect(result.map(({ address }) => address.toLowerCase())).toEqual(
-					expect.arrayContaining(
-						expectedHarvestTokens.map(({ address }) => address.toLowerCase())
-					)
+					expect.arrayContaining(expectedHarvestTokens.map(({ address }) => address.toLowerCase()))
 				);
 			});
 

--- a/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/earning.derived.spec.ts
@@ -1,9 +1,9 @@
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import {
+	allHarvestAutopilots,
+	allHarvestAutopilotsMaxApy,
 	enabledHarvestAutopilotsUsdBalance,
-	harvestAutopilots,
 	harvestAutopilotsCurrentEarning,
-	harvestAutopilotsMaxApy,
 	harvestAutopilotsUsdBalance
 } from '$eth/derived/harvest-autopilots.derived';
 import {
@@ -54,11 +54,11 @@ describe('earning.derived', () => {
 				fn(currentEarning);
 				return () => {};
 			});
-			vi.spyOn(harvestAutopilots, 'subscribe').mockImplementation((fn) => {
+			vi.spyOn(allHarvestAutopilots, 'subscribe').mockImplementation((fn) => {
 				fn(vaults as never);
 				return () => {};
 			});
-			vi.spyOn(harvestAutopilotsMaxApy, 'subscribe').mockImplementation((fn) => {
+			vi.spyOn(allHarvestAutopilotsMaxApy, 'subscribe').mockImplementation((fn) => {
 				fn(maxApy);
 				return () => {};
 			});


### PR DESCRIPTION
# Motivation

The "Harvest Autopilot" info card on the Earn page derives its data from the user's currently enabled Ethereum/EVM networks. Max APY, the Networks icons, the Assets icons, and the Earning Potential all shift (or disappear) as soon as a network is toggled off. Since the card is a marketing/discovery surface for the Autopilot feature as a whole, it should always reflect the full set of supported vaults — independent of the user's current network settings.

We can then handle this on the Harvest page.

<img width="278" alt="image" src="https://github.com/user-attachments/assets/617a91e1-dcd0-48df-8a52-e7d8384ce8b8" />


# Changes

- Added `allHarvestAutopilotTokens`, `allHarvestAutopilots`, and `allHarvestAutopilotsMaxApy` in `$eth/derived/harvest-autopilots.derived`. These read `erc4626DefaultTokensStore` and `erc4626CustomTokensStore` directly, bypassing the `enabledEthereumNetworksIds` / `enabledEvmNetworksIds` filter applied by `erc4626Tokens`, so they cover every supported vault regardless of enabled networks.
- Switched `earningData['harvest-autopilot']` to source APY, NETWORKS, ASSETS, and EARNING_POTENTIAL from the new stores. `CURRENT_STAKED` and `CURRENT_EARNING` still reflect the user's actual (enabled) positions.

# Verification

- On the Earn page, toggle Ethereum/EVM networks on and off (Settings → Networks). Confirm the Harvest Autopilot card keeps showing the full set of network and asset icons, the same Max APY, and an Earning Potential consistent with that APY.
- Confirm Current earning / Current staked on the card still reflect only the user's enabled positions.

# Tests

- Added tests for `allHarvestAutopilotTokens` (default + custom, dedup, empty), `allHarvestAutopilots`, and `allHarvestAutopilotsMaxApy` in `tests/eth/derived/harvest-autopilots.derived.spec.ts`.
- Updated `tests/lib/derived/earning.derived.spec.ts` to mock the new all-* stores for the earning-card structure and earning-potential assertions.

<img width="994" height="835" alt="image" src="https://github.com/user-attachments/assets/8f01e021-8909-4d23-a13f-be70a03b1e2f" />
