### PR TITLE
feat(backend): skip exchange rate refresh for tokens cached within half the interval

### DIFF
--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -30,10 +30,13 @@ const PRICE_REFRESH_INTERVAL_SEC: u64 = 5 * 60;
 /// and skipped during price refreshes (1 hour).
 pub const PRICE_ACTIVITY_THRESHOLD_SEC: u64 = 60 * 60;
 
-/// A token's cached price is considered "fresh enough" if it was written less
-/// than `PRICE_REFRESH_INTERVAL_SEC / 2` ago. Such tokens are skipped on the
+/// A token's cached price is considered "fresh enough" if its
+/// [`ExchangeData::timestamp_ns`] (the provider-reported `last_updated_at`,
+/// or `time()` when the provider doesn't supply one) is within
+/// `PRICE_REFRESH_INTERVAL_SEC / 2` of now. Such tokens are skipped on the
 /// next refresh tick to avoid duplicate upstream calls when, e.g., a lazy
-/// bootstrap or a manual refresh has just populated the cache.
+/// bootstrap or a manual refresh has just populated the cache with a price
+/// the provider also reports as recent.
 const PRICE_FRESHNESS_GRACE_NS: u64 = (PRICE_REFRESH_INTERVAL_SEC / 2) * 1_000_000_000;
 
 /// Native tokens whose prices are always fetched, regardless of user activity.
@@ -73,17 +76,6 @@ pub(crate) fn start_exchange_rate_timer() {
             }
         });
     });
-}
-
-/// Returns `true` if the cached price for `token_id` was written at or after
-/// `freshness_floor_ns`, meaning it is considered fresh enough to skip on the
-/// current refresh tick.
-fn is_price_fresh_enough(token_id: &StoredTokenId, freshness_floor_ns: u64) -> bool {
-    read_state(|s| {
-        s.exchange_rates
-            .get(token_id)
-            .is_some_and(|r| r.0.usd.timestamp_ns >= freshness_floor_ns)
-    })
 }
 
 fn update_price(token_id: &StoredTokenId, exchange_data: &ExchangeData) {
@@ -139,7 +131,13 @@ pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
     tokens_to_fetch.dedup();
 
     let freshness_floor_ns = now.saturating_sub(PRICE_FRESHNESS_GRACE_NS);
-    tokens_to_fetch.retain(|t| !is_price_fresh_enough(t, freshness_floor_ns));
+    read_state(|s| {
+        tokens_to_fetch.retain(|t| {
+            s.exchange_rates
+                .get(t)
+                .is_none_or(|r| r.0.usd.timestamp_ns < freshness_floor_ns)
+        });
+    });
 
     if tokens_to_fetch.is_empty() {
         return Ok(());

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -30,6 +30,12 @@ const PRICE_REFRESH_INTERVAL_SEC: u64 = 5 * 60;
 /// and skipped during price refreshes (1 hour).
 pub const PRICE_ACTIVITY_THRESHOLD_SEC: u64 = 60 * 60;
 
+/// A token's cached price is considered "fresh enough" if it was written less
+/// than `PRICE_REFRESH_INTERVAL_SEC / 2` ago. Such tokens are skipped on the
+/// next refresh tick to avoid duplicate upstream calls when, e.g., a lazy
+/// bootstrap or a manual refresh has just populated the cache.
+const PRICE_FRESHNESS_GRACE_NS: u64 = (PRICE_REFRESH_INTERVAL_SEC / 2) * 1_000_000_000;
+
 /// Native tokens whose prices are always fetched, regardless of user activity.
 fn native_token_ids() -> Vec<StoredTokenId> {
     vec![
@@ -67,6 +73,17 @@ pub(crate) fn start_exchange_rate_timer() {
             }
         });
     });
+}
+
+/// Returns `true` if the cached price for `token_id` was written at or after
+/// `freshness_floor_ns`, meaning it is considered fresh enough to skip on the
+/// current refresh tick.
+fn is_price_fresh_enough(token_id: &StoredTokenId, freshness_floor_ns: u64) -> bool {
+    read_state(|s| {
+        s.exchange_rates
+            .get(token_id)
+            .is_some_and(|r| r.0.usd.timestamp_ns >= freshness_floor_ns)
+    })
 }
 
 fn update_price(token_id: &StoredTokenId, exchange_data: &ExchangeData) {
@@ -120,6 +137,9 @@ pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
     tokens_to_fetch.extend(active_custom_tokens);
     tokens_to_fetch.sort_unstable();
     tokens_to_fetch.dedup();
+
+    let freshness_floor_ns = now.saturating_sub(PRICE_FRESHNESS_GRACE_NS);
+    tokens_to_fetch.retain(|t| !is_price_fresh_enough(t, freshness_floor_ns));
 
     if tokens_to_fetch.is_empty() {
         return Ok(());


### PR DESCRIPTION
# Motivation

The 5 min refresh tick re-fetches every active token unconditionally, even ones whose cached price was just written (e.g. by an upcoming lazy-bootstrap path or by a manual refresh). That double-pays CoinGecko quota for no fresher data.
