### PR TITLE
style(frontend): left-align activity filter dropdowns on non-mobile

### DIFF
--- a/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
+++ b/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
@@ -65,7 +65,7 @@
 	<IconExpandMore size="20" />
 </button>
 
-<ResponsivePopover {button} bind:visible>
+<ResponsivePopover {button} direction="ltr" bind:visible>
 	{#snippet content()}
 		<div
 			class="flex flex-col gap-2 p-1 {panelWidthClass ?? 'w-full min-w-60'}"

--- a/src/frontend/src/lib/components/ui/ResponsivePopover.svelte
+++ b/src/frontend/src/lib/components/ui/ResponsivePopover.svelte
@@ -9,13 +9,14 @@
 		visible: boolean;
 		button?: HTMLButtonElement;
 		content: Snippet;
+		direction?: 'rtl' | 'ltr';
 	}
 
-	let { visible = $bindable(), button, content }: Props = $props();
+	let { visible = $bindable(), button, content, direction = 'rtl' }: Props = $props();
 </script>
 
 <Responsive up="sm">
-	<Popover anchor={button} direction="rtl" invisibleBackdrop bind:visible>
+	<Popover anchor={button} {direction} invisibleBackdrop bind:visible>
 		{@render content()}
 	</Popover>
 </Responsive>


### PR DESCRIPTION
# Motivation

On non-mobile screens the activity page's filter dropdowns (types, tokens, contacts) opened with their right edge anchored to the trigger button (`direction="rtl"`), so the panel extended leftwards away from the trigger label. Aligning them to the left of the trigger feels more natural for a filter toolbar that reads left-to-right.