### PR TITLE
feat(frontend): optional fixed width for activity filter dropdowns

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
@@ -12,6 +12,7 @@
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.contacts_aria_label}
 	count={selectedSet.size}
+	panelWidthClass="w-72"
 	testId={TRANSACTIONS_FILTER_CONTACTS_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.contacts_label}
 >

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
@@ -12,7 +12,7 @@
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.contacts_aria_label}
 	count={selectedSet.size}
-	panelWidthClass="w-72"
+	panelWidthClass="w-full sm:w-72"
 	testId={TRANSACTIONS_FILTER_CONTACTS_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.contacts_label}
 >

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -12,7 +12,7 @@
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.tokens_aria_label}
 	count={selectedSet.size}
-	panelWidthClass="w-80"
+	panelWidthClass="w-full sm:w-80"
 	testId={TRANSACTIONS_FILTER_TOKENS_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.tokens_label}
 >

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -12,6 +12,7 @@
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.tokens_aria_label}
 	count={selectedSet.size}
+	panelWidthClass="w-80"
 	testId={TRANSACTIONS_FILTER_TOKENS_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.tokens_label}
 >

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
@@ -26,6 +26,7 @@
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.types_aria_label}
 	count={selectedSet.size}
+	panelWidthClass="w-64"
 	testId={TRANSACTIONS_FILTER_TYPES_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.types_label}
 >

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
@@ -26,7 +26,7 @@
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.types_aria_label}
 	count={selectedSet.size}
-	panelWidthClass="w-64"
+	panelWidthClass="w-full sm:w-64"
 	testId={TRANSACTIONS_FILTER_TYPES_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.types_label}
 >

--- a/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
+++ b/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
@@ -5,6 +5,7 @@
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import InputSearch from '$lib/components/ui/InputSearch.svelte';
 	import ResponsivePopover from '$lib/components/ui/ResponsivePopover.svelte';
+	import { MULTI_SELECT_DROPDOWN_PANEL_SHELL } from '$lib/constants/test-ids.constants';
 
 	interface Props {
 		triggerLabel: string;
@@ -66,7 +67,10 @@
 
 <ResponsivePopover {button} bind:visible>
 	{#snippet content()}
-		<div class="flex flex-col gap-2 p-1 {panelWidthClass ?? 'w-full min-w-60'}">
+		<div
+			class="flex flex-col gap-2 p-1 {panelWidthClass ?? 'w-full min-w-60'}"
+			data-tid={MULTI_SELECT_DROPDOWN_PANEL_SHELL}
+		>
 			{#if searchable}
 				<InputSearch
 					autofocus

--- a/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
+++ b/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
@@ -16,6 +16,7 @@
 		testId?: string;
 		triggerIcon?: Snippet;
 		panel: Snippet;
+		panelWidthClass?: string;
 	}
 
 	let {
@@ -27,7 +28,8 @@
 		searchValue = $bindable(''),
 		testId,
 		triggerIcon,
-		panel
+		panel,
+		panelWidthClass
 	}: Props = $props();
 
 	let visible = $state(false);
@@ -64,7 +66,7 @@
 
 <ResponsivePopover {button} bind:visible>
 	{#snippet content()}
-		<div class="flex w-full min-w-60 flex-col gap-2 p-1">
+		<div class="flex flex-col gap-2 p-1 {panelWidthClass ?? 'w-full min-w-60'}">
 			{#if searchable}
 				<InputSearch
 					autofocus

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -212,6 +212,8 @@ export const ACTIVITY_TRANSACTION_SKELETON_PREFIX = 'all-transactions-skeleton-c
 export const TRANSACTIONS_DATE_GROUP_PREFIX = 'transactions-date-group-';
 export const TRANSACTION_CHILDREN_CONTAINER = 'transaction-children-container';
 
+export const MULTI_SELECT_DROPDOWN_PANEL_SHELL = 'multi-select-dropdown-panel-shell';
+
 export const TRANSACTIONS_FILTER_TOOLBAR = 'transactions-filter-toolbar';
 export const TRANSACTIONS_FILTER_TYPES_DROPDOWN = 'transactions-filter-types-dropdown';
 export const TRANSACTIONS_FILTER_TOKENS_DROPDOWN = 'transactions-filter-tokens-dropdown';

--- a/src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts
@@ -1,5 +1,5 @@
-import { screensStore } from '$lib/stores/screens.store';
 import { MULTI_SELECT_DROPDOWN_PANEL_SHELL } from '$lib/constants/test-ids.constants';
+import { screensStore } from '$lib/stores/screens.store';
 import MultiSelectDropdownTest from '$tests/lib/components/ui/MultiSelectDropdownTest.svelte';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 

--- a/src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts
@@ -1,4 +1,5 @@
 import { screensStore } from '$lib/stores/screens.store';
+import { MULTI_SELECT_DROPDOWN_PANEL_SHELL } from '$lib/constants/test-ids.constants';
 import MultiSelectDropdownTest from '$tests/lib/components/ui/MultiSelectDropdownTest.svelte';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 
@@ -60,6 +61,35 @@ describe('MultiSelectDropdown', () => {
 
 		await waitFor(() => {
 			expect(queryByPlaceholderText('Search items')).not.toBeInTheDocument();
+		});
+	});
+
+	it('uses default panel width classes when panelWidthClass is omitted', async () => {
+		const { getByTestId } = render(MultiSelectDropdownTest);
+
+		await fireEvent.click(getByTestId('multi-select-dropdown'));
+
+		await waitFor(() => {
+			const shell = getByTestId(MULTI_SELECT_DROPDOWN_PANEL_SHELL);
+
+			expect(shell.className).toContain('w-full');
+			expect(shell.className).toContain('min-w-60');
+		});
+	});
+
+	it('applies panelWidthClass instead of default width classes when provided', async () => {
+		const { getByTestId } = render(MultiSelectDropdownTest, {
+			props: { panelWidthClass: 'w-full sm:w-80' }
+		});
+
+		await fireEvent.click(getByTestId('multi-select-dropdown'));
+
+		await waitFor(() => {
+			const shell = getByTestId(MULTI_SELECT_DROPDOWN_PANEL_SHELL);
+
+			expect(shell.className).toContain('w-full');
+			expect(shell.className).toContain('sm:w-80');
+			expect(shell.className).not.toContain('min-w-60');
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/ui/MultiSelectDropdownTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/MultiSelectDropdownTest.svelte
@@ -4,14 +4,16 @@
 	interface Props {
 		count?: number;
 		searchable?: boolean;
+		panelWidthClass?: string;
 	}
 
-	let { count = 0, searchable = false }: Props = $props();
+	let { count = 0, searchable = false, panelWidthClass }: Props = $props();
 </script>
 
 <MultiSelectDropdown
 	ariaLabel="Filter"
 	{count}
+	{panelWidthClass}
 	searchPlaceholder="Search items"
 	{searchable}
 	testId="multi-select-dropdown"


### PR DESCRIPTION
# Motivation

Suggestion by @DenysKarmazynDFINITY 

On the Activity page, the token and contact filter popovers resized when the search query changed, because the panel width followed the visible list content. That made the UI feel jumpy.

# Changes

- Extended `MultiSelectDropdown` with an optional `panelWidthClass` prop. When omitted, behavior stays `w-full min-w-60` as before.
- Set fixed widths per Activity toolbar filter: types `w-64`, tokens `w-80`, contacts `w-72`.

