### PR TITLE
refactor(frontend): use isTokenEthereumNative where applicable

### DIFF
--- a/src/frontend/src/eth/utils/erc20.utils.ts
+++ b/src/frontend/src/eth/utils/erc20.utils.ts
@@ -1,6 +1,7 @@
 import type { Erc20Contract, Erc20Metadata, Erc20Token } from '$eth/types/erc20';
 import type { Erc20CustomToken, EthereumCustomToken } from '$eth/types/erc20-custom-token';
 import type { EthereumNetwork } from '$eth/types/network';
+import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
 import { DEFAULT_TOKEN_TAGS } from '$lib/constants/token-tag.constants';
 import type { Token } from '$lib/types/token';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
@@ -26,4 +27,4 @@ export const isTokenErc20CustomToken = (token: Token): token is Erc20CustomToken
 	isTokenErc20(token) && isTokenToggleable(token);
 
 export const isTokenEthereumCustomToken = (token: Token): token is EthereumCustomToken =>
-	(token.standard.code === 'ethereum' || isTokenErc20(token)) && isTokenToggleable(token);
+	(isTokenEthereumNative(token) || isTokenErc20(token)) && isTokenToggleable(token);

--- a/src/frontend/src/eth/utils/eth.utils.ts
+++ b/src/frontend/src/eth/utils/eth.utils.ts
@@ -2,13 +2,14 @@ import {
 	SUPPORTED_ETHEREUM_TOKEN_IDS,
 	type SUPPORTED_ETHEREUM_TOKENS
 } from '$env/tokens/tokens.eth.env';
+import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
 import { DEFAULT_ETHEREUM_NETWORK } from '$lib/constants/networks.constants';
 import type { Network } from '$lib/types/network';
 import type { OptionToken, TokenId } from '$lib/types/token';
 import { nonNullish } from '@dfinity/utils';
 
 export const isDefaultEthereumToken = (token: OptionToken): boolean =>
-	nonNullish(token) && token.category === 'default' && token.standard.code === 'ethereum';
+	nonNullish(token) && token.category === 'default' && isTokenEthereumNative(token);
 
 export const isNotDefaultEthereumToken = (token: OptionToken): boolean =>
 	!isDefaultEthereumToken(token);

--- a/src/frontend/src/eth/utils/native-token.utils.ts
+++ b/src/frontend/src/eth/utils/native-token.utils.ts
@@ -1,0 +1,3 @@
+import type { Token } from '$lib/types/token';
+
+export const isTokenEthereumNative = (token: Token): boolean => token.standard?.code === 'ethereum';

--- a/src/frontend/src/eth/utils/token.utils.ts
+++ b/src/frontend/src/eth/utils/token.utils.ts
@@ -98,5 +98,3 @@ export const calculateUsdValues = ({
 		sumInUSD: amountInUSD + feeInUSD
 	};
 };
-
-export const isTokenEthereumNative = (token: Token): boolean => token.standard?.code === 'ethereum';

--- a/src/frontend/src/icp-eth/derived/cketh.derived.ts
+++ b/src/frontend/src/icp-eth/derived/cketh.derived.ts
@@ -10,6 +10,7 @@ import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
 import type { OptionEthAddress } from '$eth/types/address';
 import type { EthereumNetwork } from '$eth/types/network';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
