### PR TITLE
feat(frontend): improve UTXO selection to smallest-sufficient greedy algorithm

### DIFF
--- a/src/frontend/src/btc/utils/btc-utxos.utils.ts
+++ b/src/frontend/src/btc/utils/btc-utxos.utils.ts
@@ -45,8 +45,17 @@ export const estimateTransactionSize = ({
 };
 
 /**
- * Main function to select UTXOs for a transaction with fee consideration
- * This function iteratively selects UTXOs and calculates fees until sufficient funds are found
+ * Main function to select UTXOs for a transaction with fee consideration.
+ *
+ * Algorithm (greedy, smallest-sufficient):
+ * 1. Compute how many satoshis are still needed: amount + fee(N+1 inputs) - accumulated total.
+ * 2. Pick the smallest UTXO whose value alone covers that need → minimises change and input count.
+ * 3. If no such UTXO exists, pick the largest available UTXO to reduce the gap as fast as
+ *    possible, then restart from step 1 with the updated totals.
+ *
+ * The fee is recalculated after every pick because each additional input increases transaction
+ * size.  Using fee(N+1) as the target when searching for the next UTXO ensures the selected
+ * set will remain sufficient once the UTXO is added.
  */
 export const calculateUtxoSelection = ({
 	availableUtxos,
@@ -67,53 +76,66 @@ export const calculateUtxoSelection = ({
 		};
 	}
 
-	// Sort UTXOs by value in descending order
-	const sortedUtxos = [...availableUtxos].sort((a, b) => {
-		const aValue = BigInt(a.value);
-		const bValue = BigInt(b.value);
-		return aValue > bValue ? -1 : aValue < bValue ? 1 : 0;
-	});
+	const calcFee = (numInputs: number): bigint => {
+		const txSize = estimateTransactionSize({ numInputs, numOutputs: 2 });
+		return (BigInt(txSize) * feeRateMiliSatoshisPerVByte + 999n) / 1000n;
+	};
 
 	const selectedUtxos: CkBtcMinterDid.Utxo[] = [];
 	let totalInputValue = ZERO;
-	let estimatedFee = ZERO;
+	const remaining = [...availableUtxos];
 
-	// Iteratively add UTXOs until we have enough to cover amount and fee
-	for (const utxo of sortedUtxos) {
-		selectedUtxos.push(utxo);
-		totalInputValue += BigInt(utxo.value);
+	while (remaining.length > 0) {
+		// Fee for the transaction once we add one more input.
+		const fee = calcFee(selectedUtxos.length + 1);
+		const needed = amountSatoshis + fee - totalInputValue;
 
-		// Calculate current transaction size and fee
-		// 2 outputs: one for recipient, one for change (if needed)
-		const txSize = estimateTransactionSize({
-			numInputs: selectedUtxos.length,
-			numOutputs: 2
-		});
-		// Round up to ensure fee meets minimum rate requirements
-		estimatedFee = (BigInt(txSize) * feeRateMiliSatoshisPerVByte + 999n) / 1000n;
-		const totalRequired = amountSatoshis + estimatedFee;
+		// Step 1: find the smallest UTXO that alone covers the remaining need.
+		let smallestSufficient: CkBtcMinterDid.Utxo | undefined;
+		let smallestSufficientValue = ZERO;
+		for (const utxo of remaining) {
+			const val = BigInt(utxo.value);
+			if (val >= needed && (smallestSufficient === undefined || val < smallestSufficientValue)) {
+				smallestSufficient = utxo;
+				smallestSufficientValue = val;
+			}
+		}
 
-		// Check if we have enough to cover amount and fee
-		if (totalInputValue >= totalRequired) {
-			const changeAmount = totalInputValue - totalRequired;
-
+		if (smallestSufficient !== undefined) {
+			selectedUtxos.push(smallestSufficient);
+			totalInputValue += smallestSufficientValue;
+			const feeSatoshis = calcFee(selectedUtxos.length);
 			return {
 				selectedUtxos,
 				totalInputValue,
-				changeAmount,
+				changeAmount: totalInputValue - amountSatoshis - feeSatoshis,
 				sufficientFunds: true,
-				feeSatoshis: estimatedFee
+				feeSatoshis
 			};
 		}
+
+		// Step 2: no single UTXO covers the need; pick the largest to reduce the gap.
+		let largestIndex = 0;
+		let largestValue = BigInt(remaining[0].value);
+		for (let i = 1; i < remaining.length; i++) {
+			const val = BigInt(remaining[i].value);
+			if (val > largestValue) {
+				largestValue = val;
+				largestIndex = i;
+			}
+		}
+		selectedUtxos.push(remaining[largestIndex]);
+		totalInputValue += largestValue;
+		remaining.splice(largestIndex, 1);
 	}
 
-	// If we get here, we don't have sufficient funds
+	// Insufficient funds.
 	return {
 		selectedUtxos,
 		totalInputValue,
 		changeAmount: ZERO,
 		sufficientFunds: false,
-		feeSatoshis: estimatedFee
+		feeSatoshis: calcFee(selectedUtxos.length)
 	};
 };
 

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -140,15 +140,17 @@ describe('btc-utxos.utils', () => {
 			expect(result.feeSatoshis).toBeGreaterThan(ZERO);
 		});
 
-		it('should select UTXOs in descending order by value', () => {
+		it('should select the smallest UTXO that covers amount + fee', () => {
 			const result = calculateUtxoSelection({
 				availableUtxos: utxos,
 				amountSatoshis: 100_000n,
 				feeRateMiliSatoshisPerVByte: 1000n
 			});
 
-			// Should select the largest UTXO first (300_000)
-			expect(result.selectedUtxos[0].value).toBe(300_000n);
+			// fee(1 input) = 141 sats; needed = 100_141. Candidates >= 100_141: 200_000 and 300_000.
+			// Smallest sufficient is 200_000.
+			expect(result.selectedUtxos).toHaveLength(1);
+			expect(result.selectedUtxos[0].value).toBe(200_000n);
 			expect(result.sufficientFunds).toBeTruthy();
 			expect(result.feeSatoshis).toBeGreaterThan(ZERO);
 		});
@@ -207,6 +209,237 @@ describe('btc-utxos.utils', () => {
 			expect(result.changeAmount).toBe(50_000n); // No fees
 			expect(result.sufficientFunds).toBeTruthy();
 			expect(result.feeSatoshis).toBe(ZERO);
+		});
+	});
+
+	describe('calculateUtxoSelection — algorithm scenarios', () => {
+		// Fee reference at feeRateMiliSatoshisPerVByte = 1000n (1 sat/vbyte):
+		//   1 input : 11 + 1×68 + 2×31 = 141 sats
+		//   2 inputs: 11 + 2×68 + 2×31 = 209 sats
+		//   3 inputs: 11 + 3×68 + 2×31 = 277 sats
+
+		const FEE_RATE = 1000n;
+		const FEE_1_INPUT = 141n;
+		const FEE_2_INPUTS = 209n;
+		const FEE_3_INPUTS = 277n;
+
+		describe('single-input selection', () => {
+			it('picks the smallest UTXO that alone covers amount + fee when several candidates qualify', () => {
+				// Mirrors user example: [4,2,6,40,8,12,43] → send 10 → pick 12
+				const utxos = [
+					createMockUtxo({ value: 400_000 }),
+					createMockUtxo({ value: 200_000 }),
+					createMockUtxo({ value: 600_000 }),
+					createMockUtxo({ value: 4_000_000 }),
+					createMockUtxo({ value: 800_000 }),
+					createMockUtxo({ value: 1_200_000 }),
+					createMockUtxo({ value: 4_300_000 })
+				];
+
+				// needed = 1_000_000 + 141 = 1_000_141
+				// Candidates ≥ 1_000_141: 1_200_000, 4_000_000, 4_300_000 → pick 1_200_000
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 1_000_000n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.selectedUtxos).toHaveLength(1);
+				expect(result.selectedUtxos[0].value).toBe(1_200_000n);
+				expect(result.feeSatoshis).toBe(FEE_1_INPUT);
+				expect(result.changeAmount).toBe(1_200_000n - 1_000_000n - FEE_1_INPUT);
+				expect(result.sufficientFunds).toBeTruthy();
+			});
+
+			it('picks the UTXO that exactly covers amount + fee (zero change)', () => {
+				// 100_000 + 141 = 100_141 → UTXO of exactly 100_141 should be selected
+				const utxos = [
+					createMockUtxo({ value: 200_000 }),
+					createMockUtxo({ value: 100_141 }),
+					createMockUtxo({ value: 500_000 })
+				];
+
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 100_000n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.selectedUtxos).toHaveLength(1);
+				expect(result.selectedUtxos[0].value).toBe(100_141n);
+				expect(result.changeAmount).toBe(ZERO);
+				expect(result.feeSatoshis).toBe(FEE_1_INPUT);
+				expect(result.sufficientFunds).toBeTruthy();
+			});
+
+			it('is insufficient when the only UTXO is 1 sat below amount + fee', () => {
+				// 100_000 + 141 = 100_141; UTXO = 100_140 → cannot satisfy
+				const result = calculateUtxoSelection({
+					availableUtxos: [createMockUtxo({ value: 100_140 })],
+					amountSatoshis: 100_000n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.sufficientFunds).toBeFalsy();
+				expect(result.changeAmount).toBe(ZERO);
+			});
+		});
+
+		describe('two-input selection (restart after picking largest)', () => {
+			it('picks smallest sufficient UTXO on the second pass, not the next-largest', () => {
+				// Mirrors user example: [3,7,2,6,1] → send 10 → pick [7, 3] not [7, 6]
+				// Scaled: send 999_791 so that amount + fee(2) = 1_000_000 exactly
+				const utxos = [
+					createMockUtxo({ value: 300_000 }),
+					createMockUtxo({ value: 700_000 }),
+					createMockUtxo({ value: 200_000 }),
+					createMockUtxo({ value: 600_000 }),
+					createMockUtxo({ value: 100_000 })
+				];
+
+				// Pass 1: needed = 999_791 + 141 = 999_932 → no single UTXO qualifies → pick largest (700_000)
+				// Pass 2: needed = 999_791 + 209 − 700_000 = 300_000 → candidates ≥ 300_000: {300_000, 600_000} → pick 300_000
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 999_791n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.selectedUtxos).toHaveLength(2);
+				expect(result.selectedUtxos[0].value).toBe(700_000n);
+				expect(result.selectedUtxos[1].value).toBe(300_000n);
+				expect(result.feeSatoshis).toBe(FEE_2_INPUTS);
+				expect(result.changeAmount).toBe(ZERO);
+				expect(result.sufficientFunds).toBeTruthy();
+			});
+
+			it('produces less change than a largest-first approach would', () => {
+				// [700k, 600k, 300k] → amount chosen so largest-first would pick [700k, 600k]
+				// but smallest-sufficient restart gives [700k, 300k]
+				const utxos = [
+					createMockUtxo({ value: 700_000 }),
+					createMockUtxo({ value: 600_000 }),
+					createMockUtxo({ value: 300_000 })
+				];
+
+				// Pass 1: needed = 999_791 + 141 = 999_932 → no UTXO qualifies → pick 700_000
+				// Pass 2: needed = 999_791 + 209 − 700_000 = 300_000 → pick 300_000 (not 600_000)
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 999_791n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.selectedUtxos).toHaveLength(2);
+				expect(result.selectedUtxos[1].value).toBe(300_000n); // smallest sufficient, not 600_000
+				expect(result.changeAmount).toBe(ZERO);
+				expect(result.sufficientFunds).toBeTruthy();
+			});
+		});
+
+		describe('three-input selection', () => {
+			it('restarts the smallest-sufficient search after each largest-UTXO pick', () => {
+				const utxos = [
+					createMockUtxo({ value: 400_000 }),
+					createMockUtxo({ value: 350_000 }),
+					createMockUtxo({ value: 300_000 }),
+					createMockUtxo({ value: 200_000 }),
+					createMockUtxo({ value: 100_000 })
+				];
+
+				// Pass 1: needed = 900_000 + 141 = 900_141 → no UTXO qualifies → pick 400_000
+				// Pass 2: needed = 900_000 + 209 − 400_000 = 500_209 → no UTXO qualifies → pick 350_000
+				// Pass 3: needed = 900_000 + 277 − 750_000 = 150_277 → candidates ≥ 150_277: {300_000, 200_000} → pick 200_000
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 900_000n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.selectedUtxos).toHaveLength(3);
+				expect(result.selectedUtxos[0].value).toBe(400_000n);
+				expect(result.selectedUtxos[1].value).toBe(350_000n);
+				expect(result.selectedUtxos[2].value).toBe(200_000n); // not 300_000
+				expect(result.feeSatoshis).toBe(FEE_3_INPUTS);
+				expect(result.changeAmount).toBe(950_000n - 900_000n - FEE_3_INPUTS); // 49_723
+				expect(result.sufficientFunds).toBeTruthy();
+			});
+		});
+
+		describe('fee grows with each additional input', () => {
+			it('accounts for the higher fee when a second input is required', () => {
+				// Single UTXO of 600_000 is enough for amount 500_000 + fee(1) = 500_141.
+				// But here the largest UTXO is 300_000 which is below the needed 500_141,
+				// forcing a second pick — at which point fee(2) = 209 applies.
+				const utxos = [createMockUtxo({ value: 300_000 }), createMockUtxo({ value: 250_000 })];
+
+				// Pass 1: needed = 500_000 + 141 = 500_141 → no UTXO qualifies → pick 300_000
+				// Pass 2: needed = 500_000 + 209 − 300_000 = 200_209 → 250_000 ≥ 200_209 → pick 250_000
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 500_000n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.selectedUtxos).toHaveLength(2);
+				expect(result.feeSatoshis).toBe(FEE_2_INPUTS);
+				expect(result.changeAmount).toBe(550_000n - 500_000n - FEE_2_INPUTS); // 49_791
+				expect(result.sufficientFunds).toBeTruthy();
+			});
+		});
+
+		describe('UTXOs with equal values', () => {
+			it('selects one UTXO when any single one covers amount + fee', () => {
+				const utxos = [
+					createMockUtxo({ value: 500_000, vout: 0 }),
+					createMockUtxo({ value: 500_000, vout: 1 }),
+					createMockUtxo({ value: 500_000, vout: 2 })
+				];
+
+				// needed = 450_000 + 141 = 450_141 → 500_000 qualifies → pick one
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 450_000n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.selectedUtxos).toHaveLength(1);
+				expect(result.selectedUtxos[0].value).toBe(500_000n);
+				expect(result.sufficientFunds).toBeTruthy();
+			});
+		});
+
+		describe('insufficient funds', () => {
+			it('returns all available UTXOs when total is still not enough', () => {
+				const utxos = [createMockUtxo({ value: 100_000 }), createMockUtxo({ value: 50_000 })];
+
+				// 100_000 + 50_000 = 150_000 < 200_000 + 141
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 200_000n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.sufficientFunds).toBeFalsy();
+				expect(result.selectedUtxos).toHaveLength(2);
+				expect(result.changeAmount).toBe(ZERO);
+			});
+
+			it('is insufficient when the total exactly covers amount but not amount + fee', () => {
+				// total = 200_000, amount = 200_000, fee(2) = 209 → 200_000 < 200_209
+				const utxos = [
+					createMockUtxo({ value: 100_000 }),
+					createMockUtxo({ value: 100_000, vout: 1 })
+				];
+
+				const result = calculateUtxoSelection({
+					availableUtxos: utxos,
+					amountSatoshis: 200_000n,
+					feeRateMiliSatoshisPerVByte: FEE_RATE
+				});
+
+				expect(result.sufficientFunds).toBeFalsy();
+			});
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Replaces the frontend Bitcoin UTXO selection algorithm in calculateUtxoSelection with a smallest-sufficient greedy approach that minimises change output and avoids unnecessarily consuming large UTXOs.                                                                                                                                          
   
### Problem with the previous algorithm:
                  
The old implementation sorted UTXOs descending (largest first) and accumulated until the sum covered amount + fee. This meant that for a send of 10 BTC from a wallet holding [2, 4, 6, 8, 12, 40, 43] BTC, it would pick 40 — wasting 30 BTC as change — instead of picking 12.
                                                                                                                                                                                
### New algorithm:

  **At each step**:                                                                                                                                                                 
  1. Compute needed = amount + fee(N+1 inputs) − accumulated total.
  2. Pick the smallest UTXO that alone covers needed — minimises change and requires no further inputs.                                                                         
  3. If no single UTXO qualifies, pick the largest available to close the gap as fast as possible, then restart from step 1 with updated totals and fee.
                                                                                                                                                                                
The fee is recalculated at every step because each additional input increases transaction size. Using fee(N+1) as the target guarantees the selection remains sufficient once the UTXO is added.            
                  
### Tests:
                  
  - Updated one existing test whose assertion encoded the old largest-first behaviour.                                                                                          
  - Added 10 new tests covering: single-input smallest-sufficient selection, two-input restart behaviour, three-input restart, fee recalculation per added input, equal-value UTXOs, exact zero-change coverage, off-by-one insufficient, and total-below-amount insufficient cases.    
