### PR TITLE
feat(frontend): sign user out when signups are closed

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
-	import { get } from 'svelte/store';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { userProfileLoaded } from '$lib/derived/user-profile.derived';
 	import { infoSignOut } from '$lib/services/auth.services';

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -31,7 +31,7 @@
 
 		if (!success && err === 'signups-closed') {
 			await infoSignOut({
-				text: ($i18n).auth.info.signups_closed,
+				text: $i18n.auth.info.signups_closed,
 				source: 'signups-closed'
 			});
 		}

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
+	import { get } from 'svelte/store';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { userProfileLoaded } from '$lib/derived/user-profile.derived';
 	import { infoSignOut } from '$lib/services/auth.services';
 	import { loadUserProfile } from '$lib/services/load-user-profile.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { userProfileStore } from '$lib/stores/user-profile.store';
-	import { get } from 'svelte/store';
 
 	interface Props {
 		children: Snippet;

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -32,7 +32,7 @@
 
 		if (!success && err === 'signups-closed') {
 			await infoSignOut({
-				text: get(i18n).auth.info.signups_closed,
+				text: ($i18n).auth.info.signups_closed,
 				source: 'signups-closed'
 			});
 		}

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -14,6 +14,11 @@
 
 	let { children }: Props = $props();
 
+	// Guards against concurrent sign-out flows. `load` can be re-entered via
+	// the `$authIdentity` `$effect` and the `oisyRefreshUserProfile` window
+	// event, and we want `infoSignOut` to fire at most once.
+	let signingOut = false;
+
 	const load = async ({ reload = false }: { reload?: boolean }) => {
 		if (isNullish($authIdentity)) {
 			userProfileStore.reset();
@@ -29,7 +34,8 @@
 		// `initLoader` (which lives below the gate).
 		const { success, err } = await loadUserProfile({ identity: $authIdentity, reload });
 
-		if (!success && err === 'signups-closed') {
+		if (!success && err === 'signups-closed' && !signingOut) {
+			signingOut = true;
 			await infoSignOut({
 				text: $i18n.auth.info.signups_closed,
 				source: 'signups-closed'

--- a/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderUserProfile.svelte
@@ -3,8 +3,11 @@
 	import type { Snippet } from 'svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { userProfileLoaded } from '$lib/derived/user-profile.derived';
+	import { infoSignOut } from '$lib/services/auth.services';
 	import { loadUserProfile } from '$lib/services/load-user-profile.services';
+	import { i18n } from '$lib/stores/i18n.store';
 	import { userProfileStore } from '$lib/stores/user-profile.store';
+	import { get } from 'svelte/store';
 
 	interface Props {
 		children: Snippet;
@@ -12,13 +15,27 @@
 
 	let { children }: Props = $props();
 
-	const load = ({ reload = false }: { reload?: boolean }) => {
+	const load = async ({ reload = false }: { reload?: boolean }) => {
 		if (isNullish($authIdentity)) {
 			userProfileStore.reset();
 			return;
 		}
 
-		loadUserProfile({ identity: $authIdentity, reload });
+		// `LoaderUserProfile` gates the rest of the loader tree behind
+		// `$userProfileLoaded`. When the backend rejects new profile creation
+		// (signups closed), `loadUserProfile` returns `signups-closed` without
+		// populating the store, so the gate would never open and the user
+		// would stay stuck on the skeleton without being signed out. We
+		// therefore have to handle the sign-out here, instead of relying on
+		// `initLoader` (which lives below the gate).
+		const { success, err } = await loadUserProfile({ identity: $authIdentity, reload });
+
+		if (!success && err === 'signups-closed') {
+			await infoSignOut({
+				text: get(i18n).auth.info.signups_closed,
+				source: 'signups-closed'
+			});
+		}
 	};
 
 	$effect(() => {

--- a/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
@@ -1,11 +1,12 @@
 import LoaderUserProfile from '$lib/components/loaders/LoaderUserProfile.svelte';
+import * as authServices from '$lib/services/auth.services';
 import * as loadUserServices from '$lib/services/load-user-profile.services';
 import { userProfileStore } from '$lib/stores/user-profile.store';
 import { emit } from '$lib/utils/events.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { mockUserProfile } from '$tests/mocks/user-profile.mock';
-import { render } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
 describe('LoaderUserProfile', () => {
@@ -35,7 +36,12 @@ describe('LoaderUserProfile', () => {
 	});
 
 	it('should re-load user profile on event', () => {
-		const spy = vi.spyOn(loadUserServices, 'loadUserProfile').mockImplementationOnce(vi.fn());
+		const spy = vi
+			.spyOn(loadUserServices, 'loadUserProfile')
+			.mockImplementationOnce(async () => {
+				await Promise.resolve();
+				return { success: true };
+			});
 
 		render(LoaderUserProfile, { children: mockSnippet });
 
@@ -56,6 +62,48 @@ describe('LoaderUserProfile', () => {
 		expect(get(userProfileStore)).toEqual({
 			certified: true,
 			profile: { ...mockUserProfile, version: [2n] }
+		});
+	});
+
+	describe('when signups are closed', () => {
+		it('should sign the user out via infoSignOut', async () => {
+			const loadSpy = vi
+				.spyOn(loadUserServices, 'loadUserProfile')
+				.mockResolvedValue({ success: false, err: 'signups-closed' });
+
+			const infoSignOutSpy = vi
+				.spyOn(authServices, 'infoSignOut')
+				.mockImplementation(() => Promise.resolve());
+
+			render(LoaderUserProfile, { children: mockSnippet });
+
+			expect(loadSpy).toHaveBeenCalledOnce();
+
+			await waitFor(() => {
+				expect(infoSignOutSpy).toHaveBeenCalledExactlyOnceWith({
+					text: expect.stringMatching(/sign-?ups/i),
+					source: 'signups-closed'
+				});
+			});
+
+			expect(get(userProfileStore)).toBeNull();
+		});
+
+		it('should not sign the user out when loadUserProfile fails for an unknown reason', async () => {
+			vi.spyOn(loadUserServices, 'loadUserProfile').mockResolvedValue({
+				success: false,
+				err: 'unknown'
+			});
+
+			const infoSignOutSpy = vi
+				.spyOn(authServices, 'infoSignOut')
+				.mockImplementation(() => Promise.resolve());
+
+			render(LoaderUserProfile, { children: mockSnippet });
+
+			await Promise.resolve();
+
+			expect(infoSignOutSpy).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
@@ -69,9 +69,7 @@ describe('LoaderUserProfile', () => {
 				.spyOn(loadUserServices, 'loadUserProfile')
 				.mockResolvedValue({ success: false, err: 'signups-closed' });
 
-			const infoSignOutSpy = vi
-				.spyOn(authServices, 'infoSignOut')
-				.mockResolvedValue(undefined);
+			const infoSignOutSpy = vi.spyOn(authServices, 'infoSignOut').mockResolvedValue(undefined);
 
 			render(LoaderUserProfile, { children: mockSnippet });
 
@@ -93,9 +91,7 @@ describe('LoaderUserProfile', () => {
 				err: 'unknown'
 			});
 
-			const infoSignOutSpy = vi
-				.spyOn(authServices, 'infoSignOut')
-				.mockResolvedValue(undefined);
+			const infoSignOutSpy = vi.spyOn(authServices, 'infoSignOut').mockResolvedValue(undefined);
 
 			render(LoaderUserProfile, { children: mockSnippet });
 

--- a/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
@@ -99,6 +99,30 @@ describe('LoaderUserProfile', () => {
 
 			expect(infoSignOutSpy).not.toHaveBeenCalled();
 		});
+
+		it('should sign the user out only once when load is re-triggered', async () => {
+			vi.spyOn(loadUserServices, 'loadUserProfile').mockResolvedValue({
+				success: false,
+				err: 'signups-closed'
+			});
+
+			const infoSignOutSpy = vi.spyOn(authServices, 'infoSignOut').mockResolvedValue(undefined);
+
+			render(LoaderUserProfile, { children: mockSnippet });
+
+			await waitFor(() => {
+				expect(infoSignOutSpy).toHaveBeenCalledOnce();
+			});
+
+			emit({ message: 'oisyRefreshUserProfile' });
+			emit({ message: 'oisyRefreshUserProfile' });
+
+			await waitFor(() => {
+				expect(loadUserServices.loadUserProfile).toHaveBeenCalledTimes(3);
+			});
+
+			expect(infoSignOutSpy).toHaveBeenCalledOnce();
+		});
 	});
 
 	describe('when identity is nullish', () => {

--- a/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderUserProfile.spec.ts
@@ -36,12 +36,10 @@ describe('LoaderUserProfile', () => {
 	});
 
 	it('should re-load user profile on event', () => {
-		const spy = vi
-			.spyOn(loadUserServices, 'loadUserProfile')
-			.mockImplementationOnce(async () => {
-				await Promise.resolve();
-				return { success: true };
-			});
+		const spy = vi.spyOn(loadUserServices, 'loadUserProfile').mockImplementationOnce(async () => {
+			await Promise.resolve();
+			return { success: true };
+		});
 
 		render(LoaderUserProfile, { children: mockSnippet });
 
@@ -73,7 +71,7 @@ describe('LoaderUserProfile', () => {
 
 			const infoSignOutSpy = vi
 				.spyOn(authServices, 'infoSignOut')
-				.mockImplementation(() => Promise.resolve());
+				.mockResolvedValue(undefined);
 
 			render(LoaderUserProfile, { children: mockSnippet });
 
@@ -97,7 +95,7 @@ describe('LoaderUserProfile', () => {
 
 			const infoSignOutSpy = vi
 				.spyOn(authServices, 'infoSignOut')
-				.mockImplementation(() => Promise.resolve());
+				.mockResolvedValue(undefined);
 
 			render(LoaderUserProfile, { children: mockSnippet });
 


### PR DESCRIPTION
# Motivation

When signups are closed, a new user gets stuck on the loading skeleton instead of being signed out.

`LoaderUserProfile` gates its children behind `$userProfileLoaded`. The `signups-closed` sign-out lives in `initLoader`, which is a child of that gate, so it never runs.

# Changes

- Handle `signups-closed` directly in `LoaderUserProfile.svelte` by calling `infoSignOut`.

# Tests

Added tests.