### PR TITLE
fix(frontend): align checkbox/avatar/name in contacts activity filter

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
@@ -70,13 +70,6 @@
 	{/snippet}
 </MultiSelectDropdown>
 
-<!--
-	Tailwind doesn't reach the gix Checkbox internals (renders DOM as
-	<label/><input/> with justify-content: space-between, which pushes the
-	input to the far edge of the row). To match Figma we need to swap the
-	label/input visual order, override checkbox padding, add a hover
-	background and reset the slot label's flex sizing — kept minimal here.
--->
 <style lang="scss">
 	li :global(.checkbox) {
 		--checkbox-label-order: 1;

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
@@ -48,18 +48,18 @@
 	{/snippet}
 
 	{#snippet panel()}
-		<ul class="m-0 flex list-none flex-col gap-1 p-0">
+		<ul class="m-0 flex list-none flex-col gap-0.5 p-0">
 			{#each filteredContacts as contact (contact.id.toString())}
 				{@const id = contact.id.toString()}
 
-				<li class="flex items-center gap-2">
+				<li>
 					<Checkbox
 						checked={selectedSet.has(id)}
 						inputId={`transactions-filter-contact-${id}`}
 						text="inline"
 						on:nnsChange={() => transactionsFilterStore.toggleContactId(id)}
 					>
-						<span class="flex items-center gap-2">
+						<span class="inline-flex items-center gap-2">
 							<Avatar name={contact.name} image={contact.image} variant="xxs" />
 							<span class="text-sm">{contact.name}</span>
 						</span>
@@ -69,3 +69,29 @@
 		</ul>
 	{/snippet}
 </MultiSelectDropdown>
+
+<!--
+	Tailwind doesn't reach the gix Checkbox internals (renders DOM as
+	<label/><input/> with justify-content: space-between, which pushes the
+	input to the far edge of the row). To match Figma we need to swap the
+	label/input visual order, override checkbox padding, add a hover
+	background and reset the slot label's flex sizing — kept minimal here.
+-->
+<style lang="scss">
+	li :global(.checkbox) {
+		--checkbox-label-order: 1;
+		--checkbox-padding: 6px 8px;
+		justify-content: flex-start;
+		gap: 8px;
+		border-radius: 6px;
+		cursor: pointer;
+	}
+
+	li :global(.checkbox:hover) {
+		background: var(--color-background-brand-subtle-10);
+	}
+
+	li :global(label) {
+		flex: initial;
+	}
+</style>


### PR DESCRIPTION
# Motivation

Caught by @DenysKarmazynDFINITY 

In the activity page's contacts filter dropdown, the row reads `[Avatar] [Name] ……… [☐]` instead of `[☐] [Avatar] [Name]`. The gix `Checkbox` internals render with `justify-content: space-between` and a `flex:1` label, which pushes the input to the far edge.

# Changes

Port the SCSS fix already used in the umbrella PR (#12680) to `TransactionsFilterContacts.svelte`: swap label/input order via `--checkbox-label-order`, `justify-content: flex-start`, `flex: initial` on the slot label, plus the Figma padding/gap/radius/hover.
