### PR TITLE
feat(frontend): add transactions filter store with persistence

### DIFF
--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -10,6 +10,7 @@
 	import { authLocked } from '$lib/stores/locked.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { tokenCategoryFilterStore, tokensSortStore } from '$lib/stores/settings.store';
+	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 	import { InternetIdentityDomain, type OpenIdProvider } from '$lib/types/auth';
 	import { componentToHtml } from '$lib/utils/component.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -43,6 +44,8 @@
 			tokensSortStore.reset({ key: 'tokens-sort' });
 
 			tokenCategoryFilterStore.reset({ key: 'token-category-filter' });
+
+			transactionsFilterStore.clear();
 		} else if (success === 'cancelled' || success === 'error') {
 			modalStore.openAuthHelp({ id: modalId, data: false });
 		}

--- a/src/frontend/src/lib/derived/transactions-filter.derived.ts
+++ b/src/frontend/src/lib/derived/transactions-filter.derived.ts
@@ -1,0 +1,23 @@
+import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
+import { derived, type Readable } from 'svelte/store';
+
+export const selectedTransactionsFilterTypesCount: Readable<number> = derived(
+	transactionsFilterStore,
+	($filter) => $filter.types.length
+);
+
+export const selectedTransactionsFilterTokensCount: Readable<number> = derived(
+	transactionsFilterStore,
+	($filter) => $filter.tokenIds.length
+);
+
+export const selectedTransactionsFilterContactsCount: Readable<number> = derived(
+	transactionsFilterStore,
+	($filter) => $filter.contactIds.length
+);
+
+export const hasActiveTransactionsFilter: Readable<boolean> = derived(
+	transactionsFilterStore,
+	($filter) =>
+		$filter.types.length > 0 || $filter.tokenIds.length > 0 || $filter.contactIds.length > 0
+);

--- a/src/frontend/src/lib/stores/transactions-filter.store.ts
+++ b/src/frontend/src/lib/stores/transactions-filter.store.ts
@@ -1,0 +1,56 @@
+import { initStorageStore, type StorageStore } from '$lib/stores/storage.store';
+import type { TransactionType } from '$lib/types/transaction';
+import { EMPTY_TRANSACTIONS_FILTER, type TransactionsFilter } from '$lib/types/transactions-filter';
+import { get as getStore } from 'svelte/store';
+
+export const TRANSACTIONS_FILTER_STORAGE_KEY = 'oisy_transactions_filter';
+
+export interface TransactionsFilterStore extends StorageStore<TransactionsFilter> {
+	toggleType: (type: TransactionType) => void;
+	toggleTokenId: (tokenId: string) => void;
+	toggleContactId: (contactId: string) => void;
+	clear: () => void;
+}
+
+const toggle = <T>({ values, value }: { values: T[]; value: T }): T[] =>
+	values.includes(value) ? values.filter((v) => v !== value) : [...values, value];
+
+const initTransactionsFilterStore = (): TransactionsFilterStore => {
+	const store = initStorageStore<TransactionsFilter>({
+		key: TRANSACTIONS_FILTER_STORAGE_KEY,
+		defaultValue: EMPTY_TRANSACTIONS_FILTER
+	});
+
+	// initStorageStore exposes the raw `writable.update`, which mutates memory
+	// only. To keep the in-memory value and the persisted localStorage entry in
+	// sync we have to go through `store.set({ key, value })` — this helper hides
+	// that boilerplate and lets each toggle method read like a plain Svelte
+	// `update((current) => next)` callback.
+	const mutate = (mutator: (current: TransactionsFilter) => TransactionsFilter) =>
+		store.set({
+			key: TRANSACTIONS_FILTER_STORAGE_KEY,
+			value: mutator(getStore(store))
+		});
+
+	return {
+		...store,
+		toggleType: (type) =>
+			mutate((current) => ({
+				...current,
+				types: toggle({ values: current.types, value: type })
+			})),
+		toggleTokenId: (tokenId) =>
+			mutate((current) => ({
+				...current,
+				tokenIds: toggle({ values: current.tokenIds, value: tokenId })
+			})),
+		toggleContactId: (contactId) =>
+			mutate((current) => ({
+				...current,
+				contactIds: toggle({ values: current.contactIds, value: contactId })
+			})),
+		clear: () => store.reset({ key: TRANSACTIONS_FILTER_STORAGE_KEY })
+	};
+};
+
+export const transactionsFilterStore: TransactionsFilterStore = initTransactionsFilterStore();

--- a/src/frontend/src/lib/types/transactions-filter.ts
+++ b/src/frontend/src/lib/types/transactions-filter.ts
@@ -1,0 +1,13 @@
+import type { TransactionType } from '$lib/types/transaction';
+
+export interface TransactionsFilter {
+	types: TransactionType[];
+	tokenIds: string[];
+	contactIds: string[];
+}
+
+export const EMPTY_TRANSACTIONS_FILTER: TransactionsFilter = {
+	types: [],
+	tokenIds: [],
+	contactIds: []
+};

