### PR TITLE
refactor(frontend): expose per-provider source data in swap store

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -57,7 +57,7 @@
 				...$allSortedIcrcTokens,
 				...$allCrossChainSwapTokens
 			],
-			supportedData: $swapSupportedTokensStore,
+			supportedData: $swapSupportedTokensStore?.aggregated,
 			compatibleTokenIds
 		})
 	);

--- a/src/frontend/src/lib/derived/swap.derived.ts
+++ b/src/frontend/src/lib/derived/swap.derived.ts
@@ -51,7 +51,7 @@ export const isPageTokenSwappable: Readable<boolean> = derived(
 
 		const result = filterSwapTokens({
 			tokens: [{ ...$selectedSwappableToken, enabled: true }],
-			supportedData: $swapSupportedTokensStore
+			supportedData: $swapSupportedTokensStore?.aggregated
 		});
 
 		return result.length > 0;

--- a/src/frontend/src/lib/services/swap-supported-tokens.services.ts
+++ b/src/frontend/src/lib/services/swap-supported-tokens.services.ts
@@ -4,62 +4,66 @@ import { solSwapProviders } from '$lib/providers/sol-swap.providers';
 import { swapProviders } from '$lib/providers/swap.providers';
 import {
 	swapSupportedTokensStore,
+	type SwapProviderSupport,
+	type SwapSupportedTokensData,
 	type SwapSupportedTokensInfo
 } from '$lib/stores/swap-supported-tokens.store';
+import type { GetSupportedDestinationsFn, SwapProvider, SwapTokenCategory } from '$lib/types/swap';
 import { determineCoverage } from '$lib/utils/swap-tokens-filter.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 
-/**
- * Filters providers that have `getSupportedTokens` and calls it in a single pass,
- * collecting the resulting promises without non-null assertions.
- */
-const buildFetchTokenSets = <
-	P extends { getSupportedTokens?: (...args: never[]) => Promise<Set<string>> }
+const resolveProviderGroup = <
+	P extends {
+		key: SwapProvider;
+		isEnabled: boolean;
+		getSupportedTokens?: (...args: never[]) => Promise<Set<string>>;
+		getSupportedDestinations: GetSupportedDestinationsFn;
+	}
 >({
 	providers,
+	sourceCategory,
 	callFn
 }: {
 	providers: P[];
+	sourceCategory: SwapTokenCategory;
 	callFn: (getSupportedTokens: NonNullable<P['getSupportedTokens']>) => Promise<Set<string>>;
-}): Promise<Set<string>>[] =>
-	providers.reduce<Promise<Set<string>>[]>((acc, provider) => {
-		if (nonNullish(provider.getSupportedTokens)) {
-			acc.push(callFn(provider.getSupportedTokens));
+}): Promise<SwapProviderSupport[]> =>
+	Promise.all(
+		providers
+			.filter(({ isEnabled }) => isEnabled)
+			.map(async (provider) => {
+				let supportedSourceTokens: Set<string> | undefined;
+				if (nonNullish(provider.getSupportedTokens)) {
+					try {
+						supportedSourceTokens = await callFn(provider.getSupportedTokens);
+					} catch (_err) {
+						supportedSourceTokens = new Set();
+					}
+				}
+				return {
+					key: provider.key,
+					sourceCategory,
+					supportedSourceTokens,
+					getSupportedDestinations: provider.getSupportedDestinations
+				};
+			})
+	);
+
+const aggregateCategory = (resolutions: SwapProviderSupport[]): SwapSupportedTokensInfo => {
+	const totalEnabled = resolutions.length;
+	const withList = resolutions.filter((r) => nonNullish(r.supportedSourceTokens)).length;
+	const supportedTokenIds = resolutions.reduce<Set<string>>((acc, { supportedSourceTokens }) => {
+		if (nonNullish(supportedSourceTokens)) {
+			supportedSourceTokens.forEach((id) => acc.add(id));
 		}
-
-		return acc;
-	}, []);
-
-const collectSupportedTokens = async ({
-	totalEnabled,
-	fetchTokenSets
-}: {
-	totalEnabled: number;
-	fetchTokenSets: Promise<Set<string>>[];
-}): Promise<SwapSupportedTokensInfo> => {
-	const coverage = determineCoverage({
-		totalEnabled,
-		withList: fetchTokenSets.length
-	});
-
-	if (coverage === 'none') {
-		return { coverage, supportedTokenIds: new Set() };
-	}
-
-	const results = await Promise.allSettled(fetchTokenSets);
-
-	const supportedTokenIds = results.reduce<Set<string>>((acc, result) => {
-		if (result.status === 'fulfilled') {
-			for (const id of result.value) {
-				acc.add(id);
-			}
-		}
-
 		return acc;
 	}, new Set());
 
-	return { coverage, supportedTokenIds };
+	return {
+		coverage: determineCoverage({ totalEnabled, withList }),
+		supportedTokenIds
+	};
 };
 
 export const loadSwapSupportedTokens = async ({
@@ -67,35 +71,38 @@ export const loadSwapSupportedTokens = async ({
 }: {
 	identity: Identity;
 }): Promise<void> => {
-	const enabledIcpProviders = [
-		...swapProviders.filter(({ isEnabled }) => isEnabled),
-		...icpBridgeProviders.filter(({ isEnabled }) => isEnabled)
-	];
-	const enabledEvmProviders = evmSwapProviders.filter(({ isEnabled }) => isEnabled);
-	const enabledSolProviders = solSwapProviders.filter(({ isEnabled }) => isEnabled);
-	const [icp, evm, sol] = await Promise.all([
-		collectSupportedTokens({
-			totalEnabled: enabledIcpProviders.length,
-			fetchTokenSets: buildFetchTokenSets({
-				providers: enabledIcpProviders,
-				callFn: (fn) => fn({ identity })
-			})
+	const [icpProviders, icpBridgeProvidersResolved, evmProviders, solProviders] = await Promise.all([
+		resolveProviderGroup({
+			providers: swapProviders,
+			sourceCategory: 'icp',
+			callFn: (fn) => fn({ identity })
 		}),
-		collectSupportedTokens({
-			totalEnabled: enabledEvmProviders.length,
-			fetchTokenSets: buildFetchTokenSets({
-				providers: enabledEvmProviders,
-				callFn: (fn) => fn()
-			})
+		resolveProviderGroup({
+			providers: icpBridgeProviders,
+			sourceCategory: 'icp',
+			callFn: (fn) => fn()
 		}),
-		collectSupportedTokens({
-			totalEnabled: enabledSolProviders.length,
-			fetchTokenSets: buildFetchTokenSets({
-				providers: enabledSolProviders,
-				callFn: (fn) => fn()
-			})
+		resolveProviderGroup({
+			providers: evmSwapProviders,
+			sourceCategory: 'evm',
+			callFn: (fn) => fn()
+		}),
+		resolveProviderGroup({
+			providers: solSwapProviders,
+			sourceCategory: 'sol',
+			callFn: (fn) => fn()
 		})
 	]);
 
-	swapSupportedTokensStore.set({ icp, evm, sol });
+	const icpResolutions = [...icpProviders, ...icpBridgeProvidersResolved];
+
+	const aggregated: SwapSupportedTokensData = {
+		icp: aggregateCategory(icpResolutions),
+		evm: aggregateCategory(evmProviders),
+		sol: aggregateCategory(solProviders)
+	};
+
+	const providers: SwapProviderSupport[] = [...icpResolutions, ...evmProviders, ...solProviders];
+
+	swapSupportedTokensStore.set({ aggregated, providers });
 };

--- a/src/frontend/src/lib/stores/swap-supported-tokens.store.ts
+++ b/src/frontend/src/lib/stores/swap-supported-tokens.store.ts
@@ -1,3 +1,4 @@
+import type { GetSupportedDestinationsFn, SwapProvider, SwapTokenCategory } from '$lib/types/swap';
 import { writable, type Readable } from 'svelte/store';
 
 export type SwapProviderListCoverage = 'all' | 'some' | 'none';
@@ -7,15 +8,28 @@ export interface SwapSupportedTokensInfo {
 	supportedTokenIds: Set<string>;
 }
 
-export type SwapSupportedTokensData = Record<string, SwapSupportedTokensInfo>;
+export type SwapSupportedTokensData = Record<SwapTokenCategory, SwapSupportedTokensInfo>;
 
-export interface SwapSupportedTokensStore extends Readable<SwapSupportedTokensData | undefined> {
-	set: (data: SwapSupportedTokensData) => void;
+export interface SwapProviderSupport {
+	key: SwapProvider;
+	sourceCategory: SwapTokenCategory;
+	// `undefined` when the provider does not expose `getSupportedTokens` (e.g. Velora).
+	supportedSourceTokens: Set<string> | undefined;
+	getSupportedDestinations: GetSupportedDestinationsFn;
+}
+
+export interface SwapSupportedState {
+	aggregated: SwapSupportedTokensData;
+	providers: SwapProviderSupport[];
+}
+
+export interface SwapSupportedTokensStore extends Readable<SwapSupportedState | undefined> {
+	set: (state: SwapSupportedState) => void;
 	reset: () => void;
 }
 
 const initSwapSupportedTokensStore = (): SwapSupportedTokensStore => {
-	const { subscribe, set } = writable<SwapSupportedTokensData | undefined>(undefined);
+	const { subscribe, set } = writable<SwapSupportedState | undefined>(undefined);
 
 	return {
 		subscribe,

--- a/src/frontend/src/tests/lib/components/loaders/LoaderSwapTokens.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderSwapTokens.spec.ts
@@ -43,9 +43,12 @@ describe('LoaderSwapTokens', () => {
 		mockAuthStore();
 
 		const mockData = {
-			icp: { coverage: 'all' as const, supportedTokenIds: new Set<string>() },
-			evm: { coverage: 'all' as const, supportedTokenIds: new Set<string>() },
-			sol: { coverage: 'all' as const, supportedTokenIds: new Set<string>() }
+			aggregated: {
+				icp: { coverage: 'all' as const, supportedTokenIds: new Set<string>() },
+				evm: { coverage: 'all' as const, supportedTokenIds: new Set<string>() },
+				sol: { coverage: 'all' as const, supportedTokenIds: new Set<string>() }
+			},
+			providers: []
 		};
 		swapSupportedTokensStore.set(mockData);
 

--- a/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/swap.derived.spec.ts
@@ -148,9 +148,12 @@ describe('swap.derived', () => {
 				mockPage.mockToken(SOLANA_TOKEN);
 
 				swapSupportedTokensStore.set({
-					icp: { coverage: 'none', supportedTokenIds: new Set() },
-					evm: { coverage: 'none', supportedTokenIds: new Set() },
-					sol: { coverage: 'all', supportedTokenIds: new Set(['some-other-token']) }
+					aggregated: {
+						icp: { coverage: 'none', supportedTokenIds: new Set() },
+						evm: { coverage: 'none', supportedTokenIds: new Set() },
+						sol: { coverage: 'all', supportedTokenIds: new Set(['some-other-token']) }
+					},
+					providers: []
 				});
 
 				expect(get(isPageTokenSwappable)).toBeFalsy();
@@ -160,12 +163,15 @@ describe('swap.derived', () => {
 				mockPage.mockToken(SOLANA_TOKEN);
 
 				swapSupportedTokensStore.set({
-					icp: { coverage: 'none', supportedTokenIds: new Set() },
-					evm: { coverage: 'none', supportedTokenIds: new Set() },
-					sol: {
-						coverage: 'all',
-						supportedTokenIds: new Set([SOLANA_TOKEN.symbol.toLowerCase()])
-					}
+					aggregated: {
+						icp: { coverage: 'none', supportedTokenIds: new Set() },
+						evm: { coverage: 'none', supportedTokenIds: new Set() },
+						sol: {
+							coverage: 'all',
+							supportedTokenIds: new Set([SOLANA_TOKEN.symbol.toLowerCase()])
+						}
+					},
+					providers: []
 				});
 
 				expect(get(isPageTokenSwappable)).toBeTruthy();
@@ -175,9 +181,12 @@ describe('swap.derived', () => {
 				mockPage.mockToken(ETHEREUM_TOKEN);
 
 				swapSupportedTokensStore.set({
-					icp: { coverage: 'none', supportedTokenIds: new Set() },
-					evm: { coverage: 'none', supportedTokenIds: new Set() },
-					sol: { coverage: 'all', supportedTokenIds: new Set() }
+					aggregated: {
+						icp: { coverage: 'none', supportedTokenIds: new Set() },
+						evm: { coverage: 'none', supportedTokenIds: new Set() },
+						sol: { coverage: 'all', supportedTokenIds: new Set() }
+					},
+					providers: []
 				});
 
 				expect(get(isPageTokenSwappable)).toBeTruthy();
@@ -203,9 +212,12 @@ describe('swap.derived', () => {
 
 				vi.spyOn(swapSupportedTokensStore, 'subscribe').mockImplementation((fn) => {
 					fn({
-						icp: { coverage: 'none', supportedTokenIds: new Set() },
-						evm: { coverage: 'none', supportedTokenIds: new Set() },
-						sol: { coverage: 'all', supportedTokenIds: new Set(['different-address']) }
+						aggregated: {
+							icp: { coverage: 'none', supportedTokenIds: new Set() },
+							evm: { coverage: 'none', supportedTokenIds: new Set() },
+							sol: { coverage: 'all', supportedTokenIds: new Set(['different-address']) }
+						},
+						providers: []
 					});
 					return () => {};
 				});
@@ -219,20 +231,26 @@ describe('swap.derived', () => {
 				expect(get(isPageTokenSwappable)).toBeTruthy();
 
 				swapSupportedTokensStore.set({
-					icp: { coverage: 'none', supportedTokenIds: new Set() },
-					evm: { coverage: 'none', supportedTokenIds: new Set() },
-					sol: { coverage: 'all', supportedTokenIds: new Set(['not-sol']) }
+					aggregated: {
+						icp: { coverage: 'none', supportedTokenIds: new Set() },
+						evm: { coverage: 'none', supportedTokenIds: new Set() },
+						sol: { coverage: 'all', supportedTokenIds: new Set(['not-sol']) }
+					},
+					providers: []
 				});
 
 				expect(get(isPageTokenSwappable)).toBeFalsy();
 
 				swapSupportedTokensStore.set({
-					icp: { coverage: 'none', supportedTokenIds: new Set() },
-					evm: { coverage: 'none', supportedTokenIds: new Set() },
-					sol: {
-						coverage: 'all',
-						supportedTokenIds: new Set([SOLANA_TOKEN.symbol.toLowerCase()])
-					}
+					aggregated: {
+						icp: { coverage: 'none', supportedTokenIds: new Set() },
+						evm: { coverage: 'none', supportedTokenIds: new Set() },
+						sol: {
+							coverage: 'all',
+							supportedTokenIds: new Set([SOLANA_TOKEN.symbol.toLowerCase()])
+						}
+					},
+					providers: []
 				});
 
 				expect(get(isPageTokenSwappable)).toBeTruthy();

--- a/src/frontend/src/tests/lib/services/swap-supported-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap-supported-tokens.services.spec.ts
@@ -10,6 +10,13 @@ const mockEvmGetSupportedTokens = vi.fn();
 const mockSolGetQuote = vi.fn();
 const mockSolGetSupportedTokens = vi.fn();
 
+const kongDestinations = vi.fn(() => ({}));
+const icpSwapDestinations = vi.fn(() => ({}));
+const icpBridgeDestinations = vi.fn(() => ({}));
+const veloraDestinations = vi.fn(() => ({}));
+const nearEvmDestinations = vi.fn(() => ({}));
+const nearSolDestinations = vi.fn(() => ({}));
+
 vi.mock('$lib/providers/swap.providers', () => ({
 	swapProviders: [
 		{
@@ -17,14 +24,16 @@ vi.mock('$lib/providers/swap.providers', () => ({
 			getQuote: vi.fn(),
 			mapQuoteResult: vi.fn(),
 			isEnabled: true,
-			getSupportedTokens: mockKongSupportedTokens
+			getSupportedTokens: mockKongSupportedTokens,
+			getSupportedDestinations: kongDestinations
 		},
 		{
 			key: 'icpSwap',
 			getQuote: vi.fn(),
 			mapQuoteResult: vi.fn(),
 			isEnabled: true,
-			getSupportedTokens: mockIcpSwapSupportedTokens
+			getSupportedTokens: mockIcpSwapSupportedTokens,
+			getSupportedDestinations: icpSwapDestinations
 		}
 	]
 }));
@@ -35,7 +44,8 @@ vi.mock('$lib/providers/icp-bridge-swap.providers', () => ({
 			key: 'oneSec',
 			getQuote: vi.fn(),
 			isEnabled: true,
-			getSupportedTokens: mockIcpBridgeSupportedTokens
+			getSupportedTokens: mockIcpBridgeSupportedTokens,
+			getSupportedDestinations: icpBridgeDestinations
 		}
 	]
 }));
@@ -45,13 +55,15 @@ vi.mock('$lib/providers/evm-swap.providers', () => ({
 		{
 			key: 'velora',
 			getQuote: mockEvmGetQuote,
-			isEnabled: true
+			isEnabled: true,
+			getSupportedDestinations: veloraDestinations
 		},
 		{
 			key: 'nearIntents',
 			getQuote: vi.fn(),
 			isEnabled: true,
-			getSupportedTokens: mockEvmGetSupportedTokens
+			getSupportedTokens: mockEvmGetSupportedTokens,
+			getSupportedDestinations: nearEvmDestinations
 		}
 	]
 }));
@@ -62,7 +74,8 @@ vi.mock('$lib/providers/sol-swap.providers', () => ({
 			key: 'nearIntents',
 			getQuote: mockSolGetQuote,
 			isEnabled: true,
-			getSupportedTokens: mockSolGetSupportedTokens
+			getSupportedTokens: mockSolGetSupportedTokens,
+			getSupportedDestinations: nearSolDestinations
 		}
 	]
 }));
@@ -89,18 +102,49 @@ describe('swap-supported-tokens.services', () => {
 		expect(stored).toBeDefined();
 
 		// ICP: Kong, ICP Swap and OneSec all have lists → 'all'
-		expect(stored?.icp.coverage).toBe('all');
-		expect(stored?.icp.supportedTokenIds).toEqual(
+		expect(stored?.aggregated.icp.coverage).toBe('all');
+		expect(stored?.aggregated.icp.supportedTokenIds).toEqual(
 			new Set(['canister-a', 'canister-b', 'canister-c', 'canister-d'])
 		);
 
 		// EVM: Velora has no list, NEAR Intents does → 'some'
-		expect(stored?.evm.coverage).toBe('some');
-		expect(stored?.evm.supportedTokenIds).toEqual(new Set(['0xabc', '0xdef']));
+		expect(stored?.aggregated.evm.coverage).toBe('some');
+		expect(stored?.aggregated.evm.supportedTokenIds).toEqual(new Set(['0xabc', '0xdef']));
 
 		// SOL: NEAR Intents has list, only provider → 'all'
-		expect(stored?.sol.coverage).toBe('all');
-		expect(stored?.sol.supportedTokenIds).toEqual(new Set(['SplAddr1']));
+		expect(stored?.aggregated.sol.coverage).toBe('all');
+		expect(stored?.aggregated.sol.supportedTokenIds).toEqual(new Set(['SplAddr1']));
+	});
+
+	it('should record per-provider source sets and destination resolvers', async () => {
+		mockKongSupportedTokens.mockResolvedValue(new Set(['canister-a']));
+		mockIcpSwapSupportedTokens.mockResolvedValue(new Set(['canister-b']));
+		mockIcpBridgeSupportedTokens.mockResolvedValue(new Set(['canister-c']));
+		mockEvmGetSupportedTokens.mockResolvedValue(new Set(['0xabc']));
+		mockSolGetSupportedTokens.mockResolvedValue(new Set(['SplAddr1']));
+
+		const { loadSwapSupportedTokens } =
+			await import('$lib/services/swap-supported-tokens.services');
+		await loadSwapSupportedTokens({ identity: mockIdentity });
+
+		const stored = get(swapSupportedTokensStore);
+
+		expect(stored?.providers).toHaveLength(6);
+
+		const veloraEntry = stored?.providers.find(
+			(p) => p.key === 'velora' && p.sourceCategory === 'evm'
+		);
+
+		expect(veloraEntry).toBeDefined();
+		expect(veloraEntry?.supportedSourceTokens).toBeUndefined();
+		expect(veloraEntry?.getSupportedDestinations).toBe(veloraDestinations);
+
+		const kongEntry = stored?.providers.find(
+			(p) => p.key === 'kongSwap' && p.sourceCategory === 'icp'
+		);
+
+		expect(kongEntry?.supportedSourceTokens).toEqual(new Set(['canister-a']));
+		expect(kongEntry?.getSupportedDestinations).toBe(kongDestinations);
 	});
 
 	it('should handle provider getSupportedTokens failures gracefully', async () => {
@@ -119,16 +163,16 @@ describe('swap-supported-tokens.services', () => {
 		expect(stored).toBeDefined();
 
 		// ICP Swap failed: S only contains Kong's tokens, but coverage stays 'all'
-		expect(stored?.icp.coverage).toBe('all');
-		expect(stored?.icp.supportedTokenIds).toEqual(new Set(['canister-a']));
+		expect(stored?.aggregated.icp.coverage).toBe('all');
+		expect(stored?.aggregated.icp.supportedTokenIds).toEqual(new Set(['canister-a']));
 
 		// NEAR Intents failed: empty set, but coverage stays 'some'
-		expect(stored?.evm.coverage).toBe('some');
-		expect(stored?.evm.supportedTokenIds.size).toBe(0);
+		expect(stored?.aggregated.evm.coverage).toBe('some');
+		expect(stored?.aggregated.evm.supportedTokenIds.size).toBe(0);
 
 		// SOL: NEAR Intents succeeded
-		expect(stored?.sol.coverage).toBe('all');
-		expect(stored?.sol.supportedTokenIds).toEqual(new Set(['SplAddr1']));
+		expect(stored?.aggregated.sol.coverage).toBe('all');
+		expect(stored?.aggregated.sol.supportedTokenIds).toEqual(new Set(['SplAddr1']));
 	});
 
 	it('should union token IDs across multiple providers in the same group', async () => {
@@ -144,7 +188,7 @@ describe('swap-supported-tokens.services', () => {
 
 		const stored = get(swapSupportedTokensStore);
 
-		expect(stored?.icp.supportedTokenIds).toEqual(
+		expect(stored?.aggregated.icp.supportedTokenIds).toEqual(
 			new Set(['id-1', 'id-2', 'id-3', 'id-4', 'id-shared'])
 		);
 	});

--- a/src/frontend/src/tests/lib/stores/swap-supported-tokens.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap-supported-tokens.store.spec.ts
@@ -10,32 +10,39 @@ describe('swap-supported-tokens.store', () => {
 		expect(get(swapSupportedTokensStore)).toBeUndefined();
 	});
 
-	it('should set supported tokens data', () => {
-		const data = {
-			icp: { coverage: 'all' as const, supportedTokenIds: new Set(['canister-1', 'canister-2']) },
-			evm: { coverage: 'some' as const, supportedTokenIds: new Set(['0xabc']) },
-			sol: { coverage: 'none' as const, supportedTokenIds: new Set<string>() }
+	it('should set supported tokens state', () => {
+		const state = {
+			aggregated: {
+				icp: { coverage: 'all' as const, supportedTokenIds: new Set(['canister-1', 'canister-2']) },
+				evm: { coverage: 'some' as const, supportedTokenIds: new Set(['0xabc']) },
+				sol: { coverage: 'none' as const, supportedTokenIds: new Set<string>() }
+			},
+			providers: []
 		};
 
-		swapSupportedTokensStore.set(data);
+		swapSupportedTokensStore.set(state);
 
 		const stored = get(swapSupportedTokensStore);
 
 		expect(stored).toBeDefined();
-		expect(stored?.icp.coverage).toBe('all');
-		expect(stored?.icp.supportedTokenIds.has('canister-1')).toBeTruthy();
-		expect(stored?.icp.supportedTokenIds.has('canister-2')).toBeTruthy();
-		expect(stored?.evm.coverage).toBe('some');
-		expect(stored?.evm.supportedTokenIds.has('0xabc')).toBeTruthy();
-		expect(stored?.sol.coverage).toBe('none');
-		expect(stored?.sol.supportedTokenIds.size).toBe(0);
+		expect(stored?.aggregated.icp.coverage).toBe('all');
+		expect(stored?.aggregated.icp.supportedTokenIds.has('canister-1')).toBeTruthy();
+		expect(stored?.aggregated.icp.supportedTokenIds.has('canister-2')).toBeTruthy();
+		expect(stored?.aggregated.evm.coverage).toBe('some');
+		expect(stored?.aggregated.evm.supportedTokenIds.has('0xabc')).toBeTruthy();
+		expect(stored?.aggregated.sol.coverage).toBe('none');
+		expect(stored?.aggregated.sol.supportedTokenIds.size).toBe(0);
+		expect(stored?.providers).toEqual([]);
 	});
 
 	it('should reset to undefined', () => {
 		swapSupportedTokensStore.set({
-			icp: { coverage: 'all', supportedTokenIds: new Set(['a']) },
-			evm: { coverage: 'none', supportedTokenIds: new Set() },
-			sol: { coverage: 'none', supportedTokenIds: new Set() }
+			aggregated: {
+				icp: { coverage: 'all', supportedTokenIds: new Set(['a']) },
+				evm: { coverage: 'none', supportedTokenIds: new Set() },
+				sol: { coverage: 'none', supportedTokenIds: new Set() }
+			},
+			providers: []
 		});
 
 		expect(get(swapSupportedTokensStore)).toBeDefined();

--- a/src/frontend/src/tests/lib/utils/swap-tokens-filter.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap-tokens-filter.utils.spec.ts
@@ -291,22 +291,6 @@ describe('filterSwapTokens', () => {
 		});
 	});
 
-	describe('missing network key in supportedData (undefined info)', () => {
-		it('falls back to enabled check when supportedData lacks the network key', () => {
-			const supportedData: SwapSupportedTokensData = {};
-
-			const result = filterSwapTokens({
-				tokens: [icpTokenActive, icpTokenInactive, erc20Active, erc20Inactive],
-				supportedData
-			});
-
-			expect(result).toContain(icpTokenActive);
-			expect(result).not.toContain(icpTokenInactive);
-			expect(result).toContain(erc20Active);
-			expect(result).not.toContain(erc20Inactive);
-		});
-	});
-
 	describe('compatibleTokenIds', () => {
 		const supportedData: SwapSupportedTokensData = {
 			icp: {


### PR DESCRIPTION
# Motivation

Carries per-provider data through the supported-tokens load pipeline so a future destination-aggregator can consult each provider's source set and getSupportedDestinations resolver. No UX change: filterSwapTokens still drives the token list off the same aggregated payload, just nested one level deeper.

  - swapSupportedTokensStore payload: SwapSupportedTokensData → { aggregated: SwapSupportedTokensData; providers: SwapProviderSupport[] }.                                      
  - loadSwapSupportedTokens refactored: resolves each provider once into a SwapProviderSupport (key, sourceCategory, supportedSourceTokens, getSupportedDestinations), then
  folds resolutions per category to produce aggregated. Same coverage semantics as before; same failure handling (a provider's failure → empty source set, doesn't block        
  aggregation).                                                                                                                                                               
  - Existing consumers (isPageTokenSwappable in swap.derived.ts, SwapTokensList.svelte) read ?.aggregated — one-line each.                                                      
  - Test specs updated to match the new shape; one new test in services.spec.ts asserts the providers payload (per-provider source set + destination resolver are recorded). 

