### PR TITLE
feat(frontend): pin native ICP token first in ICP group

### DIFF
--- a/src/frontend/src/env/tokens/tokens.icp.env.ts
+++ b/src/frontend/src/env/tokens/tokens.icp.env.ts
@@ -45,7 +45,8 @@ export const ICP_TOKEN: RequiredToken<Omit<IcToken, 'deprecated' | 'alternativeN
 	buy: {
 		onramperId: 'icp_icp'
 	},
-	groupData: ICP_TOKEN_GROUP
+	groupData: ICP_TOKEN_GROUP,
+	neverCollapseInTokenGroup: true
 };
 
 /**


### PR DESCRIPTION
# Motivation

Follow-up to #12575. After that PR introduced an alphabetical-by-network tiebreaker for tokens inside an expanded token group, the native ICP token (on the Internet Computer Network) ends up *last* inside the ICP group when balances are equal — `Arbitrum → Base → Ethereum → Internet Computer`. That feels wrong: the native version of a token should always be the one shown first.

The reason is that, unlike every other group's canonical version (native ETH, native BTC, USDC on Ethereum, USDT on Ethereum, LINK / UNI / SHIB / PEPE / WBTC / etc. on Ethereum), the native ICP token in `tokens.icp.env.ts` was never flagged with `neverCollapseInTokenGroup: true`. So it falls straight through the value/`neverCollapseInTokenGroup`/`isCkToken` tiebreakers and lands in the alphabetical bucket.

<img width="600" height="323" alt="image" src="https://github.com/user-attachments/assets/41950d5d-f163-4dd5-91ae-8603aa854520" />

# Changes

- **`tokens.icp.env.ts`** — set `neverCollapseInTokenGroup: true` on `ICP_TOKEN`. The flag is consumed only by the equal-balance sort tiebreaker in `TokenGroupCard.svelte` (despite its name), and is exactly how every other group already pins its native/issuer-chain version. With this, the ICP group orders `Internet Computer (native) → Arbitrum → Base → Ethereum` when balances are equal. The "highest USD balance first" rule is unchanged.

# Tests

No new tests. Existing `TokenGroupCard.spec.ts` (8 tests) passes locally; those tests cover counts/visibility, not the sort tiebreaker. The sort-order behavior is covered visually by #12575.

|New User|With ICP|
|---|---|
|<img width="610" height="327" alt="image" src="https://github.com/user-attachments/assets/ad574fc9-be9f-4189-b4a4-d272f70e4973" />|<img width="603" height="326" alt="image" src="https://github.com/user-attachments/assets/a5c3e926-ce3c-41ca-9e32-3991beafdb4e" />|


🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.7)