### PR TITLE
feat(frontend): custom evm networks store

### DIFF
--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -2,8 +2,8 @@ import { NetworkEnvironmentSchema, NetworkIdSchema } from '$lib/schema/network.s
 import { UrlSchema } from '$lib/validation/url.validation';
 import * as z from 'zod';
 
-const BigIntStringSchema = z.string().regex(/^\d+$/, {
-	message: 'Must be a non-negative integer string'
+const BigIntStringSchema = z.string().regex(/^[1-9]\d*$/, {
+	message: 'Must be a positive integer string'
 });
 
 /**

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -1,0 +1,45 @@
+import { NetworkEnvironmentSchema, NetworkIdSchema } from '$lib/schema/network.schema';
+import { UrlSchema } from '$lib/validation/url.validation';
+import * as z from 'zod';
+
+const BigIntStringSchema = z.string().regex(/^\d+$/, {
+	message: 'Must be a non-negative integer string'
+});
+
+/**
+ * Runtime representation of a user-added EVM network.
+ *
+ * Deliberately separate from `EthereumNetwork` (built-in chains) because custom
+ * chains take a different code path: generic JSON-RPC provider, no Infura/Alchemy,
+ * and no participation in features gated by those providers (NFT API, CoinGecko
+ * pricing, onramp). The `Evm` naming reinforces that distinction at call sites.
+ */
+export const CustomEvmNetworkSchema = z.object({
+	id: NetworkIdSchema,
+	chainId: z.bigint().positive(),
+	name: z.string().min(1),
+	rpcUrl: UrlSchema,
+	currencySymbol: z.string().min(1),
+	explorerUrl: UrlSchema.optional(),
+	iconUrl: UrlSchema.optional(),
+	env: NetworkEnvironmentSchema
+});
+
+/**
+ * Serialized representation persisted in localStorage.
+ *
+ * `NetworkId` is a branded `symbol` and cannot be JSON-serialized, so it is
+ * dropped at write time and re-derived deterministically from `chainId` on read.
+ * `chainId` is stored as a decimal string because `bigint` has no JSON form.
+ */
+export const PersistedCustomEvmNetworkSchema = z.object({
+	chainId: BigIntStringSchema,
+	name: z.string().min(1),
+	rpcUrl: UrlSchema,
+	currencySymbol: z.string().min(1),
+	explorerUrl: UrlSchema.optional(),
+	iconUrl: UrlSchema.optional(),
+	env: NetworkEnvironmentSchema
+});
+
+export const PersistedCustomEvmNetworkListSchema = z.array(PersistedCustomEvmNetworkSchema);

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -12,8 +12,9 @@ const BigIntStringSchema = z.string().regex(/^[1-9]\d*$/, {
  *
  * The generic `UrlSchema` permits `ipfs:` because it doubles as the validator
  * for asset URLs (icons, metadata). That is not valid for an RPC endpoint,
- * which must speak HTTP(S) or WebSocket(S). Keep this narrow so bogus URLs
- * fail at input time rather than at the first `eth_*` call.
+ * which must speak HTTPS or secure WebSocket. Plain `http:` and `ws:` are
+ * rejected in line with the existing `allowHttpLocally: false` stance on the
+ * generic schema — we do not accept unencrypted remote endpoints even in dev.
  */
 const RpcUrlSchema = createUrlSchema({
 	additionalProtocols: ['wss:'],

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -26,6 +26,13 @@ export const CustomEvmNetworkSchema = z.object({
 });
 
 /**
+ * Input shape for `customEvmNetworksStore.add`: the full network minus the
+ * derived `NetworkId`. Validated before the id is computed so that invalid
+ * inputs don't populate the module-level `networkIdCache`.
+ */
+export const CustomEvmNetworkInputSchema = CustomEvmNetworkSchema.omit({ id: true });
+
+/**
  * Serialized representation persisted in localStorage.
  *
  * `NetworkId` is a branded `symbol` and cannot be JSON-serialized, so it is

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -1,9 +1,23 @@
 import { NetworkEnvironmentSchema, NetworkIdSchema } from '$lib/schema/network.schema';
 import { UrlSchema } from '$lib/validation/url.validation';
+import { createUrlSchema } from '@dfinity/zod-schemas';
 import * as z from 'zod';
 
 const BigIntStringSchema = z.string().regex(/^[1-9]\d*$/, {
 	message: 'Must be a positive integer string'
+});
+
+/**
+ * URL schema for JSON-RPC endpoints.
+ *
+ * The generic `UrlSchema` permits `ipfs:` because it doubles as the validator
+ * for asset URLs (icons, metadata). That is not valid for an RPC endpoint,
+ * which must speak HTTP(S) or WebSocket(S). Keep this narrow so bogus URLs
+ * fail at input time rather than at the first `eth_*` call.
+ */
+const RpcUrlSchema = createUrlSchema({
+	additionalProtocols: ['wss:'],
+	allowHttpLocally: false
 });
 
 /**
@@ -18,7 +32,7 @@ export const CustomEvmNetworkSchema = z.object({
 	id: NetworkIdSchema,
 	chainId: z.bigint().positive(),
 	name: z.string().min(1),
-	rpcUrl: UrlSchema,
+	rpcUrl: RpcUrlSchema,
 	currencySymbol: z.string().min(1),
 	explorerUrl: UrlSchema.optional(),
 	iconUrl: UrlSchema.optional(),
@@ -42,7 +56,7 @@ export const CustomEvmNetworkInputSchema = CustomEvmNetworkSchema.omit({ id: tru
 export const PersistedCustomEvmNetworkSchema = z.object({
 	chainId: BigIntStringSchema,
 	name: z.string().min(1),
-	rpcUrl: UrlSchema,
+	rpcUrl: RpcUrlSchema,
 	currencySymbol: z.string().min(1),
 	explorerUrl: UrlSchema.optional(),
 	iconUrl: UrlSchema.optional(),

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -47,13 +47,24 @@ const fromPersisted = (persisted: PersistedCustomEvmNetwork): CustomEvmNetwork =
 	};
 };
 
+const dedupeByChainId = (networks: PersistedCustomEvmNetwork[]): PersistedCustomEvmNetwork[] => {
+	const seen = new Set<string>();
+	return networks.filter(({ chainId }) => {
+		if (seen.has(chainId)) {
+			return false;
+		}
+		seen.add(chainId);
+		return true;
+	});
+};
+
 const loadFromStorage = (): CustomEvmNetwork[] => {
 	const raw = getStorage<unknown>({ key: CUSTOM_EVM_NETWORKS_STORAGE_KEY });
 	const parsed = PersistedCustomEvmNetworkListSchema.safeParse(raw ?? []);
 	if (!parsed.success) {
 		return [];
 	}
-	return parsed.data.map(fromPersisted);
+	return dedupeByChainId(parsed.data).map(fromPersisted);
 };
 
 export type CustomEvmNetworkInput = Omit<CustomEvmNetwork, 'id'>;

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -109,7 +109,7 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 				if (!parsed.success) {
 					throw new Error(`Invalid custom EVM network: ${parsed.error.message}`);
 				}
-				const entry: CustomEvmNetwork = { ...input, id: toNetworkId(input.chainId) };
+				const entry: CustomEvmNetwork = { ...parsed.data, id: toNetworkId(parsed.data.chainId) };
 				const next: CustomEvmNetwork[] = [...current, entry];
 				persist(next);
 				return next;
@@ -121,13 +121,19 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 				if (index === -1) {
 					throw new Error(`No custom EVM network with chainId ${chainId} exists; cannot update.`);
 				}
-				const merged: CustomEvmNetwork = { ...current[index], ...patch };
+				const existing = current[index];
+				const merged: CustomEvmNetwork = {
+					...existing,
+					...patch,
+					id: existing.id,
+					chainId: existing.chainId
+				};
 				const parsed = CustomEvmNetworkSchema.safeParse(merged);
 				if (!parsed.success) {
 					throw new Error(`Invalid custom EVM network update: ${parsed.error.message}`);
 				}
 				const next = [...current];
-				next[index] = merged;
+				next[index] = parsed.data;
 				persist(next);
 				return next;
 			});

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -7,7 +7,7 @@ import type { CustomEvmNetwork, PersistedCustomEvmNetwork } from '$eth/types/cus
 import type { NetworkId } from '$lib/types/network';
 import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
-import { writable } from 'svelte/store';
+import { writable, type Readable } from 'svelte/store';
 
 export const CUSTOM_EVM_NETWORKS_STORAGE_KEY = 'custom-evm-networks';
 
@@ -72,8 +72,7 @@ export type CustomEvmNetworkInput = Omit<CustomEvmNetwork, 'id'>;
 
 export type CustomEvmNetworkPatch = Partial<Omit<CustomEvmNetwork, 'id' | 'chainId'>>;
 
-export interface CustomEvmNetworksStore {
-	subscribe: (run: (value: CustomEvmNetwork[]) => void) => () => void;
+export interface CustomEvmNetworksStore extends Readable<CustomEvmNetwork[]> {
 	add: (network: CustomEvmNetworkInput) => void;
 	update: (params: { chainId: bigint; patch: CustomEvmNetworkPatch }) => void;
 	remove: (params: { chainId: bigint }) => void;
@@ -103,6 +102,9 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 						`A custom EVM network with chainId ${input.chainId} has already been added.`
 					);
 				}
+				// Validate the raw input (without `id`) so that invalid chainIds
+				// don't populate the networkIdCache. The derived `id` is deterministic
+				// given a valid chainId, so it does not require a second pass.
 				const parsed = CustomEvmNetworkInputSchema.safeParse(input);
 				if (!parsed.success) {
 					throw new Error(`Invalid custom EVM network: ${parsed.error.message}`);

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -1,4 +1,7 @@
-import { PersistedCustomEvmNetworkListSchema } from '$eth/schema/custom-network.schema';
+import {
+	CustomEvmNetworkSchema,
+	PersistedCustomEvmNetworkListSchema
+} from '$eth/schema/custom-network.schema';
 import type { CustomEvmNetwork, PersistedCustomEvmNetwork } from '$eth/types/custom-network';
 import type { NetworkId } from '$lib/types/network';
 import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
@@ -88,7 +91,12 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 						`A custom EVM network with chainId ${input.chainId} has already been added.`
 					);
 				}
-				const next: CustomEvmNetwork[] = [...current, { ...input, id: toNetworkId(input.chainId) }];
+				const entry: CustomEvmNetwork = { ...input, id: toNetworkId(input.chainId) };
+				const parsed = CustomEvmNetworkSchema.safeParse(entry);
+				if (!parsed.success) {
+					throw new Error(`Invalid custom EVM network: ${parsed.error.message}`);
+				}
+				const next: CustomEvmNetwork[] = [...current, entry];
 				persist(next);
 				return next;
 			});
@@ -99,8 +107,13 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 				if (index === -1) {
 					throw new Error(`No custom EVM network with chainId ${chainId} exists; cannot update.`);
 				}
+				const merged: CustomEvmNetwork = { ...current[index], ...patch };
+				const parsed = CustomEvmNetworkSchema.safeParse(merged);
+				if (!parsed.success) {
+					throw new Error(`Invalid custom EVM network update: ${parsed.error.message}`);
+				}
 				const next = [...current];
-				next[index] = { ...next[index], ...patch };
+				next[index] = merged;
 				persist(next);
 				return next;
 			});

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -108,6 +108,9 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 		remove: ({ chainId }) => {
 			updateWritable((current) => {
 				const next = current.filter((n) => n.chainId !== chainId);
+				if (next.length === current.length) {
+					return current;
+				}
 				persist(next);
 				return next;
 			});

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -1,0 +1,123 @@
+import { PersistedCustomEvmNetworkListSchema } from '$eth/schema/custom-network.schema';
+import type { CustomEvmNetwork, PersistedCustomEvmNetwork } from '$eth/types/custom-network';
+import type { NetworkId } from '$lib/types/network';
+import { parseNetworkId } from '$lib/validation/network.validation';
+import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
+import { writable } from 'svelte/store';
+
+export const CUSTOM_EVM_NETWORKS_STORAGE_KEY = 'custom-evm-networks';
+
+const networkIdCache = new Map<string, NetworkId>();
+
+const toNetworkId = (chainId: bigint): NetworkId => {
+	const key = chainId.toString();
+	const cached = networkIdCache.get(key);
+	if (cached !== undefined) {
+		return cached;
+	}
+	const id = parseNetworkId(`custom-evm:${key}`);
+	networkIdCache.set(key, id);
+	return id;
+};
+
+const toPersisted = (network: CustomEvmNetwork): PersistedCustomEvmNetwork => ({
+	chainId: network.chainId.toString(),
+	name: network.name,
+	rpcUrl: network.rpcUrl,
+	currencySymbol: network.currencySymbol,
+	explorerUrl: network.explorerUrl,
+	iconUrl: network.iconUrl,
+	env: network.env
+});
+
+const fromPersisted = (persisted: PersistedCustomEvmNetwork): CustomEvmNetwork => {
+	const chainId = BigInt(persisted.chainId);
+	return {
+		id: toNetworkId(chainId),
+		chainId,
+		name: persisted.name,
+		rpcUrl: persisted.rpcUrl,
+		currencySymbol: persisted.currencySymbol,
+		explorerUrl: persisted.explorerUrl,
+		iconUrl: persisted.iconUrl,
+		env: persisted.env
+	};
+};
+
+const loadFromStorage = (): CustomEvmNetwork[] => {
+	const raw = getStorage<unknown>({ key: CUSTOM_EVM_NETWORKS_STORAGE_KEY });
+	const parsed = PersistedCustomEvmNetworkListSchema.safeParse(raw ?? []);
+	if (!parsed.success) {
+		return [];
+	}
+	return parsed.data.map(fromPersisted);
+};
+
+export type CustomEvmNetworkInput = Omit<CustomEvmNetwork, 'id'>;
+
+export type CustomEvmNetworkPatch = Partial<Omit<CustomEvmNetwork, 'id' | 'chainId'>>;
+
+export interface CustomEvmNetworksStore {
+	subscribe: (run: (value: CustomEvmNetwork[]) => void) => () => void;
+	add: (network: CustomEvmNetworkInput) => void;
+	update: (params: { chainId: bigint; patch: CustomEvmNetworkPatch }) => void;
+	remove: (params: { chainId: bigint }) => void;
+	reset: () => void;
+}
+
+export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
+	const { subscribe, update: updateWritable, set } = writable<CustomEvmNetwork[]>(loadFromStorage());
+
+	const persist = (list: CustomEvmNetwork[]) => {
+		setStorage<PersistedCustomEvmNetwork[]>({
+			key: CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+			value: list.map(toPersisted)
+		});
+	};
+
+	return {
+		subscribe,
+		add: (input) => {
+			updateWritable((current) => {
+				if (current.some(({ chainId }) => chainId === input.chainId)) {
+					throw new Error(
+						`A custom EVM network with chainId ${input.chainId} has already been added.`
+					);
+				}
+				const next: CustomEvmNetwork[] = [
+					...current,
+					{ ...input, id: toNetworkId(input.chainId) }
+				];
+				persist(next);
+				return next;
+			});
+		},
+		update: ({ chainId, patch }) => {
+			updateWritable((current) => {
+				const index = current.findIndex((n) => n.chainId === chainId);
+				if (index === -1) {
+					throw new Error(
+						`No custom EVM network with chainId ${chainId} exists; cannot update.`
+					);
+				}
+				const next = [...current];
+				next[index] = { ...next[index], ...patch };
+				persist(next);
+				return next;
+			});
+		},
+		remove: ({ chainId }) => {
+			updateWritable((current) => {
+				const next = current.filter((n) => n.chainId !== chainId);
+				persist(next);
+				return next;
+			});
+		},
+		reset: () => {
+			delStorage({ key: CUSTOM_EVM_NETWORKS_STORAGE_KEY });
+			set([]);
+		}
+	};
+};
+
+export const customEvmNetworksStore: CustomEvmNetworksStore = initCustomEvmNetworksStore();

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -1,4 +1,5 @@
 import {
+	CustomEvmNetworkInputSchema,
 	CustomEvmNetworkSchema,
 	PersistedCustomEvmNetworkListSchema
 } from '$eth/schema/custom-network.schema';
@@ -102,11 +103,11 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 						`A custom EVM network with chainId ${input.chainId} has already been added.`
 					);
 				}
-				const entry: CustomEvmNetwork = { ...input, id: toNetworkId(input.chainId) };
-				const parsed = CustomEvmNetworkSchema.safeParse(entry);
+				const parsed = CustomEvmNetworkInputSchema.safeParse(input);
 				if (!parsed.success) {
 					throw new Error(`Invalid custom EVM network: ${parsed.error.message}`);
 				}
+				const entry: CustomEvmNetwork = { ...input, id: toNetworkId(input.chainId) };
 				const next: CustomEvmNetwork[] = [...current, entry];
 				persist(next);
 				return next;

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -1,8 +1,8 @@
 import { PersistedCustomEvmNetworkListSchema } from '$eth/schema/custom-network.schema';
 import type { CustomEvmNetwork, PersistedCustomEvmNetwork } from '$eth/types/custom-network';
 import type { NetworkId } from '$lib/types/network';
-import { parseNetworkId } from '$lib/validation/network.validation';
 import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
+import { parseNetworkId } from '$lib/validation/network.validation';
 import { writable } from 'svelte/store';
 
 export const CUSTOM_EVM_NETWORKS_STORAGE_KEY = 'custom-evm-networks';
@@ -66,7 +66,11 @@ export interface CustomEvmNetworksStore {
 }
 
 export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
-	const { subscribe, update: updateWritable, set } = writable<CustomEvmNetwork[]>(loadFromStorage());
+	const {
+		subscribe,
+		update: updateWritable,
+		set
+	} = writable<CustomEvmNetwork[]>(loadFromStorage());
 
 	const persist = (list: CustomEvmNetwork[]) => {
 		setStorage<PersistedCustomEvmNetwork[]>({
@@ -84,10 +88,7 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 						`A custom EVM network with chainId ${input.chainId} has already been added.`
 					);
 				}
-				const next: CustomEvmNetwork[] = [
-					...current,
-					{ ...input, id: toNetworkId(input.chainId) }
-				];
+				const next: CustomEvmNetwork[] = [...current, { ...input, id: toNetworkId(input.chainId) }];
 				persist(next);
 				return next;
 			});
@@ -96,9 +97,7 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 			updateWritable((current) => {
 				const index = current.findIndex((n) => n.chainId === chainId);
 				if (index === -1) {
-					throw new Error(
-						`No custom EVM network with chainId ${chainId} exists; cannot update.`
-					);
+					throw new Error(`No custom EVM network with chainId ${chainId} exists; cannot update.`);
 				}
 				const next = [...current];
 				next[index] = { ...next[index], ...patch };

--- a/src/frontend/src/eth/types/custom-network.ts
+++ b/src/frontend/src/eth/types/custom-network.ts
@@ -1,0 +1,9 @@
+import type {
+	CustomEvmNetworkSchema,
+	PersistedCustomEvmNetworkSchema
+} from '$eth/schema/custom-network.schema';
+import type * as z from 'zod';
+
+export type CustomEvmNetwork = z.infer<typeof CustomEvmNetworkSchema>;
+
+export type PersistedCustomEvmNetwork = z.infer<typeof PersistedCustomEvmNetworkSchema>;

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -183,7 +183,7 @@ describe('custom-evm-networks.store', () => {
 			expect(setStorage).not.toHaveBeenCalled();
 		});
 
-		it('rejects an rpcUrl with a non-http(s)/ws(s) protocol', () => {
+		it('rejects an rpcUrl with a non-https/wss protocol', () => {
 			const store = initCustomEvmNetworksStore();
 
 			expect(() => store.add({ ...optimism, rpcUrl: 'ipfs://bafybeigdyrzt/' })).toThrow(

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -190,6 +190,14 @@ describe('custom-evm-networks.store', () => {
 			expect(get(store)).toEqual([]);
 		});
 
+		it('strips unknown caller-supplied properties', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add({ ...optimism, junk: 'ignored' } as CustomEvmNetworkInput);
+
+			expect(get(store)[0]).not.toHaveProperty('junk');
+		});
+
 		it('supports multiple distinct chains', () => {
 			const store = initCustomEvmNetworksStore();
 
@@ -223,6 +231,23 @@ describe('custom-evm-networks.store', () => {
 			const store = initCustomEvmNetworksStore();
 
 			expect(() => store.update({ chainId: 999n, patch: { name: 'x' } })).toThrow(/cannot update/);
+		});
+
+		it('preserves id and chainId even if a caller tries to override them', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+			const originalId = get(store)[0].id;
+
+			store.update({
+				chainId: 10n,
+				patch: { id: Symbol('hacked'), chainId: 99n, name: 'renamed' } as never
+			});
+
+			const [network] = get(store);
+
+			expect(network.id).toBe(originalId);
+			expect(network.chainId).toBe(10n);
+			expect(network.name).toBe('renamed');
 		});
 	});
 

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -134,6 +134,7 @@ describe('custom-evm-networks.store', () => {
 						rpcUrl: 'https://mainnet.optimism.io',
 						currencySymbol: 'ETH',
 						explorerUrl: 'https://optimistic.etherscan.io',
+						iconUrl: undefined,
 						env: 'mainnet'
 					}
 				]
@@ -147,6 +148,14 @@ describe('custom-evm-networks.store', () => {
 
 			expect(() => store.add(optimism)).toThrow(/already been added/);
 			expect(get(store)).toHaveLength(1);
+		});
+
+		it('rejects input that fails schema validation and does not persist', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(() => store.add({ ...optimism, name: '' })).toThrow(/Invalid custom EVM network/);
+			expect(get(store)).toEqual([]);
+			expect(setStorage).not.toHaveBeenCalled();
 		});
 
 		it('supports multiple distinct chains', () => {

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -89,6 +89,30 @@ describe('custom-evm-networks.store', () => {
 			expect(get(store)).toEqual([]);
 		});
 
+		it('dedupes persisted entries with the same chainId, keeping the first', () => {
+			vi.mocked(getStorage).mockImplementation(() => [
+				{
+					chainId: '10',
+					name: 'Optimism',
+					rpcUrl: 'https://mainnet.optimism.io',
+					currencySymbol: 'ETH',
+					env: 'mainnet'
+				},
+				{
+					chainId: '10',
+					name: 'Optimism duplicate',
+					rpcUrl: 'https://other.example',
+					currencySymbol: 'ETH',
+					env: 'mainnet'
+				}
+			]);
+
+			const list = get(initCustomEvmNetworksStore());
+
+			expect(list).toHaveLength(1);
+			expect(list[0].name).toBe('Optimism');
+		});
+
 		it('derives the same NetworkId symbol for the same chainId across reloads', () => {
 			vi.mocked(getStorage).mockImplementation(() => [
 				{

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -15,7 +15,7 @@ vi.mock('$lib/utils/storage.utils', () => ({
 }));
 
 describe('custom-evm-networks.store', () => {
-	const optimism: Omit<CustomEvmNetworkInput, 'id'> = {
+	const optimism: CustomEvmNetworkInput = {
 		chainId: 10n,
 		name: 'Optimism',
 		rpcUrl: 'https://mainnet.optimism.io',
@@ -24,7 +24,7 @@ describe('custom-evm-networks.store', () => {
 		env: 'mainnet'
 	};
 
-	const gnosis: Omit<CustomEvmNetworkInput, 'id'> = {
+	const gnosis: CustomEvmNetworkInput = {
 		chainId: 100n,
 		name: 'Gnosis',
 		rpcUrl: 'https://rpc.gnosischain.com',

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -1,0 +1,237 @@
+import {
+	CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+	initCustomEvmNetworksStore,
+	type CustomEvmNetworkInput
+} from '$eth/stores/custom-evm-networks.store';
+import type { PersistedCustomEvmNetwork } from '$eth/types/custom-network';
+import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
+import { get } from 'svelte/store';
+
+vi.mock('$lib/utils/storage.utils', () => ({
+	set: vi.fn(),
+	get: vi.fn(),
+	del: vi.fn()
+}));
+
+describe('custom-evm-networks.store', () => {
+	const optimism: Omit<CustomEvmNetworkInput, 'id'> = {
+		chainId: 10n,
+		name: 'Optimism',
+		rpcUrl: 'https://mainnet.optimism.io',
+		currencySymbol: 'ETH',
+		explorerUrl: 'https://optimistic.etherscan.io',
+		env: 'mainnet'
+	};
+
+	const gnosis: Omit<CustomEvmNetworkInput, 'id'> = {
+		chainId: 100n,
+		name: 'Gnosis',
+		rpcUrl: 'https://rpc.gnosischain.com',
+		currencySymbol: 'xDAI',
+		env: 'mainnet'
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getStorage).mockImplementation(() => undefined);
+	});
+
+	describe('initialization', () => {
+		it('starts empty when storage has no record', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(get(store)).toEqual([]);
+		});
+
+		it('hydrates from persisted storage', () => {
+			const persisted: PersistedCustomEvmNetwork[] = [
+				{
+					chainId: '10',
+					name: 'Optimism',
+					rpcUrl: 'https://mainnet.optimism.io',
+					currencySymbol: 'ETH',
+					explorerUrl: 'https://optimistic.etherscan.io',
+					env: 'mainnet'
+				}
+			];
+			vi.mocked(getStorage).mockImplementation(() => persisted);
+
+			const store = initCustomEvmNetworksStore();
+			const list = get(store);
+
+			expect(list).toHaveLength(1);
+			expect(list[0].chainId).toBe(10n);
+			expect(list[0].name).toBe('Optimism');
+			expect(typeof list[0].id).toBe('symbol');
+		});
+
+		it('returns empty list when persisted storage is malformed', () => {
+			vi.mocked(getStorage).mockImplementation(() => ({ not: 'an array' }));
+
+			const store = initCustomEvmNetworksStore();
+
+			expect(get(store)).toEqual([]);
+		});
+
+		it('returns empty list when a persisted entry fails schema validation', () => {
+			vi.mocked(getStorage).mockImplementation(() => [
+				{
+					chainId: 'not-a-number',
+					name: 'Bogus',
+					rpcUrl: 'https://bogus.example',
+					currencySymbol: 'BOG',
+					env: 'mainnet'
+				}
+			]);
+
+			const store = initCustomEvmNetworksStore();
+
+			expect(get(store)).toEqual([]);
+		});
+
+		it('derives the same NetworkId symbol for the same chainId across reloads', () => {
+			vi.mocked(getStorage).mockImplementation(() => [
+				{
+					chainId: '10',
+					name: 'Optimism',
+					rpcUrl: 'https://mainnet.optimism.io',
+					currencySymbol: 'ETH',
+					env: 'mainnet'
+				}
+			]);
+
+			const firstId = get(initCustomEvmNetworksStore())[0].id;
+			const secondId = get(initCustomEvmNetworksStore())[0].id;
+
+			expect(firstId).toBe(secondId);
+		});
+	});
+
+	describe('add', () => {
+		it('appends a network and derives a NetworkId symbol', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add(optimism);
+
+			const list = get(store);
+
+			expect(list).toHaveLength(1);
+			expect(list[0].chainId).toBe(10n);
+			expect(typeof list[0].id).toBe('symbol');
+		});
+
+		it('persists to localStorage in serialized form', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add(optimism);
+
+			expect(setStorage).toHaveBeenCalledExactlyOnceWith({
+				key: CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+				value: [
+					{
+						chainId: '10',
+						name: 'Optimism',
+						rpcUrl: 'https://mainnet.optimism.io',
+						currencySymbol: 'ETH',
+						explorerUrl: 'https://optimistic.etherscan.io',
+						env: 'mainnet'
+					}
+				]
+			});
+		});
+
+		it('rejects a duplicate chainId', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add(optimism);
+
+			expect(() => store.add(optimism)).toThrow(/already been added/);
+			expect(get(store)).toHaveLength(1);
+		});
+
+		it('supports multiple distinct chains', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add(optimism);
+			store.add(gnosis);
+
+			const list = get(store);
+
+			expect(list.map((n) => n.chainId)).toEqual([10n, 100n]);
+		});
+	});
+
+	describe('update', () => {
+		it('replaces only the patched fields', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+
+			store.update({
+				chainId: 10n,
+				patch: { name: 'Optimism (edited)', rpcUrl: 'https://op.example' }
+			});
+
+			const [network] = get(store);
+
+			expect(network.name).toBe('Optimism (edited)');
+			expect(network.rpcUrl).toBe('https://op.example');
+			expect(network.currencySymbol).toBe('ETH');
+		});
+
+		it('throws when the chainId is not in the store', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(() => store.update({ chainId: 999n, patch: { name: 'x' } })).toThrow(/cannot update/);
+		});
+	});
+
+	describe('remove', () => {
+		it('removes the matching network and persists', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+			store.add(gnosis);
+			vi.mocked(setStorage).mockClear();
+
+			store.remove({ chainId: 10n });
+
+			expect(get(store).map((n) => n.chainId)).toEqual([100n]);
+			expect(setStorage).toHaveBeenCalledExactlyOnceWith({
+				key: CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+				value: [
+					{
+						chainId: '100',
+						name: 'Gnosis',
+						rpcUrl: 'https://rpc.gnosischain.com',
+						currencySymbol: 'xDAI',
+						explorerUrl: undefined,
+						iconUrl: undefined,
+						env: 'mainnet'
+					}
+				]
+			});
+		});
+
+		it('is a no-op when the chainId is not present', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+
+			store.remove({ chainId: 999n });
+
+			expect(get(store)).toHaveLength(1);
+		});
+	});
+
+	describe('reset', () => {
+		it('clears the store and deletes the storage key', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+
+			store.reset();
+
+			expect(get(store)).toEqual([]);
+			expect(delStorage).toHaveBeenCalledExactlyOnceWith({
+				key: CUSTOM_EVM_NETWORKS_STORAGE_KEY
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -214,10 +214,12 @@ describe('custom-evm-networks.store', () => {
 		it('is a no-op when the chainId is not present', () => {
 			const store = initCustomEvmNetworksStore();
 			store.add(optimism);
+			vi.mocked(setStorage).mockClear();
 
 			store.remove({ chainId: 999n });
 
 			expect(get(store)).toHaveLength(1);
+			expect(setStorage).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -4,6 +4,7 @@ import {
 	type CustomEvmNetworkInput
 } from '$eth/stores/custom-evm-networks.store';
 import type { PersistedCustomEvmNetwork } from '$eth/types/custom-network';
+import { ZERO } from '$lib/constants/app.constants';
 import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
 import { get } from 'svelte/store';
 
@@ -180,6 +181,13 @@ describe('custom-evm-networks.store', () => {
 			expect(() => store.add({ ...optimism, name: '' })).toThrow(/Invalid custom EVM network/);
 			expect(get(store)).toEqual([]);
 			expect(setStorage).not.toHaveBeenCalled();
+		});
+
+		it('rejects invalid chainId before deriving a NetworkId', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(() => store.add({ ...optimism, chainId: ZERO })).toThrow(/Invalid custom EVM network/);
+			expect(get(store)).toEqual([]);
 		});
 
 		it('supports multiple distinct chains', () => {

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -183,6 +183,15 @@ describe('custom-evm-networks.store', () => {
 			expect(setStorage).not.toHaveBeenCalled();
 		});
 
+		it('rejects an rpcUrl with a non-http(s)/ws(s) protocol', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(() => store.add({ ...optimism, rpcUrl: 'ipfs://bafybeigdyrzt/' })).toThrow(
+				/Invalid custom EVM network/
+			);
+			expect(get(store)).toEqual([]);
+		});
+
 		it('rejects invalid chainId before deriving a NetworkId', () => {
 			const store = initCustomEvmNetworksStore();
 
@@ -211,9 +220,10 @@ describe('custom-evm-networks.store', () => {
 	});
 
 	describe('update', () => {
-		it('replaces only the patched fields', () => {
+		it('replaces only the patched fields and persists', () => {
 			const store = initCustomEvmNetworksStore();
 			store.add(optimism);
+			vi.mocked(setStorage).mockClear();
 
 			store.update({
 				chainId: 10n,
@@ -225,6 +235,20 @@ describe('custom-evm-networks.store', () => {
 			expect(network.name).toBe('Optimism (edited)');
 			expect(network.rpcUrl).toBe('https://op.example');
 			expect(network.currencySymbol).toBe('ETH');
+			expect(setStorage).toHaveBeenCalledExactlyOnceWith({
+				key: CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+				value: [
+					{
+						chainId: '10',
+						name: 'Optimism (edited)',
+						rpcUrl: 'https://op.example',
+						currencySymbol: 'ETH',
+						explorerUrl: 'https://optimistic.etherscan.io',
+						iconUrl: undefined,
+						env: 'mainnet'
+					}
+				]
+			});
 		});
 
 		it('throws when the chainId is not in the store', () => {


### PR DESCRIPTION
# Motivation

First PR in a series that adds MetaMask-style support for manually adding EVM chains to the wallet (network name, RPC URL, chain ID, currency symbol, optional block explorer). Oisy's built-in EVM networks are compile-time constants wired to Infura/Alchemy providers, so user-added chains need a parallel track with their own type, storage, and — in follow-up PRs — RPC provider and UI. This PR introduces the data contract and the storage layer only.

# Changes

- Add `CustomEvmNetwork` type and Zod schema (`src/frontend/src/eth/types/custom-network.ts`, `src/frontend/src/eth/schema/custom-network.schema.ts`). Kept separate from `EthereumNetwork` because custom chains do not participate in Infura/Alchemy-gated features (Alchemy NFT API, CoinGecko pricing, onramp). The `Evm` naming reinforces that distinction at call sites. A sibling `CustomEvmNetworkInputSchema` validates the store input shape (everything except the derived `id`).
- Add `customEvmNetworksStore` (`src/frontend/src/eth/stores/custom-evm-networks.store.ts`): writable Svelte store backed by localStorage that `extends Readable<CustomEvmNetwork[]>` and exposes `add` / `update` / `remove` / `reset`. Serialization drops the non-JSON `NetworkId` symbol and re-derives it deterministically from `chainId` on load via a module-level cache, keeping symbol identity stable across subscribers within a session.
- `add` rejects duplicate chainIds and validates the raw input against `CustomEvmNetworkInputSchema` *before* deriving the `NetworkId`, so invalid chainIds never pollute the `networkIdCache`. `update` throws on missing chainId, pins the existing `id`/`chainId` when applying the patch (so `as any` callers can't override them), and re-validates the merged entry with the full schema. Both paths compose the stored entry from Zod's `parsed.data` so that caller-supplied unknown keys are stripped. `remove` short-circuits without a write when the chainId is not present. Validating on write preserves the invariant assumed by `loadFromStorage`, which drops the entire persisted list if any entry fails schema validation.
- `loadFromStorage` dedupes persisted entries by `chainId` (keeping the first) so that a manually-edited or bug-seeded localStorage with duplicates does not break the store's internal uniqueness invariant.
- Malformed or schema-incompatible persisted values fall back to an empty list rather than throwing, matching the defensive posture of the existing `initStorageStore` pattern.
- Tighten `BigIntStringSchema` to `^[1-9]\d*$` so the persisted schema rejects `"0"` in line with the runtime `z.bigint().positive()` constraint.

# Tests

Unit tests covering initialization (empty / hydrated / malformed / schema-invalid / duplicates-deduped), stable `NetworkId` symbol derivation across reloads, and the full CRUD surface (add / update / remove / reset) including duplicate rejection, schema-validation rejection on `add` (both invalid fields and invalid chainId), and persistence shape — including an assertion that `remove` does not write when the chainId is not present.