### PR TITLE
feat(frontend): custom evm networks rpc provider

### DIFF
--- a/src/frontend/src/eth/providers/custom-rpc.providers.ts
+++ b/src/frontend/src/eth/providers/custom-rpc.providers.ts
@@ -1,0 +1,98 @@
+import type { EthAddress } from '$eth/types/address';
+import type { CustomEvmNetwork } from '$eth/types/custom-network';
+import type { GetFeeData } from '$eth/types/infura';
+import { TRACK_ETH_ESTIMATE_GAS_ERROR } from '$lib/constants/analytics.constants';
+import { trackEvent } from '$lib/services/analytics.services';
+import { JsonRpcProvider, Network, type FeeData, type TransactionResponse } from 'ethers/providers';
+
+/**
+ * Provider for user-added EVM chains.
+ *
+ * Mirrors the method surface of `InfuraProvider` so call sites can operate
+ * on either variant, but is backed by a plain JSON-RPC endpoint — no
+ * Infura/Alchemy integration. `staticNetwork` is set from the user-supplied
+ * `chainId`, which is validated separately at add time (see
+ * `verifyChainId`); this prevents ethers from issuing an `eth_chainId`
+ * probe on every request.
+ */
+export class CustomRpcProvider {
+	private readonly provider: JsonRpcProvider;
+	private readonly networkName: string;
+
+	constructor({ rpcUrl, chainId, name }: { rpcUrl: string; chainId: bigint; name: string }) {
+		const network = new Network(name, chainId);
+		this.provider = new JsonRpcProvider(rpcUrl, network, { staticNetwork: network });
+		this.networkName = name;
+	}
+
+	balance = (address: EthAddress): Promise<bigint> => this.provider.getBalance(address);
+
+	getFeeData = (): Promise<FeeData> => this.provider.getFeeData();
+
+	estimateGas = (params: GetFeeData): Promise<bigint> => this.provider.estimateGas(params);
+
+	safeEstimateGas = async (params: GetFeeData): Promise<bigint | undefined> => {
+		try {
+			return await this.estimateGas(params);
+		} catch (err: unknown) {
+			trackEvent({
+				name: TRACK_ETH_ESTIMATE_GAS_ERROR,
+				metadata: {
+					error: `${err}`,
+					network: this.networkName
+				},
+				warning: `Error estimating gas for custom network ${this.networkName}: ${err}`
+			});
+
+			return undefined;
+		}
+	};
+
+	sendTransaction = (signedTransaction: string): Promise<TransactionResponse> =>
+		this.provider.broadcastTransaction(signedTransaction);
+
+	getTransactionCount = ({
+		address,
+		tag
+	}: {
+		address: EthAddress;
+		tag: 'pending' | 'latest';
+	}): Promise<number> => this.provider.getTransactionCount(address, tag);
+
+	getBlockNumber = (): Promise<number> => this.provider.getBlockNumber();
+
+	destroy = (): void => {
+		this.provider.destroy();
+	};
+}
+
+const cache = new Map<string, CustomRpcProvider>();
+
+const cacheKey = ({ chainId, rpcUrl }: { chainId: bigint; rpcUrl: string }): string =>
+	`${chainId}:${rpcUrl}`;
+
+/**
+ * Returns a cached `CustomRpcProvider` for the given custom network, or
+ * constructs a new one if the cache does not yet contain an entry for the
+ * `(chainId, rpcUrl)` pair. Editing either field in the store produces a
+ * cache miss on the next call, so stale providers never serve traffic.
+ */
+export const customRpcProviders = (network: CustomEvmNetwork): CustomRpcProvider => {
+	const key = cacheKey({ chainId: network.chainId, rpcUrl: network.rpcUrl });
+	const cached = cache.get(key);
+	if (cached !== undefined) {
+		return cached;
+	}
+	const provider = new CustomRpcProvider({
+		rpcUrl: network.rpcUrl,
+		chainId: network.chainId,
+		name: network.name
+	});
+	cache.set(key, provider);
+	return provider;
+};
+
+/** Test-only: clear the module-level provider cache. */
+export const __resetCustomRpcProvidersCache = (): void => {
+	cache.clear();
+};

--- a/src/frontend/src/eth/providers/custom-rpc.providers.ts
+++ b/src/frontend/src/eth/providers/custom-rpc.providers.ts
@@ -4,6 +4,7 @@ import type { CustomEvmNetwork } from '$eth/types/custom-network';
 import type { GetFeeData } from '$eth/types/infura';
 import { TRACK_ETH_ESTIMATE_GAS_ERROR } from '$lib/constants/analytics.constants';
 import { trackEvent } from '$lib/services/analytics.services';
+import { errorDetailToString } from '$lib/utils/error.utils';
 import { JsonRpcProvider, Network, type FeeData, type TransactionResponse } from 'ethers/providers';
 
 /**
@@ -36,13 +37,14 @@ export class CustomRpcProvider {
 		try {
 			return await this.estimateGas(params);
 		} catch (err: unknown) {
+			const detail = errorDetailToString(err) ?? `${err}`;
 			trackEvent({
 				name: TRACK_ETH_ESTIMATE_GAS_ERROR,
 				metadata: {
-					error: `${err}`,
+					error: detail,
 					network: this.networkName
 				},
-				warning: `Error estimating gas for custom network ${this.networkName}: ${err}`
+				warning: `Error estimating gas for custom network ${this.networkName}: ${detail}`
 			});
 
 			return undefined;

--- a/src/frontend/src/eth/providers/custom-rpc.providers.ts
+++ b/src/frontend/src/eth/providers/custom-rpc.providers.ts
@@ -79,7 +79,7 @@ const cacheKey = ({
 	chainId: bigint;
 	rpcUrl: string;
 	name: string;
-}): string => `${chainId}:${rpcUrl}:${name}`;
+}): string => JSON.stringify([chainId.toString(), rpcUrl, name]);
 
 /**
  * Returns a cached `CustomRpcProvider` for the given custom network, or
@@ -126,7 +126,12 @@ const reconcileCache = (networks: readonly CustomEvmNetwork[]): void => {
 
 customEvmNetworksStore.subscribe(reconcileCache);
 
-/** Test-only: clear the module-level provider cache. */
+/**
+ * Test-only: clear the module-level provider cache, destroying each cached
+ * provider first so its underlying ethers resources are released. Delegates
+ * to `reconcileCache([])` so "reset" and "every network removed" take the
+ * same code path.
+ */
 export const __resetCustomRpcProvidersCache = (): void => {
-	cache.clear();
+	reconcileCache([]);
 };

--- a/src/frontend/src/eth/providers/custom-rpc.providers.ts
+++ b/src/frontend/src/eth/providers/custom-rpc.providers.ts
@@ -1,3 +1,4 @@
+import { customEvmNetworksStore } from '$eth/stores/custom-evm-networks.store';
 import type { EthAddress } from '$eth/types/address';
 import type { CustomEvmNetwork } from '$eth/types/custom-network';
 import type { GetFeeData } from '$eth/types/infura';
