### PR TITLE
feat(backend): split exchange rate refresh into native (5m) and custom (10m) tiers

### DIFF
--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -23,8 +23,16 @@ use crate::{
     types::storable::{Candid, StoredTokenId},
 };
 
-/// How often exchange rates are refreshed (5 minutes).
-const PRICE_REFRESH_INTERVAL_SEC: u64 = 5 * 60;
+/// How often native token prices are refreshed (5 minutes). Natives are the
+/// hot path: every wallet is showing them on every page, so we keep them
+/// tight.
+const NATIVE_PRICE_REFRESH_INTERVAL_SEC: u64 = 5 * 60;
+
+/// How often active custom (long-tail) token prices are refreshed (10 min).
+/// These tend to be ICRC / SPL / ERC-20 tokens specific to one user; they
+/// move slower in aggregate and we'd rather spend half the upstream budget
+/// on them.
+const CUSTOM_PRICE_REFRESH_INTERVAL_SEC: u64 = 10 * 60;
 
 /// Tokens that haven't been queried within this window are considered inactive
 /// and skipped during price refreshes (1 hour).
@@ -44,29 +52,49 @@ fn native_token_ids() -> Vec<StoredTokenId> {
     ]
 }
 
-/// Starts a recurring timer that refreshes exchange rates for active tokens
-/// every [`PRICE_REFRESH_INTERVAL_SEC`] seconds.
+/// Starts two recurring timers:
 ///
