### PR TITLE
feat(frontend): pass backend exchange rate timestamp through as last_updated_at

### DIFF
--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -226,6 +226,8 @@ export const exchangeRateSPLToUsd = async (
 	});
 };
 
+const NS_PER_MS = 1_000_000n;
+
 const mapExchangeRateToCoingecko = (
 	rate: BackendExchangeRate | undefined
 ): CoingeckoSimpleTokenPrice | undefined => {
@@ -236,7 +238,8 @@ const mapExchangeRateToCoingecko = (
 	return {
 		usd: rate.usd.price,
 		usd_24h_change: rate.usd.price24hChangePct,
-		usd_market_cap: rate.usd.marketCap ?? 0
+		usd_market_cap: rate.usd.marketCap ?? 0,
+		last_updated_at: Number(rate.usd.timestampNs / NS_PER_MS)
 	};
 };
 

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -9,6 +9,7 @@ import { KONGSWAP_PROVIDER_ENABLED } from '$env/rest/kongswap.env';
 import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import { getExchangeRates } from '$lib/api/backend.api';
+import { NANO_SECONDS_IN_MILLISECOND } from '$lib/constants/app.constants';
 import { Currency } from '$lib/enums/currency';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/coingecko.rest';
 import { fetchBatchIcpSwapPrices } from '$lib/rest/icpswap.rest';
@@ -226,8 +227,6 @@ export const exchangeRateSPLToUsd = async (
 	});
 };
 
-const NS_PER_MS = 1_000_000n;
-
 const mapExchangeRateToCoingecko = (
 	rate: BackendExchangeRate | undefined
 ): CoingeckoSimpleTokenPrice | undefined => {
@@ -239,7 +238,7 @@ const mapExchangeRateToCoingecko = (
 		usd: rate.usd.price,
 		usd_24h_change: rate.usd.price24hChangePct,
 		usd_market_cap: rate.usd.marketCap ?? 0,
-		last_updated_at: Number(rate.usd.timestampNs / NS_PER_MS)
+		last_updated_at: Number(rate.usd.timestampNs / NANO_SECONDS_IN_MILLISECOND)
 	};
 };
 

--- a/src/frontend/src/tests/lib/services/exchange.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/exchange.services.spec.ts
@@ -339,7 +339,12 @@ describe('exchange.services', () => {
 				splTokenAddresses: ['SoLaddr1']
 			});
 
-			const expectedPrice = { usd: 42000, usd_24h_change: 1.5, usd_market_cap: 800_000_000_000 };
+			const expectedPrice = {
+				usd: 42000,
+				usd_24h_change: 1.5,
+				usd_market_cap: 800_000_000_000,
+				last_updated_at: 1000
+			};
 
 			expect(result.currentErc20Prices).toEqual({ '0xabc': expectedPrice });
 			expect(result.currentIcrcPrices).toEqual({
@@ -457,7 +462,12 @@ describe('exchange.services', () => {
 				splTokenAddresses: []
 			});
 
-			const expectedPrice = { usd: 42000, usd_24h_change: 1.5, usd_market_cap: 800_000_000_000 };
+			const expectedPrice = {
+				usd: 42000,
+				usd_24h_change: 1.5,
+				usd_market_cap: 800_000_000_000,
+				last_updated_at: 1000
+			};
 
 			expect(result.currentEthPrice).toEqual({ ethereum: expectedPrice });
 			expect(result.currentBtcPrice).toEqual({ bitcoin: expectedPrice });
@@ -491,7 +501,12 @@ describe('exchange.services', () => {
 			});
 
 			expect(result.currentErc20Prices).toEqual({
-				'0xabc': { usd: 100, usd_24h_change: undefined, usd_market_cap: 0 }
+				'0xabc': {
+					usd: 100,
+					usd_24h_change: undefined,
+					usd_market_cap: 0,
+					last_updated_at: 0
+				}
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
+++ b/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
@@ -1163,7 +1163,8 @@ describe('exchange.worker', () => {
 				const expectedPrice = {
 					usd: 42000,
 					usd_24h_change: 1.5,
-					usd_market_cap: 800_000_000_000
+					usd_market_cap: 800_000_000_000,
+					last_updated_at: 1000
 				};
 
 				expect(postMessageMock).toHaveBeenCalledExactlyOnceWith({
@@ -1240,7 +1241,8 @@ describe('exchange.worker', () => {
 				const expectedPrice = {
 					usd: 42000,
 					usd_24h_change: 1.5,
-					usd_market_cap: 800_000_000_000
+					usd_market_cap: 800_000_000_000,
+					last_updated_at: 1000
 				};
 
 				expect(postedData.currentEthPrice).toEqual({ ethereum: expectedPrice });


### PR DESCRIPTION
# Motivation

The backend already attaches a `timestamp_ns` to every cached `ExchangeRate`, but `mapExchangeRateToCoingecko` was discarding it. Exposing it as `last_updated_at` (ms since epoch) on the existing CoinGecko-shaped price record lets any future UI surface "as of …" / fade stale prices without needing to refetch; and matches the convention already used by the KongSwap mapper in `exchange.utils.ts`.
