### PR TITLE
chore(frontend): add memory consumption A/B test flags

### DIFF
--- a/MEMORY_TEST_FLAGS.md
+++ b/MEMORY_TEST_FLAGS.md
@@ -1,0 +1,217 @@
+# Memory consumption — analysis and A/B test flags
+
+This document accompanies the test branch
+`chore-frontend/memory-consumption-test-flags` (PR
+[#12578](https://github.com/dfinity/oisy-wallet/pull/12578)). The branch
+is **not intended for `main`** — it exists only so we can A/B four
+candidate memory fixes against the current behavior.
+
+---
+
+## Reported symptom
+
+For users with many tokens (~50) and many transactions (~500), oisy's
+in-browser memory consumption climbs to roughly 1 GB, and **roughly
+doubles right after a hard reload** (peaking near 2 GB) before settling
+back down.
+
+The doubling pattern is consistent with two generations of state being
+live at once during init — the previous page's allocations are still
+reachable while the new page is rebuilding its world.
+
+---
+
+## Initial code-level analysis
+
+Findings from a read-only audit of `src/frontend/src/`.
+
+### 1. `transactions.store.ts` — per-token spread-merge on every update
+
+[src/frontend/src/lib/stores/transactions.store.ts](src/frontend/src/lib/stores/transactions.store.ts)
+
+Every method (`set`, `add`, `prepend`, `append`, `update`, `cleanUp`,
+`nullify`) does:
+
+```ts
+update((state) => ({
+    ...(nonNullish(state) && state),
+    [tokenId]: [...(state?.[tokenId] ?? []), ...transactions]
+}));
+```
+
+For 50 tokens × ~500 transactions, every wallet event allocates a fresh
+N-item array. On reload, all per-token workers fire near-simultaneously,
+so this fires across ~50 tokens at once.
+
+**Severity:** likely-major.
+
+### 2. `ic-transactions.derived.ts` — derived store with 9 inputs and full re-flatten
+
+[src/frontend/src/icp/derived/ic-transactions.derived.ts](src/frontend/src/icp/derived/ic-transactions.derived.ts)
+
+`icTransactions` depends on 9 stores. Any change to any of them rebuilds
+the flattened array via `getAllIcTransactions(...)`, which spreads
+pending ckBTC + pending ckETH + extended transactions into a fresh
+array. Each rebuild also runs `getIcExtendedTransactions(...)` which maps
+and creates new objects.
+
+**Severity:** likely-major.
+
+### 3. `exchange.store.ts` — `reduce`-with-spread to merge prices
+
+[src/frontend/src/lib/stores/exchange.store.ts](src/frontend/src/lib/stores/exchange.store.ts)
+
+```ts
+...tokensPrice.reduce(
+    (acc, price) => ({ ...acc, ...price }),
+    {}
+)
+```
+
+This is O(n) intermediate object allocations per refresh. With ~50
+tokens and a 30–60 s refresh cadence, it's sustained pressure.
+
+**Severity:** likely-major (cheap to fix, easy attribution).
+
+### 4. `worker.icrc-wallet.services.ts` — one Web Worker per token on non-iOS
+
+[src/frontend/src/icp/services/worker.icrc-wallet.services.ts:88](src/frontend/src/icp/services/worker.icrc-wallet.services.ts#L88)
+
+```ts
+const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
+```
+
+iOS already runs a single shared worker. On every other platform each
+ICRC token spawns its own `AppWorker` — for 50 tokens that's ~50 worker
+contexts, each with its own agent, identity, queue and scheduler. The
+existing `if (ref !== this.ledgerCanisterId) return;` guard inside the
+onMessage handler already makes a singleton worker safe.
+
+**Severity:** likely-major. Possibly the biggest single lever.
+
+### Why the post-reload spike
+
+Two effects compound during init:
+- **All workers boot simultaneously** → 50 derived recomputes hit at
+  once, each allocating 500-tx arrays in 2–3 forms (raw, parsed,
+  display).
+- **agent-js's `AgentManager` singleton** keeps cached agents reachable
+  across the boundary, so the previous page's memory hasn't been GCed
+  yet when the new page initializes its own.
+
+---
+
+## Items considered but not addressed in this PR
+
+For scope reasons we agreed to skip:
+
+- **Transaction list virtualization** — would require swapping the
+  rendering tree (`{#if flag}` around two `{#each}` blocks). Memory cost
+  is comparatively small (~1–2 MB for 500 DOM nodes).
+- **agent-js / reload cleanup** — a `beforeunload` reset of cached
+  agents could help the spike, but the effect is speculative until
+  measured. Treated as a follow-up.
+
+---
+
+## Approach we agreed on
+
+Four fixes, each behind its own runtime feature flag.
+
+- **Default: all flags off** → behavior on this branch matches `main`.
+- **Toggle at runtime** via URL param, persisted to `localStorage` —
+  no rebuild required between measurement runs.
+- **One commit per fix** for clean isolation; the prep commit adds the
+  flag mechanism.
+- **Code style is intentionally pragmatic** (`if (FLAG) { new path }
+  else { original }`). This branch does not need to be production-ready
+  because it does not aim to land.
+
+| # | Flag constant | File | What changes when enabled |
+|---|---|---|---|
+| 1 | `MEMORY_FIX_TRANSACTIONS_STORE` | [transactions.store.ts](src/frontend/src/lib/stores/transactions.store.ts) | Mutate the per-token array in place (push / unshift / in-place filter) and shallow-copy only the outer object for Svelte reactivity. |
+| 2 | `MEMORY_FIX_IC_TRANSACTIONS_DERIVED` | [ic-transactions.derived.ts](src/frontend/src/icp/derived/ic-transactions.derived.ts) | Memoize on the 9 input references; if all inputs are reference-equal to the previous call, return the cached result. |
+| 3 | `MEMORY_FIX_EXCHANGE_STORE` | [exchange.store.ts](src/frontend/src/lib/stores/exchange.store.ts) | Replace the `reduce`-with-spread merge with a single-pass `Object.assign` into one accumulator. |
+| 4 | `MEMORY_FIX_WORKER_SINGLETON` | [worker.icrc-wallet.services.ts](src/frontend/src/icp/services/worker.icrc-wallet.services.ts) | Pass `asSingleton: true` on non-iOS too — all ICRC tokens share one `AppWorker`. The per-message `ledgerCanisterId` guard already handles routing. |
+
+---
+
+## How to set the flags
+
+The flag mechanism lives at
+[src/frontend/src/lib/utils/memory-flags.utils.ts](src/frontend/src/lib/utils/memory-flags.utils.ts).
+It reads once at app startup, in this order:
+
+1. If the URL contains `?memFlags=...`, that value is used **and**
+   written to `localStorage` under `oisy.memFlags`.
+2. Otherwise the value already in `localStorage` is used.
+3. Otherwise no flags are enabled.
+
+So you only have to set the URL once per profile — reloads keep the
+configuration, which is what we need to measure the post-reload spike.
+
+### URL param syntax
+
+| URL | Result |
+|---|---|
+| (no `memFlags` param) | leaves whatever is currently in `localStorage` |
+| `?memFlags=` (empty value) | clears all flags |
+| `?memFlags=4` | enables only flag 4 |
+| `?memFlags=1,3` | enables flags 1 and 3 |
+| `?memFlags=1,2,3,4` | enables all four |
+| `?memFlags=all` | enables all four (alias) |
+
+When at least one flag is on, the console logs `[memFlags] enabled: ...`
+at startup so you can confirm the setup before profiling.
+
+### Clearing flags
+
+Either visit any page with `?memFlags=` (empty), or run in DevTools:
+
+```js
+localStorage.removeItem('oisy.memFlags');
+```
+
+Then hard-reload.
+
+---
+
+## Suggested measurement protocol
+
+The goal is to attribute baseline savings to specific fixes and to see
+which of them blunts the post-reload spike. Heap snapshots before and
+**immediately after a hard reload** are the most informative — that's
+where the doubling shows up.
+
+1. **Baseline.** Open the app with `?memFlags=` (cleared). Reproduce the
+   50-token / 500-transaction scenario. Snapshot before reload, hard
+   reload, snapshot again at the spike, snapshot once it settles.
+2. **Each flag alone.** Repeat step 1 with `?memFlags=N` for each of
+   `1`, `2`, `3`, `4`. This isolates each fix.
+3. **Combined.** Repeat step 1 with `?memFlags=all`.
+
+Notes:
+- Flag 4 (singleton worker) is most likely the largest single drop in
+  baseline; it's also the cheapest to enable.
+- Flag 2 alone is expected to show little impact, because upstream
+  stores still emit new top-level references on every update. The
+  most interesting pairing is **1 + 2**, where #1 stops emitting new
+  inner-array references and #2's memoization can actually hit.
+- Flag 3's impact will scale with how often exchange rates refresh.
+
+---
+
+## Caveats / things to watch for
+
+- **Flag 1** mutates the inner per-token array. Anything that captures
+  that inner array reference and reads it later asynchronously (e.g.
+  inside a `setTimeout`) could see mutations. The audit didn't find
+  such a consumer, but it's worth keeping in mind during measurement.
+- **Flag 2** uses reference-equality memoization only. With current
+  upstream stores it rarely hits its cache. The flag's value is mainly
+  in confirming whether the derived's recompute itself is on the hot
+  path.
+- **Flag 4** changes the threading layout. The
+  `if (ref !== this.ledgerCanisterId) return;` guard inside
+  `IcrcWalletWorker.setOnMessage` is what makes the singleton path
+  correct — review that handler if anything looks off in the data.

--- a/MEMORY_TEST_FLAGS.md
+++ b/MEMORY_TEST_FLAGS.md
@@ -109,19 +109,25 @@ For scope reasons we agreed to skip:
 - **Transaction list virtualization** — would require swapping the
   rendering tree (`{#if flag}` around two `{#each}` blocks). Memory cost
   is comparatively small (~1–2 MB for 500 DOM nodes).
-- **agent-js / reload cleanup** — a `beforeunload` reset of cached
-  agents could help the spike, but the effect is speculative until
-  measured. Treated as a follow-up.
+
+> **Update:** the `agent-js` / reload cleanup item that we initially
+> deferred was added later as flag 5 after measurements showed the
+> spike still grows reload-over-reload even with flags 1–4 on. See the
+> table below.
 
 ---
 
 ## Approach we agreed on
 
-Four fixes, each behind its own runtime feature flag.
+Five fixes, each behind its own runtime feature flag.
 
 - **Default: all flags off** → behavior on this branch matches `main`.
 - **Toggle at runtime** via URL param, persisted to `localStorage` —
   no rebuild required between measurement runs.
+- **Active flag set is shown in the footer** next to the Twitter and
+  GitHub icons (e.g. `memFlags: 1,3,4` or `memFlags: none`), so the
+  configuration is visually verifiable on every page without opening
+  DevTools.
 - **One commit per fix** for clean isolation; the prep commit adds the
   flag mechanism.
 - **Code style is intentionally pragmatic** (`if (FLAG) { new path }
@@ -160,8 +166,8 @@ configuration, which is what we need to measure the post-reload spike.
 | `?memFlags=` (empty value) | clears all flags                               |
 | `?memFlags=4`              | enables only flag 4                            |
 | `?memFlags=1,3`            | enables flags 1 and 3                          |
-| `?memFlags=1,2,3,4`        | enables all four                               |
-| `?memFlags=all`            | enables all four (alias)                       |
+| `?memFlags=1,2,3,4,5`      | enables all flags                              |
+| `?memFlags=all`            | enables all flags (alias)                      |
 
 When at least one flag is on, the console logs `[memFlags] enabled: ...`
 at startup so you can confirm the setup before profiling.
@@ -189,7 +195,7 @@ where the doubling shows up.
    50-token / 500-transaction scenario. Snapshot before reload, hard
    reload, snapshot again at the spike, snapshot once it settles.
 2. **Each flag alone.** Repeat step 1 with `?memFlags=N` for each of
-   `1`, `2`, `3`, `4`. This isolates each fix.
+   `1`, `2`, `3`, `4`, `5`. This isolates each fix.
 3. **Combined.** Repeat step 1 with `?memFlags=all`.
 
 Notes:
@@ -201,6 +207,10 @@ Notes:
   most interesting pairing is **1 + 2**, where #1 stops emitting new
   inner-array references and #2's memoization can actually hit.
 - Flag 3's impact will scale with how often exchange rates refresh.
+- Flag 5 targets the reload-over-reload accumulation specifically —
+  it should not move the first-load baseline, only the spike on
+  subsequent reloads. The most informative pairing for the spike is
+  **4 + 5**.
 
 ---
 
@@ -218,3 +228,13 @@ Notes:
   `if (ref !== this.ledgerCanisterId) return;` guard inside
   `IcrcWalletWorker.setOnMessage` is what makes the singleton path
   correct — review that handler if anything looks off in the data.
+- **Flag 5** runs cleanup synchronously inside `beforeunload` /
+  `pagehide`. The browser doesn't reliably wait for async work in
+  those events, so the cleanup is intentionally sync (worker
+  terminate + agent reset). The agent reset is best-effort —
+  `@dfinity/utils`'s `AgentManager` doesn't expose a documented reset
+  API, so the cleanup probes a few likely method names (`reset`,
+  `clear`, `destroy`, `reinitialize`) and corresponding cache fields,
+  and silently skips any that don't exist. When the cleanup runs, the
+  console logs `[memFlags#5] running pre-unload cleanup` — useful to
+  confirm it actually fired.

--- a/MEMORY_TEST_FLAGS.md
+++ b/MEMORY_TEST_FLAGS.md
@@ -34,8 +34,8 @@ Every method (`set`, `add`, `prepend`, `append`, `update`, `cleanUp`,
 
 ```ts
 update((state) => ({
-    ...(nonNullish(state) && state),
-    [tokenId]: [...(state?.[tokenId] ?? []), ...transactions]
+	...(nonNullish(state) && state),
+	[tokenId]: [...(state?.[tokenId] ?? []), ...transactions]
 }));
 ```
 
@@ -92,6 +92,7 @@ onMessage handler already makes a singleton worker safe.
 ### Why the post-reload spike
 
 Two effects compound during init:
+
 - **All workers boot simultaneously** → 50 derived recomputes hit at
   once, each allocating 500-tx arrays in 2–3 forms (raw, parsed,
   display).
@@ -124,15 +125,15 @@ Four fixes, each behind its own runtime feature flag.
 - **One commit per fix** for clean isolation; the prep commit adds the
   flag mechanism.
 - **Code style is intentionally pragmatic** (`if (FLAG) { new path }
-  else { original }`). This branch does not need to be production-ready
+else { original }`). This branch does not need to be production-ready
   because it does not aim to land.
 
-| # | Flag constant | File | What changes when enabled |
-|---|---|---|---|
-| 1 | `MEMORY_FIX_TRANSACTIONS_STORE` | [transactions.store.ts](src/frontend/src/lib/stores/transactions.store.ts) | Mutate the per-token array in place (push / unshift / in-place filter) and shallow-copy only the outer object for Svelte reactivity. |
-| 2 | `MEMORY_FIX_IC_TRANSACTIONS_DERIVED` | [ic-transactions.derived.ts](src/frontend/src/icp/derived/ic-transactions.derived.ts) | Memoize on the 9 input references; if all inputs are reference-equal to the previous call, return the cached result. |
-| 3 | `MEMORY_FIX_EXCHANGE_STORE` | [exchange.store.ts](src/frontend/src/lib/stores/exchange.store.ts) | Replace the `reduce`-with-spread merge with a single-pass `Object.assign` into one accumulator. |
-| 4 | `MEMORY_FIX_WORKER_SINGLETON` | [worker.icrc-wallet.services.ts](src/frontend/src/icp/services/worker.icrc-wallet.services.ts) | Pass `asSingleton: true` on non-iOS too — all ICRC tokens share one `AppWorker`. The per-message `ledgerCanisterId` guard already handles routing. |
+| #   | Flag constant                        | File                                                                                           | What changes when enabled                                                                                                                          |
+| --- | ------------------------------------ | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `MEMORY_FIX_TRANSACTIONS_STORE`      | [transactions.store.ts](src/frontend/src/lib/stores/transactions.store.ts)                     | Mutate the per-token array in place (push / unshift / in-place filter) and shallow-copy only the outer object for Svelte reactivity.               |
+| 2   | `MEMORY_FIX_IC_TRANSACTIONS_DERIVED` | [ic-transactions.derived.ts](src/frontend/src/icp/derived/ic-transactions.derived.ts)          | Memoize on the 9 input references; if all inputs are reference-equal to the previous call, return the cached result.                               |
+| 3   | `MEMORY_FIX_EXCHANGE_STORE`          | [exchange.store.ts](src/frontend/src/lib/stores/exchange.store.ts)                             | Replace the `reduce`-with-spread merge with a single-pass `Object.assign` into one accumulator.                                                    |
+| 4   | `MEMORY_FIX_WORKER_SINGLETON`        | [worker.icrc-wallet.services.ts](src/frontend/src/icp/services/worker.icrc-wallet.services.ts) | Pass `asSingleton: true` on non-iOS too — all ICRC tokens share one `AppWorker`. The per-message `ledgerCanisterId` guard already handles routing. |
 
 ---
 
@@ -152,14 +153,14 @@ configuration, which is what we need to measure the post-reload spike.
 
 ### URL param syntax
 
-| URL | Result |
-|---|---|
-| (no `memFlags` param) | leaves whatever is currently in `localStorage` |
-| `?memFlags=` (empty value) | clears all flags |
-| `?memFlags=4` | enables only flag 4 |
-| `?memFlags=1,3` | enables flags 1 and 3 |
-| `?memFlags=1,2,3,4` | enables all four |
-| `?memFlags=all` | enables all four (alias) |
+| URL                        | Result                                         |
+| -------------------------- | ---------------------------------------------- |
+| (no `memFlags` param)      | leaves whatever is currently in `localStorage` |
+| `?memFlags=` (empty value) | clears all flags                               |
+| `?memFlags=4`              | enables only flag 4                            |
+| `?memFlags=1,3`            | enables flags 1 and 3                          |
+| `?memFlags=1,2,3,4`        | enables all four                               |
+| `?memFlags=all`            | enables all four (alias)                       |
 
 When at least one flag is on, the console logs `[memFlags] enabled: ...`
 at startup so you can confirm the setup before profiling.
@@ -191,6 +192,7 @@ where the doubling shows up.
 3. **Combined.** Repeat step 1 with `?memFlags=all`.
 
 Notes:
+
 - Flag 4 (singleton worker) is most likely the largest single drop in
   baseline; it's also the cheapest to enable.
 - Flag 2 alone is expected to show little impact, because upstream

--- a/MEMORY_TEST_FLAGS.md
+++ b/MEMORY_TEST_FLAGS.md
@@ -134,6 +134,7 @@ else { original }`). This branch does not need to be production-ready
 | 2   | `MEMORY_FIX_IC_TRANSACTIONS_DERIVED` | [ic-transactions.derived.ts](src/frontend/src/icp/derived/ic-transactions.derived.ts)          | Memoize on the 9 input references; if all inputs are reference-equal to the previous call, return the cached result.                               |
 | 3   | `MEMORY_FIX_EXCHANGE_STORE`          | [exchange.store.ts](src/frontend/src/lib/stores/exchange.store.ts)                             | Replace the `reduce`-with-spread merge with a single-pass `Object.assign` into one accumulator.                                                    |
 | 4   | `MEMORY_FIX_WORKER_SINGLETON`        | [worker.icrc-wallet.services.ts](src/frontend/src/icp/services/worker.icrc-wallet.services.ts) | Pass `asSingleton: true` on non-iOS too — all ICRC tokens share one `AppWorker`. The per-message `ledgerCanisterId` guard already handles routing. |
+| 5   | `MEMORY_FIX_RELOAD_CLEANUP`          | [memory-reload-cleanup.utils.ts](src/frontend/src/lib/utils/memory-reload-cleanup.utils.ts)    | On `beforeunload` / `pagehide`, terminate the singleton `AppWorker` and best-effort reset the `AgentManager` cache. Targets the post-reload accumulation pattern (memory growing reload-over-reload). |
 
 ---
 

--- a/src/frontend/src/icp/derived/ic-transactions.derived.ts
+++ b/src/frontend/src/icp/derived/ic-transactions.derived.ts
@@ -13,6 +13,7 @@ import { tokens } from '$lib/derived/tokens.derived';
 import type { TokenId } from '$lib/types/token';
 import type { AnyTransactionUiWithToken } from '$lib/types/transaction-ui';
 import type { KnownDestinations } from '$lib/types/transactions';
+import { MEMORY_FIX_IC_TRANSACTIONS_DERIVED } from '$lib/utils/memory-flags.utils';
 import { getKnownDestinations } from '$lib/utils/transactions.utils';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
@@ -27,6 +28,10 @@ const icExtendedTransactions: Readable<NonNullable<IcTransactionsData>> = derive
 		})
 );
 
+let icTransactionsMemo:
+	| { inputs: readonly unknown[]; result: NonNullable<IcTransactionsData> }
+	| undefined;
+
 export const icTransactions: Readable<NonNullable<IcTransactionsData>> = derived(
 	[
 		tokenWithFallback,
@@ -39,18 +44,29 @@ export const icTransactions: Readable<NonNullable<IcTransactionsData>> = derived
 		icPendingTransactionsStore,
 		icTransactionsStore
 	],
-	([
-		$token,
-		$ckBtcPendingUtxoTransactions,
-		$ckEthPendingTransactions,
-		$icExtendedTransactions,
-		$btcStatusesStore,
-		$ckBtcMinterInfoStore,
-		$ckBtcPendingUtxosStore,
-		$icPendingTransactionsStore,
-		$icTransactionsStore
-	]) =>
-		getAllIcTransactions({
+	($values) => {
+		if (
+			MEMORY_FIX_IC_TRANSACTIONS_DERIVED &&
+			icTransactionsMemo !== undefined &&
+			icTransactionsMemo.inputs.length === $values.length &&
+			icTransactionsMemo.inputs.every((v, i) => v === $values[i])
+		) {
+			return icTransactionsMemo.result;
+		}
+
+		const [
+			$token,
+			$ckBtcPendingUtxoTransactions,
+			$ckEthPendingTransactions,
+			$icExtendedTransactions,
+			$btcStatusesStore,
+			$ckBtcMinterInfoStore,
+			$ckBtcPendingUtxosStore,
+			$icPendingTransactionsStore,
+			$icTransactionsStore
+		] = $values;
+
+		const result = getAllIcTransactions({
 			token: $token,
 			ckBtcPendingUtxoTransactions: $ckBtcPendingUtxoTransactions,
 			ckBtcPendingUtxosStore: $ckBtcPendingUtxosStore,
@@ -60,7 +76,14 @@ export const icTransactions: Readable<NonNullable<IcTransactionsData>> = derived
 			icPendingTransactionsStore: $icPendingTransactionsStore,
 			icExtendedTransactions: $icExtendedTransactions,
 			icTransactionsStore: $icTransactionsStore
-		})
+		});
+
+		if (MEMORY_FIX_IC_TRANSACTIONS_DERIVED) {
+			icTransactionsMemo = { inputs: [...$values], result };
+		}
+
+		return result;
+	}
 );
 
 export const icKnownDestinations: Readable<KnownDestinations> = derived(

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -16,6 +16,7 @@ import type {
 } from '$lib/types/post-message';
 import type { TokenId } from '$lib/types/token';
 import type { WorkerData } from '$lib/types/worker';
+import { MEMORY_FIX_WORKER_SINGLETON } from '$lib/utils/memory-flags.utils';
 import { isIOS } from '@dfinity/gix-components';
 import { nonNullish } from '@dfinity/utils';
 
@@ -85,7 +86,9 @@ export class IcrcWalletWorker extends AppWorker implements WalletWorker {
 	}: IcToken): Promise<IcrcWalletWorker> {
 		await syncWalletFromCache({ tokenId, networkId });
 
-		const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
+		const worker = await AppWorker.getInstance({
+			asSingleton: MEMORY_FIX_WORKER_SINGLETON || isIOS()
+		});
 		return new IcrcWalletWorker(worker, tokenId, ledgerCanisterId, indexCanisterId, env);
 	}
 

--- a/src/frontend/src/lib/actors/agents.ic.ts
+++ b/src/frontend/src/lib/actors/agents.ic.ts
@@ -1,6 +1,6 @@
 import { LOCAL, REPLICA_HOST } from '$lib/constants/app.constants';
 import { AgentManager } from '@dfinity/utils';
 
-const agents = AgentManager.create({ fetchRootKey: LOCAL, host: REPLICA_HOST });
+export const agents = AgentManager.create({ fetchRootKey: LOCAL, host: REPLICA_HOST });
 
 export const { getAgent } = agents;

--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -12,6 +12,7 @@
 	import { authNotSignedIn, authSignedIn } from '$lib/derived/auth.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+	import { MEMORY_FIX_ACTIVE_FLAGS } from '$lib/utils/memory-flags.utils';
 	import { isRouteTokens } from '$lib/utils/nav.utils';
 
 	let isHomePage = $derived(isRouteTokens(page));
@@ -49,6 +50,15 @@
 				>
 					<IconGitHub />
 				</ExternalLinkIcon>
+
+				<span
+					class="rounded bg-secondary px-2 py-0.5 font-mono text-xs text-primary"
+					title="Active memory test flags (set via ?memFlags=...)"
+				>
+					memFlags: {MEMORY_FIX_ACTIVE_FLAGS.length > 0
+						? MEMORY_FIX_ACTIVE_FLAGS.join(',')
+						: 'none'}
+				</span>
 			</div>
 		</div>
 

--- a/src/frontend/src/lib/components/core/Footer.svelte
+++ b/src/frontend/src/lib/components/core/Footer.svelte
@@ -52,7 +52,7 @@
 				</ExternalLinkIcon>
 
 				<span
-					class="rounded bg-secondary px-2 py-0.5 font-mono text-xs text-primary"
+					class="font-mono rounded bg-secondary px-2 py-0.5 text-xs text-primary"
 					title="Active memory test flags (set via ?memFlags=...)"
 				>
 					memFlags: {MEMORY_FIX_ACTIVE_FLAGS.length > 0

--- a/src/frontend/src/lib/stores/exchange.store.ts
+++ b/src/frontend/src/lib/stores/exchange.store.ts
@@ -1,4 +1,5 @@
 import type { CoingeckoPriceResponse } from '$lib/types/coingecko';
+import { MEMORY_FIX_EXCHANGE_STORE } from '$lib/utils/memory-flags.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { Nullish } from '@dfinity/zod-schemas';
 import { writable, type Readable } from 'svelte/store';
@@ -15,16 +16,28 @@ const initExchangeStore = (): ExchangeStore => {
 
 	return {
 		set: (tokensPrice: CoingeckoPriceResponse[]) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				...tokensPrice.reduce(
-					(acc, price) => ({
-						...acc,
-						...price
-					}),
-					{}
-				)
-			})),
+			update((state) => {
+				if (MEMORY_FIX_EXCHANGE_STORE) {
+					const next: NonNullable<CoingeckoPriceResponse> = {};
+					if (nonNullish(state)) {
+						Object.assign(next, state);
+					}
+					for (const price of tokensPrice) {
+						Object.assign(next, price);
+					}
+					return next;
+				}
+				return {
+					...(nonNullish(state) && state),
+					...tokensPrice.reduce(
+						(acc, price) => ({
+							...acc,
+							...price
+						}),
+						{}
+					)
+				};
+			}),
 		reset: () => set(null),
 		subscribe
 	};

--- a/src/frontend/src/lib/stores/transactions.store.ts
+++ b/src/frontend/src/lib/stores/transactions.store.ts
@@ -3,6 +3,7 @@ import type { CertifiedData } from '$lib/types/store';
 import type { TokenId } from '$lib/types/token';
 import type { Transaction } from '$lib/types/transaction';
 import type { AnyTransaction } from '$lib/types/transaction-ui';
+import { MEMORY_FIX_TRANSACTIONS_STORE } from '$lib/utils/memory-flags.utils';
 import { nonNullish } from '@dfinity/utils';
 
 type TransactionTypes = AnyTransaction;
@@ -56,48 +57,138 @@ export const initTransactionsStore = <T extends TransactionTypes>(): Transaction
 	): UiTransactionTypes['id'] | Transaction['hash'] =>
 		isTransactionUi(transaction) ? transaction.id : transaction.hash;
 
