### PR TITLE
fix(frontend): wrap user menu legal links to prevent popup widening

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -285,7 +285,9 @@
 
 	<Hr />
 
-	<div class="mt-4 flex justify-center gap-2 text-xs text-nowrap text-tertiary">
+	<div
+		class="mt-4 flex max-w-80 flex-wrap justify-center gap-x-2 gap-y-1 text-xs text-nowrap text-tertiary"
+	>
 		<TermsOfUseLink />
 		<PrivacyPolicyLink />
 		<LicenseAgreementLink />


### PR DESCRIPTION
# Motivation

The footer of the user menu popup (top-right user icon on the landing page) shows three links: Terms of Use, Privacy Policy and License Agreement. They are laid out as a single non-wrapping flex row, with no width constraint of their own. In several locales the translated labels are noticeably longer than in English, and together they push the popup wider than the rest of its content (which is capped at `max-w-80`). The popup ends up looking unbalanced, with a stretched footer that doesn't match the menu items above.

# Changes

- In `Menu.svelte`, change the legal-links footer container so the popup width is no longer driven by the link labels:
  - Add `max-w-80` so the footer respects the same width budget as the rest of the menu.
  - Add `flex-wrap` so a link that doesn't fit drops to a second row instead of widening the popup.
  - Replace `gap-2` with `gap-x-2 gap-y-1` to keep horizontal spacing identical and add a small vertical gap between rows.
  - Keep `justify-center` and `text-nowrap` so wrapped rows stay centered and individual labels never break mid-word.

In English the layout is unchanged (all three links still fit on one row). In locales where the third link would overflow, it now drops to a centered second line.

# Tests

- Manually verified in DevTools by editing the live class list on the existing `Menu.svelte` footer; this is a CSS-only change to a flex container.
- I was not able to drive a full visual screenshot from the local dev server in this worktree (vite `fs.allow` rejects the parent-repo `node_modules` and `main` is currently missing the `onesec-bridge` dep), so screenshots will need to be taken from a regular checkout.

|Before|After|
|---|---|
|<img width="477" height="634" alt="image" src="https://github.com/user-attachments/assets/6de9f292-e106-4627-b708-e24f2f80096e" />|<img width="477" height="634" alt="image" src="https://github.com/user-attachments/assets/5cd63bb3-b60c-4799-8002-26ee2be97c65" />|

🤖 Claude Opus 4.7