### PR TITLE
chore(dependabot): group vite and sveltejs deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,3 +61,9 @@ updates:
           - 'vitest'
           - 'vitest-mock-extended'
           - '@vitest/coverage-v8'
+      vite-group:
+        patterns:
+          - 'vite'
+          - '@sveltejs/vite-plugin-svelte'
+          - '@sveltejs/kit'
+          - '@sveltejs/adapter-static'


### PR DESCRIPTION
# Motivation

`@sveltejs/vite-plugin-svelte` and `@sveltejs/kit` have hard peer-dep ranges on `vite`, so their major versions need to bump together. Without grouping, Dependabot opens separate PRs that fail to install or break each other. Grouping them ensures coordinated upgrades land in a single PR.