### PR TITLE
feat(frontend): destination contract for swap providers

### DIFF
--- a/src/frontend/src/lib/providers/evm-swap.providers.ts
+++ b/src/frontend/src/lib/providers/evm-swap.providers.ts
@@ -10,13 +10,22 @@ import {
 import { fetchOneSecEvmToIcpQuote } from '$lib/services/onesec-swap.services';
 import { fetchVeloraSwapAmount } from '$lib/services/velora-swap.services';
 import { SwapProvider, type EvmSwapProviderConfig } from '$lib/types/swap';
-import { oneSecEvmSupportedTokens } from '$lib/utils/onesec-swap.utils';
+import { buildNearIntentsSupportedDestinations } from '$lib/utils/near-intents-swap.utils';
+import {
+	oneSecCompatibleDestinations,
+	oneSecEvmSupportedTokens
+} from '$lib/utils/onesec-swap.utils';
+import { buildSymmetricSupportedDestinations } from '$lib/utils/swap-providers.utils';
+
+const symmetricEvmDestinations = buildSymmetricSupportedDestinations('evm');
+const nearIntentsEvmDestinations = buildNearIntentsSupportedDestinations('evm');
 
 export const evmSwapProviders: EvmSwapProviderConfig[] = [
 	{
 		key: SwapProvider.VELORA,
 		getQuote: fetchVeloraSwapAmount,
-		isEnabled: true
+		isEnabled: true,
+		getSupportedDestinations: symmetricEvmDestinations
 	},
 	...(NEAR_INTENTS_SWAP_ENABLED
 		? [
@@ -27,7 +36,8 @@ export const evmSwapProviders: EvmSwapProviderConfig[] = [
 					getSupportedTokens: () =>
 						nearIntentsSupportedTokens({
 							networkIds: [ETHEREUM_NETWORK_ID, ...SUPPORTED_EVM_MAINNET_NETWORK_IDS]
-						})
+						}),
+					getSupportedDestinations: nearIntentsEvmDestinations
 				}
 			]
 		: []),
@@ -37,8 +47,14 @@ export const evmSwapProviders: EvmSwapProviderConfig[] = [
 					key: SwapProvider.ONE_SEC,
 					getQuote: fetchOneSecEvmToIcpQuote,
 					isEnabled: ONESEC_SWAP_ENABLED,
-					getSupportedTokens: () => oneSecEvmSupportedTokens({ networkIds: ONESEC_EVM_NETWORK_IDS })
-				}
+					getSupportedTokens: () =>
+						oneSecEvmSupportedTokens({ networkIds: ONESEC_EVM_NETWORK_IDS }),
+					getSupportedDestinations: ({ sourceToken }) =>
+						oneSecCompatibleDestinations({
+							sourceToken,
+							networkIds: ONESEC_EVM_NETWORK_IDS
+						})
+				} satisfies EvmSwapProviderConfig
 			]
 		: [])
 ];

--- a/src/frontend/src/lib/providers/icp-bridge-swap.providers.ts
+++ b/src/frontend/src/lib/providers/icp-bridge-swap.providers.ts
@@ -1,7 +1,11 @@
 import { ONESEC_SWAP_ENABLED } from '$env/rest/onesec.env';
+import { ONESEC_EVM_NETWORK_IDS } from '$lib/constants/swap.constants';
 import { fetchOneSecIcpToEvmQuote } from '$lib/services/onesec-swap.services';
 import { SwapProvider, type IcpBridgeSwapProviderConfig } from '$lib/types/swap';
-import { oneSecIcpSupportedTokens } from '$lib/utils/onesec-swap.utils';
+import {
+	oneSecCompatibleDestinations,
+	oneSecIcpSupportedTokens
+} from '$lib/utils/onesec-swap.utils';
 
 export const icpBridgeProviders: IcpBridgeSwapProviderConfig[] = [
 	...(ONESEC_SWAP_ENABLED
@@ -10,8 +14,13 @@ export const icpBridgeProviders: IcpBridgeSwapProviderConfig[] = [
 					key: SwapProvider.ONE_SEC,
 					getQuote: fetchOneSecIcpToEvmQuote,
 					isEnabled: ONESEC_SWAP_ENABLED,
-					getSupportedTokens: oneSecIcpSupportedTokens
-				}
+					getSupportedTokens: oneSecIcpSupportedTokens,
+					getSupportedDestinations: ({ sourceToken }) =>
+						oneSecCompatibleDestinations({
+							sourceToken,
+							networkIds: ONESEC_EVM_NETWORK_IDS
+						})
+				} satisfies IcpBridgeSwapProviderConfig
 			]
 		: [])
 ];

