### PR TITLE
fix(frontend): reuse TokensPanel in activity Tokens filter chip to unfreeze the dropdown

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -1,102 +1,25 @@
 <script lang="ts">
-	import { Checkbox } from '@dfinity/gix-components';
-	import { nonNullish } from '@dfinity/utils';
 	import IconCoins from '$lib/components/icons/lucide/IconCoins.svelte';
-	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import TransactionsFilterTokensPanel from '$lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte';
 	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
 	import { TRANSACTIONS_FILTER_TOKENS_DROPDOWN } from '$lib/constants/test-ids.constants';
-	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
-	import type { Token } from '$lib/types/token';
-	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-
-	let searchValue = $state('');
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.tokenIds));
-
-	const tokenKey = (token: Token): string | undefined => token.id.description;
-
-	let sortedTokens = $derived(
-		[...$enabledFungibleNetworkTokens].sort((a, b) =>
-			(a.name ?? a.symbol).localeCompare(b.name ?? b.symbol, undefined, {
-				sensitivity: 'base'
-			})
-		)
-	);
-
-	let filteredTokens = $derived(
-		searchValue.length === 0
-			? sortedTokens
-			: sortedTokens.filter(({ name, symbol }) => {
-					const needle = searchValue.toLowerCase();
-					return name.toLowerCase().includes(needle) || symbol.toLowerCase().includes(needle);
-				})
-	);
 </script>
 
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.tokens_aria_label}
 	count={selectedSet.size}
-	searchPlaceholder={$i18n.transaction.filter.search_tokens_placeholder}
-	searchable
 	testId={TRANSACTIONS_FILTER_TOKENS_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.tokens_label}
-	bind:searchValue
 >
 	{#snippet triggerIcon()}
 		<IconCoins size="20" />
 	{/snippet}
 
 	{#snippet panel()}
-		<ul class="m-0 flex list-none flex-col gap-0.5 p-0">
-			{#each filteredTokens as token (token.id.description)}
-				{@const key = tokenKey(token)}
-
-				{#if nonNullish(key)}
-					<li>
-						<Checkbox
-							checked={selectedSet.has(key)}
-							inputId={`transactions-filter-token-${key}`}
-							text="inline"
-							on:nnsChange={() => transactionsFilterStore.toggleTokenId(key)}
-						>
-							<span class="inline-flex items-center gap-2">
-								<TokenLogo data={token} logoSize="xxs" />
-
-								<span class="text-sm">
-									<span class="font-medium">{token.symbol}</span>
-
-									<span class="text-tertiary"
-										>{replacePlaceholders($i18n.tokens.text.on_network, {
-											$network: token.network.name
-										})}</span
-									>
-								</span>
-							</span>
-						</Checkbox>
-					</li>
-				{/if}
-			{/each}
-		</ul>
+		<TransactionsFilterTokensPanel />
 	{/snippet}
 </MultiSelectDropdown>
-
-<style lang="scss">
-	li :global(.checkbox) {
-		--checkbox-label-order: 1;
-		--checkbox-padding: 6px 8px;
-		justify-content: flex-start;
-		gap: 8px;
-		border-radius: 6px;
-		cursor: pointer;
-	}
-
-	li :global(.checkbox:hover) {
-		background: var(--color-background-brand-subtle-10);
-	}
-
-	li :global(label) {
-		flex: initial;
-	}
-</style>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -20,6 +20,6 @@
 	{/snippet}
 
 	{#snippet panel()}
-		<TransactionsFilterTokensPanel />
+		<TransactionsFilterTokensPanel autofocus />
 	{/snippet}
 </MultiSelectDropdown>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -9,6 +9,16 @@
 	import type { Token } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
+	interface Props {
+		// When the panel is rendered inside a desktop dropdown popover the
+		// caller wants the search input to grab focus on open; when it's
+		// rendered inside the mobile bottom sheet we leave it unfocused so
+		// the on-screen keyboard does not pop up unprompted.
+		autofocus?: boolean;
+	}
+
+	const { autofocus = false }: Props = $props();
+
 	// Cap the visible list when the user has not searched yet.
 	// Mounting hundreds of <Checkbox> + <TokenLogo> rows synchronously when
 	// the popover opens blocks the main thread and the dropdown feels frozen.
@@ -46,12 +56,23 @@
 	let isCapped = $derived(searchValue.length === 0 && filteredTokens.length > VISIBLE_LIMIT);
 </script>
 
-<div class="flex flex-col gap-3">
-	<InputSearch
-		placeholder={$i18n.transaction.filter.search_tokens_placeholder}
-		showResetButton={searchValue.length > 0}
-		bind:filter={searchValue}
-	/>
+<div class="flex flex-col">
+	<!--
+		The popover scrolls the panel as a whole (`MultiSelectDropdown`'s
+		wrapper has `max-h-80 overflow-y-auto`), so we make the search input
+		`sticky` with the popover background to keep it pinned at the top
+		while the rows scroll under it. `pb-3` reproduces the previous
+		`gap-3` spacing while also covering scrolled rows so they don't
+		bleed visually behind the input.
+	-->
+	<div class="sticky top-0 z-1 bg-primary pb-3">
+		<InputSearch
+			{autofocus}
+			placeholder={$i18n.transaction.filter.search_tokens_placeholder}
+			showResetButton={searchValue.length > 0}
+			bind:filter={searchValue}
+		/>
+	</div>
 
 	<ul class="m-0 flex list-none flex-col gap-0.5 p-0">
 		{#each visibleTokens as token (token.id.description)}
@@ -84,7 +105,7 @@
 	</ul>
 
 	{#if isCapped}
-		<p class="text-xs text-tertiary">
+		<p class="pt-3 text-xs text-tertiary">
 			{replacePlaceholders($i18n.transaction.filter.showing_partial, {
 				$shown: `${VISIBLE_LIMIT}`,
 				$total: `${filteredTokens.length}`


### PR DESCRIPTION
# Motivation

On `/activity`, the Tokens chip dropdown felt like it never opened. The chip wrapper inlined its own list of `<Checkbox>` + `<TokenLogo>` rows over `enabledFungibleNetworkTokens`, with no row cap — mounting all rows synchronously when the popover opens blocks the main thread long enough that the popover looks frozen. `TransactionsFilterTokensPanel` (already used by the mobile bottom sheet) ships the same list with a `VISIBLE_LIMIT = 50` cap and a search input precisely for this reason; the chip just wasn't using it.

# Changes

`TransactionsFilterTokens` now renders `<TransactionsFilterTokensPanel />` inside `MultiSelectDropdown`'s `panel` snippet, mirroring how `TransactionsFilterContacts` already uses `TransactionsFilterContactsPanel`. The Panel ships its own `InputSearch`, so we drop `searchable` / `bind:searchValue` on `MultiSelectDropdown` — the popover ends up with one search input, in the same visual position as before, plus the existing "showing N of M" hint.