@@ -68,17 +69,29 @@ export class CustomRpcProvider {
 
 const cache = new Map<string, CustomRpcProvider>();
 
-const cacheKey = ({ chainId, rpcUrl }: { chainId: bigint; rpcUrl: string }): string =>
-	`${chainId}:${rpcUrl}`;
+const cacheKey = ({
+	chainId,
+	rpcUrl,
+	name
+}: {
+	chainId: bigint;
+	rpcUrl: string;
+	name: string;
+}): string => `${chainId}:${rpcUrl}:${name}`;
 
 /**
  * Returns a cached `CustomRpcProvider` for the given custom network, or
  * constructs a new one if the cache does not yet contain an entry for the
- * `(chainId, rpcUrl)` pair. Editing either field in the store produces a
- * cache miss on the next call, so stale providers never serve traffic.
+ * `(chainId, rpcUrl, name)` tuple. Editing any of these fields in the store
+ * produces a cache miss on the next call, so stale providers never serve
+ * traffic; the evicted entry is destroyed by the store subscription below.
  */
 export const customRpcProviders = (network: CustomEvmNetwork): CustomRpcProvider => {
-	const key = cacheKey({ chainId: network.chainId, rpcUrl: network.rpcUrl });
+	const key = cacheKey({
+		chainId: network.chainId,
+		rpcUrl: network.rpcUrl,
+		name: network.name
+	});
 	const cached = cache.get(key);
 	if (cached !== undefined) {
 		return cached;
@@ -91,6 +104,25 @@ export const customRpcProviders = (network: CustomEvmNetwork): CustomRpcProvider
 	cache.set(key, provider);
 	return provider;
 };
+
+/**
+ * Reconciles the provider cache against the current set of custom networks:
+ * any cached entry whose key is no longer present is destroyed and removed.
+ * Wired to the store below so that `update`/`remove` release the underlying
+ * ethers `JsonRpcProvider` (and its websocket / keep-alive handles) instead
+ * of leaking them for the lifetime of the page.
+ */
+const reconcileCache = (networks: readonly CustomEvmNetwork[]): void => {
+	const liveKeys = new Set(networks.map((network) => cacheKey(network)));
+	for (const [key, provider] of cache) {
+		if (!liveKeys.has(key)) {
+			provider.destroy();
+			cache.delete(key);
+		}
+	}
+};
+
+customEvmNetworksStore.subscribe(reconcileCache);
 
 /** Test-only: clear the module-level provider cache. */
 export const __resetCustomRpcProvidersCache = (): void => {

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -2,8 +2,8 @@ import { NetworkEnvironmentSchema, NetworkIdSchema } from '$lib/schema/network.s
 import { UrlSchema } from '$lib/validation/url.validation';
 import * as z from 'zod';
 
-const BigIntStringSchema = z.string().regex(/^\d+$/, {
-	message: 'Must be a non-negative integer string'
+const BigIntStringSchema = z.string().regex(/^[1-9]\d*$/, {
+	message: 'Must be a positive integer string'
 });
 
 /**

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -1,0 +1,45 @@
+import { NetworkEnvironmentSchema, NetworkIdSchema } from '$lib/schema/network.schema';
+import { UrlSchema } from '$lib/validation/url.validation';
+import * as z from 'zod';
+
+const BigIntStringSchema = z.string().regex(/^\d+$/, {
+	message: 'Must be a non-negative integer string'
+});
+
+/**
+ * Runtime representation of a user-added EVM network.
+ *
+ * Deliberately separate from `EthereumNetwork` (built-in chains) because custom
+ * chains take a different code path: generic JSON-RPC provider, no Infura/Alchemy,
+ * and no participation in features gated by those providers (NFT API, CoinGecko
+ * pricing, onramp). The `Evm` naming reinforces that distinction at call sites.
+ */
+export const CustomEvmNetworkSchema = z.object({
+	id: NetworkIdSchema,
+	chainId: z.bigint().positive(),
+	name: z.string().min(1),
+	rpcUrl: UrlSchema,
+	currencySymbol: z.string().min(1),
+	explorerUrl: UrlSchema.optional(),
+	iconUrl: UrlSchema.optional(),
+	env: NetworkEnvironmentSchema
+});
+
+/**
+ * Serialized representation persisted in localStorage.
+ *
+ * `NetworkId` is a branded `symbol` and cannot be JSON-serialized, so it is
+ * dropped at write time and re-derived deterministically from `chainId` on read.
+ * `chainId` is stored as a decimal string because `bigint` has no JSON form.
+ */
+export const PersistedCustomEvmNetworkSchema = z.object({
+	chainId: BigIntStringSchema,
+	name: z.string().min(1),
+	rpcUrl: UrlSchema,
+	currencySymbol: z.string().min(1),
+	explorerUrl: UrlSchema.optional(),
+	iconUrl: UrlSchema.optional(),
+	env: NetworkEnvironmentSchema
+});
+
+export const PersistedCustomEvmNetworkListSchema = z.array(PersistedCustomEvmNetworkSchema);

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -12,8 +12,9 @@ const BigIntStringSchema = z.string().regex(/^[1-9]\d*$/, {
  *
  * The generic `UrlSchema` permits `ipfs:` because it doubles as the validator
  * for asset URLs (icons, metadata). That is not valid for an RPC endpoint,
- * which must speak HTTP(S) or WebSocket(S). Keep this narrow so bogus URLs
- * fail at input time rather than at the first `eth_*` call.
+ * which must speak HTTPS or secure WebSocket. Plain `http:` and `ws:` are
+ * rejected in line with the existing `allowHttpLocally: false` stance on the
+ * generic schema — we do not accept unencrypted remote endpoints even in dev.
  */
 const RpcUrlSchema = createUrlSchema({
 	additionalProtocols: ['wss:'],

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -26,6 +26,13 @@ export const CustomEvmNetworkSchema = z.object({
 });
 
 /**
+ * Input shape for `customEvmNetworksStore.add`: the full network minus the
+ * derived `NetworkId`. Validated before the id is computed so that invalid
+ * inputs don't populate the module-level `networkIdCache`.
+ */
+export const CustomEvmNetworkInputSchema = CustomEvmNetworkSchema.omit({ id: true });
+
+/**
  * Serialized representation persisted in localStorage.
  *
  * `NetworkId` is a branded `symbol` and cannot be JSON-serialized, so it is

--- a/src/frontend/src/eth/schema/custom-network.schema.ts
+++ b/src/frontend/src/eth/schema/custom-network.schema.ts
@@ -1,9 +1,23 @@
 import { NetworkEnvironmentSchema, NetworkIdSchema } from '$lib/schema/network.schema';
 import { UrlSchema } from '$lib/validation/url.validation';
+import { createUrlSchema } from '@dfinity/zod-schemas';
 import * as z from 'zod';
 
 const BigIntStringSchema = z.string().regex(/^[1-9]\d*$/, {
 	message: 'Must be a positive integer string'
+});
+
+/**
+ * URL schema for JSON-RPC endpoints.
+ *
+ * The generic `UrlSchema` permits `ipfs:` because it doubles as the validator
+ * for asset URLs (icons, metadata). That is not valid for an RPC endpoint,
+ * which must speak HTTP(S) or WebSocket(S). Keep this narrow so bogus URLs
+ * fail at input time rather than at the first `eth_*` call.
+ */
+const RpcUrlSchema = createUrlSchema({
+	additionalProtocols: ['wss:'],
+	allowHttpLocally: false
 });
 
 /**
@@ -18,7 +32,7 @@ export const CustomEvmNetworkSchema = z.object({
 	id: NetworkIdSchema,
 	chainId: z.bigint().positive(),
 	name: z.string().min(1),
-	rpcUrl: UrlSchema,
+	rpcUrl: RpcUrlSchema,
 	currencySymbol: z.string().min(1),
 	explorerUrl: UrlSchema.optional(),
 	iconUrl: UrlSchema.optional(),
@@ -42,7 +56,7 @@ export const CustomEvmNetworkInputSchema = CustomEvmNetworkSchema.omit({ id: tru
 export const PersistedCustomEvmNetworkSchema = z.object({
 	chainId: BigIntStringSchema,
 	name: z.string().min(1),
-	rpcUrl: UrlSchema,
+	rpcUrl: RpcUrlSchema,
 	currencySymbol: z.string().min(1),
 	explorerUrl: UrlSchema.optional(),
 	iconUrl: UrlSchema.optional(),

--- a/src/frontend/src/eth/services/chain-id-verification.services.ts
+++ b/src/frontend/src/eth/services/chain-id-verification.services.ts
@@ -1,0 +1,39 @@
+import { JsonRpcProvider } from 'ethers/providers';
+
+export type VerifyChainIdResult =
+	| { status: 'ok' }
+	| { status: 'mismatch'; actualChainId: bigint }
+	| { status: 'unreachable'; error: string };
+
+/**
+ * Probes an RPC endpoint with `eth_chainId` (via ethers' `getNetwork`) and
+ * checks the response against the chain ID the user entered.
+ *
+ * Mirrors the MetaMask "Add network" safety check: a custom chain is only
+ * accepted when the RPC's self-reported chain ID matches what the user
+ * typed, preventing phishing RPCs from masquerading as a known chain.
+ *
+ * This function constructs a throwaway provider without `staticNetwork` so
+ * ethers actually issues the chain-ID probe, then destroys the provider to
+ * release its network resources.
+ */
+export const verifyChainId = async ({
+	rpcUrl,
+	expectedChainId
+}: {
+	rpcUrl: string;
+	expectedChainId: bigint;
+}): Promise<VerifyChainIdResult> => {
+	let provider: JsonRpcProvider | undefined;
+	try {
+		provider = new JsonRpcProvider(rpcUrl);
+		const { chainId } = await provider.getNetwork();
+		return chainId === expectedChainId
+			? { status: 'ok' }
+			: { status: 'mismatch', actualChainId: chainId };
+	} catch (err: unknown) {
+		return { status: 'unreachable', error: `${err}` };
+	} finally {
+		provider?.destroy();
+	}
+};

--- a/src/frontend/src/eth/services/chain-id-verification.services.ts
+++ b/src/frontend/src/eth/services/chain-id-verification.services.ts
@@ -7,6 +7,14 @@ export type VerifyChainIdResult =
 	| { status: 'unreachable'; error: string };
 
 /**
+ * Upper bound on how long a single RPC chain-ID probe may block the UI.
+ * The user is waiting on an "Add network" click, so a dead-quiet endpoint
+ * must not hang the CTA indefinitely. MetaMask uses ~10s; we pick 5s as
+ * a tighter default for a background form validation step.
+ */
+export const VERIFY_CHAIN_ID_TIMEOUT_MS = 5_000;
+
+/**
  * Probes an RPC endpoint with `eth_chainId` (via ethers' `getNetwork`) and
  * checks the response against the chain ID the user entered.
  *
@@ -16,7 +24,9 @@ export type VerifyChainIdResult =
  *
  * This function constructs a throwaway provider without `staticNetwork` so
  * ethers actually issues the chain-ID probe, then destroys the provider to
- * release its network resources.
+ * release its network resources. The probe is raced against a fixed
+ * timeout so a silently-hung endpoint surfaces as `unreachable` instead of
+ * blocking the caller forever.
  */
 export const verifyChainId = async ({
 	rpcUrl,
@@ -26,15 +36,28 @@ export const verifyChainId = async ({
 	expectedChainId: bigint;
 }): Promise<VerifyChainIdResult> => {
 	let provider: JsonRpcProvider | undefined;
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 	try {
 		provider = new JsonRpcProvider(rpcUrl);
-		const { chainId } = await provider.getNetwork();
+		const probe = provider.getNetwork().then(({ chainId }) => chainId);
+		const timeout = new Promise<never>((_, reject) => {
+			timeoutHandle = setTimeout(
+				() => reject(new Error(`RPC probe timed out after ${VERIFY_CHAIN_ID_TIMEOUT_MS}ms`)),
+				VERIFY_CHAIN_ID_TIMEOUT_MS
+			);
+		});
+		const chainId = await Promise.race([probe, timeout]);
 		return chainId === expectedChainId
 			? { status: 'ok' }
 			: { status: 'mismatch', actualChainId: chainId };
 	} catch (err: unknown) {
 		return { status: 'unreachable', error: errorDetailToString(err) ?? `${err}` };
 	} finally {
+		if (timeoutHandle !== undefined) {
+			clearTimeout(timeoutHandle);
+		}
+		// `destroy()` also aborts the in-flight `getNetwork` fetch on timeout,
+		// so the losing race branch can't keep the connection alive.
 		provider?.destroy();
 	}
 };

--- a/src/frontend/src/eth/services/chain-id-verification.services.ts
+++ b/src/frontend/src/eth/services/chain-id-verification.services.ts
@@ -1,3 +1,4 @@
+import { errorDetailToString } from '$lib/utils/error.utils';
 import { JsonRpcProvider } from 'ethers/providers';
 
 export type VerifyChainIdResult =
@@ -32,7 +33,7 @@ export const verifyChainId = async ({
 			? { status: 'ok' }
 			: { status: 'mismatch', actualChainId: chainId };
 	} catch (err: unknown) {
-		return { status: 'unreachable', error: `${err}` };
+		return { status: 'unreachable', error: errorDetailToString(err) ?? `${err}` };
 	} finally {
 		provider?.destroy();
 	}

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -47,13 +47,24 @@ const fromPersisted = (persisted: PersistedCustomEvmNetwork): CustomEvmNetwork =
 	};
 };
 
+const dedupeByChainId = (networks: PersistedCustomEvmNetwork[]): PersistedCustomEvmNetwork[] => {
+	const seen = new Set<string>();
+	return networks.filter(({ chainId }) => {
+		if (seen.has(chainId)) {
+			return false;
+		}
+		seen.add(chainId);
+		return true;
+	});
+};
+
 const loadFromStorage = (): CustomEvmNetwork[] => {
 	const raw = getStorage<unknown>({ key: CUSTOM_EVM_NETWORKS_STORAGE_KEY });
 	const parsed = PersistedCustomEvmNetworkListSchema.safeParse(raw ?? []);
 	if (!parsed.success) {
 		return [];
 	}
-	return parsed.data.map(fromPersisted);
+	return dedupeByChainId(parsed.data).map(fromPersisted);
 };
 
 export type CustomEvmNetworkInput = Omit<CustomEvmNetwork, 'id'>;

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -109,7 +109,7 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 				if (!parsed.success) {
 					throw new Error(`Invalid custom EVM network: ${parsed.error.message}`);
 				}
-				const entry: CustomEvmNetwork = { ...input, id: toNetworkId(input.chainId) };
+				const entry: CustomEvmNetwork = { ...parsed.data, id: toNetworkId(parsed.data.chainId) };
 				const next: CustomEvmNetwork[] = [...current, entry];
 				persist(next);
 				return next;
@@ -121,13 +121,19 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 				if (index === -1) {
 					throw new Error(`No custom EVM network with chainId ${chainId} exists; cannot update.`);
 				}
-				const merged: CustomEvmNetwork = { ...current[index], ...patch };
+				const existing = current[index];
+				const merged: CustomEvmNetwork = {
+					...existing,
+					...patch,
+					id: existing.id,
+					chainId: existing.chainId
+				};
 				const parsed = CustomEvmNetworkSchema.safeParse(merged);
 				if (!parsed.success) {
 					throw new Error(`Invalid custom EVM network update: ${parsed.error.message}`);
 				}
 				const next = [...current];
-				next[index] = merged;
+				next[index] = parsed.data;
 				persist(next);
 				return next;
 			});

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -7,7 +7,7 @@ import type { CustomEvmNetwork, PersistedCustomEvmNetwork } from '$eth/types/cus
 import type { NetworkId } from '$lib/types/network';
 import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
-import { writable } from 'svelte/store';
+import { writable, type Readable } from 'svelte/store';
 
 export const CUSTOM_EVM_NETWORKS_STORAGE_KEY = 'custom-evm-networks';
 
@@ -72,8 +72,7 @@ export type CustomEvmNetworkInput = Omit<CustomEvmNetwork, 'id'>;
 
 export type CustomEvmNetworkPatch = Partial<Omit<CustomEvmNetwork, 'id' | 'chainId'>>;
 
-export interface CustomEvmNetworksStore {
-	subscribe: (run: (value: CustomEvmNetwork[]) => void) => () => void;
+export interface CustomEvmNetworksStore extends Readable<CustomEvmNetwork[]> {
 	add: (network: CustomEvmNetworkInput) => void;
 	update: (params: { chainId: bigint; patch: CustomEvmNetworkPatch }) => void;
 	remove: (params: { chainId: bigint }) => void;
@@ -103,6 +102,9 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 						`A custom EVM network with chainId ${input.chainId} has already been added.`
 					);
 				}
+				// Validate the raw input (without `id`) so that invalid chainIds
+				// don't populate the networkIdCache. The derived `id` is deterministic
+				// given a valid chainId, so it does not require a second pass.
 				const parsed = CustomEvmNetworkInputSchema.safeParse(input);
 				if (!parsed.success) {
 					throw new Error(`Invalid custom EVM network: ${parsed.error.message}`);

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -1,4 +1,7 @@
-import { PersistedCustomEvmNetworkListSchema } from '$eth/schema/custom-network.schema';
+import {
+	CustomEvmNetworkSchema,
+	PersistedCustomEvmNetworkListSchema
+} from '$eth/schema/custom-network.schema';
 import type { CustomEvmNetwork, PersistedCustomEvmNetwork } from '$eth/types/custom-network';
 import type { NetworkId } from '$lib/types/network';
 import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
@@ -88,7 +91,12 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 						`A custom EVM network with chainId ${input.chainId} has already been added.`
 					);
 				}
-				const next: CustomEvmNetwork[] = [...current, { ...input, id: toNetworkId(input.chainId) }];
+				const entry: CustomEvmNetwork = { ...input, id: toNetworkId(input.chainId) };
+				const parsed = CustomEvmNetworkSchema.safeParse(entry);
+				if (!parsed.success) {
+					throw new Error(`Invalid custom EVM network: ${parsed.error.message}`);
+				}
+				const next: CustomEvmNetwork[] = [...current, entry];
 				persist(next);
 				return next;
 			});
@@ -99,8 +107,13 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 				if (index === -1) {
 					throw new Error(`No custom EVM network with chainId ${chainId} exists; cannot update.`);
 				}
+				const merged: CustomEvmNetwork = { ...current[index], ...patch };
+				const parsed = CustomEvmNetworkSchema.safeParse(merged);
+				if (!parsed.success) {
+					throw new Error(`Invalid custom EVM network update: ${parsed.error.message}`);
+				}
 				const next = [...current];
-				next[index] = { ...next[index], ...patch };
+				next[index] = merged;
 				persist(next);
 				return next;
 			});

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -108,6 +108,9 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 		remove: ({ chainId }) => {
 			updateWritable((current) => {
 				const next = current.filter((n) => n.chainId !== chainId);
+				if (next.length === current.length) {
+					return current;
+				}
 				persist(next);
 				return next;
 			});

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -1,0 +1,123 @@
+import { PersistedCustomEvmNetworkListSchema } from '$eth/schema/custom-network.schema';
+import type { CustomEvmNetwork, PersistedCustomEvmNetwork } from '$eth/types/custom-network';
+import type { NetworkId } from '$lib/types/network';
+import { parseNetworkId } from '$lib/validation/network.validation';
+import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
+import { writable } from 'svelte/store';
+
+export const CUSTOM_EVM_NETWORKS_STORAGE_KEY = 'custom-evm-networks';
+
+const networkIdCache = new Map<string, NetworkId>();
+
+const toNetworkId = (chainId: bigint): NetworkId => {
+	const key = chainId.toString();
+	const cached = networkIdCache.get(key);
+	if (cached !== undefined) {
+		return cached;
+	}
+	const id = parseNetworkId(`custom-evm:${key}`);
+	networkIdCache.set(key, id);
+	return id;
+};
+
+const toPersisted = (network: CustomEvmNetwork): PersistedCustomEvmNetwork => ({
+	chainId: network.chainId.toString(),
+	name: network.name,
+	rpcUrl: network.rpcUrl,
+	currencySymbol: network.currencySymbol,
+	explorerUrl: network.explorerUrl,
+	iconUrl: network.iconUrl,
+	env: network.env
+});
+
+const fromPersisted = (persisted: PersistedCustomEvmNetwork): CustomEvmNetwork => {
+	const chainId = BigInt(persisted.chainId);
+	return {
+		id: toNetworkId(chainId),
+		chainId,
+		name: persisted.name,
+		rpcUrl: persisted.rpcUrl,
+		currencySymbol: persisted.currencySymbol,
+		explorerUrl: persisted.explorerUrl,
+		iconUrl: persisted.iconUrl,
+		env: persisted.env
+	};
+};
+
+const loadFromStorage = (): CustomEvmNetwork[] => {
+	const raw = getStorage<unknown>({ key: CUSTOM_EVM_NETWORKS_STORAGE_KEY });
+	const parsed = PersistedCustomEvmNetworkListSchema.safeParse(raw ?? []);
+	if (!parsed.success) {
+		return [];
+	}
+	return parsed.data.map(fromPersisted);
+};
+
+export type CustomEvmNetworkInput = Omit<CustomEvmNetwork, 'id'>;
+
+export type CustomEvmNetworkPatch = Partial<Omit<CustomEvmNetwork, 'id' | 'chainId'>>;
+
+export interface CustomEvmNetworksStore {
+	subscribe: (run: (value: CustomEvmNetwork[]) => void) => () => void;
+	add: (network: CustomEvmNetworkInput) => void;
+	update: (params: { chainId: bigint; patch: CustomEvmNetworkPatch }) => void;
+	remove: (params: { chainId: bigint }) => void;
+	reset: () => void;
+}
+
+export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
+	const { subscribe, update: updateWritable, set } = writable<CustomEvmNetwork[]>(loadFromStorage());
+
+	const persist = (list: CustomEvmNetwork[]) => {
+		setStorage<PersistedCustomEvmNetwork[]>({
+			key: CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+			value: list.map(toPersisted)
+		});
+	};
+
+	return {
+		subscribe,
+		add: (input) => {
+			updateWritable((current) => {
+				if (current.some(({ chainId }) => chainId === input.chainId)) {
+					throw new Error(
+						`A custom EVM network with chainId ${input.chainId} has already been added.`
+					);
+				}
+				const next: CustomEvmNetwork[] = [
+					...current,
+					{ ...input, id: toNetworkId(input.chainId) }
+				];
+				persist(next);
+				return next;
+			});
+		},
+		update: ({ chainId, patch }) => {
+			updateWritable((current) => {
+				const index = current.findIndex((n) => n.chainId === chainId);
+				if (index === -1) {
+					throw new Error(
+						`No custom EVM network with chainId ${chainId} exists; cannot update.`
+					);
+				}
+				const next = [...current];
+				next[index] = { ...next[index], ...patch };
+				persist(next);
+				return next;
+			});
+		},
+		remove: ({ chainId }) => {
+			updateWritable((current) => {
+				const next = current.filter((n) => n.chainId !== chainId);
+				persist(next);
+				return next;
+			});
+		},
+		reset: () => {
+			delStorage({ key: CUSTOM_EVM_NETWORKS_STORAGE_KEY });
+			set([]);
+		}
+	};
+};
+
+export const customEvmNetworksStore: CustomEvmNetworksStore = initCustomEvmNetworksStore();

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -1,4 +1,5 @@
 import {
+	CustomEvmNetworkInputSchema,
 	CustomEvmNetworkSchema,
 	PersistedCustomEvmNetworkListSchema
 } from '$eth/schema/custom-network.schema';
@@ -102,11 +103,11 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 						`A custom EVM network with chainId ${input.chainId} has already been added.`
 					);
 				}
-				const entry: CustomEvmNetwork = { ...input, id: toNetworkId(input.chainId) };
-				const parsed = CustomEvmNetworkSchema.safeParse(entry);
+				const parsed = CustomEvmNetworkInputSchema.safeParse(input);
 				if (!parsed.success) {
 					throw new Error(`Invalid custom EVM network: ${parsed.error.message}`);
 				}
+				const entry: CustomEvmNetwork = { ...input, id: toNetworkId(input.chainId) };
 				const next: CustomEvmNetwork[] = [...current, entry];
 				persist(next);
 				return next;

--- a/src/frontend/src/eth/stores/custom-evm-networks.store.ts
+++ b/src/frontend/src/eth/stores/custom-evm-networks.store.ts
@@ -1,8 +1,8 @@
 import { PersistedCustomEvmNetworkListSchema } from '$eth/schema/custom-network.schema';
 import type { CustomEvmNetwork, PersistedCustomEvmNetwork } from '$eth/types/custom-network';
 import type { NetworkId } from '$lib/types/network';
-import { parseNetworkId } from '$lib/validation/network.validation';
 import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
+import { parseNetworkId } from '$lib/validation/network.validation';
 import { writable } from 'svelte/store';
 
 export const CUSTOM_EVM_NETWORKS_STORAGE_KEY = 'custom-evm-networks';
@@ -66,7 +66,11 @@ export interface CustomEvmNetworksStore {
 }
 
 export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
-	const { subscribe, update: updateWritable, set } = writable<CustomEvmNetwork[]>(loadFromStorage());
+	const {
+		subscribe,
+		update: updateWritable,
+		set
+	} = writable<CustomEvmNetwork[]>(loadFromStorage());
 
 	const persist = (list: CustomEvmNetwork[]) => {
 		setStorage<PersistedCustomEvmNetwork[]>({
@@ -84,10 +88,7 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 						`A custom EVM network with chainId ${input.chainId} has already been added.`
 					);
 				}
-				const next: CustomEvmNetwork[] = [
-					...current,
-					{ ...input, id: toNetworkId(input.chainId) }
-				];
+				const next: CustomEvmNetwork[] = [...current, { ...input, id: toNetworkId(input.chainId) }];
 				persist(next);
 				return next;
 			});
