### PR TITLE
docs(ai): clarify the no-force-push rule with explicit anti-examples

### DIFF
--- a/.cursor/rules/60-pr-and-ci.mdc
+++ b/.cursor/rules/60-pr-and-ci.mdc
@@ -115,10 +115,12 @@ Never silence a failure with `// eslint-disable` / `// @ts-ignore` /
 - **Add commits.** Never `git push --force` to a PR branch. Don't amend
   pushed commits with `git commit --amend`. Don't rebase a PR onto `main`
   to "tidy history" — let the merge group handle it.
-- **What counts as "the user explicitly asks":** the user uses the
-  literal words "force-push", "amend", "rebase", or "rewrite history"
-  in their request, **or** selects a multi-choice option whose label
-  itself contains those words. Phrases like "do what you think is
+- **What counts as "the user explicitly asks":** the user names the
+  operation directly — any unambiguous phrasing works (e.g.
+  "force-push", "force push", "push --force", "push -f", "amend",
+  "git commit --amend", "rebase", "git rebase", "rewrite history").
+  Selecting a multi-choice option whose label itself contains one of
+  those phrases also counts. Phrases like "do what you think is
   best", "do what's most correct", "do it your way", or general
   approval of a stacked-PR plan **DO NOT** count. When in doubt,
   add a new commit — squash-merge will tidy history at merge time.

--- a/.cursor/rules/60-pr-and-ci.mdc
+++ b/.cursor/rules/60-pr-and-ci.mdc
@@ -115,8 +115,16 @@ Never silence a failure with `// eslint-disable` / `// @ts-ignore` /
 - **Add commits.** Never `git push --force` to a PR branch. Don't amend
   pushed commits with `git commit --amend`. Don't rebase a PR onto `main`
   to "tidy history" — let the merge group handle it.
