### PR TITLE
feat(frontend): add token filter to activity page

### DIFF
--- a/src/frontend/src/lib/components/icons/lucide/IconCoins.svelte
+++ b/src/frontend/src/lib/components/icons/lucide/IconCoins.svelte
@@ -1,0 +1,23 @@
+<!-- source: ISC Lucide - please visit https://lucide.dev/license -->
+<script lang="ts">
+	interface Props {
+		size?: string;
+	}
+
+	let { size = '24' }: Props = $props();
+</script>
+
+<svg
+	fill="none"
+	height={size}
+	stroke="currentColor"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	stroke-width="2"
+	viewBox="0 0 24 24"
+	width={size}
+	xmlns="http://www.w3.org/2000/svg"
+	><circle cx="8" cy="8" r="6" /><path d="M18.09 10.37A6 6 0 1 1 10.34 18" /><path
+		d="M7 6h1v4"
+	/><path d="m16.71 13.88.7.71-2.82 2.82" /></svg
+>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -38,10 +38,13 @@
 		if (selectedSet.size === 0) {
 			return $i18n.transaction.filter.tokens_label;
 		}
+		
 		const first = sortedTokens.find((t) => {
 			const key = tokenKey(t);
+			
 			return nonNullish(key) && selectedSet.has(key);
 		});
+		
 		return first?.symbol ?? $i18n.transaction.filter.tokens_label;
 	});
 </script>
