### PR TITLE
docs(ai): clarify auto-update-i18n is a structural sync, not translation

### DIFF
--- a/docs/ai/frontend/workflows/add-i18n-key.md
+++ b/docs/ai/frontend/workflows/add-i18n-key.md
@@ -62,10 +62,15 @@ Tiny but easy to get wrong. Follow these steps in order.
    **Never** dynamically construct the key path (`$i18n[someVar]`) — it
    defeats type safety.
 
-8. **Don't touch other locales.** Files like `de.json`, `fr.json`,
-   `ja.json`, `zh-CN.json`, etc. are **machine-translated** by the
-   `auto-update-i18n` workflow from `en.json`. Any manual edit will be
-   overwritten on the next run.
+8. **Other locale files sync structurally, not via translation.** The
+   `auto-update-i18n` workflow runs `npm run i18n` on every PR, which
+   keeps `de.json`, `fr.json`, `ja.json`, `zh-CN.json`, etc. aligned
+   with `en.json` by adding missing keys with empty-string
+   placeholders. **It does not translate** — existing non-empty values
+   are preserved (see
+   [`scripts/i18n.generate.keys.ts`](../../../../scripts/i18n.generate.keys.ts)).
+   Leave new keys blank in your PR unless you can translate them at
+   native quality.
 
 9. **Run the gates**:
 
@@ -106,6 +111,6 @@ The setup is **string + placeholder**, no ICU. For pluralisation, either:
 
 - Hard-code English in a component "just for now".
 - Edit the generated `i18n.d.ts` by hand.
-- Edit any locale file other than `en.json`.
+- Edit a non-en locale unless you can translate at native quality (see step 8).
 - Construct keys dynamically.
 - Leave old keys around "in case".

--- a/docs/ai/frontend/workflows/add-i18n-key.md
+++ b/docs/ai/frontend/workflows/add-i18n-key.md
@@ -63,11 +63,14 @@ Tiny but easy to get wrong. Follow these steps in order.
    defeats type safety.
 
 8. **Other locale files sync structurally, not via translation.** The
-   `auto-update-i18n` workflow runs `npm run i18n` on every PR, which
-   keeps `de.json`, `fr.json`, `ja.json`, `zh-CN.json`, etc. aligned
-   with `en.json` by adding missing keys with empty-string
-   placeholders. **It does not translate** — existing non-empty values
-   are preserved (see
+   `auto-update-i18n` workflow runs `npm run i18n` whenever a PR
+   touches `src/frontend/src/lib/i18n/*` or
+   `src/frontend/src/lib/types/i18n.d.ts`. That script rewrites each
+   non-en locale file to match `en.json`'s key structure — missing
+   keys are added with empty-string placeholders, and any extra keys
+   not in `en.json` are dropped. **It does not translate** — existing
+   non-empty values for keys that still exist in `en.json` are
+   preserved (see
    [`scripts/i18n.generate.keys.ts`](../../../../scripts/i18n.generate.keys.ts)).
    Leave new keys blank in your PR unless you can translate them at
    native quality.


### PR DESCRIPTION
# Motivation

[`docs/ai/frontend/workflows/add-i18n-key.md`](docs/ai/frontend/workflows/add-i18n-key.md) currently tells agents that non-en locale files are *machine-translated* by the `auto-update-i18n` workflow and that manual edits will be *overwritten on the next run*. Both claims are wrong, and that misinformation has affected real PR work — I propagated it onto [#12732](https://github.com/dfinity/oisy-wallet/pull/12732) before realising the doc didn't match reality.

What the workflow actually does ([`.github/workflows/auto-update-i18n.yml`](.github/workflows/auto-update-i18n.yml)): one substantive step, `npm run i18n`, which calls [`scripts/i18n.generate.keys.ts`](scripts/i18n.generate.keys.ts) and [`scripts/i18n.generate.types.mjs`](scripts/i18n.generate.types.mjs). No translation engine is wired in (no DeepL/OpenAI/Anthropic, no API keys in the workflow secrets). The script is a structural sync — `i18n.generate.keys.ts` line 26 preserves existing non-empty values explicitly: `typeof target === 'string' ? target : ''`.

Net effect: missing keys get an empty-string placeholder; existing translations are preserved across runs.

# Changes

- Rewrite step 8 of `add-i18n-key.md` to describe the actual behaviour: structural sync only, no translation, existing non-empty values preserved. Add a link to the script so the next reader can verify.
- Adjust the bullet in the "Don't" list to match: "Edit a non-en locale unless you can translate at native quality (see step 8)." The blanket "never edit other locales" rule no longer applies — the workflow won't fight you.

# Tests

- No code changes, docs-only.
- Verified the behaviour by reading `scripts/i18n.generate.keys.ts` (the script preserves existing strings) and `.github/workflows/auto-update-i18n.yml` (no translation step).

🤖 Claude Opus 4.7
