### PR TITLE
feat(frontend): extend swap tokens filter utils

### DIFF
--- a/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
+++ b/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
@@ -7,7 +7,7 @@ import type {
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { isTokenSpl } from '$sol/utils/spl.utils';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 /**
  * Resolves the provider-group info and the token identifier used for matching
@@ -21,25 +21,27 @@ const resolveSwapTokenLookup = ({
 }: {
 	token: Token;
 	supportedData: SwapSupportedTokensData;
-}): { info: SwapSupportedTokensInfo; identifier: string } | undefined => {
+}):
+	| { info: SwapSupportedTokensInfo; identifier: string; category: 'icp' | 'evm' | 'sol' }
+	| undefined => {
 	if (isIcToken(token)) {
-		return { info: supportedData.icp, identifier: token.ledgerCanisterId };
+		return { info: supportedData.icp, identifier: token.ledgerCanisterId, category: 'icp' };
 	}
 
 	if (isTokenErcFungible(token)) {
-		return { info: supportedData.evm, identifier: token.address.toLowerCase() };
+		return { info: supportedData.evm, identifier: token.address.toLowerCase(), category: 'evm' };
 	}
 
 	if (isTokenSpl(token)) {
-		return { info: supportedData.sol, identifier: token.address };
+		return { info: supportedData.sol, identifier: token.address, category: 'sol' };
 	}
 
 	if (token.standard.code === 'ethereum') {
-		return { info: supportedData.evm, identifier: token.symbol.toLowerCase() };
+		return { info: supportedData.evm, identifier: token.symbol.toLowerCase(), category: 'evm' };
 	}
 
 	if (token.standard.code === 'solana') {
-		return { info: supportedData.sol, identifier: token.symbol.toLowerCase() };
+		return { info: supportedData.sol, identifier: token.symbol.toLowerCase(), category: 'sol' };
 	}
 };
 
@@ -55,13 +57,19 @@ const resolveSwapTokenLookup = ({
  * - S  = union of supported tokens across providers that expose a list
  * - A  = active (enabled) tokens
  * - I  = inactive (disabled) tokens
+ *
+ * The optional `compatibleTokenIds` parameter narrows destinations on a per-category basis.
+ * Only categories present in the map are filtered; others pass through unchanged.
+ * This lets cross-chain providers restrict EVM destinations without hiding same-chain ICP tokens.
  */
 export const filterSwapTokens = <T extends Token>({
 	tokens,
-	supportedData
+	supportedData,
+	compatibleTokenIds
 }: {
 	tokens: TokenToggleable<T>[];
 	supportedData: SwapSupportedTokensData | undefined;
+	compatibleTokenIds?: Partial<Record<'icp' | 'evm' | 'sol', Set<string>>>;
 }): TokenToggleable<T>[] => {
 	if (isNullish(supportedData)) {
 		return tokens;
@@ -74,7 +82,7 @@ export const filterSwapTokens = <T extends Token>({
 			return token.enabled;
 		}
 
-		const { info, identifier } = lookup;
+		const { info, identifier, category } = lookup;
 
 		if (isNullish(info)) {
 			return token.enabled;
@@ -87,11 +95,19 @@ export const filterSwapTokens = <T extends Token>({
 		}
 
 		const isSupported = supportedTokenIds.has(identifier);
+		const passesCoverage = coverage === 'all' ? isSupported : token.enabled || isSupported;
 
-		if (coverage === 'all') {
-			return isSupported;
+		if (!passesCoverage) {
+			return false;
 		}
 
-		return token.enabled || isSupported;
+		if (nonNullish(compatibleTokenIds)) {
+			const categoryFilter = compatibleTokenIds[category];
+			if (nonNullish(categoryFilter)) {
+				return categoryFilter.has(identifier);
+			}
+		}
+
+		return true;
 	});
 };

--- a/src/frontend/src/tests/lib/utils/swap-tokens-filter.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap-tokens-filter.utils.spec.ts
@@ -306,4 +306,121 @@ describe('filterSwapTokens', () => {
 			expect(result).not.toContain(erc20Inactive);
 		});
 	});
+
+	describe('compatibleTokenIds', () => {
+		const supportedData: SwapSupportedTokensData = {
+			icp: {
+				coverage: 'all',
+				supportedTokenIds: new Set([
+					icpTokenActive.ledgerCanisterId,
+					icpTokenInactive.ledgerCanisterId
+				])
+			},
+			evm: {
+				coverage: 'all',
+				supportedTokenIds: new Set([
+					erc20Active.address.toLowerCase(),
+					erc20Inactive.address.toLowerCase()
+				])
+			},
+			sol: { coverage: 'all', supportedTokenIds: new Set([splActive.address]) }
+		};
+
+		it('includes token when it passes the category filter', () => {
+			const result = filterSwapTokens({
+				tokens: [erc20Active],
+				supportedData,
+				compatibleTokenIds: { evm: new Set([erc20Active.address.toLowerCase()]) }
+			});
+
+			expect(result).toContain(erc20Active);
+		});
+
+		it('excludes token when it does not pass the category filter', () => {
+			const result = filterSwapTokens({
+				tokens: [erc20Inactive],
+				supportedData,
+				compatibleTokenIds: { evm: new Set([erc20Active.address.toLowerCase()]) }
+			});
+
+			expect(result).not.toContain(erc20Inactive);
+		});
+
+		it('does not restrict categories absent from the map', () => {
+			const result = filterSwapTokens({
+				tokens: [icpTokenActive, icpTokenInactive, erc20Active],
+				supportedData,
+				compatibleTokenIds: { evm: new Set([erc20Active.address.toLowerCase()]) }
+			});
+
+			// EVM filtered
+			expect(result).toContain(erc20Active);
+			// ICP not filtered — passes through on coverage rules
+			expect(result).toContain(icpTokenActive);
+			expect(result).toContain(icpTokenInactive);
+		});
+
+		it('filters out all tokens in a category when the filter set is empty', () => {
+			const result = filterSwapTokens({
+				tokens: [erc20Active, erc20Inactive],
+				supportedData,
+				compatibleTokenIds: { evm: new Set() }
+			});
+
+			expect(result).not.toContain(erc20Active);
+			expect(result).not.toContain(erc20Inactive);
+		});
+
+		it('behaves like no filter when compatibleTokenIds is an empty map', () => {
+			const result = filterSwapTokens({
+				tokens: [icpTokenActive, icpTokenInactive, erc20Active],
+				supportedData,
+				compatibleTokenIds: {}
+			});
+
+			expect(result).toContain(icpTokenActive);
+			expect(result).toContain(icpTokenInactive);
+			expect(result).toContain(erc20Active);
+		});
+
+		it('applies independent filters per category simultaneously', () => {
+			const result = filterSwapTokens({
+				tokens: [icpTokenActive, icpTokenInactive, erc20Active, erc20Inactive, splActive],
+				supportedData,
+				compatibleTokenIds: {
+					icp: new Set([icpTokenActive.ledgerCanisterId]),
+					evm: new Set([erc20Inactive.address.toLowerCase()])
+				}
+			});
+
+			// ICP: only icpTokenActive passes the category filter
+			expect(result).toContain(icpTokenActive);
+			expect(result).not.toContain(icpTokenInactive);
+
+			// EVM: only erc20Inactive passes the category filter
+			expect(result).not.toContain(erc20Active);
+			expect(result).toContain(erc20Inactive);
+
+			// SOL: no category filter → passes through on coverage rules
+			expect(result).toContain(splActive);
+		});
+
+		it('coverage still gates tokens before compatibleTokenIds is applied', () => {
+			const noCoverageData: SwapSupportedTokensData = {
+				icp: { coverage: 'none', supportedTokenIds: new Set() },
+				evm: { coverage: 'none', supportedTokenIds: new Set() },
+				sol: { coverage: 'none', supportedTokenIds: new Set() }
+			};
+
+			const result = filterSwapTokens({
+				tokens: [erc20Active, erc20Inactive],
+				supportedData: noCoverageData,
+				compatibleTokenIds: { evm: new Set([erc20Inactive.address.toLowerCase()]) }
+			});
+
+			// coverage=none returns enabled-only regardless of compatibleTokenIds
+			expect(result).toContain(erc20Active);
+			expect(result).not.toContain(erc20Inactive);
+		});
+	});
 });


### PR DESCRIPTION
# Motivation

- Extends resolveSwapTokenLookup to return a category field ('icp' | 'evm' | 'sol') alongside info and identifier, enabling per-category post-filtering.                      
- Adds an optional compatibleTokenIds parameter to filterSwapTokens — a partial map from category to a Set<string> of allowed token identifiers. When a category is present in the map, only tokens whose identifier is in the set pass through; categories absent from the map are unaffected.                                                             
- Coverage rules still act as the primary gate — compatibleTokenIds is only evaluated on tokens that already pass the coverage check.                                         
                                                                                                                                                                                
This enables cross-chain swap providers to restrict valid destination tokens (e.g. limit EVM destinations) without hiding unrelated same-chain tokens (e.g. ICP tokens).  
