### PR TITLE
fix(frontend): scope activity token filter by token and network

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -8,6 +8,7 @@
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 	import type { Token } from '$lib/types/token';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { transactionsFilterTokenKey } from '$lib/utils/transactions-filter.utils';
 
 	interface Props {
 		// When the panel is rendered inside a desktop dropdown popover the
@@ -30,18 +31,17 @@
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.tokenIds));
 
-	const tokenFilterKey = (token: Token): string | undefined => token.id.description;
-
-	const tokenRenderKey = (token: Token): string =>
-		`${token.id.description}-${token.network.id.description}`;
+	const tokenRenderKey = (token: Token): string | undefined => transactionsFilterTokenKey(token);
 
 	const tokenInputId = (token: Token): string =>
-		`transactions-filter-token-${tokenRenderKey(token).replace(/[^A-Za-z0-9_-]/g, '-')}`;
+		`transactions-filter-token-${(tokenRenderKey(token) ?? '').replace(/[^A-Za-z0-9_-]/g, '-')}`;
 
 	let sortedTokens = $derived(
 		[
 			...new Map(
-				[...$enabledFungibleNetworkTokens].map((token) => [tokenRenderKey(token), token])
+				[...$enabledFungibleNetworkTokens]
+					.map((token) => [tokenRenderKey(token), token] as const)
+					.filter((entry): entry is [string, Token] => nonNullish(entry[0]))
 			).values()
 		].sort((a, b) =>
 			(a.name ?? a.symbol).localeCompare(b.name ?? b.symbol, undefined, {
@@ -83,7 +83,7 @@
 
 	<ul class="m-0 flex max-h-80 list-none flex-col gap-0.5 overflow-y-auto p-0">
 		{#each visibleTokens as token (tokenRenderKey(token))}
-			{@const key = tokenFilterKey(token)}
+			{@const key = tokenRenderKey(token)}
 
 			{#if nonNullish(key)}
 				<li>

--- a/src/frontend/src/lib/stores/transactions-filter.store.ts
+++ b/src/frontend/src/lib/stores/transactions-filter.store.ts
@@ -3,7 +3,8 @@ import type { TransactionType } from '$lib/types/transaction';
 import { EMPTY_TRANSACTIONS_FILTER, type TransactionsFilter } from '$lib/types/transactions-filter';
 import { get as getStore } from 'svelte/store';
 
-export const TRANSACTIONS_FILTER_STORAGE_KEY = 'oisy_transactions_filter';
+// Bumped when the persisted token filter shape changes (e.g. composite token keys).
+export const TRANSACTIONS_FILTER_STORAGE_KEY = 'oisy_transactions_filter_v2';
 
 export interface TransactionsFilterStore extends StorageStore<TransactionsFilter> {
 	toggleType: (type: TransactionType) => void;

--- a/src/frontend/src/lib/stores/transactions-filter.store.ts
+++ b/src/frontend/src/lib/stores/transactions-filter.store.ts
@@ -3,8 +3,7 @@ import type { TransactionType } from '$lib/types/transaction';
 import { EMPTY_TRANSACTIONS_FILTER, type TransactionsFilter } from '$lib/types/transactions-filter';
 import { get as getStore } from 'svelte/store';
 
-// Bumped when the persisted token filter shape changes (e.g. composite token keys).
-export const TRANSACTIONS_FILTER_STORAGE_KEY = 'oisy_transactions_filter_v2';
+export const TRANSACTIONS_FILTER_STORAGE_KEY = 'oisy_transactions_filter';
 
 export interface TransactionsFilterStore extends StorageStore<TransactionsFilter> {
 	toggleType: (type: TransactionType) => void;

--- a/src/frontend/src/lib/utils/transactions-filter.utils.ts
+++ b/src/frontend/src/lib/utils/transactions-filter.utils.ts
@@ -10,12 +10,12 @@ import { assertNever, isNullish, nonNullish, notEmptyString } from '@dfinity/uti
  * unique across networks (e.g. native ETH reuses `Symbol('ETH')` on Ethereum
  * and Base); pairing with the network id matches list rows and transactions.
  */
-export const transactionsFilterTokenKey = (token: Token): string | undefined => {
-	const tokenDesc = token.id.description;
-	const networkDesc = token.network.id.description;
+export const transactionsFilterTokenKey = ({id, network:{id:networkId}}: Token): string | undefined => {
+	const tokenDesc = id.description;
+	const networkDesc = networkId.description;
 
 	if (isNullish(tokenDesc) || isNullish(networkDesc)) {
-		return undefined;
+		return;
 	}
 
 	return `${tokenDesc}-${networkDesc}`;

--- a/src/frontend/src/lib/utils/transactions-filter.utils.ts
+++ b/src/frontend/src/lib/utils/transactions-filter.utils.ts
@@ -10,7 +10,10 @@ import { assertNever, isNullish, nonNullish, notEmptyString } from '@dfinity/uti
  * unique across networks (e.g. native ETH reuses `Symbol('ETH')` on Ethereum
  * and Base); pairing with the network id matches list rows and transactions.
  */
-export const transactionsFilterTokenKey = ({id, network:{id:networkId}}: Token): string | undefined => {
+export const transactionsFilterTokenKey = ({
+	id,
+	network: { id: networkId }
+}: Token): string | undefined => {
 	const tokenDesc = id.description;
 	const networkDesc = networkId.description;
 

--- a/src/frontend/src/lib/utils/transactions-filter.utils.ts
+++ b/src/frontend/src/lib/utils/transactions-filter.utils.ts
@@ -1,8 +1,25 @@
 import type { ContactUi } from '$lib/types/contact';
+import type { Token } from '$lib/types/token';
 import type { AllTransactionUiWithCmp } from '$lib/types/transaction-ui';
 import type { TransactionsFilter } from '$lib/types/transactions-filter';
 import { filterAddressFromContact } from '$lib/utils/contact.utils';
 import { assertNever, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
+
+/**
+ * Stable key for activity token filters. Token `id.description` alone is not
+ * unique across networks (e.g. native ETH reuses `Symbol('ETH')` on Ethereum
+ * and Base); pairing with the network id matches list rows and transactions.
+ */
+export const transactionsFilterTokenKey = (token: Token): string | undefined => {
+	const tokenDesc = token.id.description;
+	const networkDesc = token.network.id.description;
+
+	if (isNullish(tokenDesc) || isNullish(networkDesc)) {
+		return undefined;
+	}
+
+	return `${tokenDesc}-${networkDesc}`;
+};
 
 const candidateAddresses = (transactionUi: AllTransactionUiWithCmp): string[] => {
 	const collected: (string | undefined)[] = [];
@@ -92,7 +109,7 @@ export const applyTransactionsFilter = ({
 		}
 
 		if (hasTokenFilter) {
-			const tokenKey = transactionUi.token.id.description;
+			const tokenKey = transactionsFilterTokenKey(transactionUi.token);
 			if (isNullish(tokenKey) || !tokenSet.has(tokenKey)) {
 				return false;
 			}

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
@@ -2,12 +2,12 @@ import TransactionsFilterTokensPanel from '$lib/components/transactions/filter/T
 import * as networkTokensDerived from '$lib/derived/network-tokens.derived';
 import { i18n } from '$lib/stores/i18n.store';
 import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
-import { assertNonNullish } from '@dfinity/utils';
 import type { Token } from '$lib/types/token';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { transactionsFilterTokenKey } from '$lib/utils/transactions-filter.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
@@ -2,8 +2,10 @@ import TransactionsFilterTokensPanel from '$lib/components/transactions/filter/T
 import * as networkTokensDerived from '$lib/derived/network-tokens.derived';
 import { i18n } from '$lib/stores/i18n.store';
 import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
+import { assertNonNullish } from '@dfinity/utils';
 import type { Token } from '$lib/types/token';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { transactionsFilterTokenKey } from '$lib/utils/transactions-filter.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { fireEvent, render } from '@testing-library/svelte';
@@ -25,8 +27,8 @@ const buildToken = ({ id, name, symbol }: { id: string; name: string; symbol: st
 	symbol
 });
 
-const tokenInputId = ({ id, network }: Token): string =>
-	`transactions-filter-token-${`${id.description}-${network.id.description}`.replace(/[^A-Za-z0-9_-]/g, '-')}`;
+const tokenInputId = (token: Token): string =>
+	`transactions-filter-token-${(transactionsFilterTokenKey(token) ?? '').replace(/[^A-Za-z0-9_-]/g, '-')}`;
 
 describe('TransactionsFilterTokensPanel', () => {
 	const tokenAlpha = buildToken({ id: 'AlphaTokenId', name: 'Alpha', symbol: 'ALP' });
@@ -51,7 +53,9 @@ describe('TransactionsFilterTokensPanel', () => {
 	});
 
 	it('reflects the store as the checked state', () => {
-		transactionsFilterStore.toggleTokenId('AlphaTokenId');
+		const alphaKey = transactionsFilterTokenKey(tokenAlpha);
+		assertNonNullish(alphaKey);
+		transactionsFilterStore.toggleTokenId(alphaKey);
 
 		const { container } = render(TransactionsFilterTokensPanel);
 
@@ -77,7 +81,10 @@ describe('TransactionsFilterTokensPanel', () => {
 
 		await fireEvent.click(input as HTMLInputElement);
 
-		expect(get(transactionsFilterStore).tokenIds).toEqual(['AlphaTokenId']);
+		const expectedAlphaKey = transactionsFilterTokenKey(tokenAlpha);
+		assertNonNullish(expectedAlphaKey);
+
+		expect(get(transactionsFilterStore).tokenIds).toEqual([expectedAlphaKey]);
 	});
 
 	it('filters the list by token name using the search input (case-insensitive)', async () => {

--- a/src/frontend/src/tests/lib/utils/transactions-filter.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions-filter.utils.spec.ts
@@ -1,9 +1,17 @@
+import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { nonNullish } from '@dfinity/utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { ContactUi } from '$lib/types/contact';
-import type { Token } from '$lib/types/token';
 import type { AllTransactionUiWithCmp } from '$lib/types/transaction-ui';
 import { EMPTY_TRANSACTIONS_FILTER } from '$lib/types/transactions-filter';
-import { applyTransactionsFilter } from '$lib/utils/transactions-filter.utils';
+import {
+	applyTransactionsFilter,
+	transactionsFilterTokenKey
+} from '$lib/utils/transactions-filter.utils';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mock';
 import { mockPrincipalText } from '$tests/mocks/identity.mock';
@@ -22,16 +30,9 @@ const mockDerivedAccountIdentifierHex = AccountIdentifier.fromPrincipal({
 	subAccount: undefined
 }).toHex();
 
-const tokenWithSymbol = (symbol: string): Token => ({ id: Symbol(symbol) }) as unknown as Token;
-
-const btcToken = tokenWithSymbol('BTC');
-const ethToken = tokenWithSymbol('ETH');
-const icpToken = tokenWithSymbol('ICP');
-const solToken = tokenWithSymbol('SOL');
-
 const btcSendTx = {
 	component: 'bitcoin',
-	token: btcToken,
+	token: BTC_MAINNET_TOKEN,
 	transaction: {
 		id: 'btc-1',
 		type: 'send',
@@ -45,7 +46,7 @@ const btcSendTx = {
 
 const btcReceiveTx = {
 	component: 'bitcoin',
-	token: btcToken,
+	token: BTC_MAINNET_TOKEN,
 	transaction: {
 		id: 'btc-2',
 		type: 'receive',
@@ -59,7 +60,7 @@ const btcReceiveTx = {
 
 const ethSendTx = {
 	component: 'ethereum',
-	token: ethToken,
+	token: ETHEREUM_TOKEN,
 	transaction: {
 		id: 'eth-1',
 		type: 'send',
@@ -75,7 +76,7 @@ const ethSendTx = {
 
 const icpSendToHexTx = {
 	component: 'ic',
-	token: icpToken,
+	token: ICP_TOKEN,
 	transaction: {
 		id: 'icp-1',
 		type: 'send',
@@ -89,7 +90,7 @@ const icpSendToHexTx = {
 
 const icpApproveTx = {
 	component: 'ic',
-	token: icpToken,
+	token: ICP_TOKEN,
 	transaction: {
 		id: 'icp-2',
 		type: 'approve',
@@ -107,7 +108,7 @@ const icpApproveTx = {
 // via the `toOwner` preference (asserts the documented behavior).
 const solSendTx = {
 	component: 'solana',
-	token: solToken,
+	token: SOLANA_TOKEN,
 	transaction: {
 		id: 'sol-1',
 		type: 'send',
@@ -167,14 +168,55 @@ describe('applyTransactionsFilter', () => {
 	});
 
 	describe('token filter', () => {
-		it('keeps only transactions whose token id description is selected', () => {
+		it('keeps only transactions matching selected token-and-network keys', () => {
 			const result = applyTransactionsFilter({
 				transactions: allTxs,
-				filter: { ...EMPTY_TRANSACTIONS_FILTER, tokenIds: ['BTC', 'ICP'] },
+				filter: {
+					...EMPTY_TRANSACTIONS_FILTER,
+					tokenIds: [
+						transactionsFilterTokenKey(BTC_MAINNET_TOKEN),
+						transactionsFilterTokenKey(ICP_TOKEN)
+					].filter(nonNullish)
+				},
 				contacts: []
 			});
 
 			expect(result).toEqual([btcSendTx, btcReceiveTx, icpSendToHexTx, icpApproveTx]);
+		});
+
+		it('scopes by network when distinct tokens share the same token id description', () => {
+			const baseEthSendTx = {
+				...ethSendTx,
+				token: BASE_ETH_TOKEN,
+				transaction: {
+					...ethSendTx.transaction,
+					id: 'eth-base-send'
+				}
+			} as unknown as AllTransactionUiWithCmp;
+
+			const txs: AllTransactionUiWithCmp[] = [ethSendTx, baseEthSendTx];
+
+			const baseOnly = applyTransactionsFilter({
+				transactions: txs,
+				filter: {
+					...EMPTY_TRANSACTIONS_FILTER,
+					tokenIds: [transactionsFilterTokenKey(BASE_ETH_TOKEN)].filter(nonNullish)
+				},
+				contacts: []
+			});
+
+			expect(baseOnly).toEqual([baseEthSendTx]);
+
+			const mainnetOnly = applyTransactionsFilter({
+				transactions: txs,
+				filter: {
+					...EMPTY_TRANSACTIONS_FILTER,
+					tokenIds: [transactionsFilterTokenKey(ETHEREUM_TOKEN)].filter(nonNullish)
+				},
+				contacts: []
+			});
+
+			expect(mainnetOnly).toEqual([ethSendTx]);
 		});
 	});
 
@@ -276,7 +318,11 @@ describe('applyTransactionsFilter', () => {
 		it('intersects type, token and contact', () => {
 			const result = applyTransactionsFilter({
 				transactions: allTxs,
-				filter: { types: ['send'], tokenIds: ['ETH'], contactIds: ['1'] },
+				filter: {
+					types: ['send'],
+					tokenIds: [transactionsFilterTokenKey(ETHEREUM_TOKEN)].filter(nonNullish),
+					contactIds: ['1']
+				},
 				contacts: [ethContact]
 			});
 
@@ -286,7 +332,11 @@ describe('applyTransactionsFilter', () => {
 		it('returns empty when an intersection is impossible', () => {
 			const result = applyTransactionsFilter({
 				transactions: allTxs,
-				filter: { types: ['receive'], tokenIds: ['ETH'], contactIds: [] },
+				filter: {
+					types: ['receive'],
+					tokenIds: [transactionsFilterTokenKey(ETHEREUM_TOKEN)].filter(nonNullish),
+					contactIds: []
+				},
 				contacts: []
 			});
 

--- a/src/frontend/src/tests/lib/utils/transactions-filter.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions-filter.utils.spec.ts
@@ -3,7 +3,6 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
-import { nonNullish } from '@dfinity/utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { ContactUi } from '$lib/types/contact';
 import type { AllTransactionUiWithCmp } from '$lib/types/transaction-ui';
@@ -21,6 +20,7 @@ import {
 	mockSolAddress,
 	mockSolAddress2
 } from '$tests/mocks/sol.mock';
+import { nonNullish } from '@dfinity/utils';
 import { AccountIdentifier } from '@icp-sdk/canisters/ledger/icp';
 import { Principal } from '@icp-sdk/core/principal';
 


### PR DESCRIPTION
# Motivation

Selecting a token in the All Activity filter toggled every row that shared the same ticker (for example native ETH on Ethereum and Base both use `Symbol('ETH')`). The filter stored only `token.id.description`, which is not unique across networks.

# Changes

- Introduce `transactionsFilterTokenKey` combining token id and network id descriptions; use it when toggling checkboxes, persisting `tokenIds`, and in `applyTransactionsFilter`.
- Bump the persisted filter storage key to `oisy_transactions_filter_v2` so stale single-segment keys do not apply incorrectly.
- Contacts filter already keys rows by `contact.id`; no code change there.

# Tests

- Updated unit tests for `applyTransactionsFilter` and `TransactionsFilterTokensPanel`.
- Added regression coverage for ETH on Ethereum vs ETH on Base.
- Ran `npm run check` and full `npm run test` (Vitest).