@@ -96,9 +97,7 @@ export const initCustomEvmNetworksStore = (): CustomEvmNetworksStore => {
 			updateWritable((current) => {
 				const index = current.findIndex((n) => n.chainId === chainId);
 				if (index === -1) {
-					throw new Error(
-						`No custom EVM network with chainId ${chainId} exists; cannot update.`
-					);
+					throw new Error(`No custom EVM network with chainId ${chainId} exists; cannot update.`);
 				}
 				const next = [...current];
 				next[index] = { ...next[index], ...patch };

--- a/src/frontend/src/eth/types/custom-network.ts
+++ b/src/frontend/src/eth/types/custom-network.ts
@@ -1,0 +1,9 @@
+import type {
+	CustomEvmNetworkSchema,
+	PersistedCustomEvmNetworkSchema
+} from '$eth/schema/custom-network.schema';
+import type * as z from 'zod';
+
+export type CustomEvmNetwork = z.infer<typeof CustomEvmNetworkSchema>;
+
+export type PersistedCustomEvmNetwork = z.infer<typeof PersistedCustomEvmNetworkSchema>;

--- a/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
@@ -252,6 +252,29 @@ describe('custom-rpc.providers', () => {
 				expect(mockDestroy).toHaveBeenCalledOnce();
 				expect(customRpcProviders(a)).toBe(providerA);
 			});
+
+			it('does not evict when a new network is added alongside an existing one', () => {
+				const a = buildNetwork({ chainId: 10n, rpcUrl: 'https://a.example' });
+				const b = buildNetwork({ chainId: 100n, rpcUrl: 'https://b.example' });
+				customEvmNetworksStoreMock.set([a]);
+				const providerA = customRpcProviders(a);
+
+				customEvmNetworksStoreMock.set([a, b]);
+
+				expect(mockDestroy).not.toHaveBeenCalled();
+				expect(customRpcProviders(a)).toBe(providerA);
+			});
+
+			it('is a no-op when the same list is re-set (no destroy, same instance)', () => {
+				const network = buildNetwork();
+				customEvmNetworksStoreMock.set([network]);
+				const provider = customRpcProviders(network);
+
+				customEvmNetworksStoreMock.set([network]);
+
+				expect(mockDestroy).not.toHaveBeenCalled();
+				expect(customRpcProviders(network)).toBe(provider);
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
@@ -46,9 +46,12 @@ describe('custom-rpc.providers', () => {
 	const mockDestroy = vi.fn();
 
 	beforeEach(() => {
-		vi.clearAllMocks();
+		// Reset the cache first so any `destroy()` calls triggered by leftover
+		// entries from the previous test are wiped by `clearAllMocks` below
+		// rather than counted against the current test's expectations.
 		__resetCustomRpcProvidersCache();
 		customEvmNetworksStoreMock.set([]);
+		vi.clearAllMocks();
 
 		mockJsonRpcProvider.prototype.getBalance = mockGetBalance;
 		mockJsonRpcProvider.prototype.getFeeData = mockGetFeeData;
@@ -194,6 +197,16 @@ describe('custom-rpc.providers', () => {
 		it('creates a new provider when name changes', () => {
 			const first = customRpcProviders(buildNetwork({ name: 'Optimism' }));
 			const second = customRpcProviders(buildNetwork({ name: 'Optimism (renamed)' }));
+
+			expect(first).not.toBe(second);
+			expect(mockJsonRpcProvider).toHaveBeenCalledTimes(2);
+		});
+
+		it('does not collide when a moved `:` segment shifts between rpcUrl and name', () => {
+			// Sanity check for the cache-key encoding: naive `${chainId}:${rpcUrl}:${name}`
+			// would collapse these two tuples into the same string.
+			const first = customRpcProviders(buildNetwork({ rpcUrl: 'https://foo:8545', name: 'bar' }));
+			const second = customRpcProviders(buildNetwork({ rpcUrl: 'https://foo', name: '8545:bar' }));
 
 			expect(first).not.toBe(second);
 			expect(mockJsonRpcProvider).toHaveBeenCalledTimes(2);

--- a/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
@@ -143,10 +143,10 @@ describe('custom-rpc.providers', () => {
 				expect(trackSpy).toHaveBeenCalledExactlyOnceWith({
 					name: TRACK_ETH_ESTIMATE_GAS_ERROR,
 					metadata: {
-						error: 'Error: boom',
+						error: 'boom',
 						network: 'Optimism'
 					},
-					warning: 'Error estimating gas for custom network Optimism: Error: boom'
+					warning: 'Error estimating gas for custom network Optimism: boom'
 				});
 			});
 		});

--- a/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
@@ -1,0 +1,179 @@
+import {
+	CustomRpcProvider,
+	__resetCustomRpcProvidersCache,
+	customRpcProviders
+} from '$eth/providers/custom-rpc.providers';
+import type { CustomEvmNetwork } from '$eth/types/custom-network';
+import { TRACK_ETH_ESTIMATE_GAS_ERROR } from '$lib/constants/analytics.constants';
+import * as analytics from '$lib/services/analytics.services';
+import { parseNetworkId } from '$lib/validation/network.validation';
+import { JsonRpcProvider, Network } from 'ethers/providers';
+
+const buildNetwork = (overrides: Partial<CustomEvmNetwork> = {}): CustomEvmNetwork => ({
+	id: parseNetworkId('custom-evm-test'),
+	chainId: 10n,
+	name: 'Optimism',
+	rpcUrl: 'https://mainnet.optimism.io',
+	currencySymbol: 'ETH',
+	env: 'mainnet',
+	...overrides
+});
+
+describe('custom-rpc.providers', () => {
+	const mockJsonRpcProvider = vi.mocked(JsonRpcProvider);
+	const mockNetwork = vi.mocked(Network);
+
+	const mockGetBalance = vi.fn();
+	const mockGetFeeData = vi.fn();
+	const mockEstimateGas = vi.fn();
+	const mockBroadcastTransaction = vi.fn();
+	const mockGetTransactionCount = vi.fn();
+	const mockGetBlockNumber = vi.fn();
+	const mockDestroy = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		__resetCustomRpcProvidersCache();
+
+		mockJsonRpcProvider.prototype.getBalance = mockGetBalance;
+		mockJsonRpcProvider.prototype.getFeeData = mockGetFeeData;
+		mockJsonRpcProvider.prototype.estimateGas = mockEstimateGas;
+		mockJsonRpcProvider.prototype.broadcastTransaction = mockBroadcastTransaction;
+		mockJsonRpcProvider.prototype.getTransactionCount = mockGetTransactionCount;
+		mockJsonRpcProvider.prototype.getBlockNumber = mockGetBlockNumber;
+		mockJsonRpcProvider.prototype.destroy = mockDestroy;
+	});
+
+	describe('CustomRpcProvider', () => {
+		it('constructs a JsonRpcProvider with the user-supplied URL and a static Network', () => {
+			new CustomRpcProvider({
+				rpcUrl: 'https://rpc.example',
+				chainId: 10n,
+				name: 'Optimism'
+			});
+
+			expect(mockNetwork).toHaveBeenCalledExactlyOnceWith('Optimism', 10n);
+			expect(mockJsonRpcProvider).toHaveBeenCalledExactlyOnceWith(
+				'https://rpc.example',
+				expect.any(Object),
+				{ staticNetwork: expect.any(Object) }
+			);
+		});
+
+		it('delegates balance to provider.getBalance', async () => {
+			mockGetBalance.mockResolvedValue(42n);
+			const provider = new CustomRpcProvider({
+				rpcUrl: 'https://rpc.example',
+				chainId: 10n,
+				name: 'Optimism'
+			});
+
+			const result = await provider.balance('0xabc');
+
+			expect(result).toBe(42n);
+			expect(mockGetBalance).toHaveBeenCalledExactlyOnceWith('0xabc');
+		});
+
+		it('delegates getFeeData, getBlockNumber, sendTransaction, getTransactionCount, estimateGas', async () => {
+			mockGetFeeData.mockResolvedValue('fee-data');
+			mockGetBlockNumber.mockResolvedValue(123);
+			mockBroadcastTransaction.mockResolvedValue('tx-response');
+			mockGetTransactionCount.mockResolvedValue(7);
+			mockEstimateGas.mockResolvedValue(21000n);
+
+			const provider = new CustomRpcProvider({
+				rpcUrl: 'https://rpc.example',
+				chainId: 10n,
+				name: 'Optimism'
+			});
+
+			await expect(provider.getFeeData()).resolves.toBe('fee-data');
+			await expect(provider.getBlockNumber()).resolves.toBe(123);
+			await expect(provider.sendTransaction('0xsigned')).resolves.toBe('tx-response');
+			await expect(provider.getTransactionCount({ address: '0xabc', tag: 'latest' })).resolves.toBe(
+				7
+			);
+			await expect(provider.estimateGas({ to: '0xabc' } as never)).resolves.toBe(21000n);
+
+			expect(mockBroadcastTransaction).toHaveBeenCalledExactlyOnceWith('0xsigned');
+			expect(mockGetTransactionCount).toHaveBeenCalledExactlyOnceWith('0xabc', 'latest');
+		});
+
+		describe('safeEstimateGas', () => {
+			it('returns the estimate on success', async () => {
+				mockEstimateGas.mockResolvedValue(21000n);
+				const provider = new CustomRpcProvider({
+					rpcUrl: 'https://rpc.example',
+					chainId: 10n,
+					name: 'Optimism'
+				});
+
+				const result = await provider.safeEstimateGas({ to: '0xabc' } as never);
+
+				expect(result).toBe(21000n);
+			});
+
+			it('tracks an analytics event and returns undefined on failure', async () => {
+				const trackSpy = vi.spyOn(analytics, 'trackEvent').mockImplementation(() => undefined);
+				mockEstimateGas.mockRejectedValue(new Error('boom'));
+				const provider = new CustomRpcProvider({
+					rpcUrl: 'https://rpc.example',
+					chainId: 10n,
+					name: 'Optimism'
+				});
+
+				const result = await provider.safeEstimateGas({ to: '0xabc' } as never);
+
+				expect(result).toBeUndefined();
+				expect(trackSpy).toHaveBeenCalledExactlyOnceWith({
+					name: TRACK_ETH_ESTIMATE_GAS_ERROR,
+					metadata: {
+						error: 'Error: boom',
+						network: 'Optimism'
+					},
+					warning: 'Error estimating gas for custom network Optimism: Error: boom'
+				});
+			});
+		});
+
+		it('destroy delegates to provider.destroy', () => {
+			const provider = new CustomRpcProvider({
+				rpcUrl: 'https://rpc.example',
+				chainId: 10n,
+				name: 'Optimism'
+			});
+
+			provider.destroy();
+
+			expect(mockDestroy).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('customRpcProviders (factory)', () => {
+		it('caches providers per (chainId, rpcUrl) pair', () => {
+			const network = buildNetwork();
+
+			const first = customRpcProviders(network);
+			const second = customRpcProviders(network);
+
+			expect(first).toBe(second);
+			expect(mockJsonRpcProvider).toHaveBeenCalledOnce();
+		});
+
+		it('creates a new provider when rpcUrl changes', () => {
+			const first = customRpcProviders(buildNetwork({ rpcUrl: 'https://a.example' }));
+			const second = customRpcProviders(buildNetwork({ rpcUrl: 'https://b.example' }));
+
+			expect(first).not.toBe(second);
+			expect(mockJsonRpcProvider).toHaveBeenCalledTimes(2);
+		});
+
+		it('creates a new provider when chainId changes', () => {
+			const first = customRpcProviders(buildNetwork({ chainId: 10n }));
+			const second = customRpcProviders(buildNetwork({ chainId: 100n }));
+
+			expect(first).not.toBe(second);
+			expect(mockJsonRpcProvider).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/custom-rpc.providers.spec.ts
@@ -8,6 +8,20 @@ import { TRACK_ETH_ESTIMATE_GAS_ERROR } from '$lib/constants/analytics.constants
 import * as analytics from '$lib/services/analytics.services';
 import { parseNetworkId } from '$lib/validation/network.validation';
 import { JsonRpcProvider, Network } from 'ethers/providers';
+import type { Writable, writable } from 'svelte/store';
+
+const { customEvmNetworksStoreMock } = vi.hoisted(
+	(): { customEvmNetworksStoreMock: Writable<CustomEvmNetwork[]> } => {
+		// Require so that the writable is created before `vi.mock` is hoisted.
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const svelteStore = require('svelte/store') as { writable: typeof writable };
+		return { customEvmNetworksStoreMock: svelteStore.writable<CustomEvmNetwork[]>([]) };
+	}
+);
+
+vi.mock('$eth/stores/custom-evm-networks.store', () => ({
+	customEvmNetworksStore: customEvmNetworksStoreMock
+}));
 
 const buildNetwork = (overrides: Partial<CustomEvmNetwork> = {}): CustomEvmNetwork => ({
 	id: parseNetworkId('custom-evm-test'),
@@ -34,6 +48,7 @@ describe('custom-rpc.providers', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		__resetCustomRpcProvidersCache();
+		customEvmNetworksStoreMock.set([]);
 
 		mockJsonRpcProvider.prototype.getBalance = mockGetBalance;
 		mockJsonRpcProvider.prototype.getFeeData = mockGetFeeData;
@@ -150,7 +165,7 @@ describe('custom-rpc.providers', () => {
 	});
 
 	describe('customRpcProviders (factory)', () => {
-		it('caches providers per (chainId, rpcUrl) pair', () => {
+		it('caches providers per (chainId, rpcUrl, name) tuple', () => {
 			const network = buildNetwork();
 
 			const first = customRpcProviders(network);
@@ -174,6 +189,56 @@ describe('custom-rpc.providers', () => {
 
 			expect(first).not.toBe(second);
 			expect(mockJsonRpcProvider).toHaveBeenCalledTimes(2);
+		});
+
+		it('creates a new provider when name changes', () => {
+			const first = customRpcProviders(buildNetwork({ name: 'Optimism' }));
+			const second = customRpcProviders(buildNetwork({ name: 'Optimism (renamed)' }));
+
+			expect(first).not.toBe(second);
+			expect(mockJsonRpcProvider).toHaveBeenCalledTimes(2);
+		});
+
+		describe('cache eviction via store subscription', () => {
+			it('destroys and drops cached providers that are no longer in the store', () => {
+				const network = buildNetwork();
+				customEvmNetworksStoreMock.set([network]);
+
+				const provider = customRpcProviders(network);
+
+				customEvmNetworksStoreMock.set([]);
+
+				expect(mockDestroy).toHaveBeenCalledOnce();
+
+				const rebuilt = customRpcProviders(network);
+
+				expect(rebuilt).not.toBe(provider);
+				expect(mockJsonRpcProvider).toHaveBeenCalledTimes(2);
+			});
+
+			it('evicts the stale entry when a network is edited (rpcUrl, name, or chainId)', () => {
+				const original = buildNetwork({ rpcUrl: 'https://a.example' });
+				customEvmNetworksStoreMock.set([original]);
+				customRpcProviders(original);
+
+				const edited = { ...original, rpcUrl: 'https://b.example' };
+				customEvmNetworksStoreMock.set([edited]);
+
+				expect(mockDestroy).toHaveBeenCalledOnce();
+			});
+
+			it('leaves unrelated cached providers intact', () => {
+				const a = buildNetwork({ chainId: 10n, rpcUrl: 'https://a.example' });
+				const b = buildNetwork({ chainId: 100n, rpcUrl: 'https://b.example' });
+				customEvmNetworksStoreMock.set([a, b]);
+				const providerA = customRpcProviders(a);
+				customRpcProviders(b);
+
+				customEvmNetworksStoreMock.set([a]);
+
+				expect(mockDestroy).toHaveBeenCalledOnce();
+				expect(customRpcProviders(a)).toBe(providerA);
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/services/chain-id-verification.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/chain-id-verification.services.spec.ts
@@ -1,0 +1,65 @@
+import { verifyChainId } from '$eth/services/chain-id-verification.services';
+import { JsonRpcProvider } from 'ethers/providers';
+
+describe('chain-id-verification.services', () => {
+	const mockJsonRpcProvider = vi.mocked(JsonRpcProvider);
+	const mockGetNetwork = vi.fn();
+	const mockDestroy = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockJsonRpcProvider.prototype.getNetwork = mockGetNetwork;
+		mockJsonRpcProvider.prototype.destroy = mockDestroy;
+	});
+
+	it('returns ok when chainId matches', async () => {
+		mockGetNetwork.mockResolvedValue({ chainId: 10n });
+
+		const result = await verifyChainId({
+			rpcUrl: 'https://rpc.example',
+			expectedChainId: 10n
+		});
+
+		expect(result).toEqual({ status: 'ok' });
+		expect(mockJsonRpcProvider).toHaveBeenCalledExactlyOnceWith('https://rpc.example');
+		expect(mockDestroy).toHaveBeenCalledOnce();
+	});
+
+	it('returns mismatch with the actual chainId when they differ', async () => {
+		mockGetNetwork.mockResolvedValue({ chainId: 999n });
+
+		const result = await verifyChainId({
+			rpcUrl: 'https://rpc.example',
+			expectedChainId: 10n
+		});
+
+		expect(result).toEqual({ status: 'mismatch', actualChainId: 999n });
+		expect(mockDestroy).toHaveBeenCalledOnce();
+	});
+
+	it('returns unreachable when the probe throws', async () => {
+		mockGetNetwork.mockRejectedValue(new Error('ECONNREFUSED'));
+
+		const result = await verifyChainId({
+			rpcUrl: 'https://rpc.example',
+			expectedChainId: 10n
+		});
+
+		expect(result).toEqual({ status: 'unreachable', error: 'Error: ECONNREFUSED' });
+		expect(mockDestroy).toHaveBeenCalledOnce();
+	});
+
+	it('returns unreachable when constructing the provider throws', async () => {
+		mockJsonRpcProvider.mockImplementationOnce(() => {
+			throw new Error('invalid URL');
+		});
+
+		const result = await verifyChainId({
+			rpcUrl: 'not-a-url',
+			expectedChainId: 10n
+		});
+
+		expect(result.status).toBe('unreachable');
+		expect(mockDestroy).not.toHaveBeenCalled();
+	});
+});

--- a/src/frontend/src/tests/eth/services/chain-id-verification.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/chain-id-verification.services.spec.ts
@@ -1,4 +1,7 @@
-import { verifyChainId } from '$eth/services/chain-id-verification.services';
+import {
+	VERIFY_CHAIN_ID_TIMEOUT_MS,
+	verifyChainId
+} from '$eth/services/chain-id-verification.services';
 import { JsonRpcProvider } from 'ethers/providers';
 
 describe('chain-id-verification.services', () => {
@@ -61,5 +64,31 @@ describe('chain-id-verification.services', () => {
 
 		expect(result.status).toBe('unreachable');
 		expect(mockDestroy).not.toHaveBeenCalled();
+	});
+
+	it('returns unreachable and destroys the provider when the probe exceeds the timeout', async () => {
+		vi.useFakeTimers();
+		// A promise that never resolves — simulates a silently-hung RPC.
+		mockGetNetwork.mockImplementation(() => new Promise(() => {}));
+
+		try {
+			const pending = verifyChainId({
+				rpcUrl: 'https://slow.example',
+				expectedChainId: 10n
+			});
+
+			await vi.advanceTimersByTimeAsync(VERIFY_CHAIN_ID_TIMEOUT_MS);
+
+			const result = await pending;
+
+			expect(result.status).toBe('unreachable');
+			expect(result).toEqual({
+				status: 'unreachable',
+				error: `RPC probe timed out after ${VERIFY_CHAIN_ID_TIMEOUT_MS}ms`
+			});
+			expect(mockDestroy).toHaveBeenCalledOnce();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/src/frontend/src/tests/eth/services/chain-id-verification.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/chain-id-verification.services.spec.ts
@@ -45,7 +45,7 @@ describe('chain-id-verification.services', () => {
 			expectedChainId: 10n
 		});
 
-		expect(result).toEqual({ status: 'unreachable', error: 'Error: ECONNREFUSED' });
+		expect(result).toEqual({ status: 'unreachable', error: 'ECONNREFUSED' });
 		expect(mockDestroy).toHaveBeenCalledOnce();
 	});
 

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -183,7 +183,7 @@ describe('custom-evm-networks.store', () => {
 			expect(setStorage).not.toHaveBeenCalled();
 		});
 
-		it('rejects an rpcUrl with a non-http(s)/ws(s) protocol', () => {
+		it('rejects an rpcUrl with a non-https/wss protocol', () => {
 			const store = initCustomEvmNetworksStore();
 
 			expect(() => store.add({ ...optimism, rpcUrl: 'ipfs://bafybeigdyrzt/' })).toThrow(

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -190,6 +190,14 @@ describe('custom-evm-networks.store', () => {
 			expect(get(store)).toEqual([]);
 		});
 
+		it('strips unknown caller-supplied properties', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add({ ...optimism, junk: 'ignored' } as CustomEvmNetworkInput);
+
+			expect(get(store)[0]).not.toHaveProperty('junk');
+		});
+
 		it('supports multiple distinct chains', () => {
 			const store = initCustomEvmNetworksStore();
 
@@ -223,6 +231,23 @@ describe('custom-evm-networks.store', () => {
 			const store = initCustomEvmNetworksStore();
 
 			expect(() => store.update({ chainId: 999n, patch: { name: 'x' } })).toThrow(/cannot update/);
+		});
+
+		it('preserves id and chainId even if a caller tries to override them', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+			const originalId = get(store)[0].id;
+
+			store.update({
+				chainId: 10n,
+				patch: { id: Symbol('hacked'), chainId: 99n, name: 'renamed' } as never
+			});
+
+			const [network] = get(store);
+
+			expect(network.id).toBe(originalId);
+			expect(network.chainId).toBe(10n);
+			expect(network.name).toBe('renamed');
 		});
 	});
 

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -134,6 +134,7 @@ describe('custom-evm-networks.store', () => {
 						rpcUrl: 'https://mainnet.optimism.io',
 						currencySymbol: 'ETH',
 						explorerUrl: 'https://optimistic.etherscan.io',
+						iconUrl: undefined,
 						env: 'mainnet'
 					}
 				]
@@ -147,6 +148,14 @@ describe('custom-evm-networks.store', () => {
 
 			expect(() => store.add(optimism)).toThrow(/already been added/);
 			expect(get(store)).toHaveLength(1);
+		});
+
+		it('rejects input that fails schema validation and does not persist', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(() => store.add({ ...optimism, name: '' })).toThrow(/Invalid custom EVM network/);
+			expect(get(store)).toEqual([]);
+			expect(setStorage).not.toHaveBeenCalled();
 		});
 
 		it('supports multiple distinct chains', () => {

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -89,6 +89,30 @@ describe('custom-evm-networks.store', () => {
 			expect(get(store)).toEqual([]);
 		});
 
+		it('dedupes persisted entries with the same chainId, keeping the first', () => {
+			vi.mocked(getStorage).mockImplementation(() => [
+				{
+					chainId: '10',
+					name: 'Optimism',
+					rpcUrl: 'https://mainnet.optimism.io',
+					currencySymbol: 'ETH',
+					env: 'mainnet'
+				},
+				{
+					chainId: '10',
+					name: 'Optimism duplicate',
+					rpcUrl: 'https://other.example',
+					currencySymbol: 'ETH',
+					env: 'mainnet'
+				}
+			]);
+
+			const list = get(initCustomEvmNetworksStore());
+
+			expect(list).toHaveLength(1);
+			expect(list[0].name).toBe('Optimism');
+		});
+
 		it('derives the same NetworkId symbol for the same chainId across reloads', () => {
 			vi.mocked(getStorage).mockImplementation(() => [
 				{

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -15,7 +15,7 @@ vi.mock('$lib/utils/storage.utils', () => ({
 }));
 
 describe('custom-evm-networks.store', () => {
-	const optimism: Omit<CustomEvmNetworkInput, 'id'> = {
+	const optimism: CustomEvmNetworkInput = {
 		chainId: 10n,
 		name: 'Optimism',
 		rpcUrl: 'https://mainnet.optimism.io',
@@ -24,7 +24,7 @@ describe('custom-evm-networks.store', () => {
 		env: 'mainnet'
 	};
 
-	const gnosis: Omit<CustomEvmNetworkInput, 'id'> = {
+	const gnosis: CustomEvmNetworkInput = {
 		chainId: 100n,
 		name: 'Gnosis',
 		rpcUrl: 'https://rpc.gnosischain.com',

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -1,0 +1,237 @@
+import {
+	CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+	initCustomEvmNetworksStore,
+	type CustomEvmNetworkInput
+} from '$eth/stores/custom-evm-networks.store';
+import type { PersistedCustomEvmNetwork } from '$eth/types/custom-network';
+import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
+import { get } from 'svelte/store';
+
+vi.mock('$lib/utils/storage.utils', () => ({
+	set: vi.fn(),
+	get: vi.fn(),
+	del: vi.fn()
+}));
+
+describe('custom-evm-networks.store', () => {
+	const optimism: Omit<CustomEvmNetworkInput, 'id'> = {
+		chainId: 10n,
+		name: 'Optimism',
+		rpcUrl: 'https://mainnet.optimism.io',
+		currencySymbol: 'ETH',
+		explorerUrl: 'https://optimistic.etherscan.io',
+		env: 'mainnet'
+	};
+
+	const gnosis: Omit<CustomEvmNetworkInput, 'id'> = {
+		chainId: 100n,
+		name: 'Gnosis',
+		rpcUrl: 'https://rpc.gnosischain.com',
+		currencySymbol: 'xDAI',
+		env: 'mainnet'
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getStorage).mockImplementation(() => undefined);
+	});
+
+	describe('initialization', () => {
+		it('starts empty when storage has no record', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(get(store)).toEqual([]);
+		});
+
+		it('hydrates from persisted storage', () => {
+			const persisted: PersistedCustomEvmNetwork[] = [
+				{
+					chainId: '10',
+					name: 'Optimism',
+					rpcUrl: 'https://mainnet.optimism.io',
+					currencySymbol: 'ETH',
+					explorerUrl: 'https://optimistic.etherscan.io',
+					env: 'mainnet'
+				}
+			];
+			vi.mocked(getStorage).mockImplementation(() => persisted);
+
+			const store = initCustomEvmNetworksStore();
+			const list = get(store);
+
+			expect(list).toHaveLength(1);
+			expect(list[0].chainId).toBe(10n);
+			expect(list[0].name).toBe('Optimism');
+			expect(typeof list[0].id).toBe('symbol');
+		});
+
+		it('returns empty list when persisted storage is malformed', () => {
+			vi.mocked(getStorage).mockImplementation(() => ({ not: 'an array' }));
+
+			const store = initCustomEvmNetworksStore();
+
+			expect(get(store)).toEqual([]);
+		});
+
+		it('returns empty list when a persisted entry fails schema validation', () => {
+			vi.mocked(getStorage).mockImplementation(() => [
+				{
+					chainId: 'not-a-number',
+					name: 'Bogus',
+					rpcUrl: 'https://bogus.example',
+					currencySymbol: 'BOG',
+					env: 'mainnet'
+				}
+			]);
+
+			const store = initCustomEvmNetworksStore();
+
+			expect(get(store)).toEqual([]);
+		});
+
+		it('derives the same NetworkId symbol for the same chainId across reloads', () => {
+			vi.mocked(getStorage).mockImplementation(() => [
+				{
+					chainId: '10',
+					name: 'Optimism',
+					rpcUrl: 'https://mainnet.optimism.io',
+					currencySymbol: 'ETH',
+					env: 'mainnet'
+				}
+			]);
+
+			const firstId = get(initCustomEvmNetworksStore())[0].id;
+			const secondId = get(initCustomEvmNetworksStore())[0].id;
+
+			expect(firstId).toBe(secondId);
+		});
+	});
+
+	describe('add', () => {
+		it('appends a network and derives a NetworkId symbol', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add(optimism);
+
+			const list = get(store);
+
+			expect(list).toHaveLength(1);
+			expect(list[0].chainId).toBe(10n);
+			expect(typeof list[0].id).toBe('symbol');
+		});
+
+		it('persists to localStorage in serialized form', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add(optimism);
+
+			expect(setStorage).toHaveBeenCalledExactlyOnceWith({
+				key: CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+				value: [
+					{
+						chainId: '10',
+						name: 'Optimism',
+						rpcUrl: 'https://mainnet.optimism.io',
+						currencySymbol: 'ETH',
+						explorerUrl: 'https://optimistic.etherscan.io',
+						env: 'mainnet'
+					}
+				]
+			});
+		});
+
+		it('rejects a duplicate chainId', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add(optimism);
+
+			expect(() => store.add(optimism)).toThrow(/already been added/);
+			expect(get(store)).toHaveLength(1);
+		});
+
+		it('supports multiple distinct chains', () => {
+			const store = initCustomEvmNetworksStore();
+
+			store.add(optimism);
+			store.add(gnosis);
+
+			const list = get(store);
+
+			expect(list.map((n) => n.chainId)).toEqual([10n, 100n]);
+		});
+	});
+
+	describe('update', () => {
+		it('replaces only the patched fields', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+
+			store.update({
+				chainId: 10n,
+				patch: { name: 'Optimism (edited)', rpcUrl: 'https://op.example' }
+			});
+
+			const [network] = get(store);
+
+			expect(network.name).toBe('Optimism (edited)');
+			expect(network.rpcUrl).toBe('https://op.example');
+			expect(network.currencySymbol).toBe('ETH');
+		});
+
+		it('throws when the chainId is not in the store', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(() => store.update({ chainId: 999n, patch: { name: 'x' } })).toThrow(/cannot update/);
+		});
+	});
+
+	describe('remove', () => {
+		it('removes the matching network and persists', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+			store.add(gnosis);
+			vi.mocked(setStorage).mockClear();
+
+			store.remove({ chainId: 10n });
+
+			expect(get(store).map((n) => n.chainId)).toEqual([100n]);
+			expect(setStorage).toHaveBeenCalledExactlyOnceWith({
+				key: CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+				value: [
+					{
+						chainId: '100',
+						name: 'Gnosis',
+						rpcUrl: 'https://rpc.gnosischain.com',
+						currencySymbol: 'xDAI',
+						explorerUrl: undefined,
+						iconUrl: undefined,
+						env: 'mainnet'
+					}
+				]
+			});
+		});
+
+		it('is a no-op when the chainId is not present', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+
+			store.remove({ chainId: 999n });
+
+			expect(get(store)).toHaveLength(1);
+		});
+	});
+
+	describe('reset', () => {
+		it('clears the store and deletes the storage key', () => {
+			const store = initCustomEvmNetworksStore();
+			store.add(optimism);
+
+			store.reset();
+
+			expect(get(store)).toEqual([]);
+			expect(delStorage).toHaveBeenCalledExactlyOnceWith({
+				key: CUSTOM_EVM_NETWORKS_STORAGE_KEY
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -214,10 +214,12 @@ describe('custom-evm-networks.store', () => {
 		it('is a no-op when the chainId is not present', () => {
 			const store = initCustomEvmNetworksStore();
 			store.add(optimism);
+			vi.mocked(setStorage).mockClear();
 
 			store.remove({ chainId: 999n });
 
 			expect(get(store)).toHaveLength(1);
+			expect(setStorage).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -4,6 +4,7 @@ import {
 	type CustomEvmNetworkInput
 } from '$eth/stores/custom-evm-networks.store';
 import type { PersistedCustomEvmNetwork } from '$eth/types/custom-network';
+import { ZERO } from '$lib/constants/app.constants';
 import { del as delStorage, get as getStorage, set as setStorage } from '$lib/utils/storage.utils';
 import { get } from 'svelte/store';
 
@@ -180,6 +181,13 @@ describe('custom-evm-networks.store', () => {
 			expect(() => store.add({ ...optimism, name: '' })).toThrow(/Invalid custom EVM network/);
 			expect(get(store)).toEqual([]);
 			expect(setStorage).not.toHaveBeenCalled();
+		});
+
+		it('rejects invalid chainId before deriving a NetworkId', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(() => store.add({ ...optimism, chainId: ZERO })).toThrow(/Invalid custom EVM network/);
+			expect(get(store)).toEqual([]);
 		});
 
 		it('supports multiple distinct chains', () => {

--- a/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
+++ b/src/frontend/src/tests/eth/stores/custom-evm-networks.store.spec.ts
@@ -183,6 +183,15 @@ describe('custom-evm-networks.store', () => {
 			expect(setStorage).not.toHaveBeenCalled();
 		});
 
+		it('rejects an rpcUrl with a non-http(s)/ws(s) protocol', () => {
+			const store = initCustomEvmNetworksStore();
+
+			expect(() => store.add({ ...optimism, rpcUrl: 'ipfs://bafybeigdyrzt/' })).toThrow(
+				/Invalid custom EVM network/
+			);
+			expect(get(store)).toEqual([]);
+		});
+
 		it('rejects invalid chainId before deriving a NetworkId', () => {
 			const store = initCustomEvmNetworksStore();
 
@@ -211,9 +220,10 @@ describe('custom-evm-networks.store', () => {
 	});
 
 	describe('update', () => {
-		it('replaces only the patched fields', () => {
+		it('replaces only the patched fields and persists', () => {
 			const store = initCustomEvmNetworksStore();
 			store.add(optimism);
+			vi.mocked(setStorage).mockClear();
 
 			store.update({
 				chainId: 10n,
@@ -225,6 +235,20 @@ describe('custom-evm-networks.store', () => {
 			expect(network.name).toBe('Optimism (edited)');
 			expect(network.rpcUrl).toBe('https://op.example');
 			expect(network.currencySymbol).toBe('ETH');
+			expect(setStorage).toHaveBeenCalledExactlyOnceWith({
+				key: CUSTOM_EVM_NETWORKS_STORAGE_KEY,
+				value: [
+					{
+						chainId: '10',
+						name: 'Optimism (edited)',
+						rpcUrl: 'https://op.example',
+						currencySymbol: 'ETH',
+						explorerUrl: 'https://optimistic.etherscan.io',
+						iconUrl: undefined,
+						env: 'mainnet'
+					}
+				]
+			});
 		});
 
 		it('throws when the chainId is not in the store', () => {


### PR DESCRIPTION
# Motivation

Stacked on top of [#12497](https://github.com/dfinity/oisy-wallet/pull/12497).

The custom EVM networks feature needs a runtime RPC path that does not depend on Infura/Alchemy, plus a safety check that rejects RPC endpoints whose `eth_chainId` does not match what the user entered (same behavior MetaMask applies on "Add network"). This PR adds both — pure runtime wiring, no UI yet.

# Changes

- Add `CustomRpcProvider` (`src/frontend/src/eth/providers/custom-rpc.providers.ts`) mirroring the method surface of `InfuraProvider` (balance, getFeeData, estimateGas / safeEstimateGas, sendTransaction, getTransactionCount, getBlockNumber), backed by `ethers.JsonRpcProvider` with a `staticNetwork` built from the user-supplied `chainId`.
- Add `customRpcProviders(network)` factory with a `(chainId, rpcUrl)`-keyed cache so edits to either field produce a cache miss and stale providers never serve traffic.
- Add `verifyChainId({ rpcUrl, expectedChainId })` (`src/frontend/src/eth/services/chain-id-verification.services.ts`) returning a discriminated union (`ok` / `mismatch` / `unreachable`) so the UI can surface each failure mode distinctly.

# Tests

Unit tests for `CustomRpcProvider` (constructor wiring, method delegation, `safeEstimateGas` success and error paths including analytics event, factory cache semantics) and for `verifyChainId` (match / mismatch / probe failure / constructor failure, including provider cleanup).