+	type StateRecord = Record<TokenId, TransactionsData<T>>;
+
+	const ensure = (state: StateRecord | undefined): StateRecord =>
+		state ?? ({} as StateRecord);
+
 	return {
 		set: ({ tokenId, transactions }: TransactionsStoreParams<T>) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: transactions
-			})),
+			update((state) => {
+				if (MEMORY_FIX_TRANSACTIONS_STORE) {
+					const next = ensure(state);
+					next[tokenId] = transactions;
+					return { ...next };
+				}
+				return {
+					...(nonNullish(state) && state),
+					[tokenId]: transactions
+				};
+			}),
 		add: ({ tokenId, transactions }: TransactionsStoreParams<T>) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: [...(state?.[tokenId] ?? []), ...transactions]
-			})),
+			update((state) => {
+				if (MEMORY_FIX_TRANSACTIONS_STORE) {
+					const next = ensure(state);
+					const existing = next[tokenId];
+					if (existing == null) {
+						next[tokenId] = [...transactions];
+					} else {
+						for (const tx of transactions) {
+							existing.push(tx);
+						}
+					}
+					return { ...next };
+				}
+				return {
+					...(nonNullish(state) && state),
+					[tokenId]: [...(state?.[tokenId] ?? []), ...transactions]
+				};
+			}),
 		prepend: ({ tokenId, transactions }: TransactionsStoreParams<T>) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: [
-					...transactions,
-					...((state ?? {})[tokenId] ?? []).filter(
-						({ data }) =>
-							!transactions.some(({ data: tx }) => getIdentifier(tx) === getIdentifier(data))
-					)
-				]
-			})),
+			update((state) => {
+				if (MEMORY_FIX_TRANSACTIONS_STORE) {
+					const next = ensure(state);
+					const existing = next[tokenId];
+					if (existing == null || existing.length === 0) {
+						next[tokenId] = [...transactions];
+					} else {
+						const incomingIds = new Set(
+							transactions.map(({ data }) => getIdentifier(data))
+						);
+						let writeIdx = 0;
+						for (let i = 0; i < existing.length; i++) {
+							const item = existing[i];
+							if (!incomingIds.has(getIdentifier(item.data))) {
+								existing[writeIdx] = item;
+								writeIdx++;
+							}
+						}
+						existing.length = writeIdx;
+						existing.unshift(...transactions);
+					}
+					return { ...next };
+				}
+				return {
+					...(nonNullish(state) && state),
+					[tokenId]: [
+						...transactions,
+						...((state ?? {})[tokenId] ?? []).filter(
+							({ data }) =>
+								!transactions.some(({ data: tx }) => getIdentifier(tx) === getIdentifier(data))
+						)
+					]
+				};
+			}),
 		append: ({ tokenId, transactions }: TransactionsStoreParams<T>) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: [
-					...((state ?? {})[tokenId] ?? []),
-					...transactions.filter(
-						({ data }) =>
-							!((state ?? {})[tokenId] ?? []).some(
-								({ data: tx }) => getIdentifier(tx) === getIdentifier(data)
-							)
-					)
-				]
-			})),
+			update((state) => {
+				if (MEMORY_FIX_TRANSACTIONS_STORE) {
+					const next = ensure(state);
+					const existing = next[tokenId];
+					if (existing == null || existing.length === 0) {
+						next[tokenId] = [...transactions];
+					} else {
+						const existingIds = new Set(
+							existing.map(({ data }) => getIdentifier(data))
+						);
+						for (const tx of transactions) {
+							if (!existingIds.has(getIdentifier(tx.data))) {
+								existing.push(tx);
+							}
+						}
+					}
+					return { ...next };
+				}
+				return {
+					...(nonNullish(state) && state),
+					[tokenId]: [
+						...((state ?? {})[tokenId] ?? []),
+						...transactions.filter(
+							({ data }) =>
+								!((state ?? {})[tokenId] ?? []).some(
+									({ data: tx }) => getIdentifier(tx) === getIdentifier(data)
+								)
+						)
+					]
+				};
+			}),
 		cleanUp: ({ tokenId, transactionIds }: TransactionsStoreIdParams<T>) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: ((state ?? {})[tokenId] ?? []).filter(
-					({ data }) => !transactionIds.includes(`${getIdentifier(data)}`)
-				)
-			})),
+			update((state) => {
+				if (MEMORY_FIX_TRANSACTIONS_STORE) {
+					const next = ensure(state);
+					const existing = next[tokenId];
+					if (existing == null) {
+						next[tokenId] = [];
+					} else {
+						const idSet = new Set(transactionIds.map((id) => `${id}`));
+						let writeIdx = 0;
+						for (let i = 0; i < existing.length; i++) {
+							const item = existing[i];
+							if (!idSet.has(`${getIdentifier(item.data)}`)) {
+								existing[writeIdx] = item;
+								writeIdx++;
+							}
+						}
+						existing.length = writeIdx;
+					}
+					return { ...next };
+				}
+				return {
+					...(nonNullish(state) && state),
+					[tokenId]: ((state ?? {})[tokenId] ?? []).filter(
+						({ data }) => !transactionIds.includes(`${getIdentifier(data)}`)
+					)
+				};
+			}),
 		update: ({
 			tokenId,
 			transaction
@@ -105,20 +196,49 @@ export const initTransactionsStore = <T extends TransactionTypes>(): Transaction
 			tokenId: TokenId;
 			transaction: CertifiedTransaction<T>;
 		}) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: [
-					...(state?.[tokenId] ?? []).filter(
-						({ data }) => getIdentifier(data) !== getIdentifier(transaction.data)
-					),
-					transaction
-				]
-			})),
+			update((state) => {
+				if (MEMORY_FIX_TRANSACTIONS_STORE) {
+					const next = ensure(state);
+					const existing = next[tokenId];
+					if (existing == null) {
+						next[tokenId] = [transaction];
+					} else {
+						const targetId = getIdentifier(transaction.data);
+						let writeIdx = 0;
+						for (let i = 0; i < existing.length; i++) {
+							const item = existing[i];
+							if (getIdentifier(item.data) !== targetId) {
+								existing[writeIdx] = item;
+								writeIdx++;
+							}
+						}
+						existing.length = writeIdx;
+						existing.push(transaction);
+					}
+					return { ...next };
+				}
+				return {
+					...(nonNullish(state) && state),
+					[tokenId]: [
+						...(state?.[tokenId] ?? []).filter(
+							({ data }) => getIdentifier(data) !== getIdentifier(transaction.data)
+						),
+						transaction
+					]
+				};
+			}),
 		nullify: (tokenId) =>
