### PR TITLE
fix(frontend): consistent row height & vertical alignment in activity filters

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte
@@ -51,7 +51,9 @@
 					on:nnsChange={() => transactionsFilterStore.toggleContactId(id)}
 				>
 					<span class="inline-flex items-center gap-2">
-						<Avatar name={contact.name} image={contact.image} variant="xxs" />
+						<span class="flex shrink-0 items-center">
+							<Avatar name={contact.name} image={contact.image} variant="xxs" />
+						</span>
 						<span class="text-sm">{contact.name}</span>
 					</span>
 				</Checkbox>
@@ -75,7 +77,9 @@
 		--checkbox-label-order: 1;
 		--checkbox-padding: 6px 8px;
 		justify-content: flex-start;
+		align-items: center;
 		gap: 8px;
+		min-height: 32px;
 		border-radius: 6px;
 		cursor: pointer;
 	}
@@ -86,5 +90,7 @@
 
 	li :global(label) {
 		flex: initial;
+		display: inline-flex;
+		align-items: center;
 	}
 </style>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -65,7 +65,9 @@
 						on:nnsChange={() => transactionsFilterStore.toggleTokenId(key)}
 					>
 						<span class="inline-flex items-center gap-2">
-							<TokenLogo data={token} logoSize="xxs" />
+							<span class="flex shrink-0 items-center">
+								<TokenLogo data={token} logoSize="xxs" />
+							</span>
 							<span class="text-sm">
 								<span class="font-medium">{token.symbol}</span>
 								<span class="text-tertiary"
@@ -96,7 +98,9 @@
 		--checkbox-label-order: 1;
 		--checkbox-padding: 6px 8px;
 		justify-content: flex-start;
+		align-items: center;
 		gap: 8px;
+		min-height: 34px;
 		border-radius: 6px;
 		cursor: pointer;
 	}
@@ -107,5 +111,7 @@
 
 	li :global(label) {
 		flex: initial;
+		display: inline-flex;
+		align-items: center;
 	}
 </style>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypesPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypesPanel.svelte
@@ -40,7 +40,9 @@
 		--checkbox-label-order: 1;
 		--checkbox-padding: 6px 8px;
 		justify-content: flex-start;
+		align-items: center;
 		gap: 8px;
+		min-height: 32px;
 		border-radius: 6px;
 		cursor: pointer;
 	}
@@ -51,5 +53,7 @@
 
 	li :global(label) {
 		flex: initial;
+		display: inline-flex;
+		align-items: center;
 	}
 </style>


### PR DESCRIPTION
# Motivation

Rows in the activity-filter dropdowns (contacts, tokens, types) render at slightly different heights and the avatar/logo isn't always vertically centered against the name and checkbox.

Two underlying causes:

1. The `Avatar` / `TokenLogo` had no `flex-shrink: 0` wrapper inside the slot. With a long contact/token name a row could squeeze the logo, changing the content box and therefore the row height.
2. The gix `<label>` is rendered as `display: inline` by the browser, so its `inline-flex` child participates in a line box rather than a flex line, which can produce baseline-aligned (instead of center-aligned) avatars depending on the contained glyphs.

# Changes

Applied uniformly to `TransactionsFilterContactsPanel.svelte`, `TransactionsFilterTokensPanel.svelte`, and `TransactionsFilterTypesPanel.svelte`:

- Wrap `Avatar` / `TokenLogo` in `<span class="flex shrink-0 items-center">` so the logo keeps its footprint and stays centered.
- Force the slot label to `display: inline-flex; align-items: center` so the avatar+name span is always vertically centered.
- Pin `.checkbox { align-items: center }` and add a `min-height` (`32px` for contacts/types, `34px` for tokens whose logo is 22px) so every row is the same height regardless of content.

# Tests

No behavioural change; existing unit tests for the three panels still pass (they query by `li span.text-sm`, `li span.font-medium`, and `input[id=…]`, all unaffected).
