### PR TITLE
refactor(frontend): drop pending-tx guard from OCP token preparation

### DIFF
--- a/src/frontend/src/lib/components/scanner/ScannerCode.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerCode.svelte
@@ -75,8 +75,7 @@
 			const baseTokens = prepareBasePayableTokens({
 				transferAmounts: paymentData.transferAmounts,
 				networks: $networksMainnets,
-				availableTokens: $enabledTokens,
-				btcAddressMainnet: $btcAddressMainnet
+				availableTokens: $enabledTokens
 			});
 
 			const tokensWithFees = await calculateTokensWithFees(baseTokens);

--- a/src/frontend/src/lib/types/open-crypto-pay.ts
+++ b/src/frontend/src/lib/types/open-crypto-pay.ts
@@ -1,4 +1,4 @@
-import type { BtcAddress, OptionBtcAddress } from '$btc/types/address';
+import type { BtcAddress } from '$btc/types/address';
 import type { UtxosFee } from '$btc/types/btc-send';
 import type { EthFeeResult } from '$eth/types/pay';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
@@ -95,7 +95,6 @@ export interface PrepareTokensParams {
 	transferAmounts: TransferAmount[];
 	networks: Network[];
 	availableTokens: Token[];
-	btcAddressMainnet: OptionBtcAddress;
 }
 
 export interface PayableTokenWithConvertedAmount extends PayableTokenWithFees {

--- a/src/frontend/src/lib/utils/open-crypto-pay.utils.ts
+++ b/src/frontend/src/lib/utils/open-crypto-pay.utils.ts
@@ -7,7 +7,6 @@ import {
 	validateEthEvmTransfer
 } from '$eth/utils/eth-open-crypto-pay.utils';
 import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
-import { getPendingTransactions } from '$icp/utils/btc.utils';
 import {
 	enrichIcPayableToken,
 	isIcPayableToken,
@@ -159,8 +158,7 @@ export const mapTokenToPayableToken = ({
 export const prepareBasePayableTokens = ({
 	transferAmounts,
 	networks,
-	availableTokens,
-	btcAddressMainnet
+	availableTokens
 }: PrepareTokensParams): PayableToken[] => {
 	if (transferAmounts.length === 0 || networks.length === 0 || availableTokens.length === 0) {
 		return [];
@@ -175,19 +173,10 @@ export const prepareBasePayableTokens = ({
 		const payableToken = mapTokenToPayableToken({ token, methodDataMap });
 
 		if (nonNullish(payableToken)) {
-			if (isBitcoinToken(payableToken)) {
-				if (!OCP_PAY_WITH_BTC_ENABLED) {
-					return acc;
-				}
-
-				const btcPendingSentTransactions = getPendingTransactions(btcAddressMainnet ?? '');
-
-				if (nonNullish(btcPendingSentTransactions) && btcPendingSentTransactions.length === 0) {
-					acc.push(payableToken);
-				}
-			} else {
-				acc.push(payableToken);
+			if (isBitcoinToken(payableToken) && !OCP_PAY_WITH_BTC_ENABLED) {
+				return acc;
 			}
+			acc.push(payableToken);
 		}
 		return acc;
 	}, []);

--- a/src/frontend/src/tests/lib/utils/open-crypto-pay.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/open-crypto-pay.utils.spec.ts
@@ -24,7 +24,6 @@ import {
 	mapTokenToPayableToken,
 	prepareBasePayableTokens
 } from '$lib/utils/open-crypto-pay.utils';
-import { mockBtcAddress } from '$tests/mocks/btc.mock';
 
 describe('open-crypto-pay.utils', () => {
 	describe('decodeLNURL', () => {
@@ -899,8 +898,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: [],
 				networks: mockNetworks,
-				availableTokens: mockAvailableTokens,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: mockAvailableTokens
 			});
 
 			expect(result).toEqual([]);
@@ -910,8 +908,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: mockTransferAmounts,
 				networks: [],
-				availableTokens: mockAvailableTokens,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: mockAvailableTokens
 			});
 
 			expect(result).toEqual([]);
@@ -921,8 +918,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: mockTransferAmounts,
 				networks: mockNetworks,
-				availableTokens: [],
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: []
 			});
 
 			expect(result).toEqual([]);
@@ -932,8 +928,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: [],
 				networks: [],
-				availableTokens: [],
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: []
 			});
 
 			expect(result).toEqual([]);
@@ -943,8 +938,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: mockTransferAmounts,
 				networks: mockNetworks,
-				availableTokens: mockAvailableTokens,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: mockAvailableTokens
 			});
 
 			expect(result).toHaveLength(4);
@@ -1005,8 +999,7 @@ describe('open-crypto-pay.utils', () => {
 						pay: { openCryptoPay: 'Solana' }
 					} as unknown as Network
 				],
-				availableTokens: tokensWithUnsupported,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: tokensWithUnsupported
 			});
 
 			expect(result).toHaveLength(4);
