### PR TITLE
fix(frontend): include `HiddenMicroTransactionsInfoBox` in `AllTransactions` banners logic

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import type { DismissedNotification } from '$declarations/backend/backend.did';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import type { IcToken } from '$icp/types/ic-token';
 	import { hasNoIndexCanister } from '$icp/validation/ic-token.validation';
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
 	import AllTransactionsList from '$lib/components/transactions/AllTransactionsList.svelte';
+	import HiddenMicroTransactionsInfoBox from '$lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import PageTitle from '$lib/components/ui/PageTitle.svelte';
 	import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
@@ -13,13 +13,12 @@
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import {
-		hideMicroTransactions,
+		hiddenMicroTransactionsBannerVisible,
 		userDismissedNotifications,
 		userProfileVersion
 	} from '$lib/derived/user-profile.derived';
 	import { dismissNotifications } from '$lib/services/notification.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
 	import type { TokenUi } from '$lib/types/token-ui';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import {
@@ -119,53 +118,11 @@
 		}
 	};
 
-	let hiddenMicroTransactionsBackendDismissed = $derived(
-		isSimpleNotificationDismissed({
-			kind: 'HiddenMicroTransactions',
-			dismissedNotifications: allDismissedNotifications
-		})
-	);
-
-	// When the user toggles the "hide micro transactions" feature, we re-show the
-	// info box even if the backend still has the notification stored as dismissed. The override
-	// is cleared as soon as the user dismisses the info box again.
-	let hiddenMicroTransactionsDismissed = $derived(
-		hiddenMicroTransactionsBackendDismissed && !$hiddenMicroTransactionsResetStore.enabled
-	);
-
-	let hiddenMicroTransactionsVisible = $derived(
-		$hideMicroTransactions && !hiddenMicroTransactionsDismissed
-	);
-
-	const dismissHiddenMicroTransactionsBanner = () => {
-		const notifications: DismissedNotification[] = [
-			{
-				Simple: {
-					kind: { HiddenMicroTransactions: null },
-					version: NOTIFICATION_VERSIONS.HiddenMicroTransactions
-				}
-			}
-		];
-
-		temporaryDismissedNotifications = [...temporaryDismissedNotifications, ...notifications];
-
-		hiddenMicroTransactionsResetStore.set({
-			key: 'hidden-micro-transactions-reset',
-			value: { enabled: false }
-		});
-
-		dismissNotifications({
-			notifications,
-			identity: $authIdentity,
-			currentUserVersion: $userProfileVersion
-		});
-	};
-
 	let hasBanners = $derived(
 		undismissedNoCanister.length > 0 ||
 			tokensWithUnavailableCanister.length > 0 ||
 			!btcBannerDismissed ||
-			hiddenMicroTransactionsVisible
+			$hiddenMicroTransactionsBannerVisible
 	);
 </script>
 
@@ -205,11 +162,7 @@
 				</MessageBox>
 			{/if}
 
-			{#if hiddenMicroTransactionsVisible}
-				<MessageBox level="plain" onDismiss={dismissHiddenMicroTransactionsBanner}>
-					<Html text={$i18n.activity.info.hidden_micro_transactions} />
-				</MessageBox>
-			{/if}
+			<HiddenMicroTransactionsInfoBox />
 		</div>
 	{/if}
 

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import { Html } from '@dfinity/gix-components';
 	import type { DismissedNotification } from '$declarations/backend/backend.did';
 	import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 	import type { IcToken } from '$icp/types/ic-token';
 	import { hasNoIndexCanister } from '$icp/validation/ic-token.validation';
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
 	import AllTransactionsList from '$lib/components/transactions/AllTransactionsList.svelte';
-	import HiddenMicroTransactionsInfoBox from '$lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import PageTitle from '$lib/components/ui/PageTitle.svelte';
 	import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
@@ -13,11 +13,13 @@
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import {
+		hideMicroTransactions,
 		userDismissedNotifications,
 		userProfileVersion
 	} from '$lib/derived/user-profile.derived';
 	import { dismissNotifications } from '$lib/services/notification.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
 	import type { TokenUi } from '$lib/types/token-ui';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import {
@@ -117,7 +119,47 @@
 		}
 	};
 
