### PR TITLE
refactor(frontend): use native-token helpers and share determineCoverage

### DIFF
--- a/src/frontend/src/lib/services/swap-supported-tokens.services.ts
+++ b/src/frontend/src/lib/services/swap-supported-tokens.services.ts
@@ -4,25 +4,11 @@ import { solSwapProviders } from '$lib/providers/sol-swap.providers';
 import { swapProviders } from '$lib/providers/swap.providers';
 import {
 	swapSupportedTokensStore,
-	type SwapProviderListCoverage,
 	type SwapSupportedTokensInfo
 } from '$lib/stores/swap-supported-tokens.store';
+import { determineCoverage } from '$lib/utils/swap-tokens-filter.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
-
-const determineCoverage = ({
-	totalEnabled,
-	withList
-}: {
-	totalEnabled: number;
-	withList: number;
-}): SwapProviderListCoverage => {
-	if (totalEnabled === 0 || withList === 0) {
-		return 'none';
-	}
-
-	return withList >= totalEnabled ? 'all' : 'some';
-};
 
 /**
  * Filters providers that have `getSupportedTokens` and calls it in a single pass,

--- a/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
+++ b/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
@@ -1,13 +1,30 @@
 import { isTokenErcFungible } from '$eth/utils/erc-fungible.utils';
+import { isTokenEthereumNative } from '$eth/utils/token.utils';
 import { isIcToken } from '$icp/validation/ic-token.validation';
 import type {
+	SwapProviderListCoverage,
 	SwapSupportedTokensData,
 	SwapSupportedTokensInfo
 } from '$lib/stores/swap-supported-tokens.store';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { isTokenSpl } from '$sol/utils/spl.utils';
+import { isTokenSolanaNative } from '$sol/utils/token.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+
+export const determineCoverage = ({
+	totalEnabled,
+	withList
+}: {
+	totalEnabled: number;
+	withList: number;
+}): SwapProviderListCoverage => {
+	if (totalEnabled === 0 || withList === 0) {
+		return 'none';
+	}
+
+	return withList >= totalEnabled ? 'all' : 'some';
+};
 
 /**
  * Resolves the provider-group info and the token identifier used for matching
@@ -15,7 +32,7 @@ import { isNullish, nonNullish } from '@dfinity/utils';
  *
  * Returns `undefined` when the token doesn't belong to a known swap network.
  */
-const resolveSwapTokenLookup = ({
+export const resolveSwapTokenLookup = ({
 	token,
 	supportedData
 }: {
@@ -36,11 +53,11 @@ const resolveSwapTokenLookup = ({
 		return { info: supportedData.sol, identifier: token.address, category: 'sol' };
 	}
 
-	if (token.standard.code === 'ethereum') {
+	if (isTokenEthereumNative(token)) {
 		return { info: supportedData.evm, identifier: token.symbol.toLowerCase(), category: 'evm' };
 	}
 
-	if (token.standard.code === 'solana') {
+	if (isTokenSolanaNative(token)) {
 		return { info: supportedData.sol, identifier: token.symbol.toLowerCase(), category: 'sol' };
 	}
 };


### PR DESCRIPTION
# Motivation

Pure refactor of swap supported-tokens utilities. No behavior change. Groundwork for upcoming directed-pair destination filtering.                                                                                                  
   
  - swap-tokens-filter.utils.ts:                                                                                                                                                
    - Replace inline token.standard.code === 'ethereum' / 'solana' checks in resolveSwapTokenLookup with the existing isTokenEthereumNative / isTokenSolanaNative helpers (consistency with the rest of the codebase, and lets the helper carry the optional-chaining of token.standard?.code).                                                         
    - Export resolveSwapTokenLookup so other utils can reuse it.
  - Move determineCoverage here from swap-supported-tokens.services.ts and export it. It's about provider-list coverage classification — a util-layer concern, not a service  concern — and an upcoming destination-aggregation helper needs to call it from outside the service.                                                                           
  - swap-supported-tokens.services.ts: drop the local determineCoverage, import it from utils. The SwapProviderListCoverage import is also dropped since it was only used by the moved function.  
