### PR TITLE
chore(frontend): rename activity filter "Clear filters" label to "Clear"

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1636,7 +1636,7 @@
 			"contacts_aria_label": "Filter by contact",
 			"search_tokens_placeholder": "Start typing...",
 			"search_contacts_placeholder": "Start typing name...",
-			"clear": "Clear filters",
+			"clear": "Clear",
 			"sheet_title": "Filter activity",
 			"open_filters_aria_label": "Open activity filters"
 		},


### PR DESCRIPTION
# Motivation

The "Clear filters" label in the activity filter UI is unnecessarily verbose. A shorter "Clear" reads better in context where it sits next to the filters and its purpose is already clear from placement.