### PR TITLE
fix(frontend): render `Guards` only after user profile is loaded

### DIFF
--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -60,9 +60,9 @@
 
 		{@render children()}
 	</Loader>
-</LoaderUserProfile>
 
-<Guards />
+	<Guards />
+</LoaderUserProfile>
 
 <WalletConnectListener />
 

--- a/src/frontend/src/routes/(sign)/sign/+page.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+page.svelte
@@ -74,8 +74,8 @@
 					<SignerCallCanister />
 				{/if}
 			</SignerAccounts>
-		</LoaderUserProfile>
 
-		<AgreementsGuard />
+			<AgreementsGuard />
+		</LoaderUserProfile>
 	{/if}
 </article>


### PR DESCRIPTION
# Motivation

Guards that trigger authenticated backend updates (e.g. `AgreementsGuard`) were rendered as siblings of `LoaderUserProfile`, so they could fire on first sign-in before the caller's user profile had been created; racing with profile creation and producing avoidable canister rejects. Rendering them inside `LoaderUserProfile` makes sure they only run once the profile is loaded.

