### PR TITLE
feat(frontend): gate BTC convert flow on parallel-send feature flag

### DIFF
--- a/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertForm.svelte
@@ -8,6 +8,7 @@
 		initPendingSentTransactionsStatus
 	} from '$btc/derived/btc-pending-sent-transactions-status.derived';
 	import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeContext } from '$btc/stores/utxos-fee.store';
+	import { BTC_EXTENSION_FEATURE_FLAG_ENABLED } from '$env/btc.env';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
 	import { BTC_CONVERT_FORM_TEST_ID } from '$lib/constants/test-ids.constants';
 	import {
@@ -46,13 +47,23 @@
 
 	let hasPendingTransactionsStore = $derived(initPendingSentTransactionsStatus(source));
 
+	// When BTC extension is enabled, parallel transactions are allowed, so we
+	// neither block the submit button nor surface the "wait for the previous
+	// send" warning. The legacy single-send path is still reachable when the
+	// flag is off.
+	let pendingTransactionsStatus = $derived(
+		BTC_EXTENSION_FEATURE_FLAG_ENABLED
+			? BtcPendingSentTransactionsStatus.NONE
+			: $hasPendingTransactionsStore
+	);
+
 	let utxosFee = $derived(nonNullish(sendAmount) ? $storeUtxosFeeData?.utxosFee : undefined);
 
 	let invalid = $derived(
 		$insufficientFunds ||
 			$insufficientFundsForFee ||
 			invalidAmount(sendAmount) ||
-			$hasPendingTransactionsStore !== BtcPendingSentTransactionsStatus.NONE ||
+			pendingTransactionsStatus !== BtcPendingSentTransactionsStatus.NONE ||
 			isNullish($storeUtxosFeeData?.utxosFee?.utxos) ||
 			$storeUtxosFeeData.utxosFee.utxos.length === 0
 	);
@@ -70,9 +81,9 @@
 	bind:receiveAmount
 >
 	{#snippet message()}
-		{#if nonNullish($hasPendingTransactionsStore)}
+		{#if nonNullish(pendingTransactionsStatus)}
 			<div class="mb-4" data-tid="btc-convert-form-send-warnings">
-				<BtcSendWarnings pendingTransactionsStatus={$hasPendingTransactionsStore} {utxosFee} />
+				<BtcSendWarnings {pendingTransactionsStatus} {utxosFee} />
 			</div>
 		{/if}
 	{/snippet}

--- a/src/frontend/src/btc/components/convert/BtcConvertTokenWizard.svelte
+++ b/src/frontend/src/btc/components/convert/BtcConvertTokenWizard.svelte
@@ -7,11 +7,12 @@
 	import BtcConvertReview from '$btc/components/convert/BtcConvertReview.svelte';
 	import UtxosFeeLoader from '$btc/components/fee/UtxosFeeLoader.svelte';
 	import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
-	import { sendBtc } from '$btc/services/btc-send.services';
+	import { sendBtc, validateBtcSend } from '$btc/services/btc-send.services';
 	import {
 		UTXOS_FEE_CONTEXT_KEY,
 		type UtxosFeeContext as UtxosFeeContextType
 	} from '$btc/stores/utxos-fee.store';
+	import { BTC_EXTENSION_FEATURE_FLAG_ENABLED } from '$env/btc.env';
 	import { btcAddressStore } from '$icp/stores/btc.store';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -113,6 +114,24 @@
 		}
 
 		onNext();
+
+		if (BTC_EXTENSION_FEATURE_FLAG_ENABLED) {
+			// Last-line guard against a race: between fee preview and broadcast
+			// another tab may have reserved one of the UTXOs we selected.
+			try {
+				await validateBtcSend({
+					utxosFee: $utxosFeeStore.utxosFee,
+					source: sourceAddress,
+					amount: sendAmount,
+					network,
+					identity: $authIdentity
+				});
+			} catch (_: unknown) {
+				// Go back so the user can refresh the fee preview and retry.
+				back();
+				return;
+			}
+		}
 
 		try {
 			await sendBtc({

--- a/src/frontend/src/btc/components/send/BtcSendForm.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendForm.svelte
@@ -93,7 +93,6 @@
 
 	{#snippet info()}
 		<div class="mt-8">
-			<!-- TODO remove pendingTransactionsStatus as soon as parallel BTC transactions are also enabled for BTC convert -->
 			<BtcSendWarnings {pendingTransactionsStatus} utxosFee={$storeUtxosFeeData?.utxosFee} />
 		</div>
 	{/snippet}

--- a/src/frontend/src/btc/components/send/BtcSendWarnings.svelte
+++ b/src/frontend/src/btc/components/send/BtcSendWarnings.svelte
@@ -13,7 +13,6 @@
 	let { pendingTransactionsStatus, utxosFee }: Props = $props();
 </script>
 
-<!-- TODO remove this as soon as parallel BTC transactions are also enabled for BTC convert -->
 {#if pendingTransactionsStatus === BtcPendingSentTransactionsStatus.SOME}
 	<div class="w-full" in:fade>
 		<MessageBox level="warning">

--- a/src/frontend/src/env/btc.env.ts
+++ b/src/frontend/src/env/btc.env.ts
@@ -1,1 +1,1 @@
-export const BTC_EXTENSION_FEATURE_FLAG_ENABLED = false;
+export const BTC_EXTENSION_FEATURE_FLAG_ENABLED = true;

--- a/src/frontend/src/tests/btc/components/convert/BtcConvertForm.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertForm.spec.ts
@@ -62,7 +62,6 @@ describe('BtcConvertForm', () => {
 			.mockImplementation(() => readable(status));
 
 	const buttonTestId = 'convert-form-button-next';
-	const btcSendWarningsTestId = 'btc-convert-form-send-warnings';
 
 	beforeEach(() => {
 		mockPage.reset();
@@ -139,26 +138,27 @@ describe('BtcConvertForm', () => {
 		expect(getByTestId(buttonTestId)).toHaveAttribute('disabled');
 	});
 
-	it('should render btc send warning message and keep button disabled if there some pending txs', async () => {
+	it('should keep button clickable and not render pending warning when there are pending txs', async () => {
+		// With multi-send enabled, a previous unconfirmed send no longer blocks
+		// the convert button or surfaces the "wait for the previous send" warning.
+		store.setUtxosFee({ utxosFee: mockUtxosFee });
 		mockBtcPendingSendTransactionsStatusStore(
 			btcPendingSendTransactionsStatusStore.BtcPendingSentTransactionsStatus.SOME
 		);
 
-		const { getByTestId } = render(BtcConvertForm, {
+		const { getByTestId, queryByText } = render(BtcConvertForm, {
 			props,
 			context: mockContext({ utxosFeeStore: store })
 		});
 
 		await waitFor(() => {
-			expect(getByTestId(btcSendWarningsTestId)).toHaveTextContent(
-				en.send.info.pending_bitcoin_transaction
-			);
-
-			expect(getByTestId(buttonTestId)).toHaveAttribute('disabled');
+			expect(queryByText(en.send.info.pending_bitcoin_transaction)).toBeNull();
+			expect(getByTestId(buttonTestId)).not.toHaveAttribute('disabled');
 		});
 	});
 
-	it('should keep button disabled if there pending txs have not been loaded yet', async () => {
+	it('should keep button clickable even while pending txs are still loading', async () => {
+		store.setUtxosFee({ utxosFee: mockUtxosFee });
 		mockBtcPendingSendTransactionsStatusStore(
 			btcPendingSendTransactionsStatusStore.BtcPendingSentTransactionsStatus.LOADING
 		);
@@ -169,7 +169,7 @@ describe('BtcConvertForm', () => {
 		});
 
 		await waitFor(() => {
-			expect(getByTestId(buttonTestId)).toHaveAttribute('disabled');
+			expect(getByTestId(buttonTestId)).not.toHaveAttribute('disabled');
 		});
 	});
 });

--- a/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
@@ -1,5 +1,6 @@
 import BtcConvertTokenWizard from '$btc/components/convert/BtcConvertTokenWizard.svelte';
 import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
+import * as btcSendServices from '$btc/services/btc-send.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
@@ -131,6 +132,7 @@ describe('BtcConvertTokenWizard', () => {
 			next_page: []
 		});
 		vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
+		vi.spyOn(btcSendServices, 'validateBtcSend').mockResolvedValue(undefined);
 	});
 
 	it('should call sendBtc if all requirements are met', async () => {

--- a/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
@@ -1,5 +1,6 @@
 import BtcSendTokenWizard from '$btc/components/send/BtcSendTokenWizard.svelte';
 import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
+import * as btcSendServices from '$btc/services/btc-send.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
@@ -123,6 +124,7 @@ describe('BtcSendTokenWizard', () => {
 			next_page: []
 		});
 		vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
+		vi.spyOn(btcSendServices, 'validateBtcSend').mockResolvedValue(undefined);
 	});
 
 	it('should call sendBtc if all requirements are met', async () => {


### PR DESCRIPTION
# Motivation

The BTC send flow is already wired for the parallel-send rollout: when `BTC_EXTENSION_FEATURE_FLAG_ENABLED` is on, `BtcSendForm` stops surfacing the "wait for the previous send" warning and `BtcSendTokenWizard` runs a last-line  `validateBtcSend` race guard against UTXO reservations. The BTC convert flow (BTC → ckBTC) was left behind on the old single-send constraint.

This PR brings convert to parity with send. Also, we enable the BTC flag in the same PR to avoid issues with tests.

# Changes

 - `BtcConvertForm.svelte`:
    - Derive `pendingTransactionsStatus` from the feature flag: forced to `NONE` when the flag is on, otherwise falls back to the existing pending-transactions store. Mirrors `BtcSendForm`.
    - Submit-button gating and the pending-send warning now both read from this derived value, so an unconfirmed previous send no longer blocks the form once parallel sends are enabled.
  - `BtcConvertTokenWizard.svelte`:
    - Added a `validateBtcSend` call between `onNext()` and `sendBtc()` when the flag is on. Closes the race where another tab reserves one of the selected outpoints between fee preview and broadcast. On validation failure, the
 wizard transitions back so the user can refresh the fee preview and retry.
  - `BtcSendForm.svelte` / `BtcSendWarnings.svelte`: dropped two `// TODO remove ... as soon as parallel BTC transactions are also enabled for BTC convert` comments — they're satisfied by this PR.
