### PR TITLE
fix(frontend): restore conditional bg-page on sticky activity filter toolbar

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -20,6 +20,7 @@
 	import TransactionsDateGroup from '$lib/components/transactions/TransactionsDateGroup.svelte';
 	import TransactionsPlaceholder from '$lib/components/transactions/TransactionsPlaceholder.svelte';
 	import TransactionsFilterToolbar from '$lib/components/transactions/filter/TransactionsFilterToolbar.svelte';
+	import StickyHeader from '$lib/components/ui/StickyHeader.svelte';
 	import { ACTIVITY_TRANSACTION_SKELETON_PREFIX } from '$lib/constants/test-ids.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { allContacts } from '$lib/derived/contacts.derived';
@@ -124,29 +125,46 @@
 	);
 </script>
 
-<div class="sticky top-0 z-10 -mx-1 bg-page px-1 pt-6 pb-3">
-	<TransactionsFilterToolbar />
-</div>
+<!--
+	The toolbar is sticky in its OWN stacking context at z-10 (passed
+	through `StickyHeader`). Each `TransactionsDateGroup` uses the same
+	`StickyHeader` internally at the default z-3, so without a stronger
+	z-index here the gix Popover that the chips open would be trapped
+	inside the toolbar's z-3 context and the date stickies (also z-3,
+	but rendered later in DOM) would paint on top of it. Bumping to z-10
+	puts the popover's containing stacking context above all date z-3
+	contexts, so the dropdown content paints on top of the date headers.
 
-<AllTransactionsSkeletons testIdPrefix={ACTIVITY_TRANSACTION_SKELETON_PREFIX}>
-	<AllTransactionsLoader transactions={allTransactions}>
-		<AllTransactionsScroll {sortedTransactions} bind:transactionsToDisplay>
-			{#if Object.values(groupedTransactions).length > 0}
-				{#each Object.entries(groupedTransactions) as [formattedDate, transactions], index (formattedDate)}
-					<TransactionsDateGroup
-						{formattedDate}
-						testId={`all-transactions-date-group-${index}`}
-						{transactions}
-					/>
-				{/each}
-			{/if}
+	Reusing `StickyHeader` (rather than an inline sticky div with a
+	hard-coded `bg-page`) gives us back its conditional `bg-page` / `pt-6`
+	behavior — the toolbar is fully transparent until the user actually
+	scrolls into it, matching the date headers below.
+-->
+<StickyHeader zIndex={10}>
+	{#snippet header()}
+		<TransactionsFilterToolbar />
+	{/snippet}
 
-			{#if Object.values(groupedTransactions).length === 0}
-				<TransactionsPlaceholder />
-			{/if}
-		</AllTransactionsScroll>
-	</AllTransactionsLoader>
-</AllTransactionsSkeletons>
+	<AllTransactionsSkeletons testIdPrefix={ACTIVITY_TRANSACTION_SKELETON_PREFIX}>
+		<AllTransactionsLoader transactions={allTransactions}>
+			<AllTransactionsScroll {sortedTransactions} bind:transactionsToDisplay>
+				{#if Object.values(groupedTransactions).length > 0}
+					{#each Object.entries(groupedTransactions) as [formattedDate, transactions], index (formattedDate)}
+						<TransactionsDateGroup
+							{formattedDate}
+							testId={`all-transactions-date-group-${index}`}
+							{transactions}
+						/>
+					{/each}
+				{/if}
+
+				{#if Object.values(groupedTransactions).length === 0}
+					<TransactionsPlaceholder />
+				{/if}
+			</AllTransactionsScroll>
+		</AllTransactionsLoader>
+	</AllTransactionsSkeletons>
+</StickyHeader>
 
 {#if $modalBtcTransaction && nonNullish(selectedBtcTransaction)}
 	<BtcTransactionModal token={selectedBtcToken} transaction={selectedBtcTransaction} />

--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -5,9 +5,15 @@
 	interface Props {
 		header: Snippet;
 		children: Snippet;
+		// Optional stacking-context override. Defaults to `z-3` to match the
+		// historical behavior shared by every sticky header in the app. Pass
+		// `10` for headers whose contents open a popover that must paint above
+		// other sibling sticky headers (also at `z-3`) rendered later in the
+		// DOM — see `AllTransactionsList`.
+		zIndex?: 3 | 10;
 	}
 
-	const { header, children }: Props = $props();
+	const { header, children, zIndex = 3 }: Props = $props();
 
 	const SPACING_UNIT = 4;
 	const SPACING_TOP = SPACING_UNIT * 6; // since we add pt-6 we need to trigger earlier
@@ -29,9 +35,11 @@
 
 <div bind:this={rootElement}>
 	<div
-		class="sticky top-0 z-3 px-1 whitespace-nowrap"
+		class="sticky top-0 px-1 whitespace-nowrap"
 		class:bg-page={scrolledSoon}
 		class:pt-6={scrolledSoon}
+		class:z-10={zIndex === 10}
+		class:z-3={zIndex === 3}
 	>
 		{@render header()}
 	</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

> **Superseded by #12707**, which targets `main` directly (this one was stacked on #12703). Please close.

The original motivation: stacked on top of #12703.

The unbox in #12703 (which escapes the gix `Popover` from the toolbar's `z-3` stacking trap) replaced `<StickyHeader>` with a plain sticky div that hard-codes `bg-page pt-6`. That regressed the "transparent until the user actually scrolls into it" behavior that `StickyHeader` already gives every other sticky header in the app — same fix the date headers got in #9911.

# Changes

See #12707 for the version targeting `main`.

# Tests

See #12707.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1409485f-f2bc-420d-9b91-44f614ef8968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1409485f-f2bc-420d-9b91-44f614ef8968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

