### PR TITLE
fix(frontend): non-overlapping breakpoint for activity filter toolbar

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -9,10 +9,7 @@
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
-	import {
-		TRANSACTIONS_FILTER_MOBILE_TRIGGER,
-		TRANSACTIONS_FILTER_TOOLBAR
-	} from '$lib/constants/test-ids.constants';
+	import { TRANSACTIONS_FILTER_TOOLBAR } from '$lib/constants/test-ids.constants';
 	import {
 		selectedTransactionsFilterContactsCount,
 		selectedTransactionsFilterTokensCount,
@@ -54,7 +51,6 @@
 				colorStyle="muted"
 				link={false}
 				onclick={() => (mobileSheetVisible = true)}
-				testId={TRANSACTIONS_FILTER_MOBILE_TRIGGER}
 			>
 				{#snippet icon()}
 					<span class="relative flex">

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -1,17 +1,84 @@
 <script lang="ts">
+	import { derived } from 'svelte/store';
+	import IconListFilter from '$lib/components/icons/lucide/IconListFilter.svelte';
 	import TransactionsFilterClearButton from '$lib/components/transactions/filter/TransactionsFilterClearButton.svelte';
 	import TransactionsFilterContacts from '$lib/components/transactions/filter/TransactionsFilterContacts.svelte';
+	import TransactionsFilterMobileSheet from '$lib/components/transactions/filter/TransactionsFilterMobileSheet.svelte';
 	import TransactionsFilterTokens from '$lib/components/transactions/filter/TransactionsFilterTokens.svelte';
 	import TransactionsFilterTypes from '$lib/components/transactions/filter/TransactionsFilterTypes.svelte';
-	import { TRANSACTIONS_FILTER_TOOLBAR } from '$lib/constants/test-ids.constants';
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
+	import {
+		TRANSACTIONS_FILTER_MOBILE_TRIGGER,
+		TRANSACTIONS_FILTER_TOOLBAR
+	} from '$lib/constants/test-ids.constants';
+	import {
+		selectedTransactionsFilterContactsCount,
+		selectedTransactionsFilterTokensCount,
+		selectedTransactionsFilterTypesCount
+	} from '$lib/derived/transactions-filter.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	let mobileSheetVisible = $state(false);
+
+	const totalSelected = derived(
+		[
+			selectedTransactionsFilterTypesCount,
+			selectedTransactionsFilterTokensCount,
+			selectedTransactionsFilterContactsCount
+		],
+		([$types, $tokens, $contacts]) => $types + $tokens + $contacts
+	);
 </script>
 
-<div class="mb-4 flex flex-wrap items-center gap-2" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
-	<TransactionsFilterTypes />
+<!--
+	The `md` / `sm` boundary is non-overlapping: `up="md"` renders for
+	`activeScreen` of `md` and wider, `down="sm"` renders for `sm` and
+	narrower. Using `up="sm"` would also include `sm`, where `down="sm"`
+	already renders, so the chip row and the mobile trigger would both be
+	visible at viewports between 512–640px. The `md` boundary also gives
+	the chip row enough horizontal room to fit on one line without
+	flex-wrap shimmying.
+-->
+<div class="mb-4 w-full" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
+	<Responsive up="md">
+		<div class="flex flex-wrap items-center gap-2">
+			<TransactionsFilterTypes />
 
-	<TransactionsFilterTokens />
+			<TransactionsFilterTokens />
 
-	<TransactionsFilterContacts />
+			<TransactionsFilterContacts />
 
-	<TransactionsFilterClearButton />
+			<TransactionsFilterClearButton />
+		</div>
+	</Responsive>
+
+	<Responsive down="sm">
+		<div class="flex items-center justify-end gap-2">
+			<TransactionsFilterClearButton />
+
+			<ButtonIcon
+				ariaLabel={$i18n.transaction.filter.open_filters_aria_label}
+				colorStyle="muted"
+				link={false}
+				onclick={() => (mobileSheetVisible = true)}
+				testId={TRANSACTIONS_FILTER_MOBILE_TRIGGER}
+			>
+				{#snippet icon()}
+					<span class="relative flex">
+						<IconListFilter size="20" />
+
+						{#if $totalSelected > 0}
+							<span class="absolute -top-2 -right-2">
+								<Badge variant="info" width="w-fit">{$totalSelected}</Badge>
+							</span>
+						{/if}
+					</span>
+				{/snippet}
+			</ButtonIcon>
+		</div>
+
+		<TransactionsFilterMobileSheet bind:visible={mobileSheetVisible} />
+	</Responsive>
 </div>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -32,15 +32,6 @@
 	);
 </script>
 
-<!--
-	The `md` / `sm` boundary is non-overlapping: `up="md"` renders for
-	`activeScreen` of `md` and wider, `down="sm"` renders for `sm` and
-	narrower. Using `up="sm"` would also include `sm`, where `down="sm"`
-	already renders, so the chip row and the mobile trigger would both be
-	visible at viewports between 512–640px. The `md` boundary also gives
-	the chip row enough horizontal room to fit on one line without
-	flex-wrap shimmying.
--->
 <div class="mb-4 w-full" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
 	<Responsive up="md">
 		<div class="flex flex-wrap items-center gap-2">

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -217,6 +217,7 @@ export const TRANSACTIONS_FILTER_TYPES_DROPDOWN = 'transactions-filter-types-dro
 export const TRANSACTIONS_FILTER_TOKENS_DROPDOWN = 'transactions-filter-tokens-dropdown';
 export const TRANSACTIONS_FILTER_CONTACTS_DROPDOWN = 'transactions-filter-contacts-dropdown';
 export const TRANSACTIONS_FILTER_CLEAR_BUTTON = 'transactions-filter-clear-button';
+export const TRANSACTIONS_FILTER_MOBILE_TRIGGER = 'transactions-filter-mobile-trigger';
 
 export const BTC_CONVERT_FORM_TEST_ID = 'btc-convert-form-test-id';
 export const IC_CONVERT_FORM_TEST_ID = 'ic-convert-form-test-id';

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -217,7 +217,6 @@ export const TRANSACTIONS_FILTER_TYPES_DROPDOWN = 'transactions-filter-types-dro
 export const TRANSACTIONS_FILTER_TOKENS_DROPDOWN = 'transactions-filter-tokens-dropdown';
 export const TRANSACTIONS_FILTER_CONTACTS_DROPDOWN = 'transactions-filter-contacts-dropdown';
 export const TRANSACTIONS_FILTER_CLEAR_BUTTON = 'transactions-filter-clear-button';
-export const TRANSACTIONS_FILTER_MOBILE_TRIGGER = 'transactions-filter-mobile-trigger';
 
 export const BTC_CONVERT_FORM_TEST_ID = 'btc-convert-form-test-id';
 export const IC_CONVERT_FORM_TEST_ID = 'ic-convert-form-test-id';


### PR DESCRIPTION
# Motivation

The activity filter toolbar should swap between the desktop chip row and a single mobile filter button via `Responsive.svelte`, but the wiring (a) is missing on `main`, and (b) when re-introduced via #12678 used `up="sm"` / `down="sm"`, which both include `sm` (see `filterScreens` in `src/frontend/src/lib/utils/screens.utils.ts`) — so at `activeScreen === 'sm'` (viewport ~512–640px) the chip row and the mobile trigger render at the same time.

# Changes

- `TransactionsFilterToolbar.svelte` — wraps the chip row in `<Responsive up="md">` and the single-button trigger + `TransactionsFilterMobileSheet` in `<Responsive down="sm">`. Non-overlapping pair (matches `ConfirmButtonWithModal.svelte`); `md` also gives the four chips room to fit on one line without flex-wrap shimmying.
- `test-ids.constants.ts` — adds `TRANSACTIONS_FILTER_MOBILE_TRIGGER`.

# Tests

- This PR is intentionally **incomplete on `main`**: it references `TransactionsFilterMobileSheet`, `selected*Count` derived stores and the `open_filters_aria_label` i18n key, all of which live on #12678. It is expected to compile only once those land on `main`.
- Prettier + ESLint clean on the two touched files.

