### PR TITLE
feat(frontend): extend SwapIcpWizard with OneSec

### DIFF
--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -2,6 +2,7 @@
 	import type { WizardStep } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import IcTokenFeeContext from '$icp/components/fee/IcTokenFeeContext.svelte';
 	import SwapIcpForm from '$icp/components/swap/SwapIcpForm.svelte';
 	import { isIcrcTokenSupportIcrc2 } from '$icp/services/icrc.services';
@@ -19,11 +20,12 @@
 		TRACK_COUNT_SWAP_ERROR,
 		TRACK_COUNT_SWAP_SUCCESS
 	} from '$lib/constants/analytics.constants';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 	import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
-	import { swapService } from '$lib/services/swap.services';
+	import { fetchOneSecIcpToEvmSwap, swapService } from '$lib/services/swap.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		SWAP_AMOUNTS_CONTEXT_KEY,
@@ -152,34 +154,56 @@
 		};
 
 		const sourceLedgerCanisterId = ($sourceToken as IcToken).ledgerCanisterId;
-		const destinationLedgerCanisterId = ($destinationToken as IcToken).ledgerCanisterId;
+		const destinationLedgerCanisterId = isIcToken($destinationToken)
+			? $destinationToken.ledgerCanisterId
+			: '';
 
 		onNext();
 
 		try {
 			clearFailedProgressStep();
 
-			await swapService[$swapAmountsStore.selectedProvider.provider]({
-				identity: $authIdentity,
-				progress,
-				sourceToken: $sourceToken as IcTokenToggleable,
-				destinationToken: $destinationToken as IcTokenToggleable,
-				swapAmount,
-				receiveAmount: $swapAmountsStore.selectedProvider.receiveAmount,
-				slippageValue,
-				sourceTokenFee,
-				isSourceTokenIcrc2: $isSourceTokenIcrc2,
-				setFailedProgressStep,
-				tryToWithdraw:
-					nonNullish($failedSwapError?.errorType) &&
-					($failedSwapError?.errorType === SwapErrorCodes.SWAP_FAILED_WITHDRAW_FAILED ||
-						$failedSwapError?.errorType === SwapErrorCodes.SWAP_SUCCESS_WITHDRAW_FAILED ||
-						$failedSwapError?.errorType === SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED),
-				withdrawDestinationTokens:
-					nonNullish($failedSwapError?.errorType) &&
-					($failedSwapError?.errorType === SwapErrorCodes.SWAP_SUCCESS_WITHDRAW_FAILED ||
-						$failedSwapError?.swapSucceded)
-			});
+			if ($swapAmountsStore.selectedProvider.provider === SwapProvider.ONE_SEC) {
+				if (!isTokenErc20($destinationToken) || isNullish($ethAddress)) {
+					toastsError({
+						msg: { text: $i18n.swap.error.unexpected_missing_data }
+					});
+					onBack();
+					return;
+				}
+
+				await fetchOneSecIcpToEvmSwap({
+					identity: $authIdentity,
+					progress,
+					sourceToken: $sourceToken as IcToken,
+					destinationToken: $destinationToken,
+					swapAmount,
+					userEthAddress: $ethAddress,
+					setFailedProgressStep
+				});
+			} else {
+				await swapService[$swapAmountsStore.selectedProvider.provider]({
+					identity: $authIdentity,
+					progress,
+					sourceToken: $sourceToken as IcTokenToggleable,
+					destinationToken: $destinationToken as IcTokenToggleable,
+					swapAmount,
+					receiveAmount: $swapAmountsStore.selectedProvider.receiveAmount,
+					slippageValue,
+					sourceTokenFee,
+					isSourceTokenIcrc2: $isSourceTokenIcrc2,
+					setFailedProgressStep,
+					tryToWithdraw:
+						nonNullish($failedSwapError?.errorType) &&
+						($failedSwapError?.errorType === SwapErrorCodes.SWAP_FAILED_WITHDRAW_FAILED ||
+							$failedSwapError?.errorType === SwapErrorCodes.SWAP_SUCCESS_WITHDRAW_FAILED ||
+							$failedSwapError?.errorType === SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED),
+					withdrawDestinationTokens:
+						nonNullish($failedSwapError?.errorType) &&
+						($failedSwapError?.errorType === SwapErrorCodes.SWAP_SUCCESS_WITHDRAW_FAILED ||
+							$failedSwapError?.swapSucceded)
+				});
+			}
 
 			progress(ProgressStepsSwap.DONE);
 

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
@@ -1,6 +1,7 @@
 import SwapIcpWizard from '$icp/components/swap/SwapIcpWizard.svelte';
 import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 import type { IcToken } from '$icp/types/ic-token';
+import * as addrDerived from '$lib/derived/address.derived';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 import * as analytics from '$lib/services/analytics.services';
@@ -8,8 +9,10 @@ import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap
 import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
 import * as toasts from '$lib/stores/toasts.store';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
-import { mockSwapProviders } from '$tests/mocks/swap.mocks';
+import { mockOneSecProvider, mockSwapProviders } from '$tests/mocks/swap.mocks';
 import { fireEvent, render } from '@testing-library/svelte';
 import { readable, writable } from 'svelte/store';
 
@@ -22,8 +25,10 @@ vi.mock('$icp/api/icrc-ledger.api', () => ({
 }));
 
 const mockSwapFn = vi.fn();
+const mockOneSecFn = vi.fn();
 
 vi.mock('$lib/services/swap.services', () => ({
+	fetchOneSecIcpToEvmSwap: (...args: unknown[]) => mockOneSecFn(...args),
 	swapService: {
 		icpSwap: (...args: unknown[]) => mockSwapFn(...args)
 	}
@@ -233,6 +238,108 @@ describe('SwapIcpWizard', () => {
 			await fireEvent.click(getByRole('checkbox'));
 
 			expect(swapButton).toBeEnabled();
+		});
+
+		describe('OneSec ICP→EVM swap', () => {
+			const setOneSecContext = ({
+				destinationToken = mockValidErc20Token
+			}: { destinationToken?: object } = {}) => {
+				mockContext.set(SWAP_CONTEXT_KEY, {
+					...(mockContext.get(SWAP_CONTEXT_KEY) as object),
+					destinationToken: readable(destinationToken)
+				});
+
+				const oneSecAmountsStore = initSwapAmountsStore();
+				oneSecAmountsStore.setSwaps({
+					swaps: [mockOneSecProvider],
+					amountForSwap: 1,
+					selectedProvider: mockOneSecProvider
+				});
+				mockContext.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: oneSecAmountsStore });
+			};
+
+			beforeEach(() => {
+				mockOneSecFn.mockResolvedValue(undefined);
+				vi.spyOn(addrDerived, 'ethAddress', 'get').mockReturnValue(readable(mockEthAddress));
+				setOneSecContext();
+			});
+
+			it('calls fetchOneSecIcpToEvmSwap and then onClose on success', async () => {
+				const { getByText, queryByRole } = renderWithStep(WizardStepsSwap.REVIEW);
+
+				const valueDifferenceCheckbox = queryByRole('checkbox');
+				if (valueDifferenceCheckbox) {
+					await fireEvent.click(valueDifferenceCheckbox);
+				}
+
+				await fireEvent.click(getByText('Swap now'));
+				await vi.runOnlyPendingTimersAsync();
+
+				expect(mockOneSecFn).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						sourceToken: mockToken,
+						destinationToken: mockValidErc20Token,
+						swapAmount: BASE_PROPS.swapAmount,
+						userEthAddress: mockEthAddress
+					})
+				);
+				expect(BASE_PROPS.onClose).toHaveBeenCalledOnce();
+				expect(BASE_PROPS.onBack).not.toHaveBeenCalled();
+			});
+
+			it('calls onBack and shows error toast when swap throws', async () => {
+				mockOneSecFn.mockRejectedValue(new Error('Bridge error'));
+
+				const { getByText, queryByRole } = renderWithStep(WizardStepsSwap.REVIEW);
+
+				const valueDifferenceCheckbox = queryByRole('checkbox');
+				if (valueDifferenceCheckbox) {
+					await fireEvent.click(valueDifferenceCheckbox);
+				}
+
+				await fireEvent.click(getByText('Swap now'));
+				await vi.runOnlyPendingTimersAsync();
+
+				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+				expect(BASE_PROPS.onClose).not.toHaveBeenCalled();
+				expect(toasts.toastsError).toHaveBeenCalled();
+			});
+
+			it('shows error toast and calls onBack when destination is not ERC20', async () => {
+				setOneSecContext({ destinationToken: mockValidIcCkToken });
+
+				const { getByText, queryByRole } = renderWithStep(WizardStepsSwap.REVIEW);
+
+				const valueDifferenceCheckbox = queryByRole('checkbox');
+				if (valueDifferenceCheckbox) {
+					await fireEvent.click(valueDifferenceCheckbox);
+				}
+
+				await fireEvent.click(getByText('Swap now'));
+				await vi.runOnlyPendingTimersAsync();
+
+				expect(mockOneSecFn).not.toHaveBeenCalled();
+				expect(toasts.toastsError).toHaveBeenCalled();
+				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+			});
+
+			it('shows error toast and calls onBack when ethAddress is nullish', async () => {
+				vi.spyOn(addrDerived, 'ethAddress', 'get').mockReturnValue(readable(undefined));
+
+				const { getByText, queryByRole } = renderWithStep(WizardStepsSwap.REVIEW);
+
+				const valueDifferenceCheckbox = queryByRole('checkbox');
+				if (valueDifferenceCheckbox) {
+					await fireEvent.click(valueDifferenceCheckbox);
+				}
+
+				await fireEvent.click(getByText('Swap now'));
+				await vi.runOnlyPendingTimersAsync();
+
+				expect(mockOneSecFn).not.toHaveBeenCalled();
+				expect(toasts.toastsError).toHaveBeenCalled();
+				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+			});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

  - Adds OneSec ICP→EVM swap execution path to SwapIcpWizard: when the selected provider is SwapProvider.ONE_SEC, the wizard now calls fetchOneSecIcpToEvmSwap instead of
  routing through swapService                                                                                                                                                   
  - Validates that the destination token is ERC-20 and that ethAddress is present before executing; shows an error toast and navigates back if either check fails
  - Fixes destinationLedgerCanisterId derivation to handle non-IcToken destinations gracefully (falls back to empty string for EVM tokens)  
