### PR TITLE
feat(frontend): implement OneSec services

### DIFF
--- a/src/frontend/src/lib/services/onesec-swap.services.ts
+++ b/src/frontend/src/lib/services/onesec-swap.services.ts
@@ -1,0 +1,273 @@
+import { ONESEC_SWAP_ENABLED } from '$env/rest/onesec.env';
+import { send } from '$eth/services/send.services';
+import type { IcToken } from '$icp/types/ic-token';
+import { isIcToken } from '$icp/validation/ic-token.validation';
+import { getAgent } from '$lib/actors/agents.ic';
+import { authIdentity } from '$lib/derived/auth.derived';
+import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import {
+	SwapProvider,
+	type EvmQuoteParams,
+	type IcpBridgeQuoteParams,
+	type OneSecEvmToIcpParams,
+	type OneSecIcpToEvmParams,
+	type SwapMappedResult
+} from '$lib/types/swap';
+import { consoleError } from '$lib/utils/console.utils';
+import { isNetworkIdICP } from '$lib/utils/network.utils';
+import { computeReceiveAmount, ICP_LEDGER_TO_TOKEN } from '$lib/utils/onesec-swap.utils';
+import { parseToken } from '$lib/utils/parse.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import {
+	EvmToIcpBridgeBuilder,
+	IcpToEvmBridgeBuilder,
+	type BridgingPlan,
+	type EvmChain
+} from 'onesec-bridge';
+import { get } from 'svelte/store';
+
+const resolveQuoteFromPlan = async ({
+	plan,
+	amount,
+	decimals
+}: {
+	plan: BridgingPlan;
+	amount: bigint;
+	decimals: number;
+}): Promise<SwapMappedResult | undefined> => {
+	const feeStep = plan.nextStepToRun();
+	if (!feeStep) {
+		return;
+	}
+
+	const status = await feeStep.run();
+	if (status.state !== 'succeeded' || !status.expectedFee) {
+		return;
+	}
+
+	const transferFeeInUnits = status.expectedFee.transferFee().inUnits;
+	const protocolFeeInPercent = status.expectedFee.protocolFeeInPercent();
+
+	return {
+		provider: SwapProvider.ONE_SEC,
+		receiveAmount: computeReceiveAmount({
+			amount,
+			transferFeeInUnits,
+			protocolFeeInPercent,
+			decimals
+		}),
+		swapDetails: { transferFeeInUnits, protocolFeeInPercent }
+	};
+};
+
+/**
+ * Fetches a OneSec bridge quote for the EVM → ICP direction.
+ * Called from evmSwapProviders when the source is EVM and destination is an ICP token.
+ */
+export const fetchOneSecEvmToIcpQuote = async ({
+	sourceToken,
+	destinationToken,
+	amount
+}: EvmQuoteParams): Promise<SwapMappedResult | undefined> => {
+	const identity = get(authIdentity);
+	if (!ONESEC_SWAP_ENABLED || isNullish(identity) || !isNetworkIdICP(destinationToken.network.id)) {
+		return;
+	}
+
+	const entry = ICP_LEDGER_TO_TOKEN[(destinationToken as IcToken).ledgerCanisterId];
+	if (isNullish(entry)) {
+		return;
+	}
+
+	try {
+		const plan = await new EvmToIcpBridgeBuilder(sourceToken.network.name as EvmChain, entry.token)
+			.receiver(identity.getPrincipal())
+			.amountInUnits(amount)
+			.forward();
+
+		return resolveQuoteFromPlan({ plan, amount, decimals: destinationToken.decimals });
+	} catch (e) {
+		consoleError(e);
+	}
+};
+
+/**
+ * Fetches a OneSec bridge quote for the ICP → EVM direction.
+ * Called from icpBridgeProviders when source is an ICP token and destination is EVM.
+ */
+export const fetchOneSecIcpToEvmQuote = async ({
+	sourceToken,
+	destinationToken,
+	amount,
+	userEthAddress
+}: IcpBridgeQuoteParams): Promise<SwapMappedResult | undefined> => {
+	const identity = get(authIdentity);
+	if (
+		!ONESEC_SWAP_ENABLED ||
+		isNullish(identity) ||
+		!isIcToken(sourceToken) ||
+		isNullish(userEthAddress)
+	) {
+		return;
+	}
+
+	const entry = ICP_LEDGER_TO_TOKEN[sourceToken.ledgerCanisterId];
+	if (isNullish(entry)) {
+		return;
+	}
+
+	try {
+		const agent = await getAgent({ identity });
+		const plan = await new IcpToEvmBridgeBuilder(
+			agent,
+			destinationToken.network.name as EvmChain,
+			entry.token
+		)
+			.receiver(userEthAddress)
+			.amountInUnits(amount)
+			.build();
+
+		return resolveQuoteFromPlan({ plan, amount, decimals: destinationToken.decimals });
+	} catch (e) {
+		consoleError(e);
+	}
+};
+
+/**
+ * Executes an ICP → EVM bridge via OneSec.
+ *
+ * Rebuilds the bridging plan (re-validating fees) and runs all steps in sequence,
+ * reporting progress through the provided callback. Throws on failure; callers are
+ * responsible for enabling the destination token and triggering a wallet refresh.
+ */
+export const executeOneSecIcpToEvmBridge = async ({
+	identity,
+	progress,
+	sourceToken,
+	destinationToken,
+	swapAmount,
+	userEthAddress,
+	setFailedProgressStep
+}: OneSecIcpToEvmParams): Promise<void> => {
+	const entry = ICP_LEDGER_TO_TOKEN[sourceToken.ledgerCanisterId];
+
+	if (isNullish(entry)) {
+		throw new Error('Source token is not supported by the OneSec bridge');
+	}
+
+	const parsedAmount = parseToken({
+		value: `${swapAmount}`,
+		unitName: sourceToken.decimals
+	});
+
+	const agent = await getAgent({ identity });
+
+	const plan = await new IcpToEvmBridgeBuilder(
+		agent,
+		destinationToken.network.name as EvmChain,
+		entry.token
+	)
+		.sender(identity.getPrincipal())
+		.receiver(userEthAddress)
+		.amountInUnits(parsedAmount)
+		.build();
+
+	let step;
+	while ((step = plan.nextStepToRun()) !== undefined) {
+		// Step 0 is the fee-check step — keep the UI at INITIALIZATION.
+		// Step 1+ are the actual bridge operations (approve, transfer, wait for EVM tx).
+		if (step.index() >= 1) {
+			progress(ProgressStepsSwap.SWAP);
+		}
+
+		const result = await step.run();
+
+		if (result.state === 'failed') {
+			setFailedProgressStep?.(ProgressStepsSwap.SWAP);
+			throw new Error(result.error?.message ?? 'OneSec bridge step failed unexpectedly');
+		}
+	}
+};
+
+/**
+ * Executes an EVM → ICP bridge via OneSec using a forwarding address.
+ *
+ * Builds a forwarding plan, retrieves the deterministic forwarding address, sends the
+ * EVM tokens to that address using OISY's send service, then runs the remaining SDK
+ * steps (notify, validate, wait for ICP tx). Throws on failure; callers are responsible
+ * for enabling the destination token and triggering a wallet refresh.
+ */
+export const executeOneSecEvmToIcpBridge = async ({
+	identity,
+	progress,
+	sourceToken,
+	destinationToken,
+	swapAmount,
+	userEthAddress,
+	gas,
+	maxFeePerGas,
+	maxPriorityFeePerGas,
+	setFailedProgressStep
+}: OneSecEvmToIcpParams): Promise<void> => {
+	const entry = ICP_LEDGER_TO_TOKEN[destinationToken.ledgerCanisterId];
+	if (isNullish(entry)) {
+		throw new Error('Destination token is not supported by the OneSec bridge');
+	}
+
+	const parsedAmount = parseToken({
+		value: `${swapAmount}`,
+		unitName: sourceToken.decimals
+	});
+
+	const plan = await new EvmToIcpBridgeBuilder(sourceToken.network.name as EvmChain, entry.token)
+		.receiver(identity.getPrincipal())
+		.amountInUnits(parsedAmount)
+		.forward();
+
+	// Step 0: fee validation
+	let step = plan.nextStepToRun();
+	if (nonNullish(step)) {
+		const result = await step.run();
+		if (result.state === 'failed') {
+			setFailedProgressStep?.(ProgressStepsSwap.SWAP);
+			throw new Error(result.error?.message ?? 'OneSec fee check failed');
+		}
+	}
+
+	// Step 1: compute forwarding address
+	step = plan.nextStepToRun();
+	if (isNullish(step)) {
+		throw new Error('OneSec bridge plan is missing the forwarding address step');
+	}
+
+	const addressResult = await step.run();
+	if (addressResult.state === 'failed' || isNullish(addressResult.forwardingAddress)) {
+		setFailedProgressStep?.(ProgressStepsSwap.SWAP);
+		throw new Error(
+			addressResult.error?.message ?? 'Failed to compute the OneSec forwarding address'
+		);
+	}
+
+	// Send EVM tokens to the forwarding address
+	progress(ProgressStepsSwap.SWAP);
+	await send({
+		identity,
+		token: sourceToken,
+		from: userEthAddress,
+		to: addressResult.forwardingAddress,
+		amount: parsedAmount,
+		sourceNetwork: sourceToken.network,
+		gas,
+		maxFeePerGas,
+		maxPriorityFeePerGas
+	});
+
+	// Run remaining steps: notify OneSec, validate receipt, wait for ICP tx
+	while ((step = plan.nextStepToRun()) !== undefined) {
+		const result = await step.run();
+		if (result.state === 'failed') {
+			setFailedProgressStep?.(ProgressStepsSwap.SWAP);
+			throw new Error(result.error?.message ?? 'OneSec bridge step failed unexpectedly');
+		}
+	}
+};

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -805,6 +805,9 @@ export const swapService = {
 	},
 	[SwapProvider.NEAR_INTENTS]: () => {
 		throw new Error(get(i18n).swap.error.unexpected);
+	},
+	[SwapProvider.ONE_SEC]: () => {
+		throw new Error(get(i18n).swap.error.unexpected);
 	}
 };
 

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -30,7 +30,8 @@ export enum SwapProvider {
 	ICP_SWAP = 'icpSwap',
 	KONG_SWAP = 'kongSwap',
 	VELORA = 'velora',
-	NEAR_INTENTS = 'nearIntents'
+	NEAR_INTENTS = 'nearIntents',
+	ONE_SEC = 'oneSec'
 }
 
 export enum VeloraSwapTypes {
@@ -101,6 +102,13 @@ export type SwapMappedResult =
 			receiveAmount: bigint;
 			receiveOutMinimum?: bigint;
 			swapDetails: NearIntentsQuoteResponse;
+			type?: string;
+	  }
+	| {
+			provider: SwapProvider.ONE_SEC;
+			receiveAmount: bigint;
+			receiveOutMinimum?: bigint;
+			swapDetails: OneSecSwapDetails;
 			type?: string;
 	  };
 
