### PR TITLE
feat(frontend): add reusable MultiSelectDropdown component

### DIFF
--- a/src/frontend/src/lib/components/icons/lucide/IconListFilter.svelte
+++ b/src/frontend/src/lib/components/icons/lucide/IconListFilter.svelte
@@ -1,0 +1,21 @@
+<!-- source: ISC Lucide - please visit https://lucide.dev/license -->
+<script lang="ts">
+	interface Props {
+		size?: string;
+	}
+
+	let { size = '24' }: Props = $props();
+</script>
+
+<svg
+	fill="none"
+	height={size}
+	stroke="currentColor"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	stroke-width="2"
+	viewBox="0 0 24 24"
+	width={size}
+	xmlns="http://www.w3.org/2000/svg"
+	><path d="M3 6h18" /><path d="M7 12h10" /><path d="M10 18h4" /></svg
+>

--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -19,8 +19,10 @@
 	import AllTransactionsSkeletons from '$lib/components/transactions/AllTransactionsSkeletons.svelte';
 	import TransactionsDateGroup from '$lib/components/transactions/TransactionsDateGroup.svelte';
 	import TransactionsPlaceholder from '$lib/components/transactions/TransactionsPlaceholder.svelte';
+	import TransactionsFilterToolbar from '$lib/components/transactions/filter/TransactionsFilterToolbar.svelte';
 	import { ACTIVITY_TRANSACTION_SKELETON_PREFIX } from '$lib/constants/test-ids.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
+	import { allContacts } from '$lib/derived/contacts.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import {
 		modalBtcTransaction,
@@ -34,8 +36,10 @@
 	} from '$lib/derived/network-tokens.derived';
 	import { hideMicroTransactions } from '$lib/derived/user-profile.derived';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 	import type { AllTransactionUiWithCmp } from '$lib/types/transaction-ui';
 	import { groupTransactionsByDate, mapTransactionModalData } from '$lib/utils/transaction.utils';
+	import { applyTransactionsFilter } from '$lib/utils/transactions-filter.utils';
 	import {
 		filterReceivedMicroTransactions,
 		mapAllTransactionsUi,
@@ -64,13 +68,21 @@
 	// Filtering is only applied on the display path. The unfiltered `allTransactions` is fed to
 	// `AllTransactionsLoader` so its `transactions.length === 0` short-circuit and `minTimestamp`
 	// pagination anchor remain based on the actual loaded set, not the filtered one.
-	let displayTransactions = $derived(
+	let microFilteredTransactions = $derived(
 		$hideMicroTransactions
 			? filterReceivedMicroTransactions({
 					transactions: allTransactions,
 					exchanges: $exchanges
 				})
 			: allTransactions
+	);
+
+	let displayTransactions = $derived(
+		applyTransactionsFilter({
+			transactions: microFilteredTransactions,
+			filter: $transactionsFilterStore,
+			contacts: $allContacts
+		})
 	);
 
 	let sortedTransactions = $derived(
@@ -111,6 +123,8 @@
 		})
 	);
 </script>
+
+<TransactionsFilterToolbar />
 
 <AllTransactionsSkeletons testIdPrefix={ACTIVITY_TRANSACTION_SKELETON_PREFIX}>
 	<AllTransactionsLoader transactions={allTransactions}>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import TransactionsFilterTypes from '$lib/components/transactions/filter/TransactionsFilterTypes.svelte';
