### PR TITLE
fix(frontend): activity filter stacking and tokens dropdown freeze

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -22,7 +22,12 @@
 	import { walletConnectListenerStore } from '$lib/stores/wallet-connect.store';
 	import { isRouteNfts, isRouteTransactions } from '$lib/utils/nav.utils';
 
-	// Used to set z-index dynamically (https://github.com/dfinity/oisy-wallet/pull/8340)
+	// Used to set z-index dynamically (https://github.com/dfinity/oisy-wallet/pull/8340).
+	// When any of these is open, we bump the Header's z-index above the
+	// activity filter toolbar's `StickyHeader` (which now sits at `z-10` to
+	// escape the chip-popover stacking trap — see `AllTransactionsList`),
+	// so the user-menu / network-switcher popovers anchored inside Header
+	// paint above the toolbar.
 	let networkSwitcherOpen = $state(false);
 	let menuOpen = $state(false);
 
@@ -47,11 +52,11 @@
 	class:1.5xl:fixed={$authSignedIn}
 	class:1.5xl:inset-x-0={$authSignedIn}
 	class:1.5xl:top-0={$authSignedIn}
-	class:1.5xl:z-10={$authSignedIn}
+	class:1.5xl:z-20={$authSignedIn}
 	class:pb-10={$authNotSignedIn}
 	class:sm:pb-8={$authNotSignedIn}
+	class:z-20={biggerOverlay}
 	class:z-3={!biggerOverlay}
-	class:z-4={biggerOverlay}
 >
 	<div class="pointer-events-auto">
 		<OisyWalletLogoLink />

--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -125,7 +125,17 @@
 	);
 </script>
 
-<StickyHeader>
+<!--
+	Each `TransactionsDateGroup` uses `StickyHeader` internally at the
+	default `z-3`, creating a sibling stacking context per date label. If
+	the toolbar's `StickyHeader` were also at `z-3`, the gix Popover that
+	the chips open would be trapped inside the toolbar's `z-3` context and
+	the date stickies (also `z-3`, but rendered later in DOM) would paint
+	on top of it — visually freezing the dropdown. Using `zIndex={10}`
+	lifts the popover's containing stacking context above every date `z-3`
+	context, so the dropdown content paints on top of the date headers.
+-->
+<StickyHeader zIndex={10}>
 	{#snippet header()}
 		<TransactionsFilterToolbar />
 	{/snippet}

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -1,102 +1,25 @@
 <script lang="ts">
-	import { Checkbox } from '@dfinity/gix-components';
-	import { nonNullish } from '@dfinity/utils';
 	import IconCoins from '$lib/components/icons/lucide/IconCoins.svelte';
-	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import TransactionsFilterTokensPanel from '$lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte';
 	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
 	import { TRANSACTIONS_FILTER_TOKENS_DROPDOWN } from '$lib/constants/test-ids.constants';
-	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
-	import type { Token } from '$lib/types/token';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-
-	let searchValue = $state('');
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.tokenIds));
-
-	const tokenKey = (token: Token): string | undefined => token.id.description;
-
-	let sortedTokens = $derived(
-		[...$enabledFungibleNetworkTokens].sort((a, b) =>
-			(a.name ?? a.symbol).localeCompare(b.name ?? b.symbol, undefined, {
-				sensitivity: 'base'
-			})
-		)
-	);
-
-	let filteredTokens = $derived(
-		searchValue.length === 0
-			? sortedTokens
-			: sortedTokens.filter(({ name, symbol }) => {
-					const needle = searchValue.toLowerCase();
-					return name.toLowerCase().includes(needle) || symbol.toLowerCase().includes(needle);
-				})
-	);
 </script>
 
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.tokens_aria_label}
 	count={selectedSet.size}
-	searchPlaceholder={$i18n.transaction.filter.search_tokens_placeholder}
-	searchable
 	testId={TRANSACTIONS_FILTER_TOKENS_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.tokens_label}
