### PR TITLE
feat(frontend): use blue-dot active indicator on mobile activity filter button

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -1,32 +1,18 @@
 <script lang="ts">
-	import { derived } from 'svelte/store';
 	import IconListFilter from '$lib/components/icons/lucide/IconListFilter.svelte';
 	import TransactionsFilterClearButton from '$lib/components/transactions/filter/TransactionsFilterClearButton.svelte';
 	import TransactionsFilterContacts from '$lib/components/transactions/filter/TransactionsFilterContacts.svelte';
 	import TransactionsFilterMobileSheet from '$lib/components/transactions/filter/TransactionsFilterMobileSheet.svelte';
 	import TransactionsFilterTokens from '$lib/components/transactions/filter/TransactionsFilterTokens.svelte';
 	import TransactionsFilterTypes from '$lib/components/transactions/filter/TransactionsFilterTypes.svelte';
-	import Badge from '$lib/components/ui/Badge.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
+	import NotificationBlob from '$lib/components/ui/NotificationBlob.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { TRANSACTIONS_FILTER_TOOLBAR } from '$lib/constants/test-ids.constants';
-	import {
-		selectedTransactionsFilterContactsCount,
-		selectedTransactionsFilterTokensCount,
-		selectedTransactionsFilterTypesCount
-	} from '$lib/derived/transactions-filter.derived';
+	import { hasActiveTransactionsFilter } from '$lib/derived/transactions-filter.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	let mobileSheetVisible = $state(false);
-
-	const totalSelected = derived(
-		[
-			selectedTransactionsFilterTypesCount,
-			selectedTransactionsFilterTokensCount,
-			selectedTransactionsFilterContactsCount
-		],
-		([$types, $tokens, $contacts]) => $types + $tokens + $contacts
-	);
 </script>
 
 <div class="mb-4 w-full" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
@@ -53,15 +39,9 @@
 				onclick={() => (mobileSheetVisible = true)}
 			>
 				{#snippet icon()}
-					<span class="relative flex">
+					<NotificationBlob display={$hasActiveTransactionsFilter} position="top-right">
 						<IconListFilter size="20" />
-
-						{#if $totalSelected > 0}
-							<span class="absolute -top-2 -right-2">
-								<Badge variant="info" width="w-fit">{$totalSelected}</Badge>
-							</span>
-						{/if}
-					</span>
+					</NotificationBlob>
 				{/snippet}
 			</ButtonIcon>
 		</div>


### PR DESCRIPTION
# Motivation

The mobile activity filter trigger renders a count `Badge` on top of the filter icon when filters are active. Other parts of the app (e.g. the Tokens settings menu in `TokensMenu.svelte`) use the standard `NotificationBlob` blue dot to signal an active list setting. Align the activity filter trigger with that pattern.

# Changes

- In `TransactionsFilterToolbar.svelte`, replace the count `Badge` rendered on top of `IconListFilter` with `NotificationBlob` (the standard blue-dot indicator).
- Drive the indicator from the existing `hasActiveTransactionsFilter` derived, and drop the local `totalSelected` derived plus the per-bucket count subscriptions that were only used to render the badge.


