### PR TITLE
fix(frontend): scope activity token filter to enabled tokens for selected network

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -5,7 +5,7 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
 	import { TRANSACTIONS_FILTER_TOKENS_DROPDOWN } from '$lib/constants/test-ids.constants';
-	import { allFungibleTokens } from '$lib/derived/all-tokens.derived';
+	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 	import type { Token } from '$lib/types/token';
@@ -18,7 +18,7 @@
 	const tokenKey = (token: Token): string | undefined => token.id.description;
 
 	let sortedTokens = $derived(
-		[...$allFungibleTokens].sort((a, b) =>
+		[...$enabledFungibleNetworkTokens].sort((a, b) =>
 			(a.name ?? a.symbol).localeCompare(b.name ?? b.symbol, undefined, {
 				sensitivity: 'base'
 			})

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -3,7 +3,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import InputSearch from '$lib/components/ui/InputSearch.svelte';
-	import { allFungibleTokens } from '$lib/derived/all-tokens.derived';
+	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 	import type { Token } from '$lib/types/token';
@@ -23,7 +23,7 @@
 	const tokenKey = (token: Token): string | undefined => token.id.description;
 
 	let sortedTokens = $derived(
-		[...$allFungibleTokens].sort((a, b) =>
+		[...$enabledFungibleNetworkTokens].sort((a, b) =>
 			(a.name ?? a.symbol).localeCompare(b.name ?? b.symbol, undefined, {
 				sensitivity: 'base'
 			})

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterMobileSheet.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterMobileSheet.spec.ts
@@ -1,6 +1,6 @@
 import TransactionsFilterMobileSheet from '$lib/components/transactions/filter/TransactionsFilterMobileSheet.svelte';
-import * as allTokensDerived from '$lib/derived/all-tokens.derived';
 import * as contactsDerived from '$lib/derived/contacts.derived';
+import * as networkTokensDerived from '$lib/derived/network-tokens.derived';
 import { i18n } from '$lib/stores/i18n.store';
 import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 import { fireEvent, render } from '@testing-library/svelte';
@@ -12,10 +12,12 @@ describe('TransactionsFilterMobileSheet', () => {
 		localStorage.clear();
 		transactionsFilterStore.clear();
 
-		vi.spyOn(allTokensDerived.allFungibleTokens, 'subscribe').mockImplementation((fn) => {
-			fn([]);
-			return () => {};
-		});
+		vi.spyOn(networkTokensDerived.enabledFungibleNetworkTokens, 'subscribe').mockImplementation(
+			(fn) => {
+				fn([]);
+				return () => {};
+			}
+		);
 		vi.spyOn(contactsDerived.allContacts, 'subscribe').mockImplementation((fn) => {
 			fn([]);
 			return () => {};

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
@@ -1,5 +1,5 @@
 import TransactionsFilterTokensPanel from '$lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte';
-import * as allTokensDerived from '$lib/derived/all-tokens.derived';
+import * as networkTokensDerived from '$lib/derived/network-tokens.derived';
 import { i18n } from '$lib/stores/i18n.store';
 import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 import type { Token } from '$lib/types/token';
@@ -9,11 +9,13 @@ import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
-const mockAllFungibleTokens = (tokens: Token[]) => {
-	vi.spyOn(allTokensDerived.allFungibleTokens, 'subscribe').mockImplementation((fn) => {
-		fn(tokens);
-		return () => {};
-	});
+const mockEnabledFungibleNetworkTokens = (tokens: Token[]) => {
+	vi.spyOn(networkTokensDerived.enabledFungibleNetworkTokens, 'subscribe').mockImplementation(
+		(fn) => {
+			fn(tokens);
+			return () => {};
+		}
+	);
 };
 
 const buildToken = ({ id, name, symbol }: { id: string; name: string; symbol: string }): Token => ({
@@ -32,7 +34,7 @@ describe('TransactionsFilterTokensPanel', () => {
 		vi.restoreAllMocks();
 		localStorage.clear();
 		transactionsFilterStore.clear();
-		mockAllFungibleTokens([tokenBeta, tokenAlpha, tokenGamma]);
+		mockEnabledFungibleNetworkTokens([tokenBeta, tokenAlpha, tokenGamma]);
 	});
 
 	it('renders one row per fungible token, alphabetically sorted by name', () => {
@@ -109,7 +111,7 @@ describe('TransactionsFilterTokensPanel', () => {
 				symbol: `T${i.toString().padStart(3, '0')}`
 			})
 		);
-		mockAllFungibleTokens(tokens);
+		mockEnabledFungibleNetworkTokens(tokens);
 
 		const { container, getByText } = render(TransactionsFilterTokensPanel);
 
@@ -131,7 +133,7 @@ describe('TransactionsFilterTokensPanel', () => {
 				symbol: `T${i.toString().padStart(3, '0')}`
 			})
 		);
-		mockAllFungibleTokens(tokens);
+		mockEnabledFungibleNetworkTokens(tokens);
 
 		const { container, getByPlaceholderText } = render(TransactionsFilterTokensPanel);
 


### PR DESCRIPTION
# Motivation

The token filter on the Activity page (`TransactionsFilterTokens` and `TransactionsFilterTokensPanel`) was sourced from `allFungibleTokens`, i.e. **every** known fungible token — including disabled ones and tokens that don't belong to the currently selected network. That is inconsistent with the rest of the page (`AllTransactions.svelte` / `AllTransactionsList.svelte` already build the transaction list from `enabledFungibleNetworkTokens`), so the filter could offer to filter by tokens that have no chance of producing any rows.

# Changes

- `TransactionsFilterTokens.svelte`, `TransactionsFilterTokensPanel.svelte`: switch the source of the token list from `allFungibleTokens` (`$lib/derived/all-tokens.derived`) to the existing `enabledFungibleNetworkTokens` (`$lib/derived/network-tokens.derived`), so the dropdown / sheet only lists user-enabled tokens that match the active network filter (or chain fusion when no network is selected).
- `TransactionsFilterTokensPanel.spec.ts`, `TransactionsFilterMobileSheet.spec.ts`: update the test mocks accordingly (spy on `enabledFungibleNetworkTokens.subscribe` instead of `allFungibleTokens.subscribe`).

No public API, store, or i18n key is touched; `transactionsFilterStore` and the panel/sheet behavior stay identical apart from the source set.

# Tests

- `npx vitest run src/frontend/src/tests/lib/components/transactions/filter/` — 4 files, 25 tests, all green.
- `npx vitest run src/frontend/src/tests/lib/components/transactions/` — 15 files, 111 tests, all green.
- `npx prettier --check` on the changed files — clean.