--- a/src/frontend/src/lib/providers/sol-swap.providers.ts
+++ b/src/frontend/src/lib/providers/sol-swap.providers.ts
@@ -5,6 +5,9 @@ import {
 	nearIntentsSupportedTokens
 } from '$lib/services/near-intents.services';
 import { SwapProvider, type SolSwapProviderConfig } from '$lib/types/swap';
+import { buildNearIntentsSupportedDestinations } from '$lib/utils/near-intents-swap.utils';
+
+const nearIntentsSolDestinations = buildNearIntentsSupportedDestinations('sol');
 
 export const solSwapProviders: SolSwapProviderConfig[] = [
 	...(NEAR_INTENTS_SWAP_ENABLED
@@ -14,7 +17,8 @@ export const solSwapProviders: SolSwapProviderConfig[] = [
 					getQuote: fetchNearIntentsSwapQuote,
 					isEnabled: NEAR_INTENTS_SWAP_ENABLED,
 					getSupportedTokens: () =>
-						nearIntentsSupportedTokens({ networkIds: [SOLANA_MAINNET_NETWORK_ID] })
+						nearIntentsSupportedTokens({ networkIds: [SOLANA_MAINNET_NETWORK_ID] }),
+					getSupportedDestinations: nearIntentsSolDestinations
 				}
 			]
 		: [])

--- a/src/frontend/src/lib/providers/swap.providers.ts
+++ b/src/frontend/src/lib/providers/swap.providers.ts
@@ -3,7 +3,10 @@ import { kongSwapAmounts } from '$lib/api/kong_backend.api';
 import { icpSwapAmounts, icpSwapSupportedTokens } from '$lib/services/icp-swap.services';
 import { kongSwapSupportedTokens } from '$lib/services/kong-swap.services';
 import { SwapProvider, type SwapProviderConfig } from '$lib/types/swap';
+import { buildSymmetricSupportedDestinations } from '$lib/utils/swap-providers.utils';
 import { mapIcpSwapResult, mapKongSwapResult } from '$lib/utils/swap.utils';
