### PR TITLE
refactor(backend): `Duration` using a larger unit to be more readable

### DIFF
--- a/src/backend/src/utils/housekeeping.rs
+++ b/src/backend/src/utils/housekeeping.rs
@@ -129,7 +129,7 @@ pub(crate) fn start_periodic_housekeeping_timers() {
     set_timer(immediate, spawn_housekeeping_if_idle);
 
     // Then periodically:
-    let hour = Duration::from_secs(60 * 60);
+    let hour = Duration::from_hours(1);
     let _ = set_timer_interval(hour, spawn_housekeeping_if_idle);
 }
 

--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -235,7 +235,7 @@ fn test_housekeeping_lock_resets_after_failed_topup() {
     // (no cycles ledger) and must release the guard so the next tick can
     // spawn a new one.
     for _ in 0..3 {
-        pic_setup.pic.advance_time(Duration::from_secs(60 * 60));
+        pic_setup.pic.advance_time(Duration::from_hours(1));
         for _ in 0..10 {
             pic_setup.pic.tick();
         }
@@ -294,7 +294,7 @@ fn test_housekeeping_resumes_after_cycles_ledger_becomes_available() {
 
     // Advance well past the first hourly interval and process messages, giving
     // the canister time to run housekeeping with a working cycles ledger.
-    pic_setup.pic.advance_time(Duration::from_secs(2 * 60 * 60));
+    pic_setup.pic.advance_time(Duration::from_hours(2));
     for _ in 0..20 {
         pic_setup.pic.tick();
     }


### PR DESCRIPTION
# Motivation

As per new lint rules (see https://github.com/dfinity/oisy-wallet/actions/runs/24709123056/job/72269196826?pr=12511), we need to make `Duration` more readable for larger units.
