### PR TITLE
feat(frontend): allow importing tokens with a duplicate symbol on the same network

### DIFF
--- a/src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte
+++ b/src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte
@@ -43,27 +43,6 @@
 			});
 
 			onBack();
-
-			return;
-		}
-
-		// This does not happen at this point, but it is useful type-wise
-		assertIsNetworkEthereum(network);
-
-		if (
-			nonNullish(
-				[...$erc20Tokens, ...$erc721Tokens]?.find(
-					({ symbol, network: tokenNetwork }) =>
-						symbol.toLowerCase() === (metadata?.symbol?.toLowerCase() ?? '') &&
-						tokenNetwork.chainId === network.chainId
-				)
-			)
-		) {
-			toastsError({
-				msg: { text: $i18n.tokens.error.duplicate_metadata }
-			});
-
-			onBack();
 		}
 	};
 

--- a/src/frontend/src/icp/services/ext-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ext-add-custom-tokens.service.ts
@@ -4,7 +4,6 @@ import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { NullishIdentity } from '$lib/types/identity';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
-import { assertExistingTokens } from '$lib/utils/tokens.utils';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -53,16 +52,6 @@ export const loadAndAssertAddCustomToken = ({
 				msg: { text: get(i18n).tokens.import.error.no_metadata }
 			});
 
-			return { result: 'error' };
-		}
-
-		const { valid } = assertExistingTokens({
-			existingTokens: extTokens,
-			token,
-			errorMsg: get(i18n).tokens.error.duplicate_metadata
-		});
-
-		if (!valid) {
 			return { result: 'error' };
 		}
 

--- a/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/ic-add-custom-tokens.service.ts
@@ -7,7 +7,6 @@ import { ZERO } from '$lib/constants/app.constants';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { NullishIdentity } from '$lib/types/identity';
-import { assertExistingTokens } from '$lib/utils/tokens.utils';
 import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { get } from 'svelte/store';
@@ -76,16 +75,6 @@ export const loadAndAssertAddCustomToken = async ({
 				msg: { text: get(i18n).tokens.import.error.no_metadata }
 			});
 
-			return { result: 'error' };
-		}
-
-		const { valid } = assertExistingTokens({
-			existingTokens: icrcTokens,
-			token,
-			errorMsg: get(i18n).tokens.error.duplicate_metadata
-		});
-
-		if (!valid) {
 			return { result: 'error' };
 		}
 

--- a/src/frontend/src/icp/services/icpunks-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/icpunks-add-custom-tokens.service.ts
@@ -8,7 +8,6 @@ import { mapIcPunksToken } from '$icp/utils/icpunks.utils';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError } from '$lib/stores/toasts.store';
 import type { NullishIdentity } from '$lib/types/identity';
-import { assertExistingTokens } from '$lib/utils/tokens.utils';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { get } from 'svelte/store';
@@ -58,16 +57,6 @@ export const loadAndAssertAddCustomToken = async ({
 				msg: { text: get(i18n).tokens.import.error.no_metadata }
 			});
 
-			return { result: 'error' };
-		}
-
-		const { valid } = assertExistingTokens({
-			existingTokens: icPunksTokens,
-			token,
-			errorMsg: get(i18n).tokens.error.duplicate_metadata
-		});
-
-		if (!valid) {
 			return { result: 'error' };
 		}
 

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1376,7 +1376,6 @@
 			"already_available": "التوكن متاح بالفعل.",
 			"not_toggleable": "لا يمكن تبديل التوكن، لا يمكن إخفاؤه.",
 			"incomplete_metadata": "لا يوجد اسم أو رمز في البيانات الوصفية.",
-			"duplicate_metadata": "توكن بنفس الاسم أو الرمز موجود بالفعل.",
 			"unexpected_undefined": "التوكن غير معرف. هذا غير متوقع.",
 			"unexpected_error_on_token_delete": "حدث خطأ ما أثناء إزالة التوكن.",
 			"unexpected_error_on_token_update": "حدث خطأ ما أثناء تحديث التوكن."

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Token je již k dispozici.",
 			"not_toggleable": "Token nelze přepnout, nelze jej skrýt.",
 			"incomplete_metadata": "V metadatech není uveden žádný název ani symbol.",
