### PR TITLE
fix(frontend): restore full activity list when clearing the filter in place

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactionsScroll.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsScroll.svelte
@@ -15,22 +15,18 @@
 
 	let pages = $state(1);
 
-	// Stable signature of the persisted activity filter. We use it both as the
-	// dependency that resets the page counter and as the `{#key}` of the
-	// `InfiniteScroll` below. Without remounting, switching filters can leave
-	// `transactionsToDisplay` capped at the previous page count because the
-	// upstream `IntersectionObserver` does not re-fire for a sentinel that stays
-	// in view as the list grows under it (e.g. clearing a 2-item filter on a
-	// page that already had `disabled=true`). Remounting matches the user's
-	// manual workaround of navigating away and back.
-	let filterSignature = $derived(JSON.stringify($transactionsFilterStore));
-
+	// Filter changes need to remount the `InfiniteScroll` below: the upstream
+	// gix-components `IntersectionObserver` does not re-fire for a sentinel
+	// that stays in view as the list grows under it, so without a fresh
+	// observer `transactionsToDisplay` can stay capped at the previous page
+	// count (e.g. clearing a 2-item filter that had `disabled=true`). Every
+	// `transactionsFilterStore` mutation produces a new object reference, so
+	// the store value is already a stable `{#key}`. `$effect.pre` resets the
+	// page counter before the re-key happens; doing it after would let the
+	// freshly-mounted observer fire `onIntersect` against the stale `pages`
+	// and the increment would then be clobbered by this effect.
 	$effect.pre(() => {
-		// Read for reactivity so the page counter resets before the `{#key}`
-		// re-renders the `InfiniteScroll` below. If we reset after the remount,
-		// the fresh observer fires `onIntersect` against the stale page count
-		// and the increment is then clobbered by this effect.
-		[filterSignature];
+		[$transactionsFilterStore];
 
 		pages = 1;
 	});
@@ -51,7 +47,7 @@
 	});
 </script>
 
