### PR TITLE
fix(frontend): avoid duplicate keys in activities token dropdown

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -85,7 +85,7 @@
 		{#each visibleTokens as token (tokenRenderKey(token))}
 			{@const key = tokenFilterKey(token)}
 			{@const rowKey = tokenRenderKey(token)}
-			
+
 			{#if nonNullish(key)}
 				<li>
 					<Checkbox

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -35,6 +35,9 @@
 	const tokenRenderKey = (token: Token): string =>
 		`${token.id.description}-${token.network.id.description}`;
 
+	const tokenInputId = (token: Token): string =>
+		`transactions-filter-token-${tokenRenderKey(token).replace(/[^A-Za-z0-9_-]/g, '-')}`;
+
 	let sortedTokens = $derived(
 		[
 			...new Map(
@@ -84,13 +87,12 @@
 	<ul class="m-0 flex list-none flex-col gap-0.5 p-0">
 		{#each visibleTokens as token (tokenRenderKey(token))}
 			{@const key = tokenFilterKey(token)}
-			{@const rowKey = tokenRenderKey(token)}
 
 			{#if nonNullish(key)}
 				<li>
 					<Checkbox
 						checked={selectedSet.has(key)}
-						inputId={`transactions-filter-token-${rowKey}`}
+						inputId={tokenInputId(token)}
 						text="inline"
 						on:nnsChange={() => transactionsFilterStore.toggleTokenId(key)}
 					>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -30,10 +30,17 @@
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.tokenIds));
 
-	const tokenKey = (token: Token): string | undefined => token.id.description;
+	const tokenFilterKey = (token: Token): string | undefined => token.id.description;
+
+	const tokenRenderKey = (token: Token): string =>
+		`${token.id.description}-${token.network.id.description}`;
 
 	let sortedTokens = $derived(
-		[...$enabledFungibleNetworkTokens].sort((a, b) =>
+		[
+			...new Map(
+				[...$enabledFungibleNetworkTokens].map((token) => [tokenRenderKey(token), token])
+			).values()
+		].sort((a, b) =>
 			(a.name ?? a.symbol).localeCompare(b.name ?? b.symbol, undefined, {
 				sensitivity: 'base'
 			})
@@ -75,13 +82,14 @@
 	</div>
 
 	<ul class="m-0 flex list-none flex-col gap-0.5 p-0">
-		{#each visibleTokens as token (token.id.description)}
-			{@const key = tokenKey(token)}
+		{#each visibleTokens as token (tokenRenderKey(token))}
+			{@const key = tokenFilterKey(token)}
+			{@const rowKey = tokenRenderKey(token)}
 			{#if nonNullish(key)}
 				<li>
 					<Checkbox
 						checked={selectedSet.has(key)}
-						inputId={`transactions-filter-token-${key}`}
+						inputId={`transactions-filter-token-${rowKey}`}
 						text="inline"
 						on:nnsChange={() => transactionsFilterStore.toggleTokenId(key)}
 					>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -85,6 +85,7 @@
 		{#each visibleTokens as token (tokenRenderKey(token))}
 			{@const key = tokenFilterKey(token)}
 			{@const rowKey = tokenRenderKey(token)}
+			
 			{#if nonNullish(key)}
 				<li>
 					<Checkbox

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
@@ -69,7 +69,9 @@ describe('TransactionsFilterTokensPanel', () => {
 	it('toggles the corresponding token id in the store when a checkbox changes', async () => {
 		const { container } = render(TransactionsFilterTokensPanel);
 
-		const input = container.querySelector<HTMLInputElement>(`input[id="${tokenInputId(tokenAlpha)}"]`);
+		const input = container.querySelector<HTMLInputElement>(
+			`input[id="${tokenInputId(tokenAlpha)}"]`
+		);
 
 		expect(input).not.toBeNull();
 

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
@@ -26,7 +26,7 @@ const buildToken = ({ id, name, symbol }: { id: string; name: string; symbol: st
 });
 
 const tokenInputId = ({ id, network }: Token): string =>
-	`transactions-filter-token-${id.description}-${network.id.description}`;
+	`transactions-filter-token-${`${id.description}-${network.id.description}`.replace(/[^A-Za-z0-9_-]/g, '-')}`;
 
 describe('TransactionsFilterTokensPanel', () => {
 	const tokenAlpha = buildToken({ id: 'AlphaTokenId', name: 'Alpha', symbol: 'ALP' });

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
@@ -25,6 +25,9 @@ const buildToken = ({ id, name, symbol }: { id: string; name: string; symbol: st
 	symbol
 });
 
+const tokenInputId = ({ id, network }: Token): string =>
+	`transactions-filter-token-${id.description}-${network.id.description}`;
+
 describe('TransactionsFilterTokensPanel', () => {
 	const tokenAlpha = buildToken({ id: 'AlphaTokenId', name: 'Alpha', symbol: 'ALP' });
 	const tokenBeta = buildToken({ id: 'BetaTokenId', name: 'Beta', symbol: 'BTA' });
@@ -53,10 +56,10 @@ describe('TransactionsFilterTokensPanel', () => {
 		const { container } = render(TransactionsFilterTokensPanel);
 
 		const alphaInput = container.querySelector<HTMLInputElement>(
-			'input[id="transactions-filter-token-AlphaTokenId"]'
+			`input[id="${tokenInputId(tokenAlpha)}"]`
 		);
 		const betaInput = container.querySelector<HTMLInputElement>(
-			'input[id="transactions-filter-token-BetaTokenId"]'
+			`input[id="${tokenInputId(tokenBeta)}"]`
 		);
 
 		expect(alphaInput?.checked).toBeTruthy();
@@ -66,9 +69,7 @@ describe('TransactionsFilterTokensPanel', () => {
 	it('toggles the corresponding token id in the store when a checkbox changes', async () => {
 		const { container } = render(TransactionsFilterTokensPanel);
 
-		const input = container.querySelector<HTMLInputElement>(
-			'input[id="transactions-filter-token-AlphaTokenId"]'
-		);
+		const input = container.querySelector<HTMLInputElement>(`input[id="${tokenInputId(tokenAlpha)}"]`);
 
 		expect(input).not.toBeNull();
 


### PR DESCRIPTION
# Motivation

Fix crash when opening token filter in All activities due to duplicate Svelte each keys.


