### PR TITLE
feat(frontend): surface signups-closed reason from `loadUserProfile`

### DIFF
--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -102,8 +102,6 @@ export const loadUserProfile = async ({
 		}
 	} catch (err: unknown) {
 		if (err instanceof SignupsClosedError) {
-			// Caller decides how to surface this (info toast + sign-out); don't show a generic
-			// error toast here.
 			return { success: false, err: 'signups-closed' };
 		}
 

--- a/src/frontend/src/lib/services/load-user-profile.services.ts
+++ b/src/frontend/src/lib/services/load-user-profile.services.ts
@@ -61,13 +61,15 @@ export const loadCertifiedUserProfile = async ({
 	}
 };
 
+export type LoadUserProfileFailureReason = 'signups-closed' | 'unknown';
+
 export const loadUserProfile = async ({
 	identity,
 	reload = true
 }: {
 	identity: NullishIdentity;
 	reload?: boolean;
-}): Promise<ResultSuccess> => {
+}): Promise<ResultSuccess<LoadUserProfileFailureReason>> => {
 	// We just want to verify that the store is empty, without being interested in the data.
 	// So we fetch it imperatively, instead of passing as parameter.
 	// If it is not empty, and we don't want to reload, we can return early.
@@ -99,12 +101,18 @@ export const loadUserProfile = async ({
 			loadCertifiedUserProfile({ identity });
 		}
 	} catch (err: unknown) {
+		if (err instanceof SignupsClosedError) {
+			// Caller decides how to surface this (info toast + sign-out); don't show a generic
+			// error toast here.
+			return { success: false, err: 'signups-closed' };
+		}
+
 		const { settings } = get(i18n);
 		toastsError({
 			msg: { text: settings.error.loading_profile },
 			err
 		});
-		return { success: false };
+		return { success: false, err: 'unknown' };
 	}
 
 	return { success: true };

--- a/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
+++ b/src/frontend/src/tests/lib/services/load-user-profile.spec.ts
@@ -2,6 +2,7 @@ import type { UserProfile } from '$declarations/backend/backend.did';
 import * as backendApi from '$lib/api/backend.api';
 import { loadUserProfile } from '$lib/services/load-user-profile.services';
 import { userProfileStore } from '$lib/stores/user-profile.store';
+import { SignupsClosedError } from '$lib/types/errors';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockUserProfile } from '$tests/mocks/user-profile.mock';
@@ -122,7 +123,7 @@ describe('load-user-profile.services', () => {
 
 			const result = await loadUserProfile({ identity: mockIdentity });
 
-			expect(result).toEqual({ success: false });
+			expect(result).toEqual({ success: false, err: 'unknown' });
 		});
 
 		it('should handle unknown error from getUserProfile', async () => {
@@ -132,7 +133,23 @@ describe('load-user-profile.services', () => {
 
 			const result = await loadUserProfile({ identity: mockIdentity });
 
-			expect(result).toEqual({ success: false });
+			expect(result).toEqual({ success: false, err: 'unknown' });
+		});
+
+		it('should surface signups-closed when createUserProfile rejects with SignupsClosedError', async () => {
+			vi.spyOn(backendApi, 'getUserProfile').mockResolvedValue({ Err: { NotFound: null } });
+			const createUserProfileSpy = vi
+				.spyOn(backendApi, 'createUserProfile')
+				.mockRejectedValue(new SignupsClosedError());
+
+			const result = await loadUserProfile({ identity: mockIdentity });
+
+			expect(result).toEqual({ success: false, err: 'signups-closed' });
+			expect(createUserProfileSpy).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				nullishIdentityErrorMessage
+			});
+			expect(get(userProfileStore)).toBeNull();
 		});
 
 		it('should handle certified profile load failure gracefully', async () => {


### PR DESCRIPTION
# Motivation

Let `loadUserProfile` distinguish a closed-sign-ups failure from a generic one, so callers can react to it explicitly.

# Changes

- `loadUserProfile` returns `{ success: false, err: 'signups-closed' | 'unknown' }`.
- On `SignupsClosedError`, skips the generic error toast.

# Tests

Added tests.
