### PR TITLE
feat(frontend): extend SwapTokensList with OneSec

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
@@ -239,6 +239,7 @@
 			onCloseTokensList={closeTokenList}
 			onSelectNetworkFilter={() => goToStep(WizardStepsSwap.FILTER_NETWORKS)}
 			onSelectToken={selectToken}
+			side={selectTokenType}
 		/>
 	{:else if currentStep?.name === WizardStepsSwap.FILTER_NETWORKS}
 		<ModalNetworksFilter

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -19,6 +19,7 @@
 	} from '$lib/stores/modal-tokens-list.store';
 	import { swapSupportedTokensStore } from '$lib/stores/swap-supported-tokens.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
+	import type { SwapSelectTokenType } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
 	import type { TokenToggleable } from '$lib/types/token-toggleable';
 	import type { TokenUi } from '$lib/types/token-ui';
@@ -28,19 +29,20 @@
 	import { sortTokens } from '$lib/utils/tokens.utils';
 
 	interface Props {
+		side?: SwapSelectTokenType;
 		onSelectToken: (token: Token) => void;
 		onSelectNetworkFilter: () => void;
 		onCloseTokensList: () => void;
 	}
 
-	let { onSelectToken, onSelectNetworkFilter, onCloseTokensList }: Props = $props();
+	let { side, onSelectToken, onSelectNetworkFilter, onCloseTokensList }: Props = $props();
 
 	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
 	let compatibleTokenIds = $derived(
-		nonNullish($sourceToken)
+		side === 'destination' && nonNullish($sourceToken)
 			? oneSecCompatibleDestinations({
 					sourceToken: $sourceToken,
 					networkIds: ONESEC_EVM_NETWORK_IDS

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import { ONESEC_EVM_NETWORK_IDS } from '$lib/constants/swap.constants';
 	import { allCrossChainSwapTokens, allSortedIcrcTokens } from '$lib/derived/all-tokens.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { networks } from '$lib/derived/networks.derived';
@@ -20,6 +22,7 @@
 	import type { Token } from '$lib/types/token';
 	import type { TokenToggleable } from '$lib/types/token-toggleable';
 	import type { TokenUi } from '$lib/types/token-ui';
+	import { oneSecCompatibleDestinations } from '$lib/utils/onesec-swap.utils';
 	import { filterSwapTokens } from '$lib/utils/swap-tokens-filter.utils';
 	import { mapTokenUi } from '$lib/utils/token.utils';
 	import { sortTokens } from '$lib/utils/tokens.utils';
@@ -36,6 +39,15 @@
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
+	let compatibleTokenIds = $derived(
+		nonNullish($sourceToken)
+			? oneSecCompatibleDestinations({
+					sourceToken: $sourceToken,
+					networkIds: ONESEC_EVM_NETWORK_IDS
+				})
+			: undefined
+	);
+
 	let allSwapTokens: TokenToggleable<Token>[] = $derived(
 		filterSwapTokens({
 			tokens: [
@@ -43,7 +55,8 @@
 				...$allSortedIcrcTokens,
 				...$allCrossChainSwapTokens
 			],
-			supportedData: $swapSupportedTokensStore
+			supportedData: $swapSupportedTokensStore,
+			compatibleTokenIds
 		})
 	);
 

--- a/src/frontend/src/tests/lib/components/swap/SwapTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapTokensList.spec.ts
@@ -29,6 +29,8 @@ describe('SwapTokensList', () => {
 		onCloseTokensList: () => {}
 	};
 
+	const destinationProps = { ...props, side: 'destination' as const };
+
 	const mockContext = (sourceToken?: Token) => {
 		const result = new Map();
 
@@ -57,13 +59,22 @@ describe('SwapTokensList', () => {
 	});
 
 	it('does not call oneSecCompatibleDestinations when sourceToken is nullish', () => {
-		render(SwapTokensList, { props, context: mockContext() });
+		render(SwapTokensList, { props: destinationProps, context: mockContext() });
+
+		expect(oneSecSwapUtils.oneSecCompatibleDestinations).not.toHaveBeenCalled();
+	});
+
+	it('does not call oneSecCompatibleDestinations when side is source', () => {
+		render(SwapTokensList, {
+			props: { ...props, side: 'source' },
+			context: mockContext(mockValidIcToken)
+		});
 
 		expect(oneSecSwapUtils.oneSecCompatibleDestinations).not.toHaveBeenCalled();
 	});
 
 	it('calls oneSecCompatibleDestinations with ICP sourceToken and ONESEC_EVM_NETWORK_IDS', () => {
-		render(SwapTokensList, { props, context: mockContext(mockValidIcToken) });
+		render(SwapTokensList, { props: destinationProps, context: mockContext(mockValidIcToken) });
 
 		expect(oneSecSwapUtils.oneSecCompatibleDestinations).toHaveBeenCalledWith({
 			sourceToken: mockValidIcToken,
@@ -72,7 +83,7 @@ describe('SwapTokensList', () => {
 	});
 
 	it('calls oneSecCompatibleDestinations with EVM sourceToken and ONESEC_EVM_NETWORK_IDS', () => {
-		render(SwapTokensList, { props, context: mockContext(mockValidErc20Token) });
+		render(SwapTokensList, { props: destinationProps, context: mockContext(mockValidErc20Token) });
 
 		expect(oneSecSwapUtils.oneSecCompatibleDestinations).toHaveBeenCalledWith({
 			sourceToken: mockValidErc20Token,

--- a/src/frontend/src/tests/lib/components/swap/SwapTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapTokensList.spec.ts
@@ -1,14 +1,26 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
+import { ONESEC_EVM_NETWORK_IDS } from '$lib/constants/swap.constants';
 import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
 import {
 	initModalTokensListContext,
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
 import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
-import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
+import type { Token } from '$lib/types/token';
+import * as oneSecSwapUtils from '$lib/utils/onesec-swap.utils';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
+
+vi.mock('$lib/utils/onesec-swap.utils', async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...(actual as Record<string, unknown>),
+		oneSecCompatibleDestinations: vi.fn()
+	};
+});
 
 describe('SwapTokensList', () => {
 	const props = {
@@ -17,10 +29,11 @@ describe('SwapTokensList', () => {
 		onCloseTokensList: () => {}
 	};
 
-	const mockContext = () => {
+	const mockContext = (sourceToken?: Token) => {
 		const result = new Map();
 
 		result.set(SWAP_CONTEXT_KEY, {
+			sourceToken: readable(sourceToken),
 			destinationToken: readable(mockValidIcCkToken),
 			destinationTokenExchangeRate: readable(0.00002)
 		});
@@ -41,5 +54,29 @@ describe('SwapTokensList', () => {
 		});
 
 		expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
+	});
+
+	it('does not call oneSecCompatibleDestinations when sourceToken is nullish', () => {
+		render(SwapTokensList, { props, context: mockContext() });
+
+		expect(oneSecSwapUtils.oneSecCompatibleDestinations).not.toHaveBeenCalled();
+	});
+
+	it('calls oneSecCompatibleDestinations with ICP sourceToken and ONESEC_EVM_NETWORK_IDS', () => {
+		render(SwapTokensList, { props, context: mockContext(mockValidIcToken) });
+
+		expect(oneSecSwapUtils.oneSecCompatibleDestinations).toHaveBeenCalledWith({
+			sourceToken: mockValidIcToken,
+			networkIds: ONESEC_EVM_NETWORK_IDS
+		});
+	});
+
+	it('calls oneSecCompatibleDestinations with EVM sourceToken and ONESEC_EVM_NETWORK_IDS', () => {
+		render(SwapTokensList, { props, context: mockContext(mockValidErc20Token) });
+
+		expect(oneSecSwapUtils.oneSecCompatibleDestinations).toHaveBeenCalledWith({
+			sourceToken: mockValidErc20Token,
+			networkIds: ONESEC_EVM_NETWORK_IDS
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

  - SwapTokensList now computes compatibleTokenIds reactively from the swap context's sourceToken via oneSecCompatibleDestinations. When the source is an ICP token, the result restricts EVM destination candidates to the OneSec-supported ERC-20 addresses on each configured network; when the source is an EVM token, it restricts ICP destination candidates to the matching ledger canister ID.
  - compatibleTokenIds is passed to filterSwapTokens, so the destination token list is automatically narrowed to tokens the OneSec bridge can actually handle without hiding unrelated same-chain tokens.                                                                                                                                                  
  - When sourceToken is nullish, compatibleTokenIds is undefined and no extra filtering is applied.

