### PR TITLE
feat(frontend): define ICP bridge providers

### DIFF
--- a/src/frontend/src/lib/providers/icp-bridge-swap.providers.ts
+++ b/src/frontend/src/lib/providers/icp-bridge-swap.providers.ts
@@ -1,0 +1,17 @@
+import { ONESEC_SWAP_ENABLED } from '$env/rest/onesec.env';
+import { fetchOneSecIcpToEvmQuote } from '$lib/services/onesec-swap.services';
+import { SwapProvider, type IcpBridgeSwapProviderConfig } from '$lib/types/swap';
+import { oneSecIcpSupportedTokens } from '$lib/utils/onesec-swap.utils';
+
+export const icpBridgeProviders: IcpBridgeSwapProviderConfig[] = [
+	...(ONESEC_SWAP_ENABLED
+		? [
+				{
+					key: SwapProvider.ONE_SEC,
+					getQuote: fetchOneSecIcpToEvmQuote,
+					isEnabled: ONESEC_SWAP_ENABLED,
+					getSupportedTokens: oneSecIcpSupportedTokens
+				}
+			]
+		: [])
+];


### PR DESCRIPTION
# Motivation

We can define ICP bridge providers - for now, it's gonna be just OneSec.