-	let hiddenMicroTransactionsVisible = $state(false);
+	let hiddenMicroTransactionsBackendDismissed = $derived(
+		isSimpleNotificationDismissed({
+			kind: 'HiddenMicroTransactions',
+			dismissedNotifications: allDismissedNotifications
+		})
+	);
+
+	// When the user toggles the "hide micro transactions" feature, we re-show the
+	// info box even if the backend still has the notification stored as dismissed. The override
+	// is cleared as soon as the user dismisses the info box again.
+	let hiddenMicroTransactionsDismissed = $derived(
+		hiddenMicroTransactionsBackendDismissed && !$hiddenMicroTransactionsResetStore.enabled
+	);
+
+	let hiddenMicroTransactionsVisible = $derived(
+		$hideMicroTransactions && !hiddenMicroTransactionsDismissed
+	);
+
+	const dismissHiddenMicroTransactionsBanner = () => {
+		const notifications: DismissedNotification[] = [
+			{
+				Simple: {
+					kind: { HiddenMicroTransactions: null },
+					version: NOTIFICATION_VERSIONS.HiddenMicroTransactions
+				}
+			}
+		];
+
+		temporaryDismissedNotifications = [...temporaryDismissedNotifications, ...notifications];
+
+		hiddenMicroTransactionsResetStore.set({
+			key: 'hidden-micro-transactions-reset',
+			value: { enabled: false }
+		});
+
+		dismissNotifications({
+			notifications,
+			identity: $authIdentity,
+			currentUserVersion: $userProfileVersion
+		});
+	};
 
 	let hasBanners = $derived(
 		undismissedNoCanister.length > 0 ||
@@ -162,10 +204,14 @@
 					{$i18n.activity.info.btc_transactions}
 				</MessageBox>
 			{/if}
+
+			{#if hiddenMicroTransactionsVisible}
+				<MessageBox level="plain" onDismiss={dismissHiddenMicroTransactionsBanner}>
+					<Html text={$i18n.activity.info.hidden_micro_transactions} />
+				</MessageBox>
+			{/if}
 		</div>
 	{/if}
-
-	<HiddenMicroTransactionsInfoBox bind:visible={hiddenMicroTransactionsVisible} />
 
 	<AllTransactionsList />
 </div>

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -117,10 +117,13 @@
 		}
 	};
 
+	let hiddenMicroTransactionsVisible = $state(false);
+
 	let hasBanners = $derived(
 		undismissedNoCanister.length > 0 ||
 			tokensWithUnavailableCanister.length > 0 ||
-			!btcBannerDismissed
+			!btcBannerDismissed ||
+			hiddenMicroTransactionsVisible
 	);
 </script>
 
@@ -162,7 +165,7 @@
 		</div>
 	{/if}
 
-	<HiddenMicroTransactionsInfoBox />
+	<HiddenMicroTransactionsInfoBox bind:visible={hiddenMicroTransactionsVisible} />
 
 	<AllTransactionsList />
 </div>

--- a/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
+++ b/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
@@ -14,12 +14,6 @@
 	import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
 	import { isSimpleNotificationDismissed } from '$lib/utils/notification.utils';
 
