### PR TITLE
fix(frontend): Reset hidden micro transactions info box on feature toggle

### DIFF
--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -52,7 +52,7 @@
 			});
 
 			// Reset the local override so the `HiddenMicroTransactionsInfoBox` reappears after the
-			// user switches the feature (OISY-2876). The backend keeps the dismissed notification,
+			// user switches the feature. The backend keeps the dismissed notification,
 			// but this flag overrides it until the user dismisses the info box again.
 			hiddenMicroTransactionsResetStore.set({
 				key: 'hidden-micro-transactions-reset',

--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -24,6 +24,7 @@
 	import { authRemainingTimeStore } from '$lib/stores/auth.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
 	import { toastsShow } from '$lib/stores/toasts.store';
 	import { emit } from '$lib/utils/events.utils';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
@@ -48,6 +49,14 @@
 				identity: $authIdentity,
 				hideMicroTransactions: !$hideMicroTransactions,
 				currentUserVersion: $userProfileVersion
+			});
+
+			// Reset the local override so the `HiddenMicroTransactionsInfoBox` reappears after the
+			// user switches the feature (OISY-2876). The backend keeps the dismissed notification,
+			// but this flag overrides it until the user dismisses the info box again.
+			hiddenMicroTransactionsResetStore.set({
+				key: 'hidden-micro-transactions-reset',
+				value: { enabled: true }
 			});
 
 			emit({ message: 'oisyRefreshUserProfile' });

--- a/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
+++ b/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
@@ -11,6 +11,7 @@
 	} from '$lib/derived/user-profile.derived';
 	import { dismissNotifications } from '$lib/services/notification.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
 	import { isSimpleNotificationDismissed } from '$lib/utils/notification.utils';
 
 	let temporaryDismissedNotifications = $state<DismissedNotification[]>([]);
@@ -20,12 +21,17 @@
 		...temporaryDismissedNotifications
 	]);
 
-	let dismissed = $derived(
+	let backendDismissed = $derived(
 		isSimpleNotificationDismissed({
 			kind: 'HiddenMicroTransactions',
 			dismissedNotifications: allDismissedNotifications
 		})
 	);
+
+	// OISY-2876: when the user toggles the "hide micro transactions" feature, we re-show the
+	// info box even if the backend still has the notification stored as dismissed. The override
+	// is cleared as soon as the user dismisses the info box again.
+	let dismissed = $derived(backendDismissed && !$hiddenMicroTransactionsResetStore.enabled);
 
 	let visible = $derived($hideMicroTransactions && !dismissed);
 
@@ -40,6 +46,11 @@
 		];
 
 		temporaryDismissedNotifications = [...temporaryDismissedNotifications, ...notifications];
+
+		hiddenMicroTransactionsResetStore.set({
+			key: 'hidden-micro-transactions-reset',
+			value: { enabled: false }
+		});
 
 		dismissNotifications({
 			notifications,

--- a/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
+++ b/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
@@ -28,7 +28,7 @@
 		})
 	);
 
-	// OISY-2876: when the user toggles the "hide micro transactions" feature, we re-show the
+	// When the user toggles the "hide micro transactions" feature, we re-show the
 	// info box even if the backend still has the notification stored as dismissed. The override
 	// is cleared as soon as the user dismisses the info box again.
 	let dismissed = $derived(backendDismissed && !$hiddenMicroTransactionsResetStore.enabled);

--- a/src/frontend/src/lib/stores/settings.store.ts
+++ b/src/frontend/src/lib/stores/settings.store.ts
@@ -27,6 +27,16 @@ export const showSpamStore = initStorageStore<SettingsData>({
 	defaultValue: { enabled: false }
 });
 
