### PR TITLE
feat(frontend): source-aware destination filtering in swap modal

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapContexts.svelte
+++ b/src/frontend/src/lib/components/swap/SwapContexts.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { setContext, type Snippet } from 'svelte';
+	import { get } from 'svelte/store';
 	import {
 		IC_TOKEN_FEE_CONTEXT_KEY,
 		type IcTokenFeeContext,
@@ -27,6 +28,7 @@
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
 	import { initSwapContext, SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
+	import { filterSwapTokens } from '$lib/utils/swap-tokens-filter.utils';
 
 	interface Props {
 		children: Snippet;
@@ -38,7 +40,38 @@
 		store: initSwapAmountsStore()
 	});
 
-	setContext<SwapContext>(SWAP_CONTEXT_KEY, initSwapContext());
+	const swapContext = initSwapContext();
+	setContext<SwapContext>(SWAP_CONTEXT_KEY, swapContext);
+
+	const { destinationToken, receiveSupportedData, setDestinationToken } = swapContext;
+
+	// Re-evaluate the destination whenever the source or provider data changes (i.e. when
+	// `receiveSupportedData` re-derives). If the previously chosen destination is no longer
+	// reachable, clear it. The current destination is read non-reactively so picking a new
+	// destination doesn't re-trigger this effect.
+	$effect(() => {
+		const supportedData = $receiveSupportedData;
+
+		if (isNullish(supportedData)) {
+			return;
+		}
+
+		const dest = get(destinationToken);
+
+		if (isNullish(dest)) {
+			return;
+		}
+
+		const stillReachable =
+			filterSwapTokens({
+				tokens: [{ ...dest, enabled: true }],
+				supportedData
+			}).length > 0;
+
+		if (!stillReachable) {
+			setDestinationToken(undefined);
+		}
+	});
 
 	const tokensListContext = initModalTokensListContext({
 		tokens: [],

--- a/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
@@ -2,12 +2,15 @@
 	import type { WizardModal, WizardStep, WizardSteps } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import { get } from 'svelte/store';
 	import SwapProviderListModal from '$lib/components/swap/SwapProviderListModal.svelte';
 	import SwapTokenWizard from '$lib/components/swap/SwapTokenWizard.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
 	import ModalNetworksFilter from '$lib/components/tokens/ModalNetworksFilter.svelte';
 	import { SUPPORTED_CROSS_SWAP_NETWORKS } from '$lib/constants/swap.constants';
+	import { crossChainSwapNetworksMainnets } from '$lib/derived/cross-chain-networks.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
+	import { allSwapUniverseTokens } from '$lib/derived/swap.derived';
 	import type { ProgressStepsSwap } from '$lib/enums/progress-steps';
 	import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 	import {
@@ -28,6 +31,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { SwapMappedResult, SwapSelectTokenType } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
+	import { networksWithSupport } from '$lib/utils/swap-tokens-filter.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	interface Props {
@@ -60,8 +64,13 @@
 		onClose
 	}: Props = $props();
 
-	const { setSourceToken, setDestinationToken, sourceToken, destinationToken } =
-		getContext<SwapContext>(SWAP_CONTEXT_KEY);
+	const {
+		setSourceToken,
+		setDestinationToken,
+		sourceToken,
+		destinationToken,
+		receiveSupportedData
+	} = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const { setFilterNetwork, setFilterQuery } = getContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY
@@ -129,6 +138,29 @@
 		}, undefined);
 	};
 
+	const computeDestinationAllowedIds = (source: Token): NetworkId[] | undefined => {
+		const baseAllowedIds = SUPPORTED_CROSS_SWAP_NETWORKS[source.network.id];
+
+		const supportedData = get(receiveSupportedData);
+		if (isNullish(supportedData)) {
+			return baseAllowedIds;
+		}
+
+		const reachableIds = networksWithSupport({
+			networks: get(crossChainSwapNetworksMainnets),
+			tokens: get(allSwapUniverseTokens),
+			supportedData
+		});
+
+		const reachableSet = new Set(reachableIds);
+
+		if (isNullish(baseAllowedIds)) {
+			return reachableIds;
+		}
+
+		return baseAllowedIds.filter((id) => reachableSet.has(id));
+	};
+
 	const applyListConstraints = (side: TokenSide) => {
 		// SOURCE list: user can browse all networks (but keep current network preselected if any)
 		if (side === 'source') {
@@ -149,8 +181,9 @@
 			return;
 		}
 
-		// source selected (constraints apply)
-		const allowedIds = SUPPORTED_CROSS_SWAP_NETWORKS[$sourceToken.network.id];
+		// source selected: intersect the static cross-swap pre-filter with networks
+		// that have at least one reachable destination via the providers supporting the source.
+		const allowedIds = computeDestinationAllowedIds($sourceToken);
 
 		setNetworksMode({ enabled: false, allowedIds });
 
@@ -181,30 +214,11 @@
 		selectTokenType = undefined;
 	};
 
