### PR TITLE
fix(frontend): hide both landing backgrounds by default

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -162,7 +162,9 @@
 
 			/* Default background: landing page artwork (shown pre-hydration and on the signed-out landing screen). */
 			#app-background-light,
-			#app-background-dark {
+			#app-background-dark,
+			#app-background-landing-light,
+			#app-background-landing-dark {
 				display: none;
 			}
 

--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -152,7 +152,9 @@
 			}
 
 			#app-background-light,
-			#app-background-dark {
+			#app-background-dark,
+			#app-background-landing-light,
+			#app-background-landing-dark {
 				contain: paint;
 				pointer-events: none;
 
@@ -199,21 +201,27 @@
 				id="app-background-light"
 				src="/images/oisy_bg_light.webp"
 				alt="OISY Background light theme"
+				decoding="sync"
 			/>
 			<img
 				id="app-background-dark"
 				src="/images/oisy_bg_dark.webp"
 				alt="OISY Background dark theme"
+				decoding="sync"
 			/>
 			<img
 				id="app-background-landing-light"
 				src="/images/landing_bg_light.webp"
 				alt="OISY Background light theme"
+				fetchpriority="high"
+				decoding="sync"
 			/>
 			<img
 				id="app-background-landing-dark"
 				src="/images/landing_bg_dark.webp"
 				alt="OISY Background dark theme"
+				fetchpriority="high"
+				decoding="sync"
 			/>
 		</div>
 


### PR DESCRIPTION
# Motivation

Follow-up to #12532. The default CSS rule in `app.html` only hid the two classic OISY backgrounds, but not the two new landing backgrounds. Since `<img>` elements are visible by default, both `#app-background-landing-light` and `#app-background-landing-dark` were being rendered simultaneously, and the dark image (last in DOM order) covered the light one — so the light-theme landing background never appeared, and the dark one showed up even in light theme.

# Changes

- Include `#app-background-landing-light` and `#app-background-landing-dark` in the default `display: none` rule in `src/frontend/src/app.html`, so only the theme-matching landing image is toggled to `display: block`.

# Tests

Manually verified the landing page now shows the correct background for each theme (light/dark), and the in-app `[data-app-view]` fallback to the classic OISY background still works as expected.