### PR TITLE
style(frontend): Adapt landing title colors

### DIFF
--- a/src/frontend/src/lib/components/hero/HeroSignIn.svelte
+++ b/src/frontend/src/lib/components/hero/HeroSignIn.svelte
@@ -13,9 +13,7 @@
 
 	<div class="mt-5 mb-7 pt-2">
 		<h1 class="text-4xl md:leading-tight lg:text-5xl">
-			{replaceOisyPlaceholders($i18n.auth.text.title_part_1)}<br /><span
-				class="text-brand-primary-alt">{$i18n.auth.text.title_part_2}</span
-			>
+			{replaceOisyPlaceholders($i18n.auth.text.title_part_1)}<br />{$i18n.auth.text.title_part_2}
 		</h1>
 	</div>
 


### PR DESCRIPTION
# Motivation

On the signed-out landing page, the second line of the hero title is styled differently form the first one. The new design shows both title lines in the primary text color.

# Changes

### Before

<img width="573" height="374" alt="Screenshot 2026-04-22 at 17 12 28" src="https://github.com/user-attachments/assets/52ed97fe-8af6-4f53-979a-c3c5ed5869ab" />

### After

<img width="510" height="369" alt="Screenshot 2026-04-22 at 17 12 11" src="https://github.com/user-attachments/assets/7b9ce019-9c79-4dc6-a894-e0f9982967cd" />


