### PR TITLE
chore(frontend): show notice instead of OnRamper widget pending signed-URL work

### DIFF
--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -1,6 +1,6 @@
 import { LOCAL, STAGING } from '$lib/constants/app.constants';
 
-export const ONRAMPER_ENABLED = false;
+export const ONRAMPER_ENABLED: boolean = false;
 
 const ONRAMPER_ENV: 'dev' | 'prod' = LOCAL || STAGING ? 'dev' : 'prod';
 

--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -1,5 +1,6 @@
 import { LOCAL, STAGING } from '$lib/constants/app.constants';
 
+// TODO: Enable (or remove this flag?) when OnRamper is functional again
 export const ONRAMPER_ENABLED: boolean = false;
 
 const ONRAMPER_ENV: 'dev' | 'prod' = LOCAL || STAGING ? 'dev' : 'prod';

--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -1,7 +1,7 @@
 import { LOCAL, STAGING } from '$lib/constants/app.constants';
 
 // TODO: Enable (or remove this flag?) when OnRamper is functional again
-export const ONRAMPER_ENABLED = false;
+export const ONRAMPER_ENABLED = false as boolean;
 
 const ONRAMPER_ENV: 'dev' | 'prod' = LOCAL || STAGING ? 'dev' : 'prod';
 

--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -1,7 +1,7 @@
 import { LOCAL, STAGING } from '$lib/constants/app.constants';
 
 // TODO: Enable (or remove this flag?) when OnRamper is functional again
-export const ONRAMPER_ENABLED: boolean = false;
+export const ONRAMPER_ENABLED = false;
 
 const ONRAMPER_ENV: 'dev' | 'prod' = LOCAL || STAGING ? 'dev' : 'prod';
 

--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -1,5 +1,7 @@
 import { LOCAL, STAGING } from '$lib/constants/app.constants';
 
