### PR TITLE
feat(frontend): extend swap services with OneSec

### DIFF
--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -827,12 +827,12 @@ export const fetchOneSecEvmToIcpSwap = async (params: OneSecEvmToIcpParams): Pro
 
 export const fetchOneSecIcpToEvmSwap = async (params: OneSecIcpToEvmParams): Promise<void> => {
 	await executeOneSecIcpToEvmBridge(params);
+	params.progress(ProgressStepsSwap.UPDATE_UI);
 
 	await enableSwapDestinationToken({
 		destinationToken: params.destinationToken,
 		identity: params.identity
 	});
-	params.progress(ProgressStepsSwap.UPDATE_UI);
 	await waitAndTriggerWallet();
 };
 

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -43,6 +43,7 @@ import { exchanges } from '$lib/derived/exchange.derived';
 import { PLAUSIBLE_EVENTS, PLAUSIBLE_EVENT_CONTEXTS } from '$lib/enums/plausible';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import { evmSwapProviders } from '$lib/providers/evm-swap.providers';
+import { icpBridgeProviders } from '$lib/providers/icp-bridge-swap.providers';
 import { solSwapProviders } from '$lib/providers/sol-swap.providers';
 import { swapProviders } from '$lib/providers/swap.providers';
 import { trackEvent } from '$lib/services/analytics.services';
@@ -50,6 +51,10 @@ import {
 	pollNearIntentsStatus,
 	submitNearIntentsDepositTx
 } from '$lib/services/near-intents.services';
+import {
+	executeOneSecEvmToIcpBridge,
+	executeOneSecIcpToEvmBridge
+} from '$lib/services/onesec-swap.services';
 import { retryWithDelay } from '$lib/services/rest.services';
 import { throwSwapError } from '$lib/services/swap-errors.services';
 import { autoLoadSingleToken } from '$lib/services/token.services';
