### PR TITLE
feat(frontend): Feature cards in landing page

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -49,8 +49,9 @@
 </script>
 
 <div
-	class="flex w-full flex-col items-center md:items-start"
+	class="flex w-full flex-col items-center"
 	class:md:items-center={helpAlignment === 'center'}
+	class:md:items-start={helpAlignment !== 'center'}
 >
 	<ButtonAuthenticate
 		{fullWidth}

--- a/src/frontend/src/lib/components/auth/FeatureCards.svelte
+++ b/src/frontend/src/lib/components/auth/FeatureCards.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import IconSocialLogin from '$lib/components/icons/IconSocialLogin.svelte';
+	import IconScanFace from '$lib/components/icons/lucide/IconScanFace.svelte';
+	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
+	import IconSparkles from '$lib/components/icons/lucide/IconSparkles.svelte';
+	import IconWallet from '$lib/components/icons/lucide/IconWallet.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	const cards = $derived([
+		{
+			icon: IconWallet,
+			label: $i18n.auth.text.asset_types
+		},
+		{
+			icon: IconShieldCheck,
+			label: $i18n.auth.text.advanced_cryptography
+		},
+		{
+			icon: IconSparkles,
+			label: $i18n.auth.text.instant_and_private
+		},
+		{
+			icon: IconScanFace,
+			label: $i18n.auth.text.social_login,
+			extra: IconSocialLogin
+		}
+	]);
+</script>
+
+<div class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 1.5md:grid-cols-4">
+	{#each cards as { icon: IconCmp, label, extra: ExtraCmp } (label)}
+		<div
+			class="flex min-h-32 flex-col justify-between gap-4 rounded-xl border border-brand-subtle-10 bg-brand-subtle-10 py-4 pr-12 pl-4 text-primary backdrop-blur-md sm:min-h-44 sm:rounded-3xl"
+		>
+			<div class="flex size-8 items-center justify-start text-brand-primary sm:size-10">
+				<IconCmp />
+			</div>
+
+			{#if ExtraCmp}
+				<div class="flex items-center">
+					<ExtraCmp />
+				</div>
+			{/if}
+
+			<p class="m-0 text-lg leading-tight">
+				{label}
+			</p>
+		</div>
+	{/each}
+</div>

--- a/src/frontend/src/lib/components/auth/FeatureCards.svelte
+++ b/src/frontend/src/lib/components/auth/FeatureCards.svelte
@@ -8,18 +8,22 @@
 
 	const cards = $derived([
 		{
+			id: 'asset_types',
 			icon: IconWallet,
 			label: $i18n.auth.text.asset_types
 		},
 		{
+			id: 'advanced_cryptography',
 			icon: IconShieldCheck,
 			label: $i18n.auth.text.advanced_cryptography
 		},
 		{
+			id: 'instant_and_private',
 			icon: IconSparkles,
 			label: $i18n.auth.text.instant_and_private
 		},
 		{
+			id: 'social_login',
 			icon: IconScanFace,
 			label: $i18n.auth.text.social_login,
 			extra: IconSocialLogin
@@ -28,7 +32,7 @@
 </script>
 
 <div class="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 1.5md:grid-cols-4">
-	{#each cards as { icon: IconCmp, label, extra: ExtraCmp } (label)}
+	{#each cards as { id, icon: IconCmp, label, extra: ExtraCmp } (id)}
 		<div
 			class="flex min-h-32 flex-col justify-between gap-4 rounded-xl border border-brand-subtle-10 bg-brand-subtle-10 py-4 pr-12 pl-4 text-primary backdrop-blur-md sm:min-h-44 sm:rounded-3xl"
 		>

--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -2,6 +2,7 @@
 	import { themeStore } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
+	import FeatureCards from '$lib/components/auth/FeatureCards.svelte';
 	import HeroSignIn from '$lib/components/hero/HeroSignIn.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import { modalAuthHelp, modalAuthHelpData } from '$lib/derived/modal.derived';
@@ -11,15 +12,21 @@
 	const ariaLabel = $derived(replaceOisyPlaceholders($i18n.auth.alt.preview));
 </script>
 
-<div class="mx-auto flex w-full max-w-screen-md flex-1 flex-col items-center gap-8 md:gap-20 px-5 md:px-8">
-	<div class="flex w-full flex-col items-center justify-center">
+<div
+	class="mx-auto flex w-full max-w-screen-xl flex-1 flex-col items-center gap-8 px-5 md:gap-12 md:px-8"
+>
+	<div class="flex w-full max-w-screen-md flex-col items-center">
 		<HeroSignIn />
 	</div>
 
 	<div class="flex w-full justify-center">
 		{#await import(`$lib/assets/main-image-${$themeStore ?? 'light'}.webp`) then { default: src }}
-			<Img {src} alt={ariaLabel} styleClass="h-full w-full object-cover" />
+			<Img alt={ariaLabel} {src} styleClass="h-full w-full object-cover" />
 		{/await}
+	</div>
+
+	<div class="w-full sm:-mt-48">
+		<FeatureCards />
 	</div>
 </div>
 

--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -3,7 +3,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
 	import HeroSignIn from '$lib/components/hero/HeroSignIn.svelte';
-	import BgImg from '$lib/components/ui/BgImg.svelte';
+	import Img from '$lib/components/ui/Img.svelte';
 	import { modalAuthHelp, modalAuthHelpData } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
@@ -11,20 +11,14 @@
 	const ariaLabel = $derived(replaceOisyPlaceholders($i18n.auth.alt.preview));
 </script>
 
-<div class="flex grid w-full max-w-screen-2.5xl flex-1 grid-cols-1 gap-5 md:grid-cols-2 xl:m-auto">
-	<div class="flex h-full flex-col justify-center px-5 md:px-8">
+<div class="mx-auto flex w-full max-w-screen-md flex-1 flex-col items-center gap-8 md:gap-20 px-5 md:px-8">
+	<div class="flex w-full flex-col items-center justify-center">
 		<HeroSignIn />
 	</div>
 
-	<div class="min-h-[85dvh] md:mt-8 md:min-h-[65dvh] 2.5xl:min-h-[75dvh]">
+	<div class="flex w-full justify-center">
 		{#await import(`$lib/assets/main-image-${$themeStore ?? 'light'}.webp`) then { default: src }}
-			<BgImg
-				{ariaLabel}
-				imageUrl={src}
-				shadow="none"
-				size="contain"
-				styleClass="min-h-[75dvh] 2.5xl:min-h-[85dvh] min-w-[1400px] bg-left absolute"
-			/>
+			<Img {src} alt={ariaLabel} styleClass="h-full w-full object-cover" />
 		{/await}
 	</div>
 </div>

--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -1,34 +1,8 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
 	import ButtonAuthenticateWithHelp from '$lib/components/auth/ButtonAuthenticateWithHelp.svelte';
-	import IconSocialLogin from '$lib/components/icons/IconSocialLogin.svelte';
-	import IconScanFace from '$lib/components/icons/lucide/IconScanFace.svelte';
-	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
-	import IconSparkles from '$lib/components/icons/lucide/IconSparkles.svelte';
-	import IconWallet from '$lib/components/icons/lucide/IconWallet.svelte';
 	import InviteRewardsBanner from '$lib/components/ui/InviteRewardsBanner.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
-
-	const infoList = $derived([
-		{
-			label: $i18n.auth.text.asset_types,
-			icon: IconWallet
-		},
-		{
-			label: $i18n.auth.text.instant_and_private,
-			icon: IconSparkles
-		},
-		{
-			label: $i18n.auth.text.advanced_cryptography,
-			icon: IconShieldCheck
-		},
-		{
-			label: $i18n.auth.text.social_login,
-			icon: IconScanFace,
-			endIcon: IconSocialLogin
-		}
-	]);
 </script>
 
 <div class="flex flex-col items-center text-center">
@@ -43,25 +17,6 @@
 				class="text-brand-primary-alt">{$i18n.auth.text.title_part_2}</span
 			>
 		</h1>
-	</div>
-
-	<div class="mb-7 flex flex-col items-center gap-2 md:gap-3 md:text-lg">
-		{#each infoList as { label, icon: IconCmp, endIcon: EndIconCmp } (label)}
-			<div class="flex items-center gap-4">
-				<div class="hidden md:block">
-					<IconCmp />
-				</div>
-
-				<div>
-					{label}
-					{#if nonNullish(EndIconCmp)}
-						<span class="inline-block align-text-top">
-							<EndIconCmp />
-						</span>
-					{/if}
-				</div>
-			</div>
-		{/each}
 	</div>
 
 	<ButtonAuthenticateWithHelp helpAlignment="center" needHelpLink={false} />

--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -31,9 +31,9 @@
 	]);
 </script>
 
-<div class="flex flex-col items-center text-center md:items-start md:text-left">
+<div class="flex flex-col items-center text-center">
 	<!-- Invite Rewards Banner -->
-	<div class="flex justify-center md:justify-start">
+	<div class="flex justify-center">
 		<InviteRewardsBanner />
 	</div>
 
@@ -45,7 +45,7 @@
 		</h1>
 	</div>
 
-	<div class="mb-7 flex flex-col items-center gap-2 md:items-start md:gap-3 md:text-lg">
+	<div class="mb-7 flex flex-col items-center gap-2 md:gap-3 md:text-lg">
 		{#each infoList as { label, icon: IconCmp, endIcon: EndIconCmp } (label)}
 			<div class="flex items-center gap-4">
 				<div class="hidden md:block">
@@ -64,5 +64,5 @@
 		{/each}
 	</div>
 
-	<ButtonAuthenticateWithHelp needHelpLink={false} />
+	<ButtonAuthenticateWithHelp helpAlignment="center" needHelpLink={false} />
 </div>

--- a/src/frontend/src/lib/components/icons/lucide/IconScanFace.svelte
+++ b/src/frontend/src/lib/components/icons/lucide/IconScanFace.svelte
@@ -1,13 +1,21 @@
 <!-- source: ISC Lucide - please visit https://lucide.dev/license -->
+<script lang="ts">
+	interface Props {
+		size?: string;
+	}
+
+	let { size = '24' }: Props = $props();
+</script>
+
 <svg
 	fill="none"
-	height="24"
+	height={size}
 	stroke="currentColor"
 	stroke-linecap="round"
 	stroke-linejoin="round"
 	stroke-width="2"
 	viewBox="0 0 24 24"
-	width="24"
+	width={size}
 	xmlns="http://www.w3.org/2000/svg"
 >
 	<path d="M3 7V5a2 2 0 0 1 2-2h2" />

--- a/src/frontend/src/lib/components/icons/lucide/IconSparkles.svelte
+++ b/src/frontend/src/lib/components/icons/lucide/IconSparkles.svelte
@@ -1,6 +1,10 @@
 <!-- source: ISC Lucide - please visit https://lucide.dev/license -->
 <script lang="ts">
-	export const size = '24';
+	interface Props {
+		size?: string;
+	}
+
+	let { size = '24' }: Props = $props();
 </script>
 
 <svg fill="none" height={size} viewBox="0 0 24 24" width={size} xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
# Motivation

For the new design of the landing page, we create feature cards instead of having the bullet points.

<img width="3584" height="1585" alt="Screenshot 2026-04-22 at 15 32 09" src="https://github.com/user-attachments/assets/4c951104-f0f5-4edc-8aa6-f823c3825b8b" />
<img width="1312" height="1551" alt="Screenshot 2026-04-22 at 15 32 16" src="https://github.com/user-attachments/assets/aa7a41bf-1b78-4408-b3a9-7f8c0c612ecb" />
<img width="933" height="1544" alt="Screenshot 2026-04-22 at 15 32 26" src="https://github.com/user-attachments/assets/e28a6faf-3f7c-4a7f-aef7-a11db7cf4878" />
<img width="720" height="1549" alt="Screenshot 2026-04-22 at 15 32 33" src="https://github.com/user-attachments/assets/879e9d31-c509-432f-bf51-23f7ba91bda0" />
<img width="311" height="675" alt="Screenshot 2026-04-22 at 15 32 48" src="https://github.com/user-attachments/assets/74994f6a-f9dd-45a9-85a4-df686e336a83" />
<img width="435" height="1544" alt="Screenshot 2026-04-22 at 15 32 56" src="https://github.com/user-attachments/assets/9ed7ff30-7550-432e-8021-47b68d7a6017" />

