### PR TITLE
fix(frontend): use /authorize path for Internet Identity sign-in URL

### DIFF
--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -93,11 +93,16 @@ const initAuthStore = (): AuthStore => {
 				throw new AuthClientNotInitializedError();
 			}
 
+			// `@icp-sdk/auth` v6 relies on ICRC-29 `PostMessageTransport` (heartbeat
+			// + JSON-RPC), which Internet Identity serves from `/authorize`. The
+			// root `/` on `id.ai` returns the marketing landing page and the
+			// heartbeat handshake silently times out there, which is why sign-in
+			// appeared to do nothing after the v4 → v6 migration.
 			const identityProvider = nonNullish(INTERNET_IDENTITY_CANISTER_ID)
 				? /apple/i.test(navigator?.vendor)
 					? `http://localhost:4943?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
 					: `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:4943`
-				: `https://${domain ?? InternetIdentityDomain.VERSION_1_0}${domain === InternetIdentityDomain.VERSION_2_0 ? '/?feature_flag_min_guided_upgrade=true' : ''}`;
+				: `https://${domain ?? InternetIdentityDomain.VERSION_1_0}/authorize${domain === InternetIdentityDomain.VERSION_2_0 ? '?feature_flag_min_guided_upgrade=true' : ''}`;
 
 			// In `@icp-sdk/auth` v6, `identityProvider`, `windowOpenerFeatures` and
 			// `derivationOrigin` are constructor-bound rather than `login()` params, so


### PR DESCRIPTION
# Motivation

After the v4 → v6 migration of [`@icp-sdk/auth`](https://www.npmjs.com/package/@icp-sdk/auth), sign-in silently stopped working on the production landing page: clicking the button would appear to do nothing, with no visible error.

The root cause is that v6 swaps the transport layer under the hood. v4 used a custom Internet-Identity-specific postMessage protocol that was tolerant to whichever page loaded in the popup; v6 uses the standardised **ICRC-29 `PostMessageTransport`** (heartbeat + JSON-RPC 2.0), which requires the popup page to implement the ICRC-29 handshake.

Internet Identity serves the ICRC-29 endpoint from the **`/authorize`** path. The previous `identityProvider` URL pointed at the root of the II host — on `id.ai` the root now returns the new marketing landing page (a fully SSR'd SvelteKit page with FAQs / "Experience Real Privacy" / etc.), which does not respond to the `icrc29_status` poll. The heartbeat silently times out after the 10 s establish timeout and the sign-in promise never resolves.

This is also consistent with the SDK's own documented default of [`https://id.ai/authorize`](https://github.com/dfinity/icp-js-auth/blob/main/src/client/auth-client.ts).

# Changes

- `stores/auth.store.ts`: append `/authorize` to the `identityProvider` URL when targeting a production II host.

# Tests

Adapted tests and the manual login worked.