-	bind:searchValue
 >
 	{#snippet triggerIcon()}
 		<IconCoins size="20" />
 	{/snippet}
 
 	{#snippet panel()}
-		<ul class="m-0 flex list-none flex-col gap-0.5 p-0">
-			{#each filteredTokens as token (token.id.description)}
-				{@const key = tokenKey(token)}
-
-				{#if nonNullish(key)}
-					<li>
-						<Checkbox
-							checked={selectedSet.has(key)}
-							inputId={`transactions-filter-token-${key}`}
-							text="inline"
-							on:nnsChange={() => transactionsFilterStore.toggleTokenId(key)}
-						>
-							<span class="inline-flex items-center gap-2">
-								<TokenLogo data={token} logoSize="xxs" />
-
-								<span class="text-sm">
-									<span class="font-medium">{token.symbol}</span>
-
-									<span class="text-tertiary"
-										>{replacePlaceholders($i18n.tokens.text.on_network, {
-											$network: token.network.name
-										})}</span
-									>
-								</span>
-							</span>
-						</Checkbox>
-					</li>
-				{/if}
-			{/each}
-		</ul>
+		<TransactionsFilterTokensPanel />
 	{/snippet}
 </MultiSelectDropdown>
-
-<style lang="scss">
-	li :global(.checkbox) {
-		--checkbox-label-order: 1;
-		--checkbox-padding: 6px 8px;
-		justify-content: flex-start;
-		gap: 8px;
-		border-radius: 6px;
-		cursor: pointer;
-	}
-
-	li :global(.checkbox:hover) {
-		background: var(--color-background-brand-subtle-10);
-	}
-
-	li :global(label) {
-		flex: initial;
-	}
-</style>

--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -5,9 +5,15 @@
 	interface Props {
 		header: Snippet;
 		children: Snippet;
+		// Optional stacking-context override. Defaults to `3` to match the
+		// historical behavior shared by every sticky header in the app
+		// (date stickies, `Assets`, `TokensList`). Pass a higher value for
+		// headers whose contents open a popover that must paint above other
+		// sibling sticky headers — see `AllTransactionsList`.
+		zIndex?: number;
 	}
 
-	const { header, children }: Props = $props();
+	const { header, children, zIndex = 3 }: Props = $props();
 
 	const SPACING_UNIT = 4;
 	const SPACING_TOP = SPACING_UNIT * 6; // since we add pt-6 we need to trigger earlier
@@ -29,7 +35,8 @@
 
 <div bind:this={rootElement}>
 	<div
-		class="sticky top-0 z-3 px-1 whitespace-nowrap"
+		style:z-index={zIndex}
+		class="sticky top-0 px-1 whitespace-nowrap"
 		class:bg-page={scrolledSoon}
 		class:pt-6={scrolledSoon}
 	>

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -31,8 +31,11 @@
 
 	--overlay-z-index: calc(var(--z-index) + 1);
 	--modal-z-index: calc(var(--overlay-z-index) + 3);
-	--toast-info-z-index: calc(var(--overlay-z-index) + 4);
-	--toast-error-z-index: calc(var(--overlay-z-index) + 5);
+	// Toasts sit above popovers (so they're never hidden by an open chip
+	// dropdown) but below modals and bottom sheets (so a bottom sheet open
+	// over the activity filters isn't covered by an incoming toast).
+	--toast-info-z-index: calc(var(--overlay-z-index) + 1);
+	--toast-error-z-index: calc(var(--overlay-z-index) + 2);
 
 	--overlay-box-shadow: 0 4px 16px 0 #0000001f;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

Tracker for the four `/activity` regressions reported together. **Not for merge** — superseded by the per-concern split below.

# Changes

This PR was split into:

- #12712 — escape `z-3` stacking trap for the activity filter toolbar (also restores conditional `bg-page`).
- #12713 — bump Header z-index above the toolbar so the user menu paints on top.
- #12714 — lower toast z-index below modals and bottom sheets.
- #12715 — reuse `TransactionsFilterTokensPanel` in the Tokens chip to unfreeze the dropdown.

# Tests

See each split PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1409485f-f2bc-420d-9b91-44f614ef8968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1409485f-f2bc-420d-9b91-44f614ef8968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

