### PR TITLE
chore(frontend): remove IC USDT token

### DIFF
--- a/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.additional.env.ts
+++ b/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.additional.env.ts
@@ -34,13 +34,9 @@ export const TICRC1_LEDGER_CANISTER_ID: LedgerCanisterIdText =
 export const IC_USDC_LEDGER_CANISTER_ID: LedgerCanisterIdText =
 	ADDITIONAL_ICRC_PRODUCTION_DATA.USDC?.ledgerCanisterId ?? '53nhb-haaaa-aaaar-qbn5q-cai';
 
-export const IC_USDT_LEDGER_CANISTER_ID: LedgerCanisterIdText =
-	ADDITIONAL_ICRC_PRODUCTION_DATA.USDT?.ledgerCanisterId ?? 'ij33n-oiaaa-aaaar-qbooa-cai';
-
 // Suggested non-Chain-Fusion ICRC tokens to be enabled by default if the user set no preference
 export const ICRC_SUGGESTED_LEDGER_CANISTER_IDS: LedgerCanisterIdText[] = [
-	IC_USDC_LEDGER_CANISTER_ID,
-	IC_USDT_LEDGER_CANISTER_ID
+	IC_USDC_LEDGER_CANISTER_ID
 ];
 
 export const ADDITIONAL_ICRC_TOKENS: IcTokenWithoutId[] = Object.values(

--- a/src/frontend/src/env/tokens/tokens.icrc.json
+++ b/src/frontend/src/env/tokens/tokens.icrc.json
@@ -265,24 +265,5 @@
 			"__bigint__": "10000"
 		},
 		"icon": "/icons/icrc/53nhb-haaaa-aaaar-qbn5q-cai.svg"
-	},
-	"USDT": {
-		"ledgerCanisterId": "ij33n-oiaaa-aaaar-qbooa-cai",
-		"indexCanisterId": "fvhuy-zyaaa-aaaar-qbpha-cai",
-		"mintingAccount": "5okwm-giaaa-aaaar-qbn6a-cai",
-		"tags": [
-			{
-				"type": "category",
-				"value": "stablecoin"
-			}
-		],
-		"groupDataId": "USDT",
-		"decimals": 6,
-		"name": "USDT",
-		"symbol": "USDT",
-		"fee": {
-			"__bigint__": "10000"
-		},
-		"icon": "/icons/icrc/ij33n-oiaaa-aaaar-qbooa-cai.svg"
 	}
 }

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -12,10 +12,7 @@ import { USDT_TOKEN as USDT_BSC_TOKEN } from '$env/tokens/tokens-evm/tokens-bsc/
 import { USDC_TOKEN as USDC_POLYGON_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdc.env';
 import { USDT_TOKEN as USDT_POLYGON_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens-erc20/tokens.usdt.env';
 import * as tokensIcrcAdditionalEnv from '$env/tokens/tokens-icrc/tokens.icrc.additional.env';
-import {
-	IC_USDC_LEDGER_CANISTER_ID,
-	IC_USDT_LEDGER_CANISTER_ID
-} from '$env/tokens/tokens-icrc/tokens.icrc.additional.env';
+import { IC_USDC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.additional.env';
 import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env';
 import * as tokensIcrcCkEnv from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
 import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.eth.env';
@@ -570,14 +567,8 @@ describe('token.utils', () => {
 		};
 
 		const dummyIcUSDC = { ...mockValidIcToken, ledgerCanisterId: IC_USDC_LEDGER_CANISTER_ID };
-		const dummyIcUSDT = { ...mockValidIcToken, ledgerCanisterId: IC_USDT_LEDGER_CANISTER_ID };
 
 		describe.each([
-			{
-				description: 'Suggested ICRC token ckUSDT',
-				token: dummyCkUSDT,
-				setupMock: setupSuggestedTokenMock
-			},
 			{
 				description: 'Suggested native ICRC token USDC',
 				token: dummyIcUSDC,

--- a/src/frontend/src/tests/lib/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token.utils.spec.ts
@@ -570,13 +570,13 @@ describe('token.utils', () => {
 
 		describe.each([
 			{
-				description: 'Suggested native ICRC token USDC',
-				token: dummyIcUSDC,
-				setupMock: setupIcrcSuggestedTokenMock
+				description: 'Suggested ICRC token ckUSDT',
+				token: dummyCkUSDT,
+				setupMock: setupSuggestedTokenMock
 			},
 			{
-				description: 'Suggested native ICRC token USDT',
-				token: dummyIcUSDT,
+				description: 'Suggested native ICRC token USDC',
+				token: dummyIcUSDC,
 				setupMock: setupIcrcSuggestedTokenMock
 			},
 			{ description: 'Suggested ERC20 token USDC', token: USDC_TOKEN },


### PR DESCRIPTION
# Motivation

USDT on IC has limited use due to shallow pools on ICPSwap.
And we already had a first support case (related to USDC, but the same) related to it.

So let's remove the icrc usdt until a reasonable pool exists.

# Changes

- remove it from the suggested tokens
- remove it from the icrc tokens
- but keep the icon, so users who want it can still see it properly


# Tests