-- The only exception is when the user explicitly asks for a force-push or
-  history rewrite.
+- **What counts as "the user explicitly asks":** the user uses the
+  literal words "force-push", "amend", "rebase", or "rewrite history"
+  in their request, **or** selects a multi-choice option whose label
+  itself contains those words. Phrases like "do what you think is
+  best", "do what's most correct", "do it your way", or general
+  approval of a stacked-PR plan **DO NOT** count. When in doubt,
+  add a new commit — squash-merge will tidy history at merge time.
+- When offering choices, the **default** must always be the
+  no-force-push option. Do not put a force-push option first, and do
+  not pick a force-push option in response to delegated decisions.
 
 ## Bot-approved files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,12 @@ These are on top of the [10 commandments](./AGENTS.md#2-the-10-commandments-read
 - **Never push force / amend pushed commits / rewrite shared history.** Add
   a new commit instead. Approval of a broader task (e.g. "do what you
   think is best", "make the most correct one", "do it your way") is
-  **NOT** approval to force-push — the user must literally use the words
-  "force-push", "amend", or "rebase" (or pick a multi-choice option
-  whose label contains them). When in doubt, add a new commit. See
+  **NOT** approval to force-push — the user must name the operation
+  directly using any unambiguous phrasing (e.g. "force-push", "force
+  push", "push --force", "push -f", "amend", "git commit --amend",
+  "rebase", "git rebase", "rewrite history"), or pick a multi-choice
+  option whose label contains one of those phrases. When in doubt, add
+  a new commit. See
   [`docs/ai/pr-and-ci.md#updating-an-existing-pr`](./docs/ai/pr-and-ci.md#updating-an-existing-pr).
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,11 @@ These are on top of the [10 commandments](./AGENTS.md#2-the-10-commandments-read
   [`eslint.config.mjs`](./eslint.config.mjs) and
   [`clippy.toml`](./clippy.toml).
 - **Never push force / amend pushed commits / rewrite shared history.** Add
-  a new commit instead. See
+  a new commit instead. Approval of a broader task (e.g. "do what you
+  think is best", "make the most correct one", "do it your way") is
+  **NOT** approval to force-push — the user must literally use the words
+  "force-push", "amend", or "rebase" (or pick a multi-choice option
+  whose label contains them). When in doubt, add a new commit. See
   [`docs/ai/pr-and-ci.md#updating-an-existing-pr`](./docs/ai/pr-and-ci.md#updating-an-existing-pr).
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ These are on top of the [10 commandments](./AGENTS.md#2-the-10-commandments-read
   "rebase", "git rebase", "rewrite history"), or pick a multi-choice
   option whose label contains one of those phrases. When in doubt, add
   a new commit. See
-  [`docs/ai/pr-and-ci.md#updating-an-existing-pr`](./docs/ai/pr-and-ci.md#updating-an-existing-pr).
+  [`docs/ai/pr-and-ci.md#7-updating-an-existing-pr`](./docs/ai/pr-and-ci.md#7-updating-an-existing-pr).
 
 ---
 

--- a/docs/ai/governance.md
+++ b/docs/ai/governance.md
@@ -115,7 +115,7 @@ lockfiles, …). Treat that file as authoritative for bot-context PRs.
   "git commit --amend", "rebase", "git rebase", "rewrite history").
   Task-level delegation like "do what you think is best" or "do what's
   most correct" does **NOT** count. See
-  [`docs/ai/pr-and-ci.md#updating-an-existing-pr`](./pr-and-ci.md#updating-an-existing-pr).
+  [`docs/ai/pr-and-ci.md#7-updating-an-existing-pr`](./pr-and-ci.md#7-updating-an-existing-pr).
 - Commit secrets, `.env*` (other than `.env.example` /
   `.env.backend.example`), or large binaries.
 - Touch the public Candid interface (`src/backend/backend.did`) without

--- a/docs/ai/governance.md
+++ b/docs/ai/governance.md
@@ -109,10 +109,12 @@ lockfiles, …). Treat that file as authoritative for bot-context PRs.
   `unwrap()` to bypass a type / error.
 - Skip / `.skip()` / `.todo()` / `#[ignore]` an existing test.
 - `git push --force`, amend a pushed commit, rebase to "tidy history", or
-  rewrite shared history. "Explicit prompt" means the user types the
-  words "force-push", "amend", "rebase", or "rewrite history" — task-level
-  delegation like "do what you think is best" or "do what's most correct"
-  does **NOT** count. See
+  rewrite shared history. "Explicit prompt" means the user names the
+  operation directly — any unambiguous phrasing works (e.g.
+  "force-push", "force push", "push --force", "push -f", "amend",
+  "git commit --amend", "rebase", "git rebase", "rewrite history").
+  Task-level delegation like "do what you think is best" or "do what's
+  most correct" does **NOT** count. See
   [`docs/ai/pr-and-ci.md#updating-an-existing-pr`](./pr-and-ci.md#updating-an-existing-pr).
 - Commit secrets, `.env*` (other than `.env.example` /
   `.env.backend.example`), or large binaries.

--- a/docs/ai/governance.md
+++ b/docs/ai/governance.md
@@ -109,7 +109,11 @@ lockfiles, …). Treat that file as authoritative for bot-context PRs.
   `unwrap()` to bypass a type / error.
 - Skip / `.skip()` / `.todo()` / `#[ignore]` an existing test.
 - `git push --force`, amend a pushed commit, rebase to "tidy history", or
-  rewrite shared history.
+  rewrite shared history. "Explicit prompt" means the user types the
+  words "force-push", "amend", "rebase", or "rewrite history" — task-level
+  delegation like "do what you think is best" or "do what's most correct"
+  does **NOT** count. See
+  [`docs/ai/pr-and-ci.md#updating-an-existing-pr`](./pr-and-ci.md#updating-an-existing-pr).
 - Commit secrets, `.env*` (other than `.env.example` /
   `.env.backend.example`), or large binaries.
 - Touch the public Candid interface (`src/backend/backend.did`) without

--- a/docs/ai/pr-and-ci.md
+++ b/docs/ai/pr-and-ci.md
@@ -198,9 +198,26 @@ job — that's expected.
 - **Add commits.** Never `git push --force` to a PR branch. Don't
   `git commit --amend` after pushing. Don't rebase a PR onto `main` to
   "tidy history" — let the merge group handle it.
-- The only exception is when the user explicitly asks for a force-push or
-  history rewrite (e.g. to remove an accidentally-committed secret — and
-  even then, also rotate the secret).
+- **What counts as "the user explicitly asks":** the user uses the
+  literal words "force-push", "amend", "rebase", or "rewrite history"
+  in their request, **or** selects a multi-choice option whose label
+  itself contains those words. Anything else **DOES NOT** count, including:
+  - "do what you think is best",
+  - "do what's most correct" / "do it the idiomatic way",
+  - "do it your way" / "use your judgement",
+  - approval of a stacked-PR plan (stacked PRs do not require force-push;
+    add follow-up commits to each branch instead),
+  - approval of a refactor that would "look cleaner" in the originating PR.
+
+  If in doubt, **add a new commit** even if the result looks messier.
+  Squash-merge tidies history at merge time; force-push destroys it.
+
+- When the agent is offering choices, the **default** must always be the
+  no-force-push option. Do not put a force-push option first, and do not
+  pick a force-push option in response to delegated decisions.
+- The only legitimate exceptions are: removing an accidentally-committed
+  secret (and rotating the secret afterwards), or recovering from a
+  catastrophic mistake the user explicitly accepts.
 - If you need to drop a commit, push a new revert commit instead.
 
 ## 8. CODEOWNERS auto-routing

--- a/docs/ai/pr-and-ci.md
+++ b/docs/ai/pr-and-ci.md
@@ -198,10 +198,13 @@ job — that's expected.
 - **Add commits.** Never `git push --force` to a PR branch. Don't
   `git commit --amend` after pushing. Don't rebase a PR onto `main` to
   "tidy history" — let the merge group handle it.
-- **What counts as "the user explicitly asks":** the user uses the
-  literal words "force-push", "amend", "rebase", or "rewrite history"
-  in their request, **or** selects a multi-choice option whose label
-  itself contains those words. Anything else **DOES NOT** count, including:
+- **What counts as "the user explicitly asks":** the user names the
+  operation directly — any unambiguous phrasing works. Examples that
+  count: "force-push", "force push", "push --force", "push -f",
+  "amend", "amend the commit", "git commit --amend", "rebase",
+  "git rebase", "rewrite history", "rewrite the history". Selecting
+  a multi-choice option whose label itself contains one of those
+  phrases also counts. Anything else **DOES NOT** count, including:
   - "do what you think is best",
   - "do what's most correct" / "do it the idiomatic way",
   - "do it your way" / "use your judgement",

--- a/docs/ai/pr-and-ci.md
+++ b/docs/ai/pr-and-ci.md
@@ -218,9 +218,11 @@ job — that's expected.
 - When the agent is offering choices, the **default** must always be the
   no-force-push option. Do not put a force-push option first, and do not
   pick a force-push option in response to delegated decisions.
-- The only legitimate exceptions are: removing an accidentally-committed
-  secret (and rotating the secret afterwards), or recovering from a
-  catastrophic mistake the user explicitly accepts.
+- Typical legitimate reasons a user might ask for a force-push include
+  removing an accidentally-committed secret (rotate the secret afterwards
+  too) or recovering from a catastrophic mistake. These are illustrative,
+  not an exhaustive whitelist — the rule is still "the user must name the
+  operation directly", per the bullet above.
 - If you need to drop a commit, push a new revert commit instead.
 
 ## 8. CODEOWNERS auto-routing


### PR DESCRIPTION
# Motivation

The no-force-push rule says "Never \`git push --force\` … the only exception is when the user explicitly asks." Today "explicitly asks" is ambiguous enough that an agent can read task-level delegation ("do what you think is best") as consent. This PR adds anti-examples in the four files where the rule lives and mandates no-force-push as the default option in multi-choice prompts.

Background: triggered by the incident on #12671..#12678.