### PR TITLE
fix(frontend): restrict ICP destinations when EVM source's not in 1Sec

### DIFF
--- a/src/frontend/src/lib/utils/onesec-swap.utils.ts
+++ b/src/frontend/src/lib/utils/onesec-swap.utils.ts
@@ -130,7 +130,10 @@ export const oneSecCompatibleDestinations = ({
 		const address = getEvmAddressForNetwork({ config, networkId: sourceToken.network.id });
 		if (nonNullish(address) && address.toLowerCase() === srcAddress.toLowerCase()) {
 			const ledger = config.ledgerMainnet ?? config.ledger;
-			return nonNullish(ledger) ? { icp: new Set([ledger]) } : undefined;
+			return nonNullish(ledger) ? { icp: new Set([ledger]) } : { icp: new Set() };
 		}
 	}
+
+	// No OneSec config matched this EVM address: restrict ICP destinations to nothing.
+	return { icp: new Set() };
 };

--- a/src/frontend/src/tests/lib/utils/onesec-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/onesec-swap.utils.spec.ts
@@ -308,13 +308,27 @@ describe('onesec-swap.utils', () => {
 				expect(result?.icp).toContain(USDC_LEDGER);
 			});
 
-			it('returns undefined for an unknown EVM address', () => {
+			it('returns empty icp set for an unknown EVM address', () => {
 				const result = oneSecCompatibleDestinations({
 					sourceToken: makeErc20Token({ address: '0x0000000000000000000000000000000000000001' }),
 					networkIds: [ETHEREUM_NETWORK.id]
 				});
 
-				expect(result).toBeUndefined();
+				expect(result?.icp).toBeDefined();
+				expect(result?.icp?.size).toBe(0);
+			});
+
+			it('returns empty icp set for USDT on Arbitrum (no Arbitrum address in OneSec config)', () => {
+				const result = oneSecCompatibleDestinations({
+					sourceToken: makeErc20Token({
+						address: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+						network: ARBITRUM_MAINNET_NETWORK
+					}),
+					networkIds: [ARBITRUM_MAINNET_NETWORK.id]
+				});
+
+				expect(result?.icp).toBeDefined();
+				expect(result?.icp?.size).toBe(0);
 			});
 
 			it('does not set evm or sol keys for EVM source', () => {


### PR DESCRIPTION
# Motivation

When selecting an EVM source token that OneSec does not have a bridging route for (e.g. USDT on Arbitrum — OneSec's config only contains a USDT address for Ethereum mainnet, not Arbitrum), oneSecCompatibleDestinations fell through the entire token-config loop without returning and implicitly returned undefined. 

undefined from oneSecCompatibleDestinations is interpreted by filterSwapTokens as "no OneSec constraint", so the compatibleTokenIds guard is skipped and every ICP token that passes the provider coverage check reaches return true. The result: filtering destination tokens by the Internet Computer network shows all IC tokens instead of none.

# Changes

Return { icp: new Set() } (an explicit empty set) instead of undefined in both EVM-source failure paths. An empty set tells filterSwapTokens "OneSec is aware of this categorybut has zero valid destinations", which correctly filters out all ICP tokens.