### PR TITLE
refactor(backend): `Duration` using a larger unit to be more readable

### DIFF
--- a/src/shared/src/types/bitcoin.rs
+++ b/src/shared/src/types/bitcoin.rs
@@ -32,7 +32,7 @@ pub const MAX_UTXOS_LEN: usize = 128;
 pub const FEE_PERCENTILES_INITIAL_DELAY: Duration = Duration::from_secs(10);
 
 /// Timer interval for updating fee percentiles cache (1 minute)
-pub const FEE_PERCENTILES_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
+pub const FEE_PERCENTILES_UPDATE_INTERVAL: Duration = Duration::from_mins(1);
 
 /// Safety timeout: if an update has been "in progress" for longer than this,
 /// assume it was lost to a trap and allow a new one. Set to 5× the update interval.


### PR DESCRIPTION
# Motivation

As per new lint rules (see https://github.com/dfinity/oisy-wallet/actions/runs/24709123056/job/72269196826?pr=12511), we need to make `Duration` more readable for larger units.
