### PR TITLE
fix(frontend): define `h-md` as a Tailwind v4 custom variant

### DIFF
--- a/src/frontend/src/lib/styles/global.scss
+++ b/src/frontend/src/lib/styles/global.scss
@@ -9,6 +9,14 @@ Additionally, we need to explicitly set the base path in order to avoid issues w
 @import 'tailwindcss' source("../../../../../src");
 @config '../../../../../tailwind.config.ts';
 
+/*
+Custom max-height variant (~1090px).
+Defined here instead of in the `screens` config because Tailwind v4 treats
+any entry in `screens` as a width breakpoint for the `container` utility,
+which breaks raw media queries like `(max-height: 68rem)`.
+*/
+@custom-variant h-md (@media (max-height: 68rem)); // ~1090px
+
 @layer base {
 	::view-transition-old(header),
 	::view-transition-new(header) {

--- a/src/frontend/src/lib/styles/tailwind/theme-variables.ts
+++ b/src/frontend/src/lib/styles/tailwind/theme-variables.ts
@@ -7,8 +7,7 @@ export const themeVariables = {
 		'1.5md': '56rem', // 896px
 		'1.5lg': '72rem', // 1152px
 		'1.5xl': '88rem', // 1408px
-		'2.5xl': '108rem', // 1728px
-		'h-md': { raw: '(max-height: 68rem)' } // ~1090px
+		'2.5xl': '108rem' // 1728px
 	},
 	background: {
 		page: 'var(--color-background-page)',


### PR DESCRIPTION
# Motivation

Running `npm run build` emits the following Lightning CSS warning during the production CSS optimization pass:

```
Found 1 warning while optimizing generated CSS:

│   .container {
│     width: 100%;
│     @media (width >= (max-height: 68rem)) {
┆                     ^-- Unexpected token ParenthesisBlock
┆
│       max-width: (max-height: 68rem);
│     }
```

The custom `h-md` breakpoint was defined in `theme-variables.ts` using the Tailwind v3 raw media-query syntax:

```ts
'h-md': { raw: '(max-height: 68rem)' } // ~1090px
```

In **Tailwind v4** this no longer works correctly:
- Every entry under `screens` is also consumed by the built-in `container` utility as a **width** breakpoint.
- v4 picks up `(max-height: 68rem)` as if it were a width value and generates invalid CSS:
  ```css
  .container {
    @media (width >= (max-height: 68rem)) {
      max-width: (max-height: 68rem);
    }
  }
  ```
- Hence the `Unexpected token ParenthesisBlock` warning from Lightning CSS.

The Tailwind v4 idiomatic replacement for raw media-query screens is `@custom-variant` declared in CSS:

1. Removed the `h-md` entry from `themeVariables.screens` in `src/frontend/src/lib/styles/tailwind/theme-variables.ts`.
2. Registered `h-md` as a custom variant in `src/frontend/src/lib/styles/global.scss`:
   ```css
   @custom-variant h-md (@media (max-height: 68rem)); // ~1090px
   ```

Stacked usages in `Footer.svelte` such as `md:h-md:pr-0`, `lg:h-md:block`, `md:h-md:hidden` keep working because `@custom-variant` variants can be composed with the built-in screen variants exactly like before.

`AVAILABLE_SCREENS` in `src/frontend/src/lib/utils/screens.utils.ts` was already filtering out non-string entries (`typeof v === 'string'`), so runtime screen logic is unaffected.

# Changes

- `src/frontend/src/lib/styles/tailwind/theme-variables.ts`: drop the `h-md` raw-media-query entry from `screens`.
- `src/frontend/src/lib/styles/global.scss`: declare `@custom-variant h-md (@media (max-height: 68rem))` right after the `@import 'tailwindcss'` / `@config` lines.

# Tests

- `npm run build` completes successfully and no longer emits the `Unexpected token ParenthesisBlock` / `max-height: 68rem` warning.
- The `h-md` variant is still applied in `src/frontend/src/lib/components/core/Footer.svelte` where it was used stacked with `md:` and `lg:`.
