### PR TITLE
docs(ai): trim discoverable codebase-overview content from entry layers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,19 +4,14 @@
 > for every AI coding agent in this repository (Copilot included). The rest
 > of this file is a thin Copilot-specific layer that never contradicts it.
 
-## TL;DR for Copilot
+## Pointers for Copilot
 
-- This is a multi-stack repo: **SvelteKit + Svelte 5 + TS + Tailwind v4**
-  frontend (`src/frontend/`) and a **Rust IC canister** backend
-  (`src/backend/`, with shared crate `src/shared/`).
-- For the chain-specific frontend layout (`$btc`, `$eth`, `$evm`, `$icp`,
-  `$sol`, `$icp-eth`, `$lib`, `$env`, `$routes`), see
+- Frontend structure (path aliases, file suffixes, decision tree):
   [`docs/ai/frontend/structure.md`](../docs/ai/frontend/structure.md).
-- For the Rust canister layout (`api/`, `state/`, `types/`, `utils/`,
-  `signer/`, …) and the shared types crate, see
+- Backend / Rust canister structure:
   [`docs/ai/backend/structure.md`](../docs/ai/backend/structure.md).
-- PR title is enforced by CI: `verb(scope): description`. Body must include
-  `# Motivation`, `# Changes`, `# Tests`. Full rules:
+- PR title is enforced by CI: `verb(scope): description`. Body must
+  include `# Motivation`, `# Changes`, `# Tests`. Full rules:
   [`docs/ai/pr-and-ci.md`](../docs/ai/pr-and-ci.md).
 
 ## Non-negotiables on every suggestion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,21 +13,19 @@ file. If it doesn't, point it here.
 ## 1. What this repo is
 
 `dfinity/oisy-wallet` is a multi-chain crypto wallet running entirely on the
-Internet Computer. It is a multi-stack repo:
+Internet Computer. Stack and dependencies are discoverable from `package.json`
+and `Cargo.toml`. The non-obvious bits:
 