-	const isDestinationCompatibleWithSource = ({
-		source,
-		destination
-	}: {
-		source: Token;
-		destination: Token;
-	}): boolean => {
-		const allowed = SUPPORTED_CROSS_SWAP_NETWORKS[source.network.id];
-
-		return isNullish(allowed) ? true : allowed.includes(destination.network.id);
-	};
-
 	const selectToken = (token: Token) => {
 		if (selectTokenType === 'source') {
 			setSourceToken(token);
 
 			setFilterNetwork(token.network);
-
-			if (
-				nonNullish($destinationToken) &&
-				!isDestinationCompatibleWithSource({ source: token, destination: $destinationToken })
-			) {
-				setDestinationToken(undefined);
-			}
 		} else if (selectTokenType === 'destination') {
 			setDestinationToken(token);
 

--- a/src/frontend/src/lib/components/swap/SwapTokensList.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokensList.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
-	import { ONESEC_EVM_NETWORK_IDS } from '$lib/constants/swap.constants';
-	import { allCrossChainSwapTokens, allSortedIcrcTokens } from '$lib/derived/all-tokens.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { networks } from '$lib/derived/networks.derived';
 	import { stakeBalances } from '$lib/derived/stake.derived';
+	import { allSwapUniverseTokens } from '$lib/derived/swap.derived';
 	import { tokensToPin } from '$lib/derived/tokens.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -23,7 +20,6 @@
 	import type { Token } from '$lib/types/token';
 	import type { TokenToggleable } from '$lib/types/token-toggleable';
 	import type { TokenUi } from '$lib/types/token-ui';
-	import { oneSecCompatibleDestinations } from '$lib/utils/onesec-swap.utils';
 	import { filterSwapTokens } from '$lib/utils/swap-tokens-filter.utils';
 	import { mapTokenUi } from '$lib/utils/token.utils';
 	import { sortTokens } from '$lib/utils/tokens.utils';
@@ -37,28 +33,22 @@
 
 	let { side, onSelectToken, onSelectNetworkFilter, onCloseTokensList }: Props = $props();
 
-	const { sourceToken, destinationToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
+	const { sourceToken, destinationToken, receiveSupportedData } =
+		getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
-	let compatibleTokenIds = $derived(
-		side === 'destination' && nonNullish($sourceToken)
-			? oneSecCompatibleDestinations({
-					sourceToken: $sourceToken,
-					networkIds: ONESEC_EVM_NETWORK_IDS
-				})
-			: undefined
+	// On the destination side use the per-source receive data (when available); on the source
+	// side fall back to the aggregated source-side data. Both come from the same provider state,
+	// just shaped differently.
+	let supportedData = $derived(
+		side === 'destination' ? $receiveSupportedData : $swapSupportedTokensStore?.aggregated
 	);
 
 	let allSwapTokens: TokenToggleable<Token>[] = $derived(
 		filterSwapTokens({
-			tokens: [
-				{ ...ICP_TOKEN, enabled: true },
-				...$allSortedIcrcTokens,
-				...$allCrossChainSwapTokens
-			],
-			supportedData: $swapSupportedTokensStore?.aggregated,
-			compatibleTokenIds
+			tokens: $allSwapUniverseTokens,
+			supportedData
 		})
 	);
 

--- a/src/frontend/src/lib/derived/swap.derived.ts
+++ b/src/frontend/src/lib/derived/swap.derived.ts
@@ -2,6 +2,7 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { ZERO } from '$lib/constants/app.constants';
 import {
 	allCrossChainSwapTokens,
+	allSortedIcrcTokens,
 	allSwapCompatibleIcrcTokens
 } from '$lib/derived/all-tokens.derived';
 import { pageToken } from '$lib/derived/page-token.derived';
@@ -9,6 +10,7 @@ import { balancesStore } from '$lib/stores/balances.store';
 import { swapSupportedTokensStore } from '$lib/stores/swap-supported-tokens.store';
 import type { Balance } from '$lib/types/balance';
 import type { Token } from '$lib/types/token';
+import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { filterSwapTokens } from '$lib/utils/swap-tokens-filter.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
@@ -17,6 +19,20 @@ export interface SwappableTokens {
 	sourceToken: Token | undefined;
 	destinationToken: Token | undefined;
 }
+
+/**
+ * The unfiltered universe of tokens that can appear in either side of the swap UI:
+ * ICP + all known ICRC tokens + all cross-chain (EVM/SOL) tokens. Provider-supported
+ * filtering is applied on top via `filterSwapTokens`.
+ */
+export const allSwapUniverseTokens: Readable<TokenToggleable<Token>[]> = derived(
+	[allSortedIcrcTokens, allCrossChainSwapTokens],
+	([$allSortedIcrcTokens, $allCrossChainSwapTokens]) => [
+		{ ...ICP_TOKEN, enabled: true },
+		...$allSortedIcrcTokens,
+		...$allCrossChainSwapTokens
+	]
+);
 
 const selectedSwappableToken: Readable<Token | undefined> = derived(
 	[pageToken, allSwapCompatibleIcrcTokens, allCrossChainSwapTokens],

--- a/src/frontend/src/lib/stores/swap.store.ts
+++ b/src/frontend/src/lib/stores/swap.store.ts
@@ -3,8 +3,13 @@ import { isIcToken } from '$icp/validation/ic-token.validation';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { swappableTokens } from '$lib/derived/swap.derived';
 import { balancesStore } from '$lib/stores/balances.store';
+import {
+	swapSupportedTokensStore,
+	type SwapSupportedTokensData
+} from '$lib/stores/swap-supported-tokens.store';
 import type { Balance } from '$lib/types/balance';
 import type { Token } from '$lib/types/token';
+import { computeReceiveSupportedTokens } from '$lib/utils/swap-tokens-filter.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { derived, get, writable, type Readable, type Writable } from 'svelte/store';
 
@@ -83,6 +88,20 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 		}
 	);
 
+	// Aggregated per-provider directed destinations reachable from the current source.
+	// Shared by the destination token list, the destination network filter, and the
+	// auto-clear effect, so the per-source aggregation runs once per (source, providers) change.
+	const receiveSupportedData = derived(
+		[sourceToken, swapSupportedTokensStore],
+		([$sourceToken, $swapSupportedTokensStore]) =>
+			nonNullish($sourceToken) && nonNullish($swapSupportedTokensStore)
+				? computeReceiveSupportedTokens({
+						sourceToken: $sourceToken,
+						providers: $swapSupportedTokensStore.providers
+					})
+				: undefined
+	);
+
 	return {
 		sourceToken,
 		destinationToken,
@@ -92,6 +111,7 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 		destinationTokenExchangeRate,
 		isSourceTokenIcrc2,
 		isSourceTokenPermitSupported,
+		receiveSupportedData,
 		failedSwapError: writable<SwapError | undefined>(undefined),
 		setSourceToken: (token: Token) =>
 			update((state) => ({
@@ -155,6 +175,7 @@ export interface SwapContext {
 	destinationTokenExchangeRate: Readable<number | undefined>;
 	isSourceTokenIcrc2: Readable<boolean | undefined>;
 	isSourceTokenPermitSupported: Readable<boolean | undefined>;
+	receiveSupportedData: Readable<SwapSupportedTokensData | undefined>;
 	failedSwapError: Writable<SwapError | undefined>;
 	setIsTokensIcrc2: (args: { ledgerCanisterId: string; isIcrc2Supported: boolean }) => void;
 	setIsTokenPermitSupported: ({

--- a/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
+++ b/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
@@ -3,9 +3,12 @@ import { isTokenEthereumNative } from '$eth/utils/token.utils';
 import { isIcToken } from '$icp/validation/ic-token.validation';
 import type {
 	SwapProviderListCoverage,
+	SwapProviderSupport,
 	SwapSupportedTokensData,
 	SwapSupportedTokensInfo
 } from '$lib/stores/swap-supported-tokens.store';
+import type { Network, NetworkId } from '$lib/types/network';
+import type { SwapProvider, SwapTokenCategory } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import { isTokenSpl } from '$sol/utils/spl.utils';
@@ -26,6 +29,12 @@ export const determineCoverage = ({
 	return withList >= totalEnabled ? 'all' : 'some';
 };
 
+interface SwapTokenLookup {
+	info: SwapSupportedTokensInfo | undefined;
+	identifier: string;
+	category: SwapTokenCategory;
+}
+
 /**
  * Resolves the provider-group info and the token identifier used for matching
  * against provider supported-token sets.
@@ -38,19 +47,21 @@ export const resolveSwapTokenLookup = ({
 }: {
 	token: Token;
 	supportedData?: SwapSupportedTokensData;
-}):
-	| {
-			info: SwapSupportedTokensInfo | undefined;
-			identifier: string;
-			category: 'icp' | 'evm' | 'sol';
-	  }
-	| undefined => {
+}): SwapTokenLookup | undefined => {
 	if (isIcToken(token)) {
-		return { info: supportedData?.icp, identifier: token.ledgerCanisterId, category: 'icp' };
+		return {
+			info: supportedData?.icp,
+			identifier: token.ledgerCanisterId,
+			category: 'icp'
+		};
 	}
 
 	if (isTokenErcFungible(token)) {
-		return { info: supportedData?.evm, identifier: token.address.toLowerCase(), category: 'evm' };
+		return {
+			info: supportedData?.evm,
+			identifier: token.address.toLowerCase(),
+			category: 'evm'
+		};
 	}
 
 	if (isTokenSpl(token)) {
@@ -58,11 +69,19 @@ export const resolveSwapTokenLookup = ({
 	}
 
 	if (isTokenEthereumNative(token)) {
-		return { info: supportedData?.evm, identifier: token.symbol.toLowerCase(), category: 'evm' };
+		return {
+			info: supportedData?.evm,
+			identifier: token.symbol.toLowerCase(),
+			category: 'evm'
+		};
 	}
 
 	if (isTokenSolanaNative(token)) {
-		return { info: supportedData?.sol, identifier: token.symbol.toLowerCase(), category: 'sol' };
+		return {
+			info: supportedData?.sol,
+			identifier: token.symbol.toLowerCase(),
+			category: 'sol'
+		};
 	}
 };
 
@@ -78,19 +97,13 @@ export const resolveSwapTokenLookup = ({
  * - S  = union of supported tokens across providers that expose a list
  * - A  = active (enabled) tokens
  * - I  = inactive (disabled) tokens
- *
- * The optional `compatibleTokenIds` parameter narrows destinations on a per-category basis.
- * Only categories present in the map are filtered; others pass through unchanged.
- * This lets cross-chain providers restrict EVM destinations without hiding same-chain ICP tokens.
  */
 export const filterSwapTokens = <T extends Token>({
 	tokens,
-	supportedData,
-	compatibleTokenIds
+	supportedData
 }: {
 	tokens: TokenToggleable<T>[];
 	supportedData: SwapSupportedTokensData | undefined;
-	compatibleTokenIds?: Partial<Record<'icp' | 'evm' | 'sol', Set<string>>>;
 }): TokenToggleable<T>[] => {
 	if (isNullish(supportedData)) {
 		return tokens;
@@ -99,36 +112,122 @@ export const filterSwapTokens = <T extends Token>({
 	return tokens.filter((token) => {
 		const lookup = resolveSwapTokenLookup({ token, supportedData });
 
-		if (isNullish(lookup)) {
+		if (isNullish(lookup) || isNullish(lookup.info)) {
 			return token.enabled;
 		}
 
-		const { info, identifier, category } = lookup;
-
-		if (isNullish(info)) {
-			return token.enabled;
-		}
-
+		const { info } = lookup;
 		const { coverage, supportedTokenIds } = info;
 
 		if (coverage === 'none') {
 			return token.enabled;
 		}
 
-		const isSupported = supportedTokenIds.has(identifier);
-		const passesCoverage = coverage === 'all' ? isSupported : token.enabled || isSupported;
+		const isSupported = supportedTokenIds.has(lookup.identifier);
+		return coverage === 'all' ? isSupported : token.enabled || isSupported;
+	});
+};
 
-		if (!passesCoverage) {
-			return false;
-		}
+interface CategoryAccum {
+	total: number;
+	withList: number;
+	ids: Set<string>;
+}
 
-		if (nonNullish(compatibleTokenIds)) {
-			const categoryFilter = compatibleTokenIds[category];
-			if (nonNullish(categoryFilter)) {
-				return categoryFilter.has(identifier);
+// A category with no supporting provider for the source is returned as coverage='all' with an
+// empty supported set, so filterSwapTokens rejects every token in this category (intersection
+// is empty). Each blocked category gets a fresh Set to avoid sharing mutable state.
+const toInfo = ({ total, withList, ids }: CategoryAccum): SwapSupportedTokensInfo =>
+	total === 0
+		? { coverage: 'all', supportedTokenIds: new Set() }
+		: {
+				coverage: determineCoverage({ totalEnabled: total, withList }),
+				supportedTokenIds: ids
+			};
+
+/**
+ * Aggregates per-provider directed-pair destinations for a given source token,
+ * producing data with the same shape as the pay-side `SwapSupportedTokensData`.
+ *
+ * Each provider's `getSupportedDestinations` returns:
+ * - `undefined`: provider does not support the source → skip.
+ * - `{}` (empty map): provider supports the source as a wildcard contributor with
+ *   no explicit destination list. Bumps the source category's `total` count only,
+ *   so the category falls back to coverage='some' / 'none' rules.
+ * - `{ icp: Set, evm: Set, ... }`: explicit destinations per category. Each populated
+ *   category bumps both `total` and `withList` and unions its IDs.
+ *
+ * A category with `total === 0` (no provider supports the source there) is returned
+ * as coverage='all' + empty supported set, which causes `filterSwapTokens` to drop
+ * every token of that category — preserving the directed-pair semantics.
+ */
+export const computeReceiveSupportedTokens = ({
+	sourceToken,
+	providers
+}: {
+	sourceToken: Token;
+	providers: SwapProviderSupport[];
+}): SwapSupportedTokensData => {
+	const accum: Record<SwapTokenCategory, CategoryAccum> = {
+		icp: { total: 0, withList: 0, ids: new Set() },
+		evm: { total: 0, withList: 0, ids: new Set() },
+		sol: { total: 0, withList: 0, ids: new Set() }
+	};
+
+	const findProviderSourceTokens = ({
+		key,
+		category
+	}: {
+		key: SwapProvider;
+		category: SwapTokenCategory;
+	}): Set<string> | undefined =>
+		providers.find((p) => p.key === key && p.sourceCategory === category)?.supportedSourceTokens;
+
+	for (const provider of providers) {
+		const dests = provider.getSupportedDestinations({
+			sourceToken,
+			supportedSourceTokens: provider.supportedSourceTokens,
+			findProviderSourceTokens
+		});
+
+		if (nonNullish(dests)) {
+			const entries = Object.entries(dests) as [SwapTokenCategory, Set<string>][];
+
+			if (entries.length === 0) {
+				accum[provider.sourceCategory].total++;
+			} else {
+				for (const [category, ids] of entries) {
+					accum[category].total++;
+					accum[category].withList++;
+					ids.forEach((id) => accum[category].ids.add(id));
+				}
 			}
 		}
+	}
 
-		return true;
-	});
+	return {
+		icp: toInfo(accum.icp),
+		evm: toInfo(accum.evm),
+		sol: toInfo(accum.sol)
+	};
+};
+
+/**
+ * Returns the subset of `networks` that have at least one token in `tokens`
+ * passing `filterSwapTokens` against `supportedData`.
+ */
+export const networksWithSupport = ({
+	networks,
+	tokens,
+	supportedData
+}: {
+	networks: Network[];
+	tokens: TokenToggleable<Token>[];
+	supportedData: SwapSupportedTokensData;
+}): NetworkId[] => {
+	const passingNetworkIds = new Set(
+		filterSwapTokens({ tokens, supportedData }).map((t) => t.network.id)
+	);
+
+	return networks.filter(({ id }) => passingNetworkIds.has(id)).map(({ id }) => id);
 };

--- a/src/frontend/src/tests/lib/components/swap/SwapContexts.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapContexts.spec.ts
@@ -10,8 +10,12 @@ import {
 } from '$lib/stores/modal-networks-list.store';
 import { MODAL_TOKENS_LIST_CONTEXT_KEY } from '$lib/stores/modal-tokens-list.store';
 import { SWAP_AMOUNTS_CONTEXT_KEY } from '$lib/stores/swap-amounts.store';
+import { swapSupportedTokensStore } from '$lib/stores/swap-supported-tokens.store';
 import * as swapStoreModule from '$lib/stores/swap.store';
 import { initSwapContext, SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
+import { SwapProvider } from '$lib/types/swap';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidIcrcToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockSnippet, mockSnippetTestId } from '$tests/mocks/snippet.mock';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { render } from '@testing-library/svelte';
@@ -173,6 +177,94 @@ describe('SwapContexts', () => {
 			const updatedNetworks = get(networksListContext.filteredNetworks);
 
 			expect(updatedNetworks).toEqual([ICP_NETWORK]);
+		});
+	});
+
+	describe('auto-clear destination when source changes', () => {
+		afterEach(() => {
+			swapSupportedTokensStore.reset();
+		});
+
+		const otherIcrcLedger = 'uf2wh-taaaa-aaaaq-aabna-cai';
+
+		const setProvidersOnlySupporting = (icpLedgerId: string) => {
+			swapSupportedTokensStore.set({
+				aggregated: {
+					icp: { coverage: 'all', supportedTokenIds: new Set([icpLedgerId]) },
+					evm: { coverage: 'none', supportedTokenIds: new Set() },
+					sol: { coverage: 'none', supportedTokenIds: new Set() }
+				},
+				providers: [
+					{
+						key: SwapProvider.KONG_SWAP,
+						sourceCategory: 'icp',
+						supportedSourceTokens: new Set([icpLedgerId]),
+						getSupportedDestinations: ({ sourceToken, supportedSourceTokens }) =>
+							supportedSourceTokens?.has((sourceToken as typeof mockValidIcToken).ledgerCanisterId)
+								? { icp: supportedSourceTokens }
+								: undefined
+					}
+				]
+			});
+		};
+
+		it('clears destination when it falls outside the new receive support', async () => {
+			render(SwapContexts, { children: mockSnippet });
+
+			const unreachableDest = { ...mockValidIcrcToken, ledgerCanisterId: otherIcrcLedger };
+			swapContext.setSourceToken(mockValidIcToken);
+			swapContext.setDestinationToken(unreachableDest);
+
+			// Provider only supports the source going to itself; the destination is not reachable.
+			setProvidersOnlySupporting(mockValidIcToken.ledgerCanisterId);
+			await tick();
+
+			expect(get(swapContext.destinationToken)).toBeUndefined();
+		});
+
+		it('keeps destination when it remains reachable', async () => {
+			render(SwapContexts, { children: mockSnippet });
+
+			const reachableDest = { ...mockValidIcrcToken, ledgerCanisterId: otherIcrcLedger };
+			swapContext.setSourceToken(mockValidIcToken);
+			swapContext.setDestinationToken(reachableDest);
+
+			swapSupportedTokensStore.set({
+				aggregated: {
+					icp: {
+						coverage: 'all',
+						supportedTokenIds: new Set([mockValidIcToken.ledgerCanisterId, otherIcrcLedger])
+					},
+					evm: { coverage: 'none', supportedTokenIds: new Set() },
+					sol: { coverage: 'none', supportedTokenIds: new Set() }
+				},
+				providers: [
+					{
+						key: SwapProvider.KONG_SWAP,
+						sourceCategory: 'icp',
+						supportedSourceTokens: new Set([mockValidIcToken.ledgerCanisterId, otherIcrcLedger]),
+						getSupportedDestinations: ({ sourceToken, supportedSourceTokens }) =>
+							supportedSourceTokens?.has((sourceToken as typeof mockValidIcToken).ledgerCanisterId)
+								? { icp: supportedSourceTokens }
+								: undefined
+					}
+				]
+			});
+			await tick();
+
+			expect(get(swapContext.destinationToken)).toEqual(reachableDest);
+		});
+
+		it('does nothing when source is unset', async () => {
+			render(SwapContexts, { children: mockSnippet });
+
+			const dest = mockValidErc20Token;
+			swapContext.setDestinationToken(dest);
+
+			setProvidersOnlySupporting(mockValidIcToken.ledgerCanisterId);
+			await tick();
+
+			expect(get(swapContext.destinationToken)).toEqual(dest);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/swap/SwapTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapTokensList.spec.ts
@@ -1,26 +1,20 @@
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
-import { ONESEC_EVM_NETWORK_IDS } from '$lib/constants/swap.constants';
 import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
 import {
 	initModalTokensListContext,
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
+import {
+	swapSupportedTokensStore,
+	type SwapSupportedTokensData
+} from '$lib/stores/swap-supported-tokens.store';
 import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
+import { SwapProvider } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
-import * as oneSecSwapUtils from '$lib/utils/onesec-swap.utils';
-import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
-
-vi.mock('$lib/utils/onesec-swap.utils', async (importOriginal) => {
-	const actual = await importOriginal();
-	return {
-		...(actual as Record<string, unknown>),
-		oneSecCompatibleDestinations: vi.fn()
-	};
-});
 
 describe('SwapTokensList', () => {
 	const props = {
@@ -31,13 +25,20 @@ describe('SwapTokensList', () => {
 
 	const destinationProps = { ...props, side: 'destination' as const };
 
-	const mockContext = (sourceToken?: Token) => {
+	const mockContext = ({
+		sourceToken,
+		receiveSupportedData
+	}: {
+		sourceToken?: Token;
+		receiveSupportedData?: SwapSupportedTokensData;
+	} = {}) => {
 		const result = new Map();
 
 		result.set(SWAP_CONTEXT_KEY, {
 			sourceToken: readable(sourceToken),
 			destinationToken: readable(mockValidIcCkToken),
-			destinationTokenExchangeRate: readable(0.00002)
+			destinationTokenExchangeRate: readable(0.00002),
+			receiveSupportedData: readable(receiveSupportedData)
 		});
 
 		result.set(MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [ICP_TOKEN] }));
@@ -46,7 +47,7 @@ describe('SwapTokensList', () => {
 	};
 
 	beforeEach(() => {
-		vi.clearAllMocks();
+		swapSupportedTokensStore.reset();
 	});
 
 	it('renders tokens list', () => {
@@ -58,36 +59,44 @@ describe('SwapTokensList', () => {
 		expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
 	});
 
-	it('does not call oneSecCompatibleDestinations when sourceToken is nullish', () => {
-		render(SwapTokensList, { props: destinationProps, context: mockContext() });
-
-		expect(oneSecSwapUtils.oneSecCompatibleDestinations).not.toHaveBeenCalled();
-	});
-
-	it('does not call oneSecCompatibleDestinations when side is source', () => {
-		render(SwapTokensList, {
-			props: { ...props, side: 'source' },
-			context: mockContext(mockValidIcToken)
+	it('renders tokens list on the destination side without a source', () => {
+		const { getByTestId } = render(SwapTokensList, {
+			props: destinationProps,
+			context: mockContext()
 		});
 
-		expect(oneSecSwapUtils.oneSecCompatibleDestinations).not.toHaveBeenCalled();
+		expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
 	});
 
-	it('calls oneSecCompatibleDestinations with ICP sourceToken and ONESEC_EVM_NETWORK_IDS', () => {
-		render(SwapTokensList, { props: destinationProps, context: mockContext(mockValidIcToken) });
-
-		expect(oneSecSwapUtils.oneSecCompatibleDestinations).toHaveBeenCalledWith({
-			sourceToken: mockValidIcToken,
-			networkIds: ONESEC_EVM_NETWORK_IDS
+	it('renders tokens list on the destination side with receive supported data', () => {
+		swapSupportedTokensStore.set({
+			aggregated: {
+				icp: { coverage: 'all', supportedTokenIds: new Set() },
+				evm: { coverage: 'none', supportedTokenIds: new Set() },
+				sol: { coverage: 'none', supportedTokenIds: new Set() }
+			},
+			providers: [
+				{
+					key: SwapProvider.ONE_SEC,
+					sourceCategory: 'icp',
+					supportedSourceTokens: new Set([mockValidIcToken.ledgerCanisterId]),
+					getSupportedDestinations: () => undefined
+				}
+			]
 		});
-	});
 
-	it('calls oneSecCompatibleDestinations with EVM sourceToken and ONESEC_EVM_NETWORK_IDS', () => {
-		render(SwapTokensList, { props: destinationProps, context: mockContext(mockValidErc20Token) });
-
-		expect(oneSecSwapUtils.oneSecCompatibleDestinations).toHaveBeenCalledWith({
-			sourceToken: mockValidErc20Token,
-			networkIds: ONESEC_EVM_NETWORK_IDS
+		const { getByTestId } = render(SwapTokensList, {
+			props: destinationProps,
+			context: mockContext({
+				sourceToken: mockValidIcToken,
+				receiveSupportedData: {
+					icp: { coverage: 'all', supportedTokenIds: new Set() },
+					evm: { coverage: 'all', supportedTokenIds: new Set() },
+					sol: { coverage: 'all', supportedTokenIds: new Set() }
+				}
+			})
 		});
+
+		expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/stores/swap.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap.store.spec.ts
@@ -414,4 +414,58 @@ describe('swapStore', () => {
 			expect(get(isSourceTokenPermitSupported)).toBeUndefined();
 		});
 	});
+
+	describe('receiveSupportedData', () => {
+		it('returns undefined when source is unset', () => {
+			const { receiveSupportedData } = initSwapContext();
+
+			expect(get(receiveSupportedData)).toBeUndefined();
+		});
+
+		it('returns undefined when supported tokens store is empty', async () => {
+			const { swapSupportedTokensStore } = await import('$lib/stores/swap-supported-tokens.store');
+			swapSupportedTokensStore.reset();
+
+			const { receiveSupportedData } = initSwapContext({ sourceToken: mockToken1 });
+
+			expect(get(receiveSupportedData)).toBeUndefined();
+		});
+
+		it('aggregates per-provider destinations for the current source', async () => {
+			const { SwapProvider } = await import('$lib/types/swap');
+			const { swapSupportedTokensStore } = await import('$lib/stores/swap-supported-tokens.store');
+
+			const ckBtcLedger = mockToken1.ledgerCanisterId;
+			const supportedSet = new Set([ckBtcLedger]);
+
+			swapSupportedTokensStore.set({
+				aggregated: {
+					icp: { coverage: 'all', supportedTokenIds: supportedSet },
+					evm: { coverage: 'none', supportedTokenIds: new Set() },
+					sol: { coverage: 'none', supportedTokenIds: new Set() }
+				},
+				providers: [
+					{
+						key: SwapProvider.KONG_SWAP,
+						sourceCategory: 'icp',
+						supportedSourceTokens: supportedSet,
+						getSupportedDestinations: ({ supportedSourceTokens }) => ({
+							icp: supportedSourceTokens ?? new Set()
+						})
+					}
+				]
+			});
+
+			const { receiveSupportedData } = initSwapContext({ sourceToken: mockToken1 });
+			const data = get(receiveSupportedData);
+
+			expect(data?.icp.coverage).toBe('all');
+			expect(data?.icp.supportedTokenIds).toEqual(supportedSet);
+			// EVM/SOL have no supporting provider for this source → blocked.
+			expect(data?.evm).toEqual({ coverage: 'all', supportedTokenIds: new Set() });
+			expect(data?.sol).toEqual({ coverage: 'all', supportedTokenIds: new Set() });
+
+			swapSupportedTokensStore.reset();
+		});
+	});
 });

--- a/src/frontend/src/tests/lib/utils/swap-tokens-filter.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap-tokens-filter.utils.spec.ts
@@ -1,8 +1,16 @@
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
-import type { SwapSupportedTokensData } from '$lib/stores/swap-supported-tokens.store';
+import type {
+	SwapProviderSupport,
+	SwapSupportedTokensData
+} from '$lib/stores/swap-supported-tokens.store';
+import { SwapProvider } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
-import { filterSwapTokens } from '$lib/utils/swap-tokens-filter.utils';
+import { buildNearIntentsSupportedDestinations } from '$lib/utils/near-intents-swap.utils';
+import {
+	computeReceiveSupportedTokens,
+	filterSwapTokens
+} from '$lib/utils/swap-tokens-filter.utils';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
 import { mockValidIcToken, mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
@@ -290,121 +298,277 @@ describe('filterSwapTokens', () => {
 			expect(result).not.toContain(btcInactive);
 		});
 	});
+});
 
-	describe('compatibleTokenIds', () => {
-		const supportedData: SwapSupportedTokensData = {
-			icp: {
-				coverage: 'all',
-				supportedTokenIds: new Set([
-					icpTokenActive.ledgerCanisterId,
-					icpTokenInactive.ledgerCanisterId
-				])
+describe('computeReceiveSupportedTokens', () => {
+	const icpSourceToken = mockValidIcToken;
+	const icpSourceId = icpSourceToken.ledgerCanisterId;
+	const icpOtherTokenId = 'uf2wh-taaaa-aaaaq-aabna-cai';
+
+	const evmSourceToken = mockValidErc20Token;
+	const evmSourceId = evmSourceToken.address.toLowerCase();
+	const evmOtherTokenId = '0xotherevm';
+
+	it('returns BLOCKED categories when no provider supports the source', () => {
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.KONG_SWAP,
+				sourceCategory: 'icp',
+				supportedSourceTokens: new Set(),
+				getSupportedDestinations: () => undefined
+			}
+		];
+
+		const data = computeReceiveSupportedTokens({ sourceToken: icpSourceToken, providers });
+
+		expect(data.icp).toEqual({ coverage: 'all', supportedTokenIds: new Set() });
+		expect(data.evm).toEqual({ coverage: 'all', supportedTokenIds: new Set() });
+		expect(data.sol).toEqual({ coverage: 'all', supportedTokenIds: new Set() });
+	});
+
+	it('symmetric ICP provider returns its supported set as ICP destinations', () => {
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.KONG_SWAP,
+				sourceCategory: 'icp',
+				supportedSourceTokens: new Set([icpSourceId, icpOtherTokenId]),
+				getSupportedDestinations: ({ sourceToken, supportedSourceTokens }) =>
+					supportedSourceTokens?.has((sourceToken as typeof icpSourceToken).ledgerCanisterId)
+						? { icp: supportedSourceTokens }
+						: undefined
+			}
+		];
+
+		const data = computeReceiveSupportedTokens({ sourceToken: icpSourceToken, providers });
+
+		expect(data.icp.coverage).toBe('all');
+		expect(data.icp.supportedTokenIds).toEqual(new Set([icpSourceId, icpOtherTokenId]));
+		expect(data.evm.coverage).toBe('all');
+		expect(data.evm.supportedTokenIds.size).toBe(0);
+	});
+
+	it('OneSec ICP→EVM returns explicit EVM destinations from a directed pair', () => {
+		const oneSecEvmAddresses = new Set([evmSourceId]);
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.ONE_SEC,
+				sourceCategory: 'icp',
+				supportedSourceTokens: new Set([icpSourceId]),
+				getSupportedDestinations: () => ({ evm: oneSecEvmAddresses })
+			}
+		];
+
+		const data = computeReceiveSupportedTokens({ sourceToken: icpSourceToken, providers });
+
+		expect(data.evm.coverage).toBe('all');
+		expect(data.evm.supportedTokenIds).toEqual(oneSecEvmAddresses);
+		// no ICP supporter → blocked
+		expect(data.icp).toEqual({ coverage: 'all', supportedTokenIds: new Set() });
+	});
+
+	it('mixes symmetric ICP supporters with OneSec EVM destinations', () => {
+		const kongSet = new Set([icpSourceId, icpOtherTokenId]);
+		const oneSecEvm = new Set(['0xceth', '0xcusdc']);
+
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.KONG_SWAP,
+				sourceCategory: 'icp',
+				supportedSourceTokens: kongSet,
+				getSupportedDestinations: ({ sourceToken, supportedSourceTokens }) =>
+					supportedSourceTokens?.has((sourceToken as typeof icpSourceToken).ledgerCanisterId)
+						? { icp: supportedSourceTokens }
+						: undefined
 			},
-			evm: {
-				coverage: 'all',
-				supportedTokenIds: new Set([
-					erc20Active.address.toLowerCase(),
-					erc20Inactive.address.toLowerCase()
-				])
+			{
+				key: SwapProvider.ICP_SWAP,
+				sourceCategory: 'icp',
+				supportedSourceTokens: new Set([icpSourceId]),
+				getSupportedDestinations: ({ sourceToken, supportedSourceTokens }) =>
+					supportedSourceTokens?.has((sourceToken as typeof icpSourceToken).ledgerCanisterId)
+						? { icp: supportedSourceTokens }
+						: undefined
 			},
-			sol: { coverage: 'all', supportedTokenIds: new Set([splActive.address]) }
+			{
+				key: SwapProvider.ONE_SEC,
+				sourceCategory: 'icp',
+				supportedSourceTokens: new Set([icpSourceId]),
+				getSupportedDestinations: () => ({ evm: oneSecEvm })
+			}
+		];
+
+		const data = computeReceiveSupportedTokens({ sourceToken: icpSourceToken, providers });
+
+		expect(data.icp.coverage).toBe('all');
+		expect(data.icp.supportedTokenIds).toEqual(new Set([icpSourceId, icpOtherTokenId]));
+		expect(data.evm.coverage).toBe('all');
+		expect(data.evm.supportedTokenIds).toEqual(oneSecEvm);
+	});
+
+	it('Velora-style wildcard EVM provider yields coverage=none on EVM (enabled tokens pass)', () => {
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.VELORA,
+				sourceCategory: 'evm',
+				supportedSourceTokens: undefined,
+				getSupportedDestinations: () => ({})
+			}
+		];
+
+		const data = computeReceiveSupportedTokens({ sourceToken: evmSourceToken, providers });
+
+		expect(data.evm.coverage).toBe('none');
+		expect(data.evm.supportedTokenIds.size).toBe(0);
+
+		// filterSwapTokens with coverage=none lets enabled tokens through
+		const enabledToken = { ...evmSourceToken, enabled: true };
+		const result = filterSwapTokens({ tokens: [enabledToken], supportedData: data });
+
+		expect(result).toHaveLength(1);
+	});
+
+	it('OneSec EVM→ICP narrows ICP destinations to a single canister', () => {
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.VELORA,
+				sourceCategory: 'evm',
+				supportedSourceTokens: undefined,
+				getSupportedDestinations: () => ({})
+			},
+			{
+				key: SwapProvider.ONE_SEC,
+				sourceCategory: 'evm',
+				supportedSourceTokens: new Set([evmSourceId]),
+				getSupportedDestinations: () => ({ icp: new Set([icpSourceId]) })
+			}
+		];
+
+		const data = computeReceiveSupportedTokens({ sourceToken: evmSourceToken, providers });
+
+		expect(data.icp.coverage).toBe('all');
+		expect(data.icp.supportedTokenIds).toEqual(new Set([icpSourceId]));
+
+		// EVM: Velora wildcard → coverage=none
+		expect(data.evm.coverage).toBe('none');
+
+		// Confirm: a different ICP token is filtered out as a destination
+		const otherIcpToken = {
+			...mockValidIcrcToken,
+			ledgerCanisterId: icpOtherTokenId,
+			enabled: true
 		};
-
-		it('includes token when it passes the category filter', () => {
-			const result = filterSwapTokens({
-				tokens: [erc20Active],
-				supportedData,
-				compatibleTokenIds: { evm: new Set([erc20Active.address.toLowerCase()]) }
-			});
-
-			expect(result).toContain(erc20Active);
+		const result = filterSwapTokens({
+			tokens: [otherIcpToken],
+			supportedData: data
 		});
 
-		it('excludes token when it does not pass the category filter', () => {
-			const result = filterSwapTokens({
-				tokens: [erc20Inactive],
-				supportedData,
-				compatibleTokenIds: { evm: new Set([erc20Active.address.toLowerCase()]) }
-			});
+		expect(result).toHaveLength(0);
+	});
 
-			expect(result).not.toContain(erc20Inactive);
-		});
+	it('falls back to coverage=some when at least one provider lists destinations and another is wildcard', () => {
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.VELORA,
+				sourceCategory: 'evm',
+				supportedSourceTokens: undefined,
+				getSupportedDestinations: () => ({})
+			},
+			{
+				key: SwapProvider.NEAR_INTENTS,
+				sourceCategory: 'evm',
+				supportedSourceTokens: new Set([evmSourceId, evmOtherTokenId]),
+				getSupportedDestinations: ({ sourceToken, supportedSourceTokens }) =>
+					supportedSourceTokens?.has((sourceToken as typeof evmSourceToken).address.toLowerCase())
+						? { evm: supportedSourceTokens }
+						: undefined
+			}
+		];
 
-		it('does not restrict categories absent from the map', () => {
-			const result = filterSwapTokens({
-				tokens: [icpTokenActive, icpTokenInactive, erc20Active],
-				supportedData,
-				compatibleTokenIds: { evm: new Set([erc20Active.address.toLowerCase()]) }
-			});
+		const data = computeReceiveSupportedTokens({ sourceToken: evmSourceToken, providers });
 
-			// EVM filtered
-			expect(result).toContain(erc20Active);
-			// ICP not filtered — passes through on coverage rules
-			expect(result).toContain(icpTokenActive);
-			expect(result).toContain(icpTokenInactive);
-		});
+		expect(data.evm.coverage).toBe('some');
+		expect(data.evm.supportedTokenIds).toEqual(new Set([evmSourceId, evmOtherTokenId]));
+	});
 
-		it('filters out all tokens in a category when the filter set is empty', () => {
-			const result = filterSwapTokens({
-				tokens: [erc20Active, erc20Inactive],
-				supportedData,
-				compatibleTokenIds: { evm: new Set() }
-			});
+	it('NEAR Intents EVM source exposes both EVM and SOL destinations', () => {
+		const evmTokens = new Set([evmSourceId]);
+		const solTokens = new Set([mockValidSplToken.address]);
 
-			expect(result).not.toContain(erc20Active);
-			expect(result).not.toContain(erc20Inactive);
-		});
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.NEAR_INTENTS,
+				sourceCategory: 'evm',
+				supportedSourceTokens: evmTokens,
+				getSupportedDestinations: buildNearIntentsSupportedDestinations('evm')
+			},
+			{
+				key: SwapProvider.NEAR_INTENTS,
+				sourceCategory: 'sol',
+				supportedSourceTokens: solTokens,
+				getSupportedDestinations: buildNearIntentsSupportedDestinations('sol')
+			}
+		];
 
-		it('behaves like no filter when compatibleTokenIds is an empty map', () => {
-			const result = filterSwapTokens({
-				tokens: [icpTokenActive, icpTokenInactive, erc20Active],
-				supportedData,
-				compatibleTokenIds: {}
-			});
+		const data = computeReceiveSupportedTokens({ sourceToken: evmSourceToken, providers });
 
-			expect(result).toContain(icpTokenActive);
-			expect(result).toContain(icpTokenInactive);
-			expect(result).toContain(erc20Active);
-		});
+		expect(data.evm.coverage).toBe('all');
+		expect(data.evm.supportedTokenIds).toEqual(evmTokens);
+		expect(data.sol.coverage).toBe('all');
+		expect(data.sol.supportedTokenIds).toEqual(solTokens);
+	});
 
-		it('applies independent filters per category simultaneously', () => {
-			const result = filterSwapTokens({
-				tokens: [icpTokenActive, icpTokenInactive, erc20Active, erc20Inactive, splActive],
-				supportedData,
-				compatibleTokenIds: {
-					icp: new Set([icpTokenActive.ledgerCanisterId]),
-					evm: new Set([erc20Inactive.address.toLowerCase()])
-				}
-			});
+	it('NEAR Intents SOL source exposes both EVM and SOL destinations', () => {
+		const evmTokens = new Set([evmSourceId]);
+		const solTokens = new Set([mockValidSplToken.address]);
 
-			// ICP: only icpTokenActive passes the category filter
-			expect(result).toContain(icpTokenActive);
-			expect(result).not.toContain(icpTokenInactive);
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.NEAR_INTENTS,
+				sourceCategory: 'evm',
+				supportedSourceTokens: evmTokens,
+				getSupportedDestinations: buildNearIntentsSupportedDestinations('evm')
+			},
+			{
+				key: SwapProvider.NEAR_INTENTS,
+				sourceCategory: 'sol',
+				supportedSourceTokens: solTokens,
+				getSupportedDestinations: buildNearIntentsSupportedDestinations('sol')
+			}
+		];
 
-			// EVM: only erc20Inactive passes the category filter
-			expect(result).not.toContain(erc20Active);
-			expect(result).toContain(erc20Inactive);
+		const data = computeReceiveSupportedTokens({ sourceToken: mockValidSplToken, providers });
 
-			// SOL: no category filter → passes through on coverage rules
-			expect(result).toContain(splActive);
-		});
+		expect(data.evm.coverage).toBe('all');
+		expect(data.evm.supportedTokenIds).toEqual(evmTokens);
+		expect(data.sol.coverage).toBe('all');
+		expect(data.sol.supportedTokenIds).toEqual(solTokens);
+	});
 
-		it('coverage still gates tokens before compatibleTokenIds is applied', () => {
-			const noCoverageData: SwapSupportedTokensData = {
-				icp: { coverage: 'none', supportedTokenIds: new Set() },
-				evm: { coverage: 'none', supportedTokenIds: new Set() },
-				sol: { coverage: 'none', supportedTokenIds: new Set() }
-			};
+	it('NEAR Intents skips entries when source category does not match the entry', () => {
+		// Only the EVM entry contributes; the SOL entry's getSupportedDestinations should return undefined
+		// when the source is EVM (and vice versa), avoiding double-counting.
+		const evmTokens = new Set([evmSourceId]);
+		const solTokens = new Set([mockValidSplToken.address]);
 
-			const result = filterSwapTokens({
-				tokens: [erc20Active, erc20Inactive],
-				supportedData: noCoverageData,
-				compatibleTokenIds: { evm: new Set([erc20Inactive.address.toLowerCase()]) }
-			});
+		const providers: SwapProviderSupport[] = [
+			{
+				key: SwapProvider.NEAR_INTENTS,
+				sourceCategory: 'evm',
+				supportedSourceTokens: evmTokens,
+				getSupportedDestinations: buildNearIntentsSupportedDestinations('evm')
+			},
+			{
+				key: SwapProvider.NEAR_INTENTS,
+				sourceCategory: 'sol',
+				supportedSourceTokens: solTokens,
+				getSupportedDestinations: buildNearIntentsSupportedDestinations('sol')
+			}
+		];
 
-			// coverage=none returns enabled-only regardless of compatibleTokenIds
-			expect(result).toContain(erc20Active);
-			expect(result).not.toContain(erc20Inactive);
-		});
+		// Both entries, EVM source: only the EVM entry contributes → withList=1 per category, coverage='all'
+		const data = computeReceiveSupportedTokens({ sourceToken: evmSourceToken, providers });
+
+		expect(data.evm.coverage).toBe('all');
+		expect(data.sol.coverage).toBe('all');
 	});
 });


### PR DESCRIPTION
# Motivation

Filters the swap destination list and network options based on which destinations the providers can actually reach from the chosen source. Builds on the destination contract from #12685 and the per-provider state plumbing from #12686.
                                                                                                                                                                                
  - New util computeReceiveSupportedTokens walks each SwapProviderSupport and asks getSupportedDestinations what destinations it offers from the current source. Folds the per-provider results into the same SwapSupportedTokensData shape filterSwapTokens already understands.
  - SwapContext now exposes receiveSupportedData, derived from source token + per-provider state. The destination tokens list and the destination network filter both read it.  
  - SwapContexts.svelte adds an auto-clear effect: if the current destination falls outside the new receive support (e.g. user changes source), it's cleared so a stale selection isn't carried into the form.                                                                                                                                        
  - networksWithSupport powers the destination-side network chip filter — only networks with at least one reachable token remain.                                               
  - filterSwapTokens loses the compatibleTokenIds parameter; the new directed-pair data flow makes it redundant. 