### PR TITLE
refactor(frontend): extract `AiAssistantResetButton` component

### DIFF
--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
@@ -157,7 +157,7 @@
 		<h5 class="mx-2 w-full">{replaceOisyPlaceholders($i18n.ai_assistant.text.title)}</h5>
 
 		<div class="mr-2">
-			<AiAssistantResetButton />
+			<AiAssistantResetButton {loading} />
 		</div>
 
 		<button

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
@@ -5,8 +5,8 @@
 	import AiAssistantActionButton from '$lib/components/ai-assistant/AiAssistantActionButton.svelte';
 	import AiAssistantForm from '$lib/components/ai-assistant/AiAssistantForm.svelte';
 	import AiAssistantMessages from '$lib/components/ai-assistant/AiAssistantMessages.svelte';
+	import AiAssistantResetButton from '$lib/components/ai-assistant/AiAssistantResetButton.svelte';
 	import IconAiAssistant from '$lib/components/icons/IconAiAssistant.svelte';
-	import IconRepeat from '$lib/components/icons/IconRepeat.svelte';
 	import IconSend from '$lib/components/icons/lucide/IconSend.svelte';
 	import IconUserSquare from '$lib/components/icons/lucide/IconUserSquare.svelte';
 	import IconWallet from '$lib/components/icons/lucide/IconWallet.svelte';
@@ -156,17 +156,7 @@
 
 		<h5 class="mx-2 w-full">{replaceOisyPlaceholders($i18n.ai_assistant.text.title)}</h5>
 
-		<button
-			class="mr-2 transition-colors"
-			class:hover:text-primary={!loading}
-			class:text-tertiary={!loading}
-			class:text-tertiary-inverted={loading}
-			aria-label={$i18n.ai_assistant.text.reset_chat_history}
-			disabled={loading}
-			onclick={aiAssistantStore.resetChatHistory}
-		>
-			<IconRepeat size="18" />
-		</button>
+		<AiAssistantResetButton {loading} />
 
 		<button
 			class="text-tertiary transition-colors hover:text-primary"

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
@@ -2,8 +2,8 @@
 	import { IconClose } from '@dfinity/gix-components';
 	import { fade } from 'svelte/transition';
 	import AiAssistantChat from '$lib/components/ai-assistant/AiAssistantChat.svelte';
-	import IconAiAssistant from '$lib/components/icons/IconAiAssistant.svelte';
 	import AiAssistantResetButton from '$lib/components/ai-assistant/AiAssistantResetButton.svelte';
+	import IconAiAssistant from '$lib/components/icons/IconAiAssistant.svelte';
 	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
@@ -156,7 +156,9 @@
 
 		<h5 class="mx-2 w-full">{replaceOisyPlaceholders($i18n.ai_assistant.text.title)}</h5>
 
-		<AiAssistantResetButton {loading} />
+		<div class="mr-2">
+			<AiAssistantResetButton />
+		</div>
 
 		<button
 			class="text-tertiary transition-colors hover:text-primary"

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
@@ -3,26 +3,7 @@
 	import { fade } from 'svelte/transition';
 	import AiAssistantChat from '$lib/components/ai-assistant/AiAssistantChat.svelte';
 	import IconAiAssistant from '$lib/components/icons/IconAiAssistant.svelte';
-	import IconRepeat from '$lib/components/icons/IconRepeat.svelte';
-	import AiAssistantActionButton from '$lib/components/ai-assistant/AiAssistantActionButton.svelte';
-	import AiAssistantForm from '$lib/components/ai-assistant/AiAssistantForm.svelte';
-	import AiAssistantMessages from '$lib/components/ai-assistant/AiAssistantMessages.svelte';
 	import AiAssistantResetButton from '$lib/components/ai-assistant/AiAssistantResetButton.svelte';
