### PR TITLE
fix(frontend): align checkbox in tokens & types activity filters

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -63,19 +63,19 @@
 	{/snippet}
 
 	{#snippet panel()}
-		<ul class="m-0 flex list-none flex-col gap-1 p-0">
+		<ul class="m-0 flex list-none flex-col gap-0.5 p-0">
 			{#each filteredTokens as token (token.id.description)}
 				{@const key = tokenKey(token)}
 
 				{#if nonNullish(key)}
-					<li class="flex items-center gap-2">
+					<li>
 						<Checkbox
 							checked={selectedSet.has(key)}
 							inputId={`transactions-filter-token-${key}`}
 							text="inline"
 							on:nnsChange={() => transactionsFilterStore.toggleTokenId(key)}
 						>
-							<span class="flex items-center gap-2">
+							<span class="inline-flex items-center gap-2">
 								<TokenLogo data={token} logoSize="xxs" />
 
 								<span class="text-sm">
@@ -95,3 +95,29 @@
 		</ul>
 	{/snippet}
 </MultiSelectDropdown>
+
+<!--
+	Tailwind doesn't reach the gix Checkbox internals (renders DOM as
+	<label/><input/> with justify-content: space-between, which pushes the
+	input to the far edge of the row). To match Figma we need to swap the
+	label/input visual order, override checkbox padding, add a hover
+	background and reset the slot label's flex sizing — kept minimal here.
+-->
+<style lang="scss">
+	li :global(.checkbox) {
+		--checkbox-label-order: 1;
+		--checkbox-padding: 6px 8px;
+		justify-content: flex-start;
+		gap: 8px;
+		border-radius: 6px;
+		cursor: pointer;
+	}
+
+	li :global(.checkbox:hover) {
+		background: var(--color-background-brand-subtle-10);
+	}
+
+	li :global(label) {
+		flex: initial;
+	}
+</style>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -96,13 +96,6 @@
 	{/snippet}
 </MultiSelectDropdown>
 
-<!--
-	Tailwind doesn't reach the gix Checkbox internals (renders DOM as
-	<label/><input/> with justify-content: space-between, which pushes the
-	input to the far edge of the row). To match Figma we need to swap the
-	label/input visual order, override checkbox padding, add a hover
-	background and reset the slot label's flex sizing — kept minimal here.
--->
 <style lang="scss">
 	li :global(.checkbox) {
 		--checkbox-label-order: 1;

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
@@ -57,13 +57,6 @@
 	{/snippet}
 </MultiSelectDropdown>
 
-<!--
-	Tailwind doesn't reach the gix Checkbox internals (renders DOM as
-	<label/><input/> with justify-content: space-between, which pushes the
-	input to the far edge of the row). To match Figma we need to swap the
-	label/input visual order, override checkbox padding, add a hover
-	background and reset the slot label's flex sizing — kept minimal here.
--->
 <style lang="scss">
 	li :global(.checkbox) {
 		--checkbox-label-order: 1;

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
@@ -40,9 +40,9 @@
 	{/snippet}
 
 	{#snippet panel()}
-		<ul class="m-0 flex list-none flex-col gap-1 p-0">
+		<ul class="m-0 flex list-none flex-col gap-0.5 p-0">
 			{#each sortedTypes as { type, label } (type)}
-				<li class="flex items-center">
+				<li>
 					<Checkbox
 						checked={selectedSet.has(type)}
 						inputId={`transactions-filter-type-${type}`}
@@ -56,3 +56,29 @@
 		</ul>
 	{/snippet}
 </MultiSelectDropdown>
+
+<!--
+	Tailwind doesn't reach the gix Checkbox internals (renders DOM as
+	<label/><input/> with justify-content: space-between, which pushes the
+	input to the far edge of the row). To match Figma we need to swap the
+	label/input visual order, override checkbox padding, add a hover
+	background and reset the slot label's flex sizing — kept minimal here.
+-->
+<style lang="scss">
+	li :global(.checkbox) {
+		--checkbox-label-order: 1;
+		--checkbox-padding: 6px 8px;
+		justify-content: flex-start;
+		gap: 8px;
+		border-radius: 6px;
+		cursor: pointer;
+	}
+
+	li :global(.checkbox:hover) {
+		background: var(--color-background-brand-subtle-10);
+	}
+
+	li :global(label) {
+		flex: initial;
+	}
+</style>


### PR DESCRIPTION
# Motivation

Same gix `Checkbox` alignment quirk as the contacts filter (#12697): default `justify-content: space-between` with a `flex:1` label pushes the checkbox input to the far edge of the row.

# Changes

Port the SCSS fix already used in the umbrella PR (#12680) to `TransactionsFilterTokens.svelte` and `TransactionsFilterTypes.svelte`: swap label/input order via `--checkbox-label-order`, `justify-content: flex-start`, `flex: initial` on the slot label, plus the Figma padding/gap/radius/hover.
