### PR TITLE
style(frontend): Centralize the landing page

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -49,8 +49,9 @@
 </script>
 
 <div
-	class="flex w-full flex-col items-center md:items-start"
+	class="flex w-full flex-col items-center"
 	class:md:items-center={helpAlignment === 'center'}
+	class:md:items-start={helpAlignment !== 'center'}
 >
 	<ButtonAuthenticate
 		{fullWidth}

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -48,10 +48,7 @@
 	};
 </script>
 
-<div
-	class="flex w-full flex-col items-center"
-	class:md:items-start={helpAlignment !== 'center'}
->
+<div class="flex w-full flex-col items-center" class:md:items-start={helpAlignment !== 'center'}>
 	<ButtonAuthenticate
 		{fullWidth}
 		onclick={() => onAuthenticate(InternetIdentityDomain.VERSION_2_0)}

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -50,7 +50,6 @@
 
 <div
 	class="flex w-full flex-col items-center"
-	class:md:items-center={helpAlignment === 'center'}
 	class:md:items-start={helpAlignment !== 'center'}
 >
 	<ButtonAuthenticate

--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -3,7 +3,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
 	import HeroSignIn from '$lib/components/hero/HeroSignIn.svelte';
-	import BgImg from '$lib/components/ui/BgImg.svelte';
+	import Img from '$lib/components/ui/Img.svelte';
 	import { modalAuthHelp, modalAuthHelpData } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
@@ -11,20 +11,14 @@
 	const ariaLabel = $derived(replaceOisyPlaceholders($i18n.auth.alt.preview));
 </script>
 
-<div class="flex grid w-full max-w-screen-2.5xl flex-1 grid-cols-1 gap-5 md:grid-cols-2 xl:m-auto">
-	<div class="flex h-full flex-col justify-center px-5 md:px-8">
+<div class="mx-auto flex w-full max-w-screen-md flex-1 flex-col items-center gap-8 md:gap-20 px-5 md:px-8">
+	<div class="flex w-full flex-col items-center justify-center">
 		<HeroSignIn />
 	</div>
 
-	<div class="min-h-[85dvh] md:mt-8 md:min-h-[65dvh] 2.5xl:min-h-[75dvh]">
+	<div class="flex w-full justify-center">
 		{#await import(`$lib/assets/main-image-${$themeStore ?? 'light'}.webp`) then { default: src }}
-			<BgImg
-				{ariaLabel}
-				imageUrl={src}
-				shadow="none"
-				size="contain"
-				styleClass="min-h-[75dvh] 2.5xl:min-h-[85dvh] min-w-[1400px] bg-left absolute"
-			/>
+			<Img {src} alt={ariaLabel} styleClass="h-full w-full object-cover" />
 		{/await}
 	</div>
 </div>

--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -11,14 +11,16 @@
 	const ariaLabel = $derived(replaceOisyPlaceholders($i18n.auth.alt.preview));
 </script>
 
-<div class="mx-auto flex w-full max-w-screen-md flex-1 flex-col items-center gap-8 md:gap-20 px-5 md:px-8">
+<div
+	class="mx-auto flex w-full max-w-screen-md flex-1 flex-col items-center gap-8 px-5 md:gap-20 md:px-8"
+>
 	<div class="flex w-full flex-col items-center justify-center">
 		<HeroSignIn />
 	</div>
 
 	<div class="flex w-full justify-center">
 		{#await import(`$lib/assets/main-image-${$themeStore ?? 'light'}.webp`) then { default: src }}
-			<Img {src} alt={ariaLabel} styleClass="h-full w-full object-cover" />
+			<Img alt={ariaLabel} {src} styleClass="h-full w-full object-cover" />
 		{/await}
 	</div>
 </div>

--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -31,9 +31,9 @@
 	]);
 </script>
 
-<div class="flex flex-col items-center text-center md:items-start md:text-left">
+<div class="flex flex-col items-center text-center">
 	<!-- Invite Rewards Banner -->
-	<div class="flex justify-center md:justify-start">
+	<div class="flex justify-center">
 		<InviteRewardsBanner />
 	</div>
 
@@ -45,7 +45,7 @@
 		</h1>
 	</div>
 
-	<div class="mb-7 flex flex-col items-center gap-2 md:items-start md:gap-3 md:text-lg">
+	<div class="mb-7 flex flex-col items-center gap-2 md:gap-3 md:text-lg">
 		{#each infoList as { label, icon: IconCmp, endIcon: EndIconCmp } (label)}
 			<div class="flex items-center gap-4">
 				<div class="hidden md:block">
@@ -64,5 +64,5 @@
 		{/each}
 	</div>
 
-	<ButtonAuthenticateWithHelp needHelpLink={false} />
+	<ButtonAuthenticateWithHelp helpAlignment="center" needHelpLink={false} />
 </div>


### PR DESCRIPTION
# Motivation

As part of the new design, we first centralize the landing page elements, in all sizes.

<img width="388" height="843" alt="Screenshot 2026-04-22 at 11 24 12" src="https://github.com/user-attachments/assets/c4499337-557a-440d-8c78-493c5a52e145" />
<img width="1029" height="1455" alt="Screenshot 2026-04-22 at 11 24 17" src="https://github.com/user-attachments/assets/6e92b5b9-9098-4fdb-93ff-36498ba2769e" />
<img width="2842" height="1458" alt="Screenshot 2026-04-22 at 11 24 23" src="https://github.com/user-attachments/assets/21454ad8-2017-490d-80c2-f6374628161e" />



