### PR TITLE
refactor(frontend): extract mobile activity filter trigger into its own component

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterMobileButton.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterMobileButton.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import IconListFilter from '$lib/components/icons/lucide/IconListFilter.svelte';
+	import TransactionsFilterMobileSheet from '$lib/components/transactions/filter/TransactionsFilterMobileSheet.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
+	import NotificationBlob from '$lib/components/ui/NotificationBlob.svelte';
+	import { hasActiveTransactionsFilter } from '$lib/derived/transactions-filter.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	let mobileSheetVisible = $state(false);
+</script>
+
+<ButtonIcon
+	ariaLabel={$i18n.transaction.filter.open_filters_aria_label}
+	colorStyle="muted"
+	link={false}
+	onclick={() => (mobileSheetVisible = true)}
+>
+	{#snippet icon()}
+		<NotificationBlob display={$hasActiveTransactionsFilter} position="top-right">
+			<IconListFilter size="20" />
+		</NotificationBlob>
+	{/snippet}
+</ButtonIcon>
+
+<TransactionsFilterMobileSheet bind:visible={mobileSheetVisible} />

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterToolbar.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
-	import IconListFilter from '$lib/components/icons/lucide/IconListFilter.svelte';
 	import TransactionsFilterClearButton from '$lib/components/transactions/filter/TransactionsFilterClearButton.svelte';
 	import TransactionsFilterContacts from '$lib/components/transactions/filter/TransactionsFilterContacts.svelte';
-	import TransactionsFilterMobileSheet from '$lib/components/transactions/filter/TransactionsFilterMobileSheet.svelte';
+	import TransactionsFilterMobileButton from '$lib/components/transactions/filter/TransactionsFilterMobileButton.svelte';
 	import TransactionsFilterTokens from '$lib/components/transactions/filter/TransactionsFilterTokens.svelte';
 	import TransactionsFilterTypes from '$lib/components/transactions/filter/TransactionsFilterTypes.svelte';
-	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
-	import NotificationBlob from '$lib/components/ui/NotificationBlob.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 	import { TRANSACTIONS_FILTER_TOOLBAR } from '$lib/constants/test-ids.constants';
-	import { hasActiveTransactionsFilter } from '$lib/derived/transactions-filter.derived';
-	import { i18n } from '$lib/stores/i18n.store';
-
-	let mobileSheetVisible = $state(false);
 </script>
 
 <div class="mb-4 w-full" data-tid={TRANSACTIONS_FILTER_TOOLBAR}>
@@ -30,20 +23,7 @@
 
 	<Responsive down="sm">
 		<div class="flex items-center justify-end gap-2">
-			<ButtonIcon
-				ariaLabel={$i18n.transaction.filter.open_filters_aria_label}
-				colorStyle="muted"
-				link={false}
-				onclick={() => (mobileSheetVisible = true)}
-			>
-				{#snippet icon()}
-					<NotificationBlob display={$hasActiveTransactionsFilter} position="top-right">
-						<IconListFilter size="20" />
-					</NotificationBlob>
-				{/snippet}
-			</ButtonIcon>
+			<TransactionsFilterMobileButton />
 		</div>
-
-		<TransactionsFilterMobileSheet bind:visible={mobileSheetVisible} />
 	</Responsive>
 </div>

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterMobileButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterMobileButton.spec.ts
@@ -1,0 +1,51 @@
+import TransactionsFilterMobileButton from '$lib/components/transactions/filter/TransactionsFilterMobileButton.svelte';
+import { i18n } from '$lib/stores/i18n.store';
+import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
+import { fireEvent, render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+
+describe('TransactionsFilterMobileButton', () => {
+	const getNotificationBlob = (container: HTMLElement) =>
+		container.querySelector('.rounded-full.bg-brand-primary');
+
+	beforeEach(() => {
+		localStorage.clear();
+		transactionsFilterStore.clear();
+	});
+
+	it('renders the filter button with the proper aria-label', () => {
+		const { getByLabelText } = render(TransactionsFilterMobileButton);
+
+		expect(
+			getByLabelText(get(i18n).transaction.filter.open_filters_aria_label)
+		).toBeInTheDocument();
+	});
+
+	it('hides the blue-dot indicator when no filter is active', () => {
+		const { container } = render(TransactionsFilterMobileButton);
+
+		const blob = getNotificationBlob(container);
+
+		expect(blob).toBeInTheDocument();
+		expect(blob?.classList.contains('opacity-0')).toBeTruthy();
+	});
+
+	it('shows the blue-dot indicator when at least one filter is active', () => {
+		transactionsFilterStore.toggleType('send');
+
+		const { container } = render(TransactionsFilterMobileButton);
+
+		const blob = getNotificationBlob(container);
+
+		expect(blob).toBeInTheDocument();
+		expect(blob?.classList.contains('opacity-100')).toBeTruthy();
+	});
+
+	it('opens the bottom sheet when the button is clicked', async () => {
+		const { getByLabelText, getByText } = render(TransactionsFilterMobileButton);
+
+		await fireEvent.click(getByLabelText(get(i18n).transaction.filter.open_filters_aria_label));
+
+		expect(getByText(get(i18n).transaction.filter.sheet_title)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

Pure refactor to prepare follow-up changes: the mobile activity filter trigger (icon + blue-dot + bottom sheet) is the only piece of `TransactionsFilterToolbar.svelte` that needs to be reusable from a different location. Extracting it now keeps the diff of the next PR focused on layout, not on moving logic.
