### PR TITLE
feat(backend): require a user profile on authenticated update calls

### DIFF
--- a/src/backend/src/api/bitcoin.rs
+++ b/src/backend/src/api/bitcoin.rs
@@ -23,7 +23,7 @@ use crate::{
     delegation, signer,
     state::mutate_state,
     utils::{
-        guards::caller_is_not_anonymous,
+        guards::{caller_is_not_anonymous, caller_is_registered_user},
         rate_limiter::{
             self, BTC_ADD_PENDING_TX_RATE_LIMITER, BTC_GET_PENDING_TX_RATE_LIMITER,
             BTC_SELECT_UTXOS_FEE_RATE_LIMITER,
@@ -64,7 +64,7 @@ pub fn btc_get_current_fee_percentiles(
 ///
 /// # Errors
 /// Errors are enumerated by: `SelectedUtxosFeeError`.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub async fn btc_select_user_utxos_fee(
     params: SelectedUtxosFeeRequest,
 ) -> BtcSelectUserUtxosFeeResult {
@@ -161,7 +161,7 @@ pub async fn btc_select_user_utxos_fee(
 ///
 /// # Errors
 /// Errors are enumerated by: `BtcAddPendingTransactionError`.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub async fn btc_add_pending_transaction(
     params: BtcAddPendingTransactionRequest,
 ) -> BtcAddPendingTransactionResult {
@@ -259,7 +259,7 @@ pub async fn btc_add_pending_transaction(
 ///
 /// # Errors
 /// Errors are enumerated by: `BtcGetPendingTransactionsError`.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub async fn btc_get_pending_transactions(
     params: BtcGetPendingTransactionsRequest,
 ) -> BtcGetPendingTransactionsResult {

--- a/src/backend/src/api/contacts.rs
+++ b/src/backend/src/api/contacts.rs
@@ -7,7 +7,10 @@ use shared::types::{
     },
 };
 
-use crate::{contacts, utils::guards::caller_is_not_anonymous};
+use crate::{
+    contacts,
+    utils::guards::{caller_is_not_anonymous, caller_is_registered_user},
+};
 
 /// Creates a new contact for the caller.
 ///
@@ -17,7 +20,7 @@ use crate::{contacts, utils::guards::caller_is_not_anonymous};
 /// # Returns
 /// The created contact on success.
 
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub async fn create_contact(request: CreateContactRequest) -> CreateContactResult {
     let result = contacts::create_contact(request).await;
@@ -28,7 +31,7 @@ pub async fn create_contact(request: CreateContactRequest) -> CreateContactResul
 ///
 /// # Errors
 /// Errors are enumerated by: `ContactError`.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn update_contact(request: UpdateContactRequest) -> UpdateContactResult {
     let result = contacts::update_contact(request);
@@ -42,7 +45,7 @@ pub fn update_contact(request: UpdateContactRequest) -> UpdateContactResult {
 ///
 /// # Notes
 /// This operation is idempotent - it will return OK if the contact has already been deleted.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn delete_contact(contact_id: u64) -> DeleteContactResult {
     let result = contacts::delete_contact(contact_id);

--- a/src/backend/src/api/custom_tokens.rs
+++ b/src/backend/src/api/custom_tokens.rs
@@ -8,11 +8,11 @@ use crate::{
     state::{mutate_state, read_state},
     token::{self, MAX_TOKEN_LIST_LENGTH},
     types::StoredPrincipal,
-    utils::guards::caller_is_not_anonymous,
+    utils::guards::caller_is_registered_user,
 };
 
 /// Add or update custom token for the user.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub fn set_custom_token(token: CustomToken) {
     let stored_principal = StoredPrincipal(msg_caller());
 
@@ -30,7 +30,7 @@ pub fn set_custom_token(token: CustomToken) {
     token::mark_token_active(&TokenId::from(&token));
 }
 
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub fn set_many_custom_tokens(tokens: Vec<CustomToken>) {
     let tokens = tokens.into_boxed_slice();
 
@@ -57,7 +57,7 @@ pub fn set_many_custom_tokens(tokens: Vec<CustomToken>) {
 }
 
 /// Remove custom token for the user.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub fn remove_custom_token(token: CustomToken) {
     let CustomToken { token, .. } = token;
 
@@ -85,7 +85,7 @@ pub fn remove_custom_token(token: CustomToken) {
 /// - It consumes cycles as an update call.
 /// - Integrations that previously relied on query semantics must be updated to invoke this as an
 ///   update method.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn list_custom_tokens() -> Vec<CustomToken> {
     let stored_principal = StoredPrincipal(msg_caller());

--- a/src/backend/src/api/signer.rs
+++ b/src/backend/src/api/signer.rs
@@ -15,7 +15,7 @@ use shared::types::{
 use crate::{
     delegation, signer,
     utils::{
-        guards::{caller_is_controller, caller_is_not_anonymous},
+        guards::{caller_is_controller, caller_is_registered_user},
         rate_limiter::{self, ALLOW_SIGNING_GUARD_LIMITER, ALLOW_SIGNING_RATE_LIMITER},
     },
 };
@@ -40,7 +40,7 @@ pub async fn top_up_cycles_ledger(
 /// # Errors
 /// - `FailedToContactCyclesLedger`: If the call to the cycles ledger canister failed
 /// - `Other`: If another error occurred during the operation
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub async fn get_allowed_cycles() -> GetAllowedCyclesResult {
     let allowed_cycles = signer::get_allowed_cycles().await;
     match allowed_cycles {
@@ -68,7 +68,7 @@ pub async fn get_allowed_cycles() -> GetAllowedCyclesResult {
 ///
 /// # Errors
 /// Errors are enumerated by: `AllowSigningError`.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub async fn allow_signing(request: Option<AllowSigningRequest>) -> AllowSigningResult {
     async fn inner(
         request: Option<AllowSigningRequest>,

--- a/src/backend/src/api/transactions.rs
+++ b/src/backend/src/api/transactions.rs
@@ -7,7 +7,7 @@ use shared::types::{
 use crate::{
     state::{mutate_state, read_state},
     transactions::model,
-    utils::guards::caller_is_not_anonymous,
+    utils::guards::{caller_is_not_anonymous, caller_is_registered_user},
 };
 
 /// Retrieves stored finalized transactions for the caller, with cursor-based pagination.
@@ -45,7 +45,7 @@ pub fn get_user_transactions(request: GetUserTransactionsRequest) -> GetUserTran
 ///
 /// # Errors
 /// Errors are enumerated by: `UserTransactionError`.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 pub fn save_user_transactions(request: SaveUserTransactionsRequest) -> SaveUserTransactionsResult {
     let SaveUserTransactionsRequest {
         token_id,

--- a/src/backend/src/api/user_profile.rs
+++ b/src/backend/src/api/user_profile.rs
@@ -21,7 +21,10 @@ use crate::{
     state::{mutate_state, read_state},
     types::StoredPrincipal,
     user_profile::{model::UserProfileModel, service},
-    utils::{guards::caller_is_not_anonymous, housekeeping::spawn_allow_signing_if_below_limit},
+    utils::{
+        guards::{caller_is_not_anonymous, caller_is_registered_user},
+        housekeeping::spawn_allow_signing_if_below_limit,
+    },
 };
 
 /// Updates the user's preference to enable (or disable) networks in the interface, merging with any
@@ -33,7 +36,7 @@ use crate::{
 ///
 /// # Errors
 /// - Returns `Err` if the user profile is not found, or the user profile version is not up-to-date.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn update_user_network_settings(
     request: SaveNetworksSettingsRequest,
@@ -62,7 +65,7 @@ pub fn update_user_network_settings(
 ///
 /// # Errors
 /// - Returns `Err` if the user profile is not found, or the user profile version is not up-to-date.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn set_user_show_testnets(request: SetShowTestnetsRequest) -> SetUserShowTestnetsResult {
     let user_principal = msg_caller();
@@ -91,7 +94,7 @@ pub fn set_user_show_testnets(request: SetShowTestnetsRequest) -> SetUserShowTes
 ///
 /// # Errors
 /// - Returns `Err` if the user profile is not found, or the user profile version is not up-to-date.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn add_user_hidden_dapp_id(request: AddHiddenDappIdRequest) -> AddUserHiddenDappIdResult {
     fn inner(request: AddHiddenDappIdRequest) -> Result<(), AddDappSettingsError> {
@@ -125,7 +128,7 @@ pub fn add_user_hidden_dapp_id(request: AddHiddenDappIdRequest) -> AddUserHidden
 /// # Errors
 /// - Returns `Err` if the user profile is not found, the user profile version is not up-to-date, or
 ///   the batch is too large.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn add_user_dismissed_notification(
     request: AddDismissedNotificationRequest,
@@ -163,7 +166,7 @@ pub fn add_user_dismissed_notification(
 ///
 /// # Errors
 /// - Returns `Err` if the user profile is not found, or the user profile version is not up-to-date.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn update_user_agreements(request: UpdateUserAgreementsRequest) -> UpdateUserAgreementsResult {
     let UpdateUserAgreementsRequest {
@@ -198,7 +201,7 @@ pub fn update_user_agreements(request: UpdateUserAgreementsRequest) -> UpdateUse
 ///
 /// # Errors
 /// - Returns `Err` if the user profile is not found, or the user profile version is not up-to-date.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn update_provider_agreements(
     request: UpdateProviderAgreementsRequest,
@@ -256,7 +259,7 @@ pub fn get_user_agreement_history() -> GetAgreementHistoryResult {
 ///
 /// # Errors
 /// - Returns `Err` if the user profile is not found, or the user profile version is not up-to-date.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn update_user_experimental_feature_settings(
     request: UpdateExperimentalFeaturesSettingsRequest,
@@ -285,7 +288,7 @@ pub fn update_user_experimental_feature_settings(
 ///
 /// # Errors
 /// - Returns `Err` if the user profile is not found, or the user profile version is not up-to-date.
-#[update(guard = "caller_is_not_anonymous")]
+#[update(guard = "caller_is_registered_user")]
 #[must_use]
 pub fn update_user_transaction_filter_settings(
     request: UpdateTransactionFilterSettingsRequest,

--- a/src/backend/src/utils/guards.rs
+++ b/src/backend/src/utils/guards.rs
@@ -1,13 +1,43 @@
 use candid::Principal;
 use ic_cdk::api::{is_controller, msg_caller};
 
-use crate::state::read_config;
+use crate::{
+    state::{read_config, read_state},
+    types::StoredPrincipal,
+};
 
 pub(crate) fn caller_is_not_anonymous() -> Result<(), String> {
     if msg_caller() == Principal::anonymous() {
         Err("Update call error. RejectionCode: CanisterReject, Error: Anonymous caller not authorized.".to_string())
     } else {
         Ok(())
+    }
+}
+
+/// Guard for authenticated endpoints that require the caller to already have a
+/// registered user profile. It ensures that:
+/// - the caller is not the anonymous principal, and
+/// - a user profile exists for the caller in the canister state.
+///
+/// New users must therefore call `create_user_profile` (which is only protected
+/// by `caller_is_not_anonymous`) before they can invoke any other update call
+/// protected by this guard.
+///
+/// Note: controllers are *not* exempt. These endpoints are user-facing and
+/// their state is keyed to the caller principal, so a controller without a
+/// profile is, conceptually, not a "registered user" either. Controller-only
+/// administrative endpoints use dedicated guards (`caller_is_controller`,
+/// `caller_is_allowed`) instead.
+pub(crate) fn caller_is_registered_user() -> Result<(), String> {
+    caller_is_not_anonymous()?;
+
+    let stored_principal = StoredPrincipal(msg_caller());
+    let has_profile = read_state(|s| s.user_profile_updated.contains_key(&stored_principal));
+
+    if has_profile {
+        Ok(())
+    } else {
+        Err("Update call error. RejectionCode: CanisterReject, Error: Caller has no user profile. Please create a user profile first via `create_user_profile`.".to_string())
     }
 }
 

--- a/src/backend/src/utils/guards.rs
+++ b/src/backend/src/utils/guards.rs
@@ -1,11 +1,7 @@
 use candid::Principal;
 use ic_cdk::api::{is_controller, msg_caller};
 
-use crate::{
-    state::read_config,
-    types::StoredPrincipal,
-    user_profile::service::has_user_profile,
-};
+use crate::{state::read_config, types::StoredPrincipal, user_profile::service::has_user_profile};
 
 pub(crate) fn caller_is_not_anonymous() -> Result<(), String> {
     if msg_caller() == Principal::anonymous() {

--- a/src/backend/src/utils/guards.rs
+++ b/src/backend/src/utils/guards.rs
@@ -2,8 +2,9 @@ use candid::Principal;
 use ic_cdk::api::{is_controller, msg_caller};
 
 use crate::{
-    state::{read_config, read_state},
+    state::read_config,
     types::StoredPrincipal,
+    user_profile::service::has_user_profile,
 };
 
 pub(crate) fn caller_is_not_anonymous() -> Result<(), String> {
@@ -31,10 +32,7 @@ pub(crate) fn caller_is_not_anonymous() -> Result<(), String> {
 pub(crate) fn caller_is_registered_user() -> Result<(), String> {
     caller_is_not_anonymous()?;
 
-    let stored_principal = StoredPrincipal(msg_caller());
-    let has_profile = read_state(|s| s.user_profile_updated.contains_key(&stored_principal));
-
-    if has_profile {
+    if has_user_profile(StoredPrincipal(msg_caller())) {
         Ok(())
     } else {
         Err("Update call error. RejectionCode: CanisterReject, Error: Caller has no user profile. Please create a user profile first via `create_user_profile`.".to_string())

--- a/src/backend/tests/it/bitcoin.rs
+++ b/src/backend/tests/it/bitcoin.rs
@@ -46,6 +46,7 @@ fn test_select_user_utxos_fee_returns_zero_when_user_has_insufficient_funds() {
     );
 
     let caller = Principal::self_authenticating(&delegation_chain.public_key);
+    pic_setup.ensure_user_profile(caller);
 
     let request = SelectedUtxosFeeRequest {
         amount_satoshis: 100_000_000u64,
@@ -74,6 +75,7 @@ fn test_add_pending_transaction_requires_delegation_chain() {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let add_request = BtcAddPendingTransactionRequest {
         txid: vec![],
@@ -104,6 +106,7 @@ fn test_add_pending_transaction_without_delegation_chain_passes_when_guard_disab
     let pic_setup = setup_with_production_config();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let add_request = BtcAddPendingTransactionRequest {
         txid: vec![],
@@ -146,6 +149,7 @@ fn test_get_pending_transactions_returns_empty_for_new_user() {
     );
 
     let caller = Principal::self_authenticating(&delegation_chain.public_key);
+    pic_setup.ensure_user_profile(caller);
 
     let read_request = BtcGetPendingTransactionsRequest {
         address: MOCK_ADDRESS.to_string(),
@@ -182,6 +186,7 @@ fn test_add_pending_transaction_with_valid_delegation() {
     );
 
     let caller = Principal::self_authenticating(&delegation_chain.public_key);
+    pic_setup.ensure_user_profile(caller);
 
     let add_request = BtcAddPendingTransactionRequest {
         txid: vec![],
@@ -209,6 +214,7 @@ fn test_add_pending_transaction_with_valid_delegation() {
 #[test]
 fn test_controller_bypasses_delegation_check() {
     let pic_setup = setup();
+    pic_setup.ensure_user_profile(controller());
 
     let add_request = BtcAddPendingTransactionRequest {
         txid: vec![],
@@ -242,6 +248,7 @@ fn test_controller_bypasses_delegation_check() {
 fn test_select_user_utxos_fee_requires_delegation_chain() {
     let pic_setup = setup();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let request = SelectedUtxosFeeRequest {
         amount_satoshis: 100_000_000u64,
@@ -271,6 +278,7 @@ fn test_select_user_utxos_fee_requires_delegation_chain() {
 fn test_select_user_utxos_fee_without_delegation_chain_passes_when_guard_disabled() {
     let pic_setup = setup_with_production_config();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let request = SelectedUtxosFeeRequest {
         amount_satoshis: 100_000_000u64,
@@ -299,6 +307,7 @@ fn test_select_user_utxos_fee_without_delegation_chain_passes_when_guard_disable
 #[test]
 fn test_select_user_utxos_fee_controller_bypasses_delegation_check() {
     let pic_setup = setup();
+    pic_setup.ensure_user_profile(controller());
 
     let request = SelectedUtxosFeeRequest {
         amount_satoshis: 100_000_000u64,
@@ -342,6 +351,7 @@ fn test_select_user_utxos_fee_with_valid_delegation() {
     );
 
     let caller = Principal::self_authenticating(&delegation_chain.public_key);
+    pic_setup.ensure_user_profile(caller);
 
     let request = SelectedUtxosFeeRequest {
         amount_satoshis: 100_000_000u64,
@@ -371,6 +381,7 @@ fn test_select_user_utxos_fee_with_valid_delegation() {
 fn test_get_pending_transactions_requires_delegation_chain() {
     let pic_setup = setup();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let request = BtcGetPendingTransactionsRequest {
         address: MOCK_ADDRESS.to_string(),
@@ -399,6 +410,7 @@ fn test_get_pending_transactions_requires_delegation_chain() {
 fn test_get_pending_transactions_without_delegation_chain_passes_when_guard_disabled() {
     let pic_setup = setup_with_production_config();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let request = BtcGetPendingTransactionsRequest {
         address: MOCK_ADDRESS.to_string(),
@@ -426,6 +438,7 @@ fn test_get_pending_transactions_without_delegation_chain_passes_when_guard_disa
 #[test]
 fn test_get_pending_transactions_controller_bypasses_delegation_check() {
     let pic_setup = setup();
+    pic_setup.ensure_user_profile(controller());
 
     let request = BtcGetPendingTransactionsRequest {
         address: MOCK_ADDRESS.to_string(),
@@ -468,6 +481,7 @@ fn test_get_pending_transactions_with_valid_delegation() {
     );
 
     let caller = Principal::self_authenticating(&delegation_chain.public_key);
+    pic_setup.ensure_user_profile(caller);
 
     let request = BtcGetPendingTransactionsRequest {
         address: MOCK_ADDRESS.to_string(),
@@ -517,6 +531,7 @@ fn call_btc_select_user_utxos_fee(
 fn test_btc_select_user_utxos_fee_rate_limited_after_exceeding_limit() {
     let pic_setup = setup();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     for i in 0..10 {
         let result = call_btc_select_user_utxos_fee(&pic_setup, caller);
@@ -546,6 +561,7 @@ fn test_btc_select_user_utxos_fee_rate_limited_after_exceeding_limit() {
 fn test_btc_select_user_utxos_fee_rate_limit_resets_after_window() {
     let pic_setup = setup();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     for _ in 0..10 {
         let _ = call_btc_select_user_utxos_fee(&pic_setup, caller);
@@ -599,6 +615,7 @@ fn call_btc_add_pending_transaction(
 fn test_btc_add_pending_transaction_rate_limited_after_exceeding_limit() {
     let pic_setup = setup();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     for i in 0..10 {
         let result = call_btc_add_pending_transaction(&pic_setup, caller);
@@ -651,6 +668,7 @@ fn call_btc_get_pending_transactions(
 fn test_btc_get_pending_transactions_rate_limited_after_exceeding_limit() {
     let pic_setup = setup();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     for i in 0..15 {
         let result = call_btc_get_pending_transactions(&pic_setup, caller);
@@ -681,6 +699,8 @@ fn test_btc_get_pending_transactions_rate_limit_is_per_caller() {
     let pic_setup = setup();
     let caller_a = Principal::from_text(CALLER).unwrap();
     let caller_b = Principal::self_authenticating("btc-rate-limit-b");
+    pic_setup.ensure_user_profile(caller_a);
+    pic_setup.ensure_user_profile(caller_b);
 
     // Exhaust caller_a's rate limit (15 calls/min).
     for _ in 0..15 {

--- a/src/backend/tests/it/contacts.rs
+++ b/src/backend/tests/it/contacts.rs
@@ -118,6 +118,37 @@ fn test_create_contact_requires_authenticated_user() {
         "Error should indicate unauthorized anonymous caller"
     );
 }
+
+/// Sanity check for the `caller_is_registered_user` guard on
+/// `create_contact`: a non-anonymous caller that has not created a user
+/// profile must be rejected by the guard before any endpoint logic runs.
+#[test]
+fn test_create_contact_requires_registered_user() {
+    let pic_setup = setup();
+    // Non-anonymous caller, but no user profile has been created.
+    let caller = Principal::from_text(CALLER).unwrap();
+
+    let request = CreateContactRequest {
+        name: "Test Contact".to_string(),
+        image: None,
+    };
+    let result =
+        pic_setup.update::<Result<Contact, ContactError>>(caller, "create_contact", request);
+
+    assert!(
+        result.is_err(),
+        "Caller without a user profile should not be able to create contacts"
+    );
+    assert!(
+        result
+            .clone()
+            .unwrap_err()
+            .contains("Caller has no user profile"),
+        "Error should indicate the caller has no user profile, got: {:?}",
+        result.unwrap_err()
+    );
+}
+
 #[test]
 fn test_create_contact_should_succeed_with_valid_name() {
     let pic_setup = setup();

--- a/src/backend/tests/it/contacts.rs
+++ b/src/backend/tests/it/contacts.rs
@@ -25,6 +25,7 @@ pub fn call_create_contact(
     caller: Principal,
     name: String,
 ) -> Result<Contact, ContactError> {
+    pic_setup.ensure_user_profile(caller);
     let request = CreateContactRequest { name, image: None };
     let wrapped_result =
         pic_setup.update::<Result<Contact, ContactError>>(caller, "create_contact", request);
@@ -53,6 +54,7 @@ pub fn call_update_contact(
     caller: Principal,
     contact: Contact,
 ) -> Result<Contact, ContactError> {
+    pic_setup.ensure_user_profile(caller);
     let request = UpdateContactRequest {
         id: contact.id,
         name: contact.name,
@@ -166,6 +168,7 @@ fn test_create_contact_should_fail_when_limit_reached() {
 fn test_create_contact_should_fail_with_whitespace_name() {
     let pic_setup = setup();
     let caller: Principal = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     // Test empty string
     let wrapped_result = pic_setup.update::<Result<Contact, ContactError>>(
@@ -197,6 +200,7 @@ fn test_create_contact_should_fail_with_whitespace_name() {
 fn test_create_contact_should_fail_with_leading_and_trailing_whitespace_name() {
     let pic_setup = setup();
     let caller: Principal = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     // Create a contact with a name that has leading whitespace
     let wrapped_result = pic_setup.update::<Result<Contact, ContactError>>(

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -161,6 +161,23 @@ fn test_add_custom_tokens() {
     }
 }
 
+/// Sanity check for the `caller_is_registered_user` guard on
+/// `set_custom_token`: a non-anonymous caller that has not created a user
+/// profile must be rejected by the guard before any endpoint logic runs.
+#[test]
+fn test_set_custom_token_requires_registered_user() {
+    let pic_setup = setup();
+    // Non-anonymous caller, but no user profile has been created.
+    let caller = Principal::from_text(CALLER).unwrap();
+
+    let response = pic_setup.update::<()>(caller, "set_custom_token", USER_TOKEN.clone());
+
+    assert_eq!(
+        response,
+        Err("Update call error. RejectionCode: CanisterReject, Error: Update call error. RejectionCode: CanisterReject, Error: Caller has no user profile. Please create a user profile first via `create_user_profile`.".to_string())
+    );
+}
+
 fn test_add_custom_token(user_token: &CustomToken) {
     let pic_setup = setup();
 

--- a/src/backend/tests/it/custom_token.rs
+++ b/src/backend/tests/it/custom_token.rs
@@ -165,6 +165,7 @@ fn test_add_custom_token(user_token: &CustomToken) {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let before_set = pic_setup.update::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
@@ -234,6 +235,7 @@ fn test_remove_custom_token(token: &CustomToken) {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let before_set = pic_setup.update::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
@@ -271,6 +273,7 @@ fn test_update_custom_token(user_token: &CustomToken) {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let result = pic_setup.update::<()>(caller, "set_custom_token", user_token.clone());
 
@@ -321,6 +324,7 @@ fn test_add_many_custom_tokens(user_token: &CustomToken) {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let before_set = pic_setup.update::<Vec<CustomToken>>(caller, "list_custom_tokens", ());
 
@@ -356,6 +360,7 @@ fn test_update_many_custom_tokens(user_token: &CustomToken) {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let tokens: Vec<CustomToken> = vec![user_token.clone(), ANOTHER_USER_TOKEN.clone()];
 
@@ -416,6 +421,7 @@ fn test_list_custom_tokens() {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let _ = pic_setup.update::<()>(caller, "set_custom_token", USER_TOKEN.clone());
 
@@ -449,6 +455,7 @@ fn test_cannot_update_custom_token_without_version(user_token: &CustomToken) {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let result = pic_setup.update::<()>(caller, "set_custom_token", user_token.clone());
 
@@ -484,6 +491,7 @@ fn test_cannot_update_custom_token_with_invalid_version(user_token: &CustomToken
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let result = pic_setup.update::<()>(caller, "set_custom_token", user_token.clone());
 
@@ -544,12 +552,14 @@ fn test_user_cannot_list_another_custom_tokens() {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let _ = pic_setup.update::<()>(caller, "set_custom_token", USER_TOKEN.clone());
 
     let another_caller =
         Principal::from_text("yaa3n-twfur-6xz6e-3z7ep-xln56-222kz-w2b2m-y5wqz-vu6kk-s3fdg-lqe")
             .unwrap();
+    pic_setup.ensure_user_profile(another_caller);
 
     let results = pic_setup.update::<Vec<CustomToken>>(another_caller, "list_custom_tokens", ());
 
@@ -565,6 +575,7 @@ fn test_set_custom_token_tracks_activity() {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let stats_before = pic_setup
         .query::<Stats>(controller(), "stats", ())
@@ -588,6 +599,7 @@ fn test_set_many_custom_tokens_tracks_activity() {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let tokens: Vec<CustomToken> = vec![USER_TOKEN.clone(), ANOTHER_USER_TOKEN.clone()];
 
@@ -607,6 +619,7 @@ fn test_set_custom_token_updates_activity_for_same_token() {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     pic_setup
         .update::<()>(caller, "set_custom_token", USER_TOKEN.clone())

--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -165,6 +165,29 @@ fn test_get_allowed_cycles_requires_authenticated_user() {
     );
 }
 
+/// Sanity check for the `caller_is_registered_user` guard: a non-anonymous
+/// caller that has not created a user profile must be rejected by the guard
+/// *before* any endpoint logic runs. Without this test, dropping the guard
+/// from a user-keyed endpoint would go unnoticed, because every other test
+/// calls `create_user_profile`/`ensure_user_profile` up front.
+#[test]
+fn test_get_allowed_cycles_requires_registered_user() {
+    let pic_setup = setup_with_cycles_ledger();
+    // Non-anonymous caller, but no user profile has been created.
+    let caller = Principal::from_text(USER_1).unwrap();
+
+    let response = pic_setup.update::<Result<GetAllowedCyclesResponse, GetAllowedCyclesError>>(
+        caller,
+        "get_allowed_cycles",
+        (),
+    );
+
+    assert_eq!(
+        response,
+        Err("Update call error. RejectionCode: CanisterReject, Error: Update call error. RejectionCode: CanisterReject, Error: Caller has no user profile. Please create a user profile first via `create_user_profile`.".to_string())
+    );
+}
+
 #[test]
 fn test_get_allowed_cycles_returns_correct_amount() {
     let pic_setup = setup_with_cycles_ledger();

--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -192,6 +192,7 @@ fn test_get_allowed_cycles_returns_correct_amount() {
 fn test_get_allowed_cycles_returns_zero_when_no_allowance() {
     let pic_setup = setup_with_cycles_ledger();
     let caller = Principal::from_text(USER_1).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     // Call get_allowed_cycles
     let result = call_get_allowed_cycles(&pic_setup, caller);
@@ -206,6 +207,7 @@ fn test_get_allowed_cycles_returns_correct_error_when_cycles_ledger_unavailable(
     // Regular setup without cycles ledger
     let pic_setup = setup();
     let caller = Principal::from_text(USER_1).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     // Call get_allowed_cycles - should fail since cycles ledger is not available
     let result = call_get_allowed_cycles(&pic_setup, caller);
@@ -562,6 +564,7 @@ fn test_allow_signing_guard_resets_independently_of_business_limiter() {
 fn test_allow_signing_requires_delegation_chain() {
     let pic_setup = setup();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let result = call_allow_signing_with_delegation(&pic_setup, caller, None);
 
@@ -578,6 +581,7 @@ fn test_allow_signing_requires_delegation_chain() {
 fn test_allow_signing_without_delegation_chain_passes_when_guard_disabled() {
     let pic_setup = setup_with_production_config();
     let caller = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(caller);
 
     let result = call_allow_signing_with_delegation(&pic_setup, caller, None);
 
@@ -593,6 +597,7 @@ fn test_allow_signing_without_delegation_chain_passes_when_guard_disabled() {
 #[test]
 fn test_allow_signing_controller_bypasses_delegation_check() {
     let pic_setup = setup();
+    pic_setup.ensure_user_profile(controller());
 
     let result = call_allow_signing_with_delegation(&pic_setup, controller(), None);
 
@@ -623,6 +628,7 @@ fn test_allow_signing_with_valid_delegation() {
     );
 
     let caller = Principal::self_authenticating(&delegation_chain.public_key);
+    pic_setup.ensure_user_profile(caller);
 
     let result = call_allow_signing_with_delegation(&pic_setup, caller, Some(delegation_chain));
 

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -9,7 +9,7 @@ pub use pic_canister::PicCanisterTrait;
 use pocket_ic::{PocketIc, PocketIcBuilder};
 use shared::types::{
     backend_config::{Arg, InitArg},
-    user_profile::{OisyUser, UserProfile},
+    user_profile::{HasUserProfileResponse, OisyUser, UserProfile},
 };
 
 use super::mock::{CONTROLLER, FRONTEND_DERIVATION_ORIGIN, II_CANISTER_ID, SIGNER_CANISTER_ID};
@@ -536,10 +536,25 @@ impl PicBackend {
     ///
     /// Most guarded update endpoints require the caller to already have a user
     /// profile, so tests that exercise such endpoints as an authenticated user
-    /// must first call `create_user_profile`. This helper is idempotent: the
-    /// `create_user_profile` endpoint itself returns the existing profile if
-    /// one exists, so callers can invoke this freely before each test action.
+    /// must first call `create_user_profile`.
+    ///
+    /// This helper is idempotent and designed to be safe to call repeatedly:
+    /// it first issues a `has_user_profile` query and only invokes the
+    /// `create_user_profile` update when the profile does not yet exist. This
+    /// avoids the side effects of `create_user_profile` (notably
+    /// `spawn_allow_signing_if_below_limit`, which consumes per-caller
+    /// rate-limit entries and spawns an inter-canister call) on repeated
+    /// invocations.
     pub fn ensure_user_profile(&self, caller: Principal) {
+        let exists = self
+            .query::<HasUserProfileResponse>(caller, "has_user_profile", ())
+            .expect("Failed to query has_user_profile")
+            .has_user_profile;
+
+        if exists {
+            return;
+        }
+
         let response = self.update::<UserProfile>(caller, "create_user_profile", ());
         assert!(
             response.is_ok(),

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -531,4 +531,19 @@ impl PicBackend {
         }
         expected_users
     }
+
+    /// Test helper that ensures the given `caller` has a user profile created.
+    ///
+    /// Most guarded update endpoints require the caller to already have a user
+    /// profile, so tests that exercise such endpoints as an authenticated user
+    /// must first call `create_user_profile`. This helper is idempotent: the
+    /// `create_user_profile` endpoint itself returns the existing profile if
+    /// one exists, so callers can invoke this freely before each test action.
+    pub fn ensure_user_profile(&self, caller: Principal) {
+        let response = self.update::<UserProfile>(caller, "create_user_profile", ());
+        assert!(
+            response.is_ok(),
+            "Failed to create user profile for caller {caller}: {response:?}"
+        );
+    }
 }


### PR DESCRIPTION
# Motivation

Authenticated update endpoints previously only checked that the caller wasn't anonymous, so a caller with no user profile could still hit endpoints that implicitly assume one exists: some returned `UserNotFound`, others would happily create per-user state keyed to a principal that was never registered. This introduces a single guard, `caller_is_registered_user`, that rejects such calls at the canister boundary while still letting new users sign up via `create_user_profile`.

Controllers are intentionally not exempt: these endpoints are user-facing and their state is keyed to the caller principal, so a controller without a profile isn't a "registered user" either. Administrative endpoints already have dedicated guards (`caller_is_controller`, `caller_is_allowed`) and are untouched.

# Changes

- Add `caller_is_registered_user` in `src/backend/src/utils/guards.rs` (not-anonymous + profile-exists).
- Apply it to all authenticated `#[update]` methods except `create_user_profile`:
  - `user_profile.rs` (settings, agreements, provider agreements, dapp, notifications, experimental features, transaction filter)
  - `signer.rs` (`get_allowed_cycles`, `allow_signing`)
  - `bitcoin.rs` (`btc_select_user_utxos_fee`, `btc_add_pending_transaction`, `btc_get_pending_transactions`)
  - `transactions.rs` (`save_user_transactions`)
  - `custom_tokens.rs` (`set_custom_token`, `set_many_custom_tokens`, `remove_custom_token`, `list_custom_tokens`)
  - `contacts.rs` (`create_contact`, `update_contact`, `delete_contact`)

# Tests

New tests and adapted.
