### PR TITLE
fix(frontend): correct Buy button aria-label

### DIFF
--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <ButtonHero
-	ariaLabel={$i18n.send.text.send}
+	ariaLabel={$i18n.buy.text.buy}
 	disabled={$isBusy || isNullishOrEmpty(ONRAMPER_API_KEY) || $inflowActionsDisabled}
 	{onclick}
 	testId={BUY_TOKENS_MODAL_OPEN_BUTTON}

--- a/src/frontend/src/tests/lib/components/buy/BuyButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyButton.spec.ts
@@ -4,6 +4,7 @@ import { BUY_TOKENS_MODAL_OPEN_BUTTON } from '$lib/constants/test-ids.constants'
 import { isBusy } from '$lib/derived/busy.derived';
 import { busy } from '$lib/stores/busy.store';
 import { HERO_CONTEXT_KEY, initHeroContext, type HeroContext } from '$lib/stores/hero.store';
+import en from '$tests/mocks/i18n.mock';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
@@ -37,6 +38,15 @@ describe('BuyButton', () => {
 		});
 
 		expect(getByTestId(BUY_TOKENS_MODAL_OPEN_BUTTON)).toBeInTheDocument();
+	});
+
+	it('uses the Buy label as the accessible name', () => {
+		const { getByRole } = render(BuyButton, {
+			props,
+			context: mockContext(mockContextStore)
+		});
+
+		expect(getByRole('button', { name: en.buy.text.buy })).toBeInTheDocument();
 	});
 
 	it('should be enabled if not busy and inflow actions enabled', async () => {


### PR DESCRIPTION
# Motivation

The Buy hero button's `ariaLabel` was inherited from a Send-button refactor and never updated — screen readers currently announce the Buy button as "Send". Caught by Copilot on [#12732](https://github.com/dfinity/oisy-wallet/pull/12732), split into its own PR to keep that one atomic.

# Changes

- `BuyButton.svelte`: `ariaLabel={$i18n.send.text.send}` → `ariaLabel={$i18n.buy.text.buy}`, matching the convention used by `SendButton`, `ReceiveButton`, and `SwapButton` (each reuses its own `text.<action>` key as the aria-label).

# Tests

- One-line, type-safe i18n key change against an existing key. No new keys.
- `npm run format` clean. Existing `BuyButton.spec.ts` suite still passes.

🤖 Claude Opus 4.7
