### PR TITLE
feat(backend): Add `/status` endpoint for signup-rate monitoring

### DIFF
--- a/src/backend/src/api/admin.rs
+++ b/src/backend/src/api/admin.rs
@@ -10,6 +10,7 @@ use shared::{
 
 use crate::{
     state::{read_config, read_state},
+    status,
     types::StoredPrincipal,
     utils::guards::caller_is_allowed,
 };
@@ -34,6 +35,7 @@ pub fn http_request(request: HttpRequest) -> HttpResponse {
 
     match path {
         "/metrics" => get_metrics(),
+        "/status" => status::handle(),
         _ => HttpResponse {
             status_code: 404,
             headers: vec![],

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -56,6 +56,7 @@ mod delegation;
 mod exchange;
 mod signer;
 mod state;
+mod status;
 mod token;
 mod transactions;
 mod types;

--- a/src/backend/src/status/cache.rs
+++ b/src/backend/src/status/cache.rs
@@ -1,0 +1,114 @@
+//! Per-replica memoization cache for the `/status` response.
+//!
+//! ICP queries are typically served by a single replica per call, and the `/status` endpoint is a
+//! `#[query]` (so it cannot durably mutate replicated state anyway). A `thread_local!` cache is
+//! sufficient to bound the cost of the underlying scan to roughly once per minute per replica,
+//! which is the goal: spam the endpoint as much as you like, the heavy work runs at most 1x/min.
+//!
+//! The cache is intentionally not persisted across upgrades. The first call after an upgrade
+//! simply recomputes.
+
+use std::cell::RefCell;
+
+use shared::types::Timestamp;
+
+use crate::status::StatusResponse;
+
+/// Time-to-live of a cached status response, in nanoseconds (60 seconds).
+pub const CACHE_TTL_NS: u64 = 60 * 1_000_000_000;
+
+thread_local! {
+    /// `(computed_at_ns, response)`. `None` means the cache has never been populated on this
+    /// replica.
+    static CACHE: RefCell<Option<(Timestamp, StatusResponse)>> = const { RefCell::new(None) };
+}
+
+/// Returns a cached [`StatusResponse`] if one was computed within the last [`CACHE_TTL_NS`],
+/// otherwise invokes `recompute(now)`, stores its result, and returns it.
+pub fn get_or_recompute<F>(now: Timestamp, recompute: F) -> StatusResponse
+where
+    F: FnOnce(Timestamp) -> StatusResponse,
+{
+    if let Some(cached) = CACHE.with(|c| {
+        c.borrow().as_ref().and_then(|(computed_at, response)| {
+            (now.saturating_sub(*computed_at) < CACHE_TTL_NS).then(|| response.clone())
+        })
+    }) {
+        return cached;
+    }
+
+    let fresh = recompute(now);
+    CACHE.with(|c| {
+        *c.borrow_mut() = Some((now, fresh.clone()));
+    });
+    fresh
+}
+
+#[cfg(test)]
+pub(crate) fn reset_for_tests() {
+    CACHE.with(|c| {
+        *c.borrow_mut() = None;
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use pretty_assertions::assert_eq;
+
+    use super::{get_or_recompute, reset_for_tests, CACHE_TTL_NS};
+    use crate::status::{HealthStatus, MetricEntry, StatusResponse};
+
+    fn make_response(now: u64, status: HealthStatus) -> StatusResponse {
+        StatusResponse::from_metrics(now, [("test", MetricEntry { status })])
+    }
+
+    #[test]
+    fn returns_cached_value_within_ttl() {
+        reset_for_tests();
+        let calls = Cell::new(0);
+
+        let first = get_or_recompute(1_000, |now| {
+            calls.set(calls.get() + 1);
+            make_response(now, HealthStatus::Ok)
+        });
+        assert_eq!(calls.get(), 1);
+        assert_eq!(first.status, HealthStatus::Ok);
+        assert_eq!(first.timestamp_ns, 1_000);
+
+        let second = get_or_recompute(1_000 + CACHE_TTL_NS - 1, |now| {
+            calls.set(calls.get() + 1);
+            make_response(now, HealthStatus::Critical)
+        });
+        assert_eq!(
+            calls.get(),
+            1,
+            "recompute should not run while cache is fresh"
+        );
+        assert_eq!(
+            second.status,
+            HealthStatus::Ok,
+            "served value must be the cached one, not the would-be-fresh one"
+        );
+        assert_eq!(second.timestamp_ns, 1_000);
+    }
+
+    #[test]
+    fn recomputes_after_ttl_expires() {
+        reset_for_tests();
+        let calls = Cell::new(0);
+
+        let _ = get_or_recompute(2_000, |now| {
+            calls.set(calls.get() + 1);
+            make_response(now, HealthStatus::Ok)
+        });
+        let later = get_or_recompute(2_000 + CACHE_TTL_NS, |now| {
+            calls.set(calls.get() + 1);
+            make_response(now, HealthStatus::Warn)
+        });
+        assert_eq!(calls.get(), 2);
+        assert_eq!(later.status, HealthStatus::Warn);
+        assert_eq!(later.timestamp_ns, 2_000 + CACHE_TTL_NS);
+    }
+}

--- a/src/backend/src/status/metrics.rs
+++ b/src/backend/src/status/metrics.rs
@@ -61,9 +61,7 @@ pub fn evaluate_all(now: Timestamp) -> StatusResponse {
 mod tests {
     use pretty_assertions::assert_eq;
 
-    use super::{
-        classify_signups, SIGNUPS_CRITICAL_THRESHOLD, SIGNUPS_WARN_THRESHOLD,
-    };
+    use super::{classify_signups, SIGNUPS_CRITICAL_THRESHOLD, SIGNUPS_WARN_THRESHOLD};
     use crate::status::HealthStatus;
 
     #[test]

--- a/src/backend/src/status/metrics.rs
+++ b/src/backend/src/status/metrics.rs
@@ -1,0 +1,103 @@
+//! Individual health metrics evaluated for the `/status` endpoint.
+//!
+//! Thresholds are intentionally hardcoded for v1; if/when ops needs to retune without a code
+//! change, migrate them into `Config` (see plan).
+
+use shared::types::Timestamp;
+
+use crate::{
+    state::read_state,
+    status::{HealthStatus, MetricEntry, StatusResponse},
+};
+
+/// Window over which signups are counted, in nanoseconds (30 minutes).
+pub(crate) const SIGNUPS_WINDOW_NS: u64 = 30 * 60 * 1_000_000_000;
+
+/// Number of signups in [`SIGNUPS_WINDOW_NS`] above which the status is `warn`.
+pub(crate) const SIGNUPS_WARN_THRESHOLD: u64 = 50;
+
+/// Number of signups in [`SIGNUPS_WINDOW_NS`] above which the status is `critical`.
+pub(crate) const SIGNUPS_CRITICAL_THRESHOLD: u64 = 200;
+
+/// Pure thresholding helper, exposed so it can be unit-tested without touching state.
+fn classify_signups(count: u64) -> HealthStatus {
+    if count >= SIGNUPS_CRITICAL_THRESHOLD {
+        HealthStatus::Critical
+    } else if count >= SIGNUPS_WARN_THRESHOLD {
+        HealthStatus::Warn
+    } else {
+        HealthStatus::Ok
+    }
+}
+
+/// Counts profiles whose `created_timestamp` falls within `[now - SIGNUPS_WINDOW_NS, now]`.
+///
+/// Iterates the full `user_profile` map. The cost is acceptable because the caller memoizes the
+/// result (see [`crate::status::cache`]) so this runs at most once per minute per replica.
+fn count_signups_in_window(now: Timestamp) -> u64 {
+    let cutoff = now.saturating_sub(SIGNUPS_WINDOW_NS);
+    read_state(|s| {
+        s.user_profile
+            .iter()
+            .filter(|entry| entry.value().created_timestamp >= cutoff)
+            .count() as u64
+    })
+}
+
+/// Evaluates the `signups_30m` metric.
+fn evaluate_signups_30m(now: Timestamp) -> MetricEntry {
+    let status = classify_signups(count_signups_in_window(now));
+    MetricEntry { status }
+}
+
+/// Evaluates all metrics and assembles the public response. The top-level status is derived as
+/// the worst of the children inside [`StatusResponse::from_metrics`].
+#[must_use]
+pub fn evaluate_all(now: Timestamp) -> StatusResponse {
+    StatusResponse::from_metrics(now, [("signups_30m", evaluate_signups_30m(now))])
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::{
+        classify_signups, SIGNUPS_CRITICAL_THRESHOLD, SIGNUPS_WARN_THRESHOLD,
+    };
+    use crate::status::HealthStatus;
+
+    #[test]
+    fn classify_signups_ok_below_warn() {
+        assert_eq!(classify_signups(0), HealthStatus::Ok);
+        assert_eq!(classify_signups(1), HealthStatus::Ok);
+        assert_eq!(
+            classify_signups(SIGNUPS_WARN_THRESHOLD - 1),
+            HealthStatus::Ok
+        );
+    }
+
+    #[test]
+    fn classify_signups_warn_at_threshold() {
+        assert_eq!(classify_signups(SIGNUPS_WARN_THRESHOLD), HealthStatus::Warn);
+        assert_eq!(
+            classify_signups(SIGNUPS_WARN_THRESHOLD + 1),
+            HealthStatus::Warn
+        );
+        assert_eq!(
+            classify_signups(SIGNUPS_CRITICAL_THRESHOLD - 1),
+            HealthStatus::Warn
+        );
+    }
+
+    #[test]
+    fn classify_signups_critical_at_threshold() {
+        assert_eq!(
+            classify_signups(SIGNUPS_CRITICAL_THRESHOLD),
+            HealthStatus::Critical
+        );
+        assert_eq!(
+            classify_signups(SIGNUPS_CRITICAL_THRESHOLD + 1_000),
+            HealthStatus::Critical
+        );
+    }
+}

--- a/src/backend/src/status/metrics.rs
+++ b/src/backend/src/status/metrics.rs
@@ -13,10 +13,10 @@ use crate::{
 /// Window over which signups are counted, in nanoseconds (30 minutes).
 pub(crate) const SIGNUPS_WINDOW_NS: u64 = 30 * 60 * 1_000_000_000;
 
-/// Number of signups in [`SIGNUPS_WINDOW_NS`] above which the status is `warn`.
+/// Number of signups in [`SIGNUPS_WINDOW_NS`] at or above which the status is `warn`.
 pub(crate) const SIGNUPS_WARN_THRESHOLD: u64 = 50;
 
-/// Number of signups in [`SIGNUPS_WINDOW_NS`] above which the status is `critical`.
+/// Number of signups in [`SIGNUPS_WINDOW_NS`] at or above which the status is `critical`.
 pub(crate) const SIGNUPS_CRITICAL_THRESHOLD: u64 = 200;
 
 /// Pure thresholding helper, exposed so it can be unit-tested without touching state.
@@ -31,6 +31,9 @@ fn classify_signups(count: u64) -> HealthStatus {
 }
 
 /// Counts profiles whose `created_timestamp` falls within `[now - SIGNUPS_WINDOW_NS, now]`.
+///
+/// Only the lower bound is enforced explicitly: `created_timestamp` is always set by the canister
+/// via [`ic_cdk::api::time`], so timestamps are never in the future relative to `now`.
 ///
 /// Iterates the full `user_profile` map. The cost is acceptable because the caller memoizes the
 /// result (see [`crate::status::cache`]) so this runs at most once per minute per replica.

--- a/src/backend/src/status/mod.rs
+++ b/src/backend/src/status/mod.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeMap;
 
 use ic_cdk::api::time;
+use serde::Serialize;
 use serde_bytes::ByteBuf;
 use shared::http::HttpResponse;
 
@@ -44,7 +45,7 @@ pub fn handle() -> HttpResponse {
 ///
 /// `Ord` is derived such that `Ok < Warn < Critical`, allowing the top-level rollup to be computed
 /// as the maximum across child metrics.
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum HealthStatus {
     Ok,
@@ -53,13 +54,13 @@ pub enum HealthStatus {
 }
 
 /// One metric entry in the public response. Intentionally minimal: no counts, no messages.
-#[derive(Clone, Copy, Debug, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub struct MetricEntry {
     pub status: HealthStatus,
 }
 
 /// Top-level `/status` response payload.
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct StatusResponse {
     pub status: HealthStatus,
     pub version: u32,

--- a/src/backend/src/status/mod.rs
+++ b/src/backend/src/status/mod.rs
@@ -1,0 +1,173 @@
+//! Public, pull-based health-status endpoint for external monitors.
+//!
+//! Exposed as `GET /status` via the canister's `http_request` query. The response is intentionally
+//! coarse-grained: per-metric `status` values (`ok` / `warn` / `critical`) without raw counts, so
+//! the public payload is safe to leak. Operators inspect the authenticated `stats()` and
+//! `get_account_creation_timestamps()` methods for the underlying numbers.
+
+use std::collections::BTreeMap;
+
+use ic_cdk::api::time;
+use serde_bytes::ByteBuf;
+use shared::http::HttpResponse;
+
+pub mod cache;
+pub mod metrics;
+
+/// Schema version for the JSON payload. Bump on breaking changes so monitors can pin.
+const STATUS_RESPONSE_VERSION: u32 = 1;
+
+/// Handles `GET /status` requests.
+///
+/// Returns the cached status if it is still fresh (see [`cache::CACHE_TTL_NS`]), otherwise
+/// recomputes all metrics and refreshes the cache. Always returns HTTP 200 with a JSON body.
+#[must_use]
+pub fn handle() -> HttpResponse {
+    let now = time();
+    let response = cache::get_or_recompute(now, metrics::evaluate_all);
+
+    let body = serde_json::to_vec(&response).unwrap_or_else(|_| {
+        // Serialization of a fixed-shape struct with primitive fields cannot realistically fail,
+        // but if it ever does we fall back to a static safe payload rather than panicking in a
+        // public unauthenticated query.
+        br#"{"status":"critical","version":1,"metrics":{}}"#.to_vec()
+    });
+
+    HttpResponse {
+        status_code: 200,
+        headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+        body: ByteBuf::from(body),
+    }
+}
+
+/// A coarse-grained health classification.
+///
+/// `Ord` is derived such that `Ok < Warn < Critical`, allowing the top-level rollup to be computed
+/// as the maximum across child metrics.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthStatus {
+    Ok,
+    Warn,
+    Critical,
+}
+
+/// One metric entry in the public response. Intentionally minimal: no counts, no messages.
+#[derive(Clone, Copy, Debug, serde::Serialize)]
+pub struct MetricEntry {
+    pub status: HealthStatus,
+}
+
+/// Top-level `/status` response payload.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct StatusResponse {
+    pub status: HealthStatus,
+    pub version: u32,
+    pub timestamp_ns: u64,
+    pub metrics: BTreeMap<&'static str, MetricEntry>,
+}
+
+impl StatusResponse {
+    /// Builds a [`StatusResponse`] from an iterator of named metric entries, computing the
+    /// top-level `status` as the worst child status.
+    pub(crate) fn from_metrics<I>(now: u64, entries: I) -> Self
+    where
+        I: IntoIterator<Item = (&'static str, MetricEntry)>,
+    {
+        let metrics: BTreeMap<_, _> = entries.into_iter().collect();
+        let status = metrics
+            .values()
+            .map(|m| m.status)
+            .max()
+            .unwrap_or(HealthStatus::Ok);
+        Self {
+            status,
+            version: STATUS_RESPONSE_VERSION,
+            timestamp_ns: now,
+            metrics,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::{HealthStatus, MetricEntry, StatusResponse};
+
+    #[test]
+    fn status_ordering_is_ok_warn_critical() {
+        assert!(HealthStatus::Ok < HealthStatus::Warn);
+        assert!(HealthStatus::Warn < HealthStatus::Critical);
+    }
+
+    #[test]
+    fn rollup_takes_worst_child_status() {
+        let response = StatusResponse::from_metrics(
+            42,
+            [
+                (
+                    "a",
+                    MetricEntry {
+                        status: HealthStatus::Ok,
+                    },
+                ),
+                (
+                    "b",
+                    MetricEntry {
+                        status: HealthStatus::Warn,
+                    },
+                ),
+            ],
+        );
+        assert_eq!(response.status, HealthStatus::Warn);
+        assert_eq!(response.timestamp_ns, 42);
+
+        let response = StatusResponse::from_metrics(
+            7,
+            [
+                (
+                    "a",
+                    MetricEntry {
+                        status: HealthStatus::Warn,
+                    },
+                ),
+                (
+                    "b",
+                    MetricEntry {
+                        status: HealthStatus::Critical,
+                    },
+                ),
+            ],
+        );
+        assert_eq!(response.status, HealthStatus::Critical);
+    }
+
+    #[test]
+    fn rollup_with_no_metrics_is_ok() {
+        let response = StatusResponse::from_metrics(0, []);
+        assert_eq!(response.status, HealthStatus::Ok);
+    }
+
+    #[test]
+    fn json_serialization_is_lowercase_status() {
+        let response = StatusResponse::from_metrics(
+            123,
+            [(
+                "signups_30m",
+                MetricEntry {
+                    status: HealthStatus::Ok,
+                },
+            )],
+        );
+        let json = serde_json::to_string(&response).expect("serialization should succeed");
+        assert!(json.contains("\"status\":\"ok\""), "got: {json}");
+        assert!(json.contains("\"signups_30m\""), "got: {json}");
+        assert!(json.contains("\"version\":1"), "got: {json}");
+        assert!(json.contains("\"timestamp_ns\":123"), "got: {json}");
+        assert!(
+            !json.contains("count") && !json.contains("message"),
+            "payload must not leak counts or messages: {json}"
+        );
+    }
+}

--- a/src/backend/src/status/mod.rs
+++ b/src/backend/src/status/mod.rs
@@ -29,9 +29,12 @@ pub fn handle() -> HttpResponse {
 
     let body = serde_json::to_vec(&response).unwrap_or_else(|_| {
         // Serialization of a fixed-shape struct with primitive fields cannot realistically fail,
-        // but if it ever does we fall back to a static safe payload rather than panicking in a
-        // public unauthenticated query.
-        br#"{"status":"critical","version":1,"metrics":{}}"#.to_vec()
+        // but if it ever does we fall back to a safe payload that preserves the documented schema
+        // rather than panicking in a public unauthenticated query.
+        format!(
+            r#"{{"status":"critical","version":{STATUS_RESPONSE_VERSION},"timestamp_ns":{now},"metrics":{{}}}}"#
+        )
+        .into_bytes()
     });
 
     HttpResponse {

--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -6,6 +6,7 @@ mod custom_token;
 mod settings;
 mod signer;
 mod stats;
+mod status;
 mod transactions;
 mod user_profile;
 mod utils;

--- a/src/backend/tests/it/status.rs
+++ b/src/backend/tests/it/status.rs
@@ -32,7 +32,11 @@ fn make_request(url: &str) -> HttpRequest {
 
 fn fetch_status<P: PicCanisterTrait>(pic_setup: &P) -> (HttpResponse, Value) {
     let response: HttpResponse = pic_setup
-        .query(Principal::anonymous(), "http_request", make_request("/status"))
+        .query(
+            Principal::anonymous(),
+            "http_request",
+            make_request("/status"),
+        )
         .expect("/status should always return Ok");
     let body: Value =
         serde_json::from_slice(response.body.as_ref()).expect("response body must be JSON");

--- a/src/backend/tests/it/status.rs
+++ b/src/backend/tests/it/status.rs
@@ -1,0 +1,181 @@
+//! `PocketIc` integration tests for the public `/status` HTTP endpoint.
+//!
+//! The endpoint is wired through the `http_request` query in
+//! `src/backend/src/api/admin.rs` and routes to the `status` module. It is intentionally
+//! unauthenticated and exposes only coarse-grained statuses (no counts).
+
+use std::time::Duration;
+
+use candid::Principal;
+use pretty_assertions::assert_eq;
+use serde_bytes::ByteBuf;
+use serde_json::Value;
+use shared::http::{HttpRequest, HttpResponse};
+
+use crate::utils::pocketic::{BackendBuilder, PicCanisterTrait};
+
+/// Mirror of `crate::status::cache::CACHE_TTL_NS` (60s). Hardcoded here to keep this test crate
+/// independent of the canister-internal module.
+const CACHE_TTL_SECS: u64 = 60;
+
+/// Mirror of `crate::status::metrics::SIGNUPS_WARN_THRESHOLD`.
+const SIGNUPS_WARN_THRESHOLD: u8 = 50;
+
+fn make_request(url: &str) -> HttpRequest {
+    HttpRequest {
+        method: "GET".to_string(),
+        url: url.to_string(),
+        headers: vec![],
+        body: ByteBuf::from(Vec::<u8>::new()),
+    }
+}
+
+fn fetch_status<P: PicCanisterTrait>(pic_setup: &P) -> (HttpResponse, Value) {
+    let response: HttpResponse = pic_setup
+        .query(Principal::anonymous(), "http_request", make_request("/status"))
+        .expect("/status should always return Ok");
+    let body: Value =
+        serde_json::from_slice(response.body.as_ref()).expect("response body must be JSON");
+    (response, body)
+}
+
+#[test]
+fn status_endpoint_returns_ok_on_empty_canister() {
+    let pic_setup = BackendBuilder::default().deploy();
+
+    let (response, body) = fetch_status(&pic_setup);
+
+    assert_eq!(response.status_code, 200);
+    let content_type = response
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("Content-Type"))
+        .map(|(_, v)| v.as_str());
+    assert_eq!(content_type, Some("application/json"));
+
+    assert_eq!(body["status"], Value::String("ok".to_string()));
+    assert_eq!(body["version"], Value::from(1));
+    assert_eq!(
+        body["metrics"]["signups_30m"]["status"],
+        Value::String("ok".to_string()),
+        "body was: {body}"
+    );
+}
+
+#[test]
+fn status_endpoint_does_not_leak_counts_or_messages() {
+    let pic_setup = BackendBuilder::default().deploy();
+
+    // Even after creating some users, the public payload must never include numeric counts or
+    // free-form messages: only coarse-grained statuses.
+    let _ = pic_setup.create_users(1..=5);
+
+    // Advance past the cache TTL so the response reflects the new state, not the empty boot.
+    pic_setup
+        .pic()
+        .advance_time(Duration::from_secs(CACHE_TTL_SECS + 1));
+
+    let (_, body) = fetch_status(&pic_setup);
+    let raw = body.to_string();
+
+    assert!(
+        !raw.contains("count"),
+        "payload must not embed any 'count' field: {raw}"
+    );
+    assert!(
+        !raw.contains("message"),
+        "payload must not embed any 'message' field: {raw}"
+    );
+
+    let entry = &body["metrics"]["signups_30m"];
+    let keys: Vec<&str> = entry
+        .as_object()
+        .expect("metric entry must be an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        keys,
+        vec!["status"],
+        "signups_30m metric must only expose `status`"
+    );
+}
+
+#[test]
+fn status_endpoint_flips_to_warn_when_signups_exceed_threshold() {
+    let pic_setup = BackendBuilder::default().deploy();
+
+    // Sanity: empty canister is `ok`.
+    let (_, body) = fetch_status(&pic_setup);
+    assert_eq!(body["metrics"]["signups_30m"]["status"], "ok");
+
+    // Cross the warn threshold. `create_users` advances pocket-ic time by 10s per user, so
+    // creating WARN users moves time forward by ~500s — well past the 60s cache TTL, naturally
+    // invalidating the previous cached response.
+    let _ = pic_setup.create_users(1..=SIGNUPS_WARN_THRESHOLD);
+
+    let (_, body) = fetch_status(&pic_setup);
+    assert_eq!(
+        body["metrics"]["signups_30m"]["status"],
+        Value::String("warn".to_string()),
+        "expected warn after >= {SIGNUPS_WARN_THRESHOLD} signups, body: {body}"
+    );
+    assert_eq!(
+        body["status"],
+        Value::String("warn".to_string()),
+        "top-level rollup must reflect the worst child: {body}"
+    );
+}
+
+#[test]
+fn status_endpoint_caches_within_ttl() {
+    let pic_setup = BackendBuilder::default().deploy();
+
+    let (_, first) = fetch_status(&pic_setup);
+    let first_ts = first["timestamp_ns"]
+        .as_u64()
+        .expect("timestamp_ns must be a u64");
+
+    // Repeated calls within the TTL window must return the cached payload — same timestamp,
+    // same status. We avoid `advance_time` here so we stay strictly inside the 60s TTL.
+    for _ in 0..3 {
+        let (_, again) = fetch_status(&pic_setup);
+        assert_eq!(
+            again["timestamp_ns"].as_u64().unwrap(),
+            first_ts,
+            "cached response must keep the same timestamp within TTL"
+        );
+        assert_eq!(again["status"], first["status"]);
+    }
+
+    // Past the TTL, the canister must recompute and return a fresh timestamp. `advance_time`
+    // alone is not enough on PocketIC: a `tick` is needed for the new time to become visible to
+    // subsequent canister calls.
+    pic_setup
+        .pic()
+        .advance_time(Duration::from_secs(CACHE_TTL_SECS + 1));
+    pic_setup.pic().tick();
+
+    let (_, refreshed) = fetch_status(&pic_setup);
+    let refreshed_ts = refreshed["timestamp_ns"]
+        .as_u64()
+        .expect("timestamp_ns must be a u64");
+    assert!(
+        refreshed_ts > first_ts,
+        "after TTL expiry, response timestamp must advance (first={first_ts}, refreshed={refreshed_ts})"
+    );
+}
+
+#[test]
+fn status_endpoint_returns_404_for_unknown_path() {
+    let pic_setup = BackendBuilder::default().deploy();
+
+    let response: HttpResponse = pic_setup
+        .query(
+            Principal::anonymous(),
+            "http_request",
+            make_request("/does-not-exist"),
+        )
+        .expect("http_request must always succeed at the canister boundary");
+    assert_eq!(response.status_code, 404);
+}

--- a/src/backend/tests/it/status.rs
+++ b/src/backend/tests/it/status.rs
@@ -18,8 +18,16 @@ use crate::utils::pocketic::{BackendBuilder, PicCanisterTrait};
 /// independent of the canister-internal module.
 const CACHE_TTL_SECS: u64 = 60;
 
-/// Mirror of `crate::status::metrics::SIGNUPS_WARN_THRESHOLD`.
-const SIGNUPS_WARN_THRESHOLD: u8 = 50;
+/// Mirror of `crate::status::metrics::SIGNUPS_WARN_THRESHOLD`. Kept as `u64` to match the
+/// canister-side type; narrowed to `u8` at the call site below since `create_users` takes a
+/// `RangeBounds<u8>`. The `try_from` will trip if the threshold is ever bumped past `u8::MAX`,
+/// which is exactly the signal we want to retune this test rather than silently truncate.
+const SIGNUPS_WARN_THRESHOLD: u64 = 50;
+
+fn signups_warn_threshold_u8() -> u8 {
+    u8::try_from(SIGNUPS_WARN_THRESHOLD)
+        .expect("SIGNUPS_WARN_THRESHOLD must fit into u8 for create_users")
+}
 
 fn make_request(url: &str) -> HttpRequest {
     HttpRequest {
@@ -116,7 +124,7 @@ fn status_endpoint_flips_to_warn_when_signups_exceed_threshold() {
     // Cross the warn threshold. `create_users` advances pocket-ic time by 10s per user, so
     // creating WARN users moves time forward by ~500s — well past the 60s cache TTL, naturally
     // invalidating the previous cached response.
-    let _ = pic_setup.create_users(1..=SIGNUPS_WARN_THRESHOLD);
+    let _ = pic_setup.create_users(1..=signups_warn_threshold_u8());
 
     let (_, body) = fetch_status(&pic_setup);
     assert_eq!(


### PR DESCRIPTION
# Motivation

We want to give external monitors (UptimeRobot, a Slack bot, etc.) a way to detect abnormal sign-up activity without exposing user counts, pull-based via HTTP so the canister never has to push.

The logic is mostly a replica of the `/metrics` endpoint.

# Changes

- New public `GET /status` HTTP endpoint, routed inside the existing `http_request` query in `src/backend/src/api/admin.rs` (no auth, alongside `/metrics`).
- New `status` module with three files:
  - `mod.rs` — `HealthStatus` (`ok`/`warn`/`critical`, `Ord`-derived for the rollup), `MetricEntry`, `StatusResponse`, JSON handler.
  - `metrics.rs` — `signups_30m` metric with hardcoded thresholds (warn at 50, critical at 200 signups in the last 30 min); easy to migrate to ` Config` later.
  - `cache.rs` — per-replica `thread_local!` memoization with 60s TTL so the underlying `user_profile.iter()` scan runs at most once per minute.
- Response payload only ever exposes per-metric `status` strings, never counts or messages. Top-level `status` is the worst child status.

Response shape:

```json
{
  \"status\": \"ok\",
  \"version\": 1,
  \"timestamp_ns\": 1745923200000000000,
  \"metrics\": { \"signups_30m\": { \"status\": \"ok\" } }
}
```

# Tests

Added tests.

