### PR TITLE
fix(frontend): reference static token icons as URL strings

### DIFF
--- a/src/frontend/src/env/tokens/groups/groups.bob.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.bob.env.ts
@@ -1,6 +1,5 @@
 import type { TokenGroupData, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
-import bob from '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png';
 
 const BOB_TOKEN_GROUP_SYMBOL = 'BOB';
 
@@ -8,7 +7,7 @@ export const BOB_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(BOB_TOKEN_GROU
 
 export const BOB_TOKEN_GROUP: TokenGroupData = {
 	id: BOB_TOKEN_GROUP_ID,
-	icon: bob,
+	icon: '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png',
 	name: 'BOB',
 	symbol: BOB_TOKEN_GROUP_SYMBOL
 };

--- a/src/frontend/src/env/tokens/groups/groups.chat.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.chat.env.ts
@@ -1,6 +1,5 @@
 import type { TokenGroupData, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
-import chat from '/icons/sns/2ouva-viaaa-aaaaq-aaamq-cai.png';
 
 const CHAT_TOKEN_GROUP_SYMBOL = 'CHAT';
 
@@ -8,7 +7,7 @@ export const CHAT_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(CHAT_TOKEN_GR
 
 export const CHAT_TOKEN_GROUP: TokenGroupData = {
 	id: CHAT_TOKEN_GROUP_ID,
-	icon: chat,
+	icon: '/icons/sns/2ouva-viaaa-aaaaq-aaamq-cai.png',
 	name: 'CHAT',
 	symbol: CHAT_TOKEN_GROUP_SYMBOL
 };

--- a/src/frontend/src/env/tokens/groups/groups.gldt.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.gldt.env.ts
@@ -1,6 +1,5 @@
 import type { TokenGroupData, TokenGroupId } from '$lib/types/token-group';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
-import gldt from '/icons/icrc/6c7su-kiaaa-aaaar-qaira-cai.png';
 
 const GLDT_TOKEN_GROUP_SYMBOL = 'GLDT';
 
@@ -8,7 +7,7 @@ export const GLDT_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(GLDT_TOKEN_GR
 
 export const GLDT_TOKEN_GROUP: TokenGroupData = {
 	id: GLDT_TOKEN_GROUP_ID,
-	icon: gldt,
+	icon: '/icons/icrc/6c7su-kiaaa-aaaar-qaira-cai.png',
 	name: 'GLDT',
 	symbol: GLDT_TOKEN_GROUP_SYMBOL
 };

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.bob.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.bob.env.ts
@@ -4,7 +4,6 @@ import type { RequiredAdditionalErc20Token } from '$eth/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import bob from '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png';
 
 const BOB_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const BOB_TOKEN: RequiredAdditionalErc20Token = {
 	name: 'BOB',
 	symbol: BOB_SYMBOL,
 	decimals: BOB_DECIMALS,
-	icon: bob,
+	icon: '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png',
 	address: '0xecc5f868AdD75F4ff9FD00bbBDE12C35BA2C9C89',
 	groupData: BOB_TOKEN_GROUP
 };

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.chat.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.chat.env.ts
@@ -4,7 +4,6 @@ import type { RequiredAdditionalErc20Token } from '$eth/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import chat from '/icons/sns/2ouva-viaaa-aaaaq-aaamq-cai.png';
 
 const CHAT_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const CHAT_TOKEN: RequiredAdditionalErc20Token = {
 	name: 'CHAT',
 	symbol: CHAT_SYMBOL,
 	decimals: CHAT_DECIMALS,
-	icon: chat,
+	icon: '/icons/sns/2ouva-viaaa-aaaaq-aaamq-cai.png',
 	address: '0xDb95092C454235E7e666c4E226dBBbCdeb499d25',
 	groupData: CHAT_TOKEN_GROUP
 };

--- a/src/frontend/src/env/tokens/tokens-erc20/tokens.gldt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-erc20/tokens.gldt.env.ts
@@ -4,7 +4,6 @@ import type { RequiredAdditionalErc20Token } from '$eth/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import gldt from '/icons/icrc/6c7su-kiaaa-aaaar-qaira-cai.png';
 
 const GLDT_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const GLDT_TOKEN: RequiredAdditionalErc20Token = {
 	name: 'GLDT',
 	symbol: GLDT_SYMBOL,
 	decimals: GLDT_DECIMALS,
-	icon: gldt,
+	icon: '/icons/icrc/6c7su-kiaaa-aaaar-qaira-cai.png',
 	address: '0x86856814e74456893Cfc8946BedcBb472b5fA856',
 	groupData: GLDT_TOKEN_GROUP
 };

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.bob.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.bob.env.ts
@@ -4,7 +4,6 @@ import type { RequiredEvmErc20Token } from '$evm/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import bob from '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png';
 
 export const BOB_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const BOB_TOKEN: RequiredEvmErc20Token = {
 	name: 'BOB',
 	symbol: BOB_SYMBOL,
 	decimals: BOB_DECIMALS,
-	icon: bob,
+	icon: '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png',
 	address: '0xecc5f868AdD75F4ff9FD00bbBDE12C35BA2C9C89',
 	groupData: BOB_TOKEN_GROUP
 };

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.chat.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.chat.env.ts
@@ -4,7 +4,6 @@ import type { RequiredEvmErc20Token } from '$evm/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import chat from '/icons/sns/2ouva-viaaa-aaaaq-aaamq-cai.png';
 
 export const CHAT_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const CHAT_TOKEN: RequiredEvmErc20Token = {
 	name: 'CHAT',
 	symbol: CHAT_SYMBOL,
 	decimals: CHAT_DECIMALS,
-	icon: chat,
+	icon: '/icons/sns/2ouva-viaaa-aaaaq-aaamq-cai.png',
 	address: '0xDb95092C454235E7e666c4E226dBBbCdeb499d25',
 	groupData: CHAT_TOKEN_GROUP
 };

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.gldt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.gldt.env.ts
@@ -4,7 +4,6 @@ import type { RequiredEvmErc20Token } from '$evm/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import gldt from '/icons/icrc/6c7su-kiaaa-aaaar-qaira-cai.png';
 
 export const GLDT_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const GLDT_TOKEN: RequiredEvmErc20Token = {
 	name: 'GLDT',
 	symbol: GLDT_SYMBOL,
 	decimals: GLDT_DECIMALS,
-	icon: gldt,
+	icon: '/icons/icrc/6c7su-kiaaa-aaaar-qaira-cai.png',
 	address: '0x86856814e74456893Cfc8946BedcBb472b5fA856',
 	groupData: GLDT_TOKEN_GROUP
 };

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.bob.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.bob.env.ts
@@ -4,7 +4,6 @@ import type { RequiredEvmErc20Token } from '$evm/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import bob from '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png';
 
 export const BOB_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const BOB_TOKEN: RequiredEvmErc20Token = {
 	name: 'BOB',
 	symbol: BOB_SYMBOL,
 	decimals: BOB_DECIMALS,
-	icon: bob,
+	icon: '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png',
 	address: '0xecc5f868AdD75F4ff9FD00bbBDE12C35BA2C9C89',
 	groupData: BOB_TOKEN_GROUP
 };

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.chat.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.chat.env.ts
@@ -4,7 +4,6 @@ import type { RequiredEvmErc20Token } from '$evm/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import chat from '/icons/sns/2ouva-viaaa-aaaaq-aaamq-cai.png';
 
 export const CHAT_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const CHAT_TOKEN: RequiredEvmErc20Token = {
 	name: 'CHAT',
 	symbol: CHAT_SYMBOL,
 	decimals: CHAT_DECIMALS,
-	icon: chat,
+	icon: '/icons/sns/2ouva-viaaa-aaaaq-aaamq-cai.png',
 	address: '0xDb95092C454235E7e666c4E226dBBbCdeb499d25',
 	groupData: CHAT_TOKEN_GROUP
 };

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.gldt.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.gldt.env.ts
@@ -4,7 +4,6 @@ import type { RequiredEvmErc20Token } from '$evm/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
-import gldt from '/icons/icrc/6c7su-kiaaa-aaaar-qaira-cai.png';
 
 export const GLDT_DECIMALS = 8;
 
@@ -21,7 +20,7 @@ export const GLDT_TOKEN: RequiredEvmErc20Token = {
 	name: 'GLDT',
 	symbol: GLDT_SYMBOL,
 	decimals: GLDT_DECIMALS,
-	icon: gldt,
+	icon: '/icons/icrc/6c7su-kiaaa-aaaar-qaira-cai.png',
 	address: '0x86856814e74456893Cfc8946BedcBb472b5fA856',
 	groupData: GLDT_TOKEN_GROUP
 };


### PR DESCRIPTION
# Motivation

Running `npm run dev` produced repeated console errors and broke the app from loading:

```
:5174/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png?import:1 Failed to load module script:
  Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "image/png".
TypeError: Failed to fetch dynamically imported module:
  http://localhost:5174/.svelte-kit/generated/client/nodes/0.js
```

The BOB, GLDT and CHAT token/group env files were importing their PNG icons from the SvelteKit `static/` folder as ES modules:

```ts
import bob from '/icons/icrc/7pail-xaaaa-aaaas-aabmq-cai.png';
```

Files in `static/` are served verbatim at the matching URL path — they are **not** part of the Vite module graph. In dev, Vite appends `?import` and the browser rejects the PNG response under strict MIME checks, which then cascades into the `nodes/0.js` failure that prevents the whole app from loading.

The rest of the codebase (e.g. `tokens.icrc.env.ts`) already uses the correct pattern: plain URL strings pointing at `/icons/...`.

## Prod vs local behavior

| Environment | Before (broken `import`)                                                                                                                        | After (URL string)                                  |
| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| `npm run dev` (local)         | Vite serves the PNG with a `?import` query → browser rejects it under strict MIME → cascading `Failed to fetch dynamically imported module` → app fails to load | Served directly from `static/` as `image/png`, works |
| `npm run build` / deployed canister | Vite resolves the static `import` to a hashed copy under `_app/immutable/assets/...`, duplicating the file and breaking the deterministic `/icons/...` URL contract | Served directly from `static/` at `/icons/...`, works   |

The fix aligns these newer token files with the same convention every other ICRC/SNS token in the app already uses (e.g. `icon: `/icons/icrc/${ledgerCanisterId}.png``), so behavior is consistent across environments.

> [!NOTE]
> Plain string paths are not fingerprinted/hashed. If a PNG's content is ever updated at the same filename, users may see a stale cached version until their browser refreshes. This already matches how every other ICRC/SNS icon in the app behaves.

# Changes

- Replace `import x from '/icons/.../x.png'` + `icon: x` with a direct URL string `icon: '/icons/.../x.png'` across relevant files.

# Tests

Re-ran `npm run dev` locally: console errors gone, app loads correctly, BOB / GLDT / CHAT icons render as expected.