-{#key filterSignature}
+{#key $transactionsFilterStore}
 	<InfiniteScroll disabled={disableInfiniteScroll} {onIntersect}>
 		{@render children()}
 	</InfiniteScroll>

--- a/src/frontend/src/lib/components/transactions/AllTransactionsScroll.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsScroll.svelte
@@ -15,16 +15,8 @@
 
 	let pages = $state(1);
 
-	// Filter changes need to remount the `InfiniteScroll` below: the upstream
-	// gix-components `IntersectionObserver` does not re-fire for a sentinel
-	// that stays in view as the list grows under it, so without a fresh
-	// observer `transactionsToDisplay` can stay capped at the previous page
-	// count (e.g. clearing a 2-item filter that had `disabled=true`). Every
-	// `transactionsFilterStore` mutation produces a new object reference, so
-	// the store value is already a stable `{#key}`. `$effect.pre` resets the
-	// page counter before the re-key happens; doing it after would let the
-	// freshly-mounted observer fire `onIntersect` against the stale `pages`
-	// and the increment would then be clobbered by this effect.
+	// Reset pagination on filter change so the re-keyed `InfiniteScroll`
+	// below mounts with a fresh observer and `pages = 1`.
 	$effect.pre(() => {
 		[$transactionsFilterStore];
 

--- a/src/frontend/src/lib/components/transactions/AllTransactionsScroll.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsScroll.svelte
@@ -2,6 +2,7 @@
 	import { InfiniteScroll } from '@dfinity/gix-components';
 	import type { Snippet } from 'svelte';
 	import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 	import type { AllTransactionUiWithCmp } from '$lib/types/transaction-ui';
 
 	interface Props {
@@ -13,6 +14,26 @@
 	let { sortedTransactions, transactionsToDisplay = $bindable([]), children }: Props = $props();
 
 	let pages = $state(1);
+
+	// Stable signature of the persisted activity filter. We use it both as the
+	// dependency that resets the page counter and as the `{#key}` of the
+	// `InfiniteScroll` below. Without remounting, switching filters can leave
+	// `transactionsToDisplay` capped at the previous page count because the
+	// upstream `IntersectionObserver` does not re-fire for a sentinel that stays
+	// in view as the list grows under it (e.g. clearing a 2-item filter on a
+	// page that already had `disabled=true`). Remounting matches the user's
+	// manual workaround of navigating away and back.
+	let filterSignature = $derived(JSON.stringify($transactionsFilterStore));
+
+	$effect.pre(() => {
+		// Read for reactivity so the page counter resets before the `{#key}`
+		// re-renders the `InfiniteScroll` below. If we reset after the remount,
+		// the fresh observer fires `onIntersect` against the stale page count
+		// and the increment is then clobbered by this effect.
+		[filterSignature];
+
+		pages = 1;
+	});
 
 	let disableInfiniteScroll = $derived(transactionsToDisplay.length >= sortedTransactions.length);
 
@@ -30,6 +51,8 @@
 	});
 </script>
 
-<InfiniteScroll disabled={disableInfiniteScroll} {onIntersect}>
-	{@render children()}
-</InfiniteScroll>
+{#key filterSignature}
+	<InfiniteScroll disabled={disableInfiniteScroll} {onIntersect}>
+		{@render children()}
+	</InfiniteScroll>
+{/key}

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
@@ -244,30 +244,32 @@ describe('AllTransactionsList', () => {
 				value: TrackedIntersectionObserver
 			});
 
-			render(AllTransactionsList);
-			await tick();
+			try {
+				render(AllTransactionsList);
+				await tick();
 
-			const initialCalls = constructorCalls;
+				const initialCalls = constructorCalls;
 
-			expect(initialCalls).toBeGreaterThan(0);
+				expect(initialCalls).toBeGreaterThan(0);
 
-			transactionsFilterStore.toggleType('send');
-			await tick();
+				transactionsFilterStore.toggleType('send');
+				await tick();
 
-			expect(constructorCalls).toBeGreaterThan(initialCalls);
+				expect(constructorCalls).toBeGreaterThan(initialCalls);
 
-			const callsAfterApply = constructorCalls;
+				const callsAfterApply = constructorCalls;
 
-			transactionsFilterStore.clear();
-			await tick();
+				transactionsFilterStore.clear();
+				await tick();
 
-			expect(constructorCalls).toBeGreaterThan(callsAfterApply);
-
-			Object.defineProperty(window, 'IntersectionObserver', {
-				writable: true,
-				configurable: true,
-				value: IntersectionObserverOnce
-			});
+				expect(constructorCalls).toBeGreaterThan(callsAfterApply);
+			} finally {
+				Object.defineProperty(window, 'IntersectionObserver', {
+					writable: true,
+					configurable: true,
+					value: IntersectionObserverOnce
+				});
+			}
 		});
 
 		it('re-runs the pagination cycle after clearing a narrow filter', async () => {

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
@@ -9,6 +9,7 @@ import { SOLANA_TOKEN_ID } from '$env/tokens/tokens.sol.env';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import AllTransactionsList from '$lib/components/transactions/AllTransactionsList.svelte';
+import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 import * as transactionsUtils from '$lib/utils/transactions.utils';
 import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
 import { createMockBtcTransactionsUi } from '$tests/mocks/blockchain-transactions.mock';
@@ -17,9 +18,11 @@ import en from '$tests/mocks/i18n.mock';
 import { createMockIcTransactionsUi } from '$tests/mocks/ic-transactions.mock';
 import {
 	IntersectionObserverActive,
+	IntersectionObserverOnce,
 	IntersectionObserverPassive
 } from '$tests/mocks/infinite-scroll.mock';
 import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
 
 describe('AllTransactionsList', () => {
 	beforeAll(() => {
@@ -168,6 +171,125 @@ describe('AllTransactionsList', () => {
 			expect(transactionComponents).toHaveLength(
 				btcTransactionsNumber + ethTransactionsNumber + icTransactionsNumber
 			);
+		});
+	});
+
+	// Regression coverage for the "Clear filter leaves the list capped at the
+	// first page" bug: clearing a narrow filter used to keep
+	// `AllTransactionsScroll` stuck at `pages = 1` because the upstream
+	// gix-components `InfiniteScroll` does not re-fire its `IntersectionObserver`
+	// for a sentinel that stays in view as the list grows under it. Re-keying
+	// the `InfiniteScroll` on the persisted filter signature re-runs the
+	// load-on-mount cycle with a fresh observer.
+	describe('when the persisted filter changes', () => {
+		const todayTimestamp = new Date().getTime();
+		const sendCount = 2;
+		const receiveCount = 15;
+
+		beforeAll(() => {
+			Object.defineProperty(window, 'IntersectionObserver', {
+				writable: true,
+				configurable: true,
+				value: IntersectionObserverOnce
+			});
+		});
+
+		beforeEach(() => {
+			btcTransactionsStore.reset(BTC_MAINNET_TOKEN_ID);
+			ethTransactionsStore.nullify(ETHEREUM_TOKEN_ID);
+			icTransactionsStore.reset(ICP_TOKEN_ID);
+			solTransactionsStore.reset(SOLANA_TOKEN_ID);
+
+			btcTransactionsStore.append({
+				tokenId: BTC_MAINNET_TOKEN_ID,
+				transactions: createMockBtcTransactionsUi(sendCount).map((transaction) => ({
+					data: { ...transaction, type: 'send', timestamp: BigInt(todayTimestamp) },
+					certified: false
+				}))
+			});
+
+			btcTransactionsStore.append({
+				tokenId: BTC_MAINNET_TOKEN_ID,
+				transactions: createMockBtcTransactionsUi(receiveCount).map((transaction) => ({
+					data: { ...transaction, type: 'receive', timestamp: BigInt(todayTimestamp) },
+					certified: false
+				}))
+			});
+
+			localStorage.clear();
+			transactionsFilterStore.clear();
+		});
+
+		afterEach(() => {
+			transactionsFilterStore.clear();
+		});
+
+		afterAll(() => {
+			Object.defineProperty(window, 'IntersectionObserver', {
+				writable: true,
+				configurable: true,
+				value: IntersectionObserverActive
+			});
+		});
+
+		it('creates a new IntersectionObserver when the filter signature changes', async () => {
+			let constructorCalls = 0;
+
+			class TrackedIntersectionObserver extends IntersectionObserverOnce {
+				constructor(callback: IntersectionObserverCallback) {
+					super(callback);
+					constructorCalls++;
+				}
+			}
+
+			Object.defineProperty(window, 'IntersectionObserver', {
+				writable: true,
+				configurable: true,
+				value: TrackedIntersectionObserver
+			});
+
+			render(AllTransactionsList);
+			await tick();
+
+			const initialCalls = constructorCalls;
+
+			expect(initialCalls).toBeGreaterThan(0);
+
+			transactionsFilterStore.toggleType('send');
+			await tick();
+
+			expect(constructorCalls).toBeGreaterThan(initialCalls);
+
+			const callsAfterApply = constructorCalls;
+
+			transactionsFilterStore.clear();
+			await tick();
+
+			expect(constructorCalls).toBeGreaterThan(callsAfterApply);
+
+			Object.defineProperty(window, 'IntersectionObserver', {
+				writable: true,
+				configurable: true,
+				value: IntersectionObserverOnce
+			});
+		});
+
+		it('re-runs the pagination cycle after clearing a narrow filter', async () => {
+			transactionsFilterStore.toggleType('send');
+
+			const { container } = render(AllTransactionsList);
+			await tick();
+
+			const filteredRows = container.querySelectorAll('button.contents');
+
+			expect(filteredRows).toHaveLength(sendCount);
+
+			transactionsFilterStore.clear();
+			await tick();
+
+			const rowsAfterClear = container.querySelectorAll('button.contents');
+
+			expect(rowsAfterClear).toHaveLength(sendCount + receiveCount);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsList.spec.ts
@@ -174,13 +174,9 @@ describe('AllTransactionsList', () => {
 		});
 	});
 
-	// Regression coverage for the "Clear filter leaves the list capped at the
-	// first page" bug: clearing a narrow filter used to keep
-	// `AllTransactionsScroll` stuck at `pages = 1` because the upstream
-	// gix-components `InfiniteScroll` does not re-fire its `IntersectionObserver`
-	// for a sentinel that stays in view as the list grows under it. Re-keying
-	// the `InfiniteScroll` on the persisted filter signature re-runs the
-	// load-on-mount cycle with a fresh observer.
+	// Regression: clearing a narrow filter used to leave `AllTransactionsScroll`
+	// stuck at `pages = 1` because the upstream `InfiniteScroll` observer never
+	// re-fires for a sentinel that stays in view.
 	describe('when the persisted filter changes', () => {
 		const todayTimestamp = new Date().getTime();
 		const sendCount = 2;

--- a/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
+++ b/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
@@ -71,8 +71,14 @@ export class IntersectionObserverOnce implements IntersectionObserver {
 			this
 		);
 	}
-	disconnect = () => null;
-	unobserve = () => null;
+
+	unobserve(element: Element) {
+		this.observed.delete(element);
+	}
+
+	disconnect() {
+		this.observed = new WeakSet<Element>();
+	}
 }
 
 export const INTERSECTION_OBSERVER_ACTIVE_INTERVAL = 5000;

--- a/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
+++ b/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
@@ -35,13 +35,8 @@ export class IntersectionObserverActive implements IntersectionObserver {
 }
 
 /**
- * Mimics the real-browser IntersectionObserver more closely than
- * `IntersectionObserverActive`: it fires the callback once per
- * `(observer instance, target)` pair (matching the spec's initial-state
- * notification) and stays silent on subsequent `observe()` calls for the same
- * target. Use this when a test needs to exercise the "sentinel stays in view"
- * path that the upstream gix-components `InfiniteScroll` cannot recover from
- * without remounting.
+ * Fires the callback once per `(observer instance, target)` pair, then stays
+ * silent. Matches the spec's initial-state notification.
  */
 export class IntersectionObserverOnce implements IntersectionObserver {
 	public readonly root: Element | Document | null = null;

--- a/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
+++ b/src/frontend/src/tests/mocks/infinite-scroll.mock.ts
@@ -34,6 +34,52 @@ export class IntersectionObserverActive implements IntersectionObserver {
 	unobserve = () => null;
 }
 
+/**
+ * Mimics the real-browser IntersectionObserver more closely than
+ * `IntersectionObserverActive`: it fires the callback once per
+ * `(observer instance, target)` pair (matching the spec's initial-state
+ * notification) and stays silent on subsequent `observe()` calls for the same
+ * target. Use this when a test needs to exercise the "sentinel stays in view"
+ * path that the upstream gix-components `InfiniteScroll` cannot recover from
+ * without remounting.
+ */
+export class IntersectionObserverOnce implements IntersectionObserver {
+	public readonly root: Element | Document | null = null;
+	public readonly rootMargin: string = '';
+	public readonly thresholds: ReadonlyArray<number> = [];
+	public takeRecords: () => IntersectionObserverEntry[] = () => [];
+
+	private observed = new WeakSet<Element>();
+
+	constructor(
+		private callback: (
+			entries: IntersectionObserverEntry[],
+			observer: IntersectionObserver
+		) => void,
+		private options?: IntersectionObserverInit
+	) {}
+
+	observe(element: HTMLElement) {
+		if (this.observed.has(element)) {
+			return;
+		}
+
+		this.observed.add(element);
+
+		this.callback(
+			[
+				{
+					isIntersecting: true,
+					target: element
+				} as unknown as IntersectionObserverEntry
+			],
+			this
+		);
+	}
+	disconnect = () => null;
+	unobserve = () => null;
+}
+
 export const INTERSECTION_OBSERVER_ACTIVE_INTERVAL = 5000;
 
 export class IntersectionObserverActiveInterval implements IntersectionObserver {


### PR DESCRIPTION
# Motivation

Clearing the activity filter after navigating away and back left the list capped at the first page (10 rows). 



https://github.com/user-attachments/assets/1e664d77-5643-42c9-bebe-dbe97b7e3123