+// Local override that re-shows the `HiddenMicroTransactionsInfoBox` after the user toggles
+// the "hide micro transactions" feature, even if the backend still has the notification
+// stored as dismissed. The backend has no endpoint to remove a dismissed notification, so
+// this flag takes precedence over the backend-dismissed state. It is cleared when the user
+// dismisses the info box again.
+export const hiddenMicroTransactionsResetStore = initStorageStore<SettingsData>({
+	key: 'hidden-micro-transactions-reset',
+	defaultValue: { enabled: false }
+});
+
 export const tokensSortStore = initStorageStore<TokensSortingType>({
 	key: 'tokens-sort',
 	defaultValue: {

--- a/src/frontend/src/lib/stores/settings.store.ts
+++ b/src/frontend/src/lib/stores/settings.store.ts
@@ -27,11 +27,6 @@ export const showSpamStore = initStorageStore<SettingsData>({
 	defaultValue: { enabled: false }
 });
 
-// Local override that re-shows the `HiddenMicroTransactionsInfoBox` after the user toggles
-// the "hide micro transactions" feature, even if the backend still has the notification
-// stored as dismissed. The backend has no endpoint to remove a dismissed notification, so
-// this flag takes precedence over the backend-dismissed state. It is cleared when the user
-// dismisses the info box again.
 export const hiddenMicroTransactionsResetStore = initStorageStore<SettingsData>({
 	key: 'hidden-micro-transactions-reset',
 	defaultValue: { enabled: false }

--- a/src/frontend/src/tests/lib/components/transactions/HiddenMicroTransactionsInfoBox.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/HiddenMicroTransactionsInfoBox.spec.ts
@@ -1,0 +1,112 @@
+import type { DismissedNotification } from '$declarations/backend/backend.did';
+import HiddenMicroTransactionsInfoBox from '$lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte';
+import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
+import * as notificationServices from '$lib/services/notification.services';
+import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
+import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
+import { toNullable } from '@dfinity/utils';
+import { fireEvent, render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+
+describe('HiddenMicroTransactionsInfoBox', () => {
+	const dismissedHiddenMicroTransactions: DismissedNotification = {
+		Simple: {
+			kind: { HiddenMicroTransactions: null },
+			version: NOTIFICATION_VERSIONS.HiddenMicroTransactions
+		}
+	};
+
+	const setUserProfile = ({
+		hideMicroTransactions,
+		dismissed = []
+	}: {
+		hideMicroTransactions: boolean;
+		dismissed?: DismissedNotification[];
+	}) => {
+		userProfileStore.set({
+			certified: true,
+			profile: {
+				...mockUserProfile,
+				settings: toNullable({
+					...mockUserSettings,
+					transactions: [{ filter: [{ hide_micro_transactions: hideMicroTransactions }] }],
+					notifications: toNullable({ dismissed_notifications: dismissed })
+				})
+			}
+		});
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(notificationServices, 'dismissNotifications').mockResolvedValue();
+
+		hiddenMicroTransactionsResetStore.reset({ key: 'hidden-micro-transactions-reset' });
+		userProfileStore.reset();
+	});
+
+	it('is visible when the feature is on and nothing is dismissed', () => {
+		setUserProfile({ hideMicroTransactions: true });
+
+		const { queryByRole } = render(HiddenMicroTransactionsInfoBox);
+
+		expect(queryByRole('button', { name: 'Close' })).toBeInTheDocument();
+	});
+
+	it('is hidden when the feature is off', () => {
+		setUserProfile({ hideMicroTransactions: false });
+
+		const { queryByRole } = render(HiddenMicroTransactionsInfoBox);
+
+		expect(queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+	});
+
+	it('is hidden when the backend notification is dismissed and the reset flag is off', () => {
+		setUserProfile({
+			hideMicroTransactions: true,
+			dismissed: [dismissedHiddenMicroTransactions]
+		});
+
+		const { queryByRole } = render(HiddenMicroTransactionsInfoBox);
+
+		expect(queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+	});
+
+	it('re-shows the info box when the reset flag is on, even if the backend notification is dismissed (OISY-2876)', () => {
+		setUserProfile({
+			hideMicroTransactions: true,
+			dismissed: [dismissedHiddenMicroTransactions]
+		});
+		hiddenMicroTransactionsResetStore.set({
+			key: 'hidden-micro-transactions-reset',
+			value: { enabled: true }
+		});
+
+		const { queryByRole } = render(HiddenMicroTransactionsInfoBox);
+
+		expect(queryByRole('button', { name: 'Close' })).toBeInTheDocument();
+	});
+
+	it('clears the reset flag and persists the backend dismissal when the user closes the box', async () => {
+		setUserProfile({
+			hideMicroTransactions: true,
+			dismissed: [dismissedHiddenMicroTransactions]
+		});
+		hiddenMicroTransactionsResetStore.set({
+			key: 'hidden-micro-transactions-reset',
+			value: { enabled: true }
+		});
+
+		const { getByRole } = render(HiddenMicroTransactionsInfoBox);
+
+		await fireEvent.click(getByRole('button', { name: 'Close' }));
+
+		expect(get(hiddenMicroTransactionsResetStore).enabled).toBeFalsy();
+
+		expect(notificationServices.dismissNotifications).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({
+				notifications: [dismissedHiddenMicroTransactions]
+			})
+		);
+	});
+});

--- a/src/frontend/src/tests/lib/components/transactions/HiddenMicroTransactionsInfoBox.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/HiddenMicroTransactionsInfoBox.spec.ts
@@ -4,6 +4,7 @@ import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
 import * as notificationServices from '$lib/services/notification.services';
 import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import en from '$tests/mocks/i18n.mock';
 import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
 import { toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
@@ -50,7 +51,7 @@ describe('HiddenMicroTransactionsInfoBox', () => {
 
 		const { queryByRole } = render(HiddenMicroTransactionsInfoBox);
 
-		expect(queryByRole('button', { name: 'Close' })).toBeInTheDocument();
+		expect(queryByRole('button', { name: en.core.text.close })).toBeInTheDocument();
 	});
 
 	it('is hidden when the feature is off', () => {
@@ -58,7 +59,7 @@ describe('HiddenMicroTransactionsInfoBox', () => {
 
 		const { queryByRole } = render(HiddenMicroTransactionsInfoBox);
 
-		expect(queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+		expect(queryByRole('button', { name: en.core.text.close })).not.toBeInTheDocument();
 	});
 
 	it('is hidden when the backend notification is dismissed and the reset flag is off', () => {
@@ -69,7 +70,7 @@ describe('HiddenMicroTransactionsInfoBox', () => {
 
 		const { queryByRole } = render(HiddenMicroTransactionsInfoBox);
 
-		expect(queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+		expect(queryByRole('button', { name: en.core.text.close })).not.toBeInTheDocument();
 	});
 
 	it('re-shows the info box when the reset flag is on, even if the backend notification is dismissed (OISY-2876)', () => {
@@ -84,7 +85,7 @@ describe('HiddenMicroTransactionsInfoBox', () => {
 
 		const { queryByRole } = render(HiddenMicroTransactionsInfoBox);
 
-		expect(queryByRole('button', { name: 'Close' })).toBeInTheDocument();
+		expect(queryByRole('button', { name: en.core.text.close })).toBeInTheDocument();
 	});
 
 	it('clears the reset flag and persists the backend dismissal when the user closes the box', async () => {
@@ -99,7 +100,7 @@ describe('HiddenMicroTransactionsInfoBox', () => {
 
 		const { getByRole } = render(HiddenMicroTransactionsInfoBox);
 
-		await fireEvent.click(getByRole('button', { name: 'Close' }));
+		await fireEvent.click(getByRole('button', { name: en.core.text.close }));
 
 		expect(get(hiddenMicroTransactionsResetStore).enabled).toBeFalsy();
 


### PR DESCRIPTION
# Motivation

We want to reset the user's small transaction "closed" setting when a user switches the feature back on (or when switching off).