-	interface Props {
-		visible?: boolean;
-	}
-
-	let { visible = $bindable(false) }: Props = $props();
-
 	let temporaryDismissedNotifications = $state<DismissedNotification[]>([]);
 
 	let allDismissedNotifications = $derived([
@@ -39,9 +33,7 @@
 	// is cleared as soon as the user dismisses the info box again.
 	let dismissed = $derived(backendDismissed && !$hiddenMicroTransactionsResetStore.enabled);
 
-	$effect(() => {
-		visible = $hideMicroTransactions && !dismissed;
-	});
+	let visible = $derived($hideMicroTransactions && !dismissed);
 
 	const dismiss = () => {
 		const notifications: DismissedNotification[] = [

--- a/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
+++ b/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
@@ -14,6 +14,12 @@
 	import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
 	import { isSimpleNotificationDismissed } from '$lib/utils/notification.utils';
 
+	interface Props {
+		visible?: boolean;
+	}
+
+	let { visible = $bindable(false) }: Props = $props();
+
 	let temporaryDismissedNotifications = $state<DismissedNotification[]>([]);
 
 	let allDismissedNotifications = $derived([
@@ -33,7 +39,9 @@
 	// is cleared as soon as the user dismisses the info box again.
 	let dismissed = $derived(backendDismissed && !$hiddenMicroTransactionsResetStore.enabled);
 
-	let visible = $derived($hideMicroTransactions && !dismissed);
+	$effect(() => {
+		visible = $hideMicroTransactions && !dismissed;
+	});
 
 	const dismiss = () => {
 		const notifications: DismissedNotification[] = [

--- a/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
+++ b/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
@@ -5,37 +5,34 @@
 	import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
-		hideMicroTransactions,
-		userDismissedNotifications,
+		hiddenMicroTransactionsBannerVisible,
 		userProfileVersion
 	} from '$lib/derived/user-profile.derived';
 	import { dismissNotifications } from '$lib/services/notification.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
-	import { isSimpleNotificationDismissed } from '$lib/utils/notification.utils';
 
-	let temporaryDismissedNotifications = $state<DismissedNotification[]>([]);
+	// Optimistic local dismissal: the backend dismiss call is an update call that takes
+	// some time to complete. Keep an instant local override so the box hides immediately
+	// when the user clicks dismiss; it is cleared once the global signal turns off.
+	let locallyDismissed = $state(false);
 
-	let allDismissedNotifications = $derived([
-		...$userDismissedNotifications,
-		...temporaryDismissedNotifications
-	]);
+	$effect(() => {
+		if (!$hiddenMicroTransactionsBannerVisible) {
+			locallyDismissed = false;
+		}
+	});
 
-	let backendDismissed = $derived(
-		isSimpleNotificationDismissed({
-			kind: 'HiddenMicroTransactions',
-			dismissedNotifications: allDismissedNotifications
-		})
-	);
-
-	// When the user toggles the "hide micro transactions" feature, we re-show the
-	// info box even if the backend still has the notification stored as dismissed. The override
-	// is cleared as soon as the user dismisses the info box again.
-	let dismissed = $derived(backendDismissed && !$hiddenMicroTransactionsResetStore.enabled);
-
-	let visible = $derived($hideMicroTransactions && !dismissed);
+	let visible = $derived($hiddenMicroTransactionsBannerVisible && !locallyDismissed);
 
 	const dismiss = () => {
+		locallyDismissed = true;
+
+		hiddenMicroTransactionsResetStore.set({
+			key: 'hidden-micro-transactions-reset',
+			value: { enabled: false }
+		});
+
 		const notifications: DismissedNotification[] = [
 			{
 				Simple: {
@@ -44,13 +41,6 @@
 				}
 			}
 		];
-
-		temporaryDismissedNotifications = [...temporaryDismissedNotifications, ...notifications];
-
-		hiddenMicroTransactionsResetStore.set({
-			key: 'hidden-micro-transactions-reset',
-			value: { enabled: false }
-		});
 
 		dismissNotifications({
 			notifications,

--- a/src/frontend/src/lib/derived/user-profile.derived.ts
+++ b/src/frontend/src/lib/derived/user-profile.derived.ts
@@ -9,7 +9,9 @@ import type {
 	TransactionSettings,
 	UserProfile
 } from '$declarations/backend/backend.did';
+import { hiddenMicroTransactionsResetStore } from '$lib/stores/settings.store';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import { isSimpleNotificationDismissed } from '$lib/utils/notification.utils';
 import { fromNullishNullable, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -71,4 +73,27 @@ export const userTransactionFilterSettings: Readable<TransactionFilterSettings> 
 export const hideMicroTransactions: Readable<boolean> = derived(
 	[userTransactionFilterSettings],
 	([$userTransactionFilterSettings]) => $userTransactionFilterSettings.hide_micro_transactions
+);
+
+// Whether the "hidden micro transactions" info banner should be visible. Derived from
+// global state only (no component-local optimistic dismissal), so it can be consumed both
+// by `HiddenMicroTransactionsInfoBox` (which renders it) and by parents that need to know
+// about its visibility (e.g. to include it in a "has banners" derivation).
+export const hiddenMicroTransactionsBannerVisible: Readable<boolean> = derived(
+	[hideMicroTransactions, userDismissedNotifications, hiddenMicroTransactionsResetStore],
+	([$hideMicroTransactions, $userDismissedNotifications, $hiddenMicroTransactionsResetStore]) => {
+		if (!$hideMicroTransactions) {
+			return false;
+		}
+
+		const backendDismissed = isSimpleNotificationDismissed({
+			kind: 'HiddenMicroTransactions',
+			dismissedNotifications: $userDismissedNotifications
+		});
+
+		// When the user toggles the "hide micro transactions" feature, we re-show the info
+		// box even if the backend still has the notification stored as dismissed. The override
+		// is cleared as soon as the user dismisses the info box again.
+		return !(backendDismissed && !$hiddenMicroTransactionsResetStore.enabled);
+	}
 );


### PR DESCRIPTION
# Motivation

The `hasBanners` derivation in `AllTransactions.svelte` decides whether the banners wrapper renders, but it was not aware of `HiddenMicroTransactionsInfoBox`'s visibility. As a result, the hidden-micro-transactions info box was not considered a banner for layout/derivation purposes.

# Changes

- Expose visibility from `HiddenMicroTransactionsInfoBox` via an optional `$bindable` prop.
- Bind it in `AllTransactions` and include it in `hasBanners`.