-/// An immediate one-shot refresh runs first so that rates are available right
-/// after canister init / upgrade instead of waiting for the first interval tick.
+/// - one that refreshes native token prices every [`NATIVE_PRICE_REFRESH_INTERVAL_SEC`] seconds,
+///   and
+/// - one that refreshes active custom token prices every [`CUSTOM_PRICE_REFRESH_INTERVAL_SEC`]
+///   seconds.
+///
+/// An immediate one-shot refresh of both runs first so that rates are
+/// available right after canister init / upgrade instead of waiting for the
+/// first interval tick.
 pub(crate) fn start_exchange_rate_timer() {
     set_timer(Duration::ZERO, || {
         ic_cdk::futures::spawn(async {
-            if let Err(err) = refresh_exchange_rates().await {
-                ic_cdk::println!("Exchange rate initial refresh skipped: {err:?}");
+            if let Err(err) = refresh_native_exchange_rates().await {
+                ic_cdk::println!("Native exchange rate initial refresh skipped: {err:?}");
+            }
+            if let Err(err) = refresh_custom_exchange_rates().await {
+                ic_cdk::println!("Custom exchange rate initial refresh skipped: {err:?}");
             }
         });
     });
 
-    let refresh_interval = Duration::from_secs(PRICE_REFRESH_INTERVAL_SEC);
+    let _ = set_timer_interval(
+        Duration::from_secs(NATIVE_PRICE_REFRESH_INTERVAL_SEC),
+        || {
+            ic_cdk::futures::spawn(async {
+                if let Err(err) = refresh_native_exchange_rates().await {
+                    ic_cdk::println!("Native exchange rate refresh skipped: {err:?}");
+                }
+            });
+        },
+    );
 
-    let _ = set_timer_interval(refresh_interval, || {
-        ic_cdk::futures::spawn(async {
-            if let Err(err) = refresh_exchange_rates().await {
-                ic_cdk::println!("Exchange rate refresh skipped: {err:?}");
-            }
-        });
-    });
+    let _ = set_timer_interval(
+        Duration::from_secs(CUSTOM_PRICE_REFRESH_INTERVAL_SEC),
+        || {
+            ic_cdk::futures::spawn(async {
+                if let Err(err) = refresh_custom_exchange_rates().await {
+                    ic_cdk::println!("Custom exchange rate refresh skipped: {err:?}");
+                }
+            });
+        },
+    );
 }
 
 fn update_price(token_id: &StoredTokenId, exchange_data: &ExchangeData) {
@@ -90,7 +118,33 @@ fn supplemental_price_providers() -> Vec<Box<dyn SupplementalPriceProvider>> {
     vec![Box::new(IcpSwapProvider::default())]
 }
 
-pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
+pub(crate) async fn refresh_native_exchange_rates() -> Result<(), ExchangeError> {
+    fetch_and_store(&native_token_ids()).await
+}
+
+pub(crate) async fn refresh_custom_exchange_rates() -> Result<(), ExchangeError> {
+    let now = time();
+    let threshold = now.saturating_sub(PRICE_ACTIVITY_THRESHOLD_SEC * 1_000_000_000);
+
+    let mut tokens_to_fetch: Vec<StoredTokenId> = read_state(|s| {
+        s.token_activity
+            .iter()
+            .filter(|entry| entry.value() > threshold)
+            .map(|entry| entry.key().clone())
+            .collect()
+    });
+
+    tokens_to_fetch.sort_unstable();
+    tokens_to_fetch.dedup();
+
+    fetch_and_store(&tokens_to_fetch).await
+}
+
+async fn fetch_and_store(tokens: &[StoredTokenId]) -> Result<(), ExchangeError> {
+    if tokens.is_empty() {
+        return Ok(());
+    }
+
     let enabled = with_api_keys(|keys| {
         keys.coingecko_api_key.is_some() && keys.exchange_rate_enabled != Some(false)
     });
@@ -103,30 +157,8 @@ pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
         with_api_keys(|keys| keys.coingecko_api_key.clone()).ok_or(ExchangeError::ApiKeyNotSet)?;
 
     let provider = CoinGeckoProvider::new(api_key);
-
-    let now = time();
-    let threshold = now.saturating_sub(PRICE_ACTIVITY_THRESHOLD_SEC * 1_000_000_000);
-
-    let mut tokens_to_fetch: Vec<StoredTokenId> = native_token_ids();
-
-    let active_custom_tokens: Vec<StoredTokenId> = read_state(|s| {
-        s.token_activity
-            .iter()
-            .filter(|entry| entry.value() > threshold)
-            .map(|entry| entry.key().clone())
-            .collect()
-    });
-
-    tokens_to_fetch.extend(active_custom_tokens);
-    tokens_to_fetch.sort_unstable();
-    tokens_to_fetch.dedup();
-
-    if tokens_to_fetch.is_empty() {
-        return Ok(());
-    }
-
     let supplementals = supplemental_price_providers();
-    let prices = fetch_all_prices(&provider, &supplementals, &tokens_to_fetch).await;
+    let prices = fetch_all_prices(&provider, &supplementals, tokens).await;
 
     for (token_id, exchange_data) in prices {
         update_price(&token_id, &exchange_data);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

Today every active token — natives and long-tail customs alike — refreshes on the same 5 min tick. Natives are the hot path (every wallet shows them on every page) and need to stay tight; custom tokens are typically held by one or two users, move slower in aggregate, and don't justify the same upstream cadence.

# Changes

- Replaced `PRICE_REFRESH_INTERVAL_SEC` with two constants: `NATIVE_PRICE_REFRESH_INTERVAL_SEC = 5 * 60` and `CUSTOM_PRICE_REFRESH_INTERVAL_SEC = 10 * 60`.
- Split `refresh_exchange_rates` into `refresh_native_exchange_rates` and `refresh_custom_exchange_rates`, sharing a new `fetch_and_store` helper.
- `start_exchange_rate_timer` now schedules two recurring timers and an immediate one-shot of both.

# Tests

- `cargo check -p backend` ✅
- `cargo test -p backend --lib` ✅ (141 passed)
- `./scripts/lint.rust.sh` ✅
- `bash scripts/format.rust.sh` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3a69cfd-a626-40ed-ba52-5f79d4a54770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3a69cfd-a626-40ed-ba52-5f79d4a54770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

