### PR TITLE
refactor(frontend): match reserved BTC UTXOs by outpoint, not txid

### DIFF
--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -4,9 +4,9 @@ import { getFeeRateFromPercentiles } from '$btc/services/btc-utxos.service';
 import type { BtcAddress } from '$btc/types/address';
 import { BtcSendValidationError, BtcValidationError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
-import { estimateTransactionVSize, extractUtxoTxIds } from '$btc/utils/btc-utxos.utils';
+import { estimateTransactionVSize, extractUtxoOutpoints } from '$btc/utils/btc-utxos.utils';
 import type { SendBtcResponse, SignBtcResponse } from '$declarations/signer/signer.did';
-import { getPendingTransactionUtxoTxIds, txidStringToUint8Array } from '$icp/utils/btc.utils';
+import { getPendingTransactionUtxoOutpoints, txidStringToUint8Array } from '$icp/utils/btc.utils';
 import { addPendingBtcTransaction } from '$lib/api/backend.api';
 import { sendBtc as sendBtcApi, signBtc as signBtcApi } from '$lib/api/signer.api';
 import { ZERO } from '$lib/constants/app.constants';
@@ -171,17 +171,19 @@ export const validateBtcSend = async ({
 		address: source
 	});
 
-	const pendingUtxoTxIds = getPendingTransactionUtxoTxIds(source);
+	const pendingUtxoOutpoints = getPendingTransactionUtxoOutpoints(source);
 
-	if (isNullish(pendingUtxoTxIds)) {
+	if (isNullish(pendingUtxoOutpoints)) {
 		// when no pending transactions have been initiated, we cannot validate UTXO's and therefore, validation must fail
 		throw new BtcValidationError(BtcSendValidationError.PendingTransactionsNotAvailable);
 	}
 
-	if (pendingUtxoTxIds.length > 0) {
-		const providedUtxoTxIds = extractUtxoTxIds(utxos);
-		for (const utxoTxId of providedUtxoTxIds) {
-			if (pendingUtxoTxIds.includes(utxoTxId)) {
+	if (pendingUtxoOutpoints.length > 0) {
+		const reserved = new Set(pendingUtxoOutpoints);
+		const providedOutpoints = extractUtxoOutpoints(utxos);
+
+		for (const outpointKey of providedOutpoints) {
+			if (reserved.has(outpointKey)) {
 				throw new BtcValidationError(BtcSendValidationError.UtxoLocked);
 			}
 		}

--- a/src/frontend/src/btc/services/btc-utxos.service.ts
+++ b/src/frontend/src/btc/services/btc-utxos.service.ts
@@ -3,7 +3,7 @@ import type { BtcAddress } from '$btc/types/address';
 import { BtcPrepareSendError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { calculateUtxoSelection, filterAvailableUtxos } from '$btc/utils/btc-utxos.utils';
-import { getPendingTransactionUtxoTxIds } from '$icp/utils/btc.utils';
+import { getPendingTransactionUtxoOutpoints } from '$icp/utils/btc.utils';
 import { getCurrentBtcFeePercentiles } from '$lib/api/backend.api';
 import { ZERO } from '$lib/constants/app.constants';
 import type { Amount } from '$lib/types/send';
@@ -31,8 +31,9 @@ export const prepareBtcSend = ({
 }: BtcReviewServiceParams): UtxosFee => {
 	const requiredMinConfirmations = CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS;
 
-	const pendingUtxoTxIds = getPendingTransactionUtxoTxIds(source);
-	if (isNullish(pendingUtxoTxIds)) {
+	const pendingUtxoOutpoints = getPendingTransactionUtxoOutpoints(source);
+
+	if (isNullish(pendingUtxoOutpoints)) {
 		return {
 			feeSatoshis: ZERO,
 			utxos: [],
@@ -51,12 +52,12 @@ export const prepareBtcSend = ({
 		};
 	}
 
-	// Filter UTXOs based on confirmations and exclude locked ones
+	// Filter UTXOs based on confirmations and exclude reserved ones
 	const filteredUtxos = filterAvailableUtxos({
 		utxos: allUtxos,
 		options: {
 			minConfirmations: requiredMinConfirmations,
-			pendingUtxoTxIds
+			pendingUtxoOutpoints
 		}
 	});
 

--- a/src/frontend/src/btc/utils/btc-utxos.utils.ts
+++ b/src/frontend/src/btc/utils/btc-utxos.utils.ts
@@ -1,7 +1,7 @@
 import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
-import { utxoTxIdToString } from '$icp/utils/btc.utils';
+import { outpointToKey } from '$icp/utils/btc.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { CkBtcMinterDid } from '@icp-sdk/canisters/ckbtc';
 
@@ -14,10 +14,12 @@ export interface UtxoSelectionResult {
 }
 
 /**
- * Extracts transaction IDs from an array of UTXOs
+ * Extracts outpoint keys (txid + vout) from an array of UTXOs.
+ * Outpoints uniquely identify a UTXO; matching on txid alone over-filters
+ * UTXOs that share a parent transaction.
  */
-export const extractUtxoTxIds = (utxos: CkBtcMinterDid.Utxo[]): string[] =>
-	utxos.map(({ outpoint: { txid } }) => utxoTxIdToString(txid));
+export const extractUtxoOutpoints = (utxos: CkBtcMinterDid.Utxo[]): string[] =>
+	utxos.map(({ outpoint }) => outpointToKey(outpoint));
 
 /**
  * Estimates transaction virtual size (vbytes) based on number of inputs and outputs.
@@ -143,22 +145,26 @@ export const calculateUtxoSelection = ({
 };
 
 /**
- * Filters out UTXOs that are locked by pending transactions
+ * Filters out UTXOs that are reserved by pending transactions.
+ *
+ * Matching is at the outpoint level (txid + vout) so that unrelated UTXOs
+ * sharing a parent txid stay available — this is what allows a user to keep
+ * sending while a previous unconfirmed send is still pending.
  */
 export const filterLockedUtxos = ({
 	utxos,
-	pendingUtxoTxIds
+	pendingUtxoOutpoints
 }: {
 	utxos: CkBtcMinterDid.Utxo[];
-	pendingUtxoTxIds: string[];
-}): CkBtcMinterDid.Utxo[] =>
-	utxos.filter((utxo) => {
-		const txIdHex = utxoTxIdToString(utxo.outpoint.txid);
-		return !pendingUtxoTxIds.includes(txIdHex);
-	});
+	pendingUtxoOutpoints: string[];
+}): CkBtcMinterDid.Utxo[] => {
+	const reserved = new Set(pendingUtxoOutpoints);
+
+	return utxos.filter((utxo) => !reserved.has(outpointToKey(utxo.outpoint)));
+};
 
 /**
- * Filters UTXOs based on confirmations and excludes those locked by pending transactions
+ * Filters UTXOs based on confirmations and excludes those reserved by pending transactions
  */
 export const filterAvailableUtxos = ({
 	utxos,
@@ -167,10 +173,10 @@ export const filterAvailableUtxos = ({
 	utxos: CkBtcMinterDid.Utxo[];
 	options: {
 		minConfirmations: number;
-		pendingUtxoTxIds: string[];
+		pendingUtxoOutpoints: string[];
 	};
 }): CkBtcMinterDid.Utxo[] => {
-	const { minConfirmations, pendingUtxoTxIds } = options;
+	const { minConfirmations, pendingUtxoOutpoints } = options;
 
 	// First filter by confirmations to ensure transaction security
 	// Note: UTXOs are pre-filtered by the Bitcoin canister endpoint
@@ -187,7 +193,7 @@ export const filterAvailableUtxos = ({
 	// Then filter out locked UTXOs
 	return filterLockedUtxos({
 		utxos: confirmedUtxos,
-		pendingUtxoTxIds
+		pendingUtxoOutpoints
 	});
 };
 

--- a/src/frontend/src/icp/utils/btc.utils.ts
+++ b/src/frontend/src/icp/utils/btc.utils.ts
@@ -146,11 +146,7 @@ export const getPendingTransactionUtxoOutpoints = (address: string): string[] | 
 		if (nonNullish(tx.utxos)) {
 			for (const utxo of tx.utxos) {
 				const outpoint = utxo?.outpoint;
-				if (
-					nonNullish(outpoint?.txid) &&
-					outpoint.txid.length > 0 &&
-					nonNullish(outpoint.vout)
-				) {
+				if (nonNullish(outpoint?.txid) && outpoint.txid.length > 0 && nonNullish(outpoint.vout)) {
 					outpointKeys.push(outpointToKey(outpoint));
 				}
 			}

--- a/src/frontend/src/icp/utils/btc.utils.ts
+++ b/src/frontend/src/icp/utils/btc.utils.ts
@@ -117,37 +117,47 @@ export const getPendingTransactionIds = (address: string): string[] | null => {
 };
 
 /**
- * Get all UTXO transaction IDs from all pending transactions for a given address.
- * These are the transaction IDs that UTXOs reference (inputs being spent), not the pending transaction IDs themselves.
+ * Build a stable string key for an outpoint, used to compare reserved UTXOs
+ * against available UTXOs across the FE.
  *
- * @param address - Bitcoin address to get pending UTXO transaction IDs for
- * @returns Array of UTXO transaction ID strings, or null if no pending data available
+ * Format: `${reversed-txid-hex}:${vout}`.
  */
-export const getPendingTransactionUtxoTxIds = (address: string): string[] | null => {
+export const outpointToKey = ({ txid, vout }: { txid: Uint8Array; vout: number }): string =>
+	`${utxoTxIdToString(txid)}:${vout}`;
+
+/**
+ * Get the outpoint keys (txid + vout) of every UTXO reserved by a pending
+ * transaction for a given address. These are the inputs already committed to
+ * an unconfirmed send and therefore unavailable for a new selection.
+ *
+ * @param address - Bitcoin address to get reserved outpoints for
+ * @returns Array of outpoint keys, or null if no pending data available
+ */
+export const getPendingTransactionUtxoOutpoints = (address: string): string[] | null => {
 	const pendingTransactions = getPendingTransactions(address);
 
 	if (isNullish(pendingTransactions)) {
 		return null;
 	}
 
-	// Extract all UTXO transaction IDs from all pending transactions
-	const utxoTxIds: string[] = [];
+	const outpointKeys: string[] = [];
 
 	for (const tx of pendingTransactions) {
 		if (nonNullish(tx.utxos)) {
 			for (const utxo of tx.utxos) {
-				if (nonNullish(utxo?.outpoint?.txid)) {
-					const utxoTxId = utxoTxIdToString(utxo.outpoint.txid);
-					if (notEmptyString(utxoTxId)) {
-						utxoTxIds.push(utxoTxId);
-					}
+				const outpoint = utxo?.outpoint;
+				if (
+					nonNullish(outpoint?.txid) &&
+					outpoint.txid.length > 0 &&
+					nonNullish(outpoint.vout)
+				) {
+					outpointKeys.push(outpointToKey(outpoint));
 				}
 			}
 		}
 	}
 
-	// Remove duplicates and return
-	return Array.from(new Set(utxoTxIds));
+	return Array.from(new Set(outpointKeys));
 };
 
 /**

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -134,8 +134,8 @@ describe('btc-send.services', () => {
 				btcPendingSentTransactionsServices,
 				'loadBtcPendingSentTransactions'
 			).mockResolvedValue({ success: true });
-			vi.spyOn(btcUtils, 'getPendingTransactionUtxoTxIds').mockReturnValue([]);
-			vi.spyOn(btcUtxosUtils, 'extractUtxoTxIds').mockReturnValue(['txid1', 'txid2']);
+			vi.spyOn(btcUtils, 'getPendingTransactionUtxoOutpoints').mockReturnValue([]);
+			vi.spyOn(btcUtxosUtils, 'extractUtxoOutpoints').mockReturnValue(['txid1:0', 'txid2:0']);
 			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
 			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
 		});
@@ -271,9 +271,9 @@ describe('btc-send.services', () => {
 			});
 		});
 
-		it('should throw UtxoLocked error when UTXO is in pending transactions', async () => {
-			vi.spyOn(btcUtils, 'getPendingTransactionUtxoTxIds').mockReturnValue(['txid1']);
-			vi.spyOn(btcUtxosUtils, 'extractUtxoTxIds').mockReturnValue(['txid1']);
+		it('should throw UtxoLocked error when a UTXO outpoint is reserved by a pending tx', async () => {
+			vi.spyOn(btcUtils, 'getPendingTransactionUtxoOutpoints').mockReturnValue(['txid1:0']);
+			vi.spyOn(btcUtxosUtils, 'extractUtxoOutpoints').mockReturnValue(['txid1:0']);
 
 			await expect(validateBtcSend(defaultValidateParams)).rejects.toThrow(BtcValidationError);
 
@@ -282,6 +282,15 @@ describe('btc-send.services', () => {
 			} catch (error: unknown) {
 				expect((error as BtcValidationError).type).toBe(BtcSendValidationError.UtxoLocked);
 			}
+		});
+
+		it('should not throw UtxoLocked when a reserved outpoint shares a txid but differs in vout', async () => {
+			// A previous send reserved (txid1, vout=0); the new selection picks (txid1, vout=1)
+			// — that is a different outpoint and must remain spendable.
+			vi.spyOn(btcUtils, 'getPendingTransactionUtxoOutpoints').mockReturnValue(['txid1:0']);
+			vi.spyOn(btcUtxosUtils, 'extractUtxoOutpoints').mockReturnValue(['txid1:1']);
+
+			await expect(validateBtcSend(defaultValidateParams)).resolves.not.toThrow();
 		});
 
 		describe('InvalidFeeCalculation validation', () => {

--- a/src/frontend/src/tests/btc/services/btc-utxos.service.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-utxos.service.spec.ts
@@ -216,6 +216,85 @@ describe('btc-utxos.service', () => {
 			expect(result.utxos.length).toBeGreaterThan(0);
 		});
 
+		it('should keep a UTXO available when only a different vout of the same parent tx is reserved', () => {
+			// Two UTXOs share the same parent txid but differ in vout. The pending
+			// tx reserves vout=0; vout=1 must remain spendable.
+			const sharedTxid = new Uint8Array([10, 20, 30, 40]);
+			const reservedUtxo: CkBtcMinterDid.Utxo = {
+				value: 200_000n,
+				height: 100,
+				outpoint: { txid: sharedTxid, vout: 0 }
+			};
+			const spendableUtxo: CkBtcMinterDid.Utxo = {
+				value: 500_000n,
+				height: 100,
+				outpoint: { txid: sharedTxid, vout: 1 }
+			};
+
+			mockStoreApi.setStoreValue({
+				[mockBtcAddress]: {
+					certified: true as const,
+					data: [
+						{
+							txid: new Uint8Array([99]),
+							utxos: [{ value: 200_000n, outpoint: { txid: sharedTxid, vout: 0 } }]
+						}
+					]
+				}
+			});
+
+			const result = prepareBtcSend({
+				...defaultParams,
+				allUtxos: [reservedUtxo, spendableUtxo]
+			});
+
+			expect(result.error).toBeUndefined();
+			expect(result.utxos).toHaveLength(1);
+			expect(result.utxos[0].outpoint.vout).toBe(1);
+			expect(result.utxos[0].value).toBe(500_000n);
+		});
+
+		it('should return UtxoLocked when every available UTXO is reserved by pending transactions', () => {
+			const txidA = new Uint8Array([1, 2, 3, 4]);
+			const txidB = new Uint8Array([5, 6, 7, 8]);
+			const utxoA: CkBtcMinterDid.Utxo = {
+				value: 200_000n,
+				height: 100,
+				outpoint: { txid: txidA, vout: 0 }
+			};
+			const utxoB: CkBtcMinterDid.Utxo = {
+				value: 300_000n,
+				height: 100,
+				outpoint: { txid: txidB, vout: 0 }
+			};
+
+			mockStoreApi.setStoreValue({
+				[mockBtcAddress]: {
+					certified: true as const,
+					data: [
+						{
+							txid: new Uint8Array([99]),
+							utxos: [
+								{ value: 200_000n, outpoint: { txid: txidA, vout: 0 } },
+								{ value: 300_000n, outpoint: { txid: txidB, vout: 0 } }
+							]
+						}
+					]
+				}
+			});
+
+			const result = prepareBtcSend({
+				...defaultParams,
+				allUtxos: [utxoA, utxoB]
+			});
+
+			expect(result).toEqual({
+				feeSatoshis: ZERO,
+				utxos: [],
+				error: BtcPrepareSendError.UtxoLocked
+			});
+		});
+
 		it('should return UtxoLocked error when all UTXOs are filtered out by confirmations', () => {
 			const unconfirmedUtxo: CkBtcMinterDid.Utxo = {
 				value: 500000n,

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -4,7 +4,7 @@ import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store'
 import {
 	calculateUtxoSelection,
 	estimateTransactionVSize,
-	extractUtxoTxIds,
+	extractUtxoOutpoints,
 	filterAvailableUtxos,
 	filterLockedUtxos,
 	resetUtxosDataStores,
@@ -58,20 +58,29 @@ describe('btc-utxos.utils', () => {
 		});
 	});
 
-	describe('extractUtxoTxIds', () => {
-		it('should extract transaction IDs from UTXOs', () => {
+	describe('extractUtxoOutpoints', () => {
+		it('should extract outpoint keys (txid + vout) from UTXOs', () => {
 			const utxos = [
-				createMockUtxo({ value: 100_000, txid: new Uint8Array([1, 2, 3, 4]) }),
-				createMockUtxo({ value: 200_000, txid: new Uint8Array([5, 6, 7, 8]) })
+				createMockUtxo({ value: 100_000, txid: new Uint8Array([1, 2, 3, 4]), vout: 0 }),
+				createMockUtxo({ value: 200_000, txid: new Uint8Array([5, 6, 7, 8]), vout: 3 })
 			];
 
-			const result = extractUtxoTxIds(utxos);
+			const result = extractUtxoOutpoints(utxos);
 
-			expect(result).toEqual(['04030201', '08070605']);
+			expect(result).toEqual(['04030201:0', '08070605:3']);
+		});
+
+		it('should distinguish UTXOs sharing a txid by their vout', () => {
+			const utxos = [
+				createMockUtxo({ value: 100_000, txid: new Uint8Array([1, 2, 3, 4]), vout: 0 }),
+				createMockUtxo({ value: 200_000, txid: new Uint8Array([1, 2, 3, 4]), vout: 1 })
+			];
+
+			expect(extractUtxoOutpoints(utxos)).toEqual(['04030201:0', '04030201:1']);
 		});
 
 		it('should return empty array for empty input', () => {
-			const result = extractUtxoTxIds([]);
+			const result = extractUtxoOutpoints([]);
 
 			expect(result).toEqual([]);
 		});
@@ -447,34 +456,53 @@ describe('btc-utxos.utils', () => {
 		const utxos = [
 			createMockUtxo({
 				value: 100_000,
-				txid: new Uint8Array([1, 2, 3, 4])
+				txid: new Uint8Array([1, 2, 3, 4]),
+				vout: 0
 			}),
 			createMockUtxo({
 				value: 200_000,
-				txid: new Uint8Array([5, 6, 7, 8])
+				txid: new Uint8Array([5, 6, 7, 8]),
+				vout: 0
 			}),
 			createMockUtxo({
 				value: 300_000,
-				txid: new Uint8Array([9, 10, 11, 12])
+				txid: new Uint8Array([9, 10, 11, 12]),
+				vout: 0
 			})
 		];
 
-		it('should filter out locked UTXOs', () => {
-			const pendingUtxoTxIds = ['04030201', '0c0b0a09']; // Hex of [1,2,3,4] and [9,10,11,12] reversed
+		it('should filter out reserved UTXOs by outpoint', () => {
+			const pendingUtxoOutpoints = ['04030201:0', '0c0b0a09:0'];
 
 			const result = filterLockedUtxos({
 				utxos,
-				pendingUtxoTxIds
+				pendingUtxoOutpoints
 			});
 
 			expect(result).toHaveLength(1);
 			expect(result[0].value).toBe(200_000n);
 		});
 
+		it('should keep UTXOs that share a txid with a reserved outpoint but differ in vout', () => {
+			const sharedTxidUtxos = [
+				createMockUtxo({ value: 100_000, txid: new Uint8Array([1, 2, 3, 4]), vout: 0 }),
+				createMockUtxo({ value: 200_000, txid: new Uint8Array([1, 2, 3, 4]), vout: 1 }),
+				createMockUtxo({ value: 300_000, txid: new Uint8Array([1, 2, 3, 4]), vout: 2 })
+			];
+
+			// Only vout=0 is reserved; vouts 1 and 2 must remain spendable.
+			const result = filterLockedUtxos({
+				utxos: sharedTxidUtxos,
+				pendingUtxoOutpoints: ['04030201:0']
+			});
+
+			expect(result.map((u) => u.outpoint.vout)).toEqual([1, 2]);
+		});
+
 		it('should return all UTXOs when no pending transactions', () => {
 			const result = filterLockedUtxos({
 				utxos,
-				pendingUtxoTxIds: []
+				pendingUtxoOutpoints: []
 			});
 
 			expect(result).toHaveLength(3);
@@ -483,7 +511,7 @@ describe('btc-utxos.utils', () => {
 		it('should handle empty UTXO array', () => {
 			const result = filterLockedUtxos({
 				utxos: [],
-				pendingUtxoTxIds: ['04030201']
+				pendingUtxoOutpoints: ['04030201:0']
 			});
 
 			expect(result).toEqual([]);
@@ -498,12 +526,14 @@ describe('btc-utxos.utils', () => {
 			createMockUtxo({
 				value: 400_000,
 				height: 15,
-				txid: new Uint8Array([5, 6, 7, 8])
-			}), // Good but might be locked
+				txid: new Uint8Array([5, 6, 7, 8]),
+				vout: 0
+			}), // Good but might be reserved
 			createMockUtxo({
 				value: 500_000,
 				height: 20,
-				txid: new Uint8Array([9, 10, 11, 12])
+				txid: new Uint8Array([9, 10, 11, 12]),
+				vout: 0
 			}) // Good
 		];
 
@@ -512,7 +542,7 @@ describe('btc-utxos.utils', () => {
 				utxos,
 				options: {
 					minConfirmations: 6,
-					pendingUtxoTxIds: []
+					pendingUtxoOutpoints: []
 				}
 			});
 
@@ -525,7 +555,7 @@ describe('btc-utxos.utils', () => {
 				utxos,
 				options: {
 					minConfirmations: 1,
-					pendingUtxoTxIds: []
+					pendingUtxoOutpoints: []
 				}
 			});
 
@@ -534,14 +564,14 @@ describe('btc-utxos.utils', () => {
 			expect(result.every((utxo) => utxo.height > 0)).toBeTruthy();
 		});
 
-		it('should filter out locked UTXOs', () => {
-			const pendingUtxoTxIds = ['08070605']; // Hex of [5, 6, 7, 8] reversed
+		it('should filter out reserved UTXOs', () => {
+			const pendingUtxoOutpoints = ['08070605:0'];
 
 			const result = filterAvailableUtxos({
 				utxos,
 				options: {
 					minConfirmations: 6,
-					pendingUtxoTxIds
+					pendingUtxoOutpoints
 				}
 			});
 
@@ -549,18 +579,47 @@ describe('btc-utxos.utils', () => {
 			expect(result.map((u) => Number(u.value))).toEqual([300_000, 500_000]);
 		});
 
+		it('should keep UTXOs sharing a txid with a reserved outpoint but a different vout', () => {
+			const sharedTxidUtxos = [
+				createMockUtxo({
+					value: 400_000,
+					height: 15,
+					txid: new Uint8Array([5, 6, 7, 8]),
+					vout: 0
+				}),
+				createMockUtxo({
+					value: 600_000,
+					height: 18,
+					txid: new Uint8Array([5, 6, 7, 8]),
+					vout: 1
+				})
+			];
+
+			const result = filterAvailableUtxos({
+				utxos: sharedTxidUtxos,
+				options: {
+					minConfirmations: 6,
+					pendingUtxoOutpoints: ['08070605:0']
+				}
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].value).toBe(600_000n);
+			expect(result[0].outpoint.vout).toBe(1);
+		});
+
 		it('should apply both confirmation and lock filters', () => {
-			const pendingUtxoTxIds = ['0c0b0a09']; // Hex of [9, 10, 11, 12] reversed
+			const pendingUtxoOutpoints = ['0c0b0a09:0'];
 
 			const result = filterAvailableUtxos({
 				utxos,
 				options: {
 					minConfirmations: 10,
-					pendingUtxoTxIds
+					pendingUtxoOutpoints
 				}
 			});
 
-			// Should only have the 300_000 and 400_000 UTXOs (height >= 10, not locked)
+			// Should only have the 300_000 and 400_000 UTXOs (height >= 10, not reserved)
 			expect(result).toHaveLength(2);
 			expect(result.map((u) => Number(u.value))).toEqual([300_000, 400_000]);
 		});
@@ -570,7 +629,7 @@ describe('btc-utxos.utils', () => {
 				utxos: [],
 				options: {
 					minConfirmations: 1,
-					pendingUtxoTxIds: []
+					pendingUtxoOutpoints: []
 				}
 			});
 

--- a/src/frontend/src/tests/icp/utils/btc.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/btc.utils.spec.ts
@@ -29,8 +29,9 @@ vi.mock('$btc/stores/btc-pending-sent-transactions.store', async () => {
 // Import after mocks
 import {
 	getPendingTransactionIds,
-	getPendingTransactionUtxoTxIds,
+	getPendingTransactionUtxoOutpoints,
 	getPendingTransactions,
+	outpointToKey,
 	pendingTransactionTxidToString,
 	utxoTxIdToString
 } from '$icp/utils/btc.utils';
@@ -141,15 +142,26 @@ describe('btc.utils', () => {
 		});
 	});
 
-	describe('getPendingTransactionUtxoTxIds', () => {
+	describe('outpointToKey', () => {
+		it('encodes a (txid, vout) pair as `${reversed-txid-hex}:${vout}`', () => {
+			expect(outpointToKey({ txid: new Uint8Array([0x01, 0x02, 0x03, 0x04]), vout: 0 })).toBe(
+				'04030201:0'
+			);
+			expect(outpointToKey({ txid: new Uint8Array([0x01, 0x02, 0x03, 0x04]), vout: 7 })).toBe(
+				'04030201:7'
+			);
+		});
+	});
+
+	describe('getPendingTransactionUtxoOutpoints', () => {
 		it('returns null when data is null or missing', () => {
 			mockStoreApi.setStoreValue({ [addr]: { certified: true as const, data: null } });
 
-			expect(getPendingTransactionUtxoTxIds(addr)).toEqual(null);
+			expect(getPendingTransactionUtxoOutpoints(addr)).toEqual(null);
 
 			mockStoreApi.setStoreValue({}); // address not present
 
-			expect(getPendingTransactionUtxoTxIds(addr)).toEqual(null);
+			expect(getPendingTransactionUtxoOutpoints(addr)).toEqual(null);
 		});
 
 		it('returns empty array when no pending transactions', () => {
@@ -157,10 +169,10 @@ describe('btc.utils', () => {
 				[addr]: { certified: true as const, data: [] }
 			});
 
-			expect(getPendingTransactionUtxoTxIds(addr)).toEqual([]);
+			expect(getPendingTransactionUtxoOutpoints(addr)).toEqual([]);
 		});
 
-		it('extracts UTXO transaction IDs from pending transactions', () => {
+		it('extracts outpoint keys from pending transactions', () => {
 			mockStoreApi.setStoreValue({
 				[addr]: {
 					certified: true as const,
@@ -171,14 +183,14 @@ describe('btc.utils', () => {
 								{
 									value: 100000n,
 									outpoint: {
-										txid: new Uint8Array([0x01, 0x02, 0x03, 0x04]), // UTXO tx ID
+										txid: new Uint8Array([0x01, 0x02, 0x03, 0x04]),
 										vout: 0
 									}
 								},
 								{
 									value: 200000n,
 									outpoint: {
-										txid: new Uint8Array([0x05, 0x06, 0x07, 0x08]), // UTXO tx ID
+										txid: new Uint8Array([0x05, 0x06, 0x07, 0x08]),
 										vout: 1
 									}
 								}
@@ -188,10 +200,71 @@ describe('btc.utils', () => {
 				}
 			});
 
-			const result = getPendingTransactionUtxoTxIds(addr);
+			const result = getPendingTransactionUtxoOutpoints(addr);
 
-			// Should return UTXO transaction IDs (with byte reversal), not the pending transaction ID
-			expect(result).toEqual(['04030201', '08070605']);
+			// Outpoints are reversed-txid-hex + vout, never the pending tx id itself
+			expect(result).toEqual(['04030201:0', '08070605:1']);
+		});
+
+		it('keeps UTXOs with the same txid but different vout as distinct outpoints', () => {
+			mockStoreApi.setStoreValue({
+				[addr]: {
+					certified: true as const,
+					data: [
+						{
+							txid: new Uint8Array([9]),
+							utxos: [
+								{
+									value: 100000n,
+									outpoint: {
+										txid: new Uint8Array([0x01, 0x02, 0x03, 0x04]),
+										vout: 0
+									}
+								},
+								{
+									value: 200000n,
+									outpoint: {
+										txid: new Uint8Array([0x01, 0x02, 0x03, 0x04]),
+										vout: 1
+									}
+								}
+							]
+						}
+					]
+				}
+			});
+
+			expect(getPendingTransactionUtxoOutpoints(addr)).toEqual(['04030201:0', '04030201:1']);
+		});
+
+		it('deduplicates identical outpoints across multiple pending transactions', () => {
+			mockStoreApi.setStoreValue({
+				[addr]: {
+					certified: true as const,
+					data: [
+						{
+							txid: new Uint8Array([1]),
+							utxos: [
+								{
+									value: 100000n,
+									outpoint: { txid: new Uint8Array([0xaa]), vout: 0 }
+								}
+							]
+						},
+						{
+							txid: new Uint8Array([2]),
+							utxos: [
+								{
+									value: 100000n,
+									outpoint: { txid: new Uint8Array([0xaa]), vout: 0 }
+								}
+							]
+						}
+					]
+				}
+			});
+
+			expect(getPendingTransactionUtxoOutpoints(addr)).toEqual(['aa:0']);
 		});
 
 		it('handles transactions without UTXOs', () => {
@@ -211,7 +284,7 @@ describe('btc.utils', () => {
 				}
 			});
 
-			const result = getPendingTransactionUtxoTxIds(addr);
+			const result = getPendingTransactionUtxoOutpoints(addr);
 
 			expect(result).toEqual([]);
 		});


### PR DESCRIPTION
# Motivation
  
Pending BTC sends reserve specific UTXO **outpoints** (`txid + vout`), not whole parent transactions. Today the FE compares pending UTXOs by `txid` alone, so every UTXO sharing a parent tx with any unconfirmed send is filtered out -  even when only one of the parent's outputs is actually reserved.

This over-filtering is the root blocker preventing more than one in-flight BTC send. This PR fixes the matching at the foundation so that the upcoming parallel-send rollout (BTC send / convert / Open Crypto Pay) has correct UTXO selection to build on.

Pure refactor / latent-bug fix: `BTC_EXTENSION_FEATURE_FLAG_ENABLED` stays `false`, so end-user behaviour does not change in this PR. With the flag off, the form-level gate still blocks a second send while a pending tx exists; the underlying matching just becomes more accurate. Follow-up PRs wire the convert flow, simplify Open Crypto Pay, and flip the flag.

# Changes
  
  - Added `outpointToKey({ txid, vout })` helper in `icp/utils/btc.utils.ts` so
    producers and consumers share one key format (format: `${reversed-txid-hex}:${vout}`).
  - Switched reserved-UTXO lookup from `Array.includes` to a `Set` — O(n+m) vs
    O(n·m), which matters once multiple pending sends are allowed.
  - Renames:
    - `extractUtxoTxIds` → `extractUtxoOutpoints`
    - `getPendingTransactionUtxoTxIds` → `getPendingTransactionUtxoOutpoints`
    - `filterLockedUtxos` / `filterAvailableUtxos` params:
      `pendingUtxoTxIds` → `pendingUtxoOutpoints`
  - Updated callers in `btc-utxos.service.ts` (`prepareBtcSend`) and
    `btc-send.services.ts` (`validateBtcSend`).

# Tests
  
New unit tests cover the regression and the parallel-send invariants.
