### PR TITLE
chore(npm-deps): bump @solana-program/token from 0.12.0 to 0.13.0 in the solana-kit group across 1 directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@reown/walletkit": "^1.5.5",
 				"@solana-program/compute-budget": "^0.15.0",
 				"@solana-program/system": "^0.12.0",
-				"@solana-program/token": "^0.12.0",
+				"@solana-program/token": "^0.13.0",
 				"@solana-program/token-2022": "^0.9.0",
 				"@solana/kit": "^6.0.1",
 				"@velora-dex/sdk": "^9.3.3",
@@ -2733,15 +2733,15 @@
 			}
 		},
 		"node_modules/@solana-program/token": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.12.0.tgz",
-			"integrity": "sha512-hnidRNuFhmqUdW5aWkKTJ+cdzuotVMNwLsTyAk0Nd8VjLDld+vQC0fugHWqm5GPrvYe0hCNAhtpJcZVnNp7rOA==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.13.0.tgz",
+			"integrity": "sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@solana-program/system": "^0.12.0"
 			},
 			"peerDependencies": {
-				"@solana/kit": "^6.1.0"
+				"@solana/kit": "^6.5.0"
 			}
 		},
 		"node_modules/@solana-program/token-2022": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"@reown/walletkit": "^1.5.5",
 		"@solana-program/compute-budget": "^0.15.0",
 		"@solana-program/system": "^0.12.0",
-		"@solana-program/token": "^0.12.0",
+		"@solana-program/token": "^0.13.0",
 		"@solana-program/token-2022": "^0.9.0",
 		"@solana/kit": "^6.0.1",
 		"@velora-dex/sdk": "^9.3.3",

--- a/src/frontend/src/sol/utils/sol-instructions-token.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-token.utils.ts
@@ -6,6 +6,7 @@ import {
 	parseAmountToUiAmountInstruction,
 	parseApproveCheckedInstruction,
 	parseApproveInstruction,
+	parseBatchInstruction,
 	parseBurnCheckedInstruction,
 	parseBurnInstruction,
 	parseCloseAccountInstruction,
@@ -27,7 +28,9 @@ import {
 	parseThawAccountInstruction,
 	parseTransferCheckedInstruction,
 	parseTransferInstruction,
-	parseUiAmountToAmountInstruction
+	parseUiAmountToAmountInstruction,
+	parseUnwrapLamportsInstruction,
+	parseWithdrawExcessLamportsInstruction
 } from '@solana-program/token';
 import { assertIsInstructionWithAccounts, assertIsInstructionWithData } from '@solana/kit';
 
@@ -163,6 +166,21 @@ export const parseSolTokenInstruction = (
 			return {
 				...parseUiAmountToAmountInstruction(instruction),
 				instructionType: TokenInstruction.UiAmountToAmount
+			};
+		case TokenInstruction.WithdrawExcessLamports:
+			return {
+				...parseWithdrawExcessLamportsInstruction(instruction),
+				instructionType: TokenInstruction.WithdrawExcessLamports
+			};
+		case TokenInstruction.UnwrapLamports:
+			return {
+				...parseUnwrapLamportsInstruction(instruction),
+				instructionType: TokenInstruction.UnwrapLamports
+			};
+		case TokenInstruction.Batch:
+			return {
+				...parseBatchInstruction(instruction),
+				instructionType: TokenInstruction.Batch
 			};
 		default: {
 			assertNever(decodedInstruction, `Unknown Solana Token instruction: ${decodedInstruction}`);

--- a/src/frontend/src/tests/sol/utils/sol-instructions-token.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-token.utils.spec.ts
@@ -8,6 +8,7 @@ import {
 	parseAmountToUiAmountInstruction,
 	parseApproveCheckedInstruction,
 	parseApproveInstruction,
+	parseBatchInstruction,
 	parseBurnCheckedInstruction,
 	parseBurnInstruction,
 	parseCloseAccountInstruction,
@@ -29,7 +30,9 @@ import {
 	parseThawAccountInstruction,
 	parseTransferCheckedInstruction,
 	parseTransferInstruction,
-	parseUiAmountToAmountInstruction
+	parseUiAmountToAmountInstruction,
+	parseUnwrapLamportsInstruction,
+	parseWithdrawExcessLamportsInstruction
 } from '@solana-program/token';
 import { address } from '@solana/kit';
 
@@ -62,7 +65,10 @@ vi.mock(import('@solana-program/token'), async (importOriginal) => {
 		parseThawAccountInstruction: vi.fn(),
 		parseTransferCheckedInstruction: vi.fn(),
 		parseTransferInstruction: vi.fn(),
-		parseUiAmountToAmountInstruction: vi.fn()
+		parseUiAmountToAmountInstruction: vi.fn(),
+		parseUnwrapLamportsInstruction: vi.fn(),
+		parseWithdrawExcessLamportsInstruction: vi.fn(),
+		parseBatchInstruction: vi.fn()
 	};
 });
 
@@ -346,6 +352,38 @@ describe('sol-instructions-token.utils', () => {
 			});
 
 			expect(parseUiAmountToAmountInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a WithdrawExcessLamports instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.WithdrawExcessLamports);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.WithdrawExcessLamports
+			});
+
+			expect(parseWithdrawExcessLamportsInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse an UnwrapLamports instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.UnwrapLamports);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.UnwrapLamports
+			});
+
+			expect(parseUnwrapLamportsInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should parse a Batch instruction', () => {
+			vi.mocked(identifyTokenInstruction).mockReturnValue(TokenInstruction.Batch);
+
+			expect(parseSolTokenInstruction(mockInstruction)).toStrictEqual({
+				instructionType: TokenInstruction.Batch
+			});
+
+			expect(parseBatchInstruction).toHaveBeenCalledExactlyOnceWith(mockInstruction);
 		});
 
 		it('should raise an error if it is not a recognised Token instruction', () => {


### PR DESCRIPTION
# Motivation

Duplicate of #12665 (Dependabot bump of `@solana-program/token` from `0.12.0` to `0.13.0`) with the additional fix needed to keep CI green.

The original PR's `frontend-checks / check` job (and consequently the sharded `test` jobs) failed because `@solana-program/token@0.13.0` adds three new variants to the `TokenInstruction` enum (`WithdrawExcessLamports`, `UnwrapLamports`, `Batch`). The exhaustive `switch` in `parseSolTokenInstruction` therefore stopped being exhaustive and `svelte-check` rejected the `assertNever(decodedInstruction, …)` call:

```
src/frontend/src/sol/utils/sol-instructions-token.utils.ts:168:16
Error: Argument of type 'TokenInstruction.WithdrawExcessLamports | TokenInstruction.UnwrapLamports | TokenInstruction.Batch' is not assignable to parameter of type 'never'.
```

# Changes

- Bump `@solana-program/token` from `0.12.0` to `0.13.0` (cherry-picked from #12665).
- Wire the new `WithdrawExcessLamports`, `UnwrapLamports` and `Batch` parsers into `parseSolTokenInstruction`, mirroring how the same instructions are already handled in `parseSolToken2022Instruction`.

# Tests

- Added three new unit tests in `sol-instructions-token.utils.spec.ts`, one per new instruction variant, following the existing test pattern.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, and `npx vitest run src/frontend/src/tests/sol` all pass locally on the branch.



