### PR TITLE
fix(frontend): escape z-3 stacking context for activity filter toolbar

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -125,7 +125,17 @@
 	);
 </script>
 
-<StickyHeader>
+<!--
+	Each `TransactionsDateGroup` uses `StickyHeader` internally at the
+	default `z-3`, creating a sibling stacking context per date label. If
+	the toolbar's `StickyHeader` were also at `z-3`, the gix Popover that
+	the chips open would be trapped inside the toolbar's `z-3` context and
+	the date stickies (also `z-3`, but rendered later in DOM) would paint
+	on top of it — visually freezing the dropdown. Using `zIndex={10}`
+	lifts the popover's containing stacking context above every date `z-3`
+	context, so the dropdown content paints on top of the date headers.
+-->
+<StickyHeader zIndex={10}>
 	{#snippet header()}
 		<TransactionsFilterToolbar />
 	{/snippet}

--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -5,9 +5,15 @@
 	interface Props {
 		header: Snippet;
 		children: Snippet;
+		// Optional stacking-context override. Defaults to `3` to match the
+		// historical behavior shared by every sticky header in the app
+		// (date stickies, `Assets`, `TokensList`). Pass a higher value for
+		// headers whose contents open a popover that must paint above other
+		// sibling sticky headers — see `AllTransactionsList`.
+		zIndex?: number;
 	}
 
-	const { header, children }: Props = $props();
+	const { header, children, zIndex = 3 }: Props = $props();
 
 	const SPACING_UNIT = 4;
 	const SPACING_TOP = SPACING_UNIT * 6; // since we add pt-6 we need to trigger earlier
@@ -29,7 +35,8 @@
 
 <div bind:this={rootElement}>
 	<div
-		class="sticky top-0 z-3 px-1 whitespace-nowrap"
+		style:z-index={zIndex}
+		class="sticky top-0 px-1 whitespace-nowrap"
 		class:bg-page={scrolledSoon}
 		class:pt-6={scrolledSoon}
 	>


### PR DESCRIPTION
# Motivation

On `/activity`, the chip popovers were trapped in the toolbar's `z-3` stacking context and painted under the date stickies (also `z-3`, rendered later). The earlier unbox attempts to escape the trap also dropped `StickyHeader`'s conditional `bg-page` / `pt-6`, leaving the toolbar with a solid band over the wallpaper.

# Changes

`StickyHeader` gains an opt-in `zIndex?: number` prop (default `3`, applied via `style:z-index`). `AllTransactionsList` passes `<StickyHeader zIndex={10}>`. Date headers, `Assets`, `TokensList` keep today's behavior.

