### PR TITLE
feat(frontend): create ICP token group

### DIFF
--- a/src/frontend/src/env/tokens/groups/groups.icp.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.icp.env.ts
@@ -1,0 +1,14 @@
+import icpLight from '$icp/assets/icp-light.svg';
+import type { TokenGroupData, TokenGroupId } from '$lib/types/token-group';
+import { parseTokenGroupId } from '$lib/validation/token-group.validation';
+
+const ICP_TOKEN_GROUP_SYMBOL = 'ICP';
+
+export const ICP_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(ICP_TOKEN_GROUP_SYMBOL);
+
+export const ICP_TOKEN_GROUP: TokenGroupData = {
+	id: ICP_TOKEN_GROUP_ID,
+	icon: icpLight,
+	name: 'Internet Computer',
+	symbol: ICP_TOKEN_GROUP_SYMBOL
+};

--- a/src/frontend/src/env/tokens/tokens.icp.env.ts
+++ b/src/frontend/src/env/tokens/tokens.icp.env.ts
@@ -6,6 +6,7 @@ import {
 	ICP_NETWORK,
 	ICP_PSEUDO_TESTNET_NETWORK
 } from '$env/networks/networks.icp.env';
+import { ICP_TOKEN_GROUP } from '$env/tokens/groups/groups.icp.env';
 import icpLight from '$icp/assets/icp-light.svg';
 import { ICP_TRANSACTION_FEE_E8S } from '$icp/constants/icp.constants';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
@@ -43,7 +44,8 @@ export const ICP_TOKEN: RequiredToken<Omit<IcToken, 'deprecated' | 'alternativeN
 	explorerUrl: ICP_EXPLORER_URL,
 	buy: {
 		onramperId: 'icp_icp'
-	}
+	},
+	groupData: ICP_TOKEN_GROUP
 };
 
 /**

--- a/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
@@ -7,6 +7,7 @@ import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 import { ETH_TOKEN_GROUP_ID } from '$env/tokens/groups/groups.eth.env';
+import { ICP_TOKEN_GROUP_ID } from '$env/tokens/groups/groups.icp.env';
 import { ICRC_LEDGER_CANISTER_TESTNET_IDS } from '$env/tokens/tokens-icrc/tokens.icrc.testnet.env';
 import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN, ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
@@ -115,7 +116,7 @@ describe('user-snapshot.services', () => {
 						network_id: ICP_NETWORK_ID.description
 					},
 					account: mockIdentity.getPrincipal().toString(),
-					token_address: { token_symbol: ICP_TOKEN_ID.description, wraps: toNullable() },
+					token_address: { token_symbol: ICP_TOKEN_ID.description, wraps: toNullable(ICP_TOKEN_GROUP_ID.description) },
 					last_transactions: mockIcTransactions
 						.slice(0, 5)
 						.map(({ value, timestamp, to }: IcTransactionUi): Transaction_Any => {

--- a/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-snapshot.services.spec.ts
@@ -116,7 +116,10 @@ describe('user-snapshot.services', () => {
 						network_id: ICP_NETWORK_ID.description
 					},
 					account: mockIdentity.getPrincipal().toString(),
-					token_address: { token_symbol: ICP_TOKEN_ID.description, wraps: toNullable(ICP_TOKEN_GROUP_ID.description) },
+					token_address: {
+						token_symbol: ICP_TOKEN_ID.description,
+						wraps: toNullable(ICP_TOKEN_GROUP_ID.description)
+					},
 					last_transactions: mockIcTransactions
 						.slice(0, 5)
 						.map(({ value, timestamp, to }: IcTransactionUi): Transaction_Any => {


### PR DESCRIPTION
# Motivation

We are going to add additional ICP tokens on Base, ETH, etc. To group them, we need to create a respective token group.
