### PR TITLE
fix(frontend): sort token filter list by symbol then network to match displayed text

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -43,11 +43,12 @@
 					.map((token) => [tokenRenderKey(token), token] as const)
 					.filter((entry): entry is [string, Token] => nonNullish(entry[0]))
 			).values()
-		].sort((a, b) =>
-			a.symbol.localeCompare(b.symbol, undefined, {
-				sensitivity: 'base'
-			})
-		)
+		].sort((a, b) => {
+			const bySymbol = a.symbol.localeCompare(b.symbol, undefined, { sensitivity: 'base' });
+			return bySymbol !== 0
+				? bySymbol
+				: a.network.name.localeCompare(b.network.name, undefined, { sensitivity: 'base' });
+		})
 	);
 
 	let filteredTokens = $derived(

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -45,6 +45,7 @@
 			).values()
 		].sort((a, b) => {
 			const bySymbol = a.symbol.localeCompare(b.symbol, undefined, { sensitivity: 'base' });
+
 			return bySymbol !== 0
 				? bySymbol
 				: a.network.name.localeCompare(b.network.name, undefined, { sensitivity: 'base' });

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte
@@ -44,7 +44,7 @@
 					.filter((entry): entry is [string, Token] => nonNullish(entry[0]))
 			).values()
 		].sort((a, b) =>
-			(a.name ?? a.symbol).localeCompare(b.name ?? b.symbol, undefined, {
+			a.symbol.localeCompare(b.symbol, undefined, {
 				sensitivity: 'base'
 			})
 		)

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
@@ -42,7 +42,7 @@ describe('TransactionsFilterTokensPanel', () => {
 		mockEnabledFungibleNetworkTokens([tokenBeta, tokenAlpha, tokenGamma]);
 	});
 
-	it('renders one row per fungible token, alphabetically sorted by name', () => {
+	it('renders one row per fungible token, alphabetically sorted by symbol', () => {
 		const { container } = render(TransactionsFilterTokensPanel);
 
 		const symbols = Array.from(container.querySelectorAll('li span.font-medium')).map(
@@ -50,6 +50,37 @@ describe('TransactionsFilterTokensPanel', () => {
 		);
 
 		expect(symbols).toEqual(['ALP', 'BTA', 'GMA']);
+	});
+
+	it('sorts by symbol even when the alphabetical order of names disagrees', () => {
+		// Names are deliberately reverse-ordered vs. symbols so that a
+		// regression to name-based sorting would flip the rendered order.
+		const tokenZebraAaa = buildToken({ id: 'ZebraTokenId', name: 'Zebra', symbol: 'AAA' });
+		const tokenMangoMmm = buildToken({ id: 'MangoTokenId', name: 'Mango', symbol: 'MMM' });
+		const tokenAlphaZzz = buildToken({ id: 'AlphaZzzTokenId', name: 'Alpha', symbol: 'ZZZ' });
+		mockEnabledFungibleNetworkTokens([tokenAlphaZzz, tokenMangoMmm, tokenZebraAaa]);
+
+		const { container } = render(TransactionsFilterTokensPanel);
+
+		const symbols = Array.from(container.querySelectorAll('li span.font-medium')).map(
+			(el) => el.textContent?.trim() ?? ''
+		);
+
+		expect(symbols).toEqual(['AAA', 'MMM', 'ZZZ']);
+	});
+
+	it('sorts symbols case-insensitively', () => {
+		const tokenLowerB = buildToken({ id: 'LowerBTokenId', name: 'Lower B', symbol: 'btc' });
+		const tokenUpperA = buildToken({ id: 'UpperATokenId', name: 'Upper A', symbol: 'ETH' });
+		mockEnabledFungibleNetworkTokens([tokenLowerB, tokenUpperA]);
+
+		const { container } = render(TransactionsFilterTokensPanel);
+
+		const symbols = Array.from(container.querySelectorAll('li span.font-medium')).map(
+			(el) => el.textContent?.trim() ?? ''
+		);
+
+		expect(symbols).toEqual(['btc', 'ETH']);
 	});
 
 	it('reflects the store as the checked state', () => {

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterTokensPanel.spec.ts
@@ -20,11 +20,25 @@ const mockEnabledFungibleNetworkTokens = (tokens: Token[]) => {
 	);
 };
 
-const buildToken = ({ id, name, symbol }: { id: string; name: string; symbol: string }): Token => ({
+const buildToken = ({
+	id,
+	name,
+	symbol,
+	networkName
+}: {
+	id: string;
+	name: string;
+	symbol: string;
+	networkName?: string;
+}): Token => ({
 	...mockValidIcToken,
 	id: parseTokenId(id),
 	name,
-	symbol
+	symbol,
+	network:
+		networkName === undefined
+			? mockValidIcToken.network
+			: { ...mockValidIcToken.network, name: networkName }
 });
 
 const tokenInputId = (token: Token): string =>
@@ -81,6 +95,42 @@ describe('TransactionsFilterTokensPanel', () => {
 		);
 
 		expect(symbols).toEqual(['btc', 'ETH']);
+	});
+
+	it('breaks symbol ties by network name (case-insensitive)', () => {
+		// Same symbol on three networks; tiebreaker should order them by
+		// network name, regardless of the input order.
+		const tokenUsdcPolygon = buildToken({
+			id: 'UsdcPolygonTokenId',
+			name: 'USDC',
+			symbol: 'USDC',
+			networkName: 'Polygon'
+		});
+		const tokenUsdcEthereum = buildToken({
+			id: 'UsdcEthereumTokenId',
+			name: 'USDC',
+			symbol: 'USDC',
+			networkName: 'ethereum'
+		});
+		const tokenUsdcBase = buildToken({
+			id: 'UsdcBaseTokenId',
+			name: 'USDC',
+			symbol: 'USDC',
+			networkName: 'Base'
+		});
+		mockEnabledFungibleNetworkTokens([tokenUsdcPolygon, tokenUsdcEthereum, tokenUsdcBase]);
+
+		const { container } = render(TransactionsFilterTokensPanel);
+
+		const networkNames = Array.from(container.querySelectorAll('li span.text-tertiary')).map(
+			(el) => el.textContent?.trim() ?? ''
+		);
+
+		expect(networkNames).toEqual([
+			replacePlaceholders(get(i18n).tokens.text.on_network, { $network: 'Base' }).trim(),
+			replacePlaceholders(get(i18n).tokens.text.on_network, { $network: 'ethereum' }).trim(),
+			replacePlaceholders(get(i18n).tokens.text.on_network, { $network: 'Polygon' }).trim()
+		]);
 	});
 
 	it('reflects the store as the checked state', () => {


### PR DESCRIPTION
# Motivation

The token filter list shows `{symbol} on {network}` but was sorted by `name`, making the alphabet feel arbitrary (e.g. `BTC` under "B" but `ckBTC` under "c"). Same-symbol tokens on different networks also had no defined order.