### PR TITLE
feat(frontend): increase max-old-space-size in FE Dockerfile

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -40,7 +40,10 @@ RUN echo $DFX_NETWORK
 
 RUN npm ci
 RUN npm run prepare
+
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN npm run build
+
 RUN scripts/build.frontend-report.sh > build/build-report.txt
 
 


### PR DESCRIPTION
# Motivation

We need to increase `max-old-space-size` in the docker environment when building FE to prevent fails due to JS heap size.