### PR TITLE
feat(frontend): expose `newUserSignupsAllowed` backend method

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -98,6 +98,15 @@ export const getUserProfile = async ({
 	return getUserProfile({ certified });
 };
 
+export const newUserSignupsAllowed = async ({
+	identity,
+	certified
+}: CanisterApiFunctionParams<QueryParams>): Promise<boolean> => {
+	const { newUserSignupsAllowed } = await backendCanister({ identity });
+
+	return newUserSignupsAllowed({ certified });
+};
+
 export const addPendingBtcTransaction = async ({
 	identity,
 	...params

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -43,6 +43,7 @@ import type {
 	UpdateUserTransactionFilterSettings
 } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
+import { SignupsClosedError } from '$lib/types/errors';
 import type { BackendExchangeRate } from '$lib/types/exchange';
 import { mapBackendUserAgreements } from '$lib/utils/agreements.utils';
 import { mapBackendProviderAgreements } from '$lib/utils/provider-agreements.utils';
@@ -101,16 +102,28 @@ export class BackendCanister extends Canister<BackendService> {
 		return remove_custom_token(token);
 	};
 
-	createUserProfile = (): Promise<CreateUserProfileResponse> => {
+	createUserProfile = async (): Promise<CreateUserProfileResponse> => {
 		const { create_user_profile } = this.caller({ certified: true });
 
-		return create_user_profile();
+		const response = await create_user_profile();
+
+		if ('Err' in response && 'SignupsClosed' in response.Err) {
+			throw new SignupsClosedError();
+		}
+
+		return response;
 	};
 
 	getUserProfile = ({ certified }: QueryParams): Promise<GetUserProfileResponse> => {
 		const { get_user_profile } = this.caller({ certified });
 
 		return get_user_profile();
+	};
+
+	newUserSignupsAllowed = ({ certified }: QueryParams): Promise<boolean> => {
+		const { new_user_signups_allowed } = this.caller({ certified });
+
+		return new_user_signups_allowed();
 	};
 
 	btcAddPendingTransaction = async ({

--- a/src/frontend/src/tests/lib/api/backend.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/backend.api.spec.ts
@@ -10,6 +10,7 @@ import {
 	getUserProfile,
 	getUserTransactions,
 	listCustomTokens,
+	newUserSignupsAllowed,
 	removeCustomToken,
 	saveUserTransactions,
 	setCustomToken,
@@ -274,6 +275,38 @@ describe('backend.api', () => {
 			});
 
 			await expect(getUserProfile(mockParams)).rejects.toThrow();
+		});
+	});
+
+	describe('newUserSignupsAllowed', () => {
+		const mockParams: CanisterApiFunctionParams<QueryParams> = {
+			...baseParams,
+			certified
+		};
+
+		beforeEach(() => {
+			backendCanisterMock.newUserSignupsAllowed.mockResolvedValue(true);
+		});
+
+		it('should successfully call newUserSignupsAllowed endpoint', async () => {
+			const result = await newUserSignupsAllowed(mockParams);
+
+			expect(result).toBeTruthy();
+			expect(backendCanisterMock.newUserSignupsAllowed).toHaveBeenCalledExactlyOnceWith({
+				certified
+			});
+		});
+
+		it('should return false when signups are closed', async () => {
+			backendCanisterMock.newUserSignupsAllowed.mockResolvedValue(false);
+
+			const result = await newUserSignupsAllowed(mockParams);
+
+			expect(result).toBeFalsy();
+		});
+
+		it('should throw an error if identity is undefined', async () => {
+			await expect(newUserSignupsAllowed({ ...mockParams, identity: undefined })).rejects.toThrow();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -231,6 +231,18 @@ describe('backend.canister', () => {
 		expect(res).toEqual(response);
 	});
 
+	it('should throw SignupsClosedError when backend returns SignupsClosed', async () => {
+		service.create_user_profile.mockResolvedValue({ Err: { SignupsClosed: null } });
+
+		const { createUserProfile } = await createBackendCanister({
+			serviceOverride: service
+		});
+
+		const { SignupsClosedError } = await import('$lib/types/errors');
+
+		await expect(createUserProfile()).rejects.toThrow(SignupsClosedError);
+	});
+
 	it('should throw an error if create_user_profile throws', async () => {
 		service.create_user_profile.mockImplementation(async () => {
 			await Promise.resolve();


### PR DESCRIPTION
# Motivation

Expose the backend `create_user_profile` and `new_user_signups_allowed` endpoints through the frontend canister and API layer.