-	import IconAiAssistant from '$lib/components/icons/IconAiAssistant.svelte';
-	import IconSend from '$lib/components/icons/lucide/IconSend.svelte';
-	import IconUserSquare from '$lib/components/icons/lucide/IconUserSquare.svelte';
-	import IconWallet from '$lib/components/icons/lucide/IconWallet.svelte';
-	import {
-		AI_ASSISTANT_MESSAGE_FAILED_TO_BE_PARSED,
-		AI_ASSISTANT_MESSAGE_SENT
-	} from '$lib/constants/analytics.constants';
-	import {
-		aiAssistantLlmMessages,
-		aiAssistantChatMessages
-	} from '$lib/derived/ai-assistant.derived';
-	import { authIdentity } from '$lib/derived/auth.derived';
-	import { askLlm } from '$lib/services/ai-assistant.services';
-	import { trackEvent } from '$lib/services/analytics.services';
 	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
@@ -11,7 +11,6 @@
 </script>
 
 <button
-	type="button"
 	class="transition-colors"
 	class:hover:text-primary={!loading}
 	class:text-tertiary={!loading}
@@ -19,6 +18,7 @@
 	aria-label={$i18n.ai_assistant.text.reset_chat_history}
 	disabled={loading}
 	onclick={aiAssistantStore.resetChatHistory}
+	type="button"
 >
 	<IconRepeat size="18" />
 </button>

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
@@ -11,6 +11,7 @@
 </script>
 
 <button
+	type="button"
 	class="transition-colors"
 	class:hover:text-primary={!loading}
 	class:text-tertiary={!loading}

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
@@ -2,11 +2,21 @@
 	import IconRepeat from '$lib/components/icons/IconRepeat.svelte';
 	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	interface Props {
+		loading?: boolean;
+	}
+
+	let { loading = false }: Props = $props();
 </script>
 
 <button
-	class="text-tertiary transition-colors hover:text-primary"
+	class="transition-colors"
+	class:hover:text-primary={!loading}
+	class:text-tertiary={!loading}
+	class:text-tertiary-inverted={loading}
 	aria-label={$i18n.ai_assistant.text.reset_chat_history}
+	disabled={loading}
 	onclick={aiAssistantStore.resetChatHistory}
 >
 	<IconRepeat size="18" />

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
@@ -2,21 +2,11 @@
 	import IconRepeat from '$lib/components/icons/IconRepeat.svelte';
 	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 	import { i18n } from '$lib/stores/i18n.store';
-
-	interface Props {
-		loading?: boolean;
-	}
-
-	let { loading = false }: Props = $props();
 </script>
 
 <button
-	class="mr-2 transition-colors"
-	class:hover:text-primary={!loading}
-	class:text-tertiary={!loading}
-	class:text-tertiary-inverted={loading}
+	class="text-tertiary transition-colors hover:text-primary"
 	aria-label={$i18n.ai_assistant.text.reset_chat_history}
-	disabled={loading}
 	onclick={aiAssistantStore.resetChatHistory}
 >
 	<IconRepeat size="18" />

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantResetButton.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import IconRepeat from '$lib/components/icons/IconRepeat.svelte';
+	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	interface Props {
+		loading?: boolean;
+	}
+
+	let { loading = false }: Props = $props();
+</script>
+
+<button
+	class="mr-2 transition-colors"
+	class:hover:text-primary={!loading}
+	class:text-tertiary={!loading}
+	class:text-tertiary-inverted={loading}
+	aria-label={$i18n.ai_assistant.text.reset_chat_history}
+	disabled={loading}
+	onclick={aiAssistantStore.resetChatHistory}
+>
+	<IconRepeat size="18" />
+</button>


### PR DESCRIPTION
# Motivation

Extract the chat-history reset button used in `AiAssistantConsole` into its own `AiAssistantResetButton` component, so the console header is simpler and the button can be reused. Inspired by [#12186](https://github.com/dfinity/oisy-wallet/pull/12186), split out as a small, isolated refactor with no behavioural changes.
