### PR TITLE
style(frontend): Better spacing for buttons in Unlock mode

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonsSignIn.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonsSignIn.svelte
@@ -30,9 +30,11 @@
 <div
 	class="flex w-full flex-col items-center gap-4"
 	class:md:flex-row={!fullWidth && rowBreakpoint === 'md'}
+	class:md:gap-2={!fullWidth && rowBreakpoint === 'md' && variant === 'lock'}
 	class:md:justify-center={!fullWidth && rowBreakpoint === 'md' && justify === 'center'}
 	class:md:justify-start={!fullWidth && rowBreakpoint === 'md' && justify === 'start'}
 	class:sm:flex-row={!fullWidth && rowBreakpoint === 'sm'}
+	class:sm:gap-2={!fullWidth && rowBreakpoint === 'sm' && variant === 'lock'}
 >
 	<ButtonSignInInternetIdentity
 		{fullWidth}
@@ -53,6 +55,7 @@
 
 		<ButtonsSignInOpenId
 			onProviderSelected={(provider) => onAuthenticate({ openIdProvider: provider })}
+			{rowBreakpoint}
 			{variant}
 		/>
 	{/if}

--- a/src/frontend/src/lib/components/auth/ButtonsSignInOpenId.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonsSignInOpenId.svelte
@@ -13,9 +13,10 @@
 	interface Props {
 		onProviderSelected: (provider: OpenIdProvider) => void;
 		variant?: 'login' | 'lock';
+		rowBreakpoint?: 'sm' | 'md';
 	}
 
-	let { onProviderSelected, variant = 'login' }: Props = $props();
+	let { onProviderSelected, variant = 'login', rowBreakpoint = 'md' }: Props = $props();
 
 	// One-Click sign-in providers — see `@icp-sdk/auth` v6 `OpenIdProvider`.
 	// Internet Identity 2.0 performs the OIDC flow against these and returns
@@ -48,7 +49,11 @@
 	);
 </script>
 
-<div class="flex items-center justify-center gap-4">
+<div
+	class="flex items-center justify-center gap-4"
+	class:md:gap-1={rowBreakpoint === 'md' && variant === 'lock'}
+	class:sm:gap-1={rowBreakpoint === 'sm' && variant === 'lock'}
+>
 	{#each providers as { provider, icon: Icon, ariaLabel, testId } (provider)}
 		<button
 			class={`flex size-14 items-center justify-center rounded-xl transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 ${variantClasses}`}


### PR DESCRIPTION
# Motivation

Smaller improvement for spacing of login buttons in unlock mode.

<img width="926" height="1453" alt="Screenshot 2026-04-24 at 09 16 14" src="https://github.com/user-attachments/assets/6dd2f2ce-b7ae-4f87-8b09-351f75bb5447" />
<img width="391" height="842" alt="Screenshot 2026-04-24 at 09 16 24" src="https://github.com/user-attachments/assets/494c7dde-1824-42cc-a95a-cbff67cf20de" />

