### PR TITLE
refactor(frontend): extract shared `ButtonsSignIn` auth component

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -54,9 +54,9 @@
 	class:md:items-start={helpAlignment !== 'center'}
 >
 	<ButtonsSignIn
-		{onAuthenticate}
 		{fullWidth}
 		justify={helpAlignment === 'center' ? 'center' : 'start'}
+		{onAuthenticate}
 	/>
 
 	<span

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
 	import { Html } from '@dfinity/gix-components';
-	import { isNullish, nonNullish } from '@dfinity/utils';
-	import ButtonSignInInternetIdentity from '$lib/components/auth/ButtonSignInInternetIdentity.svelte';
-	import ButtonsSignInOpenId from '$lib/components/auth/ButtonsSignInOpenId.svelte';
+	import { nonNullish } from '@dfinity/utils';
+	import ButtonsSignIn from '$lib/components/auth/ButtonsSignIn.svelte';
 	import SigningInHelpLink from '$lib/components/auth/SigningInHelpLink.svelte';
 	import TermsOfUseLink from '$lib/components/terms-of-use/TermsOfUseLink.svelte';
-	import { INTERNET_IDENTITY_CANISTER_ID } from '$lib/constants/app.constants';
 	import { AUTH_SIGNING_IN_HELP_LINK } from '$lib/constants/test-ids.constants';
 	import { signIn } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -32,11 +30,6 @@
 
 	const modalId = Symbol();
 