-			update((state) => ({
-				...(nonNullish(state) && state),
-				[tokenId]: null
-			})),
+			update((state) => {
+				if (MEMORY_FIX_TRANSACTIONS_STORE) {
+					const next = ensure(state);
+					next[tokenId] = null;
+					return { ...next };
+				}
+				return {
+					...(nonNullish(state) && state),
+					[tokenId]: null
+				};
+			}),
 		reset,
 		reinitialize,
 		subscribe

--- a/src/frontend/src/lib/stores/transactions.store.ts
+++ b/src/frontend/src/lib/stores/transactions.store.ts
@@ -59,8 +59,7 @@ export const initTransactionsStore = <T extends TransactionTypes>(): Transaction
 
 	type StateRecord = Record<TokenId, TransactionsData<T>>;
 
-	const ensure = (state: StateRecord | undefined): StateRecord =>
-		state ?? ({} as StateRecord);
+	const ensure = (state: StateRecord | undefined): StateRecord => state ?? ({} as StateRecord);
 
 	return {
 		set: ({ tokenId, transactions }: TransactionsStoreParams<T>) =>
@@ -102,9 +101,7 @@ export const initTransactionsStore = <T extends TransactionTypes>(): Transaction
 					if (existing == null || existing.length === 0) {
 						next[tokenId] = [...transactions];
 					} else {
-						const incomingIds = new Set(
-							transactions.map(({ data }) => getIdentifier(data))
-						);
+						const incomingIds = new Set(transactions.map(({ data }) => getIdentifier(data)));
 						let writeIdx = 0;
 						for (let i = 0; i < existing.length; i++) {
 							const item = existing[i];
@@ -137,9 +134,7 @@ export const initTransactionsStore = <T extends TransactionTypes>(): Transaction
 					if (existing == null || existing.length === 0) {
 						next[tokenId] = [...transactions];
 					} else {
-						const existingIds = new Set(
-							existing.map(({ data }) => getIdentifier(data))
-						);
+						const existingIds = new Set(existing.map(({ data }) => getIdentifier(data)));
 						for (const tx of transactions) {
 							if (!existingIds.has(getIdentifier(tx.data))) {
 								existing.push(tx);

--- a/src/frontend/src/lib/utils/memory-flags.utils.ts
+++ b/src/frontend/src/lib/utils/memory-flags.utils.ts
@@ -15,13 +15,14 @@
 //   2 = ic-transactions derived: memoize on input references
 //   3 = exchange store: single-pass merge instead of reduce-with-spread
 //   4 = icrc wallet worker: singleton on non-iOS too
+//   5 = reload cleanup: terminate worker + best-effort agent reset on unload
 //
 // This module is intentionally not "proper" production code — it exists only
 // to A/B the memory fixes on the chore-frontend/memory-consumption-test-flags
 // branch and is not meant to land on main.
 
 const STORAGE_KEY = 'oisy.memFlags';
-const ALL_FLAGS = ['1', '2', '3', '4'] as const;
+const ALL_FLAGS = ['1', '2', '3', '4', '5'] as const;
 
 const readRaw = (): string | null => {
 	if (typeof window === 'undefined') {
@@ -64,6 +65,7 @@ export const MEMORY_FIX_TRANSACTIONS_STORE = flags.has('1');
 export const MEMORY_FIX_IC_TRANSACTIONS_DERIVED = flags.has('2');
 export const MEMORY_FIX_EXCHANGE_STORE = flags.has('3');
 export const MEMORY_FIX_WORKER_SINGLETON = flags.has('4');
+export const MEMORY_FIX_RELOAD_CLEANUP = flags.has('5');
 
 export const MEMORY_FIX_ACTIVE_FLAGS: readonly string[] = ALL_FLAGS.filter((f) => flags.has(f));
 

--- a/src/frontend/src/lib/utils/memory-flags.utils.ts
+++ b/src/frontend/src/lib/utils/memory-flags.utils.ts
@@ -1,0 +1,71 @@
+// Test-only feature flags for measuring memory consumption fixes.
+//
+// All flags default to OFF — when off, the original logic runs unchanged.
+// Enable individual flags via URL param, e.g.:
+//
+//   ?memFlags=1        only flag #1
+//   ?memFlags=1,3,4    flags #1, #3, #4
+//   ?memFlags=all      all flags
+//
+// The chosen value is persisted to localStorage under `oisy.memFlags` so it
+// survives reloads. Pass `?memFlags=` (empty value) to clear.
+//
+// Flag map:
+//   1 = transactions store: per-token slot mutate instead of full state spread
+//   2 = ic-transactions derived: memoize on input references
+//   3 = exchange store: single-pass merge instead of reduce-with-spread
+//   4 = icrc wallet worker: singleton on non-iOS too
+//
+// This module is intentionally not "proper" production code — it exists only
+// to A/B the memory fixes on the chore-frontend/memory-consumption-test-flags
+// branch and is not meant to land on main.
+
+const STORAGE_KEY = 'oisy.memFlags';
+const ALL_FLAGS = ['1', '2', '3', '4'] as const;
+
+const readRaw = (): string | null => {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+
+	try {
+		const params = new URLSearchParams(window.location.search);
+		if (params.has('memFlags')) {
+			const value = params.get('memFlags') ?? '';
+			window.localStorage.setItem(STORAGE_KEY, value);
+			return value;
+		}
+		return window.localStorage.getItem(STORAGE_KEY);
+	} catch (_err) {
+		return null;
+	}
+};
+
+const parseFlags = (raw: string | null): Set<string> => {
+	if (raw === null || raw.trim().length === 0) {
+		return new Set();
+	}
+
+	if (raw.trim().toLowerCase() === 'all') {
+		return new Set(ALL_FLAGS);
+	}
+
+	return new Set(
+		raw
+			.split(',')
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0)
+	);
+};
+
+const flags = parseFlags(readRaw());
+
+export const MEMORY_FIX_TRANSACTIONS_STORE = flags.has('1');
+export const MEMORY_FIX_IC_TRANSACTIONS_DERIVED = flags.has('2');
+export const MEMORY_FIX_EXCHANGE_STORE = flags.has('3');
+export const MEMORY_FIX_WORKER_SINGLETON = flags.has('4');
+
+if (typeof window !== 'undefined' && flags.size > 0) {
+	// eslint-disable-next-line no-console
+	console.info(`[memFlags] enabled: ${Array.from(flags).join(',')}`);
+}

--- a/src/frontend/src/lib/utils/memory-flags.utils.ts
+++ b/src/frontend/src/lib/utils/memory-flags.utils.ts
@@ -65,6 +65,8 @@ export const MEMORY_FIX_IC_TRANSACTIONS_DERIVED = flags.has('2');
 export const MEMORY_FIX_EXCHANGE_STORE = flags.has('3');
 export const MEMORY_FIX_WORKER_SINGLETON = flags.has('4');
 
+export const MEMORY_FIX_ACTIVE_FLAGS: readonly string[] = ALL_FLAGS.filter((f) => flags.has(f));
+
 if (typeof window !== 'undefined' && flags.size > 0) {
 	// eslint-disable-next-line no-console
 	console.info(`[memFlags] enabled: ${Array.from(flags).join(',')}`);

--- a/src/frontend/src/lib/utils/memory-reload-cleanup.utils.ts
+++ b/src/frontend/src/lib/utils/memory-reload-cleanup.utils.ts
@@ -1,0 +1,81 @@
+// Test-only: pre-unload cleanup hook gated by MEMORY_FIX_RELOAD_CLEANUP (?memFlags=5).
+//
+// Hypothesis: the post-reload spike grows reload-over-reload because the
+// previous page's heap is still reachable while the new page initialises
+// its own world. We try to drop as much of that retained state as we can
+// from inside `beforeunload` / `pagehide` so the new page boots with less
+// reachable garbage.
+//
+// Caveats:
+// - `beforeunload` is synchronous and short-lived; async work is not
+//   guaranteed to complete before the page goes away.
+// - `AppWorker.resetForTesting` is intended for tests, but it's the only
+//   public API to terminate the singleton AppWorker. We intentionally
+//   reuse it here on this measurement branch.
+// - Resetting the agent manager is best-effort: the @dfinity/utils
+//   `AgentManager` doesn't expose a documented reset API, so we probe a
+//   few likely method names and skip silently if none exist.
+
+import { agents } from '$lib/actors/agents.ic';
+import { AppWorker } from '$lib/services/_worker.services';
+import { MEMORY_FIX_RELOAD_CLEANUP } from '$lib/utils/memory-flags.utils';
+
+let registered = false;
+let cleanedUp = false;
+
+const tryAgentReset = () => {
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const a = agents as any;
+		for (const method of ['reset', 'clear', 'destroy', 'reinitialize']) {
+			if (typeof a?.[method] === 'function') {
+				a[method]();
+			}
+		}
+		for (const cacheKey of ['cache', 'agents', '_cache', '_agents']) {
+			const cache = a?.[cacheKey];
+			if (cache && typeof cache.clear === 'function') {
+				cache.clear();
+			}
+		}
+	} catch (err) {
+		// eslint-disable-next-line no-console
+		console.warn('[memFlags#5] agent reset attempt failed', err);
+	}
+};
+
+const tryWorkerTerminate = () => {
+	try {
+		AppWorker.resetForTesting();
+	} catch (err) {
+		// eslint-disable-next-line no-console
+		console.warn('[memFlags#5] worker terminate failed', err);
+	}
+};
+
+const cleanup = () => {
+	if (cleanedUp) {
+		return;
+	}
+	cleanedUp = true;
+	// eslint-disable-next-line no-console
+	console.info('[memFlags#5] running pre-unload cleanup');
+	tryWorkerTerminate();
+	tryAgentReset();
+};
+
+export const registerMemoryReloadCleanup = () => {
+	if (!MEMORY_FIX_RELOAD_CLEANUP) {
+		return;
+	}
+	if (registered) {
+		return;
+	}
+	if (typeof window === 'undefined') {
+		return;
+	}
+	registered = true;
+
+	window.addEventListener('beforeunload', cleanup, { capture: true });
+	window.addEventListener('pagehide', cleanup, { capture: true });
+};

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -27,6 +27,7 @@
 	import { toastsError } from '$lib/stores/toasts.store';
 	import { userSelectedNetworkStore } from '$lib/stores/user-selected-network.store';
 	import { consoleWarn } from '$lib/utils/console.utils';
+	import { registerMemoryReloadCleanup } from '$lib/utils/memory-reload-cleanup.utils';
 
 	interface Props {
 		children: Snippet;
@@ -188,6 +189,8 @@
 	onMount(() => {
 		userSelectedNetworkStore.set($networkId);
 	});
+
+	onMount(registerMemoryReloadCleanup);
 </script>
 
 {#await init()}


### PR DESCRIPTION
# Motivation

For users with many tokens (~50) and many transactions (~500), oisy's browser memory consumption climbs to ~1GB and roughly doubles right after a page reload. This PR is a measurement vehicle: it ships four candidate fixes, each behind an independent runtime feature flag, so we can A/B them in DevTools without rebuilding.

**This branch is not intended for `main`.** All flags default to off, so behavior on this branch matches main unless the URL param is set. Code style is intentionally pragmatic — `if (FLAG) { new path } else { original }` — to make each flag's diff trivial to inspect and revert.

# Toggle

Append `?memFlags=...` to the URL once. The value is persisted in `localStorage` under `oisy.memFlags`, so it survives reloads (which is essential for the post-reload spike measurement).

| URL | Effect |
|---|---|
| `?memFlags=` (empty) | clear all flags |
| `?memFlags=4` | enable only flag 4 |
| `?memFlags=1,3` | enable flags 1 and 3 |
| `?memFlags=all` | enable all flags |

When any flag is on, the console logs `[memFlags] enabled: ...` at startup.

# Flags

| # | Flag constant | What it changes |
|---|---|---|
| 1 | `MEMORY_FIX_TRANSACTIONS_STORE` | `transactions.store.ts`: replace `[...prev, ...new]` per-update with mutate-in-place on the per-token array (push / unshift / in-place filter), then a shallow outer copy for Svelte reactivity. Avoids allocating a fresh N-item array on every wallet update. |
| 2 | `MEMORY_FIX_IC_TRANSACTIONS_DERIVED` | `ic-transactions.derived.ts`: memoize the derived's result on its 9 input references; if all inputs are reference-equal to the previous call, return the cached array instead of re-running `getAllIcTransactions`. |
| 3 | `MEMORY_FIX_EXCHANGE_STORE` | `exchange.store.ts`: replace `tokensPrice.reduce((acc, p) => ({ ...acc, ...p }), {})` (O(n) intermediate object allocations) with a single-pass `Object.assign` into one accumulator. |
| 4 | `MEMORY_FIX_WORKER_SINGLETON` | `worker.icrc-wallet.services.ts`: pass `asSingleton: true` on non-iOS too, so all ICRC tokens share one `AppWorker` instead of spawning one Worker per token. Per-message `ledgerCanisterId` guard already exists. |
| 5 | `MEMORY_FIX_RELOAD_CLEANUP` | `memory-reload-cleanup.utils.ts`: on `beforeunload` / `pagehide`, terminate the singleton `AppWorker` and best-effort reset the `AgentManager` cache. Targets the post-reload accumulation pattern (memory growing reload-over-reload). |

# Suggested measurement protocol

1. **Baseline**: load the app with `?memFlags=` (cleared), reproduce the 50-token / 500-tx scenario, capture a heap snapshot before and immediately after a hard reload.
2. **Per-flag**: set `?memFlags=N` for each `N` in 1..5, repeat step 1.
3. **Combined**: set `?memFlags=all`, repeat step 1.

Measuring one flag at a time avoids attribution mixing. Note: flag 2 only meaningfully hits its cache when upstream input refs are stable, so its standalone effect may be small — combining 1+2 is the most interesting pairing.

# Notes / caveats

- Flag 1 mutates the inner per-token array. Anything that captures that inner array reference and inspects it later asynchronously could see mutations. No such consumer was identified in the audit, but flagging this for awareness during measurement.
- Flag 2's memoization compares only by reference. With `setExchange` / `setTransactions` always emitting new top-level references on main, the cache rarely hits. The flag exists to confirm whether re-running the derived is on the hot path at all.
- Flag 4 changes thread layout. The existing `ledgerCanisterId !== ref` guard inside `IcrcWalletWorker.setOnMessage` is what makes the singleton path safe — please review that handler if you have concerns.
- Flag 5 runs cleanup synchronously inside `beforeunload`/`pagehide`. The browser may not wait for any async work, so the cleanup is intentionally sync (worker terminate + agent reset). The agent reset is best-effort (probes for `reset`/`clear`/`destroy`/`reinitialize` methods on the `AgentManager` and likely cache fields, since `@dfinity/utils` doesn't expose a documented reset API).

# Commits

1. `chore(frontend): add memory consumption test flags utility` — runtime flag mechanism (URL param + `localStorage`) at `src/frontend/src/lib/utils/memory-flags.utils.ts`. No runtime effect on its own.
2. `chore(frontend): add memFlag #3 — single-pass merge in exchange store`
3. `chore(frontend): add memFlag #1 — in-place updates in transactions store`
4. `chore(frontend): add memFlag #2 — memoize icTransactions derived`
5. `chore(frontend): add memFlag #4 — singleton ICRC wallet worker on non-iOS`
6. `docs(frontend): add MEMORY_TEST_FLAGS.md analysis & toggle guide`
7. `chore(frontend): show active memFlags badge in footer` — small badge next to the Twitter/GitHub icons displaying the active flag set (or `none`).
8. `chore(frontend): add memFlag #5 — reload cleanup on beforeunload`

# Tests

Not adding new tests — flags default off, so existing suites exercise the unchanged path. Manual measurement is the point of this branch.

🤖 Claude Opus 4.7

