### PR TITLE
docs(ai): defuse anchoring on legacy Svelte-stores pattern

### DIFF
--- a/docs/ai/frontend/stack-and-patterns.md
+++ b/docs/ai/frontend/stack-and-patterns.md
@@ -6,17 +6,18 @@ code wins (truth hierarchy in [governance.md](../governance.md)). Update
 this page in the same PR — that's the
 [meta-update rule](../governance.md#meta-update-rule).
 
-## Svelte — runes preferred for new code, stores still pervasive
+## Svelte — runes for new code
 
-The repo is **Svelte 5** but uses both reactive primitives:
+The repo is **Svelte 5**. For new code, default to runes (`$state`,
+`$derived`, `$effect`, `$props`, `$bindable`).
 
-- **Runes** (`$state`, `$derived`, `$effect`, `$props`, `$bindable`) — new
-  components and component-local state.
-- **Svelte stores** (`writable`, `readable`, `derived` from
-  `svelte/store`) — cross-component / cross-route reactive state. There is
-  a large existing graph in `$lib/derived/`, `$lib/stores/`, and the
-  per-chain `*/derived/` and `*/stores/` folders. Keep adding to it where
-  it fits an existing shape.
+A large existing Svelte-store graph lives in `$lib/derived/`,
+`$lib/stores/`, and per-chain `*/derived/` and `*/stores/` folders. It
+predates the runes migration. **Read from it freely; do not migrate it
+in unrelated PRs.** Author new reactive state as runes; only fall back to
+`writable` / `readable` / `derived` from `svelte/store` when extending an
+existing store graph in place (see [Svelte stores — when to reuse them](#svelte-stores--when-to-reuse-them)
+below).
 
 Inside a component, prefer the rune syntax for new code:
 
@@ -77,9 +78,10 @@ runes` and contain no behaviour change.
   When you suspect a runaway, use `__oisyReactivityDebug.printTop()` in
   the browser console.
 
-### Svelte stores — when to use them
+### Svelte stores — when to reuse them
 
-Many cross-route values are still expressed as Svelte stores. Use them for:
+The following cross-route values are already expressed as Svelte stores.
+**Consume the existing store; do not re-implement these as runes:**
 
 - Auth / identity state (`$lib/stores/auth.store`,
   `$lib/derived/auth.derived`).
@@ -87,10 +89,11 @@ Many cross-route values are still expressed as Svelte stores. Use them for:
 - Toasts, modals, busy-state (`$lib/stores/toasts.store`,
   `modal.store`, `busy.store`).
 - Per-chain enabled tokens / networks (`$<chain>/derived/...`).
-- Anything composed via `derived([a, b], ([$a, $b]) => …)` from existing
-  stores.
 
-When unsure, look at the closest neighbour and follow the same shape.
+When extending an existing store graph (e.g. a new `derived([a, b], …)`
+composed from those stores), match the surrounding shape. For brand-new
+cross-route state with no neighbour to follow, prefer a rune-based module
+(`*.svelte.ts`).
 
 ## TypeScript
 

--- a/docs/ai/frontend/stack-and-patterns.md
+++ b/docs/ai/frontend/stack-and-patterns.md
@@ -162,14 +162,14 @@ export const exchangeRateUsdToCurrency = async (
 
 ## Stores, derived, runes — when to use which
 
-| Need                                           | Use                                                                             | Where it lives                                                         |
-| ---------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| Component-local mutable value                  | `$state`                                                                        | Inside the component                                                   |
-| Component-local computed value                 | `$derived` / `$derived.by`                                                      | Inside the component                                                   |
-| Side effect (DOM, network, subscription)       | `$effect` (or `onMount` for true mount work)                                    | Inside the component                                                   |
-| Value shared by 2+ components in the same page | Pass via props / snippets                                                       | —                                                                      |
+| Need                                           | Use                                                                                                                                                | Where it lives                                                         |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Component-local mutable value                  | `$state`                                                                                                                                           | Inside the component                                                   |
+| Component-local computed value                 | `$derived` / `$derived.by`                                                                                                                         | Inside the component                                                   |
+| Side effect (DOM, network, subscription)       | `$effect` (or `onMount` for true mount work)                                                                                                       | Inside the component                                                   |
+| Value shared by 2+ components in the same page | Pass via props / snippets                                                                                                                          | —                                                                      |
 | Value shared across routes                     | `*.svelte.ts` rune-state module by default; [reuse the existing store graph](#svelte-stores--when-to-reuse-them) when one already covers the value | `$lib/stores/`, `<chain>/stores/`, `$lib/derived/`, `<chain>/derived/` |
-| Cached server data                             | The matching `*.services.ts` owns the cache                                     | —                                                                      |
+| Cached server data                             | The matching `*.services.ts` owns the cache                                                                                                        | —                                                                      |
 
 Avoid duplicating server state into a local store — fetch via the service
 layer and let the service own caching.

--- a/docs/ai/frontend/stack-and-patterns.md
+++ b/docs/ai/frontend/stack-and-patterns.md
@@ -168,7 +168,7 @@ export const exchangeRateUsdToCurrency = async (
 | Component-local computed value                 | `$derived` / `$derived.by`                                                      | Inside the component                                                   |
 | Side effect (DOM, network, subscription)       | `$effect` (or `onMount` for true mount work)                                    | Inside the component                                                   |
 | Value shared by 2+ components in the same page | Pass via props / snippets                                                       | —                                                                      |
-| Value shared across routes                     | A Svelte `writable` / `readable` store **or** a `*.svelte.ts` rune-state module | `$lib/stores/`, `<chain>/stores/`, `$lib/derived/`, `<chain>/derived/` |
+| Value shared across routes                     | `*.svelte.ts` rune-state module by default; [reuse the existing store graph](#svelte-stores--when-to-reuse-them) when one already covers the value | `$lib/stores/`, `<chain>/stores/`, `$lib/derived/`, `<chain>/derived/` |
 | Cached server data                             | The matching `*.services.ts` owns the cache                                     | —                                                                      |
 
 Avoid duplicating server state into a local store — fetch via the service


### PR DESCRIPTION
# Motivation

Flagged by @yhabib

Per [Addy Osmani — Stop Using /init for AGENTS.md](https://addyosmani.com/blog/agents-md/), the "pink elephant" problem: a legacy pattern mentioned at equal weight in always-loaded context biases the model toward it on every prompt. Today `docs/ai/frontend/stack-and-patterns.md` heads with "runes preferred for new code, stores still pervasive" and tells the agent to "keep adding to it where it fits" — wording that pulls new reactive state toward stores even when runes would be the better default.

# Changes

- Rename the section to "Svelte — runes for new code".
- Reframe stores as an existing graph to read freely and not migrate in unrelated PRs.
- Rename "Svelte stores — when to use them" to "when to reuse them"; reframe the catalog as stores to consume, not new ones to author.
- Direct brand-new cross-route state with no neighbour to follow toward a rune-based `*.svelte.ts` module.

# Tests

Docs-only change. No code semantics change; existing components continue to work.
