### PR TITLE
feat(frontend): add ICP on ETH as suggested token

### DIFF
--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.icp.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.icp.env.ts
@@ -1,0 +1,27 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { ICP_TOKEN_GROUP } from '$env/tokens/groups/groups.icp.env';
+import type { RequiredAdditionalErc20Token } from '$eth/types/erc20';
+import icpLight from '$icp/assets/icp-light.svg';
+import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+
+const ICP_DECIMALS = 8;
+
+const ICP_SYMBOL = 'ICP';
+
+export const ICP_TOKEN_ID: TokenId = parseTokenId(ICP_SYMBOL);
+
+export const ICP_TOKEN: RequiredAdditionalErc20Token = {
+	id: ICP_TOKEN_ID,
+	network: ETHEREUM_NETWORK,
+	standard: { code: 'erc20' },
+	category: 'default',
+	tags: [{ type: TokenTagType.CATEGORY, value: TokenCategoryTagValue.CRYPTO }],
+	name: 'Internet Computer',
+	symbol: ICP_SYMBOL,
+	decimals: ICP_DECIMALS,
+	icon: icpLight,
+	address: '0x00f3C42833C3170159af4E92dbb451Fb3F708917',
+	groupData: ICP_TOKEN_GROUP
+};

--- a/src/frontend/src/env/tokens/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens.erc20.env.ts
@@ -21,6 +21,7 @@ import { EURC_TOKEN, SEPOLIA_EURC_TOKEN } from '$env/tokens/tokens-erc20/tokens.
 import { FLOKI_TOKEN } from '$env/tokens/tokens-erc20/tokens.floki.env';
 import { GLDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.gldt.env';
 import { IAUON_TOKEN } from '$env/tokens/tokens-erc20/tokens.iauon.env';
+import { ICP_TOKEN } from '$env/tokens/tokens-erc20/tokens.icp.env';
 import { IVVON_TOKEN } from '$env/tokens/tokens-erc20/tokens.ivvon.env';
 import { JASMY_TOKEN } from '$env/tokens/tokens-erc20/tokens.jasmy.env';
 import { LINK_TOKEN, SEPOLIA_LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
@@ -44,6 +45,8 @@ import { WETH_TOKEN } from '$env/tokens/tokens-erc20/tokens.weth.env';
 import { WSTETH_TOKEN } from '$env/tokens/tokens-erc20/tokens.wsteth.env';
 import { XAUT_TOKEN } from '$env/tokens/tokens-erc20/tokens.xaut.env';
 import { ZCHF_TOKEN } from '$env/tokens/tokens-erc20/tokens.zchf.env';
+import { ICP_TOKEN as ICP_ARBITRUM_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.icp.env';
+import { ICP_TOKEN as ICP_BASE_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.icp.env';
 import type {
 	Erc20Contract,
 	RequiredAdditionalErc20Token,
@@ -86,6 +89,7 @@ export const ADDITIONAL_ERC20_TOKENS: RequiredAdditionalErc20Token[] = [
 	EFAON_TOKEN,
 	FLOKI_TOKEN,
 	GLDT_TOKEN,
+	ICP_TOKEN,
 	IAUON_TOKEN,
 	IVVON_TOKEN,
 	JASMY_TOKEN,
@@ -138,4 +142,10 @@ export const ERC20_TWIN_TOKENS: RequiredErc20Token[] = defineSupportedTokens({
 export const ERC20_TWIN_TOKENS_IDS: TokenId[] = ERC20_TWIN_TOKENS.map(({ id }) => id);
 
 // Suggested tokens to be enabled by default if the user set no preference
-export const ERC20_SUGGESTED_TOKENS = [USDT_TOKEN, USDC_TOKEN];
+export const ERC20_SUGGESTED_TOKENS = [
+	USDT_TOKEN,
+	USDC_TOKEN,
+	ICP_TOKEN,
+	ICP_ARBITRUM_TOKEN,
+	ICP_BASE_TOKEN
+];

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -1,6 +1,9 @@
+import { ICP_TOKEN as ICP_ETH_TOKEN } from '$env/tokens/tokens-erc20/tokens.icp.env';
 import { LINK_TOKEN } from '$env/tokens/tokens-erc20/tokens.link.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
+import { ICP_TOKEN as ICP_ARB_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.icp.env';
+import { ICP_TOKEN as ICP_BASE_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.icp.env';
 import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env';
 import * as tokensIcrcCkEnv from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
 import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.eth.env';
@@ -551,7 +554,10 @@ describe('token.utils', () => {
 				setupMock: setupSuggestedTokenMock
 			},
 			{ description: 'Suggested ERC20 token USDC', token: USDC_TOKEN },
-			{ description: 'Suggested ERC20 token USDT', token: USDT_TOKEN }
+			{ description: 'Suggested ERC20 token USDT', token: USDT_TOKEN },
+			{ description: 'Suggested ERC20 token ICP on Ethereum', token: ICP_ETH_TOKEN },
+			{ description: 'Suggested ERC20 token ICP on Arbitrum', token: ICP_ARB_TOKEN },
+			{ description: 'Suggested ERC20 token ICP on Base', token: ICP_BASE_TOKEN }
 		])('$description - Suggested Tokens', ({ token, setupMock }) => {
 			if (setupMock) {
 				beforeEach(() => setupMock(token.ledgerCanisterId));


### PR DESCRIPTION
# Motivation

We can now add ICP on ETH, as well as list all ICP erc-20 tokens as suggested ones.