@@ -224,6 +232,46 @@ export interface GetWithdrawableTokenParams {
 	tokenAddress: string;
 	sourceToken: IcTokenToggleable;
 	destinationToken: IcTokenToggleable;
+}
+
+export interface OneSecSwapDetails {
+	transferFeeInUnits: bigint;
+	protocolFeeInPercent: number;
+}
+
+export interface OneSecIcpToEvmParams {
+	identity: Identity;
+	progress: (step: ProgressStepsSwap) => void;
+	sourceToken: IcToken;
+	destinationToken: Erc20Token;
+	swapAmount: Amount;
+	userEthAddress: EthAddress;
+	setFailedProgressStep?: (step: ProgressStepsSwap) => void;
+}
+
+export interface OneSecEvmToIcpParams extends RequiredTransactionFeeData {
+	identity: Identity;
+	progress: (step: ProgressStepsSwap) => void;
+	sourceToken: Erc20Token;
+	destinationToken: IcToken;
+	swapAmount: Amount;
+	userEthAddress: EthAddress;
+	setFailedProgressStep?: (step: ProgressStepsSwap) => void;
+}
+
+export interface IcpBridgeQuoteParams {
+	sourceToken: Token;
+	destinationToken: Token;
+	amount: bigint;
+	userEthAddress: OptionEthAddress;
+	slippage: Slippage;
+}
+
+export interface IcpBridgeSwapProviderConfig {
+	key: SwapProvider;
+	getQuote: (params: IcpBridgeQuoteParams) => Promise<SwapMappedResult | undefined>;
+	isEnabled: boolean;
+	getSupportedTokens?: () => Promise<Set<string>>;
 }
 
 export interface SwapProvidersConfig {

--- a/src/frontend/src/tests/lib/services/onesec-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/onesec-swap.services.spec.ts
@@ -1,0 +1,434 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { send } from '$eth/services/send.services';
+import type { Erc20Token } from '$eth/types/erc20';
+import type { IcToken } from '$icp/types/ic-token';
+import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import {
+	executeOneSecEvmToIcpBridge,
+	executeOneSecIcpToEvmBridge,
+	fetchOneSecEvmToIcpQuote,
+	fetchOneSecIcpToEvmQuote
+} from '$lib/services/onesec-swap.services';
+import { SwapProvider } from '$lib/types/swap';
+import { parseTokenId } from '$lib/validation/token.validation';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import type { Identity } from '@icp-sdk/core/agent';
+import type * as OneSecBridge from 'onesec-bridge';
+
+const USDC_LEDGER = '53nhb-haaaa-aaaar-qbn5q-cai';
+
+const { mockPlan, mockStep, mockExpectedFee, mockEvmToIcpBuilderObj, mockIcpToEvmBuilderObj } =
+	vi.hoisted(() => {
+		const mockExpectedFee = {
+			transferFee: vi.fn().mockReturnValue({ inUnits: 1000n }),
+			protocolFeeInPercent: vi.fn().mockReturnValue(0.1)
+		};
+		const mockStep = {
+			run: vi.fn().mockResolvedValue({ state: 'succeeded', expectedFee: mockExpectedFee }),
+			index: vi.fn().mockReturnValue(0)
+		};
+		const mockPlan = { nextStepToRun: vi.fn().mockReturnValue(undefined) };
+		const mockEvmToIcpBuilderObj = {
+			receiver: vi.fn().mockReturnThis(),
+			amountInUnits: vi.fn().mockReturnThis(),
+			forward: vi.fn().mockResolvedValue(mockPlan)
+		};
+		const mockIcpToEvmBuilderObj = {
+			sender: vi.fn().mockReturnThis(),
+			receiver: vi.fn().mockReturnThis(),
+			amountInUnits: vi.fn().mockReturnThis(),
+			build: vi.fn().mockResolvedValue(mockPlan)
+		};
+		return { mockPlan, mockStep, mockExpectedFee, mockEvmToIcpBuilderObj, mockIcpToEvmBuilderObj };
+	});
+
+vi.mock('onesec-bridge', async (importOriginal) => {
+	const actual = await importOriginal<typeof OneSecBridge>();
+	return {
+		...actual,
+		// Must use regular functions (not arrow functions) — Vitest uses Reflect.construct
+		// when `new` is used, which requires a constructable function.
+		/* eslint-disable prefer-arrow/prefer-arrow-functions, prefer-arrow-callback */
+		EvmToIcpBridgeBuilder: vi.fn().mockImplementation(function () {
+			return mockEvmToIcpBuilderObj;
+		}),
+		IcpToEvmBridgeBuilder: vi.fn().mockImplementation(function () {
+			return mockIcpToEvmBuilderObj;
+		})
+		/* eslint-enable prefer-arrow/prefer-arrow-functions, prefer-arrow-callback */
+	};
+});
+
+let mockEnabled = true;
+vi.mock('$env/rest/onesec.env', () => ({
+	get ONESEC_SWAP_ENABLED() {
+		return mockEnabled;
+	}
+}));
+
+let currentIdentity: Identity | null = mockIdentity;
+vi.mock('$lib/derived/auth.derived', () => ({
+	get authIdentity() {
+		return {
+			subscribe: (fn: (v: Identity | null) => void) => {
+				fn(currentIdentity);
+				return () => {};
+			}
+		};
+	}
+}));
+
+vi.mock('$lib/actors/agents.ic', () => ({
+	getAgent: vi.fn().mockResolvedValue({})
+}));
+
+vi.mock('$eth/services/send.services', () => ({
+	send: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('$lib/utils/console.utils', () => ({
+	consoleError: vi.fn()
+}));
+
+const makeIcToken = (ledgerCanisterId: string): IcToken => ({
+	...mockValidIcToken,
+	ledgerCanisterId
+});
+
+const makeErc20Token = (address = mockEthAddress): Erc20Token => ({
+	...mockValidErc20Token,
+	id: parseTokenId(`Erc20-${address}`),
+	address,
+	network: ETHEREUM_NETWORK
+});
+
+const mockIcDestToken = makeIcToken(USDC_LEDGER);
+const mockIcSrcToken = makeIcToken(USDC_LEDGER);
+const mockEvmSrcToken = makeErc20Token('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
+const mockEvmDestToken = makeErc20Token();
+
+const baseEvmQuoteParams = {
+	sourceToken: mockEvmSrcToken,
+	destinationToken: mockIcDestToken,
+	amount: 1_000_000n,
+	userAddress: mockEthAddress,
+	slippage: 1
+};
+
+const baseIcpQuoteParams = {
+	sourceToken: mockIcSrcToken,
+	destinationToken: mockEvmDestToken,
+	amount: 1_000_000n,
+	userEthAddress: mockEthAddress,
+	slippage: 1
+};
+
+const baseIcpToEvmParams = {
+	identity: mockIdentity,
+	progress: vi.fn(),
+	sourceToken: mockIcSrcToken,
+	destinationToken: mockEvmDestToken,
+	swapAmount: 1,
+	userEthAddress: mockEthAddress,
+	setFailedProgressStep: vi.fn()
+};
+
+const baseEvmToIcpParams = {
+	identity: mockIdentity,
+	progress: vi.fn(),
+	sourceToken: mockEvmSrcToken,
+	destinationToken: mockIcDestToken,
+	swapAmount: 1,
+	userEthAddress: mockEthAddress,
+	gas: 21000n,
+	maxFeePerGas: 1_000_000_000n,
+	maxPriorityFeePerGas: 1_000_000_000n,
+	setFailedProgressStep: vi.fn()
+};
+
+describe('onesec-swap.services', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockEnabled = true;
+		currentIdentity = mockIdentity;
+
+		mockEvmToIcpBuilderObj.receiver.mockReturnThis();
+		mockEvmToIcpBuilderObj.amountInUnits.mockReturnThis();
+		mockEvmToIcpBuilderObj.forward.mockResolvedValue(mockPlan);
+
+		mockIcpToEvmBuilderObj.sender.mockReturnThis();
+		mockIcpToEvmBuilderObj.receiver.mockReturnThis();
+		mockIcpToEvmBuilderObj.amountInUnits.mockReturnThis();
+		mockIcpToEvmBuilderObj.build.mockResolvedValue(mockPlan);
+
+		mockPlan.nextStepToRun.mockReturnValue(undefined);
+		mockStep.run.mockResolvedValue({ state: 'succeeded', expectedFee: mockExpectedFee });
+		mockStep.index.mockReturnValue(0);
+		mockExpectedFee.transferFee.mockReturnValue({ inUnits: 1000n });
+		mockExpectedFee.protocolFeeInPercent.mockReturnValue(0.1);
+	});
+
+	describe('fetchOneSecEvmToIcpQuote', () => {
+		it('returns undefined when ONESEC_SWAP_ENABLED is false', async () => {
+			mockEnabled = false;
+
+			await expect(fetchOneSecEvmToIcpQuote(baseEvmQuoteParams)).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when identity is null', async () => {
+			currentIdentity = null;
+
+			await expect(fetchOneSecEvmToIcpQuote(baseEvmQuoteParams)).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when destination is not on ICP network', async () => {
+			await expect(
+				fetchOneSecEvmToIcpQuote({ ...baseEvmQuoteParams, destinationToken: mockEvmDestToken })
+			).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when destination token is not in ICP_LEDGER_TO_TOKEN', async () => {
+			await expect(
+				fetchOneSecEvmToIcpQuote({
+					...baseEvmQuoteParams,
+					destinationToken: makeIcToken('unknown-canister-id')
+				})
+			).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when plan has no steps', async () => {
+			mockPlan.nextStepToRun.mockReturnValue(undefined);
+
+			await expect(fetchOneSecEvmToIcpQuote(baseEvmQuoteParams)).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when step state is not succeeded', async () => {
+			mockPlan.nextStepToRun.mockReturnValueOnce(mockStep);
+			mockStep.run.mockResolvedValue({ state: 'failed' });
+
+			await expect(fetchOneSecEvmToIcpQuote(baseEvmQuoteParams)).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when step has no expectedFee', async () => {
+			mockPlan.nextStepToRun.mockReturnValueOnce(mockStep);
+			mockStep.run.mockResolvedValue({ state: 'succeeded' });
+
+			await expect(fetchOneSecEvmToIcpQuote(baseEvmQuoteParams)).resolves.toBeUndefined();
+		});
+
+		it('returns a SwapMappedResult on success', async () => {
+			mockPlan.nextStepToRun.mockReturnValueOnce(mockStep).mockReturnValue(undefined);
+			const result = await fetchOneSecEvmToIcpQuote(baseEvmQuoteParams);
+
+			expect(result).toBeDefined();
+			expect(result?.provider).toBe(SwapProvider.ONE_SEC);
+			expect(result?.receiveAmount).toBeTypeOf('bigint');
+			expect(result?.swapDetails).toMatchObject({
+				transferFeeInUnits: 1000n,
+				protocolFeeInPercent: 0.1
+			});
+		});
+
+		it('logs error and returns undefined when the builder throws', async () => {
+			mockEvmToIcpBuilderObj.forward.mockRejectedValue(new Error('network error'));
+			const result = await fetchOneSecEvmToIcpQuote(baseEvmQuoteParams);
+
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('fetchOneSecIcpToEvmQuote', () => {
+		it('returns undefined when ONESEC_SWAP_ENABLED is false', async () => {
+			mockEnabled = false;
+
+			await expect(fetchOneSecIcpToEvmQuote(baseIcpQuoteParams)).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when identity is null', async () => {
+			currentIdentity = null;
+
+			await expect(fetchOneSecIcpToEvmQuote(baseIcpQuoteParams)).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when source is not an IcToken', async () => {
+			await expect(
+				fetchOneSecIcpToEvmQuote({ ...baseIcpQuoteParams, sourceToken: mockEvmSrcToken })
+			).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when userEthAddress is null', async () => {
+			await expect(
+				fetchOneSecIcpToEvmQuote({ ...baseIcpQuoteParams, userEthAddress: null })
+			).resolves.toBeUndefined();
+		});
+
+		it('returns undefined when source token is not in ICP_LEDGER_TO_TOKEN', async () => {
+			await expect(
+				fetchOneSecIcpToEvmQuote({
+					...baseIcpQuoteParams,
+					sourceToken: makeIcToken('unknown-canister-id')
+				})
+			).resolves.toBeUndefined();
+		});
+
+		it('returns a SwapMappedResult on success', async () => {
+			mockPlan.nextStepToRun.mockReturnValueOnce(mockStep).mockReturnValue(undefined);
+			const result = await fetchOneSecIcpToEvmQuote(baseIcpQuoteParams);
+
+			expect(result).toBeDefined();
+			expect(result?.provider).toBe(SwapProvider.ONE_SEC);
+			expect(result?.receiveAmount).toBeTypeOf('bigint');
+			expect(result?.swapDetails).toMatchObject({
+				transferFeeInUnits: 1000n,
+				protocolFeeInPercent: 0.1
+			});
+		});
+
+		it('logs error and returns undefined when the builder throws', async () => {
+			mockIcpToEvmBuilderObj.build.mockRejectedValue(new Error('network error'));
+
+			await expect(fetchOneSecIcpToEvmQuote(baseIcpQuoteParams)).resolves.toBeUndefined();
+		});
+	});
+
+	describe('executeOneSecIcpToEvmBridge', () => {
+		it('throws when source token is not in ICP_LEDGER_TO_TOKEN', async () => {
+			await expect(
+				executeOneSecIcpToEvmBridge({
+					...baseIcpToEvmParams,
+					sourceToken: makeIcToken('unknown-canister-id')
+				})
+			).rejects.toThrow('Source token is not supported by the OneSec bridge');
+		});
+
+		it('throws and calls setFailedProgressStep when a step fails', async () => {
+			mockPlan.nextStepToRun.mockReturnValueOnce(mockStep).mockReturnValue(undefined);
+			mockStep.run.mockResolvedValue({ state: 'failed', error: { message: 'step error' } });
+
+			await expect(executeOneSecIcpToEvmBridge(baseIcpToEvmParams)).rejects.toThrow('step error');
+			expect(baseIcpToEvmParams.setFailedProgressStep).toHaveBeenCalledWith(ProgressStepsSwap.SWAP);
+		});
+
+		it('calls progress(SWAP) only for steps with index >= 1', async () => {
+			mockPlan.nextStepToRun
+				.mockReturnValueOnce(mockStep)
+				.mockReturnValueOnce(mockStep)
+				.mockReturnValue(undefined);
+			mockStep.index.mockReturnValueOnce(0).mockReturnValueOnce(1);
+			mockStep.run.mockResolvedValue({ state: 'succeeded' });
+
+			const progress = vi.fn();
+			await executeOneSecIcpToEvmBridge({ ...baseIcpToEvmParams, progress });
+
+			expect(progress).toHaveBeenCalledExactlyOnceWith(ProgressStepsSwap.SWAP);
+		});
+
+		it('completes successfully when all steps succeed', async () => {
+			mockPlan.nextStepToRun.mockReturnValueOnce(mockStep).mockReturnValue(undefined);
+			mockStep.run.mockResolvedValue({ state: 'succeeded' });
+
+			await expect(executeOneSecIcpToEvmBridge(baseIcpToEvmParams)).resolves.toBeUndefined();
+		});
+	});
+
+	describe('executeOneSecEvmToIcpBridge', () => {
+		it('throws when destination token is not in ICP_LEDGER_TO_TOKEN', async () => {
+			await expect(
+				executeOneSecEvmToIcpBridge({
+					...baseEvmToIcpParams,
+					destinationToken: makeIcToken('unknown-canister-id')
+				})
+			).rejects.toThrow('Destination token is not supported by the OneSec bridge');
+		});
+
+		it('throws and calls setFailedProgressStep when the fee step fails', async () => {
+			mockPlan.nextStepToRun.mockReturnValueOnce(mockStep);
+			mockStep.run.mockResolvedValue({ state: 'failed', error: { message: 'fee error' } });
+
+			await expect(executeOneSecEvmToIcpBridge(baseEvmToIcpParams)).rejects.toThrow('fee error');
+			expect(baseEvmToIcpParams.setFailedProgressStep).toHaveBeenCalledWith(ProgressStepsSwap.SWAP);
+		});
+
+		it('throws when the forwarding address step is missing', async () => {
+			mockPlan.nextStepToRun
+				.mockReturnValueOnce(mockStep) // fee step
+				.mockReturnValue(undefined); // no forwarding step
+			mockStep.run.mockResolvedValue({ state: 'succeeded' });
+
+			await expect(executeOneSecEvmToIcpBridge(baseEvmToIcpParams)).rejects.toThrow(
+				'OneSec bridge plan is missing the forwarding address step'
+			);
+		});
+
+		it('throws when the forwarding address is null', async () => {
+			mockPlan.nextStepToRun
+				.mockReturnValueOnce(mockStep) // fee step
+				.mockReturnValueOnce(mockStep) // forwarding step
+				.mockReturnValue(undefined);
+			mockStep.run
+				.mockResolvedValueOnce({ state: 'succeeded' })
+				.mockResolvedValueOnce({ state: 'succeeded', forwardingAddress: null });
+
+			await expect(executeOneSecEvmToIcpBridge(baseEvmToIcpParams)).rejects.toThrow(
+				'Failed to compute the OneSec forwarding address'
+			);
+		});
+
+		it('calls send with the forwarding address', async () => {
+			const forwardingAddress = '0xdeadbeef';
+			mockPlan.nextStepToRun
+				.mockReturnValueOnce(mockStep) // fee step
+				.mockReturnValueOnce(mockStep) // forwarding step
+				.mockReturnValue(undefined); // no remaining steps
+			mockStep.run
+				.mockResolvedValueOnce({ state: 'succeeded' })
+				.mockResolvedValueOnce({ state: 'succeeded', forwardingAddress });
+
+			await executeOneSecEvmToIcpBridge(baseEvmToIcpParams);
+
+			expect(vi.mocked(send)).toHaveBeenCalledWith(
+				expect.objectContaining({ to: forwardingAddress })
+			);
+		});
+
+		it('calls progress(SWAP) before sending', async () => {
+			const forwardingAddress = '0xdeadbeef';
+			mockPlan.nextStepToRun
+				.mockReturnValueOnce(mockStep) // fee step
+				.mockReturnValueOnce(mockStep) // forwarding step
+				.mockReturnValue(undefined);
+			mockStep.run
+				.mockResolvedValueOnce({ state: 'succeeded' })
+				.mockResolvedValueOnce({ state: 'succeeded', forwardingAddress });
+
+			const progress = vi.fn();
+			await executeOneSecEvmToIcpBridge({ ...baseEvmToIcpParams, progress });
+
+			expect(progress).toHaveBeenCalledWith(ProgressStepsSwap.SWAP);
+			expect(progress.mock.invocationCallOrder[0]).toBeLessThan(
+				vi.mocked(send).mock.invocationCallOrder[0]
+			);
+		});
+
+		it('throws and calls setFailedProgressStep when a remaining step fails', async () => {
+			const forwardingAddress = '0xdeadbeef';
+			mockPlan.nextStepToRun
+				.mockReturnValueOnce(mockStep) // fee step
+				.mockReturnValueOnce(mockStep) // forwarding step
+				.mockReturnValueOnce(mockStep) // remaining step
+				.mockReturnValue(undefined);
+			mockStep.run
+				.mockResolvedValueOnce({ state: 'succeeded' })
+				.mockResolvedValueOnce({ state: 'succeeded', forwardingAddress })
+				.mockResolvedValueOnce({ state: 'failed', error: { message: 'bridge failed' } });
+
+			await expect(executeOneSecEvmToIcpBridge(baseEvmToIcpParams)).rejects.toThrow(
+				'bridge failed'
+			);
+			expect(baseEvmToIcpParams.setFailedProgressStep).toHaveBeenCalledWith(ProgressStepsSwap.SWAP);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

- Adds onesec-swap.services.ts with four exported functions that wrap the onesec-bridge SDK: fetchOneSecEvmToIcpQuote, fetchOneSecIcpToEvmQuote, executeOneSecIcpToEvmBridge,
  and executeOneSecEvmToIcpBridge                                                                                                                                               
- Quote functions share a private resolveQuoteFromPlan helper that runs the plan's fee-check step and maps the result to SwapMappedResult
- EVM → ICP execution uses the forwarding address pattern: build plan → run fee step → retrieve deterministic forwarding address → send EVM tokens via OISY's send service →  
  run remaining SDK steps (notify, validate, wait for ICP tx)                                                                                                                   
- ICP → EVM execution runs all SDK steps sequentially, keeping the UI at INITIALIZATION for step 0 (fee check) and advancing to SWAP for steps 1+                             
- Adds a full Vitest suite (27 tests) covering guard conditions, both quote directions, both execution paths, progress reporting order, and all failure branches including setFailedProgressStep callbacks