-	// One-Click OpenID sign-in only targets Internet Identity 2.0 on mainnet
-	// (`id.ai`). The local II replica doesn't support the `?openid=...` query
-	// param, so we hide the social buttons entirely in local dev.
-	const openIdEnabled = $derived(isNullish(INTERNET_IDENTITY_CANISTER_ID));
-
 	const onAuthenticate = async ({ openIdProvider }: { openIdProvider?: OpenIdProvider } = {}) => {
 		const { success } = await signIn({
 			domain: InternetIdentityDomain.VERSION_2_0,
@@ -60,27 +53,11 @@
 	class="flex w-full flex-col items-center gap-4"
 	class:md:items-start={helpAlignment !== 'center'}
 >
-	<div
-		class="flex w-full flex-col items-center gap-4"
-		class:md:flex-row={!fullWidth}
-		class:md:justify-center={!fullWidth && helpAlignment === 'center'}
-		class:md:justify-start={!fullWidth && helpAlignment !== 'center'}
-	>
-		<ButtonSignInInternetIdentity {fullWidth} onclick={() => onAuthenticate()} />
-
-		{#if openIdEnabled}
-			<div
-				class="h-px w-[35px] bg-brand-subtle-20"
-				class:md:h-[35px]={!fullWidth}
-				class:md:w-px={!fullWidth}
-				aria-hidden="true"
-			></div>
-
-			<ButtonsSignInOpenId
-				onProviderSelected={(provider) => onAuthenticate({ openIdProvider: provider })}
-			/>
-		{/if}
-	</div>
+	<ButtonsSignIn
+		{onAuthenticate}
+		{fullWidth}
+		justify={helpAlignment === 'center' ? 'center' : 'start'}
+	/>
 
 	<span
 		class="flex flex-col text-sm text-tertiary"

--- a/src/frontend/src/lib/components/auth/ButtonsSignIn.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonsSignIn.svelte
@@ -29,25 +29,25 @@
 
 <div
 	class="flex w-full flex-col items-center gap-4"
-	class:sm:flex-row={!fullWidth && rowBreakpoint === 'sm'}
 	class:md:flex-row={!fullWidth && rowBreakpoint === 'md'}
 	class:md:justify-center={!fullWidth && rowBreakpoint === 'md' && justify === 'center'}
 	class:md:justify-start={!fullWidth && rowBreakpoint === 'md' && justify === 'start'}
+	class:sm:flex-row={!fullWidth && rowBreakpoint === 'sm'}
 >
 	<ButtonSignInInternetIdentity
-		onclick={() => onAuthenticate()}
 		{fullWidth}
-		{variant}
+		onclick={() => onAuthenticate()}
 		{rowBreakpoint}
+		{variant}
 	/>
 
 	{#if openIdEnabled}
 		<div
 			class="h-px w-[35px] bg-brand-subtle-20"
-			class:sm:h-[35px]={!fullWidth && rowBreakpoint === 'sm'}
-			class:sm:w-px={!fullWidth && rowBreakpoint === 'sm'}
 			class:md:h-[35px]={!fullWidth && rowBreakpoint === 'md'}
 			class:md:w-px={!fullWidth && rowBreakpoint === 'md'}
+			class:sm:h-[35px]={!fullWidth && rowBreakpoint === 'sm'}
+			class:sm:w-px={!fullWidth && rowBreakpoint === 'sm'}
 			aria-hidden="true"
 		></div>
 

--- a/src/frontend/src/lib/components/auth/ButtonsSignIn.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonsSignIn.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import ButtonSignInInternetIdentity from '$lib/components/auth/ButtonSignInInternetIdentity.svelte';
+	import ButtonsSignInOpenId from '$lib/components/auth/ButtonsSignInOpenId.svelte';
+	import { INTERNET_IDENTITY_CANISTER_ID } from '$lib/constants/app.constants';
+	import type { OpenIdProvider } from '$lib/types/auth';
+
+	interface Props {
+		onAuthenticate: (params?: { openIdProvider?: OpenIdProvider }) => void;
+		variant?: 'login' | 'lock';
+		fullWidth?: boolean;
+		rowBreakpoint?: 'sm' | 'md';
+		justify?: 'center' | 'start';
+	}
+
+	let {
+		onAuthenticate,
+		variant = 'login',
+		fullWidth = false,
+		rowBreakpoint = 'md',
+		justify = 'start'
+	}: Props = $props();
+
+	// One-Click OpenID sign-in only targets Internet Identity 2.0 on mainnet
+	// (`id.ai`). The local II replica doesn't support the `?openid=...` query
+	// param, so we hide the social buttons entirely in local dev.
+	const openIdEnabled = $derived(isNullish(INTERNET_IDENTITY_CANISTER_ID));
+</script>
+
+<div
+	class="flex w-full flex-col items-center gap-4"
+	class:sm:flex-row={!fullWidth && rowBreakpoint === 'sm'}
+	class:md:flex-row={!fullWidth && rowBreakpoint === 'md'}
+	class:md:justify-center={!fullWidth && rowBreakpoint === 'md' && justify === 'center'}
+	class:md:justify-start={!fullWidth && rowBreakpoint === 'md' && justify === 'start'}
+>
+	<ButtonSignInInternetIdentity
+		onclick={() => onAuthenticate()}
+		{fullWidth}
+		{variant}
+		{rowBreakpoint}
+	/>
+
+	{#if openIdEnabled}
+		<div
+			class="h-px w-[35px] bg-brand-subtle-20"
+			class:sm:h-[35px]={!fullWidth && rowBreakpoint === 'sm'}
+			class:sm:w-px={!fullWidth && rowBreakpoint === 'sm'}
+			class:md:h-[35px]={!fullWidth && rowBreakpoint === 'md'}
+			class:md:w-px={!fullWidth && rowBreakpoint === 'md'}
+			aria-hidden="true"
+		></div>
+
+		<ButtonsSignInOpenId
+			onProviderSelected={(provider) => onAuthenticate({ openIdProvider: provider })}
+			{variant}
+		/>
+	{/if}
+</div>


### PR DESCRIPTION
# Motivation

`ButtonAuthenticateWithHelp` duplicates the same Internet Identity + separator + OpenID sign-in markup that will also be needed on the lock page (see #12553). Extract that row into a shared `ButtonsSignIn` component so both surfaces can reuse it without copy-pasting.

