### PR TITLE
style(frontend): Correct naming for CK minter transactions

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransaction.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransaction.svelte
@@ -143,15 +143,14 @@
 				((token as Erc20Token | undefined)?.twinTokenSymbol ?? '');
 
 		if (type === 'withdraw') {
-			return replacePlaceholders(
-				pending
-					? $i18n.transaction.label.converting_ck_token
-					: $i18n.transaction.label.ck_token_converted,
-				{
+			if (pending) {
+				return replacePlaceholders($i18n.transaction.label.converting_ck_token, {
 					$twinToken: token?.symbol ?? '',
 					$ckToken: ckTokenSymbol
-				}
-			);
+				});
+			}
+
+			return $i18n.receive.text.receive;
 		}
 
 		if (type === 'deposit') {

--- a/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
@@ -74,9 +74,7 @@ export const mapCkBTCTransaction = ({
 
 		return {
 			...tx,
-			typeLabel: isReimbursement
-				? 'transaction.label.reimbursement'
-				: 'receive.text.receive',
+			typeLabel: isReimbursement ? 'transaction.label.reimbursement' : 'receive.text.receive',
 			status: isReimbursement ? 'reimbursed' : 'executed'
 		};
 	}

--- a/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/ckbtc-transactions.utils.ts
@@ -74,10 +74,9 @@ export const mapCkBTCTransaction = ({
 
 		return {
 			...tx,
-			fromLabel: 'transaction.label.twin_network',
 			typeLabel: isReimbursement
 				? 'transaction.label.reimbursement'
-				: 'transaction.label.twin_token_converted',
+				: 'receive.text.receive',
 			status: isReimbursement ? 'reimbursed' : 'executed'
 		};
 	}

--- a/src/frontend/src/icp/utils/cketh-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/cketh-transactions.utils.ts
@@ -91,12 +91,11 @@ export const mapCkEthereumTransaction = ({
 			typeLabel:
 				memoInfo?.reimbursement === true
 					? 'transaction.label.reimbursement'
-					: 'transaction.label.twin_token_converted',
+					: 'receive.text.receive',
 			...(nonNullish(from) && {
 				from,
 				fromExplorerUrl: `${ethExplorerUrl}/address/${from}`
 			}),
-			...(isNullish(memoInfo?.fromAddress) && { fromLabel: 'transaction.label.twin_network' }),
 			status: memoInfo?.reimbursement === true ? 'reimbursed' : 'executed'
 		};
 	}

--- a/src/frontend/src/tests/eth/components/transactions/EthTransaction.spec.ts
+++ b/src/frontend/src/tests/eth/components/transactions/EthTransaction.spec.ts
@@ -285,4 +285,46 @@ describe('EthTransaction', () => {
 			expect(labelElement.textContent).toBe(get(i18n).send.text.send);
 		});
 	});
+
+	describe('with withdraw transactions', () => {
+		it('should render plain "Receive" label for completed withdraw transactions', () => {
+			const { getByTestId } = render(EthTransaction, {
+				props: {
+					transaction: { ...mockTrx, value: 123450000000000n, type: 'withdraw' },
+					token: ETHEREUM_TOKEN
+				}
+			});
+
+			const labelElement = getByTestId(TRANSACTION_CHILDREN_CONTAINER);
+
+			assertNonNullish(labelElement);
+
+			expect(labelElement.textContent).toBe(get(i18n).receive.text.receive);
+		});
+
+		it('should render "Converting" label for pending withdraw transactions', () => {
+			const { getByTestId } = render(EthTransaction, {
+				props: {
+					transaction: {
+						...mockTrx,
+						blockNumber: undefined,
+						value: 123450000000000n,
+						type: 'withdraw'
+					},
+					token: ETHEREUM_TOKEN
+				}
+			});
+
+			const labelElement = getByTestId(TRANSACTION_CHILDREN_CONTAINER);
+
+			assertNonNullish(labelElement);
+
+			expect(labelElement.textContent).toBe(
+				replacePlaceholders(get(i18n).transaction.label.converting_ck_token, {
+					$twinToken: ETHEREUM_TOKEN.symbol,
+					$ckToken: ETHEREUM_TOKEN.twinTokenSymbol ?? ''
+				})
+			);
+		});
+	});
 });

