### PR TITLE
style(frontend): remove gap between activity message boxes

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -130,27 +130,29 @@
 		</span>
 	{/if}
 
-	{#if undismissedNoCanister.length > 0}
-		<MessageBox level="warning" onDismiss={dismissNoCanisterWarning}>
-			{replacePlaceholders($i18n.activity.warning.no_index_canister, {
-				$token_list: undismissedNoCanister.map((s) => `$${s}`).join(', ')
-			})}
-		</MessageBox>
-	{/if}
+	<div class="flex flex-col">
+		{#if undismissedNoCanister.length > 0}
+			<MessageBox level="warning" onDismiss={dismissNoCanisterWarning}>
+				{replacePlaceholders($i18n.activity.warning.no_index_canister, {
+					$token_list: undismissedNoCanister.map((s) => `$${s}`).join(', ')
+				})}
+			</MessageBox>
+		{/if}
 
-	{#if tokensWithUnavailableCanister.length > 0}
-		<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
-			{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
-				$token_list: tokensWithUnavailableCanister.map((s) => `$${s}`).join(', ')
-			})}
-		</MessageBox>
-	{/if}
+		{#if tokensWithUnavailableCanister.length > 0}
+			<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
+				{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
+					$token_list: tokensWithUnavailableCanister.map((s) => `$${s}`).join(', ')
+				})}
+			</MessageBox>
+		{/if}
 
-	{#if !btcBannerDismissed}
-		<MessageBox level="plain" onDismiss={dismissBtcBanner}>
-			{$i18n.activity.info.btc_transactions}
-		</MessageBox>
-	{/if}
+		{#if !btcBannerDismissed}
+			<MessageBox level="plain" onDismiss={dismissBtcBanner}>
+				{$i18n.activity.info.btc_transactions}
+			</MessageBox>
+		{/if}
+	</div>
 
 	<HiddenMicroTransactionsInfoBox />
 

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -116,6 +116,12 @@
 			});
 		}
 	};
+
+	let hasBanners = $derived(
+		undismissedNoCanister.length > 0 ||
+			tokensWithUnavailableCanister.length > 0 ||
+			!btcBannerDismissed
+	);
 </script>
 
 <div class="flex flex-col gap-5">
@@ -130,29 +136,31 @@
 		</span>
 	{/if}
 
-	<div class="flex flex-col">
-		{#if undismissedNoCanister.length > 0}
-			<MessageBox level="warning" onDismiss={dismissNoCanisterWarning}>
-				{replacePlaceholders($i18n.activity.warning.no_index_canister, {
-					$token_list: undismissedNoCanister.map((s) => `$${s}`).join(', ')
-				})}
-			</MessageBox>
-		{/if}
+	{#if hasBanners}
+		<div class="flex flex-col">
+			{#if undismissedNoCanister.length > 0}
+				<MessageBox level="warning" onDismiss={dismissNoCanisterWarning}>
+					{replacePlaceholders($i18n.activity.warning.no_index_canister, {
+						$token_list: undismissedNoCanister.map((s) => `$${s}`).join(', ')
+					})}
+				</MessageBox>
+			{/if}
 
-		{#if tokensWithUnavailableCanister.length > 0}
-			<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
-				{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
-					$token_list: tokensWithUnavailableCanister.map((s) => `$${s}`).join(', ')
-				})}
-			</MessageBox>
-		{/if}
+			{#if tokensWithUnavailableCanister.length > 0}
+				<MessageBox closableKey="oisy_ic_hide_transaction_unavailable_canister" level="warning">
+					{replacePlaceholders($i18n.activity.warning.unavailable_index_canister, {
+						$token_list: tokensWithUnavailableCanister.map((s) => `$${s}`).join(', ')
+					})}
+				</MessageBox>
+			{/if}
 
-		{#if !btcBannerDismissed}
-			<MessageBox level="plain" onDismiss={dismissBtcBanner}>
-				{$i18n.activity.info.btc_transactions}
-			</MessageBox>
-		{/if}
-	</div>
+			{#if !btcBannerDismissed}
+				<MessageBox level="plain" onDismiss={dismissBtcBanner}>
+					{$i18n.activity.info.btc_transactions}
+				</MessageBox>
+			{/if}
+		</div>
+	{/if}
 
 	<HiddenMicroTransactionsInfoBox />
 


### PR DESCRIPTION
# Motivation

Removing the gap between the message boxes in the activity page since they already have a margin at the bottom.

### Before

<img width="622" height="692" alt="Screenshot 2026-04-27 at 13 23 56" src="https://github.com/user-attachments/assets/b2524109-81d9-440c-80f4-9e546c408ce9" />

### After

<img width="625" height="715" alt="Screenshot 2026-04-27 at 13 23 08" src="https://github.com/user-attachments/assets/05434fdc-4e9d-4963-8bae-eaab753fc6d9" />