-| Stack              | Path                                            | Language                                  | Status                                                                                                                                                                                             |
-| ------------------ | ----------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Frontend           | `src/frontend/`                                 | SvelteKit 2 + Svelte 5 + TS + Tailwind v4 | **AI-active**                                                                                                                                                                                      |
-| Backend canister   | `src/backend/`                                  | Rust (`wasm32-unknown-unknown`)           | **AI-active**                                                                                                                                                                                      |
-| Shared crate       | `src/shared/`                                   | Rust                                      | **AI-active**                                                                                                                                                                                      |
-| Generated bindings | `src/declarations/`                             | TS / Candid (generated)                   | **Do not hand-edit**                                                                                                                                                                               |
-| Benchmarks         | `src/backend/src/benchmark.rs`, `canbench.yml`  | Rust + canbench-rs                        | **Active but lightly maintained.** Update when touching hot paths — see [`docs/ai/backend/testing.md#benchmarks--canbench`](./docs/ai/backend/testing.md#benchmarks--canbench).                    |
-| E2E tests          | `e2e/`                                          | TypeScript (Playwright)                   | **Maintenance-only.** Default rule: do not add new specs — see [`docs/ai/frontend/testing.md#e2e-status-temporarily-restricted`](./docs/ai/frontend/testing.md#e2e-status-temporarily-restricted). |
-| Scripts            | `scripts/`                                      | Bash / Node                               | Restricted                                                                                                                                                                                         |
-| CI / infra         | `.github/workflows/`, `dfx.json`, `Dockerfile*` | Mixed                                     | Restricted                                                                                                                                                                                         |
-
-Both **frontend and backend** are areas where agents are expected to ship PRs
-with little to no human review. CI gates and CODEOWNERS still apply.
+- **AI-active areas (ship with little to no human review):** `src/frontend/`,
+  `src/backend/`, `src/shared/`. CI gates and CODEOWNERS still apply.
+- **Do not hand-edit:** `src/declarations/` (regenerate via `npm run generate`).
+- **Restricted (ask before changing):** `scripts/`, `.github/workflows/`,
+  `dfx.json`, `Dockerfile*`.
+- **E2E (`e2e/`) is maintenance-only** — do not add new Playwright specs by
+  default. See [`docs/ai/frontend/testing.md#e2e-status-temporarily-restricted`](./docs/ai/frontend/testing.md#e2e-status-temporarily-restricted).
+- **Benchmarks** (`src/backend/src/benchmark.rs`, `canbench.yml`) are
+  lightly maintained — update when touching hot paths. See
+  [`docs/ai/backend/testing.md#benchmarks--canbench`](./docs/ai/backend/testing.md#benchmarks--canbench).
 
 ---
 

--- a/docs/ai/frontend/README.md
+++ b/docs/ai/frontend/README.md
@@ -29,27 +29,24 @@ starting point. Read it once per session.
 
 ## Stack at a glance
 
-- **SvelteKit 2 + Svelte 5**, TypeScript everywhere. The codebase is
-  mid-migration: new code uses runes, but Svelte stores
-  (`writable` / `readable` / `derived` from `svelte/store`) remain the
-  primary cross-route reactive primitive. Both are first-class.
-- **Tailwind v4** (`@tailwindcss/postcss`).
-- **`@dfinity/gix-components`** for many UI primitives.
-- **`@icp-sdk/{auth,canisters,core}`**, **`@dfinity/utils`**,
-  **`@dfinity/zod-schemas`**, **`@dfinity/oisy-wallet-signer`** for IC plumbing.
-- **EVM:** `ethers`, `viem`. **Solana:** `@solana/kit`,
-  `@solana-program/*`. **Bitcoin:** `bitcoinjs-lib`. **WalletConnect:**
-  `@reown/walletkit`.
-- **i18n:** typed keys generated from `src/frontend/src/lib/i18n/en.json`
-  via `npm run i18n`. Other locales auto-translated by the
+Framework, UI lib, chain SDKs, and dev tooling are discoverable from
+[`package.json`](../../../package.json). The non-obvious bits:
+
+- **Svelte 5 mid-migration.** New code uses runes; existing Svelte stores
+  stay in place — do not migrate them in unrelated PRs. See
+  [`stack-and-patterns.md`](./stack-and-patterns.md).
+- **i18n** keys are generated from `src/frontend/src/lib/i18n/en.json` via
+  `npm run i18n`. Non-`en` locales are auto-translated by the
   `auto-update-i18n` workflow — never hand-edit them.
-- **Testing:** Vitest 4 + `@testing-library/svelte` + `jsdom` (sharded 20×
-  in CI). Playwright for e2e under `e2e/`.
+- **Testing.** Vitest 4 + `@testing-library/svelte` + `jsdom`, sharded 20×
+  in CI. Specs live under `src/frontend/src/tests/` mirroring source
+  (never co-located). Playwright (`e2e/`) is maintenance-only.
 - **Path aliases** (declared in
   [`svelte.config.js`](../../../svelte.config.js) and
   [`vitest.config.ts`](../../../vitest.config.ts)): `$lib`, `$routes`,
   `$btc`, `$eth`, `$evm`, `$icp`, `$sol`, `$icp-eth`, `$env`,
-  `$declarations`, `$tests`.
+  `$declarations`, `$tests`. Relative imports under `src/frontend/src/`
+  are an ESLint error.
 
 ## Where things go (one-liner)
 


### PR DESCRIPTION
# Motivation

Flagged by @yhabib

Per [Addy Osmani — Stop Using /init for AGENTS.md](https://addyosmani.com/blog/agents-md/): codebase overviews are the largest category of redundant content in agent docs (the ETH Zurich paper found 100% of Sonnet 4.5 and 99% of GPT-5.2 auto-generated files contain one) and they hurt accuracy by anchoring on equally-weighted package lists.

# Changes

- `AGENTS.md` §1: replace the verbose stack/path/language/status table with a bullet list that keeps only the non-discoverable signal (AI-active vs restricted areas, generated dirs, e2e maintenance-only, benchmarks). Stack is one read of `package.json` / `Cargo.toml` away.
- `docs/ai/frontend/README.md` "Stack at a glance": drop the enumerated package list (`ethers`, `viem`, `@solana/kit`, `@reown/walletkit`, `bitcoinjs-lib`, `@dfinity/*`, …). Keep the i18n auto-translation note, the Svelte 5 migration note, the 20-shard test setup, and the path aliases (config artifact, non-discoverable).
- `.github/copilot-instructions.md` "TL;DR": drop the multi-stack restatement; keep the structure pointers and the forbidden-substitutions list below (the substitution names are non-discoverable).

# Tests

Docs-only change. Same operational information remains available in the linked `docs/ai/**` pages, which the agent loads on demand when relevant to the task.

