### PR TITLE
refactor(frontend): drop on-page Clear button from mobile activity filter toolbar

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -44,8 +44,6 @@
 
 	<Responsive down="sm">
 		<div class="flex items-center justify-end gap-2">
-			<TransactionsFilterClearButton />
-
 			<ButtonIcon
 				ariaLabel={$i18n.transaction.filter.open_filters_aria_label}
 				colorStyle="muted"


### PR DESCRIPTION
# Motivation

On mobile, the activity page renders a Clear filters pill button on the page right next to the filter trigger. The mobile filter bottom sheet already contains its own Clear filters button at the bottom of the root step, so the on-page pill is a duplicated control.