-			"duplicate_metadata": "Token s podobným názvem nebo symbolem již existuje.",
 			"unexpected_undefined": "Token je nedefinovaný. To je neočekávané.",
 			"unexpected_error_on_token_delete": "Při odstraňování tokenu došlo k chybě.",
 			"unexpected_error_on_token_update": "Při aktualizaci tokenu došlo k chybě."

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Token ist bereits verfügbar.",
 			"not_toggleable": "Token kann nicht ausgeblendet werden.",
 			"incomplete_metadata": "Kein Name oder Symbol in den Metadaten vorhanden.",
-			"duplicate_metadata": "Ein Token mit einem ähnlichen Namen oder Symbol existiert bereits.",
 			"unexpected_undefined": "Token ist undefiniert. Das ist unerwartet.",
 			"unexpected_error_on_token_delete": "Beim Löschen des Tokens ist etwas schiefgelaufen.",
 			"unexpected_error_on_token_update": "Beim Aktualisieren des Tokens ist etwas schiefgelaufen."

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Token is already available.",
 			"not_toggleable": "Token is not toggleable, it can not be hidden.",
 			"incomplete_metadata": "No name or symbol is provided in the metadata.",
-			"duplicate_metadata": "A token with a similar name or symbol already exists.",
 			"unexpected_undefined": "Token is undefined. This is unexpected.",
 			"unexpected_error_on_token_delete": "Something went wrong while removing the token.",
 			"unexpected_error_on_token_update": "Something went wrong while updating the token."

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1376,7 +1376,6 @@
 			"already_available": "El token ya está disponible.",
 			"not_toggleable": "El token no se puede alternar, no se puede ocultar.",
 			"incomplete_metadata": "No se proporciona ningún nombre o símbolo en los metadatos.",
-			"duplicate_metadata": "Ya existe un token con un nombre o símbolo similar.",
 			"unexpected_undefined": "El token no está definido. Esto es inesperado.",
 			"unexpected_error_on_token_delete": "Algo salió mal al eliminar el token.",
 			"unexpected_error_on_token_update": "Algo salió mal al actualizar el token."

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Le token est déjà disponible.",
 			"not_toggleable": "Le token n'est pas basculable, il ne peut pas être masqué.",
 			"incomplete_metadata": "Aucun nom ou symbole n'est fourni dans les métadonnées.",
-			"duplicate_metadata": "Un token avec un nom ou un symbole similaire existe déjà.",
 			"unexpected_undefined": "Le token est indéfini. C'est inattendu.",
 			"unexpected_error_on_token_delete": "Quelque chose s'est mal passé lors de la suppression du token.",
 			"unexpected_error_on_token_update": "Quelque chose s'est mal passé lors de la mise à jour du token."

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1376,7 +1376,6 @@
 			"already_available": "टोकन पहले से उपलब्ध है।",
 			"not_toggleable": "टोकन टॉगलेबल नहीं है, इसे छिपाया नहीं जा सकता।",
 			"incomplete_metadata": "मेटाडेटा में कोई नाम या प्रतीक प्रदान नहीं किया गया है।",
-			"duplicate_metadata": "समान नाम या प्रतीक वाला एक टोकन पहले से मौजूद है।",
 			"unexpected_undefined": "टोकन अपरिभाषित है। यह अप्रत्याशित है।",
 			"unexpected_error_on_token_delete": "टोकन हटाते समय कुछ गलत हो गया।",
 			"unexpected_error_on_token_update": "टोकन अपडेट करते समय कुछ गलत हो गया।"

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Token già disponibile.",
 			"not_toggleable": "Il token non è attivabile/disattivabile, non può essere nascosto.",
 			"incomplete_metadata": "Nessun nome o simbolo è fornito nei metadati.",