+import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
 import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 import {
 	toCkErc20HelperContractAddress,
@@ -98,8 +99,7 @@ export const ckErc20HelperContractAddress: Readable<OptionEthAddress> = derived(
 export const ethToCkETHEnabled: Readable<boolean> = derived(
 	[tokenWithFallbackAsIcToken, selectedEthereumNetwork, ckEthereumNativeTokenEnabledNetwork],
 	([$tokenWithFallbackAsIcToken, $selectedEthereumNetwork, $ckEthereumNativeTokenEnabledNetwork]) =>
-		($tokenWithFallbackAsIcToken.standard.code === 'ethereum' &&
-			nonNullish($selectedEthereumNetwork)) ||
+		(isTokenEthereumNative($tokenWithFallbackAsIcToken) && nonNullish($selectedEthereumNetwork)) ||
 		(isTokenCkEthLedger($tokenWithFallbackAsIcToken) &&
 			nonNullish($ckEthereumNativeTokenEnabledNetwork))
 );

--- a/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
+++ b/src/frontend/src/lib/utils/swap-tokens-filter.utils.ts
@@ -1,5 +1,5 @@
 import { isTokenErcFungible } from '$eth/utils/erc-fungible.utils';
-import { isTokenEthereumNative } from '$eth/utils/token.utils';
+import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
 import { isIcToken } from '$icp/validation/ic-token.validation';
 import type {
 	SwapProviderListCoverage,

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -2,6 +2,7 @@ import type { BtcCertifiedTransactionsData } from '$btc/stores/btc-transactions.
 import { ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import type { EthCertifiedTransactionsData } from '$eth/stores/eth-transactions.store';
 import type { OptionEthAddress } from '$eth/types/address';
+import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
 import { mapEthTransactionUi } from '$eth/utils/transactions.utils';
 import type { CkEthMinterInfoData } from '$icp-eth/stores/cketh.store';
 import { toCkMinterInfoAddresses } from '$icp-eth/utils/cketh.utils';
@@ -91,11 +92,11 @@ const findDuplicateEthNativeTransactions = (
 	for (const networkMap of groupsByNetworkAndHash.values()) {
 		for (const group of networkMap.values()) {
 			if (group.length > 1) {
-				const hasNonNative = group.some(({ token }) => token.standard.code !== 'ethereum');
+				const hasNonNative = group.some(({ token }) => !isTokenEthereumNative(token));
 
 				if (hasNonNative) {
 					for (const tx of group) {
-						if (tx.token.standard.code === 'ethereum') {
+						if (isTokenEthereumNative(tx.token)) {
 							duplicates.add(tx);
 						}
 					}

--- a/src/frontend/src/tests/eth/utils/native-token.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/native-token.utils.spec.ts
@@ -1,0 +1,34 @@
+import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
+import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
+import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
+import { ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
+import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { SUPPORTED_SOLANA_TOKENS } from '$env/tokens/tokens.sol.env';
+import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
+import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
+
+describe('native-token.utils', () => {
+	describe('isTokenEthereumNative', () => {
+		it.each([...SUPPORTED_ETHEREUM_TOKENS, ...SUPPORTED_EVM_TOKENS])(
+			'should return true for token $name',
+			(token) => {
+				expect(isTokenEthereumNative(token)).toBeTruthy();
+			}
+		);
+
+		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS])(
+			'should return false for token $name',
+			(token) => {
+				expect(isTokenEthereumNative(token)).toBeFalsy();
+			}
+		);
+
+		it.each([ICP_TOKEN, ...SUPPORTED_BITCOIN_TOKENS, ...SUPPORTED_SOLANA_TOKENS, ...SPL_TOKENS])(
+			'should return false for token $name',
+			(token) => {
+				expect(isTokenEthereumNative(token)).toBeFalsy();
+			}
+		);
+	});
+});

--- a/src/frontend/src/tests/eth/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/token.utils.spec.ts
@@ -1,17 +1,6 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
-import { EVM_ERC20_TOKENS } from '$env/tokens/tokens-evm/tokens.erc20.env';
-import { SUPPORTED_EVM_TOKENS } from '$env/tokens/tokens-evm/tokens.evm.env';
-import { SUPPORTED_BITCOIN_TOKENS } from '$env/tokens/tokens.btc.env';
-import { ERC20_TWIN_TOKENS } from '$env/tokens/tokens.erc20.env';
-import { ETHEREUM_TOKEN, SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
-import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-import { SUPPORTED_SOLANA_TOKENS } from '$env/tokens/tokens.sol.env';
-import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
-import {
-	calculateUsdValues,
-	hasSufficientBalance,
-	isTokenEthereumNative
-} from '$eth/utils/token.utils';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { calculateUsdValues, hasSufficientBalance } from '$eth/utils/token.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
@@ -308,28 +297,5 @@ describe('token.utils', () => {
 			expect(result.feeInUSD).toBeCloseTo(0.002, 6);
 			expect(result.sumInUSD).toBeCloseTo(2000.002, 3);
 		});
-	});
-
-	describe('isTokenEthereumNative', () => {
-		it.each([...SUPPORTED_ETHEREUM_TOKENS, ...SUPPORTED_EVM_TOKENS])(
-			'should return true for token $name',
-			(token) => {
-				expect(isTokenEthereumNative(token)).toBeTruthy();
-			}
-		);
-
-		it.each([...ERC20_TWIN_TOKENS, ...EVM_ERC20_TOKENS])(
-			'should return false for token $name',
-			(token) => {
-				expect(isTokenEthereumNative(token)).toBeFalsy();
-			}
-		);
-
-		it.each([ICP_TOKEN, ...SUPPORTED_BITCOIN_TOKENS, ...SUPPORTED_SOLANA_TOKENS, ...SPL_TOKENS])(
-			'should return false for token $name',
-			(token) => {
-				expect(isTokenEthereumNative(token)).toBeFalsy();
-			}
-		);
 	});
 });

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -34,6 +34,7 @@ import type {
 	EthCertifiedTransactionsData
 } from '$eth/stores/eth-transactions.store';
 import type { EthTransactionType } from '$eth/types/eth-transaction';
+import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
 import type { IcCertifiedTransactionsData } from '$icp/stores/ic-transactions.store';
 import type { IcTransactionType, IcTransactionUi } from '$icp/types/ic-transaction';
 import { ZERO } from '$lib/constants/app.constants';
@@ -592,7 +593,7 @@ describe('transactions.utils', () => {
 				});
 
 				expect(result).toHaveLength(2);
-				expect(result.every(({ token }) => token.standard.code !== 'ethereum')).toBeTruthy();
+				expect(result.every(({ token }) => !isTokenEthereumNative(token))).toBeTruthy();
 				expect(result.map(({ token }) => token)).toEqual([PEPE_TOKEN, USDC_TOKEN]);
 			});
 


### PR DESCRIPTION
# Motivation

Replaces the remaining inline token.standard.code === 'ethereum' (and !== 'ethereum') checks with the existing isTokenEthereumNative helper, mirroring the pattern in swap-tokens-filter.utils.ts (#12684) and the symmetric isTokenSolanaNative usage. No behavior change.

Note: moved the code to a separate file to prevent import looping issues.
