### PR TITLE
feat(backend)!: add `new_user_signups_allowed` config flag and public query

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -151,7 +151,8 @@ type Config = record {
 	ecdsa_key_name : text;
 	cfs_canister_id : opt principal;
 	allowed_callers : vec principal;
-	ic_root_key_raw : opt blob
+	ic_root_key_raw : opt blob;
+	new_user_signups_allowed : opt bool
 };
 type Contact = record {
 	id : nat64;
@@ -323,7 +324,8 @@ type InitArg = record {
 	ecdsa_key_name : text;
 	cfs_canister_id : opt principal;
 	allowed_callers : vec principal;
-	ic_root_key_der : opt blob
+	ic_root_key_der : opt blob;
+	new_user_signups_allowed : opt bool
 };
 type Network = variant { mainnet; regtest; testnet };
 type NetworkSettings = record { enabled : bool; is_testnet : bool };
@@ -770,6 +772,11 @@ service : (Arg) -> {
 	// - Integrations that previously relied on query semantics must be updated to invoke this as an
 	// update method.
 	list_custom_tokens : () -> (vec CustomToken);
+	// Returns whether sign-ups of new users are currently allowed.
+	//
+	// Exposed as an unauthenticated query so the landing page can display an info banner before the
+	// user signs in.
+	new_user_signups_allowed : () -> (bool) query;
 	// Remove custom token for the user.
 	remove_custom_token : (CustomToken) -> ();
 	// Saves finalized transactions for the caller. Transactions are deduplicated by hash.

--- a/src/backend/src/api/user_profile.rs
+++ b/src/backend/src/api/user_profile.rs
@@ -18,7 +18,7 @@ use shared::types::{
 };
 
 use crate::{
-    state::{mutate_state, read_state},
+    state::{self, mutate_state, read_state},
     types::StoredPrincipal,
     user_profile::{model::UserProfileModel, service},
     utils::{
@@ -331,6 +331,16 @@ pub fn create_user_profile() -> UserProfile {
     spawn_allow_signing_if_below_limit(stored_principal);
 
     user_profile
+}
+
+/// Returns whether sign-ups of new users are currently allowed.
+///
+/// Exposed as an unauthenticated query so the landing page can display an info banner before the
+/// user signs in.
+#[query]
+#[must_use]
+pub fn new_user_signups_allowed() -> bool {
+    state::read_new_user_signups_allowed()
 }
 
 /// Returns the caller's user profile.

--- a/src/backend/src/state/mod.rs
+++ b/src/backend/src/state/mod.rs
@@ -114,6 +114,17 @@ pub(crate) fn set_config(arg: InitArg) {
     });
 }
 
+/// Returns whether sign-ups of new users are currently allowed.
+///
+/// An unset (`None`) flag is treated as "allowed" to preserve the behaviour of canisters whose
+/// config was persisted before this field existed.
+///
+/// # Panics
+/// - If the `STATE.config` is not initialized.
+pub(crate) fn read_new_user_signups_allowed() -> bool {
+    read_config(|c| c.new_user_signups_allowed.unwrap_or(true))
+}
+
 pub(crate) fn with_api_keys<R>(f: impl FnOnce(&ApiKeys) -> R) -> R {
     read_state(|state| {
         let default = ApiKeys::default();

--- a/src/backend/tests/it/user_profile.rs
+++ b/src/backend/tests/it/user_profile.rs
@@ -126,3 +126,17 @@ fn test_exists_profile_should_return_false_if_profile_not_exists() {
             .has_user_profile
     );
 }
+
+#[test]
+fn test_new_user_signups_allowed_defaults_to_true() {
+    let pic_setup = setup();
+
+    let caller = Principal::from_text(CALLER).unwrap();
+
+    let response = pic_setup.query::<bool>(caller, "new_user_signups_allowed", ());
+
+    assert_eq!(
+        response.expect("Call to new_user_signups_allowed failed"),
+        true
+    );
+}

--- a/src/backend/tests/it/utils/pocketic.rs
+++ b/src/backend/tests/it/utils/pocketic.rs
@@ -413,6 +413,7 @@ pub fn setup_with_ii() -> (PicBackend, super::ii::IICanister) {
         ),
         derivation_origin: Some(FRONTEND_DERIVATION_ORIGIN.to_string()),
         ii_canister_id: Some(ii_canister_id),
+        new_user_signups_allowed: None,
     });
 
     let mut builder = BackendBuilder::default().with_arg(encode_one(backend_init).unwrap());
@@ -485,6 +486,7 @@ fn init_arg_with_ecdsa_key(ecdsa_key_name: &str) -> Arg {
         ),
         derivation_origin: Some(FRONTEND_DERIVATION_ORIGIN.to_string()),
         ii_canister_id: Some(Principal::from_text(II_CANISTER_ID).expect("wrong ii canister id")),
+        new_user_signups_allowed: None,
     })
 }
 

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -160,6 +160,7 @@ export interface Config {
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
 	ic_root_key_raw: [] | [Uint8Array];
+	new_user_signups_allowed: [] | [boolean];
 }
 export interface Contact {
 	id: bigint;
@@ -350,6 +351,7 @@ export interface InitArg {
 	cfs_canister_id: [] | [Principal];
 	allowed_callers: Array<Principal>;
 	ic_root_key_der: [] | [Uint8Array];
+	new_user_signups_allowed: [] | [boolean];
 }
 export type Network = { mainnet: null } | { regtest: null } | { testnet: null };
 export interface NetworkSettings {
@@ -856,6 +858,13 @@ export interface _SERVICE {
 	 * update method.
 	 */
 	list_custom_tokens: ActorMethod<[], Array<CustomToken>>;
+	/**
+	 * Returns whether sign-ups of new users are currently allowed.
+	 *
+	 * Exposed as an unauthenticated query so the landing page can display an info banner before the
+	 * user signs in.
+	 */
+	new_user_signups_allowed: ActorMethod<[], boolean>;
 	/**
 	 * Remove custom token for the user.
 	 */

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -13,7 +13,8 @@ export const idlFactory = ({ IDL }) => {
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		new_user_signups_allowed: IDL.Opt(IDL.Bool)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 	const QualifiedNotificationKind = IDL.Variant({
@@ -207,7 +208,8 @@ export const idlFactory = ({ IDL }) => {
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		new_user_signups_allowed: IDL.Opt(IDL.Bool)
 	});
 	const ImageMimeType = IDL.Variant({
 		'image/gif': IDL.Null,
@@ -701,6 +703,7 @@ export const idlFactory = ({ IDL }) => {
 		http_request: IDL.Func([HttpRequest], [HttpResponse]),
 		http_request_transform: IDL.Func([TransformArgs], [HttpRequestResult]),
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)], []),
+		new_user_signups_allowed: IDL.Func([], [IDL.Bool]),
 		remove_custom_token: IDL.Func([CustomToken], [], []),
 		save_user_transactions: IDL.Func(
 			[SaveUserTransactionsRequest],
@@ -753,7 +756,8 @@ export const init = ({ IDL }) => {
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		new_user_signups_allowed: IDL.Opt(IDL.Bool)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -13,7 +13,8 @@ export const idlFactory = ({ IDL }) => {
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		new_user_signups_allowed: IDL.Opt(IDL.Bool)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 	const QualifiedNotificationKind = IDL.Variant({
@@ -207,7 +208,8 @@ export const idlFactory = ({ IDL }) => {
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		new_user_signups_allowed: IDL.Opt(IDL.Bool)
 	});
 	const ImageMimeType = IDL.Variant({
 		'image/gif': IDL.Null,
@@ -711,6 +713,7 @@ export const idlFactory = ({ IDL }) => {
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		http_request_transform: IDL.Func([TransformArgs], [HttpRequestResult], ['query']),
 		list_custom_tokens: IDL.Func([], [IDL.Vec(CustomToken)], []),
+		new_user_signups_allowed: IDL.Func([], [IDL.Bool], ['query']),
 		remove_custom_token: IDL.Func([CustomToken], [], []),
 		save_user_transactions: IDL.Func(
 			[SaveUserTransactionsRequest],
@@ -763,7 +766,8 @@ export const init = ({ IDL }) => {
 		ecdsa_key_name: IDL.Text,
 		cfs_canister_id: IDL.Opt(IDL.Principal),
 		allowed_callers: IDL.Vec(IDL.Principal),
-		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8))
+		ic_root_key_der: IDL.Opt(IDL.Vec(IDL.Nat8)),
+		new_user_signups_allowed: IDL.Opt(IDL.Bool)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
 

--- a/src/shared/src/impls.rs
+++ b/src/shared/src/impls.rs
@@ -171,6 +171,7 @@ impl From<InitArg> for Config {
             cfs_canister_id,
             derivation_origin,
             ii_canister_id,
+            new_user_signups_allowed,
         } = arg;
         let ic_root_key_raw = match extract_raw_root_pk_from_der(
             &ic_root_key_der.unwrap_or_else(|| IC_ROOT_PK_DER.to_vec()),
@@ -185,6 +186,7 @@ impl From<InitArg> for Config {
             ic_root_key_raw: Some(ic_root_key_raw),
             derivation_origin,
             ii_canister_id,
+            new_user_signups_allowed,
         }
     }
 }

--- a/src/shared/src/types/backend_config.rs
+++ b/src/shared/src/types/backend_config.rs
@@ -18,6 +18,14 @@ pub struct InitArg {
     pub derivation_origin: Option<String>,
     /// The Internet Identity canister used for delegation verification.
     pub ii_canister_id: Option<Principal>,
+    /// Whether sign-ups of new users (i.e. new user profiles) are allowed.
+    ///
+    /// When `Some(false)`, `create_user_profile` rejects callers that do not already have a
+    /// profile with `CreateUserProfileError::SignupsClosed`. Existing users are unaffected.
+    ///
+    /// `None` is treated as "allowed" (the default), ensuring backward compatibility with
+    /// deployments that pre-date this field.
+    pub new_user_signups_allowed: Option<bool>,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -42,4 +50,9 @@ pub struct Config {
     pub derivation_origin: Option<String>,
     /// The Internet Identity canister used for delegation verification.
     pub ii_canister_id: Option<Principal>,
+    /// Whether sign-ups of new users (i.e. new user profiles) are allowed.
+    ///
+    /// `None` is treated as "allowed" (the default), ensuring backward compatibility with
+    /// config payloads persisted before this field existed.
+    pub new_user_signups_allowed: Option<bool>,
 }


### PR DESCRIPTION
## Motivation

Foundation for pausing sign-ups of new users: adds the config flag and a public read endpoint. No-op at runtime (flag defaults to allowed, nothing gates on it yet).

Follow-ups (separate PRs): gate `create_user_profile`, controller-only setter, frontend UI.

BREAKING CHANGE: New method `new_user_signups_allowed`.

## Changes

- `InitArg` / `Config`: new `new_user_signups_allowed: Option<bool>` (defaults to "allowed" when `None`, so existing deployments upgrade cleanly).
- `state::read_new_user_signups_allowed()` helper.
- New public `new_user_signups_allowed : () -> (bool) query` endpoint.

## Tests

Added tests.
