### PR TITLE
fix(frontend): hide built-in minter contacts from activity contact filter

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte
@@ -26,11 +26,6 @@
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.contactIds));
 
-	// We list only user-managed contacts here. Built-in/system contacts (e.g.
-	// CK minter helper contracts, ckBTC / CK Ethereum minter principals) are
-	// still part of `allContacts` and resolved for display on transaction rows,
-	// but would otherwise dominate this dropdown without the user ever having
-	// added them.
 	let alphaSorted = $derived(
 		[...$contacts].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
 	);

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte
@@ -2,7 +2,7 @@
 	import { Checkbox } from '@dfinity/gix-components';
 	import Avatar from '$lib/components/contact/Avatar.svelte';
 	import InputSearch from '$lib/components/ui/InputSearch.svelte';
-	import { allContacts } from '$lib/derived/contacts.derived';
+	import { contacts } from '$lib/derived/contacts.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 	import { matchesContactByText } from '$lib/utils/contact.utils';
@@ -26,10 +26,13 @@
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.contactIds));
 
+	// We list only user-managed contacts here. Built-in/system contacts (e.g.
+	// CK minter helper contracts, ckBTC / CK Ethereum minter principals) are
+	// still part of `allContacts` and resolved for display on transaction rows,
+	// but would otherwise dominate this dropdown without the user ever having
+	// added them.
 	let alphaSorted = $derived(
-		[...$allContacts].sort((a, b) =>
-			a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-		)
+		[...$contacts].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
 	);
 
 	let filteredContacts = $derived(

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterContactsPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterContactsPanel.spec.ts
@@ -8,8 +8,8 @@ import { getMockContactsUi, mockContactEthAddressUi } from '$tests/mocks/contact
 import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
-const mockAllContacts = (contacts: ContactUi[]) => {
-	vi.spyOn(contactsDerived.allContacts, 'subscribe').mockImplementation((fn) => {
+const mockContacts = (contacts: ContactUi[]) => {
+	vi.spyOn(contactsDerived.contacts, 'subscribe').mockImplementation((fn) => {
 		fn(contacts);
 		return () => {};
 	});
@@ -34,7 +34,7 @@ describe('TransactionsFilterContactsPanel', () => {
 		vi.restoreAllMocks();
 		localStorage.clear();
 		transactionsFilterStore.clear();
-		mockAllContacts([bob, alice]);
+		mockContacts([bob, alice]);
 	});
 
 	it('renders one row per contact, alphabetically sorted by name', () => {
@@ -103,6 +103,17 @@ describe('TransactionsFilterContactsPanel', () => {
 		expect(names).toEqual(['Alice']);
 	});
 
+	it('does not render built-in / minter contacts (only user-managed ones)', () => {
+		// Even if the user has no contacts of their own, built-in minter
+		// contacts (which live in `allContacts` but not in `contacts`) must
+		// not pollute the activity contact filter dropdown.
+		mockContacts([]);
+
+		const { container } = render(TransactionsFilterContactsPanel);
+
+		expect(container.querySelectorAll('li')).toHaveLength(0);
+	});
+
 	it('caps the visible list to 50 rows when over the limit and renders the showing-partial hint', () => {
 		const contacts: ContactUi[] = Array.from({ length: 60 }, (_, i) => ({
 			id: BigInt(i + 1),
@@ -111,7 +122,7 @@ describe('TransactionsFilterContactsPanel', () => {
 			image: undefined,
 			addresses: []
 		}));
-		mockAllContacts(contacts);
+		mockContacts(contacts);
 
 		const { container, getByText } = render(TransactionsFilterContactsPanel);
 


### PR DESCRIPTION
# Motivation

The activity Contacts filter dropdown is dominated by built-in CK minter helper contracts and ckBTC / CK Ethereum minter principal contacts, even when the user has no transactions involving them.

# Changes

- `TransactionsFilterContactsPanel.svelte` now sources from `$contacts` (user-managed) instead of `$allContacts`. `$allContacts` still drives name resolution on transaction rows and the filter-matching path in `applyTransactionsFilter`.

# Tests

- Updated `TransactionsFilterContactsPanel.spec.ts` to mock `contacts` and added a case asserting built-in / minter contacts are not listed.


