### PR TITLE
feat(frontend): Wire up One-Click OpenID sign-in

### DIFF
--- a/src/frontend/src/lib/providers/auth-client.providers.ts
+++ b/src/frontend/src/lib/providers/auth-client.providers.ts
@@ -10,7 +10,7 @@ import type { Identity } from '@icp-sdk/core/agent';
 
 type SignInAuthClientOptions = Pick<
 	AuthClientCreateOptions,
-	'identityProvider' | 'windowOpenerFeatures' | 'derivationOrigin'
+	'identityProvider' | 'windowOpenerFeatures' | 'derivationOrigin' | 'openIdProvider'
 >;
 
 export class AuthClientProvider {
@@ -88,13 +88,19 @@ export class AuthClientProvider {
 	/**
 	 * Synchronously creates a fresh `AuthClient` tailored to a sign-in attempt.
 	 *
-	 * In `@icp-sdk/auth` v6, `identityProvider`, `windowOpenerFeatures` and `derivationOrigin`
-	 * are constructor-bound (they used to be passed to `login()`), so a new client
-	 * is required per sign-in. Construction stays synchronous so this can be
-	 * called from a user-gesture handler without triggering popup blockers.
+	 * In `@icp-sdk/auth` v6, `identityProvider`, `windowOpenerFeatures`,
+	 * `derivationOrigin` and `openIdProvider` are constructor-bound
+	 * (they used to be passed to `login()`), so a new client is required per
+	 * sign-in. Construction stays synchronous so this can be called from a
+	 * user-gesture handler without triggering popup blockers.
 	 *
 	 * The new client replaces the cached one so subsequent calls via
 	 * `createAuthClient` return the same instance.
+	 *
+	 * Passing `openIdProvider` (e.g. `'google'`) makes the SDK append an
+	 * `?openid=<issuer>` query param to the `identityProvider` URL and Internet
+	 * Identity 2.0 (id.ai) performs the OIDC flow against that provider before
+	 * returning a delegation identical to a normal II sign-in.
 	 */
 	createAuthClientForSignIn = (signInOptions: SignInAuthClientOptions): AuthClient => {
 		this.#authClient = this.#buildAuthClient(signInOptions);

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -49,9 +49,7 @@ export const signIn = async (
 
 	const trackingMetadata = {
 		domain: params.domain ?? InternetIdentityDomain.VERSION_1_0,
-		...(nonNullish(params.openIdProvider)
-			? { openid_provider: params.openIdProvider }
-			: {})
+		...(nonNullish(params.openIdProvider) ? { openid_provider: params.openIdProvider } : {})
 	};
 
 	try {

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -48,7 +48,10 @@ export const signIn = async (
 	busy.show();
 
 	const trackingMetadata = {
-		domain: params.domain ?? InternetIdentityDomain.VERSION_1_0
+		domain: params.domain ?? InternetIdentityDomain.VERSION_1_0,
+		...(nonNullish(params.openIdProvider)
+			? { openid_provider: params.openIdProvider }
+			: {})
 	};
 
 	try {

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/constants/app.constants';
 import { AuthBroadcastChannel } from '$lib/providers/auth-broadcast.providers';
 import { AuthClientProvider } from '$lib/providers/auth-client.providers';
-import { InternetIdentityDomain } from '$lib/types/auth';
+import { InternetIdentityDomain, type OpenIdProvider } from '$lib/types/auth';
 import { AuthClientNotInitializedError } from '$lib/types/errors';
 import type { NullishIdentity } from '$lib/types/identity';
 import { getOptionalDerivationOrigin } from '$lib/utils/auth.utils';
@@ -28,6 +28,13 @@ let authClient: Nullish<AuthClient>;
 export interface AuthSignInParams {
 	domain?: InternetIdentityDomain;
 	asPopup?: boolean;
+	/**
+	 * When provided, sign-in goes through Internet Identity 2.0 using the
+	 * matching OpenID Connect provider (One-Click sign-in with Google, Apple
+	 * or Microsoft). Leaving it undefined falls back to the standard II
+	 * passkey / device authentication flow.
+	 */
+	openIdProvider?: OpenIdProvider;
 }
 
 export interface AuthStore extends Readable<AuthStoreData> {
@@ -86,29 +93,38 @@ const initAuthStore = (): AuthStore => {
 			await sync({ forceSync: true });
 		},
 
-		signIn: async ({ domain, asPopup }: AuthSignInParams) => {
+		signIn: async ({ domain, asPopup, openIdProvider }: AuthSignInParams) => {
 			// When signing in, we require the authClient to be safely defined through the sync method (called when the window loads).
 			// We are not able to recreate authClient safely here since there are some browsers (like Safari) that block popups if there is an additional async call in this call stack.
 			if (isNullish(authClient)) {
 				throw new AuthClientNotInitializedError();
 			}
 
+			// One-Click OpenID sign-in is only supported by Internet Identity 2.0
+			// on mainnet (id.ai); the local II replica does not handle the
+			// `?openid=…` query param, so we always force id.ai for this flow.
+			const effectiveDomain =
+				nonNullish(openIdProvider) && isNullish(INTERNET_IDENTITY_CANISTER_ID)
+					? InternetIdentityDomain.VERSION_2_0
+					: domain;
+
 			// `@icp-sdk/auth` v6 relies on ICRC-29 `PostMessageTransport` (heartbeat
 			// + JSON-RPC), which Internet Identity serves from `/authorize`. The
 			// root `/` on `id.ai` returns the marketing landing page and the
 			// heartbeat handshake silently times out there, which is why sign-in
 			// appeared to do nothing after the v4 → v6 migration.
-			const identityProvider = nonNullish(INTERNET_IDENTITY_CANISTER_ID)
-				? /apple/i.test(navigator?.vendor)
-					? `http://localhost:4943?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
-					: `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:4943`
-				: `https://${domain ?? InternetIdentityDomain.VERSION_1_0}/authorize${domain === InternetIdentityDomain.VERSION_2_0 ? '?feature_flag_min_guided_upgrade=true' : ''}`;
+			const identityProvider =
+				nonNullish(INTERNET_IDENTITY_CANISTER_ID) && isNullish(openIdProvider)
+					? /apple/i.test(navigator?.vendor)
+						? `http://localhost:4943?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
+						: `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:4943`
+					: `https://${effectiveDomain ?? InternetIdentityDomain.VERSION_1_0}/authorize${effectiveDomain === InternetIdentityDomain.VERSION_2_0 ? '?feature_flag_min_guided_upgrade=true' : ''}`;
 
-			// In `@icp-sdk/auth` v6, `identityProvider`, `windowOpenerFeatures` and
-			// `derivationOrigin` are constructor-bound rather than `login()` params, so
-			// we build a dedicated client for this sign-in. Construction is synchronous,
-			// so the user-gesture stack is preserved up to the `signIn()` call that
-			// opens the popup.
+			// In `@icp-sdk/auth` v6, `identityProvider`, `windowOpenerFeatures`,
+			// `derivationOrigin` and `openIdProvider` are constructor-bound rather
+			// than `login()` params, so we build a dedicated client for this
+			// sign-in. Construction is synchronous, so the user-gesture stack is
+			// preserved up to the `signIn()` call that opens the popup.
 			const client = AuthClientProvider.getInstance().createAuthClientForSignIn({
 				identityProvider,
 				...(asPopup
@@ -119,6 +135,7 @@ const initAuthStore = (): AuthStore => {
 							})
 						}
 					: {}),
+				...(nonNullish(openIdProvider) ? { openIdProvider } : {}),
 				...getOptionalDerivationOrigin()
 			});
 

--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -93,11 +93,16 @@ const initAuthStore = (): AuthStore => {
 				throw new AuthClientNotInitializedError();
 			}
 
+			// `@icp-sdk/auth` v6 relies on ICRC-29 `PostMessageTransport` (heartbeat
+			// + JSON-RPC), which Internet Identity serves from `/authorize`. The
+			// root `/` on `id.ai` returns the marketing landing page and the
+			// heartbeat handshake silently times out there, which is why sign-in
+			// appeared to do nothing after the v4 → v6 migration.
 			const identityProvider = nonNullish(INTERNET_IDENTITY_CANISTER_ID)
 				? /apple/i.test(navigator?.vendor)
 					? `http://localhost:4943?canisterId=${INTERNET_IDENTITY_CANISTER_ID}`
 					: `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:4943`
-				: `https://${domain ?? InternetIdentityDomain.VERSION_1_0}${domain === InternetIdentityDomain.VERSION_2_0 ? '/?feature_flag_min_guided_upgrade=true' : ''}`;
+				: `https://${domain ?? InternetIdentityDomain.VERSION_1_0}/authorize${domain === InternetIdentityDomain.VERSION_2_0 ? '?feature_flag_min_guided_upgrade=true' : ''}`;
 
 			// In `@icp-sdk/auth` v6, `identityProvider`, `windowOpenerFeatures` and
 			// `derivationOrigin` are constructor-bound rather than `login()` params, so

--- a/src/frontend/src/lib/types/auth.ts
+++ b/src/frontend/src/lib/types/auth.ts
@@ -3,3 +3,12 @@ export enum InternetIdentityDomain {
 	VERSION_1_0 = 'identity.internetcomputer.org',
 	VERSION_2_0 = 'id.ai'
 }
+
+/**
+ * The OpenID provider identifiers supported by `@icp-sdk/auth` v6 for
+ * One-Click sign-in through Internet Identity 2.0.
+ *
+ * The SDK uses the literal string values below — they are NOT a local
+ * convention. See `@icp-sdk/auth/client` for the source of truth.
+ */
+export type OpenIdProvider = 'google' | 'apple' | 'microsoft';


### PR DESCRIPTION
# Motivation

[`@icp-sdk/auth` v6](https://www.npmjs.com/package/@icp-sdk/auth) exposes a One-Click OpenID Sign-In feature that lets users authenticate with Google, Apple or Microsoft directly through Internet Identity 2.0 (id.ai), with no separate OAuth client setup on our side — II handles the bridge and returns a delegation that is indistinguishable from a passkey-based II sign-in.

This PR lays down the service-layer plumbing so that we can surface those providers in the UI in a follow-up.

# Changes

- `types/auth.ts` — add an `OpenIdProvider` type alias (`'google' | 'apple' | 'microsoft'`) mirroring the SDK's own literal union, re-used throughout the auth layer.
- `providers/auth-client.providers.ts` — widen `SignInAuthClientOptions` to include the SDK's `openIdProvider` option (picked directly from `AuthClientCreateOptions` to stay in sync with the SDK type). The synchronous `createAuthClientForSignIn` already forwards any extra option to `new AuthClient(...)`, so no code change is needed beyond the type; documentation updated.
- `stores/auth.store.ts` —
  - Extend `AuthSignInParams` with `openIdProvider?: OpenIdProvider`.
  - When an OpenID provider is requested, force `domain` to II 2.0 (`id.ai`) and always build a production URL, since the local II replica doesn't handle the `?openid=…` query param.
  - Forward `openIdProvider` to `createAuthClientForSignIn` alongside the existing `identityProvider` / `windowOpenerFeatures` / `derivationOrigin`.
  - Preserves the user-gesture invariant: nothing new is awaited between the click handler and the SDK's `signIn()` call.
- `services/auth.services.ts` — include `openid_provider` in the analytics tracking metadata when the caller passes one; existing tracking shape is preserved otherwise.

# Tests

Adapted.
