### PR TITLE
feat(frontend): extend tracking metadata in SwapIcpWizard

### DIFF
--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -150,7 +150,10 @@
 			sourceToken: $sourceToken.symbol,
 			destinationToken: $destinationToken.symbol,
 			dApp: $swapAmountsStore.selectedProvider.provider,
-			usdSourceValue: sourceTokenUsdValue ?? ''
+			usdSourceValue: sourceTokenUsdValue ?? '',
+			swapType: $swapAmountsStore.selectedProvider.type ?? '',
+			sourceNetwork: $sourceToken.network.name,
+			destinationNetwork: $destinationToken.network.name
 		};
 
 		const sourceLedgerCanisterId = ($sourceToken as IcToken).ledgerCanisterId;


### PR DESCRIPTION
# Motivation

After introducing OneSec provider, we need to extend tracking metadata in SwapIcpWizard with `swapType`, `sourceNetwork`, and `destinationNetwork`.