### PR TITLE
fix(build): Domain fallback for prod frontend metadata

### DIFF
--- a/scripts/build.utils.mjs
+++ b/scripts/build.utils.mjs
@@ -1,3 +1,4 @@
+import { notEmptyString } from '@dfinity/utils';
 import { join } from 'node:path';
 import OISY_DOMAINS from './domains.json' with { type: 'json' };
 import { findFiles } from './utils.mjs';
@@ -27,7 +28,14 @@ const SIGNER_TARGET_MAP = {
 
 const domain_for_dfx_network = (dfx_network) => {
 	const signerTarget = process.env.OISY_SIGNER_TARGET;
-	const domainsKey = (signerTarget && SIGNER_TARGET_MAP[signerTarget]) ?? 'frontend';
+	// Note: when the Docker build is invoked without a `signer_target` build arg, the
+	// default ARG resolves to an empty string and `OISY_SIGNER_TARGET` is exported as
+	// "" (not unset). Empty/unknown values must fall back to the default `frontend` map,
+	// otherwise `OISY_DOMAINS[""]` is undefined and the prod URL becomes `https://ic.oisy.com`.
+	const domainsKey =
+		notEmptyString(signerTarget) && signerTarget in SIGNER_TARGET_MAP
+			? SIGNER_TARGET_MAP[signerTarget]
+			: 'frontend';
 	const map = OISY_DOMAINS[domainsKey];
 
 	return map?.[dfx_network] ?? `https://${dfx_network}.oisy.com`;

--- a/scripts/build.utils.mjs
+++ b/scripts/build.utils.mjs
@@ -33,7 +33,7 @@ const domain_for_dfx_network = (dfx_network) => {
 	// "" (not unset). Empty/unknown values must fall back to the default `frontend` map,
 	// otherwise `OISY_DOMAINS[""]` is undefined and the prod URL becomes `https://ic.oisy.com`.
 	const domainsKey =
-		notEmptyString(signerTarget) && signerTarget in SIGNER_TARGET_MAP
+		notEmptyString(signerTarget) && Object.hasOwn(SIGNER_TARGET_MAP, signerTarget)
 			? SIGNER_TARGET_MAP[signerTarget]
 			: 'frontend';
 	const map = OISY_DOMAINS[domainsKey];


### PR DESCRIPTION
# Motivation

The prod frontend build was rewriting `https://oisy.com` to `https://ic.oisy.com` in `app.html`, `manifest.webmanifest`, `sitemap.xml` and `robots.txt`, breaking Twitter/Open Graph link previews.

The cause was in `domain_for_dfx_network`: when `OISY_SIGNER_TARGET` is the empty string (which is what `Dockerfile.frontend` exports when invoked without a `signer_target` build arg), the previous expression resolved `domainsKey` to `""`, `OISY_DOMAINS[""]` is undefined, so the lookup fell through to `https://${dfx_network}.oisy.com` → `https://ic.oisy.com` for prod.

This PR resolves `domainsKey` only when the signer target is non-empty and known, otherwise it falls back to `frontend`.