+	import { TRANSACTIONS_FILTER_TOOLBAR } from '$lib/constants/test-ids.constants';
+</script>
+
+<div class="mb-4 flex flex-wrap items-center gap-2" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
+	<TransactionsFilterTypes />
+</div>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { Checkbox } from '@dfinity/gix-components';
+	import IconListFilter from '$lib/components/icons/lucide/IconListFilter.svelte';
+	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
+	import { TRANSACTIONS_FILTER_TYPES_DROPDOWN } from '$lib/constants/test-ids.constants';
+	import { TransactionTypeSchema } from '$lib/schema/transaction.schema';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
+	import type { TransactionType } from '$lib/types/transaction';
+
+	const allTypes: TransactionType[] = Array.from(new Set(TransactionTypeSchema.options));
+
+	let translated = $derived(
+		allTypes.map((type) => ({ type, label: $i18n.transaction.type[type] }))
+	);
+
+	let sortedTypes = $derived(
+		[...translated].sort((a, b) =>
+			a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+		)
+	);
+
+	let selectedSet = $derived(new Set<TransactionType>($transactionsFilterStore.types));
+
+	let triggerLabel = $derived(
+		selectedSet.size === 0
+			? $i18n.transaction.filter.types_label
+			: ($i18n.transaction.type[[...selectedSet][0]] ?? $i18n.transaction.filter.types_label)
+	);
+</script>
+
+<MultiSelectDropdown
+	ariaLabel={$i18n.transaction.filter.types_aria_label}
+	count={selectedSet.size}
+	testId={TRANSACTIONS_FILTER_TYPES_DROPDOWN}
+	{triggerLabel}
+>
+	{#snippet triggerIcon()}
+		<IconListFilter size="20" />
+	{/snippet}
+
+	{#snippet panel()}
+		<ul class="m-0 flex list-none flex-col gap-1 p-0">
+			{#each sortedTypes as { type, label } (type)}
+				<li class="flex items-center">
+					<Checkbox
+						checked={selectedSet.has(type)}
+						inputId={`transactions-filter-type-${type}`}
+						text="inline"
+						on:nnsChange={() => transactionsFilterStore.toggleType(type)}
+					>
+						<span class="text-sm">{label}</span>
+					</Checkbox>
+				</li>
+			{/each}
+		</ul>
+	{/snippet}
+</MultiSelectDropdown>

--- a/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
+++ b/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { IconExpandMore } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import InputSearch from '$lib/components/ui/InputSearch.svelte';
+	import ResponsivePopover from '$lib/components/ui/ResponsivePopover.svelte';
+
+	interface Props {
+		triggerLabel: string;
+		ariaLabel: string;
+		count?: number;
+		searchable?: boolean;
+		searchPlaceholder?: string;
+		searchValue?: string;
+		testId?: string;
+		triggerIcon?: Snippet;
+		panel: Snippet;
+	}
+
+	let {
+		triggerLabel,
+		ariaLabel,
+		count = 0,
+		searchable = false,
+		searchPlaceholder = '',
+		searchValue = $bindable(''),
+		testId,
+		triggerIcon,
+		panel
+	}: Props = $props();
+
+	let visible = $state(false);
+	let button = $state<HTMLButtonElement | undefined>();
+
+	const onTriggerClick = () => {
+		visible = !visible;
+	};
+</script>
+
+<button
+	bind:this={button}
+	class="dropdown-button h-[2.2rem] rounded-lg border border-solid border-primary hover:border-brand-primary"
+	class:opened={visible}
+	aria-label={ariaLabel}
+	data-tid={testId}
+	onclick={onTriggerClick}
+	type="button"
+>
+	{#if nonNullish(triggerIcon)}
+		<span class="flex items-center text-secondary">
+			{@render triggerIcon()}
+		</span>
+	{/if}
+
+	<span class="min-w-0 flex-1 truncate font-medium">{triggerLabel}</span>
+
+	{#if count > 0}
+		<Badge variant="info" width="w-fit">{count}</Badge>
+	{/if}
+
+	<IconExpandMore size="20" />
+</button>
+
+<ResponsivePopover {button} bind:visible>
+	{#snippet content()}
+		<div class="flex w-full min-w-60 flex-col gap-2 p-1">
+			{#if searchable}
+				<InputSearch
+					autofocus
+					placeholder={searchPlaceholder}
+					showResetButton={searchValue.length > 0}
+					bind:filter={searchValue}
+				/>
+			{/if}
+
+			<div class="flex max-h-80 flex-col overflow-y-auto">
+				{@render panel()}
+			</div>
+		</div>
+	{/snippet}
+</ResponsivePopover>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -212,6 +212,9 @@ export const ACTIVITY_TRANSACTION_SKELETON_PREFIX = 'all-transactions-skeleton-c
 export const TRANSACTIONS_DATE_GROUP_PREFIX = 'transactions-date-group-';
 export const TRANSACTION_CHILDREN_CONTAINER = 'transaction-children-container';
 
+export const TRANSACTIONS_FILTER_TOOLBAR = 'transactions-filter-toolbar';
+export const TRANSACTIONS_FILTER_TYPES_DROPDOWN = 'transactions-filter-types-dropdown';
+
 export const BTC_CONVERT_FORM_TEST_ID = 'btc-convert-form-test-id';
 export const IC_CONVERT_FORM_TEST_ID = 'ic-convert-form-test-id';
 export const ETH_CONVERT_FORM_TEST_ID = 'ic-convert-form-test-id';

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1627,6 +1627,19 @@
 			"burn": "حرق",
 			"mint": "إنشاء"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "تعويض",
 			"twin_token_converted": "تم التحويل من $twinToken",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1627,6 +1627,19 @@
 			"burn": "Spálit",
 			"mint": "Razit"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Náhrada",
 			"twin_token_converted": "Převedeno z $twinToken",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1627,6 +1627,19 @@
 			"burn": "Burn",
 			"mint": "Mint"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Rückerstattung",
 			"twin_token_converted": "Von $twinToken konvertiert",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1627,6 +1627,19 @@
 			"burn": "Burn",
 			"mint": "Mint"
 		},
+		"filter": {
+			"types_label": "Type",
+			"tokens_label": "Token",
+			"contacts_label": "Contacts",
+			"types_aria_label": "Filter by transaction type",
+			"tokens_aria_label": "Filter by token",
+			"contacts_aria_label": "Filter by contact",
+			"search_tokens_placeholder": "Start typing...",
+			"search_contacts_placeholder": "Start typing name...",
+			"clear": "Clear filters",
+			"sheet_title": "Filter activity",
+			"open_filters_aria_label": "Open activity filters"
+		},
 		"label": {
 			"reimbursement": "Reimbursement",
 			"twin_token_converted": "Converted from $twinToken",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1627,6 +1627,19 @@
 			"burn": "Quemar",
 			"mint": "Acuñar"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Reembolso",
 			"twin_token_converted": "Convertido desde $twinToken",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1627,6 +1627,19 @@
 			"burn": "Brûler",
 			"mint": "Minimiser"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Remboursement",
 			"twin_token_converted": "Converti depuis $twinToken",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1627,6 +1627,19 @@
 			"burn": "बर्न",
 			"mint": "मिंट"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "प्रतिपूर्ति",
 			"twin_token_converted": "$twinToken से परिवर्तित",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1627,6 +1627,19 @@
 			"burn": "Burn",
 			"mint": "Mint"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Rimborso",
 			"twin_token_converted": "Convertito da $twinToken",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1627,6 +1627,19 @@
 			"burn": "バーン",
 			"mint": "ミント"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "払い戻し",
 			"twin_token_converted": "$twinTokenから変換済み",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1627,6 +1627,19 @@
 			"burn": "소각",
 			"mint": "민트"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "환불",
 			"twin_token_converted": "$twinToken에서 전환됨",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1627,6 +1627,19 @@
 			"burn": "Spal",
 			"mint": "Wytwórz"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Zwrot kosztów",
 			"twin_token_converted": "Przekonwertowano z $twinToken",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1627,6 +1627,19 @@
 			"burn": "Burn",
 			"mint": "Mint"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Reembolso",
 			"twin_token_converted": "$twinToken Convertido",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1627,6 +1627,19 @@
 			"burn": "Сжигание",
 			"mint": "Создание"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Возмещение",
 			"twin_token_converted": "Обменяно из $twinToken",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1627,6 +1627,19 @@
 			"burn": "Đốt",
 			"mint": "Tạo"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "Hoàn tiền",
 			"twin_token_converted": "Đã chuyển đổi từ $twinToken",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1627,6 +1627,19 @@
 			"burn": "销毁",
 			"mint": "铸造"
 		},
+		"filter": {
+			"types_label": "",
+			"tokens_label": "",
+			"contacts_label": "",
+			"types_aria_label": "",
+			"tokens_aria_label": "",
+			"contacts_aria_label": "",
+			"search_tokens_placeholder": "",
+			"search_contacts_placeholder": "",
+			"clear": "",
+			"sheet_title": "",
+			"open_filters_aria_label": ""
+		},
 		"label": {
 			"reimbursement": "报销",
 			"twin_token_converted": "从 $twinToken 转换",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1301,6 +1301,19 @@ interface I18nTransaction {
 		burn: string;
 		mint: string;
 	};
+	filter: {
+		types_label: string;
+		tokens_label: string;
+		contacts_label: string;
+		types_aria_label: string;
+		tokens_aria_label: string;
+		contacts_aria_label: string;
+		search_tokens_placeholder: string;
+		search_contacts_placeholder: string;
+		clear: string;
+		sheet_title: string;
+		open_filters_aria_label: string;
+	};
 	label: {
 		reimbursement: string;
 		twin_token_converted: string;

--- a/src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts
@@ -1,0 +1,65 @@
+import { screensStore } from '$lib/stores/screens.store';
+import MultiSelectDropdownTest from '$tests/lib/components/ui/MultiSelectDropdownTest.svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+
+describe('MultiSelectDropdown', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		screensStore.set('lg');
+	});
+
+	it('renders the trigger button with the supplied label and ariaLabel', () => {
+		const { getByTestId, getByText } = render(MultiSelectDropdownTest);
+
+		const trigger = getByTestId('multi-select-dropdown');
+
+		expect(trigger).toHaveAttribute('aria-label', 'Filter');
+		expect(getByText('Filter')).toBeInTheDocument();
+	});
+
+	it('does not render the count badge when count is zero', () => {
+		const { queryByText } = render(MultiSelectDropdownTest);
+
+		expect(queryByText('0')).not.toBeInTheDocument();
+	});
+
+	it('renders the count badge when count is greater than zero', () => {
+		const { getByText } = render(MultiSelectDropdownTest, { props: { count: 3 } });
+
+		expect(getByText('3')).toBeInTheDocument();
+	});
+
+	it('opens the panel on click', async () => {
+		const { getByTestId, queryByTestId } = render(MultiSelectDropdownTest);
+
+		expect(queryByTestId('multi-select-dropdown-panel')).not.toBeInTheDocument();
+
+		await fireEvent.click(getByTestId('multi-select-dropdown'));
+
+		await waitFor(() => {
+			expect(queryByTestId('multi-select-dropdown-panel')).toBeInTheDocument();
+		});
+	});
+
+	it('renders the search input only when searchable is true', async () => {
+		const { getByTestId, queryByPlaceholderText } = render(MultiSelectDropdownTest, {
+			props: { searchable: true }
+		});
+
+		await fireEvent.click(getByTestId('multi-select-dropdown'));
+
+		await waitFor(() => {
+			expect(queryByPlaceholderText('Search items')).toBeInTheDocument();
+		});
+	});
+
+	it('does not render the search input when searchable is false', async () => {
+		const { getByTestId, queryByPlaceholderText } = render(MultiSelectDropdownTest);
+
+		await fireEvent.click(getByTestId('multi-select-dropdown'));
+
+		await waitFor(() => {
+			expect(queryByPlaceholderText('Search items')).not.toBeInTheDocument();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/components/ui/MultiSelectDropdownTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/MultiSelectDropdownTest.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
+
+	interface Props {
+		count?: number;
+		searchable?: boolean;
+	}
+
+	let { count = 0, searchable = false }: Props = $props();
+</script>
+
+<MultiSelectDropdown
+	ariaLabel="Filter"
+	{count}
+	searchPlaceholder="Search items"
+	{searchable}
+	testId="multi-select-dropdown"
+	triggerLabel="Filter"
+>
+	{#snippet panel()}
+		<div data-tid="multi-select-dropdown-panel">Panel content</div>
+	{/snippet}
+</MultiSelectDropdown>


### PR DESCRIPTION
# Motivation

Generic chip + dropdown primitive intended for re-use anywhere a multi-select trigger is needed. Kept generic — no knowledge of transactions or filters — so it can be reused outside Activity in the future.

Built on top of the existing `ResponsivePopover`, which means it already degrades to `BottomSheet` on small screens with no extra consumer wiring.

# Changes

- New `src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte`:
  - Chip-style trigger using the global `dropdown-button` style, with optional left icon (snippet) and a count badge.
  - Optional in-dropdown search input (driven by the existing `InputSearch`).
  - `panel` snippet — the consumer renders the actual checkbox rows.
  - Auto-applies on toggle (the consumer's row click handler mutates whatever store it owns).

The component is not yet mounted in any page.

# Tests

- New `src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts` (6 tests) covering trigger label / aria, badge visibility (zero vs non-zero count), open-on-click, and search-input gating.
- New `src/frontend/src/tests/lib/components/ui/MultiSelectDropdownTest.svelte` harness.