-			"duplicate_metadata": "Un token con un nome o simbolo simile esiste già.",
 			"unexpected_undefined": "Il token non è definito. Questo è inaspettato.",
 			"unexpected_error_on_token_delete": "Si è verificato un errore durante la rimozione del token.",
 			"unexpected_error_on_token_update": "Si è verificato un errore durante l'aggiornamento del token."

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1376,7 +1376,6 @@
 			"already_available": "トークンはすでに利用可能です。",
 			"not_toggleable": "トークンは切り替え不可であり、非表示にできません。",
 			"incomplete_metadata": "メタデータに名前またはシンボルが提供されていません。",
-			"duplicate_metadata": "同じ名前やシンボルのトークンが既に存在します。",
 			"unexpected_undefined": "トークンが未定義です。これは予期しないエラーです。",
 			"unexpected_error_on_token_delete": "トークンの削除中にエラーが発生しました。",
 			"unexpected_error_on_token_update": "トークンの更新中にエラーが発生しました。"

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1376,7 +1376,6 @@
 			"already_available": "토큰이 이미 사용 가능합니다.",
 			"not_toggleable": "이 토큰은 전환할 수 없어 숨길 수 없습니다.",
 			"incomplete_metadata": "메타데이터에 이름 또는 심볼이 없습니다.",
-			"duplicate_metadata": "유사한 이름 또는 심볼을 가진 토큰이 이미 존재합니다.",
 			"unexpected_undefined": "토큰이 정의되지 않았습니다. 이는 예상치 못한 상황입니다.",
 			"unexpected_error_on_token_delete": "토큰을 제거하는 중 문제가 발생했습니다.",
 			"unexpected_error_on_token_update": "토큰을 업데이트하는 중 문제가 발생했습니다."

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Token jest już dostępny.",
 			"not_toggleable": "Token nie jest przełączalny, nie można go ukryć.",
 			"incomplete_metadata": "W metadanych nie podano nazwy ani symbolu.",
-			"duplicate_metadata": "Token o podobnej nazwie lub symbolu już istnieje.",
 			"unexpected_undefined": "Token jest niezdefiniowany. To nieoczekiwane.",
 			"unexpected_error_on_token_delete": "Coś poszło nie tak podczas usuwania tokena.",
 			"unexpected_error_on_token_update": "Coś poszło nie tak podczas aktualizacji tokena."

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Token já disponível.",
 			"not_toggleable": "O token não é alternável, não pode ser ocultado.",
 			"incomplete_metadata": "Nenhum nome ou símbolo é fornecido nos metadados.",
-			"duplicate_metadata": "Um token com nome ou símbolo semelhante já existe.",
 			"unexpected_undefined": "O token é indefinido. Isso é inesperado.",
 			"unexpected_error_on_token_delete": "Algo falhou ao remover o token.",
 			"unexpected_error_on_token_update": "Algo falhou ao atualizar o token."

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Токен уже доступен.",
 			"not_toggleable": "Токен не переключаем, его нельзя скрыть.",
 			"incomplete_metadata": "В метаданных не указаны имя или символ.",
-			"duplicate_metadata": "Токен с похожим именем или символом уже существует.",
 			"unexpected_undefined": "Токен не определен. Это неожиданно.",
 			"unexpected_error_on_token_delete": "При удалении токена произошла ошибка.",
 			"unexpected_error_on_token_update": "При обновлении токена произошла ошибка."

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1376,7 +1376,6 @@
 			"already_available": "Token đã có sẵn.",
 			"not_toggleable": "Token không thể chuyển đổi, không thể ẩn.",
 			"incomplete_metadata": "Không có tên hoặc ký hiệu được cung cấp trong metadata.",
