### PR TITLE
fix(frontend): place toast z-index below modals and bottom sheets

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -31,8 +31,11 @@
 
 	--overlay-z-index: calc(var(--z-index) + 1);
 	--modal-z-index: calc(var(--overlay-z-index) + 3);
-	--toast-info-z-index: calc(var(--overlay-z-index) + 4);
-	--toast-error-z-index: calc(var(--overlay-z-index) + 5);
+	// Toasts sit above popovers (so they're never hidden by an open chip
+	// dropdown) but below modals and bottom sheets (so a bottom sheet open
+	// over the activity filters isn't covered by an incoming toast).
+	--toast-info-z-index: calc(var(--overlay-z-index) + 1);
+	--toast-error-z-index: calc(var(--overlay-z-index) + 2);
 
 	--overlay-box-shadow: 0 4px 16px 0 #0000001f;
 


### PR DESCRIPTION
# Motivation

In mobile, opening the activity filter bottom sheet (`z-14` matching gix `--bottom-sheet-z-index = --modal-z-index = 14`) and then receiving a toast painted the toast on top of the sheet, covering its content. gix toasts default to `overlay + 4` / `overlay + 5` (`15` / `16`), deliberately above modals and bottom sheets.

# Changes

`gix.scss`: `--toast-info-z-index` and `--toast-error-z-index` from `overlay + 4` / `overlay + 5` to `overlay + 1` / `overlay + 2` (`12` / `13`). Stays above popovers (`overlay-z-index = 11`) so a toast triggered from inside an open chip popover is still visible; sits below modals and bottom sheets (`14`) so the bottom sheet now covers any incoming toast.



