### PR TITLE
fix(frontend): bump Header z-index above activity filter toolbar

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -22,7 +22,12 @@
 	import { walletConnectListenerStore } from '$lib/stores/wallet-connect.store';
 	import { isRouteNfts, isRouteTransactions } from '$lib/utils/nav.utils';
 
-	// Used to set z-index dynamically (https://github.com/dfinity/oisy-wallet/pull/8340)
+	// Used to set z-index dynamically (https://github.com/dfinity/oisy-wallet/pull/8340).
+	// When any of these is open, we bump the Header's z-index above the
+	// activity filter toolbar's `StickyHeader` (which now sits at `z-10` to
+	// escape the chip-popover stacking trap — see `AllTransactionsList`),
+	// so the user-menu / network-switcher popovers anchored inside Header
+	// paint above the toolbar.
 	let networkSwitcherOpen = $state(false);
 	let menuOpen = $state(false);
 
@@ -47,11 +52,11 @@
 	class:1.5xl:fixed={$authSignedIn}
 	class:1.5xl:inset-x-0={$authSignedIn}
 	class:1.5xl:top-0={$authSignedIn}
-	class:1.5xl:z-10={$authSignedIn}
+	class:1.5xl:z-20={$authSignedIn}
 	class:pb-10={$authNotSignedIn}
 	class:sm:pb-8={$authNotSignedIn}
+	class:z-20={biggerOverlay}
 	class:z-3={!biggerOverlay}
-	class:z-4={biggerOverlay}
 >
 	<div class="pointer-events-auto">
 		<OisyWalletLogoLink />

--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -23,11 +23,6 @@
 	import { isRouteNfts, isRouteTransactions } from '$lib/utils/nav.utils';
 
 	// Used to set z-index dynamically (https://github.com/dfinity/oisy-wallet/pull/8340).
-	// When any of these is open, we bump the Header's z-index above the
-	// activity filter toolbar's `StickyHeader` (which now sits at `z-10` to
-	// escape the chip-popover stacking trap — see `AllTransactionsList`),
-	// so the user-menu / network-switcher popovers anchored inside Header
-	// paint above the toolbar.
 	let networkSwitcherOpen = $state(false);
 	let menuOpen = $state(false);
 
@@ -37,7 +32,18 @@
 		$modalWalletConnect || $modalUniversalScannerOpen || $modalPayDialogOpen
 	);
 
-	let biggerOverlay = $derived(menuOpen || networkSwitcherOpen || modalsOpen);
+	// Header-anchored popovers (user menu, network switcher) need the
+	// Header's stacking context to outrank the activity filter toolbar's
+	// `StickyHeader` (`z-10`, see `AllTransactionsList`). We do NOT bump
+	// for modals — gix modals/bottom sheets already paint above the
+	// default Header at `z-14`, and bumping here would hide them behind
+	// the Header and capture pointer events on top of the modal backdrop.
+	// Likewise we do NOT raise the `1.5xl` signed-in default — banners
+	// (`Banner`, `PwaBanner`, `AgreementsGuard`) and `FullscreenMediaModal`
+	// all sit at `z-10` and would render behind the Header otherwise.
+	let popoverOpen = $derived(menuOpen || networkSwitcherOpen);
+
+	let biggerOverlay = $derived(popoverOpen || modalsOpen);
 
 	// When WalletConnect tries to connect, it adds the "Disconnect" label, increasing the width of the header.
 	// That causes the screen to expand, without auto-zooming, and the modals overflow outside of the screen.
@@ -52,11 +58,13 @@
 	class:1.5xl:fixed={$authSignedIn}
 	class:1.5xl:inset-x-0={$authSignedIn}
 	class:1.5xl:top-0={$authSignedIn}
-	class:1.5xl:z-20={$authSignedIn}
+	class:1.5xl:z-10={$authSignedIn && !popoverOpen}
+	class:1.5xl:z-20={$authSignedIn && popoverOpen}
 	class:pb-10={$authNotSignedIn}
 	class:sm:pb-8={$authNotSignedIn}
-	class:z-20={biggerOverlay}
+	class:z-20={popoverOpen}
 	class:z-3={!biggerOverlay}
+	class:z-4={modalsOpen && !popoverOpen}
 >
 	<div class="pointer-events-auto">
 		<OisyWalletLogoLink />


### PR DESCRIPTION
# Motivation

On `/activity`, clicking the user menu opened the gix `Popover` behind the toolbar — the backdrop blur was visible but the menu itself was hidden. The toolbar's `StickyHeader` now sits at `z-10` (see #12712), at or above Header's `z-4` / `1.5xl:z-10` from #8340.

# Changes

`Header.svelte` open-overlay z-index: `z-4` → `z-20`, `1.5xl:z-10` → `1.5xl:z-20`. Strictly above the toolbar's `z-10`. Header is fixed at the top of the viewport so this changes nothing visually outside the user-menu / network-switcher / modal flows.
