### PR TITLE
feat(frontend): fix issue with OneSec compatible tokens

### DIFF
--- a/src/frontend/src/lib/utils/onesec-swap.utils.ts
+++ b/src/frontend/src/lib/utils/onesec-swap.utils.ts
@@ -52,9 +52,9 @@ const getEvmAddressForNetwork = ({
 	networkId: NetworkId;
 }): string | undefined =>
 	networkId === ARBITRUM_MAINNET_NETWORK_ID
-		? config.erc20MainnetArbitrum
+		? (config.erc20MainnetArbitrum ?? config.erc20Mainnet ?? config.erc20)
 		: networkId === BASE_NETWORK_ID
-			? config.erc20MainnetBase
+			? (config.erc20MainnetBase ?? config.erc20Mainnet ?? config.erc20)
 			: (config.erc20MainnetEthereum ?? config.erc20Mainnet ?? config.erc20);
 
 /**


### PR DESCRIPTION
# Motivation

For proper OneSec compatible destination token filtering, we need to always fallback to the same values, no matter EVM network is being used.