@@ -68,10 +73,13 @@ import {
 	type EvmQuoteParams,
 	type FetchSwapAmountsParams,
 	type ICPSwapResult,
+	type IcpBridgeQuoteParams,
 	type IcpSwapManualWithdrawParams,
 	type IcpSwapWithdrawParams,
 	type IcpSwapWithdrawResponse,
 	type NearIntentsQuoteParams,
+	type OneSecEvmToIcpParams,
+	type OneSecIcpToEvmParams,
 	type SwapMappedResult,
 	type SwapNearIntentsEvmParams,
 	type SwapNearIntentsSolParams,
@@ -319,6 +327,16 @@ export const fetchSwapAmounts = async ({
 	});
 
 	if (isNetworkIdICP(sourceToken.network.id)) {
+		if (!isNetworkIdICP(destinationToken.network.id)) {
+			return await fetchSwapAmountsICPBridge({
+				sourceToken,
+				destinationToken,
+				amount: sourceAmount,
+				userEthAddress,
+				slippage
+			});
+		}
+
 		return await fetchSwapAmountsICP({
 			identity,
 			sourceToken,
@@ -796,6 +814,28 @@ export const fetchNearIntentsSolSwap = async ({
 	});
 };
 
+export const fetchOneSecEvmToIcpSwap = async (params: OneSecEvmToIcpParams): Promise<void> => {
+	await executeOneSecEvmToIcpBridge(params);
+
+	await enableSwapDestinationToken({
+		destinationToken: params.destinationToken,
+		identity: params.identity
+	});
+	params.progress(ProgressStepsSwap.UPDATE_UI);
+	await waitAndTriggerWallet();
+};
+
+export const fetchOneSecIcpToEvmSwap = async (params: OneSecIcpToEvmParams): Promise<void> => {
+	await executeOneSecIcpToEvmBridge(params);
+
+	await enableSwapDestinationToken({
+		destinationToken: params.destinationToken,
+		identity: params.identity
+	});
+	params.progress(ProgressStepsSwap.UPDATE_UI);
+	await waitAndTriggerWallet();
+};
+
 export const swapService = {
 	[SwapProvider.ICP_SWAP]: fetchIcpSwap,
 	[SwapProvider.KONG_SWAP]: fetchKongSwap,
@@ -901,6 +941,34 @@ export const performManualWithdraw = async ({
 			swapSucceded: withdrawDestinationTokens
 		};
 	}
+};
+
+const fetchSwapAmountsICPBridge = async ({
+	sourceToken,
+	destinationToken,
+	amount,
+	userEthAddress,
+	slippage
+}: IcpBridgeQuoteParams): Promise<SwapMappedResult[]> => {
+	const enabledProviders = icpBridgeProviders.filter(({ isEnabled }) => isEnabled);
+
+	const settledResults = await Promise.allSettled(
+		enabledProviders.map(({ getQuote }) =>
+			getQuote({ sourceToken, destinationToken, amount, userEthAddress, slippage })
+		)
+	);
+
+	const results = settledResults.reduce<SwapMappedResult[]>((acc, result) => {
+		if (result.status === 'fulfilled' && nonNullish(result.value)) {
+			acc.push(result.value);
+		}
+
+		return acc;
+	}, []);
+
+	return results.sort((a, b) =>
+		a.receiveAmount === b.receiveAmount ? 0 : a.receiveAmount > b.receiveAmount ? -1 : 1
+	);
 };
 
 // This wrapper keeps the return type uniform (array of SwapMappedResult),

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -816,12 +816,12 @@ export const fetchNearIntentsSolSwap = async ({
 
 export const fetchOneSecEvmToIcpSwap = async (params: OneSecEvmToIcpParams): Promise<void> => {
 	await executeOneSecEvmToIcpBridge(params);
+	params.progress(ProgressStepsSwap.UPDATE_UI);
 
 	await enableSwapDestinationToken({
 		destinationToken: params.destinationToken,
 		identity: params.identity
 	});
-	params.progress(ProgressStepsSwap.UPDATE_UI);
 	await waitAndTriggerWallet();
 };
 

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -18,9 +18,12 @@ import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import { trackEvent } from '$lib/services/analytics.services';
 import * as icpSwapBackend from '$lib/services/icp-swap.services';
 import * as nearIntentsServices from '$lib/services/near-intents.services';
+import * as oneSecSwapServices from '$lib/services/onesec-swap.services';
 import {
 	fetchNearIntentsEvmSwap,
 	fetchNearIntentsSolSwap,
+	fetchOneSecEvmToIcpSwap,
+	fetchOneSecIcpToEvmSwap,
 	fetchSwapAmounts,
 	fetchSwapAmountsEVM,
 	fetchSwapAmountsSOL,
@@ -81,6 +84,7 @@ vi.mock('$lib/services/analytics.services', () => ({
 
 const mockVeloraGetQuote = vi.hoisted(() => vi.fn());
 const mockSolGetQuote = vi.hoisted(() => vi.fn());
+const mockIcpBridgeGetQuote = vi.hoisted(() => vi.fn());
 
 vi.mock('$lib/providers/evm-swap.providers', () => ({
 	evmSwapProviders: [
@@ -100,6 +104,21 @@ vi.mock('$lib/providers/sol-swap.providers', () => ({
 			isEnabled: true
 		}
 	]
+}));
+
+vi.mock('$lib/providers/icp-bridge-swap.providers', () => ({
+	icpBridgeProviders: [
+		{
+			key: 'one_sec',
+			getQuote: mockIcpBridgeGetQuote,
+			isEnabled: true
+		}
+	]
+}));
+
+vi.mock('$lib/services/onesec-swap.services', () => ({
+	executeOneSecEvmToIcpBridge: vi.fn(),
+	executeOneSecIcpToEvmBridge: vi.fn()
 }));
 
 vi.mock('$lib/services/near-intents.services', () => ({
@@ -421,6 +440,102 @@ describe('swap.services', () => {
 			});
 
 			expect(mockVeloraGetQuote).toHaveBeenCalled();
+		});
+
+		describe('with ICP source and non-ICP destination', () => {
+			const icpSource = mockValidIcToken as IcToken;
+			const evmDest = { ...mockValidErc20Token, network: ETHEREUM_NETWORK } as Erc20Token;
+
+			beforeEach(() => {
+				vi.clearAllMocks();
+			});
+
+			it('routes to fetchSwapAmountsICPBridge and calls icpBridgeProviders', async () => {
+				mockIcpBridgeGetQuote.mockResolvedValue({
+					provider: SwapProvider.ONE_SEC,
+					receiveAmount: 500n,
+					swapDetails: { transferFeeInUnits: 1000n, protocolFeeInPercent: 0.1 }
+				});
+
+				const result = await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: icpSource,
+					destinationToken: evmDest,
+					amount: 1000,
+					tokens: [icpSource, evmDest],
+					slippage: 0.5,
+					isSourceTokenIcrc2: true,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined
+				});
+
+				expect(mockIcpBridgeGetQuote).toHaveBeenCalledWith(
+					expect.objectContaining({
+						sourceToken: icpSource,
+						destinationToken: evmDest,
+						userEthAddress: mockEthAddress
+					})
+				);
+				expect(result).toHaveLength(1);
+				expect(result[0].provider).toBe(SwapProvider.ONE_SEC);
+			});
+
+			it('does NOT call icpBridgeProviders when both source and destination are ICP', async () => {
+				vi.mocked(kongBackendApi.kongSwapAmounts).mockResolvedValue({
+					receive_amount: 100n,
+					slippage: 0.5
+				} as SwapAmountsReply);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: icpSource,
+					destinationToken: mockValidIcrcToken as IcToken,
+					amount: 1000,
+					tokens: [icpSource, mockValidIcrcToken as IcToken],
+					slippage: 0.5,
+					isSourceTokenIcrc2: false,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined
+				});
+
+				expect(mockIcpBridgeGetQuote).not.toHaveBeenCalled();
+			});
+
+			it('returns [] when all ICP bridge providers return undefined', async () => {
+				mockIcpBridgeGetQuote.mockResolvedValue(undefined);
+
+				const result = await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: icpSource,
+					destinationToken: evmDest,
+					amount: 1000,
+					tokens: [icpSource, evmDest],
+					slippage: 0.5,
+					isSourceTokenIcrc2: true,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined
+				});
+
+				expect(result).toEqual([]);
+			});
+
+			it('skips a provider whose quote rejects and returns remaining results', async () => {
+				mockIcpBridgeGetQuote.mockRejectedValue(new Error('OneSec error'));
+
+				const result = await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: icpSource,
+					destinationToken: evmDest,
+					amount: 1000,
+					tokens: [icpSource, evmDest],
+					slippage: 0.5,
+					isSourceTokenIcrc2: true,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined
+				});
+
+				expect(result).toEqual([]);
+			});
 		});
 
 		describe('with Solana tokens', () => {
@@ -2139,6 +2254,135 @@ describe('swap.services', () => {
 				depositAddress,
 				depositMemo: 'sol-memo-123'
 			});
+		});
+	});
+
+	describe('fetchOneSecIcpToEvmSwap', () => {
+		const sourceToken = mockValidIcToken as IcToken;
+		const mockProgress = vi.fn();
+
+		const baseParams = {
+			identity: mockIdentity,
+			progress: mockProgress,
+			sourceToken,
+			swapAmount: '1',
+			userEthAddress: mockEthAddress
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			vi.mocked(oneSecSwapServices.executeOneSecIcpToEvmBridge).mockResolvedValue(undefined);
+		});
+
+		it('should call executeOneSecIcpToEvmBridge with the provided params', async () => {
+			const destinationToken = { ...mockValidErc20Token, enabled: true } as Erc20Token;
+
+			await fetchOneSecIcpToEvmSwap({ ...baseParams, destinationToken });
+
+			expect(oneSecSwapServices.executeOneSecIcpToEvmBridge).toHaveBeenCalledWith(
+				expect.objectContaining({
+					identity: mockIdentity,
+					sourceToken,
+					destinationToken,
+					swapAmount: '1',
+					userEthAddress: mockEthAddress
+				})
+			);
+		});
+
+		it('should call progress with UPDATE_UI after the bridge executes', async () => {
+			const destinationToken = { ...mockValidErc20Token, enabled: true } as Erc20Token;
+
+			await fetchOneSecIcpToEvmSwap({ ...baseParams, destinationToken });
+
+			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
+		});
+
+		it('should call setCustomToken and loadCustomErc20Tokens when ERC20 destination is disabled', async () => {
+			const destinationToken = { ...mockValidErc20Token, enabled: false } as Erc20Token;
+
+			await fetchOneSecIcpToEvmSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).toHaveBeenCalledOnce();
+			expect(loadCustomErc20Tokens).toHaveBeenCalledOnce();
+		});
+
+		it('should not call setCustomToken when ERC20 destination is already enabled', async () => {
+			const destinationToken = { ...mockValidErc20Token, enabled: true } as Erc20Token;
+
+			await fetchOneSecIcpToEvmSwap({ ...baseParams, destinationToken });
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomErc20Tokens).not.toHaveBeenCalled();
+		});
+
+		it('should propagate errors thrown by executeOneSecIcpToEvmBridge', async () => {
+			const destinationToken = { ...mockValidErc20Token, enabled: true } as Erc20Token;
+			vi.mocked(oneSecSwapServices.executeOneSecIcpToEvmBridge).mockRejectedValue(
+				new Error('Bridge failed')
+			);
+
+			await expect(fetchOneSecIcpToEvmSwap({ ...baseParams, destinationToken })).rejects.toThrow(
+				'Bridge failed'
+			);
+		});
+	});
+
+	describe('fetchOneSecEvmToIcpSwap', () => {
+		const sourceToken = { ...mockValidErc20Token, network: ETHEREUM_NETWORK } as Erc20Token;
+		const destinationToken = mockValidIcToken as IcToken;
+		const mockProgress = vi.fn();
+
+		const baseParams = {
+			identity: mockIdentity,
+			progress: mockProgress,
+			sourceToken,
+			destinationToken,
+			swapAmount: '1',
+			userEthAddress: mockEthAddress,
+			gas: 21000n,
+			maxFeePerGas: 20000000000n,
+			maxPriorityFeePerGas: 2000000000n
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			vi.mocked(oneSecSwapServices.executeOneSecEvmToIcpBridge).mockResolvedValue(undefined);
+		});
+
+		it('should call executeOneSecEvmToIcpBridge with the provided params', async () => {
+			await fetchOneSecEvmToIcpSwap(baseParams);
+
+			expect(oneSecSwapServices.executeOneSecEvmToIcpBridge).toHaveBeenCalledWith(
+				expect.objectContaining({
+					identity: mockIdentity,
+					sourceToken,
+					destinationToken,
+					swapAmount: '1',
+					userEthAddress: mockEthAddress
+				})
+			);
+		});
+
+		it('should call progress with UPDATE_UI after the bridge executes', async () => {
+			await fetchOneSecEvmToIcpSwap(baseParams);
+
+			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
+		});
+
+		it('should not call setCustomToken for an ICP destination token', async () => {
+			await fetchOneSecEvmToIcpSwap(baseParams);
+
+			expect(setCustomToken).not.toHaveBeenCalled();
+			expect(loadCustomErc20Tokens).not.toHaveBeenCalled();
+		});
+
+		it('should propagate errors thrown by executeOneSecEvmToIcpBridge', async () => {
+			vi.mocked(oneSecSwapServices.executeOneSecEvmToIcpBridge).mockRejectedValue(
+				new Error('EVM bridge failed')
+			);
+
+			await expect(fetchOneSecEvmToIcpSwap(baseParams)).rejects.toThrow('EVM bridge failed');
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

  - Adds a dedicated fetchSwapAmountsICPBridge path inside fetchSwapAmounts: when the source token is ICP and the destination is not ICP, quotes are fetched from               
  icpBridgeProviders (OneSec) instead of the existing ICP DEX providers (KongSwap / ICPSwap).                                                                                   
  - Adds fetchOneSecIcpToEvmSwap — executes an ICP → EVM bridge via OneSec, then auto-enables the destination ERC-20 token and triggers a wallet refresh.                       
  - Adds fetchOneSecEvmToIcpSwap — executes an EVM → ICP bridge via OneSec with the same post-bridge steps.                                                                     
  - Wires both new functions into swapService dispatch map.     