### PR TITLE
style(frontend): widen MultiSelectDropdown popover content

### DIFF
--- a/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
+++ b/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
@@ -64,7 +64,7 @@
 
 <ResponsivePopover {button} bind:visible>
 	{#snippet content()}
-		<div class="flex w-full min-w-60 flex-col gap-2 p-1">
+		<div class="flex w-full min-w-72 flex-col gap-3 p-2">
 			{#if searchable}
 				<InputSearch
 					autofocus


### PR DESCRIPTION
# Motivation

Tiny visual polish carried over from the now-closed activity-filters umbrella branch (#12680). The default `MultiSelectDropdown` popover felt cramped — `min-w-60` plus `gap-2 p-1` left almost no breathing room between the search input, the row checkboxes, and the popover edge.
