### PR TITLE
feat(frontend): extend SwapEthWizard with OneSec

### DIFF
--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -19,6 +19,7 @@
 	import type { ProgressStep } from '$eth/types/send';
 	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import { isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
+	import { isIcToken } from '$icp/validation/ic-token.validation';
 	import SwapGaslessFee from '$lib/components/swap/SwapGaslessFee.svelte';
 	import SwapProgress from '$lib/components/swap/SwapProgress.svelte';
 	import SwapReview from '$lib/components/swap/SwapReview.svelte';
@@ -37,6 +38,7 @@
 	import { acceptProviderAgreement } from '$lib/services/provider-agreements.services';
 	import {
 		fetchNearIntentsEvmSwap,
+		fetchOneSecEvmToIcpSwap,
 		fetchVeloraDeltaSwap,
 		fetchVeloraMarketSwap
 	} from '$lib/services/swap.services';
@@ -328,6 +330,29 @@
 				} else {
 					await fetchVeloraMarketSwap(params);
 				}
+			} else if (selectedProvider?.provider === SwapProvider.ONE_SEC) {
+				if (!isIcToken($destinationToken) || isNullish($ethAddress)) {
+					toastsError({
+						msg: { text: $i18n.swap.error.unexpected_missing_data }
+					});
+
+					onBack();
+					onStartTriggerAmount();
+
+					return;
+				}
+
+				await fetchOneSecEvmToIcpSwap({
+					identity: $authIdentity,
+					progress,
+					sourceToken: $sourceToken as Erc20Token,
+					destinationToken: $destinationToken,
+					swapAmount,
+					userEthAddress: $ethAddress,
+					gas,
+					maxFeePerGas,
+					maxPriorityFeePerGas
+				});
 			} else {
 				toastsError({
 					msg: { text: $i18n.swap.error.unexpected }

--- a/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
@@ -24,11 +24,14 @@ import {
 	type SwapMappedResult,
 	type VeloraSwapDetails
 } from '$lib/types/swap';
+import type { Token } from '$lib/types/token';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import en from '$tests/mocks/i18n.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import {
 	mockNearIntentsProvider,
+	mockOneSecProvider,
 	mockSwapProviders,
 	mockVeloraDeltaProvider,
 	mockVeloraMarketProvider
@@ -53,11 +56,13 @@ vi.mock('$eth/providers/alchemy.providers', () => ({
 const mockFetchNearIntentsEvmSwap = vi.fn();
 const mockFetchVeloraDeltaSwap = vi.fn();
 const mockFetchVeloraMarketSwap = vi.fn();
+const mockFetchOneSecEvmToIcpSwap = vi.fn();
 
 vi.mock('$lib/services/swap.services', () => ({
 	fetchNearIntentsEvmSwap: (...args: unknown[]) => mockFetchNearIntentsEvmSwap(...args),
 	fetchVeloraDeltaSwap: (...args: unknown[]) => mockFetchVeloraDeltaSwap(...args),
-	fetchVeloraMarketSwap: (...args: unknown[]) => mockFetchVeloraMarketSwap(...args)
+	fetchVeloraMarketSwap: (...args: unknown[]) => mockFetchVeloraMarketSwap(...args),
+	fetchOneSecEvmToIcpSwap: (...args: unknown[]) => mockFetchOneSecEvmToIcpSwap(...args)
 }));
 
 const mockAcceptProviderAgreement = vi.fn();
@@ -700,6 +705,180 @@ describe('SwapEthWizard', () => {
 			await vi.runOnlyPendingTimersAsync();
 
 			expect(mockAcceptProviderAgreement).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('OneSec EVM→ICP swap', () => {
+		const mockEthAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+		const mockIcDestToken = { ...mockValidIcToken, enabled: true };
+
+		const oneSecSwapProviders: SwapMappedResult[] = [mockOneSecProvider];
+
+		let feeState: Writable<FeeStoreData>;
+		let feeStore: EthFeeStore;
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+
+			feeState = writable({
+				gas: 100n,
+				maxFeePerGas: 2_000_000n,
+				maxPriorityFeePerGas: 1_000_000n
+			});
+			feeStore = {
+				subscribe: feeState.subscribe,
+				setFee: vi.fn((partial) => {
+					feeState.update((cur) => ({ ...cur, ...partial }));
+				})
+			};
+
+			vi.spyOn(feeStoreMod, 'initEthFeeStore').mockReturnValue(feeStore);
+			vi.spyOn(feeStoreMod, 'initEthFeeContext').mockImplementation((ctx) => ({
+				...ctx,
+				maxGasFee: readable(undefined),
+				minGasFee: readable(undefined)
+			}));
+			vi.spyOn(addrDerived, 'ethAddress', 'get').mockReturnValue(readable(mockEthAddress));
+			vi.spyOn(analytics, 'trackEvent').mockImplementation(() => undefined);
+			vi.spyOn(toasts, 'toastsError').mockImplementation(() => Symbol('toast'));
+			mockFetchOneSecEvmToIcpSwap.mockResolvedValue(undefined);
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		const createOneSecExecutionContext = (destinationToken: Token = mockIcDestToken) => {
+			const executionSwapAmountsStore = initSwapAmountsStore();
+			executionSwapAmountsStore.setSwaps({
+				swaps: oneSecSwapProviders,
+				amountForSwap: 1,
+				selectedProvider: oneSecSwapProviders[0]
+			});
+
+			const ctx = new Map();
+
+			ctx.set(SWAP_CONTEXT_KEY, {
+				sourceToken: readable(mockToken),
+				destinationToken: readable(destinationToken),
+				failedSwapError: writable(undefined),
+				sourceTokenExchangeRate: readable(10),
+				sourceTokenBalance: readable(undefined),
+				destinationTokenBalance: readable(undefined),
+				destinationTokenExchangeRate: readable(20),
+				isSourceTokenIcrc2: readable(false),
+				isSourceTokenPermitSupported: readable(false),
+				setSourceToken: () => {},
+				setDestinationToken: () => {},
+				setIsTokenPermitSupported: () => {},
+				switchTokens: () => {}
+			});
+
+			ctx.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: executionSwapAmountsStore });
+
+			ctx.set(
+				feeStoreMod.ETH_FEE_CONTEXT_KEY,
+				feeStoreMod.initEthFeeContext({
+					feeStore,
+					feeSymbolStore: writable(ETHEREUM_TOKEN.symbol),
+					feeTokenIdStore: writable(ETHEREUM_TOKEN.id),
+					feeDecimalsStore: writable(ETHEREUM_TOKEN.decimals)
+				})
+			);
+
+			return ctx;
+		};
+
+		it('calls fetchOneSecEvmToIcpSwap and closes on success', async () => {
+			const onClose = vi.fn();
+			const onBack = vi.fn();
+
+			const { getByText, queryByRole } = render(SwapEthWizard, {
+				props: {
+					...BASE_PROPS,
+					currentStep: { name: WizardStepsSwap.REVIEW, title: 'Swap' },
+					onClose,
+					onBack,
+					onNext: vi.fn(),
+					onStartTriggerAmount: vi.fn(),
+					onStopTriggerAmount: vi.fn()
+				},
+				context: createOneSecExecutionContext()
+			});
+
+			const valueDifferenceCheckbox = queryByRole('checkbox');
+			if (valueDifferenceCheckbox) {
+				await fireEvent.click(valueDifferenceCheckbox);
+			}
+
+			await fireEvent.click(getByText(en.swap.text.swap_button));
+			await vi.runOnlyPendingTimersAsync();
+
+			expect(mockFetchOneSecEvmToIcpSwap).toHaveBeenCalledOnce();
+			expect(onClose).toHaveBeenCalledOnce();
+			expect(onBack).not.toHaveBeenCalled();
+		});
+
+		it('calls onBack when fetchOneSecEvmToIcpSwap fails', async () => {
+			mockFetchOneSecEvmToIcpSwap.mockRejectedValueOnce(new Error('Bridge failed'));
+
+			const onClose = vi.fn();
+			const onBack = vi.fn();
+
+			const { getByText, queryByRole } = render(SwapEthWizard, {
+				props: {
+					...BASE_PROPS,
+					currentStep: { name: WizardStepsSwap.REVIEW, title: 'Swap' },
+					onClose,
+					onBack,
+					onNext: vi.fn(),
+					onStartTriggerAmount: vi.fn(),
+					onStopTriggerAmount: vi.fn()
+				},
+				context: createOneSecExecutionContext()
+			});
+
+			const valueDifferenceCheckbox = queryByRole('checkbox');
+			if (valueDifferenceCheckbox) {
+				await fireEvent.click(valueDifferenceCheckbox);
+			}
+
+			await fireEvent.click(getByText(en.swap.text.swap_button));
+			await vi.runOnlyPendingTimersAsync();
+
+			expect(onBack).toHaveBeenCalledOnce();
+			expect(onClose).not.toHaveBeenCalled();
+			expect(toasts.toastsError).toHaveBeenCalled();
+		});
+
+		it('shows error and calls onBack when destination is not an ICP token', async () => {
+			const onBack = vi.fn();
+			const onStartTriggerAmount = vi.fn();
+
+			const { getByText, queryByRole } = render(SwapEthWizard, {
+				props: {
+					...BASE_PROPS,
+					currentStep: { name: WizardStepsSwap.REVIEW, title: 'Swap' },
+					onBack,
+					onNext: vi.fn(),
+					onStartTriggerAmount,
+					onStopTriggerAmount: vi.fn()
+				},
+				context: createOneSecExecutionContext(mockDestToken)
+			});
+
+			const valueDifferenceCheckbox = queryByRole('checkbox');
+			if (valueDifferenceCheckbox) {
+				await fireEvent.click(valueDifferenceCheckbox);
+			}
+
+			await fireEvent.click(getByText(en.swap.text.swap_button));
+			await vi.runOnlyPendingTimersAsync();
+
+			expect(mockFetchOneSecEvmToIcpSwap).not.toHaveBeenCalled();
+			expect(toasts.toastsError).toHaveBeenCalled();
+			expect(onBack).toHaveBeenCalledOnce();
+			expect(onStartTriggerAmount).toHaveBeenCalledOnce();
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/swap.mocks.ts
+++ b/src/frontend/src/tests/mocks/swap.mocks.ts
@@ -53,3 +53,10 @@ export const mockNearIntentsProvider: SwapMappedResult = {
 	swapDetails: mockNearIntentsQuoteResponse as NearIntentsQuoteResponse,
 	type: undefined
 };
+
+export const mockOneSecProvider: SwapMappedResult = {
+	provider: SwapProvider.ONE_SEC,
+	receiveAmount: 880000000n,
+	swapDetails: { transferFeeInUnits: 1000n, protocolFeeInPercent: 0.1 },
+	type: undefined
+};


### PR DESCRIPTION
# Motivation

We can now use OneSec services in SwapEthWizard.