### PR TITLE
feat(frontend): Increase ICPSwap minimum TVL threshold to 500 USD

### DIFF
--- a/src/frontend/src/lib/utils/exchange.utils.ts
+++ b/src/frontend/src/lib/utils/exchange.utils.ts
@@ -31,7 +31,7 @@ export const usdValue = ({
 			) * exchangeRate
 		: Number(ZERO);
 
-const ICPSWAP_MIN_TVL_USD = 10;
+const ICPSWAP_MIN_TVL_USD = 500;
 
 export const formatIcpSwapToCoingeckoPrices = (
 	tokens: IcpSwapToken[]

--- a/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/exchange.utils.spec.ts
@@ -72,7 +72,7 @@ describe('exchange.utils', () => {
 		it('skips token where tvlUSD is exactly at the threshold', () => {
 			const mock = createMockIcpSwapToken({
 				price: '1.230000000000000000',
-				tvlUSD: '10.000000000000000000'
+				tvlUSD: '500.000000000000000000'
 			});
 			const result = formatIcpSwapToCoingeckoPrices([mock]);
 
@@ -83,7 +83,7 @@ describe('exchange.utils', () => {
 			const mock = createMockIcpSwapToken({
 				tokenLedgerId: MOCK_CANISTER_ID_1,
 				price: '1.230000000000000000',
-				tvlUSD: '10.010000000000000000'
+				tvlUSD: '500.010000000000000000'
 			});
 			const result = formatIcpSwapToCoingeckoPrices([mock]);
 


### PR DESCRIPTION
# Motivation

We use ICPSwap as a fallback rate provider when Coingecko has no price for an ICRC token. For tokens with low-liquidity ICPSwap pools (e.g. USDC), the reported price is unreliable, so we already filter out pools below a TVL cutoff (introduced in #12431).

The current threshold of 10 USD is too permissive: pools with only a handful of dollars in liquidity still pass through and can feed wildly wrong prices to the wallet.

USDC on ICP has ~$76 tvl and the price seems not reliable, and I'd rather not show a price than an unreliable one.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a0367b97-ef36-4083-8a62-d6810f9b6894" />

# Changes

- Raise `ICPSWAP_MIN_TVL_USD` from 10 to 500.
- Update the two threshold-boundary tests to match the new value.

# Tests

`exchange.utils.spec.ts` — all 31 tests pass locally.

🤖 Claude Opus 4.7