### PR TITLE
feat(frontend): Remove the agreements links in the footer

### DIFF
--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -5,9 +5,6 @@
 	import IconDfinity from '$lib/components/icons/IconDfinity.svelte';
 	import IconHeart from '$lib/components/icons/IconHeart.svelte';
 	import IconTwitter from '$lib/components/icons/IconTwitter.svelte';
-	import LicenseAgreementLink from '$lib/components/license-agreement/LicenseAgreementLink.svelte';
-	import PrivacyPolicyLink from '$lib/components/privacy-policy/PrivacyPolicyLink.svelte';
-	import TermsOfUseLink from '$lib/components/terms-of-use/TermsOfUseLink.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import ExternalLinkIcon from '$lib/components/ui/ExternalLinkIcon.svelte';
 	import { OISY_REPO_URL, OISY_TWITTER_URL } from '$lib/constants/oisy.constants';
@@ -53,13 +50,6 @@
 					<IconGitHub />
 				</ExternalLinkIcon>
 			</div>
-			{#if $authNotSignedIn}
-				<div class="mb-2 flex gap-2 text-xs text-nowrap text-tertiary">
-					<TermsOfUseLink />
-					<PrivacyPolicyLink />
-					<LicenseAgreementLink />
-				</div>
-			{/if}
 		</div>
 
 		{#if $aiAssistantConsoleOpen}


### PR DESCRIPTION
# Motivation

As per new design, we don't want the agreements link at the footer of the landing page. The page of the "Terms of Use" link below the login button already references them.

### Before

<img width="1277" height="1407" alt="Screenshot 2026-04-22 at 10 05 51" src="https://github.com/user-attachments/assets/d2d74972-c418-4d51-8886-cb4fbf9900fc" />

### After

<img width="1275" height="1448" alt="Screenshot 2026-04-22 at 10 48 08" src="https://github.com/user-attachments/assets/0c84d938-220f-4531-9ee5-4c6f852c183c" />