@@ -1029,8 +1022,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: mockTransferAmounts,
 				networks: mockNetworks,
-				availableTokens: tokensWithMissingAsset,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: tokensWithMissingAsset
 			});
 
 			expect(result).toHaveLength(4);
@@ -1041,8 +1033,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: mockTransferAmounts,
 				networks: mockNetworks,
-				availableTokens: [mockAvailableTokens[0]],
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: [mockAvailableTokens[0]]
 			});
 
 			expect(result).toHaveLength(1);
@@ -1053,8 +1044,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: [mockTransferAmounts[0]],
 				networks: mockNetworks,
-				availableTokens: mockAvailableTokens,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: mockAvailableTokens
 			});
 
 			expect(result).toHaveLength(2);
@@ -1076,8 +1066,7 @@ describe('open-crypto-pay.utils', () => {
 			const result = prepareBasePayableTokens({
 				transferAmounts: transferWithUnavailable,
 				networks: mockNetworks,
-				availableTokens: mockAvailableTokens,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: mockAvailableTokens
 			});
 
 			expect(result).toHaveLength(4);
@@ -1087,15 +1076,13 @@ describe('open-crypto-pay.utils', () => {
 			const result1 = prepareBasePayableTokens({
 				transferAmounts: mockTransferAmounts,
 				networks: mockNetworks,
-				availableTokens: mockAvailableTokens,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: mockAvailableTokens
 			});
 
 			const result2 = prepareBasePayableTokens({
 				transferAmounts: mockTransferAmounts,
 				networks: mockNetworks,
-				availableTokens: mockAvailableTokens,
-				btcAddressMainnet: mockBtcAddress
+				availableTokens: mockAvailableTokens
 			});
 
 			expect(result1).not.toBe(result2);


### PR DESCRIPTION
# Motivation

The Open Crypto Pay token-preparation step used to exclude BTC from the payable tokens whenever there was a pending BTC send — a workaround required by the old single-send constraint. Now that parallel BTC sends are enabled and the  correct outpoint-based locking is in place, this exclusion no longer matches the product behaviour: a pending BTC send must not prevent the user from starting another one via OCP.

Removing the guard also lets us drop `btcAddressMainnet` from `prepareBasePayableTokens`, which simplifies the contract and its single caller (`ScannerCode.svelte`).

# Changes

- `prepareBasePayableTokens`:
    - Removed the `btcPendingSentTransactions` lookup that excluded BTC when an
      unconfirmed send was outstanding.
    - Removed the `btcAddressMainnet` parameter — no longer needed.
    - Simplified the BTC branch to a single `OCP_PAY_WITH_BTC_ENABLED` gate.
- `PrepareTokensParams`: dropped `btcAddressMainnet`.
- `ScannerCode.svelte`: removed `btcAddressMainnet` from the call site (the
    store import is still used elsewhere in the file, so it stays).
- Updated unit tests to match the new signature and reformatted the call sites
    (`npm run format`).