-			"duplicate_metadata": "Đã tồn tại một token có tên hoặc ký hiệu tương tự.",
 			"unexpected_undefined": "Token không xác định. Điều này không mong muốn.",
 			"unexpected_error_on_token_delete": "Đã xảy ra lỗi khi xóa token.",
 			"unexpected_error_on_token_update": "Đã xảy ra lỗi khi cập nhật token."

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1376,7 +1376,6 @@
 			"already_available": "代币已存在。",
 			"not_toggleable": "该代币不可切换，无法隐藏。",
 			"incomplete_metadata": "元数据中未提供名称或符号。",
-			"duplicate_metadata": "已存在名称或符号相似的代币。",
 			"unexpected_undefined": "代币未定义。这是异常情况。",
 			"unexpected_error_on_token_delete": "移除代币时发生错误。",
 			"unexpected_error_on_token_update": "更新代币时发生错误。"

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1069,7 +1069,6 @@ interface I18nTokens {
 		already_available: string;
 		not_toggleable: string;
 		incomplete_metadata: string;
-		duplicate_metadata: string;
 		unexpected_undefined: string;
 		unexpected_error_on_token_delete: string;
 		unexpected_error_on_token_update: string;

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -16,7 +16,7 @@ import { isIcCkToken } from '$icp/validation/ic-token.validation';
 import { LOCAL, ZERO } from '$lib/constants/app.constants';
 import type { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import { saveCustomTokensWithKey } from '$lib/services/manage-tokens.services';
-import { toastsError, toastsShow } from '$lib/stores/toasts.store';
+import { toastsShow } from '$lib/stores/toasts.store';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
 import type { NullishIdentity } from '$lib/types/identity';
 import type { Token, TokenId } from '$lib/types/token';
@@ -647,30 +647,6 @@ export const filterTokensByNft = <T extends Token>({
 				const isNft = isTokenNonFungible(t);
 				return filterNfts ? isNft : !isNft;
 			});
-
-export const assertExistingTokens = <T extends Token>({
-	existingTokens,
-	token,
-	errorMsg
-}: {
-	existingTokens: T[];
-	token: Omit<T, 'id'>;
-	errorMsg: string;
-}): { valid: boolean } => {
-	if (
-		nonNullish(
-			existingTokens.find(({ symbol }) => symbol.toLowerCase() === token.symbol.toLowerCase())
-		)
-	) {
-		toastsError({
-			msg: { text: errorMsg }
-		});
-
-		return { valid: false };
-	}
-
-	return { valid: true };
-};
 
 /**
  * Returns the path to a token icon stored in the codebase.

--- a/src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte
+++ b/src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte
@@ -93,20 +93,6 @@
 				symbol,
 				name
 			};
-
-			if (
-				nonNullish(
-					$splTokens?.find(
-						({ symbol }) => symbol.toLowerCase() === (metadata?.symbol.toLowerCase() ?? '')
-					)
-				)
-			) {
-				toastsError({
-					msg: { text: $i18n.tokens.error.duplicate_metadata }
-				});
-
-				onBack();
-			}
 		} catch (_: unknown) {
 			toastsError({ msg: { text: $i18n.tokens.import.error.loading_metadata } });
 

--- a/src/frontend/src/tests/eth/components/tokens/EthAddTokenReview.spec.ts
+++ b/src/frontend/src/tests/eth/components/tokens/EthAddTokenReview.spec.ts
@@ -278,7 +278,7 @@ describe('EthAddTokenReview', () => {
 		});
 	});
 
-	it('should render an error if metadata are duplicated', async () => {
+	it('should not error when another token has the same symbol on the same network', async () => {
 		erc721CustomTokensStore.setAll([{ data: mockErc721CustomToken, certified: false }]);
 
 		const mockErc20Provider = {
@@ -311,9 +311,9 @@ describe('EthAddTokenReview', () => {
 		});
 
 		await vi.waitFor(() => {
-			expect(toastsError).toHaveBeenCalledWith({
-				msg: { text: en.tokens.error.duplicate_metadata }
-			});
+			expect(mockErc721Provider.metadata).toHaveBeenCalled();
 		});
+
+		expect(toastsError).not.toHaveBeenCalled();
 	});
 });

--- a/src/frontend/src/tests/icp/services/ext-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ext-add-custom-tokens.service.spec.ts
@@ -84,7 +84,7 @@ describe('ext-add-custom-tokens.service', () => {
 			});
 		});
 
-		it('should return error if token already exists', () => {
+		it('should successfully load a new token even if another token has the same symbol', () => {
 			const result = loadAndAssertAddCustomToken({
 				identity: mockIdentity,
 				extTokens: [
@@ -97,11 +97,7 @@ describe('ext-add-custom-tokens.service', () => {
 				canisterId: mockCanisterId
 			});
 
-			expect(result).toEqual({ result: 'error' });
-
-			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
-				msg: { text: get(i18n).tokens.error.duplicate_metadata }
-			});
+			expect(result).toStrictEqual({ result: 'success', data: { token: expectedToken } });
 		});
 
 		it('should successfully load a new token', () => {

--- a/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-add-custom-tokens.service.spec.ts
@@ -161,28 +161,6 @@ describe('ic-add-custom-tokens.service', () => {
 						msg: { text: get(i18n).tokens.import.error.no_metadata }
 					});
 				});
-
-				it('should return error if token already exits', async () => {
-					spyBalance = ledgerCanisterMock.balance.mockResolvedValue(123n);
-
-					spyMetadata = ledgerCanisterMock.metadata.mockResolvedValue([
-						['icrc1:name', { Text: tokenName }],
-						['icrc1:symbol', { Text: tokenSymbol }],
-						['icrc1:decimals', { Nat: BigInt(tokenDecimals) }],
-						['icrc1:fee', { Nat: tokenFee }]
-					]);
-
-					const result = await loadAndAssertAddCustomToken({
-						...validParams,
-						icrcTokens: [existingToken]
-					});
-
-					expect(result).toEqual({ result: 'error' });
-
-					expect(spyToastsError).toHaveBeenNthCalledWith(1, {
-						msg: { text: get(i18n).tokens.error.duplicate_metadata }
-					});
-				});
 			});
 
 			describe('with index canister', () => {
@@ -221,37 +199,6 @@ describe('ic-add-custom-tokens.service', () => {
 
 					expect(spyToastsError).toHaveBeenNthCalledWith(1, {
 						msg: { text: get(i18n).tokens.import.error.no_metadata }
-					});
-				});
-
-				it('should return error if token already exits', async () => {
-					spyLedgerId = indexCanisterMock.ledgerId.mockResolvedValue(
-						Principal.fromText(mockLedgerCanisterId)
-					);
-
-					spyGetTransactions = indexCanisterMock.getTransactions.mockResolvedValue({
-						balance: 100n,
-						transactions: [],
-						oldest_tx_id: [ZERO]
-					});
-
-					spyMetadata = ledgerCanisterMock.metadata.mockResolvedValue([
-						['icrc1:name', { Text: tokenName }],
-						['icrc1:symbol', { Text: tokenSymbol }],
-						['icrc1:decimals', { Nat: BigInt(tokenDecimals) }],
-						['icrc1:fee', { Nat: tokenFee }]
-					]);
-
-					const result = await loadAndAssertAddCustomToken({
-						...validParams,
-						indexCanisterId: mockIndexCanisterId,
-						icrcTokens: [existingToken]
-					});
-
-					expect(result).toEqual({ result: 'error' });
-
-					expect(spyToastsError).toHaveBeenNthCalledWith(1, {
-						msg: { text: get(i18n).tokens.error.duplicate_metadata }
 					});
 				});
 			});
@@ -318,6 +265,15 @@ describe('ic-add-custom-tokens.service', () => {
 				expect(result).toBe('success');
 			};
 
+			const assertLoadTokenSameMetadata = async (params: LoadAndAssertAddCustomTokenParams) => {
+				const { result } = await loadAndAssertAddCustomToken({
+					...params,
+					icrcTokens: [existingToken]
+				});
+
+				expect(result).toBe('success');
+			};
+
 			it('should init ledger with expected canister id', async () => {
 				await loadAndAssertAddCustomToken(validParams);
 
@@ -365,6 +321,10 @@ describe('ic-add-custom-tokens.service', () => {
 
 				it('should successfully load a new token if name and symbol is different', async () => {
 					await assertLoadTokenDifferent(validParams);
+				});
+
+				it('should successfully load a new token even if another token has the same symbol', async () => {
+					await assertLoadTokenSameMetadata(validParams);
 				});
 			});
 
@@ -428,6 +388,10 @@ describe('ic-add-custom-tokens.service', () => {
 
 				it('should successfully load a new token if name and symbol is different', async () => {
 					await assertLoadTokenDifferent(validParamsWithIndex);
+				});
+
+				it('should successfully load a new token even if another token has the same symbol', async () => {
+					await assertLoadTokenSameMetadata(validParamsWithIndex);
 				});
 			});
 		});

--- a/src/frontend/src/tests/icp/services/icpunks-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/icpunks-add-custom-tokens.service.spec.ts
@@ -92,7 +92,7 @@ describe('icpunks-add-custom-tokens.service', () => {
 			});
 		});
 
-		it('should return error if token already exists', async () => {
+		it('should successfully load a new token even if another token has the same symbol', async () => {
 			const result = await loadAndAssertAddCustomToken({
 				identity: mockIdentity,
 				icPunksTokens: [
@@ -105,11 +105,7 @@ describe('icpunks-add-custom-tokens.service', () => {
 				canisterId: mockCanisterId
 			});
 
-			expect(result).toEqual({ result: 'error' });
-
-			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
-				msg: { text: get(i18n).tokens.error.duplicate_metadata }
-			});
+			expect(result).toStrictEqual({ result: 'success', data: { token: expectedToken } });
 		});
 
 		it('should successfully load a new token', async () => {

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -12,14 +12,13 @@ import {
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_DEVNET_TOKEN, SOLANA_LOCAL_TOKEN, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
-import type { Erc20Token } from '$eth/types/erc20';
 import type { IcCkToken, IcToken } from '$icp/types/ic-token';
 import * as appConstants from '$lib/constants/app.constants';
 import { ZERO } from '$lib/constants/app.constants';
 import { saveCustomTokensWithKey } from '$lib/services/manage-tokens.services';
 import type { BalancesData } from '$lib/stores/balances.store';
 import type { CertifiedStoreData } from '$lib/stores/certified.store';
-import { toastsError, toastsShow } from '$lib/stores/toasts.store';
+import { toastsShow } from '$lib/stores/toasts.store';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { Network } from '$lib/types/network';
 import type { StakeBalances } from '$lib/types/stake-balance';
@@ -31,7 +30,6 @@ import type { UserNetworks } from '$lib/types/user-networks';
 import { usdValue } from '$lib/utils/exchange.utils';
 import { mapTokenUi } from '$lib/utils/token.utils';
 import {
-	assertExistingTokens,
 	defineEnabledTokens,
 	filterEnabledTokens,
 	filterTokens,
@@ -53,7 +51,7 @@ import { parseTokenId } from '$lib/validation/token.validation';
 import { bn1Bi, bn2Bi, bn3Bi, certified, mockBalances } from '$tests/mocks/balances.mock';
 import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidErc1155Token } from '$tests/mocks/erc1155-tokens.mock';
-import { createMockErc20Tokens, mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
 import { mockValidErc721Token } from '$tests/mocks/erc721-tokens.mock';
 import { mockExchanges, mockOneUsd } from '$tests/mocks/exchanges.mock';
@@ -1891,82 +1889,6 @@ describe('tokens.utils', () => {
 			const result = filterTokensByNft({ tokens: [], filterNfts: false });
 
 			expect(result).toHaveLength(0);
-		});
-	});
-
-	describe('assertExistingTokens', () => {
-		const mockErrorMsg = 'Token already exists';
-		const mockTokens: Erc20Token[] = createMockErc20Tokens({ n: 5, networkEnv: 'mainnet' });
-		const { id: _, ...mockToken } = mockTokens[mockTokens.length - 1];
-		const mockParams = {
-			existingTokens: mockTokens,
-			token: mockToken,
-			errorMsg: mockErrorMsg
-		};
-
-		beforeEach(() => {
-			vi.clearAllMocks();
-		});
-
-		it('should return true when existing tokens are empty', () => {
-			const res = assertExistingTokens({
-				...mockParams,
-				existingTokens: [] as Erc20Token[]
-			});
-
-			expect(res).toStrictEqual({ valid: true });
-
-			expect(toastsError).not.toHaveBeenCalled();
-		});
-
-		it('should return true when there is no match', () => {
-			const res = assertExistingTokens({
-				...mockParams,
-				token: { ...mockToken, symbol: 'NEW' }
-			});
-
-			expect(res).toStrictEqual({ valid: true });
-
-			expect(toastsError).not.toHaveBeenCalled();
-		});
-
-		it('should return false and toasts when symbol matches exactly', () => {
-			const res = assertExistingTokens(mockParams);
-
-			expect(res).toStrictEqual({ valid: false });
-
-			expect(toastsError).toHaveBeenCalledExactlyOnceWith({ msg: { text: mockErrorMsg } });
-		});
-
-		it('should be case-insensitive', () => {
-			expect(
-				assertExistingTokens({
-					...mockParams,
-					token: { ...mockToken, symbol: mockToken.symbol.toLowerCase() }
-				})
-			).toStrictEqual({ valid: false });
-
-			expect(
-				assertExistingTokens({
-					...mockParams,
-					token: { ...mockToken, symbol: mockToken.symbol.toUpperCase() }
-				})
-			).toStrictEqual({ valid: false });
-		});
-
-		it('should match the first item', () => {
-			const res = assertExistingTokens({
-				...mockParams,
-				existingTokens: [
-					...mockTokens,
-					mockTokens[mockTokens.length - 1],
-					mockTokens[mockTokens.length - 1]
-				]
-			});
-
-			expect(res).toEqual({ valid: false });
-
-			expect(toastsError).toHaveBeenCalledExactlyOnceWith({ msg: { text: mockErrorMsg } });
 		});
 	});
 


### PR DESCRIPTION
# Motivation

When importing a custom token, the wallet rejected the import if any token already known to the user shared the same symbol on the same network. The address (canister id / contract address) is the real identity check, so the symbol-based block was overly strict — for example, both ICP-native and 1Sec-bridged USDC share the `USDC` symbol but live at different addresses, and many ICRC tokens legitimately reuse symbols across projects.

# Changes

- `src/frontend/src/lib/utils/tokens.utils.ts` — drop the `assertExistingTokens` helper and its only caller pattern.
- `src/frontend/src/icp/services/{ic,ext,icpunks}-add-custom-tokens.service.ts` — remove the symbol-collision check after metadata load. The address-based `already_available` check still runs.
- `src/frontend/src/eth/components/tokens/EthAddTokenReview.svelte` — drop the symbol-collision check from `validateMetadata`.
- `src/frontend/src/sol/components/tokens/SolAddTokenReview.svelte` — drop the symbol-collision check after metadata load.
- `src/frontend/src/lib/i18n/*.json` and `src/frontend/src/lib/types/i18n.d.ts` — remove the now-unused `tokens.error.duplicate_metadata` key from every locale.
- Tests updated to assert the previously-blocked path now succeeds (`ic-add-custom-tokens`, `ext-add-custom-tokens`, `icpunks-add-custom-tokens`, `EthAddTokenReview`); the corresponding `assertExistingTokens` unit tests are removed.

# Tests

- `npm run check` — green
- targeted `npx vitest run` on the five affected spec files — 173 passing
- `npx eslint --fix --max-warnings 0` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.7