+export const ONRAMPER_ENABLED = false;
+
 const ONRAMPER_ENV: 'dev' | 'prod' = LOCAL || STAGING ? 'dev' : 'prod';
 
 export const isOnRamperDev = ONRAMPER_ENV === 'dev';

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -21,6 +21,7 @@
 <ButtonHero
 	ariaLabel={$i18n.buy.text.buy}
 	disabled={$isBusy ||
+		// a missing API key should only disable the button if OnRamper is enabled. If it's disabled anyway, we want the button to remain active, so we can show a modal content about why it's not available.
 		(ONRAMPER_ENABLED && isNullishOrEmpty(ONRAMPER_API_KEY)) ||
 		$inflowActionsDisabled}
 	{onclick}

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <ButtonHero
-	ariaLabel={$i18n.send.text.send}
+	ariaLabel={$i18n.buy.text.buy}
 	disabled={$isBusy ||
 		(ONRAMPER_ENABLED && isNullishOrEmpty(ONRAMPER_API_KEY)) ||
 		$inflowActionsDisabled}

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <ButtonHero
-	ariaLabel={$i18n.buy.text.send}
+	ariaLabel={$i18n.send.text.send}
 	disabled={$isBusy ||
 		(ONRAMPER_ENABLED && isNullishOrEmpty(ONRAMPER_API_KEY)) ||
 		$inflowActionsDisabled}

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -18,6 +18,7 @@
 	const { inflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 </script>
 
+<!-- API-key gate only matters while OnRamper is enabled; with the flag off, the modal shows the notice and doesn't need the key. -->
 <ButtonHero
 	ariaLabel={$i18n.buy.text.buy}
 	disabled={$isBusy ||

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -21,7 +21,6 @@
 <ButtonHero
 	ariaLabel={$i18n.buy.text.buy}
 	disabled={$isBusy ||
-		// a missing API key should only disable the button if OnRamper is enabled. If it's disabled anyway, we want the button to remain active, so we can show a modal content about why it's not available.
 		(ONRAMPER_ENABLED && isNullishOrEmpty(ONRAMPER_API_KEY)) ||
 		$inflowActionsDisabled}
 	{onclick}

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
-	import { ONRAMPER_API_KEY } from '$env/rest/onramper.env';
+	import { ONRAMPER_API_KEY, ONRAMPER_ENABLED } from '$env/rest/onramper.env';
 	import ButtonHero from '$lib/components/hero/ButtonHero.svelte';
 	import IconlyBuy from '$lib/components/icons/iconly/IconlyBuy.svelte';
 	import { BUY_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants';
@@ -20,7 +20,9 @@
 
 <ButtonHero
 	ariaLabel={$i18n.send.text.send}
-	disabled={$isBusy || isNullishOrEmpty(ONRAMPER_API_KEY) || $inflowActionsDisabled}
+	disabled={$isBusy ||
+		(ONRAMPER_ENABLED && isNullishOrEmpty(ONRAMPER_API_KEY)) ||
+		$inflowActionsDisabled}
 	{onclick}
 	testId={BUY_TOKENS_MODAL_OPEN_BUTTON}
 >

--- a/src/frontend/src/lib/components/buy/BuyModalContent.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModalContent.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
+	import { ONRAMPER_ENABLED } from '$env/rest/onramper.env';
+	import BuyUnavailableNotice from '$lib/components/buy/BuyUnavailableNotice.svelte';
 	import OnramperWidget from '$lib/components/onramper/OnramperWidget.svelte';
 </script>
 
-<div class="stretch flex overflow-hidden">
-	<div class="w-full overflow-auto">
-		<OnramperWidget />
+{#if ONRAMPER_ENABLED}
+	<div class="stretch flex overflow-hidden">
+		<div class="w-full overflow-auto">
+			<OnramperWidget />
+		</div>
 	</div>
-</div>
+{:else}
+	<BuyUnavailableNotice />
+{/if}
 
 <style lang="scss">
 	.stretch {

--- a/src/frontend/src/lib/components/buy/BuyUnavailableNotice.svelte
+++ b/src/frontend/src/lib/components/buy/BuyUnavailableNotice.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/Button.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+</script>
+
+<div class="flex flex-col items-center px-4 py-6 text-center">
+	<h2 class="mb-3 text-2xl font-bold">{$i18n.buy.text.unavailable_title}</h2>
+
+	<p class="mb-4 text-sm text-tertiary">{$i18n.buy.text.unavailable_description}</p>
+
+	<p class="mb-6 text-sm text-tertiary">{$i18n.buy.text.unavailable_fallback_hint}</p>
+
+	<Button colorStyle="primary" fullWidth onclick={modalStore.close} type="button">
+		{$i18n.buy.actions.close}
+	</Button>
+</div>

--- a/src/frontend/src/lib/components/buy/BuyUnavailableNotice.svelte
+++ b/src/frontend/src/lib/components/buy/BuyUnavailableNotice.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -7,7 +8,14 @@
 <div class="flex flex-col items-center px-4 py-6 text-center">
 	<h2 class="mb-3 text-2xl font-bold">{$i18n.buy.text.unavailable_title}</h2>
 
-	<p class="mb-4 text-sm text-tertiary">{$i18n.buy.text.unavailable_description}</p>
+	<p class="mb-4 text-sm text-tertiary">
+		<strong
+			><span class="relative -top-px mr-1 inline-block align-middle text-success-primary"
+				><IconShieldCheck size="16" /></span
+			>{$i18n.buy.text.oisy_protects_you}</strong
+		>
+		{$i18n.buy.text.unavailable_description}
+	</p>
 
 	<p class="mb-6 text-sm text-tertiary">{$i18n.buy.text.unavailable_fallback_hint}</p>
 

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "شراء",
-			"buy_dev": "شراء (بيئة تطوير)"
+			"buy_dev": "شراء (بيئة تطوير)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "شراء عبر Onramper"

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1193,6 +1193,7 @@
 			"buy": "شراء",
 			"buy_dev": "شراء (بيئة تطوير)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "شراء",
 			"buy_dev": "شراء (بيئة تطوير)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "شراء الرموز غير متاح مؤقتًا",
+			"oisy_protects_you": "OISY يحميك!",
+			"unavailable_description": "شراء الرموز معطل حاليًا بينما نواصل تحسين أمان هذه العملية من خلال إضافة توقيع عناوين URL. ستتم إعادة تفعيله بمجرد اكتمال العمل.",
+			"unavailable_fallback_hint": "في غضون ذلك، لا يزال بإمكانك استلام الرموز عن طريق مشاركة عنوان محفظتك."
 		},
 		"actions": {
-			"close": ""
+			"close": "حسنًا"
 		},
 		"onramper": {
 			"title": "شراء عبر Onramper"

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1193,6 +1193,7 @@
 			"buy": "Koupit",
 			"buy_dev": "Koupit (vývojové prostředí)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Koupit",
 			"buy_dev": "Koupit (vývojové prostředí)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "Nákup tokenů je dočasně nedostupný",
+			"oisy_protects_you": "OISY vás chrání!",
+			"unavailable_description": "Nákup tokenů je momentálně vypnutý, zatímco dále vylepšujeme zabezpečení tohoto procesu zavedením podepisování URL. Bude znovu zapnut, jakmile bude práce dokončena.",
+			"unavailable_fallback_hint": "Mezitím můžete stále přijímat tokeny sdílením adresy své peněženky."
 		},
 		"actions": {
-			"close": ""
+			"close": "Rozumím"
 		},
 		"onramper": {
 			"title": "Koupit přes Onramper"

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Koupit",
-			"buy_dev": "Koupit (vývojové prostředí)"
+			"buy_dev": "Koupit (vývojové prostředí)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Koupit přes Onramper"

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Kaufen",
 			"buy_dev": "Kaufen (Entwicklungsumgebung)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "Tokens kaufen ist vorübergehend nicht verfügbar",
+			"oisy_protects_you": "OISY schützt dich!",
+			"unavailable_description": "Der Kauf von Tokens ist derzeit deaktiviert, während wir die Sicherheit dieses Prozesses durch die Einführung von URL-Signierung weiter verbessern. Sobald die Arbeit abgeschlossen ist, wird er wieder aktiviert.",
+			"unavailable_fallback_hint": "In der Zwischenzeit kannst du weiterhin Tokens empfangen, indem du deine Wallet-Adresse teilst."
 		},
 		"actions": {
-			"close": ""
+			"close": "Verstanden"
 		},
 		"onramper": {
 			"title": "Kauf über Onramper"

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1193,6 +1193,7 @@
 			"buy": "Kaufen",
 			"buy_dev": "Kaufen (Entwicklungsumgebung)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Kaufen",
-			"buy_dev": "Kaufen (Entwicklungsumgebung)"
+			"buy_dev": "Kaufen (Entwicklungsumgebung)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Kauf über Onramper"

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Buy",
-			"buy_dev": "Buy (Dev Environment)"
+			"buy_dev": "Buy (Dev Environment)",
+			"unavailable_title": "Buying tokens is temporarily unavailable",
+			"unavailable_description": "Buying tokens is currently turned off while we improve the security of this process by introducing signed URLs. It will be turned back on as soon as the work is complete.",
+			"unavailable_fallback_hint": "In the meantime, you can still receive tokens by sharing your wallet address."
+		},
+		"actions": {
+			"close": "Got it"
 		},
 		"onramper": {
 			"title": "Buy through Onramper"

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1193,7 +1193,8 @@
 			"buy": "Buy",
 			"buy_dev": "Buy (Dev Environment)",
 			"unavailable_title": "Buying tokens is temporarily unavailable",
-			"unavailable_description": "Buying tokens is currently turned off while we improve the security of this process by introducing signed URLs. It will be turned back on as soon as the work is complete.",
+			"oisy_protects_you": "OISY protects you!",
+			"unavailable_description": "Buying tokens is currently turned off while we further improve the security of this process by introducing URL signing. It will be turned back on as soon as the work is complete.",
 			"unavailable_fallback_hint": "In the meantime, you can still receive tokens by sharing your wallet address."
 		},
 		"actions": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Comprar",
 			"buy_dev": "Comprar (Entorno de Desarrollo)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "La compra de tokens no está disponible temporalmente",
+			"oisy_protects_you": "OISY te protege!",
+			"unavailable_description": "La compra de tokens está desactivada actualmente mientras seguimos mejorando la seguridad de este proceso mediante la introducción de la firma de URL. Se reactivará en cuanto se complete el trabajo.",
+			"unavailable_fallback_hint": "Mientras tanto, aún puedes recibir tokens compartiendo la dirección de tu billetera."
 		},
 		"actions": {
-			"close": ""
+			"close": "Entendido"
 		},
 		"onramper": {
 			"title": "Comprar a través de Onramper"

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1193,6 +1193,7 @@
 			"buy": "Comprar",
 			"buy_dev": "Comprar (Entorno de Desarrollo)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Comprar",
-			"buy_dev": "Comprar (Entorno de Desarrollo)"
+			"buy_dev": "Comprar (Entorno de Desarrollo)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Comprar a través de Onramper"

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Acheter",
 			"buy_dev": "Acheter (Env. de Dév.)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "L'achat de jetons est temporairement indisponible",
+			"oisy_protects_you": "OISY vous protège!",
+			"unavailable_description": "L'achat de jetons est actuellement désactivé pendant que nous continuons à renforcer la sécurité de ce processus en introduisant la signature des URL. Il sera réactivé dès que les travaux seront terminés.",
+			"unavailable_fallback_hint": "En attendant, vous pouvez toujours recevoir des jetons en partageant l'adresse de votre portefeuille."
 		},
 		"actions": {
-			"close": ""
+			"close": "Compris"
 		},
 		"onramper": {
 			"title": "Acheter via Onramper"

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1193,6 +1193,7 @@
 			"buy": "Acheter",
 			"buy_dev": "Acheter (Env. de Dév.)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Acheter",
-			"buy_dev": "Acheter (Env. de Dév.)"
+			"buy_dev": "Acheter (Env. de Dév.)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Acheter via Onramper"

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "खरीदें",
 			"buy_dev": "खरीदें (Dev एनवायरनमेंट)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "टोकन खरीदना अस्थायी रूप से अनुपलब्ध है",
+			"oisy_protects_you": "OISY आपकी सुरक्षा करता है!",
+			"unavailable_description": "टोकन खरीदना वर्तमान में बंद है, क्योंकि हम URL साइनिंग शुरू करके इस प्रक्रिया की सुरक्षा को और बेहतर बना रहे हैं। काम पूरा होते ही इसे फिर से चालू कर दिया जाएगा।",
+			"unavailable_fallback_hint": "इस बीच, आप अभी भी अपने वॉलेट का पता साझा करके टोकन प्राप्त कर सकते हैं।"
 		},
 		"actions": {
-			"close": ""
+			"close": "समझ गया"
 		},
 		"onramper": {
 			"title": "ऑनराम्पर के माध्यम से खरीदें"

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1193,6 +1193,7 @@
 			"buy": "खरीदें",
 			"buy_dev": "खरीदें (Dev एनवायरनमेंट)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "खरीदें",
-			"buy_dev": "खरीदें (Dev एनवायरनमेंट)"
+			"buy_dev": "खरीदें (Dev एनवायरनमेंट)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "ऑनराम्पर के माध्यम से खरीदें"

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1193,6 +1193,7 @@
 			"buy": "Acquista",
 			"buy_dev": "Acquista (Ambiente di sviluppo)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Acquista",
 			"buy_dev": "Acquista (Ambiente di sviluppo)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "L'acquisto di token è temporaneamente non disponibile",
+			"oisy_protects_you": "OISY ti protegge!",
+			"unavailable_description": "L'acquisto di token è attualmente disattivato mentre continuiamo a migliorare la sicurezza di questo processo introducendo la firma degli URL. Verrà riattivato non appena il lavoro sarà completato.",
+			"unavailable_fallback_hint": "Nel frattempo, puoi comunque ricevere token condividendo l'indirizzo del tuo portafoglio."
 		},
 		"actions": {
-			"close": ""
+			"close": "Capito"
 		},
 		"onramper": {
 			"title": "Acquista tramite Onramper"

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Acquista",
-			"buy_dev": "Acquista (Ambiente di sviluppo)"
+			"buy_dev": "Acquista (Ambiente di sviluppo)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Acquista tramite Onramper"

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1193,6 +1193,7 @@
 			"buy": "購入",
 			"buy_dev": "購入（開発環境）",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "購入",
 			"buy_dev": "購入（開発環境）",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "トークンの購入は一時的にご利用いただけません",
+			"oisy_protects_you": "OISYがあなたを守ります！",
+			"unavailable_description": "URL署名の導入により、このプロセスのセキュリティをさらに強化しているため、現在トークンの購入はオフになっています。作業が完了次第、再び有効になります。",
+			"unavailable_fallback_hint": "それまでの間も、ウォレットアドレスを共有することでトークンを受け取ることができます。"
 		},
 		"actions": {
-			"close": ""
+			"close": "了解"
 		},
 		"onramper": {
 			"title": "Onramper経由で購入"

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "購入",
-			"buy_dev": "購入（開発環境）"
+			"buy_dev": "購入（開発環境）",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Onramper経由で購入"

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1193,6 +1193,7 @@
 			"buy": "구매",
 			"buy_dev": "구매 (개발 환경)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "구매",
-			"buy_dev": "구매 (개발 환경)"
+			"buy_dev": "구매 (개발 환경)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Onramper를 통해 구매"

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "구매",
 			"buy_dev": "구매 (개발 환경)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "토큰 구매는 일시적으로 사용할 수 없습니다",
+			"oisy_protects_you": "OISY가 당신을 보호합니다!",
+			"unavailable_description": "URL 서명을 도입하여 이 프로세스의 보안을 더욱 개선하는 동안 토큰 구매가 현재 꺼져 있습니다. 작업이 완료되는 즉시 다시 켜집니다.",
+			"unavailable_fallback_hint": "그동안에도 지갑 주소를 공유하여 토큰을 받을 수 있습니다."
 		},
 		"actions": {
-			"close": ""
+			"close": "확인"
 		},
 		"onramper": {
 			"title": "Onramper를 통해 구매"

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Kup",
-			"buy_dev": "Kup (środowisko deweloperskie)"
+			"buy_dev": "Kup (środowisko deweloperskie)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Kup przez Onramper"

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Kup",
 			"buy_dev": "Kup (środowisko deweloperskie)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "Kupowanie tokenów jest tymczasowo niedostępne",
+			"oisy_protects_you": "OISY cię chroni!",
+			"unavailable_description": "Kupowanie tokenów jest obecnie wyłączone, podczas gdy nadal ulepszamy bezpieczeństwo tego procesu poprzez wprowadzenie podpisywania URL. Zostanie ponownie włączone, gdy tylko praca zostanie zakończona.",
+			"unavailable_fallback_hint": "W międzyczasie nadal możesz otrzymywać tokeny, udostępniając adres swojego portfela."
 		},
 		"actions": {
-			"close": ""
+			"close": "Rozumiem"
 		},
 		"onramper": {
 			"title": "Kup przez Onramper"

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1193,6 +1193,7 @@
 			"buy": "Kup",
 			"buy_dev": "Kup (środowisko deweloperskie)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Comprar",
 			"buy_dev": "Comprar (Ambiente de Desenvolvimento)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "A compra de tokens está temporariamente indisponível",
+			"oisy_protects_you": "OISY protege você.",
+			"unavailable_description": "A compra de tokens está atualmente desativada enquanto continuamos a melhorar a segurança deste processo introduzindo a assinatura de URL. Será reativada assim que o trabalho for concluído.",
+			"unavailable_fallback_hint": "Enquanto isso, você ainda pode receber tokens compartilhando o endereço da sua carteira."
 		},
 		"actions": {
-			"close": ""
+			"close": "Entendi"
 		},
 		"onramper": {
 			"title": "Comprar via Onramper"

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1193,6 +1193,7 @@
 			"buy": "Comprar",
 			"buy_dev": "Comprar (Ambiente de Desenvolvimento)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Comprar",
-			"buy_dev": "Comprar (Ambiente de Desenvolvimento)"
+			"buy_dev": "Comprar (Ambiente de Desenvolvimento)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Comprar via Onramper"

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Купить",
-			"buy_dev": "Купить (среда разработки)"
+			"buy_dev": "Купить (среда разработки)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Купить через Onramper"

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Купить",
 			"buy_dev": "Купить (среда разработки)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "Покупка токенов временно недоступна",
+			"oisy_protects_you": "OISY защищает вас!",
+			"unavailable_description": "Покупка токенов сейчас отключена, пока мы продолжаем повышать безопасность этого процесса, внедряя подписание URL. Она будет снова включена, как только работа будет завершена.",
+			"unavailable_fallback_hint": "Тем временем вы по-прежнему можете получать токены, поделившись адресом своего кошелька."
 		},
 		"actions": {
-			"close": ""
+			"close": "Понятно"
 		},
 		"onramper": {
 			"title": "Купить через Onramper"

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1193,6 +1193,7 @@
 			"buy": "Купить",
 			"buy_dev": "Купить (среда разработки)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "Mua",
 			"buy_dev": "Mua (Dev Environment)",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "Mua token tạm thời không khả dụng",
+			"oisy_protects_you": "OISY bảo vệ bạn!",
+			"unavailable_description": "Việc mua token hiện đang tắt trong khi chúng tôi tiếp tục cải thiện bảo mật cho quy trình này bằng cách giới thiệu ký URL. Nó sẽ được bật lại ngay khi công việc hoàn tất.",
+			"unavailable_fallback_hint": "Trong thời gian chờ đợi, bạn vẫn có thể nhận token bằng cách chia sẻ địa chỉ ví của mình."
 		},
 		"actions": {
-			"close": ""
+			"close": "Đã hiểu"
 		},
 		"onramper": {
 			"title": "Mua qua Onramper"

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1193,6 +1193,7 @@
 			"buy": "Mua",
 			"buy_dev": "Mua (Dev Environment)",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "Mua",
-			"buy_dev": "Mua (Dev Environment)"
+			"buy_dev": "Mua (Dev Environment)",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "Mua qua Onramper"

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1192,13 +1192,13 @@
 		"text": {
 			"buy": "购买",
 			"buy_dev": "购买（开发环境）",
-			"unavailable_title": "",
-			"oisy_protects_you": "",
-			"unavailable_description": "",
-			"unavailable_fallback_hint": ""
+			"unavailable_title": "购买代币暂时不可用",
+			"oisy_protects_you": "OISY 保护您！",
+			"unavailable_description": "购买代币目前已关闭，我们正在通过引入 URL 签名进一步增强此流程的安全性。工作完成后将立即重新开启。",
+			"unavailable_fallback_hint": "在此期间，您仍然可以通过分享您的钱包地址来接收代币。"
 		},
 		"actions": {
-			"close": ""
+			"close": "了解"
 		},
 		"onramper": {
 			"title": "通过 Onramper 购买"

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1190,7 +1190,13 @@
 	"buy": {
 		"text": {
 			"buy": "购买",
-			"buy_dev": "购买（开发环境）"
+			"buy_dev": "购买（开发环境）",
+			"unavailable_title": "",
+			"unavailable_description": "",
+			"unavailable_fallback_hint": ""
+		},
+		"actions": {
+			"close": ""
 		},
 		"onramper": {
 			"title": "通过 Onramper 购买"

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1193,6 +1193,7 @@
 			"buy": "购买",
 			"buy_dev": "购买（开发环境）",
 			"unavailable_title": "",
+			"oisy_protects_you": "",
 			"unavailable_description": "",
 			"unavailable_fallback_hint": ""
 		},

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -908,7 +908,14 @@ interface I18nSwap {
 }
 
 interface I18nBuy {
-	text: { buy: string; buy_dev: string };
+	text: {
+		buy: string;
+		buy_dev: string;
+		unavailable_title: string;
+		unavailable_description: string;
+		unavailable_fallback_hint: string;
+	};
+	actions: { close: string };
 	onramper: { title: string };
 }
 

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -913,6 +913,7 @@ interface I18nBuy {
 		buy: string;
 		buy_dev: string;
 		unavailable_title: string;
+		oisy_protects_you: string;
 		unavailable_description: string;
 		unavailable_fallback_hint: string;
 	};

--- a/src/frontend/src/tests/lib/components/buy/BuyButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyButton.spec.ts
@@ -28,6 +28,8 @@ describe('BuyButton', () => {
 		vi.spyOn(onramperEnv, 'ONRAMPER_API_KEY', 'get').mockImplementation(
 			() => 'mock-onramper-api-key'
 		);
+
+		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => true);
 	});
 
 	it('should render the Hero button', () => {
@@ -132,5 +134,25 @@ describe('BuyButton', () => {
 		btn.click();
 
 		expect(mockOnClick).not.toHaveBeenCalled();
+	});
+
+	it('should be enabled when ONRAMPER_ENABLED is false even without an API key', async () => {
+		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => false);
+		vi.spyOn(onramperEnv, 'ONRAMPER_API_KEY', 'get').mockImplementation(() => '');
+
+		const { getByTestId } = render(BuyButton, {
+			props,
+			context: mockContext(mockContextStore)
+		});
+
+		const btn = getByTestId(BUY_TOKENS_MODAL_OPEN_BUTTON) as HTMLButtonElement;
+
+		await waitFor(() => {
+			expect(btn).toBeEnabled();
+		});
+
+		btn.click();
+
+		expect(mockOnClick).toHaveBeenCalledOnce();
 	});
 });

--- a/src/frontend/src/tests/lib/components/buy/BuyButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyButton.spec.ts
@@ -32,6 +32,10 @@ describe('BuyButton', () => {
 		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => true);
 	});
 
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('should render the Hero button', () => {
 		const { getByTestId } = render(BuyButton, {
 			props,

--- a/src/frontend/src/tests/lib/components/buy/BuyModalContent.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyModalContent.spec.ts
@@ -5,6 +5,10 @@ import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 
 describe('BuyModalContent', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('renders the Onramper iframe when ONRAMPER_ENABLED is true', () => {
 		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => true);
 

--- a/src/frontend/src/tests/lib/components/buy/BuyModalContent.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyModalContent.spec.ts
@@ -1,11 +1,24 @@
+import * as onramperEnv from '$env/rest/onramper.env';
 import BuyModalContent from '$lib/components/buy/BuyModalContent.svelte';
 import { BUY_MODAL_ONRAMPER_IFRAME } from '$lib/constants/test-ids.constants';
+import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 
 describe('BuyModalContent', () => {
-	it('renders correct title if isOnRamperDev is true', () => {
+	it('renders the Onramper iframe when ONRAMPER_ENABLED is true', () => {
+		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => true);
+
 		const { getByTestId } = render(BuyModalContent);
 
 		expect(getByTestId(BUY_MODAL_ONRAMPER_IFRAME)).toBeInTheDocument();
+	});
+
+	it('renders the unavailable notice when ONRAMPER_ENABLED is false', () => {
+		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => false);
+
+		const { getByText, queryByTestId } = render(BuyModalContent);
+
+		expect(getByText(en.buy.text.unavailable_title)).toBeInTheDocument();
+		expect(queryByTestId(BUY_MODAL_ONRAMPER_IFRAME)).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

<img height="250" alt="image" src="https://github.com/user-attachments/assets/422d7169-6299-4a5a-80fd-e70272e2cc72" />


The OnRamper Buy widget is currently broken in production. Rather than hide the Buy button (which would surprise users and silently remove a feature they may rely on), we keep it visible and clickable but show an in-modal notice that explains the temporary outage and references the signed-URL security work that is already in flight on the [`feat/onramper-url-signing`](https://github.com/dfinity/oisy-wallet/tree/feat/onramper-url-signing) branch.

The flag is a hard-coded boolean kill-switch in `src/frontend/src/env/rest/onramper.env.ts`, matching the pattern used elsewhere in `$env` (e.g. `BTC_EXTENSION_FEATURE_FLAG_ENABLED`, `BACKEND_EXCHANGE_ENABLED`). Flipping it back to `true` is the only change needed to re-enable Buy once the signed-URL work ships.

# Changes

- Add `ONRAMPER_ENABLED` (defaults to `false`) in `$env/rest/onramper.env.ts`.
- New `BuyUnavailableNotice.svelte` component shown inside the Buy modal when the flag is off. Title + two short paragraphs + a "Got it" close button. No mention of "widget" — plain user-facing copy.
- `BuyModalContent.svelte` conditionally renders the OnRamper iframe or the notice based on the flag.
- `BuyButton.svelte`: the API-key gate is only enforced while OnRamper is enabled, so the button stays clickable when the flag is off (otherwise the modal would never open).
- New i18n keys under `buy.text.unavailable_*` and `buy.actions.close`. `en.json` updated; non-en placeholders will be filled by the `auto-update-i18n` workflow on this PR.

# Tests

- `BuyModalContent.spec.ts`: two cases — iframe rendered when flag is on, notice rendered when flag is off.
- `BuyButton.spec.ts`: existing API-key gate tests now explicitly mock the flag as on; new test verifies the button is enabled when the flag is off even without an API key.
- All 11 buy-component tests pass (`vitest run`).
- `npm run format` clean. `npm run lint -- --max-warnings 0` clean.
- `npm run check` has 18 pre-existing errors on `origin/main` (missing `onesec-bridge` / `@solana-program/token` deps locally) and the same 18 on this branch — no regressions.
- Local browser preview skipped: the worktree has no `node_modules` / `.env` and the dev server needs canister IDs to boot. Deployed to `test_fe_3` after this PR opened for end-to-end verification.

<img height="350" alt="image" src="https://github.com/user-attachments/assets/ae99c2dc-e304-4ee5-90e9-d44521720c73" />

🤖 Claude Opus 4.7
