### PR TITLE
fix(frontend): show only generic label + count on activity filter chips

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
@@ -3,28 +3,17 @@
 	import TransactionsFilterContactsPanel from '$lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte';
 	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
 	import { TRANSACTIONS_FILTER_CONTACTS_DROPDOWN } from '$lib/constants/test-ids.constants';
-	import { allContacts } from '$lib/derived/contacts.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.contactIds));
-
-	let triggerLabel = $derived.by(() => {
-		if (selectedSet.size === 0) {
-			return $i18n.transaction.filter.contacts_label;
-		}
-
-		const first = $allContacts.find((c) => selectedSet.has(c.id.toString()));
-
-		return first?.name ?? $i18n.transaction.filter.contacts_label;
-	});
 </script>
 
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.contacts_aria_label}
 	count={selectedSet.size}
 	testId={TRANSACTIONS_FILTER_CONTACTS_DROPDOWN}
-	{triggerLabel}
+	triggerLabel={$i18n.transaction.filter.contacts_label}
 >
 	{#snippet triggerIcon()}
 		<IconUserSquare size="20" />

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -33,20 +33,6 @@
 					return name.toLowerCase().includes(needle) || symbol.toLowerCase().includes(needle);
 				})
 	);
-
-	let triggerLabel = $derived.by(() => {
-		if (selectedSet.size === 0) {
-			return $i18n.transaction.filter.tokens_label;
-		}
-
-		const first = sortedTokens.find((t) => {
-			const key = tokenKey(t);
-
-			return nonNullish(key) && selectedSet.has(key);
-		});
-
-		return first?.symbol ?? $i18n.transaction.filter.tokens_label;
-	});
 </script>
 
 <MultiSelectDropdown
@@ -55,7 +41,7 @@
 	searchPlaceholder={$i18n.transaction.filter.search_tokens_placeholder}
 	searchable
 	testId={TRANSACTIONS_FILTER_TOKENS_DROPDOWN}
-	{triggerLabel}
+	triggerLabel={$i18n.transaction.filter.tokens_label}
 	bind:searchValue
 >
 	{#snippet triggerIcon()}

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
@@ -21,19 +21,13 @@
 	);
 
 	let selectedSet = $derived(new Set<TransactionType>($transactionsFilterStore.types));
-
-	let triggerLabel = $derived(
-		selectedSet.size === 0
-			? $i18n.transaction.filter.types_label
-			: ($i18n.transaction.type[[...selectedSet][0]] ?? $i18n.transaction.filter.types_label)
-	);
 </script>
 
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.types_aria_label}
 	count={selectedSet.size}
 	testId={TRANSACTIONS_FILTER_TYPES_DROPDOWN}
-	{triggerLabel}
+	triggerLabel={$i18n.transaction.filter.types_label}
 >
 	{#snippet triggerIcon()}
 		<IconListFilter size="20" />


### PR DESCRIPTION
# Motivation

Per Figma, the activity filter chip's trigger should always read "Type" / "Token" / "Contacts"; the selected count is communicated by the badge next to the label. Today the chip swaps to the first selected item's name when there's a selection (e.g. "Approve", "BTC", "Alice") which loses the category context — and gets nonsensical when more than one item is picked (only the first shows).

# Changes

- `TransactionsFilterTypes.svelte`, `TransactionsFilterTokens.svelte`, `TransactionsFilterContacts.svelte` — drop the conditional `triggerLabel` derivation and always pass the static generic label. The count badge already renders via `MultiSelectDropdown` when `count > 0`.
- Drop now-dead `allContacts` import in the contacts chip (only used by the previous lookup).

# Tests

- Existing panel + store + dropdown tests stay green (25/25).
- Manual repro on `/activity`: open any chip → tick one or more items → trigger keeps the category label, badge shows the count.