### PR TITLE
feat(frontend): Add Settings toggle for hiding micro transactions

### DIFF
--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-	import { nonNullish, secondsToDuration } from '@dfinity/utils';
+	import { Toggle } from '@dfinity/gix-components';
+	import { isNullish, nonNullish, secondsToDuration } from '@dfinity/utils';
 	import { AI_ASSISTANT_CONSOLE_ENABLED } from '$env/ai-assistant.env';
+	import { updateUserTransactionFilterSettings } from '$lib/api/backend.api';
 	import EnabledNetworksPreviewIcons from '$lib/components/settings/EnabledNetworksPreviewIcons.svelte';
 	import SettingsCard from '$lib/components/settings/SettingsCard.svelte';
 	import SettingsCardItem from '$lib/components/settings/SettingsCardItem.svelte';
@@ -8,11 +10,13 @@
 	import SettingsVersion from '$lib/components/settings/SettingsVersion.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
+	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import {
 		SETTINGS_ACTIVE_NETWORKS_EDIT_BUTTON,
 		SETTINGS_ADDRESS_LABEL
 	} from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import { hideMicroTransactions, userProfileVersion } from '$lib/derived/user-profile.derived';
 	import {
 		type SettingsModalType,
 		SettingsModalType as SettingsModalEnum
@@ -20,6 +24,8 @@
 	import { authRemainingTimeStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { toastsShow } from '$lib/stores/toasts.store';
+	import { emit } from '$lib/utils/events.utils';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
@@ -27,6 +33,34 @@
 
 	const openSettingsModal = (t: SettingsModalType) =>
 		modalStore.openSettings({ id: modalId, data: t });
+
+	let filterLoading = $state(false);
+
+	const toggleMicroTransactions = async () => {
+		if (isNullish($authIdentity)) {
+			return;
+		}
+
+		filterLoading = true;
+
+		try {
+			await updateUserTransactionFilterSettings({
+				identity: $authIdentity,
+				hideMicroTransactions: !$hideMicroTransactions,
+				currentUserVersion: $userProfileVersion
+			});
+
+			emit({ message: 'oisyRefreshUserProfile' });
+
+			toastsShow({
+				text: $i18n.settings.text.save_spam_filter_success,
+				level: 'success',
+				duration: 2000
+			});
+		} finally {
+			filterLoading = false;
+		}
+	};
 </script>
 
 <SettingsCard>
@@ -68,6 +102,35 @@
 							i18n: $i18n.temporal.seconds_to_duration
 						})}
 			{/if}
+		{/snippet}
+	</SettingsCardItem>
+
+	<SettingsCardItem>
+		{#snippet key()}
+			{$i18n.settings.text.hide_micro_transactions}
+		{/snippet}
+
+		{#snippet value()}
+			<Toggle
+				ariaLabel={$hideMicroTransactions
+					? $i18n.settings.text.disable_hide_micro_transactions
+					: $i18n.settings.text.enable_hide_micro_transactions}
+				checked={$hideMicroTransactions}
+				disabled={filterLoading}
+				on:nnsToggle={toggleMicroTransactions}
+			/>
+		{/snippet}
+
+		{#snippet info()}
+			<span>
+				{$i18n.settings.text.hide_micro_transactions_description}
+
+				<ExternalLink
+					ariaLabel={$i18n.settings.text.learn_more}
+					href="https://support.oisy.com/hc/hidden-transactions"
+					iconVisible={false}>{$i18n.settings.text.learn_more}</ExternalLink
+				>
+			</span>
 		{/snippet}
 	</SettingsCardItem>
 </SettingsCard>


### PR DESCRIPTION
# Motivation

Adds the settings toggle that lets the user enable/disable the "hide micro transactions" filter.

# Changes

- Add settings toggle for hiding micro transactions in `Settings.svelte` with loading state, toast feedback, and profile refresh.

# Tests

Settings toggle tested via integration.
