### PR TITLE
fix(frontend): escape z-3 stacking context for activity filter toolbar

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -125,7 +125,17 @@
 	);
 </script>
 
-<StickyHeader>
+<!--
+	Each `TransactionsDateGroup` uses `StickyHeader` internally at the
+	default `z-3`, creating a sibling stacking context per date label. If
+	the toolbar's `StickyHeader` were also at `z-3`, the gix Popover that
+	the chips open would be trapped inside the toolbar's `z-3` context and
+	the date stickies (also `z-3`, but rendered later in DOM) would paint
+	on top of it — visually freezing the dropdown. Bumping to `z-10` lifts
+	the popover's containing stacking context above every date `z-3`
+	context, so the dropdown content paints on top of the date headers.
+-->
+<StickyHeader zIndex={10}>
 	{#snippet header()}
 		<TransactionsFilterToolbar />
 	{/snippet}

--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -5,9 +5,15 @@
 	interface Props {
 		header: Snippet;
 		children: Snippet;
+		// Optional stacking-context override. Defaults to `z-3` to match the
+		// historical behavior shared by every sticky header in the app. Pass
+		// `10` for headers whose contents open a popover that must paint above
+		// other sibling sticky headers (also at `z-3`) rendered later in the
+		// DOM — see `AllTransactionsList`.
+		zIndex?: 3 | 10;
 	}
 
-	const { header, children }: Props = $props();
+	const { header, children, zIndex = 3 }: Props = $props();
 
 	const SPACING_UNIT = 4;
 	const SPACING_TOP = SPACING_UNIT * 6; // since we add pt-6 we need to trigger earlier
@@ -29,9 +35,11 @@
 
 <div bind:this={rootElement}>
 	<div
-		class="sticky top-0 z-3 px-1 whitespace-nowrap"
+		class="sticky top-0 px-1 whitespace-nowrap"
 		class:bg-page={scrolledSoon}
 		class:pt-6={scrolledSoon}
+		class:z-10={zIndex === 10}
+		class:z-3={zIndex === 3}
 	>
 		{@render header()}
 	</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

> **Superseded by #12711**, which bundles this stacking-context fix together with the Header z-bump, the toast z-index lower, and the Tokens-chip Panel reuse — all the four `/activity` regressions in one PR. Please close.

Original motivation kept below for history.

The toolbar's `<StickyHeader>` creates a `z-3` stacking context, and each `TransactionsDateGroup` uses `<StickyHeader>` internally with the same `z-3`, trapping the gix Popover that the chips open below the date stickies. Adds an opt-in `zIndex` prop on `StickyHeader` and uses `<StickyHeader zIndex={10}>` for the toolbar.

# Changes

See #12711 for the version that bundles this with the rest.

# Tests

See #12711.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1409485f-f2bc-420d-9b91-44f614ef8968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1409485f-f2bc-420d-9b91-44f614ef8968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