--- a/src/frontend/src/tests/icp/utils/ckbtc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/ckbtc-transactions.utils.spec.ts
@@ -82,7 +82,7 @@ describe('ckbtc-transactions.utils', () => {
 		});
 
 		describe('mint transactions', () => {
-			it('should map a mint transaction as twin_token_converted', () => {
+			it('should map a mint transaction as a plain receive', () => {
 				const result = mapCkBTCTransaction({
 					transaction: createMockIcrcMintTransaction(),
 					identity: undefined,
@@ -90,8 +90,8 @@ describe('ckbtc-transactions.utils', () => {
 					env: 'mainnet'
 				});
 
-				expect(result.fromLabel).toBe('transaction.label.twin_network');
-				expect(result.typeLabel).toBe('transaction.label.twin_token_converted');
+				expect(result.fromLabel).toBeUndefined();
+				expect(result.typeLabel).toBe('receive.text.receive');
 				expect(result.status).toBe('executed');
 			});
 

--- a/src/frontend/src/tests/icp/utils/cketh-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/cketh-transactions.utils.spec.ts
@@ -61,7 +61,7 @@ describe('cketh-transactions.utils', () => {
 		});
 
 		describe('mint transactions', () => {
-			it('should map a regular mint as twin_token_converted', () => {
+			it('should map a regular mint as a plain receive', () => {
 				const fromAddress = new Uint8Array(20).fill(0xab);
 				const txHash = new Uint8Array(32).fill(0xcd);
 				const convertMemo = new Uint8Array(
@@ -75,7 +75,7 @@ describe('cketh-transactions.utils', () => {
 					env: 'mainnet'
 				});
 
-				expect(result.typeLabel).toBe('transaction.label.twin_token_converted');
+				expect(result.typeLabel).toBe('receive.text.receive');
 				expect(result.status).toBe('executed');
 				expect(result.from).toBeDefined();
 				expect(result.fromExplorerUrl).toContain(ETHEREUM_EXPLORER_URL);
@@ -112,7 +112,7 @@ describe('cketh-transactions.utils', () => {
 				expect(result.status).toBe('reimbursed');
 			});
 
-			it('should set fromLabel to twin_network when memo decoding fails', () => {
+			it('should fall back to a plain receive when memo decoding fails', () => {
 				const invalidMemo = new Uint8Array([0xff, 0xff]);
 
 				const result = mapCkEthereumTransaction({
@@ -122,11 +122,11 @@ describe('cketh-transactions.utils', () => {
 					env: 'mainnet'
 				});
 
-				expect(result.fromLabel).toBe('transaction.label.twin_network');
-				expect(result.typeLabel).toBe('transaction.label.twin_token_converted');
+				expect(result.fromLabel).toBeUndefined();
+				expect(result.typeLabel).toBe('receive.text.receive');
 			});
 
-			it('should set fromLabel to twin_network for a mint without memo', () => {
+			it('should fall back to a plain receive for a mint without memo', () => {
 				const result = mapCkEthereumTransaction({
 					transaction: createMockIcrcMintTransaction({ id: 504n }),
 					identity: undefined,
@@ -134,8 +134,8 @@ describe('cketh-transactions.utils', () => {
 					env: 'mainnet'
 				});
 
-				expect(result.fromLabel).toBe('transaction.label.twin_network');
-				expect(result.typeLabel).toBe('transaction.label.twin_token_converted');
+				expect(result.fromLabel).toBeUndefined();
+				expect(result.typeLabel).toBe('receive.text.receive');
 				expect(result.status).toBe('executed');
 			});
 


### PR DESCRIPTION
# Motivation

For CK minter transactions (ckBTC and ckETH/ckERC20), once a withdrawal/conversion is completed, the transaction row was labelled as "CK token converted" with a "Twin network" source label. On the receiving side, this reads more naturally as a standard "Receive" transaction, consistent with how other incoming transfers are displayed in the wallet. The naming has been aligned so that only the pending state surfaces the conversion wording, while the finalized state is presented as a receive.

# Changes

- `EthTransaction.svelte`: for `withdraw` type, keep the `converting_ck_token` label only while the transaction is pending; once completed, use the standard `receive.text.receive` label.
- `ckbtc-transactions.utils.ts`: drop the `transaction.label.twin_network` `fromLabel` and use `receive.text.receive` as the `typeLabel` for executed conversions (reimbursements keep their dedicated label).
- `cketh-transactions.utils.ts`: same alignment as ckBTC — use `receive.text.receive` as the `typeLabel` for executed conversions and drop the `twin_network` `fromLabel` fallback.

# Tests

Added and adapted tests.

## Manual UI checks

Please verify in the UI (screenshots to follow):

- [ ] **ckBTC — pending conversion**: trigger a ckBTC → BTC withdrawal and, while still pending, open the ckBTC transactions list. The row should show the "Converting ckBTC…" label.
- [ ] **ckBTC — completed conversion**: once the same withdrawal is finalized, the row should show the standard "Receive" label (no more "Twin network" source / "CK token converted" type).
- [ ] **ckBTC — reimbursement**: verify that a reimbursed ckBTC conversion still shows the "Reimbursement" label (unchanged behaviour).
- [ ] **ckETH — pending conversion**: trigger a ckETH → ETH withdrawal and, while pending, verify the row shows "Converting ckETH…".
- [ ] **ckETH — completed conversion**: once finalized, the row should show "Receive".
- [ ] **ckERC20 — completed conversion**: repeat the check with a ckERC20 (e.g. ckUSDC) withdrawal; completed row should show "Receive".
- [ ] **ckETH/ckERC20 — reimbursement**: verify that a reimbursed ckETH/ckERC20 conversion still shows the "Reimbursement" label.
- [ ] **Transaction details modal**: open the details modal for a completed conversion and verify that type/labels are consistent with the list view.