### PR TITLE
feat(frontend): place activity filter button next to title on mobile

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -6,8 +6,10 @@
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
 	import AllTransactionsList from '$lib/components/transactions/AllTransactionsList.svelte';
 	import HiddenMicroTransactionsInfoBox from '$lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte';
+	import TransactionsFilterMobileButton from '$lib/components/transactions/filter/TransactionsFilterMobileButton.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import PageTitle from '$lib/components/ui/PageTitle.svelte';
+	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
@@ -127,16 +129,22 @@
 </script>
 
 <div class="flex flex-col gap-5">
-	{#if !$isPrivacyMode}
-		<PageTitle>{$i18n.activity.text.title}</PageTitle>
-	{:else}
-		<span class="flex items-center gap-2">
+	<div class="flex items-center justify-between gap-2">
+		{#if !$isPrivacyMode}
 			<PageTitle>{$i18n.activity.text.title}</PageTitle>
-			<span class="text-tertiary">
-				<IconEyeOff />
+		{:else}
+			<span class="flex items-center gap-2">
+				<PageTitle>{$i18n.activity.text.title}</PageTitle>
+				<span class="text-tertiary">
+					<IconEyeOff />
+				</span>
 			</span>
-		</span>
-	{/if}
+		{/if}
+
+		<Responsive down="sm">
+			<TransactionsFilterMobileButton />
+		</Responsive>
+	</div>
 
 	{#if hasBanners}
 		<div class="flex flex-col">

--- a/src/frontend/src/lib/components/transactions/AllTransactions.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactions.svelte
@@ -133,12 +133,12 @@
 		{#if !$isPrivacyMode}
 			<PageTitle>{$i18n.activity.text.title}</PageTitle>
 		{:else}
-			<span class="flex items-center gap-2">
+			<div class="flex items-center gap-2">
 				<PageTitle>{$i18n.activity.text.title}</PageTitle>
 				<span class="text-tertiary">
 					<IconEyeOff />
 				</span>
-			</span>
+			</div>
 		{/if}
 
 		<Responsive down="sm">

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
 	import TransactionsFilterClearButton from '$lib/components/transactions/filter/TransactionsFilterClearButton.svelte';
 	import TransactionsFilterContacts from '$lib/components/transactions/filter/TransactionsFilterContacts.svelte';
-	import TransactionsFilterMobileButton from '$lib/components/transactions/filter/TransactionsFilterMobileButton.svelte';
 	import TransactionsFilterTokens from '$lib/components/transactions/filter/TransactionsFilterTokens.svelte';
 	import TransactionsFilterTypes from '$lib/components/transactions/filter/TransactionsFilterTypes.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { TRANSACTIONS_FILTER_TOOLBAR } from '$lib/constants/test-ids.constants';
 </script>
 
-<div class="mb-4 w-full" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
-	<Responsive up="md">
+<Responsive up="md">
+	<div class="mb-4 w-full" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
 		<div class="flex flex-wrap items-center gap-2">
 			<TransactionsFilterTypes />
 
@@ -19,11 +18,5 @@
 
 			<TransactionsFilterClearButton />
 		</div>
-	</Responsive>
-
-	<Responsive down="sm">
-		<div class="flex items-center justify-end gap-2">
-			<TransactionsFilterMobileButton />
-		</div>
-	</Responsive>
-</div>
+	</div>
+</Responsive>

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactions.spec.ts
@@ -307,18 +307,18 @@ describe('AllTransactions', () => {
 
 			const { container } = render(AllTransactions);
 
-			const titleContainer = container.querySelector('span.flex.items-center.gap-2');
+			const eyeOffIcon = container.querySelector('span.text-tertiary');
 
-			expect(titleContainer).toBeInTheDocument();
+			expect(eyeOffIcon).toBeInTheDocument();
+
+			const titleContainer = eyeOffIcon?.parentElement;
+
+			expect(titleContainer?.tagName.toLowerCase()).toBe('div');
 
 			const title = titleContainer?.querySelector('h1');
 
 			expect(title).toBeInTheDocument();
 			expect(title?.textContent).toBe(en.activity.text.title);
-
-			const eyeOffIcon = titleContainer?.querySelector('span.text-tertiary');
-
-			expect(eyeOffIcon).toBeInTheDocument();
 		});
 
 		it('renders simple title when privacy mode is disabled', async () => {
@@ -330,9 +330,9 @@ describe('AllTransactions', () => {
 
 			const { container } = render(AllTransactions);
 
-			const titleContainer = container.querySelector('span.flex.items-center.gap-2');
+			const eyeOffIcon = container.querySelector('span.text-tertiary');
 
-			expect(titleContainer).not.toBeInTheDocument();
+			expect(eyeOffIcon).not.toBeInTheDocument();
 
 			const title = container.querySelector('h1');
 


### PR DESCRIPTION
# Motivation

On mobile, the activity filter icon sits on its own toolbar row below the "Recent Activity" page title. The standard header-action pattern used elsewhere (e.g. the Tokens page) places action icons next to the section title. This change brings the activity page in line with that pattern.

# Changes

- Extract the mobile activity filter trigger button (and its bottom sheet) into a new dedicated `TransactionsFilterMobileButton` component.
- Render `TransactionsFilterMobileButton` next to the page title in `AllTransactions.svelte`, scoped to mobile via `Responsive down="sm"`.
- Remove the mobile filter button + bottom sheet from `TransactionsFilterToolbar.svelte`. The desktop chip toolbar (`Responsive up="md"`) is unchanged.

# Tests

Added `TransactionsFilterMobileButton.spec.ts` covering the button rendering, the count badge for active filters, and that clicking the button opens the bottom sheet.

<img width="389" height="700" alt="Screenshot 2026-05-11 at 15 38 39" src="https://github.com/user-attachments/assets/7cecb876-adce-49a2-bc3d-39e0098df75d" />


