### PR TITLE
fix(build): download kong_backend candid in generate.sh

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -51,6 +51,8 @@ DFX_NETWORK=ic ./scripts/build.signer.sh
 DFX_NETWORK=ic ./scripts/build.icp_swap_pool.sh
 # .. downloads candid for the icp_swap_factory
 DFX_NETWORK=ic ./scripts/build.icp_swap_factory.sh
+# .. downloads candid for the kong_backend
+DFX_NETWORK=ic ./scripts/build.kong_backend.sh
 # .. downloads candid for the xtc_ledger
 DFX_NETWORK=ic ./scripts/build.xtc_ledger.sh
 # .. downloads candid for the sol_rpc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

Silence the `WARN: .did file for canister 'kong_backend' does not exist` printed on every deploy.

# Changes

- Download `kong_backend` candid in `scripts/generate.sh`, like the other remote custom canisters.

# Tests

Manual: warning no longer appears after `npm run generate`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2886ac8-e161-493b-a791-cb6c04c8f153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2886ac8-e161-493b-a791-cb6c04c8f153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