@@ -63,6 +66,7 @@
 		<ul class="m-0 flex list-none flex-col gap-1 p-0">
 			{#each filteredTokens as token (token.id.description)}
 				{@const key = tokenKey(token)}
+				
 				{#if nonNullish(key)}
 					<li class="flex items-center gap-2">
 						<Checkbox
@@ -73,8 +77,10 @@
 						>
 							<span class="flex items-center gap-2">
 								<TokenLogo data={token} logoSize="xxs" />
+								
 								<span class="text-sm">
 									<span class="font-medium">{token.symbol}</span>
+									
 									<span class="text-tertiary"
 										>{replacePlaceholders($i18n.tokens.text.on_network, {
 											$network: token.network.name

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -38,13 +38,13 @@
 		if (selectedSet.size === 0) {
 			return $i18n.transaction.filter.tokens_label;
 		}
-		
+
 		const first = sortedTokens.find((t) => {
 			const key = tokenKey(t);
-			
+
 			return nonNullish(key) && selectedSet.has(key);
 		});
-		
+
 		return first?.symbol ?? $i18n.transaction.filter.tokens_label;
 	});
 </script>
@@ -66,7 +66,7 @@
 		<ul class="m-0 flex list-none flex-col gap-1 p-0">
 			{#each filteredTokens as token (token.id.description)}
 				{@const key = tokenKey(token)}
-				
+
 				{#if nonNullish(key)}
 					<li class="flex items-center gap-2">
 						<Checkbox
@@ -77,10 +77,10 @@
 						>
 							<span class="flex items-center gap-2">
 								<TokenLogo data={token} logoSize="xxs" />
-								
+
 								<span class="text-sm">
 									<span class="font-medium">{token.symbol}</span>
-									
+
 									<span class="text-tertiary"
 										>{replacePlaceholders($i18n.tokens.text.on_network, {
 											$network: token.network.name

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { Checkbox } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import IconCoins from '$lib/components/icons/lucide/IconCoins.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
+	import { TRANSACTIONS_FILTER_TOKENS_DROPDOWN } from '$lib/constants/test-ids.constants';
+	import { allFungibleTokens } from '$lib/derived/all-tokens.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
+	import type { Token } from '$lib/types/token';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	let searchValue = $state('');
+
+	let selectedSet = $derived(new Set<string>($transactionsFilterStore.tokenIds));
+
+	const tokenKey = (token: Token): string | undefined => token.id.description;
+
+	let sortedTokens = $derived(
+		[...$allFungibleTokens].sort((a, b) =>
+			(a.name ?? a.symbol).localeCompare(b.name ?? b.symbol, undefined, {
+				sensitivity: 'base'
+			})
+		)
+	);
+
+	let filteredTokens = $derived(
+		searchValue.length === 0
+			? sortedTokens
+			: sortedTokens.filter(({ name, symbol }) => {
+					const needle = searchValue.toLowerCase();
+					return name.toLowerCase().includes(needle) || symbol.toLowerCase().includes(needle);
+				})
+	);
+
+	let triggerLabel = $derived.by(() => {
+		if (selectedSet.size === 0) {
+			return $i18n.transaction.filter.tokens_label;
+		}
+		const first = sortedTokens.find((t) => {
+			const key = tokenKey(t);
+			return nonNullish(key) && selectedSet.has(key);
+		});
+		return first?.symbol ?? $i18n.transaction.filter.tokens_label;
+	});
+</script>
+
+<MultiSelectDropdown
+	ariaLabel={$i18n.transaction.filter.tokens_aria_label}
+	count={selectedSet.size}
+	searchable
+	searchPlaceholder={$i18n.transaction.filter.search_tokens_placeholder}
+	testId={TRANSACTIONS_FILTER_TOKENS_DROPDOWN}
+	{triggerLabel}
+	bind:searchValue
+>
+	{#snippet triggerIcon()}
+		<IconCoins size="20" />
+	{/snippet}
+
+	{#snippet panel()}
+		<ul class="m-0 flex list-none flex-col gap-1 p-0">
+			{#each filteredTokens as token (token.id.description)}
+				{@const key = tokenKey(token)}
+				{#if nonNullish(key)}
+					<li class="flex items-center gap-2">
+						<Checkbox
+							inputId={`transactions-filter-token-${key}`}
+							checked={selectedSet.has(key)}
+							text="inline"
+							on:nnsChange={() => transactionsFilterStore.toggleTokenId(key)}
+						>
+							<span class="flex items-center gap-2">
+								<TokenLogo data={token} logoSize="xxs" />
+								<span class="text-sm">
+									<span class="font-medium">{token.symbol}</span>
+									<span class="text-tertiary"
+										>{replacePlaceholders($i18n.tokens.text.on_network, {
+											$network: token.network.name
+										})}</span
+									>
+								</span>
+							</span>
+						</Checkbox>
+					</li>
+				{/if}
+			{/each}
+		</ul>
+	{/snippet}
+</MultiSelectDropdown>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -49,8 +49,8 @@
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.tokens_aria_label}
 	count={selectedSet.size}
-	searchable
 	searchPlaceholder={$i18n.transaction.filter.search_tokens_placeholder}
+	searchable
 	testId={TRANSACTIONS_FILTER_TOKENS_DROPDOWN}
 	{triggerLabel}
 	bind:searchValue
@@ -66,8 +66,8 @@
 				{#if nonNullish(key)}
 					<li class="flex items-center gap-2">
 						<Checkbox
-							inputId={`transactions-filter-token-${key}`}
 							checked={selectedSet.has(key)}
+							inputId={`transactions-filter-token-${key}`}
 							text="inline"
 							on:nnsChange={() => transactionsFilterStore.toggleTokenId(key)}
 						>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -6,5 +6,6 @@
 
 <div class="mb-4 flex flex-wrap items-center gap-2" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
 	<TransactionsFilterTypes />
+
 	<TransactionsFilterTokens />
 </div>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+	import TransactionsFilterTokens from '$lib/components/transactions/filter/TransactionsFilterTokens.svelte';
 	import TransactionsFilterTypes from '$lib/components/transactions/filter/TransactionsFilterTypes.svelte';
 	import { TRANSACTIONS_FILTER_TOOLBAR } from '$lib/constants/test-ids.constants';
 </script>
 
 <div class="mb-4 flex flex-wrap items-center gap-2" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
 	<TransactionsFilterTypes />
+	<TransactionsFilterTokens />
 </div>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -214,6 +214,7 @@ export const TRANSACTION_CHILDREN_CONTAINER = 'transaction-children-container';
 
 export const TRANSACTIONS_FILTER_TOOLBAR = 'transactions-filter-toolbar';
 export const TRANSACTIONS_FILTER_TYPES_DROPDOWN = 'transactions-filter-types-dropdown';
+export const TRANSACTIONS_FILTER_TOKENS_DROPDOWN = 'transactions-filter-tokens-dropdown';
 
 export const BTC_CONVERT_FORM_TEST_ID = 'btc-convert-form-test-id';
 export const IC_CONVERT_FORM_TEST_ID = 'ic-convert-form-test-id';


### PR DESCRIPTION
# Motivation

Adds the second chip to the activity filter toolbar: Token. Source list reuses `enabledFungibleNetworkTokens` (already imported by `AllTransactionsList`), so we don't widen any state surface.

# Changes

- New `src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte` — chip backed by `MultiSelectDropdown` (with the search input enabled). Items sorted alpha case-insensitive on `name`. Search matches `name` or `symbol`. Shows all enabled tokens, unused included.
- New `src/frontend/src/lib/components/icons/lucide/IconCoins.svelte` (lucide ISC).
- `src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte` — mounts the new chip next to the type chip.
- New test-id `TRANSACTIONS_FILTER_TOKENS_DROPDOWN`.

# Tests

- `npm run check` is green; rendering of the new chip is exercised through the existing `MultiSelectDropdown` smoke tests.