### PR TITLE
refactor(frontend): rename transaction size symbols to use vbytes units

### DIFF
--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -4,7 +4,7 @@ import { getFeeRateFromPercentiles } from '$btc/services/btc-utxos.service';
 import type { BtcAddress } from '$btc/types/address';
 import { BtcSendValidationError, BtcValidationError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
-import { estimateTransactionSize, extractUtxoTxIds } from '$btc/utils/btc-utxos.utils';
+import { estimateTransactionVSize, extractUtxoTxIds } from '$btc/utils/btc-utxos.utils';
 import type { SendBtcResponse, SignBtcResponse } from '$declarations/signer/signer.did';
 import { getPendingTransactionUtxoTxIds, txidStringToUint8Array } from '$icp/utils/btc.utils';
 import { addPendingBtcTransaction } from '$lib/api/backend.api';
@@ -198,11 +198,11 @@ export const validateBtcSend = async ({
 		network,
 		identity
 	});
-	const estimatedTxSize = estimateTransactionSize({
+	const estimatedTxVSize = estimateTransactionVSize({
 		numInputs: utxos.length,
 		numOutputs: 2
 	});
-	const expectedMinFee = (BigInt(estimatedTxSize) * feeRateMiliSatoshisPerVByte) / 1000n;
+	const expectedMinFee = (BigInt(estimatedTxVSize) * feeRateMiliSatoshisPerVByte) / 1000n;
 
 	// Allow some tolerance for fee calculation differences (±10%)
 	const feeToleranceRange = expectedMinFee / BTC_SEND_FEE_TOLERANCE_PERCENTAGE;

--- a/src/frontend/src/btc/utils/btc-utxos.utils.ts
+++ b/src/frontend/src/btc/utils/btc-utxos.utils.ts
@@ -20,28 +20,31 @@ export const extractUtxoTxIds = (utxos: CkBtcMinterDid.Utxo[]): string[] =>
 	utxos.map(({ outpoint: { txid } }) => utxoTxIdToString(txid));
 
 /**
- * Estimates transaction size in bytes based on number of inputs and outputs
- * This is a simplified calculation for P2WPKH transactions
+ * Estimates transaction virtual size (vbytes) based on number of inputs and outputs.
+ * This is a simplified calculation for P2WPKH transactions.
+ *
+ * All constants are in vbytes: witness data is discounted to 1/4 weight per BIP-141,
+ * so the result must be multiplied by a sat/vbyte fee rate, not a sat/byte rate.
  */
-export const estimateTransactionSize = ({
+export const estimateTransactionVSize = ({
 	numInputs,
 	numOutputs
 }: {
 	numInputs: number;
 	numOutputs: number;
 }): number => {
-	// version (4) and locktime (4) and input count (1), output count (1) and SegWit marker + flag (0.5 -> rounding to 1)
-	const baseSize = 11;
+	// version (4) + locktime (4) + input count (1) + output count (1) + SegWit marker+flag (0.5 → 1) = 11 vbytes
+	const BASE_VSIZE = 11;
 
-	// P2WPKH input size: outpoint (36) and scriptSig length (1) and scriptSig (0) and sequence (4) = 41 bytes
-	// Plus witness data: witness stack items (1) and signature (72) and pubkey (33) = 106 bytes
-	// But witness data is counted as 1/4 for fee calculation, so effective size is 41 and 106/4 = 67.5 bytes
-	const inputSize = 68;
+	// P2WPKH input: non-witness outpoint (36) + scriptSig length (1) + empty scriptSig (0) + sequence (4) = 41 vbytes
+	// witness: stack item count (1) + signature (72) + pubkey (33) = 106 bytes → 106/4 = 26.5 vbytes
+	// total: 41 + 26.5 = 67.5 → 68 vbytes
+	const INPUT_VSIZE = 68;
 
-	// P2WPKH output size: value (8) and scriptPubKey length (1) and scriptPubKey (22) = 31 bytes
-	const outputSize = 31;
+	// P2WPKH output: value (8) + scriptPubKey length (1) + scriptPubKey (22) = 31 vbytes
+	const OUTPUT_VSIZE = 31;
 
-	return baseSize + numInputs * inputSize + numOutputs * outputSize;
+	return BASE_VSIZE + numInputs * INPUT_VSIZE + numOutputs * OUTPUT_VSIZE;
 };
 
 /**
@@ -77,8 +80,8 @@ export const calculateUtxoSelection = ({
 	}
 
 	const calcFee = (numInputs: number): bigint => {
-		const txSize = estimateTransactionSize({ numInputs, numOutputs: 2 });
-		return (BigInt(txSize) * feeRateMiliSatoshisPerVByte + 999n) / 1000n;
+		const txVSize = estimateTransactionVSize({ numInputs, numOutputs: 2 });
+		return (BigInt(txVSize) * feeRateMiliSatoshisPerVByte + 999n) / 1000n;
 	};
 
 	const selectedUtxos: CkBtcMinterDid.Utxo[] = [];

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -136,7 +136,7 @@ describe('btc-send.services', () => {
 			).mockResolvedValue({ success: true });
 			vi.spyOn(btcUtils, 'getPendingTransactionUtxoTxIds').mockReturnValue([]);
 			vi.spyOn(btcUtxosUtils, 'extractUtxoTxIds').mockReturnValue(['txid1', 'txid2']);
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
+			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
 			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
 		});
 
@@ -287,7 +287,7 @@ describe('btc-send.services', () => {
 		describe('InvalidFeeCalculation validation', () => {
 			it('should throw InvalidFeeCalculation error when fee is too low', async () => {
 				// Mock estimated transaction size and fee rate to make expected fee higher than provided fee
-				vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(1000);
+				vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(1000);
 				vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(10000n);
 
 				const params = {
@@ -308,7 +308,7 @@ describe('btc-send.services', () => {
 
 			it('should throw InvalidFeeCalculation error when fee is too high', async () => {
 				// Mock estimated transaction size to make expected fee much lower than provided fee
-				vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(100);
+				vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(100);
 				vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1n);
 
 				const params = {
@@ -330,7 +330,7 @@ describe('btc-send.services', () => {
 
 		it('should throw InsufficientBalanceForFee error when UTXOs have insufficient funds', async () => {
 			// Use smaller fee and transaction size for consistent calculation
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
+			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
 			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
 
 			const params = {
@@ -352,7 +352,7 @@ describe('btc-send.services', () => {
 
 		it('should accept fee within tolerance range', async () => {
 			// Mock transaction size for predictable fee calculation
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
+			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
 			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
 
 			const expectedFee = BigInt(250) * 4n; // 1000 satoshis
@@ -386,7 +386,7 @@ describe('btc-send.services', () => {
 			};
 
 			// Mock the transaction size estimation for 2 inputs
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(370);
+			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(370);
 			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(3000n);
 
 			const params = {
@@ -413,7 +413,7 @@ describe('btc-send.services', () => {
 		});
 
 		it('should validate exact fee tolerance boundaries', async () => {
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionSize').mockReturnValue(250);
+			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
 			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
 
 			const expectedFee = 250n * 4n; // 1000 satoshis

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -3,7 +3,7 @@ import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-tr
 import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import {
 	calculateUtxoSelection,
-	estimateTransactionSize,
+	estimateTransactionVSize,
 	extractUtxoTxIds,
 	filterAvailableUtxos,
 	filterLockedUtxos,
@@ -77,9 +77,9 @@ describe('btc-utxos.utils', () => {
 		});
 	});
 
-	describe('estimateTransactionSize', () => {
+	describe('estimateTransactionVSize', () => {
 		it('should calculate transaction size correctly for multiple inputs and outputs', () => {
-			const result = estimateTransactionSize({
+			const result = estimateTransactionVSize({
 				numInputs: 2,
 				numOutputs: 2
 			});
@@ -89,7 +89,7 @@ describe('btc-utxos.utils', () => {
 		});
 
 		it('should handle single input and output', () => {
-			const result = estimateTransactionSize({
+			const result = estimateTransactionVSize({
 				numInputs: 1,
 				numOutputs: 1
 			});
@@ -99,7 +99,7 @@ describe('btc-utxos.utils', () => {
 		});
 
 		it('should handle 0n inputs and outputs', () => {
-			const result = estimateTransactionSize({
+			const result = estimateTransactionVSize({
 				numInputs: 0,
 				numOutputs: 0
 			});
@@ -109,7 +109,7 @@ describe('btc-utxos.utils', () => {
 		});
 
 		it('should handle large number of inputs and outputs', () => {
-			const result = estimateTransactionSize({
+			const result = estimateTransactionVSize({
 				numInputs: 10,
 				numOutputs: 5
 			});


### PR DESCRIPTION
# Motivation

Renames the transaction size estimation function and all related symbols to make the unit (vbytes) explicit throughout the Bitcoin fee calculation code.


Changes                                                                                                                                                                       
  - estimateTransactionSize → estimateTransactionVSize
  - Internal constants baseSize / inputSize / outputSize → BASE_VSIZE / INPUT_VSIZE / OUTPUT_VSIZE
  - Local variables txSize → txVSize and estimatedTxSize → estimatedTxVSize at all call sites                                                                                   
  - Updated comments to say "vbytes" where the witness discount applies, with the derivation made explicit: 106 bytes witness → 106/4 = 26.5 vbytes                             
  - Updated all test imports, describe labels, and vi.spyOn references accordingly    