--- a/src/frontend/src/tests/lib/stores/transactions-filter.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/transactions-filter.store.spec.ts
@@ -1,0 +1,110 @@
+import {
+	TRANSACTIONS_FILTER_STORAGE_KEY,
+	transactionsFilterStore
+} from '$lib/stores/transactions-filter.store';
+import { EMPTY_TRANSACTIONS_FILTER } from '$lib/types/transactions-filter';
+import { get } from 'svelte/store';
+
+describe('transactionsFilterStore', () => {
+	beforeEach(() => {
+		localStorage.clear();
+		transactionsFilterStore.clear();
+	});
+
+	it('starts empty by default', () => {
+		expect(get(transactionsFilterStore)).toEqual(EMPTY_TRANSACTIONS_FILTER);
+	});
+
+	describe('toggleType', () => {
+		it('adds a type when not present', () => {
+			transactionsFilterStore.toggleType('send');
+
+			expect(get(transactionsFilterStore).types).toEqual(['send']);
+		});
+
+		it('removes a type when already present', () => {
+			transactionsFilterStore.toggleType('send');
+			transactionsFilterStore.toggleType('receive');
+			transactionsFilterStore.toggleType('send');
+
+			expect(get(transactionsFilterStore).types).toEqual(['receive']);
+		});
+
+		it('keeps other facets untouched', () => {
+			transactionsFilterStore.toggleTokenId('ICP');
+			transactionsFilterStore.toggleContactId('42');
+			transactionsFilterStore.toggleType('send');
+
+			const value = get(transactionsFilterStore);
+
+			expect(value.tokenIds).toEqual(['ICP']);
+			expect(value.contactIds).toEqual(['42']);
+			expect(value.types).toEqual(['send']);
+		});
+	});
+
+	describe('toggleTokenId', () => {
+		it('toggles token ids', () => {
+			transactionsFilterStore.toggleTokenId('ICP');
+			transactionsFilterStore.toggleTokenId('ETH');
+
+			expect(get(transactionsFilterStore).tokenIds).toEqual(['ICP', 'ETH']);
+
+			transactionsFilterStore.toggleTokenId('ICP');
+
+			expect(get(transactionsFilterStore).tokenIds).toEqual(['ETH']);
+		});
+	});
+
+	describe('toggleContactId', () => {
+		it('toggles contact ids', () => {
+			transactionsFilterStore.toggleContactId('1');
+			transactionsFilterStore.toggleContactId('2');
+
+			expect(get(transactionsFilterStore).contactIds).toEqual(['1', '2']);
+
+			transactionsFilterStore.toggleContactId('2');
+
+			expect(get(transactionsFilterStore).contactIds).toEqual(['1']);
+		});
+	});
+
+	describe('clear', () => {
+		it('resets all facets to the empty filter', () => {
+			transactionsFilterStore.toggleType('send');
+			transactionsFilterStore.toggleTokenId('ICP');
+			transactionsFilterStore.toggleContactId('1');
+
+			transactionsFilterStore.clear();
+
+			expect(get(transactionsFilterStore)).toEqual(EMPTY_TRANSACTIONS_FILTER);
+		});
+
+		it('removes the persisted entry from localStorage', () => {
+			transactionsFilterStore.toggleType('send');
+
+			expect(localStorage.getItem(TRANSACTIONS_FILTER_STORAGE_KEY)).not.toBeNull();
+
+			transactionsFilterStore.clear();
+
+			expect(localStorage.getItem(TRANSACTIONS_FILTER_STORAGE_KEY)).toBeNull();
+		});
+	});
+
+	describe('persistence', () => {
+		it('writes the JSON-serialised value to localStorage on toggle', () => {
+			transactionsFilterStore.toggleType('send');
+			transactionsFilterStore.toggleTokenId('ICP');
+			transactionsFilterStore.toggleContactId('1');
+
+			const raw = localStorage.getItem(TRANSACTIONS_FILTER_STORAGE_KEY);
+
+			expect(raw).not.toBeNull();
+			expect(JSON.parse(raw ?? '{}')).toEqual({
+				types: ['send'],
+				tokenIds: ['ICP'],
+				contactIds: ['1']
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Foundation for an upcoming Activity-page filter (type / token / contacts). This PR ships only the persisted store and its derived helpers, with no UI.

The store is persisted to `localStorage` so a user's filter selection survives page reloads, navigation away and back, and screen lock — but is cleared on full sign-out / next sign-in (matching the existing reset pattern for `tokensSortStore` / `tokenCategoryFilterStore` in `ButtonAuthenticateWithHelp.svelte`).

# Changes

- New `src/frontend/src/lib/types/transactions-filter.ts` — `TransactionsFilter` shape and `EMPTY_TRANSACTIONS_FILTER` constant.
- New `src/frontend/src/lib/stores/transactions-filter.store.ts` — `transactionsFilterStore` with `toggleType` / `toggleTokenId` / `toggleContactId` / `clear`, backed by `initStorageStore` under key `oisy_transactions_filter`.
- New `src/frontend/src/lib/derived/transactions-filter.derived.ts` — `hasActiveTransactionsFilter` plus per-category counts.
- `src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte` — calls `transactionsFilterStore.clear()` after a successful sign-in, alongside the existing `tokensSortStore.reset` / `tokenCategoryFilterStore.reset` block.

# Tests

- New `src/frontend/src/tests/lib/stores/transactions-filter.store.spec.ts` covering all `toggle*` mutations, `clear()`, and the localStorage round-trip.