+
+const symmetricIcpDestinations = buildSymmetricSupportedDestinations('icp');
 
 export const swapProviders: SwapProviderConfig[] = [
 	{
@@ -11,7 +14,8 @@ export const swapProviders: SwapProviderConfig[] = [
 		getQuote: kongSwapAmounts,
 		mapQuoteResult: ({ swap, tokens }) => mapKongSwapResult({ swap, tokens }),
 		isEnabled: KONGSWAP_PROVIDER_ENABLED,
-		getSupportedTokens: kongSwapSupportedTokens
+		getSupportedTokens: kongSwapSupportedTokens,
+		getSupportedDestinations: symmetricIcpDestinations
 	},
 	{
 		key: SwapProvider.ICP_SWAP,
@@ -19,6 +23,7 @@ export const swapProviders: SwapProviderConfig[] = [
 		mapQuoteResult: ({ swap, slippage, destToken }) =>
 			mapIcpSwapResult({ swap, slippage, destToken }),
 		isEnabled: true,
-		getSupportedTokens: icpSwapSupportedTokens
+		getSupportedTokens: icpSwapSupportedTokens,
+		getSupportedDestinations: symmetricIcpDestinations
 	}
 ];

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -26,6 +26,25 @@ export type SwapSelectTokenType = 'source' | 'destination';
 
 export type DisplayUnit = 'token' | 'usd';
 
+export type SwapTokenCategory = 'icp' | 'evm' | 'sol';
+
+export type SwapCategorizedTokenIds = Partial<Record<SwapTokenCategory, Set<string>>>;
+
+export type FindProviderSourceTokens = (params: {
+	key: SwapProvider;
+	category: SwapTokenCategory;
+}) => Set<string> | undefined;
+
+export interface SwapDestinationsContext {
+	sourceToken: Token;
+	supportedSourceTokens: Set<string> | undefined;
+	findProviderSourceTokens: FindProviderSourceTokens;
+}
+
+export type GetSupportedDestinationsFn = (
+	ctx: SwapDestinationsContext
+) => SwapCategorizedTokenIds | undefined;
+
 export enum SwapProvider {
 	ICP_SWAP = 'icpSwap',
 	KONG_SWAP = 'kongSwap',
@@ -135,6 +154,7 @@ interface BaseSwapProvider<T extends SwapProvider, QuoteResult, QuoteMapParams> 
 	mapQuoteResult: (params: QuoteMapParams) => SwapMappedResult;
 	isEnabled: boolean;
 	getSupportedTokens?: (params: { identity: Identity }) => Promise<Set<string>>;
+	getSupportedDestinations: GetSupportedDestinationsFn;
 }
 
 type KongSwapProvider = BaseSwapProvider<SwapProvider.KONG_SWAP, SwapAmountsReply, KongQuoteParams>;
@@ -148,6 +168,7 @@ export interface EvmSwapProviderConfig {
 	getQuote: (params: EvmQuoteParams) => Promise<SwapMappedResult | undefined>;
 	isEnabled: boolean;
 	getSupportedTokens?: () => Promise<Set<string>>;
+	getSupportedDestinations: GetSupportedDestinationsFn;
 }
 
 export interface SolSwapProviderConfig {
@@ -155,6 +176,7 @@ export interface SolSwapProviderConfig {
 	getQuote: (params: NearIntentsQuoteParams) => Promise<SwapMappedResult | undefined>;
 	isEnabled: boolean;
 	getSupportedTokens?: () => Promise<Set<string>>;
+	getSupportedDestinations: GetSupportedDestinationsFn;
 }
 
 export interface SwapParams {
@@ -272,6 +294,7 @@ export interface IcpBridgeSwapProviderConfig {
 	getQuote: (params: IcpBridgeQuoteParams) => Promise<SwapMappedResult | undefined>;
 	isEnabled: boolean;
 	getSupportedTokens?: () => Promise<Set<string>>;
+	getSupportedDestinations: GetSupportedDestinationsFn;
 }
 
 export interface SwapProvidersConfig {

--- a/src/frontend/src/lib/utils/near-intents-swap.utils.ts
+++ b/src/frontend/src/lib/utils/near-intents-swap.utils.ts
@@ -1,0 +1,45 @@
+import {
+	SwapProvider,
+	type GetSupportedDestinationsFn,
+	type SwapTokenCategory
+} from '$lib/types/swap';
+import { resolveSwapTokenLookup } from '$lib/utils/swap-tokens-filter.utils';
+import { nonNullish } from '@dfinity/utils';
+
+/**
+ * Builds a `getSupportedDestinations` for a NEAR Intents provider entry registered
+ * under `category` (either 'evm' or 'sol').
+ *
+ * NEAR Intents bridges across both EVM and SOL — but each provider entry only
+ * caches its own category's source set. We use `findProviderSourceTokens` to look
+ * up the sibling NEAR Intents entry's set so the entry whose category matches the
+ * source can advertise the union { evm, sol } as reachable destinations.
+ */
+export const buildNearIntentsSupportedDestinations =
+	(category: Extract<SwapTokenCategory, 'evm' | 'sol'>): GetSupportedDestinationsFn =>
+	({ sourceToken, supportedSourceTokens, findProviderSourceTokens }) => {
+		const lookup = resolveSwapTokenLookup({ token: sourceToken });
+
+		if (lookup?.category !== category || !supportedSourceTokens?.has(lookup.identifier)) {
+			return;
+		}
+
+		const evmSet =
+			category === 'evm'
+				? supportedSourceTokens
+				: findProviderSourceTokens({ key: SwapProvider.NEAR_INTENTS, category: 'evm' });
+		const solSet =
+			category === 'sol'
+				? supportedSourceTokens
+				: findProviderSourceTokens({ key: SwapProvider.NEAR_INTENTS, category: 'sol' });
+
+		const result: { evm?: Set<string>; sol?: Set<string> } = {};
+		if (nonNullish(evmSet)) {
+			result.evm = evmSet;
+		}
+		if (nonNullish(solSet)) {
+			result.sol = solSet;
+		}
+
+		return result;
+	};

--- a/src/frontend/src/lib/utils/swap-providers.utils.ts
+++ b/src/frontend/src/lib/utils/swap-providers.utils.ts
@@ -1,0 +1,38 @@
+import type {
+	GetSupportedDestinationsFn,
+	SwapCategorizedTokenIds,
+	SwapTokenCategory
+} from '$lib/types/swap';
+import { resolveSwapTokenLookup } from '$lib/utils/swap-tokens-filter.utils';
+import { isNullish } from '@dfinity/utils';
+
+/**
+ * Default `getSupportedDestinations` for symmetric same-category providers.
+ *
+ * Behavior:
+ * - Source token's category does not match the provider's category → `undefined`
+ *   (provider does not support the source).
+ * - Provider has no supported-source list (e.g. Velora) → `{}` wildcard contributor.
+ * - Source is in the provider's supported set → destinations = the same set in the
+ *   provider's category.
+ * - Source is not in the provider's supported set → `undefined`.
+ */
+export const buildSymmetricSupportedDestinations =
+	(category: SwapTokenCategory): GetSupportedDestinationsFn =>
+	({ sourceToken, supportedSourceTokens }): SwapCategorizedTokenIds | undefined => {
+		const lookup = resolveSwapTokenLookup({ token: sourceToken });
+
+		if (lookup?.category !== category) {
+			return undefined;
+		}
+
+		if (isNullish(supportedSourceTokens)) {
+			return {};
+		}
+
+		if (!supportedSourceTokens.has(lookup.identifier)) {
+			return undefined;
+		}
+
+		return { [category]: supportedSourceTokens };
+	};

--- a/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
+++ b/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
@@ -37,28 +37,32 @@ export const resolveSwapTokenLookup = ({
 	supportedData
 }: {
 	token: Token;
-	supportedData: SwapSupportedTokensData;
+	supportedData?: SwapSupportedTokensData;
 }):
-	| { info: SwapSupportedTokensInfo; identifier: string; category: 'icp' | 'evm' | 'sol' }
+	| {
+			info: SwapSupportedTokensInfo | undefined;
+			identifier: string;
+			category: 'icp' | 'evm' | 'sol';
+	  }
 	| undefined => {
 	if (isIcToken(token)) {
-		return { info: supportedData.icp, identifier: token.ledgerCanisterId, category: 'icp' };
+		return { info: supportedData?.icp, identifier: token.ledgerCanisterId, category: 'icp' };
 	}
 
 	if (isTokenErcFungible(token)) {
-		return { info: supportedData.evm, identifier: token.address.toLowerCase(), category: 'evm' };
+		return { info: supportedData?.evm, identifier: token.address.toLowerCase(), category: 'evm' };
 	}
 
 	if (isTokenSpl(token)) {
-		return { info: supportedData.sol, identifier: token.address, category: 'sol' };
+		return { info: supportedData?.sol, identifier: token.address, category: 'sol' };
 	}
 
 	if (isTokenEthereumNative(token)) {
-		return { info: supportedData.evm, identifier: token.symbol.toLowerCase(), category: 'evm' };
+		return { info: supportedData?.evm, identifier: token.symbol.toLowerCase(), category: 'evm' };
 	}
 
 	if (isTokenSolanaNative(token)) {
-		return { info: supportedData.sol, identifier: token.symbol.toLowerCase(), category: 'sol' };
+		return { info: supportedData?.sol, identifier: token.symbol.toLowerCase(), category: 'sol' };
 	}
 };
 

--- a/src/frontend/src/tests/lib/utils/near-intents-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/near-intents-swap.utils.spec.ts
@@ -1,0 +1,162 @@
+import { SwapProvider, type FindProviderSourceTokens } from '$lib/types/swap';
+import { buildNearIntentsSupportedDestinations } from '$lib/utils/near-intents-swap.utils';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
+
+describe('buildNearIntentsSupportedDestinations', () => {
+	const evmId = mockValidErc20Token.address.toLowerCase();
+	const solId = mockValidSplToken.address;
+
+	const noLookup: FindProviderSourceTokens = () => undefined;
+
+	describe('category = evm', () => {
+		const evmFn = buildNearIntentsSupportedDestinations('evm');
+
+		it('returns undefined when source token category does not match (ICP source)', () => {
+			const result = evmFn({
+				sourceToken: mockValidIcToken,
+				supportedSourceTokens: new Set([evmId]),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when source token category does not match (SOL source)', () => {
+			const result = evmFn({
+				sourceToken: mockValidSplToken,
+				supportedSourceTokens: new Set([evmId]),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when source identifier is not in supportedSourceTokens', () => {
+			const result = evmFn({
+				sourceToken: mockValidErc20Token,
+				supportedSourceTokens: new Set(['0xother']),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when supportedSourceTokens is undefined', () => {
+			const result = evmFn({
+				sourceToken: mockValidErc20Token,
+				supportedSourceTokens: undefined,
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns the supported set as evm and looks up sibling sol set', () => {
+			const supportedSourceTokens = new Set([evmId]);
+			const sisterSol = new Set([solId]);
+
+			const findProviderSourceTokens: FindProviderSourceTokens = ({ key, category }) =>
+				key === SwapProvider.NEAR_INTENTS && category === 'sol' ? sisterSol : undefined;
+
+			const result = evmFn({
+				sourceToken: mockValidErc20Token,
+				supportedSourceTokens,
+				findProviderSourceTokens
+			});
+
+			expect(result).toEqual({ evm: supportedSourceTokens, sol: sisterSol });
+		});
+
+		it('omits sol when sibling lookup returns undefined', () => {
+			const supportedSourceTokens = new Set([evmId]);
+
+			const result = evmFn({
+				sourceToken: mockValidErc20Token,
+				supportedSourceTokens,
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toEqual({ evm: supportedSourceTokens });
+		});
+	});
+
+	describe('category = sol', () => {
+		const solFn = buildNearIntentsSupportedDestinations('sol');
+
+		it('returns undefined when source token category does not match (ICP source)', () => {
+			const result = solFn({
+				sourceToken: mockValidIcToken,
+				supportedSourceTokens: new Set([solId]),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when source token category does not match (EVM source)', () => {
+			const result = solFn({
+				sourceToken: mockValidErc20Token,
+				supportedSourceTokens: new Set([solId]),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when source identifier is not in supportedSourceTokens', () => {
+			const result = solFn({
+				sourceToken: mockValidSplToken,
+				supportedSourceTokens: new Set(['OtherSplAddress']),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns the supported set as sol and looks up sibling evm set', () => {
+			const supportedSourceTokens = new Set([solId]);
+			const sisterEvm = new Set([evmId]);
+
+			const findProviderSourceTokens: FindProviderSourceTokens = ({ key, category }) =>
+				key === SwapProvider.NEAR_INTENTS && category === 'evm' ? sisterEvm : undefined;
+
+			const result = solFn({
+				sourceToken: mockValidSplToken,
+				supportedSourceTokens,
+				findProviderSourceTokens
+			});
+
+			expect(result).toEqual({ sol: supportedSourceTokens, evm: sisterEvm });
+		});
+
+		it('omits evm when sibling lookup returns undefined', () => {
+			const supportedSourceTokens = new Set([solId]);
+
+			const result = solFn({
+				sourceToken: mockValidSplToken,
+				supportedSourceTokens,
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toEqual({ sol: supportedSourceTokens });
+		});
+
+		it('only queries the NEAR Intents sibling, ignoring other providers', () => {
+			const supportedSourceTokens = new Set([solId]);
+			const wrongProviderSet = new Set(['ignored']);
+
+			const findProviderSourceTokens: FindProviderSourceTokens = ({ key, category }) =>
+				key === SwapProvider.NEAR_INTENTS && category === 'evm' ? undefined : wrongProviderSet;
+
+			const result = solFn({
+				sourceToken: mockValidSplToken,
+				supportedSourceTokens,
+				findProviderSourceTokens
+			});
+
+			expect(result).toEqual({ sol: supportedSourceTokens });
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/utils/swap-providers.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap-providers.utils.spec.ts
@@ -1,0 +1,79 @@
+import type { FindProviderSourceTokens } from '$lib/types/swap';
+import { buildSymmetricSupportedDestinations } from '$lib/utils/swap-providers.utils';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
+
+const noopFindProviderSourceTokens: FindProviderSourceTokens = () => undefined;
+
+describe('buildSymmetricSupportedDestinations', () => {
+	const icpHandler = buildSymmetricSupportedDestinations('icp');
+	const evmHandler = buildSymmetricSupportedDestinations('evm');
+	const solHandler = buildSymmetricSupportedDestinations('sol');
+
+	it('returns undefined when source category does not match the provider category', () => {
+		const result = icpHandler({
+			sourceToken: mockValidErc20Token,
+			supportedSourceTokens: new Set([mockValidIcToken.ledgerCanisterId]),
+			findProviderSourceTokens: noopFindProviderSourceTokens
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('returns the supported set under the provider category when source is in the set', () => {
+		const supported = new Set([mockValidIcToken.ledgerCanisterId, 'other-canister']);
+		const result = icpHandler({
+			sourceToken: mockValidIcToken,
+			supportedSourceTokens: supported,
+			findProviderSourceTokens: noopFindProviderSourceTokens
+		});
+
+		expect(result).toEqual({ icp: supported });
+	});
+
+	it('returns undefined when source is not in the provider supported set', () => {
+		const result = icpHandler({
+			sourceToken: mockValidIcToken,
+			supportedSourceTokens: new Set(['other-canister']),
+			findProviderSourceTokens: noopFindProviderSourceTokens
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it('returns an empty wildcard map when provider has no supported list (e.g. Velora)', () => {
+		const result = evmHandler({
+			sourceToken: mockValidErc20Token,
+			supportedSourceTokens: undefined,
+			findProviderSourceTokens: noopFindProviderSourceTokens
+		});
+
+		expect(result).toEqual({});
+	});
+
+	it('matches EVM addresses case-insensitively', () => {
+		const upperToken = { ...mockValidErc20Token, address: '0xABCDEF1234' };
+		const supported = new Set(['0xabcdef1234']);
+
+		const result = evmHandler({
+			sourceToken: upperToken,
+			supportedSourceTokens: supported,
+			findProviderSourceTokens: noopFindProviderSourceTokens
+		});
+
+		expect(result).toEqual({ evm: supported });
+	});
+
+	it('handles SPL tokens by address', () => {
+		const supported = new Set([mockValidSplToken.address]);
+
+		const result = solHandler({
+			sourceToken: mockValidSplToken,
+			supportedSourceTokens: supported,
+			findProviderSourceTokens: noopFindProviderSourceTokens
+		});
+
+		expect(result).toEqual({ sol: supported });
+	});
+});


### PR DESCRIPTION
# Motivation

Introduces the typed contract every swap provider uses to advertise reachable destinations from a given source token. No consumer in this PR — services and stores still drive filterSwapTokens from the existing aggregated payload. PR 3 will start using getSupportedDestinations.
                                                                                                                                                                                
  - New types in lib/types/swap.ts: SwapTokenCategory, SwapCategorizedTokenIds, FindProviderSourceTokens, SwapDestinationsContext, GetSupportedDestinationsFn. Each provider config interface now requires a getSupportedDestinations field.
  - Two helpers cover the common patterns:                                                                                                                                      
    - buildSymmetricSupportedDestinations(category) — same-category providers (ICP-Swap, Kong, Velora). When the provider has no supported-source list (Velora), returns an empty map so it counts as a wildcard contributor.                                                                                                                             
    - buildNearIntentsSupportedDestinations(category) — NEAR Intents bridges across EVM ↔ SOL; uses findProviderSourceTokens to look up the sibling category's set so a single source advertises both EVM and SOL destinations.                                                                                                                              
  - Provider entries in swap.providers.ts, evm-swap.providers.ts, icp-bridge-swap.providers.ts, sol-swap.providers.ts set getSupportedDestinations. OneSec uses the existing oneSecCompatibleDestinations directly (directed pair).                                                                                                                        
  - resolveSwapTokenLookup now accepts supportedData? (optional) so the destination helpers can identify a token's category without needing the aggregated supported-tokens payload.                                                                                                                                                                      
                                                                                                                                                                              
## Why                                                                                                                                                                           
                                                                                                                                                                              
  Groundwork for source-aware destination filtering. Today, the destination list is filtered by the aggregated SwapSupportedTokensData payload — which represents "tokens the user could swap from", not "tokens the user can swap to given the current source". The contract added here gives each provider a place to express directed-pair semantics; later PRs route this data into the destination list, the network filter, and an auto-clear effect.                                                                            
  
