### PR TITLE
fix(frontend): keep checkbox visible after click-deselection

### DIFF
--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -374,16 +374,13 @@ div.radio {
 
 	input[type='checkbox'],
 	input[type='radio'] {
-		--secondary: var(--color-primary);
 		--focus-background: var(--color-background-primary);
 
 		&:focus {
-			--secondary: var(--color-primary);
 			--focus-background: var(--color-background-primary);
 		}
 
 		&:checked {
-			--secondary: var(--color-primary);
 			--focus-background: var(--color-background-brand-primary-alt);
 			--input-custom-border-color: var(--color-background-brand-primary-alt);
 			--input-background: var(--color-background-brand-primary-alt);


### PR DESCRIPTION
# Motivation

After checking and then unchecking an option in the activity Type (or Tokens / Contacts) filter and moving the cursor away, the checkbox box disappeared entirely — only the label remained.

# Changes

Remove the three `--secondary: var(--color-primary)` overrides on `input[type='checkbox']` / `input[type='radio']` in `gix.scss`. `--color-primary` is a legacy gix-components variable that is not defined in OISY's design tokens, so each declaration computed to the guaranteed-invalid value. The gix `:focus` rule's `border: var(--input-border-size) solid var(--secondary)` therefore collapsed to its initial `none`, and combined with the global `outline: none !important` on `:focus:not(:focus-visible)`, a click-focused unchecked checkbox rendered with no visible box at all. With the broken declarations gone, `--secondary` inherits its `:root` value (`var(--color-background-brand-primary)`) and the focused unchecked checkbox shows a 1px brand-primary border, consistent with the rest of the brand styling. The `:checked` and `:hover` paths still set explicit values and are unaffected.

# Tests

Practical test here:

<img width="1277" height="797" alt="Screenshot 2026-05-11 at 11 21 09" src="https://github.com/user-attachments/assets/0c19917a-1107-4572-ac8f-21412f5821da" />


