### PR TITLE
feat(backend): periodically evict token_activity entries older than 24h

### DIFF
--- a/src/backend/src/state/mod.rs
+++ b/src/backend/src/state/mod.rs
@@ -39,7 +39,8 @@ pub(crate) struct State {
     pub(crate) user_profile_updated: UserProfileUpdatedMap,
     pub(crate) contact: ContactMap,
     pub(crate) btc_user_pending_transactions: BtcUserPendingTransactionsMap,
-    // TODO: implement a periodic cleanup of old entries
+    // Periodic cleanup of stale entries lives in `utils::housekeeping`
+    // (`evict_inactive_tokens` with `TOKEN_ACTIVITY_RETENTION_SEC`).
     // TODO: limit the map size with an eviction policy
     pub(crate) token_activity: TokenActivityMap,
     pub(crate) exchange_rates: ExchangeRateMap,

--- a/src/backend/src/state/mod.rs
+++ b/src/backend/src/state/mod.rs
@@ -39,8 +39,6 @@ pub(crate) struct State {
     pub(crate) user_profile_updated: UserProfileUpdatedMap,
     pub(crate) contact: ContactMap,
     pub(crate) btc_user_pending_transactions: BtcUserPendingTransactionsMap,
-    // Periodic cleanup of stale entries lives in `utils::housekeeping`
-    // (`evict_inactive_tokens` with `TOKEN_ACTIVITY_RETENTION_SEC`).
     // TODO: limit the map size with an eviction policy
     pub(crate) token_activity: TokenActivityMap,
     pub(crate) exchange_rates: ExchangeRateMap,

--- a/src/backend/src/token/activity.rs
+++ b/src/backend/src/token/activity.rs
@@ -7,6 +7,15 @@ use crate::{
     types::{StoredTokenId, VMem},
 };
 
+/// How long an inactive token's activity record is kept before housekeeping
+/// evicts it (24 hours).
+///
+/// Generously larger than `PRICE_ACTIVITY_THRESHOLD_SEC` so any token that is
+/// still being refreshed is never accidentally removed; the goal here is just
+/// to bound the on-disk size of `token_activity` over time, not to gate
+/// refreshes.
+pub(crate) const TOKEN_ACTIVITY_RETENTION_SEC: u64 = 24 * 60 * 60;
+
 fn add_to_token_activity(
     token_id: StoredTokenId,
     token_activity: &mut StableBTreeMap<StoredTokenId, Timestamp, VMem>,
@@ -33,4 +42,30 @@ pub fn mark_tokens_active(token_ids: &[TokenId]) {
             add_to_token_activity(StoredTokenId(token_id.clone()), &mut s.token_activity, now);
         }
     });
+}
+
+/// Removes entries from `token_activity` whose timestamp is older than
+/// `retention_sec` seconds before now, and returns the number of removed
+/// entries.
+///
+/// Intended to be called from periodic housekeeping; safe to call when the
+/// map is empty (returns `0`).
+pub fn evict_inactive_tokens(retention_sec: u64) -> u64 {
+    let now = time();
+    let cutoff_ns = now.saturating_sub(retention_sec.saturating_mul(1_000_000_000));
+
+    mutate_state(|s| {
+        let stale: Vec<StoredTokenId> = s
+            .token_activity
+            .iter()
+            .filter(|entry| entry.value() < cutoff_ns)
+            .map(|entry| entry.key().clone())
+            .collect();
+
+        let removed = stale.len() as u64;
+        for key in stale {
+            s.token_activity.remove(&key);
+        }
+        removed
+    })
 }

--- a/src/backend/src/token/mod.rs
+++ b/src/backend/src/token/mod.rs
@@ -1,5 +1,7 @@
 mod activity;
 mod service;
 
-pub(crate) use activity::{mark_token_active, mark_tokens_active};
+pub(crate) use activity::{
+    evict_inactive_tokens, mark_token_active, mark_tokens_active, TOKEN_ACTIVITY_RETENTION_SEC,
+};
 pub(crate) use service::{add_to_user_token, remove_from_user_token, MAX_TOKEN_LIST_LENGTH};

--- a/src/backend/src/utils/housekeeping.rs
+++ b/src/backend/src/utils/housekeeping.rs
@@ -5,7 +5,11 @@ use ic_cdk_timers::{set_timer, set_timer_interval};
 use shared::types::signer::topup::TopUpCyclesLedgerResult;
 
 use super::rate_limiter::ALLOW_SIGNING_RATE_LIMITER;
-use crate::{api, signer, types::StoredPrincipal};
+use crate::{
+    api, signer,
+    token::{evict_inactive_tokens, TOKEN_ACTIVITY_RETENTION_SEC},
+    types::StoredPrincipal,
+};
 
 thread_local! {
     /// `None` means idle; `Some(ns)` is the IC timestamp when the current run started.
@@ -135,6 +139,7 @@ pub(crate) fn start_periodic_housekeeping_timers() {
 
 /// Runs hourly housekeeping tasks:
 /// - Top up the cycles ledger.
+/// - Evict `token_activity` entries older than [`TOKEN_ACTIVITY_RETENTION_SEC`].
 async fn hourly_housekeeping_tasks() {
     // Tops up the account on the cycles ledger
     {
@@ -144,6 +149,11 @@ async fn hourly_housekeeping_tasks() {
         }
         // TODO: Add monitoring for how many cycles have been topped up and whether topping up is
         // failing.
+    }
+
+    let evicted = evict_inactive_tokens(TOKEN_ACTIVITY_RETENTION_SEC);
+    if evicted > 0 {
+        ic_cdk::println!("Evicted {evicted} stale token_activity entries");
     }
 }
 


### PR DESCRIPTION
# Motivation

`token_activity` has stood with two `TODO`s in `state/mod.rs` for a while: it grows for every distinct token any user ever held, with nothing to remove old entries. That's both a stable-memory leak and a slow drag on the refresh-loop scan. Closes the periodic-cleanup half of those TODOs (the per-map size cap is left as a separate, harder change).


