### PR TITLE
feat(frontend): pin BNB and POL, unpin chain-fusion tokens

### DIFF
--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -1,4 +1,6 @@
 import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
+import { BNB_MAINNET_TOKEN } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
+import { POL_MAINNET_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN, TESTICP_TOKEN } from '$env/tokens/tokens.icp.env';
@@ -89,6 +91,8 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
 		ETHEREUM_TOKEN,
 		ICP_TOKEN,
 		TESTICP_TOKEN,
+		BNB_MAINNET_TOKEN,
+		POL_MAINNET_TOKEN,
 		SOLANA_TOKEN,
 		...$icrcChainFusionDefaultTokens,
 		...$enabledEvmTokens

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -86,16 +86,22 @@ export const tokens: Readable<Token[]> = derivedMemo(
 
 export const tokensToPin: Readable<TokenToPin[]> = derived(
 	[enabledEvmTokens],
-	([$enabledEvmTokens]) => [
-		BTC_MAINNET_TOKEN,
-		ETHEREUM_TOKEN,
-		ICP_TOKEN,
-		TESTICP_TOKEN,
-		BNB_MAINNET_TOKEN,
-		POL_MAINNET_TOKEN,
-		SOLANA_TOKEN,
-		...$enabledEvmTokens
-	]
+	([$enabledEvmTokens]) => {
+		// Native EVM tokens (e.g. BNB, POL) also appear inside `$enabledEvmTokens`.
+		// Dedupe by id so the explicit pin order above wins over the later occurrence,
+		// which would otherwise overwrite the pin index in the comparator's Map.
+		const seen = new Set<TokenToPin['id']>();
+		return [
+			BTC_MAINNET_TOKEN,
+			ETHEREUM_TOKEN,
+			ICP_TOKEN,
+			TESTICP_TOKEN,
+			BNB_MAINNET_TOKEN,
+			POL_MAINNET_TOKEN,
+			SOLANA_TOKEN,
+			...$enabledEvmTokens
+		].filter(({ id }) => (seen.has(id) ? false : (seen.add(id), true)));
+	}
 );
 
 /**

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -90,8 +90,9 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
 		// Native EVM tokens (e.g. BNB, POL) also appear inside `$enabledEvmTokens`.
 		// Dedupe by id so the explicit pin order above wins over the later occurrence,
 		// which would otherwise overwrite the pin index in the comparator's Map.
+		const result: TokenToPin[] = [];
 		const seen = new Set<TokenToPin['id']>();
-		return [
+		for (const token of [
 			BTC_MAINNET_TOKEN,
 			ETHEREUM_TOKEN,
 			ICP_TOKEN,
@@ -100,7 +101,13 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
 			POL_MAINNET_TOKEN,
 			SOLANA_TOKEN,
 			...$enabledEvmTokens
-		].filter(({ id }) => (seen.has(id) ? false : (seen.add(id), true)));
+		]) {
+			if (!seen.has(token.id)) {
+				seen.add(token.id);
+				result.push(token);
+			}
+		}
+		return result;
 	}
 );
 

--- a/src/frontend/src/lib/derived/tokens.derived.ts
+++ b/src/frontend/src/lib/derived/tokens.derived.ts
@@ -16,7 +16,7 @@ import { isTokenErc4626 } from '$eth/utils/erc4626.utils';
 import { enabledEvmTokens } from '$evm/derived/tokens.derived';
 import { extTokens } from '$icp/derived/ext.derived';
 import { icPunksTokens } from '$icp/derived/icpunks.derived';
-import { icrcChainFusionDefaultTokens, icrcTokens } from '$icp/derived/icrc.derived';
+import { icrcTokens } from '$icp/derived/icrc.derived';
 import { defaultIcpTokens } from '$icp/derived/tokens.derived';
 import type { IcToken } from '$icp/types/ic-token';
 import { isTokenIc } from '$icp/utils/icrc.utils';
@@ -85,8 +85,8 @@ export const tokens: Readable<Token[]> = derivedMemo(
 );
 
 export const tokensToPin: Readable<TokenToPin[]> = derived(
-	[icrcChainFusionDefaultTokens, enabledEvmTokens],
-	([$icrcChainFusionDefaultTokens, $enabledEvmTokens]) => [
+	[enabledEvmTokens],
+	([$enabledEvmTokens]) => [
 		BTC_MAINNET_TOKEN,
 		ETHEREUM_TOKEN,
 		ICP_TOKEN,
@@ -94,7 +94,6 @@ export const tokensToPin: Readable<TokenToPin[]> = derived(
 		BNB_MAINNET_TOKEN,
 		POL_MAINNET_TOKEN,
 		SOLANA_TOKEN,
-		...$icrcChainFusionDefaultTokens,
 		...$enabledEvmTokens
 	]
 );

--- a/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/tokens.derived.spec.ts
@@ -51,7 +51,8 @@ import {
 	enabledNonFungibleTokensWithoutSpam,
 	enabledUniqueTokensSymbols,
 	fungibleTokens,
-	tokens
+	tokens,
+	tokensToPin
 } from '$lib/derived/tokens.derived';
 import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -470,6 +471,31 @@ describe('tokens.derived', () => {
 			erc1155CustomTokensStore.resetAll();
 
 			expect(get(enabledNonFungibleTokensWithoutSpam)).toStrictEqual([]);
+		});
+	});
+
+	describe('tokensToPin', () => {
+		it('should pin the seven native tokens in the expected order, followed by the remaining EVM tokens, with no chain-fusion ICRC tokens', () => {
+			expect(get(tokensToPin)).toEqual([
+				BTC_MAINNET_TOKEN,
+				ETHEREUM_TOKEN,
+				ICP_TOKEN,
+				TESTICP_TOKEN,
+				BNB_MAINNET_TOKEN,
+				POL_MAINNET_TOKEN,
+				SOLANA_TOKEN,
+				BASE_ETH_TOKEN,
+				ARBITRUM_ETH_TOKEN
+			]);
+		});
+
+		it('should dedupe native EVM tokens that also appear via the enabled-EVM-tokens spread', () => {
+			const result = get(tokensToPin);
+
+			expect(result.filter((token) => token.id === BNB_MAINNET_TOKEN.id)).toHaveLength(1);
+			expect(result.filter((token) => token.id === POL_MAINNET_TOKEN.id)).toHaveLength(1);
+			expect(result[4]).toBe(BNB_MAINNET_TOKEN);
+			expect(result[5]).toBe(POL_MAINNET_TOKEN);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The homepage token list has a hardcoded pin set (BTC, ETH, ICP, TESTICP, SOL, then the chain-fusion default tokens, then enabled EVM tokens). Two adjustments:

- **BNB and POL deserve to sit alongside the other major L1/L2 native tokens** — they were the only ones not pinned, so they kept drifting down the list as the user added or moved tokens.
- **The chain-fusion default tokens (ckBTC, ckETH, ckUSDC) are unpinned** so they sort by the regular criteria (USD balance, symbol, etc.) like any other token, instead of being held above tokens with real balances.

# Changes

- `src/frontend/src/lib/derived/tokens.derived.ts`: insert `BNB_MAINNET_TOKEN` and `POL_MAINNET_TOKEN` between `TESTICP_TOKEN` and `SOLANA_TOKEN` in the `tokensToPin` derived store.
- `src/frontend/src/lib/derived/tokens.derived.ts`: drop `icrcChainFusionDefaultTokens` from the `tokensToPin` derived store inputs and from the spread; remove the now-unused import.
- `src/frontend/src/lib/derived/tokens.derived.ts`: dedupe `tokensToPin` by id, keeping the first occurrence. Native EVM tokens (BNB, POL) appear both as explicit pins and again inside the `enabledEvmTokens` spread; the comparator builds its pin index via `new Map(entries)`, which keeps the *last* index for a duplicate id, so without dedup the explicit pin position was being overwritten by the much higher index from the EVM section — placing SOL ahead of BNB and POL on the homepage. Caught visually on `test_fe_3`. Implementation refactored from a `filter`-with-side-effects callback to an explicit `for…of` loop after Copilot review feedback.
- `src/frontend/src/tests/lib/derived/tokens.derived.spec.ts`: add a `tokensToPin` describe block covering the head order, absence of chain-fusion ICRC tokens, and dedup behaviour (BNB and POL each appearing exactly once at their explicit pin positions).

New pin order: BTC → ETH → ICP → TESTICP → **BNB** → **POL** → SOL → enabled EVM tokens.

# Notes

- The second commit's message still uses the word "temporarily" — kept as-is to avoid amending and force-pushing. The intent is captured here in the description: the ck-token unpinning is a permanent change, not a temporary toggle.

# Tests

- `vitest run src/frontend/src/tests/lib/derived/tokens.derived.spec.ts src/frontend/src/tests/lib/utils/tokens.utils.spec.ts` — 152 / 152 passing (15 existing + 2 new in `tokens.derived.spec.ts`, 135 in `tokens.utils.spec.ts`).
- `npm run check` — no new type errors introduced (file compiles cleanly; pre-existing errors in unrelated `auth-client.providers.ts` / `auth.store.ts` are not caused by this PR).
- Visually verified on `test_fe_3` after the dedup fix.

|Before|After|
|---|---|
|<img height="600" alt="image" src="https://github.com/user-attachments/assets/fe9b7f5b-87d7-4d30-bd86-aa9d820bf41c" />|<img height="600" alt="image" src="https://github.com/user-attachments/assets/7940a5b7-682a-4d5c-b15f-e23813b7a9bd" />|


🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7)
