### PR TITLE
chore(frontend): add USDC.e token

### DIFF
--- a/src/frontend/src/env/tokens/groups/groups.usdce.env.ts
+++ b/src/frontend/src/env/tokens/groups/groups.usdce.env.ts
@@ -1,0 +1,14 @@
+import usdce from '$eth/assets/usdc.svg';
+import type { TokenGroupData, TokenGroupId } from '$lib/types/token-group';
+import { parseTokenGroupId } from '$lib/validation/token-group.validation';
+
+const USDCE_TOKEN_GROUP_SYMBOL = 'USDC.e';
+
+export const USDCE_TOKEN_GROUP_ID: TokenGroupId = parseTokenGroupId(USDCE_TOKEN_GROUP_SYMBOL);
+
+export const USDCE_TOKEN_GROUP: TokenGroupData = {
+	id: USDCE_TOKEN_GROUP_ID,
+	icon: usdce,
+	name: 'USD Coin Bridged',
+	symbol: USDCE_TOKEN_GROUP_SYMBOL
+};

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env.ts
@@ -10,7 +10,7 @@ export const USDCE_DECIMALS = 6;
 
 export const USDCE_SYMBOL = 'USDC.e';
 
-export const USDCE_TOKEN_ID: TokenId = parseTokenId(USDC_SYMBOL);
+export const USDCE_TOKEN_ID: TokenId = parseTokenId(USDCE_SYMBOL);
 
 export const USDCE_TOKEN: RequiredEvmErc20Token = {
 	id: USDCE_TOKEN_ID,

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env.ts
@@ -1,5 +1,5 @@
 import { ARBITRUM_MAINNET_NETWORK} from '$env/networks/networks-evm/networks.evm.arbitrum.env';
-import { USDCE_TOKEN_GROUP } from '$env/tokens/groups/groups.usdc.env';
+import { USDCE_TOKEN_GROUP } from '$env/tokens/groups/groups.usdce.env';
 import usdce from '$eth/assets/usdc.svg';
 import type { RequiredEvmErc20Token } from '$evm/types/erc20';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env.ts
@@ -1,4 +1,4 @@
-import { ARBITRUM_MAINNET_NETWORK} from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { USDCE_TOKEN_GROUP } from '$env/tokens/groups/groups.usdce.env';
 import usdce from '$eth/assets/usdc.svg';
 import type { RequiredEvmErc20Token } from '$evm/types/erc20';

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env.ts
@@ -1,0 +1,27 @@
+import { ARBITRUM_MAINNET_NETWORK} from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { USDCE_TOKEN_GROUP } from '$env/tokens/groups/groups.usdc.env';
+import usdce from '$eth/assets/usdc.svg';
+import type { RequiredEvmErc20Token } from '$evm/types/erc20';
+import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+
+export const USDCE_DECIMALS = 6;
+
+export const USDCE_SYMBOL = 'USDC.e';
+
+export const USDCE_TOKEN_ID: TokenId = parseTokenId(USDC_SYMBOL);
+
+export const USDCE_TOKEN: RequiredEvmErc20Token = {
+	id: USDCE_TOKEN_ID,
+	network: ARBITRUM_MAINNET_NETWORK,
+	standard: { code: 'erc20' },
+	category: 'default',
+	tags: [{ type: TokenTagType.CATEGORY, value: TokenCategoryTagValue.STABLECOIN }],
+	name: 'USD Coin Bridge',
+	symbol: USDCE_SYMBOL,
+	decimals: USDCE_DECIMALS,
+	icon: usdce,
+	address: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+	groupData: USDCE_TOKEN_GROUP
+};

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-arbitrum/tokens.erc20.env.ts
@@ -10,6 +10,7 @@ import {
 	ARB_SEPOLIA_USDC_TOKEN,
 	USDC_TOKEN
 } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdc.env';
+import { USDCE_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdce.env';
 import { USDT_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.usdt.env';
 import { WBTC_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.wbtc.env';
 import { WETH_TOKEN } from '$env/tokens/tokens-evm/tokens-arbitrum/tokens-erc20/tokens.weth.env';
@@ -21,6 +22,7 @@ const ARBITRUM_ERC20_TOKENS_SEPOLIA: RequiredEvmErc20Token[] = [ARB_SEPOLIA_USDC
 
 const ARBITRUM_ERC20_TOKENS_MAINNET: RequiredEvmErc20Token[] = [
 	USDC_TOKEN,
+	USDCE_TOKEN,
 	USDT_TOKEN,
 	ARB_TOKEN,
 	BOB_TOKEN,

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
@@ -1,4 +1,3 @@
-import { POLYGON_AMOY_NETWORK } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import { USDCE_TOKEN_GROUP } from '$env/tokens/groups/groups.usdce.env';
 import usdce from '$eth/assets/usdc.svg';
 import type { RequiredEvmErc20Token } from '$evm/types/erc20';

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
@@ -1,3 +1,4 @@
+import {POLYGON_MAINNET_NETWORK} from '$env/networks/networks-evm/networks.evm.polygon.env';
 import { USDCE_TOKEN_GROUP } from '$env/tokens/groups/groups.usdce.env';
 import usdce from '$eth/assets/usdc.svg';
 import type { RequiredEvmErc20Token } from '$evm/types/erc20';

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
@@ -1,4 +1,4 @@
-import {POLYGON_MAINNET_NETWORK} from '$env/networks/networks-evm/networks.evm.polygon.env';
+import { POLYGON_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import { USDCE_TOKEN_GROUP } from '$env/tokens/groups/groups.usdce.env';
 import usdce from '$eth/assets/usdc.svg';
 import type { RequiredEvmErc20Token } from '$evm/types/erc20';

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
@@ -1,0 +1,27 @@
+import { POLYGON_AMOY_NETWORK } from '$env/networks/networks-evm/networks.evm.polygon.env';
+import { USDCE_TOKEN_GROUP } from '$env/tokens/groups/groups.usdce.env';
+import usdce from '$eth/assets/usdc.svg';
+import type { RequiredEvmErc20Token } from '$evm/types/erc20';
+import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
+import type { TokenId } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+
+export const USDCE_DECIMALS = 6;
+
+export const USDCE_SYMBOL = 'USDC';
+
+export const USDCE_TOKEN_ID: TokenId = parseTokenId(USDCE_SYMBOL);
+
+export const USDCE_TOKEN: RequiredEvmErc20Token = {
+	id: USDCE_TOKEN_ID,
+	network: POLYGON_MAINNET_NETWORK,
+	standard: { code: 'erc20' },
+	category: 'default',
+	tags: [{ type: TokenTagType.CATEGORY, value: TokenCategoryTagValue.STABLECOIN }],
+	name: 'USD Coin Bridged',
+	symbol: USDCE_SYMBOL,
+	decimals: USDCE_DECIMALS,
+	icon: usdce,
+	address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+	groupData: USDCE_TOKEN_GROUP
+};

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env.ts
@@ -7,7 +7,7 @@ import { parseTokenId } from '$lib/validation/token.validation';
 
 export const USDCE_DECIMALS = 6;
 
-export const USDCE_SYMBOL = 'USDC';
+export const USDCE_SYMBOL = 'USDC.e';
 
 export const USDCE_TOKEN_ID: TokenId = parseTokenId(USDCE_SYMBOL);
 

--- a/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env.ts
+++ b/src/frontend/src/env/tokens/tokens-evm/tokens-polygon/tokens.erc20.env.ts
@@ -3,6 +3,7 @@ import {
 	AMOY_USDC_TOKEN,
 	USDC_TOKEN
 } from '$env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdc.env';
+import { USDCE_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdce.env';
 import { USDT_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdt.env';
 import { WBTC_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.wbtc.env';
 import { ZCHF_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.zchf.env';
@@ -13,6 +14,7 @@ const POLYGON_ERC20_TOKENS_AMOY: RequiredEvmErc20Token[] = [AMOY_USDC_TOKEN];
 
 const POLYGON_ERC20_TOKENS_MAINNET: RequiredEvmErc20Token[] = [
 	USDC_TOKEN,
+	USDCE_TOKEN,
 	USDT_TOKEN,
 	WBTC_TOKEN,
 	ZCHF_TOKEN


### PR DESCRIPTION
# Motivation

We have a user who sent USDC.e to his wallet, and currently you can't import it because of duplicate names.

# Changes

- add Arbitrum and Polygon version to the curated tokens, and add a group

# Tests
