### PR TITLE
style(frontend): drop sticky activity filter toolbar so date stickies stay visible

### DIFF
--- a/src/frontend/src/lib/components/hero/Header.svelte
+++ b/src/frontend/src/lib/components/hero/Header.svelte
@@ -33,14 +33,14 @@
 	);
 
 	// Header-anchored popovers (user menu, network switcher) need the
-	// Header's stacking context to outrank the activity filter toolbar's
-	// `StickyHeader` (`z-10`, see `AllTransactionsList`). We do NOT bump
-	// for modals — gix modals/bottom sheets already paint above the
-	// default Header at `z-14`, and bumping here would hide them behind
-	// the Header and capture pointer events on top of the modal backdrop.
-	// Likewise we do NOT raise the `1.5xl` signed-in default — banners
-	// (`Banner`, `PwaBanner`, `AgreementsGuard`) and `FullscreenMediaModal`
-	// all sit at `z-10` and would render behind the Header otherwise.
+	// Header's stacking context to outrank sibling `z-10` elements
+	// (banners: `Banner`, `PwaBanner`, `AgreementsGuard`, plus
+	// `FullscreenMediaModal`). We do NOT bump for modals — gix modals /
+	// bottom sheets already paint above the default Header at `z-14`,
+	// and bumping here would hide them behind the Header and capture
+	// pointer events on top of the modal backdrop. We also keep the
+	// `1.5xl` signed-in default at `z-10` so those banners render at
+	// the same level as the Header instead of behind it.
 	let popoverOpen = $derived(menuOpen || networkSwitcherOpen);
 
 	let biggerOverlay = $derived(popoverOpen || modalsOpen);

--- a/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsList.svelte
@@ -20,7 +20,6 @@
 	import TransactionsDateGroup from '$lib/components/transactions/TransactionsDateGroup.svelte';
 	import TransactionsPlaceholder from '$lib/components/transactions/TransactionsPlaceholder.svelte';
 	import TransactionsFilterToolbar from '$lib/components/transactions/filter/TransactionsFilterToolbar.svelte';
-	import StickyHeader from '$lib/components/ui/StickyHeader.svelte';
 	import { ACTIVITY_TRANSACTION_SKELETON_PREFIX } from '$lib/constants/test-ids.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { allContacts } from '$lib/derived/contacts.derived';
@@ -125,41 +124,27 @@
 	);
 </script>
 
-<!--
-	Each `TransactionsDateGroup` uses `StickyHeader` internally at the
-	default `z-3`, creating a sibling stacking context per date label. If
-	the toolbar's `StickyHeader` were also at `z-3`, the gix Popover that
-	the chips open would be trapped inside the toolbar's `z-3` context and
-	the date stickies (also `z-3`, but rendered later in DOM) would paint
-	on top of it — visually freezing the dropdown. Using `zIndex={10}`
-	lifts the popover's containing stacking context above every date `z-3`
-	context, so the dropdown content paints on top of the date headers.
--->
-<StickyHeader zIndex={10}>
-	{#snippet header()}
-		<TransactionsFilterToolbar />
-	{/snippet}
+<TransactionsFilterToolbar />
 
-	<AllTransactionsSkeletons testIdPrefix={ACTIVITY_TRANSACTION_SKELETON_PREFIX}>
-		<AllTransactionsLoader transactions={allTransactions}>
-			<AllTransactionsScroll {sortedTransactions} bind:transactionsToDisplay>
-				{#if Object.values(groupedTransactions).length > 0}
-					{#each Object.entries(groupedTransactions) as [formattedDate, transactions], index (formattedDate)}
-						<TransactionsDateGroup
-							{formattedDate}
-							testId={`all-transactions-date-group-${index}`}
-							{transactions}
-						/>
-					{/each}
-				{/if}
+<AllTransactionsSkeletons testIdPrefix={ACTIVITY_TRANSACTION_SKELETON_PREFIX}>
+	<AllTransactionsLoader transactions={allTransactions}>
+		<AllTransactionsScroll {sortedTransactions} bind:transactionsToDisplay>
+			{#if Object.values(groupedTransactions).length > 0}
+				{#each Object.entries(groupedTransactions) as [formattedDate, transactions], index (formattedDate)}
+					<TransactionsDateGroup
+						{formattedDate}
+						testId={`all-transactions-date-group-${index}`}
+						{transactions}
+					/>
+				{/each}
+			{/if}
 
-				{#if Object.values(groupedTransactions).length === 0}
-					<TransactionsPlaceholder />
-				{/if}
-			</AllTransactionsScroll>
-		</AllTransactionsLoader>
-	</AllTransactionsSkeletons>
-</StickyHeader>
+			{#if Object.values(groupedTransactions).length === 0}
+				<TransactionsPlaceholder />
+			{/if}
+		</AllTransactionsScroll>
+	</AllTransactionsLoader>
+</AllTransactionsSkeletons>
 
 {#if $modalBtcTransaction && nonNullish(selectedBtcTransaction)}
 	<BtcTransactionModal token={selectedBtcToken} transaction={selectedBtcTransaction} />

--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -8,8 +8,8 @@
 		// Optional stacking-context override. Defaults to `3` to match the
 		// historical behavior shared by every sticky header in the app
 		// (date stickies, `Assets`, `TokensList`). Pass a higher value for
-		// headers whose contents open a popover that must paint above other
-		// sibling sticky headers — see `AllTransactionsList`.
+		// headers whose contents open a popover that must paint above
+		// other sibling sticky headers.
 		zIndex?: number;
 	}
 


### PR DESCRIPTION
# Motivation

After the toolbar was wrapped in `StickyHeader` (#12677), the activity filter chips pin to the top of the activity list and the per-date stickies (`May 8`, `Today`, …) get covered by the toolbar instead of pinning. The desired behavior is the inverse: the filter does not need to be sticky, but the date headers should remain sticky as they were before.



https://github.com/user-attachments/assets/822b8519-caa7-4585-86a5-c32f6ff5c9ce


