### PR TITLE
fix(frontend): clear sign-in spinner when user closes the OpenID popup

### DIFF
--- a/src/frontend/src/lib/stores/auth.store.ts
+++ b/src/frontend/src/lib/stores/auth.store.ts
@@ -25,6 +25,100 @@ export interface AuthStoreData {
 
 let authClient: Nullish<AuthClient>;
 
+// Polling rate (ms) for the signer window's `closed` flag while the user is
+// signing in through One-Click OpenID / Internet Identity. Kept short so the
+// landing page exits its busy state promptly when the user closes the popup
+// or tab without completing authentication.
+const SIGNER_WINDOW_CLOSED_POLLING_RATE = 500;
+
+// `PostMessageTransport` (used internally by `@icp-sdk/auth` v6) opens its
+// signer popup with this fixed window name, derived from the identity
+// provider's origin. By pre-opening a window with the same name, the
+// browser's named-targeting semantics make the SDK's subsequent
+// `window.open(url, sameName, features)` call reuse our window — giving us
+// a reference to the popup without intercepting any global API.
+const buildSignerWindowName = (identityProvider: string): string =>
+	`${new URL(identityProvider).origin}-signer-window`;
+
+// TODO: remove `signInWithUserInterruptDetection` once `@icp-sdk/auth`
+// (Internet Identity SDK) ships native "user closed the popup" detection.
+//
+// `@dfinity/auth-client` v4 polled `idpWindow.closed` internally and called
+// `onError('UserInterrupt')` when the user dismissed the popup. The v6
+// rewrite swapped that mechanism for the generic ICRC-29
+// `PostMessageTransport` heartbeat, which only detects a missing signer via
+// ping/pong timeouts (`disconnectTimeout: 2000ms`, `pendingTimeout:
+// 300000ms`). When id.ai reports `"pending"` — e.g. while redirecting to
+// Google for One-Click sign-in — right before the user closes the tab, our
+// sign-in promise can stay pending for up to 5 minutes, leaving the UI
+// stuck on the busy spinner.
+//
+// The II team has acknowledged the gap but it isn't on their short-term
+// roadmap, so we polyfill the behaviour here. When the SDK exposes a
+// first-class signal (e.g. a dedicated user-cancelled rejection, or a
+// `PostMessageTransport` option), this helper can be deleted and
+// `client.signIn(...)` called directly — the existing catch in
+// `auth.services.signIn` already maps `'UserInterrupt'` to a `cancelled`
+// outcome.
+//
+// Known limitation: some PWA / standalone-mode contexts (notably iOS "Add
+// to Home Screen") return a popup reference whose `.closed` flag never
+// updates. The poll then silently falls back to the SDK's heartbeat
+// behaviour; the Cancel button on the busy overlay (`busy.show()` sets
+// `close: true`) remains the user's escape hatch there.
+const signInWithUserInterruptDetection = async ({
+	client,
+	identityProvider,
+	windowOpenerFeatures
+}: {
+	client: AuthClient;
+	identityProvider: string;
+	windowOpenerFeatures?: string;
+}): Promise<Identity> => {
+	// Pre-open the popup synchronously, inside the same user-gesture call
+	// stack the SDK relies on, so popup blockers don't kick in. The SDK will
+	// then reuse this window via the matching name.
+	const signerWindow = globalThis.window.open(
+		'',
+		buildSignerWindowName(identityProvider),
+		windowOpenerFeatures
+	);
+
+	let pollHandle: ReturnType<typeof setInterval> | undefined;
+
+	const userInterruptPromise = new Promise<never>((_, reject) => {
+		// If `window.open` returned `null` (popup blocked, sandbox, etc.) the
+		// SDK's own `window.open` call will fail too and reject with a
+		// transport error — we just opt out of the poll in that case.
+		if (isNullish(signerWindow)) {
+			return;
+		}
+
+		pollHandle = setInterval(() => {
+			if (signerWindow.closed) {
+				reject('UserInterrupt');
+			}
+		}, SIGNER_WINDOW_CLOSED_POLLING_RATE);
+	});
+
+	const signInPromise = client.signIn({
+		maxTimeToLive: AUTH_MAX_TIME_TO_LIVE
+	});
+
+	// Once the user-interrupt poll wins the race, the SDK promise only
+	// settles much later via its heartbeat disconnect. Silence that rejection
+	// so the runtime doesn't flag it as unhandled.
+	signInPromise.catch(() => undefined);
+
+	try {
+		return await Promise.race([signInPromise, userInterruptPromise]);
+	} finally {
+		if (nonNullish(pollHandle)) {
+			clearInterval(pollHandle);
+		}
+	}
+};
+
 export interface AuthSignInParams {
 	domain?: InternetIdentityDomain;
 	asPopup?: boolean;
@@ -120,6 +214,13 @@ const initAuthStore = (): AuthStore => {
 						: `http://${INTERNET_IDENTITY_CANISTER_ID}.localhost:4943`
 					: `https://${effectiveDomain ?? InternetIdentityDomain.VERSION_1_0}/authorize${effectiveDomain === InternetIdentityDomain.VERSION_2_0 ? '?feature_flag_min_guided_upgrade=true' : ''}`;
 
+			const windowOpenerFeatures = asPopup
+				? popupCenter({
+						width: AUTH_POPUP_WIDTH,
+						height: AUTH_POPUP_HEIGHT
+					})
+				: undefined;
+
 			// In `@icp-sdk/auth` v6, `identityProvider`, `windowOpenerFeatures`,
 			// `derivationOrigin` and `openIdProvider` are constructor-bound rather
 			// than `login()` params, so we build a dedicated client for this
@@ -127,22 +228,17 @@ const initAuthStore = (): AuthStore => {
 			// preserved up to the `signIn()` call that opens the popup.
 			const client = AuthClientProvider.getInstance().createAuthClientForSignIn({
 				identityProvider,
-				...(asPopup
-					? {
-							windowOpenerFeatures: popupCenter({
-								width: AUTH_POPUP_WIDTH,
-								height: AUTH_POPUP_HEIGHT
-							})
-						}
-					: {}),
+				...(nonNullish(windowOpenerFeatures) ? { windowOpenerFeatures } : {}),
 				...(nonNullish(openIdProvider) ? { openIdProvider } : {}),
 				...getOptionalDerivationOrigin()
 			});
 
 			authClient = client;
 
-			const identity = await client.signIn({
-				maxTimeToLive: AUTH_MAX_TIME_TO_LIVE
+			const identity = await signInWithUserInterruptDetection({
+				client,
+				identityProvider,
+				windowOpenerFeatures
 			});
 
 			set({ identity });

--- a/src/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -48,8 +48,8 @@ describe('auth.store', () => {
 				// `safeCreateAuthClient`, which would otherwise need to be mocked
 				// as well.
 				isAuthenticated: vi.fn(() => true),
-				logout: vi.fn(async () => undefined),
-				getIdentity: vi.fn(async () => mockIdentity)
+				logout: vi.fn(() => Promise.resolve()),
+				getIdentity: vi.fn(() => Promise.resolve(mockIdentity))
 			}) as unknown as AuthClient;
 
 		beforeEach(() => {
@@ -60,7 +60,7 @@ describe('auth.store', () => {
 			// doesn't throw `AuthClientNotInitializedError` before reaching the
 			// code path under test.
 			vi.spyOn(provider, 'createAuthClient').mockResolvedValue(
-				buildClient(async () => mockIdentity)
+				buildClient(() => Promise.resolve(mockIdentity))
 			);
 		});
 
@@ -75,19 +75,18 @@ describe('auth.store', () => {
 			const openSpy = vi.spyOn(window, 'open').mockReturnValue(signerWindow);
 
 			vi.spyOn(provider, 'createAuthClientForSignIn').mockReturnValue(
-				buildClient(async () => mockIdentity)
+				buildClient(() => Promise.resolve(mockIdentity))
 			);
 
 			await authStore.signIn({ domain: InternetIdentityDomain.VERSION_2_0 });
 
-			expect(openSpy).toHaveBeenCalledOnce();
-			const [url, name, features] = openSpy.mock.calls[0];
-
-			expect(url).toBe('');
 			// Window name follows `<origin>-signer-window`, the convention
 			// `PostMessageTransport` uses internally so it reuses our window.
-			expect(name).toMatch(/^https?:\/\/[^/]+-signer-window$/);
-			expect(features).toBeUndefined();
+			expect(openSpy).toHaveBeenCalledExactlyOnceWith(
+				'',
+				expect.stringMatching(/^https?:\/\/[^/]+-signer-window$/),
+				undefined
+			);
 			expect(get(authStore).identity).toBe(mockIdentity);
 		});
 
@@ -130,7 +129,7 @@ describe('auth.store', () => {
 			vi.spyOn(window, 'open').mockReturnValue(null);
 
 			vi.spyOn(provider, 'createAuthClientForSignIn').mockReturnValue(
-				buildClient(async () => mockIdentity)
+				buildClient(() => Promise.resolve(mockIdentity))
 			);
 
 			await authStore.signIn({ domain: InternetIdentityDomain.VERSION_2_0 });

--- a/src/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -1,5 +1,9 @@
 import * as constants from '$lib/constants/app.constants';
+import { AuthClientProvider } from '$lib/providers/auth-client.providers';
 import { authStore } from '$lib/stores/auth.store';
+import { InternetIdentityDomain } from '$lib/types/auth';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import type { AuthClient } from '@icp-sdk/auth/client';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import { get } from 'svelte/store';
 
@@ -23,6 +27,115 @@ describe('auth.store', () => {
 			);
 
 			spy.mockRestore();
+		});
+	});
+
+	describe('signIn', () => {
+		const provider = AuthClientProvider.getInstance();
+
+		const mockSignerWindow = (closed = false) =>
+			({
+				closed,
+				close: vi.fn(),
+				focus: vi.fn(),
+				postMessage: vi.fn()
+			}) as unknown as Window;
+
+		const buildClient = (signInImpl: () => Promise<unknown>) =>
+			({
+				signIn: vi.fn(signInImpl),
+				// Returning `true` keeps `pickAuthClient` from falling through to
+				// `safeCreateAuthClient`, which would otherwise need to be mocked
+				// as well.
+				isAuthenticated: vi.fn(() => true),
+				logout: vi.fn(async () => undefined),
+				getIdentity: vi.fn(async () => mockIdentity)
+			}) as unknown as AuthClient;
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.clearAllMocks();
+
+			// Initialize the cached `authClient` in the store so `signIn()`
+			// doesn't throw `AuthClientNotInitializedError` before reaching the
+			// code path under test.
+			vi.spyOn(provider, 'createAuthClient').mockResolvedValue(
+				buildClient(async () => mockIdentity)
+			);
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('should pre-open the signer window with the SDK-compatible name so the SDK reuses it', async () => {
+			await authStore.sync();
+
+			const signerWindow = mockSignerWindow();
+			const openSpy = vi.spyOn(window, 'open').mockReturnValue(signerWindow);
+
+			vi.spyOn(provider, 'createAuthClientForSignIn').mockReturnValue(
+				buildClient(async () => mockIdentity)
+			);
+
+			await authStore.signIn({ domain: InternetIdentityDomain.VERSION_2_0 });
+
+			expect(openSpy).toHaveBeenCalledOnce();
+			const [url, name, features] = openSpy.mock.calls[0];
+
+			expect(url).toBe('');
+			// Window name follows `<origin>-signer-window`, the convention
+			// `PostMessageTransport` uses internally so it reuses our window.
+			expect(name).toMatch(/^https?:\/\/[^/]+-signer-window$/);
+			expect(features).toBeUndefined();
+			expect(get(authStore).identity).toBe(mockIdentity);
+		});
+
+		it('should reject with "UserInterrupt" when the signer window is closed before sign-in resolves', async () => {
+			await authStore.sync();
+
+			const signerWindow = mockSignerWindow();
+			vi.spyOn(window, 'open').mockReturnValue(signerWindow);
+
+			// `client.signIn(...)` would normally be settled by the SDK's
+			// heartbeat. Here it stays pending so the user-interrupt poller is
+			// the only thing that can settle the race.
+			vi.spyOn(provider, 'createAuthClientForSignIn').mockReturnValue(
+				buildClient(() => new Promise(() => undefined))
+			);
+
+			let caught: unknown;
+			const settled = authStore
+				.signIn({ domain: InternetIdentityDomain.VERSION_2_0 })
+				.then(
+					() => {
+						caught = 'resolved';
+					},
+					(err: unknown) => {
+						caught = err;
+					}
+				);
+
+			(signerWindow as unknown as { closed: boolean }).closed = true;
+
+			await vi.advanceTimersByTimeAsync(1000);
+			await settled;
+
+			expect(caught).toBe('UserInterrupt');
+		});
+
+		it('should not poll when the popup was blocked (window.open returns null)', async () => {
+			await authStore.sync();
+
+			vi.spyOn(window, 'open').mockReturnValue(null);
+
+			vi.spyOn(provider, 'createAuthClientForSignIn').mockReturnValue(
+				buildClient(async () => mockIdentity)
+			);
+
+			await authStore.signIn({ domain: InternetIdentityDomain.VERSION_2_0 });
+
+			expect(get(authStore).identity).toBe(mockIdentity);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/stores/auth.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/auth.store.spec.ts
@@ -104,16 +104,14 @@ describe('auth.store', () => {
 			);
 
 			let caught: unknown;
-			const settled = authStore
-				.signIn({ domain: InternetIdentityDomain.VERSION_2_0 })
-				.then(
-					() => {
-						caught = 'resolved';
-					},
-					(err: unknown) => {
-						caught = err;
-					}
-				);
+			const settled = authStore.signIn({ domain: InternetIdentityDomain.VERSION_2_0 }).then(
+				() => {
+					caught = 'resolved';
+				},
+				(err: unknown) => {
+					caught = err;
+				}
+			);
 
 			(signerWindow as unknown as { closed: boolean }).closed = true;
 


### PR DESCRIPTION
# Motivation

After clicking the Google (or any OpenID) button on the landing page, if the user closes the new tab without completing sign-in, OISY stays stuck in the busy spinner — sometimes for several minutes — with no way to recover.

Behaviour that broke during the `@icp-sdk/auth` v4 → v6 upgrade: the v4 client detected a closed sign-in popup itself and rejected with `'UserInterrupt'`; v6 doesn't, so we never see the cancellation.

# Changes

- Pre-open the signer popup using the same window name the SDK reuses internally, so we get a reference to it without monkey-patching globals.
- Race the SDK's `signIn` against a short poll on `signerWindow.closed`; on closure, reject with `'UserInterrupt'` — which `auth.services.signIn` already handles as a clean cancellation.
- No change to the happy path: if sign-in completes normally, the poll is cleaned up and the identity is set as before.

# Tests

Added unit tests in `auth.store.spec.ts` covering the happy path, the user-interrupt rejection, and the popup-blocked fallback.

# Note

The "right" place for this logic is inside `@icp-sdk/auth` itself (where v4 used to live). I checked with the II team — they confirmed they plan to bring back native popup-closed detection, but it's not on their short-term roadmap. Once the SDK ships a first-class signal, the helper added here can be deleted and `client.signIn(...)` called directly. A `TODO` in the file documents this.