### PR TITLE
feat(frontend): implement OneSec utils

### DIFF
--- a/src/frontend/src/env/rest/onesec.env.ts
+++ b/src/frontend/src/env/rest/onesec.env.ts
@@ -1,0 +1,1 @@
+export const ONESEC_SWAP_ENABLED = true;

--- a/src/frontend/src/lib/utils/onesec-swap.utils.ts
+++ b/src/frontend/src/lib/utils/onesec-swap.utils.ts
@@ -1,0 +1,144 @@
+import { ARBITRUM_MAINNET_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.base.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { ONESEC_SWAP_ENABLED } from '$env/rest/onesec.env';
+import type { Erc20Token } from '$eth/types/erc20';
+import { isIcToken } from '$icp/validation/ic-token.validation';
+import { ZERO } from '$lib/constants/app.constants';
+import type { NetworkId } from '$lib/types/network';
+import type { Token as AppToken } from '$lib/types/token';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import { DEFAULT_CONFIG, type Token, type TokenConfig } from 'onesec-bridge';
+
+export interface IcpLedgerEntry {
+	token: Token;
+	config: TokenConfig;
+}
+
+const buildIcpLedgerMap = (): Record<string, IcpLedgerEntry> => {
+	const map: Record<string, IcpLedgerEntry> = {};
+	for (const [token, config] of DEFAULT_CONFIG.tokens) {
+		const ledger = config.ledgerMainnet ?? config.ledger;
+		if (nonNullish(ledger)) {
+			map[ledger] = { token, config };
+		}
+	}
+	return map;
+};
+
+export const ICP_LEDGER_TO_TOKEN = buildIcpLedgerMap();
+
+export const computeReceiveAmount = ({
+	amount,
+	transferFeeInUnits,
+	protocolFeeInPercent,
+	decimals
+}: {
+	amount: bigint;
+	transferFeeInUnits: bigint;
+	protocolFeeInPercent: number;
+	decimals: number;
+}): bigint => {
+	const amountInTokens = Number(amount) / 10 ** decimals;
+	const protocolFee = BigInt(
+		Math.ceil(amountInTokens * (protocolFeeInPercent / 100) * 10 ** decimals)
+	);
+	const totalFee = transferFeeInUnits + protocolFee;
+	return amount > totalFee ? amount - totalFee : ZERO;
+};
+
+const getEvmAddressForNetwork = ({
+	config,
+	networkId
+}: {
+	config: TokenConfig;
+	networkId: NetworkId;
+}): string | undefined => {
+	let address = config.erc20Mainnet ?? config.erc20;
+	if (networkId === ARBITRUM_MAINNET_NETWORK_ID) {
+		address = config.erc20MainnetArbitrum ?? address;
+	} else if (networkId === BASE_NETWORK_ID) {
+		address = config.erc20MainnetBase ?? address;
+	} else if (networkId === ETHEREUM_NETWORK_ID) {
+		address = config.erc20MainnetEthereum ?? address;
+	}
+	return address;
+};
+
+/**
+ * Returns ICP ledger canister IDs of tokens supported by OneSec on the ICP side.
+ */
+export const oneSecIcpSupportedTokens = (): Promise<Set<string>> =>
+	Promise.resolve(new Set(Object.keys(ICP_LEDGER_TO_TOKEN)));
+
+/**
+ * Returns ERC20 addresses (lowercased) of tokens supported by OneSec on the given EVM networks.
+ */
+export const oneSecEvmSupportedTokens = ({
+	networkIds
+}: {
+	networkIds: NetworkId[];
+}): Promise<Set<string>> => {
+	const supported = new Set<string>();
+
+	for (const networkId of networkIds) {
+		for (const [, config] of DEFAULT_CONFIG.tokens) {
+			const address = getEvmAddressForNetwork({ config, networkId });
+
+			if (address) {
+				supported.add(address.toLowerCase());
+			}
+		}
+	}
+
+	return Promise.resolve(supported);
+};
+
+/**
+ * Returns per-category token identifiers that OneSec can bridge TO from the given source token.
+ * - ICP source → { evm: Set<ERC20 address lowercased> } for the given EVM network IDs
+ * - EVM source → { icp: Set<ICP ledger canister ID> }
+ * - Unknown → undefined (no OneSec restriction applied)
+ */
+export const oneSecCompatibleDestinations = ({
+	sourceToken,
+	networkIds
+}: {
+	sourceToken: AppToken;
+	networkIds: NetworkId[];
+}): Partial<Record<'icp' | 'evm' | 'sol', Set<string>>> | undefined => {
+	if (!ONESEC_SWAP_ENABLED) {
+		return;
+	}
+
+	if (isIcToken(sourceToken)) {
+		const entry = ICP_LEDGER_TO_TOKEN[sourceToken.ledgerCanisterId];
+		if (isNullish(entry)) {
+			return;
+		}
+
+		const addresses = new Set<string>();
+		for (const networkId of networkIds) {
+			const address = getEvmAddressForNetwork({ config: entry.config, networkId });
+			if (nonNullish(address)) {
+				addresses.add(address.toLowerCase());
+			}
+		}
+
+		return addresses.size > 0 ? { evm: addresses } : undefined;
+	}
+
+	// EVM source: find OneSec token by matching ERC20 address on the source network
+	const srcAddress = (sourceToken as Erc20Token).address;
+	if (isNullish(srcAddress)) {
+		return;
+	}
+
+	for (const [, config] of DEFAULT_CONFIG.tokens) {
+		const address = getEvmAddressForNetwork({ config, networkId: sourceToken.network.id });
+		if (nonNullish(address) && address.toLowerCase() === srcAddress.toLowerCase()) {
+			const ledger = config.ledgerMainnet ?? config.ledger;
+			return nonNullish(ledger) ? { icp: new Set([ledger]) } : undefined;
+		}
+	}
+};

--- a/src/frontend/src/lib/utils/onesec-swap.utils.ts
+++ b/src/frontend/src/lib/utils/onesec-swap.utils.ts
@@ -1,6 +1,5 @@
 import { ARBITRUM_MAINNET_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { BASE_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.base.env';
-import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ONESEC_SWAP_ENABLED } from '$env/rest/onesec.env';
 import type { Erc20Token } from '$eth/types/erc20';
 import { isIcToken } from '$icp/validation/ic-token.validation';
@@ -15,16 +14,14 @@ export interface IcpLedgerEntry {
 	config: TokenConfig;
 }
 
-const buildIcpLedgerMap = (): Record<string, IcpLedgerEntry> => {
-	const map: Record<string, IcpLedgerEntry> = {};
-	for (const [token, config] of DEFAULT_CONFIG.tokens) {
+const buildIcpLedgerMap = (): Record<string, IcpLedgerEntry> =>
+	[...DEFAULT_CONFIG.tokens].reduce<Record<string, IcpLedgerEntry>>((map, [token, config]) => {
 		const ledger = config.ledgerMainnet ?? config.ledger;
 		if (nonNullish(ledger)) {
 			map[ledger] = { token, config };
 		}
-	}
-	return map;
-};
+		return map;
+	}, {});
 
 export const ICP_LEDGER_TO_TOKEN = buildIcpLedgerMap();
 
@@ -53,17 +50,12 @@ const getEvmAddressForNetwork = ({
 }: {
 	config: TokenConfig;
 	networkId: NetworkId;
-}): string | undefined => {
-	let address = config.erc20Mainnet ?? config.erc20;
-	if (networkId === ARBITRUM_MAINNET_NETWORK_ID) {
-		address = config.erc20MainnetArbitrum ?? address;
-	} else if (networkId === BASE_NETWORK_ID) {
-		address = config.erc20MainnetBase ?? address;
-	} else if (networkId === ETHEREUM_NETWORK_ID) {
-		address = config.erc20MainnetEthereum ?? address;
-	}
-	return address;
-};
+}): string | undefined =>
+	networkId === ARBITRUM_MAINNET_NETWORK_ID
+		? config.erc20MainnetArbitrum
+		: networkId === BASE_NETWORK_ID
+			? config.erc20MainnetBase
+			: (config.erc20MainnetEthereum ?? config.erc20Mainnet ?? config.erc20);
 
 /**
  * Returns ICP ledger canister IDs of tokens supported by OneSec on the ICP side.

--- a/src/frontend/src/tests/lib/utils/onesec-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/onesec-swap.utils.spec.ts
@@ -1,0 +1,331 @@
+import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import type { Erc20Token } from '$eth/types/erc20';
+import type { IcToken } from '$icp/types/ic-token';
+import { ZERO } from '$lib/constants/app.constants';
+import {
+	computeReceiveAmount,
+	ICP_LEDGER_TO_TOKEN,
+	oneSecCompatibleDestinations,
+	oneSecEvmSupportedTokens,
+	oneSecIcpSupportedTokens
+} from '$lib/utils/onesec-swap.utils';
+import { parseTokenId } from '$lib/validation/token.validation';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
+
+// Real values from onesec-bridge DEFAULT_CONFIG
+const USDC_LEDGER = '53nhb-haaaa-aaaar-qbn5q-cai';
+const USDT_LEDGER = 'ij33n-oiaaa-aaaar-qbooa-cai';
+const ICP_LEDGER = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
+const USDC_ETHEREUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const USDC_ARBITRUM = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const USDT_ETHEREUM = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+const ICP_ETHEREUM = '0x00f3C42833C3170159af4E92dbb451Fb3F708917';
+
+let mockEnabled = true;
+
+vi.mock('$env/rest/onesec.env', () => ({
+	get ONESEC_SWAP_ENABLED() {
+		return mockEnabled;
+	}
+}));
+
+const makeIcToken = (ledgerCanisterId: string): IcToken => ({
+	...mockValidIcToken,
+	ledgerCanisterId
+});
+
+const makeErc20Token = ({
+	address,
+	network = ETHEREUM_NETWORK
+}: {
+	address: string;
+	network?: Erc20Token['network'];
+}): Erc20Token => ({
+	...mockValidToken,
+	id: parseTokenId(`Erc20-${address}`),
+	standard: { code: 'erc20' },
+	address,
+	network
+});
+
+describe('onesec-swap.utils', () => {
+	beforeEach(() => {
+		mockEnabled = true;
+	});
+
+	describe('ICP_LEDGER_TO_TOKEN', () => {
+		it('contains entries for all tokens that have a ledger canister', () => {
+			expect(ICP_LEDGER_TO_TOKEN[USDC_LEDGER]).toBeDefined();
+			expect(ICP_LEDGER_TO_TOKEN[USDT_LEDGER]).toBeDefined();
+			expect(ICP_LEDGER_TO_TOKEN[ICP_LEDGER]).toBeDefined();
+		});
+
+		it('maps ledger canister IDs to the correct token name', () => {
+			expect(ICP_LEDGER_TO_TOKEN[USDC_LEDGER].token).toBe('USDC');
+			expect(ICP_LEDGER_TO_TOKEN[USDT_LEDGER].token).toBe('USDT');
+			expect(ICP_LEDGER_TO_TOKEN[ICP_LEDGER].token).toBe('ICP');
+		});
+	});
+
+	describe('computeReceiveAmount', () => {
+		it('subtracts transfer and protocol fees from amount', () => {
+			// 1 USDC (6 decimals): 0.1% protocol fee + 1000 units transfer fee
+			const result = computeReceiveAmount({
+				amount: 1_000_000n,
+				transferFeeInUnits: 1_000n,
+				protocolFeeInPercent: 0.1,
+				decimals: 6
+			});
+
+			// protocol fee = ceil(1.0 * 0.001 * 1e6) = 1000
+			// total fee = 1000 + 1000 = 2000
+			expect(result).toBe(998_000n);
+		});
+
+		it('returns ZERO when total fee exceeds amount', () => {
+			const result = computeReceiveAmount({
+				amount: 100n,
+				transferFeeInUnits: 200n,
+				protocolFeeInPercent: 0,
+				decimals: 6
+			});
+
+			expect(result).toBe(ZERO);
+		});
+
+		it('returns full amount when all fees are zero', () => {
+			const result = computeReceiveAmount({
+				amount: 5_000_000n,
+				transferFeeInUnits: ZERO,
+				protocolFeeInPercent: 0,
+				decimals: 6
+			});
+
+			expect(result).toBe(5_000_000n);
+		});
+
+		it('applies only transfer fee when protocol fee is zero', () => {
+			const result = computeReceiveAmount({
+				amount: 1_000_000n,
+				transferFeeInUnits: 500n,
+				protocolFeeInPercent: 0,
+				decimals: 6
+			});
+
+			expect(result).toBe(999_500n);
+		});
+
+		it('applies only protocol fee when transfer fee is zero', () => {
+			// 0.5% of 1_000_000 = 5000
+			const result = computeReceiveAmount({
+				amount: 1_000_000n,
+				transferFeeInUnits: ZERO,
+				protocolFeeInPercent: 0.5,
+				decimals: 6
+			});
+
+			expect(result).toBe(995_000n);
+		});
+
+		it('returns ZERO rather than a negative when fee equals amount exactly', () => {
+			const result = computeReceiveAmount({
+				amount: 1_000n,
+				transferFeeInUnits: 1_000n,
+				protocolFeeInPercent: 0,
+				decimals: 6
+			});
+
+			expect(result).toBe(ZERO);
+		});
+	});
+
+	describe('oneSecIcpSupportedTokens', () => {
+		it('returns a Set containing all known ICP ledger canister IDs', async () => {
+			const result = await oneSecIcpSupportedTokens();
+
+			expect(result).toContain(USDC_LEDGER);
+			expect(result).toContain(USDT_LEDGER);
+			expect(result).toContain(ICP_LEDGER);
+		});
+
+		it('contains no empty strings', async () => {
+			const result = await oneSecIcpSupportedTokens();
+
+			expect(result.has('')).toBeFalsy();
+		});
+	});
+
+	describe('oneSecEvmSupportedTokens', () => {
+		it('returns lowercased ERC20 addresses for Ethereum', async () => {
+			const result = await oneSecEvmSupportedTokens({ networkIds: [ETHEREUM_NETWORK.id] });
+
+			expect(result).toContain(USDC_ETHEREUM.toLowerCase());
+			expect(result).toContain(USDT_ETHEREUM.toLowerCase());
+		});
+
+		it('returns Arbitrum-specific address for USDC on Arbitrum', async () => {
+			const result = await oneSecEvmSupportedTokens({ networkIds: [ARBITRUM_MAINNET_NETWORK.id] });
+
+			expect(result).toContain(USDC_ARBITRUM.toLowerCase());
+			expect(result).not.toContain(USDC_ETHEREUM.toLowerCase());
+		});
+
+		it('returns Base-specific address for USDC on Base', async () => {
+			const result = await oneSecEvmSupportedTokens({ networkIds: [BASE_NETWORK.id] });
+
+			expect(result).toContain(USDC_BASE.toLowerCase());
+			expect(result).not.toContain(USDC_ETHEREUM.toLowerCase());
+		});
+
+		it('unions addresses across multiple networks', async () => {
+			const result = await oneSecEvmSupportedTokens({
+				networkIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id, BASE_NETWORK.id]
+			});
+
+			expect(result).toContain(USDC_ETHEREUM.toLowerCase());
+			expect(result).toContain(USDC_ARBITRUM.toLowerCase());
+			expect(result).toContain(USDC_BASE.toLowerCase());
+		});
+
+		it('returns empty set for empty network list', async () => {
+			const result = await oneSecEvmSupportedTokens({ networkIds: [] });
+
+			expect(result.size).toBe(0);
+		});
+
+		it('stores addresses in lowercase', async () => {
+			const result = await oneSecEvmSupportedTokens({ networkIds: [ETHEREUM_NETWORK.id] });
+			for (const address of result) {
+				expect(address).toBe(address.toLowerCase());
+			}
+		});
+	});
+
+	describe('oneSecCompatibleDestinations', () => {
+		it('returns undefined when ONESEC_SWAP_ENABLED is false', () => {
+			mockEnabled = false;
+			const result = oneSecCompatibleDestinations({
+				sourceToken: makeIcToken(USDC_LEDGER),
+				networkIds: [ETHEREUM_NETWORK.id]
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		describe('ICP source token', () => {
+			it('returns EVM addresses when source is a supported ICP token', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeIcToken(USDC_LEDGER),
+					networkIds: [ETHEREUM_NETWORK.id]
+				});
+
+				expect(result?.evm).toBeDefined();
+				expect(result?.evm).toContain(USDC_ETHEREUM.toLowerCase());
+			});
+
+			it('includes addresses for all requested networks', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeIcToken(USDC_LEDGER),
+					networkIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id, BASE_NETWORK.id]
+				});
+
+				expect(result?.evm).toContain(USDC_ETHEREUM.toLowerCase());
+				expect(result?.evm).toContain(USDC_ARBITRUM.toLowerCase());
+				expect(result?.evm).toContain(USDC_BASE.toLowerCase());
+			});
+
+			it('returns undefined for a supported ICP token with no EVM address on the requested network', () => {
+				// USDT only has erc20MainnetEthereum — no Arbitrum address, so Arbitrum lookup returns undefined
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeIcToken(USDT_LEDGER),
+					networkIds: [ARBITRUM_MAINNET_NETWORK.id]
+				});
+
+				expect(result).toBeUndefined();
+			});
+
+			it('returns the ICP EVM address when source is ICP token on Ethereum', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeIcToken(ICP_LEDGER),
+					networkIds: [ETHEREUM_NETWORK.id]
+				});
+
+				expect(result?.evm).toBeDefined();
+				expect(result?.evm).toContain(ICP_ETHEREUM.toLowerCase());
+			});
+
+			it('returns undefined for an unknown ICP ledger canister', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeIcToken('unknown-canister-id'),
+					networkIds: [ETHEREUM_NETWORK.id]
+				});
+
+				expect(result).toBeUndefined();
+			});
+
+			it('returns undefined when networkIds is empty', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeIcToken(USDC_LEDGER),
+					networkIds: []
+				});
+
+				expect(result).toBeUndefined();
+			});
+
+			it('does not set evm key for icp or sol', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeIcToken(USDC_LEDGER),
+					networkIds: [ETHEREUM_NETWORK.id]
+				});
+
+				expect(result?.icp).toBeUndefined();
+				expect(result?.sol).toBeUndefined();
+			});
+		});
+
+		describe('EVM source token', () => {
+			it('returns the matching ICP ledger for a known EVM address', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeErc20Token({ address: USDC_ETHEREUM }),
+					networkIds: [ETHEREUM_NETWORK.id]
+				});
+
+				expect(result?.icp).toBeDefined();
+				expect(result?.icp).toContain(USDC_LEDGER);
+				expect(result?.icp?.size).toBe(1);
+			});
+
+			it('is case-insensitive when matching the source EVM address', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeErc20Token({ address: USDC_ETHEREUM.toLowerCase() }),
+					networkIds: [ETHEREUM_NETWORK.id]
+				});
+
+				expect(result?.icp).toContain(USDC_LEDGER);
+			});
+
+			it('returns undefined for an unknown EVM address', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeErc20Token({ address: '0x0000000000000000000000000000000000000001' }),
+					networkIds: [ETHEREUM_NETWORK.id]
+				});
+
+				expect(result).toBeUndefined();
+			});
+
+			it('does not set evm or sol keys for EVM source', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeErc20Token({ address: USDC_ETHEREUM }),
+					networkIds: [ETHEREUM_NETWORK.id]
+				});
+
+				expect(result?.evm).toBeUndefined();
+				expect(result?.sol).toBeUndefined();
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

- Adds a feature flag ONESEC_SWAP_ENABLED in src/frontend/src/env/rest/onesec.env.ts to gate the OneSec integration.
- Implements src/frontend/src/lib/utils/onesec-swap.utils.ts, the foundational utility layer for OneSec bridging:                                                             
  - ICP_LEDGER_TO_TOKEN — static map from ICP ledger canister IDs to onesec-bridge token/config entries, built once from DEFAULT_CONFIG.                                      
  - computeReceiveAmount — calculates the amount a user receives after deducting the transfer fee and protocol fee (both expressed in token units).                           
  - oneSecIcpSupportedTokens() — resolves to the set of ICP ledger canister IDs OneSec can handle as a source.                                                                
  - oneSecEvmSupportedTokens({ networkIds }) — resolves to lowercased ERC20 addresses supported by OneSec on the requested EVM networks, with per-network overrides (Arbitrum,
   Base, Ethereum mainnet).                                                                                                                                                     
  - oneSecCompatibleDestinations({ sourceToken, networkIds }) — returns the set of compatible destination identifiers by category (evm or icp) for a given source token,      
  returning undefined when the feature is disabled or the token is unknown.                                                                                                     
- Adds 28 unit tests covering all exported symbols, including fee edge cases, network-specific address selection, and the ONESEC_SWAP_ENABLED guard.
