### PR TITLE
fix(devops): download ckbtc_minter wasm into target/ic, not filesystem root

### DIFF
--- a/scripts/download.ckbtc.sh
+++ b/scripts/download.ckbtc.sh
@@ -10,7 +10,7 @@ fi
 
 IC_COMMIT="03dd6ee6de80c2202f66948692c69c61eb6af54d"
 
-scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-minter.wasm.gz" /ckbtc_minter.wasm.gz
+scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-ckbtc-minter.wasm.gz" "$DIR"/ckbtc_minter.wasm.gz
 gunzip --keep --force "$DIR"/ckbtc_minter.wasm.gz
 
 scripts/download-immutable.sh "https://download.dfinity.systems/ic/$IC_COMMIT/canisters/ic-icrc1-ledger.wasm.gz" "$DIR"/ckbtc_ledger.wasm.gz


### PR DESCRIPTION
# Motivation

Follow-up to #12767. With `scripts/build.ckbtc_minter.sh` now executable, the e2e workflow gets a step further and now fails inside `scripts/download.ckbtc.sh`, which tries to download `ic-ckbtc-minter.wasm.gz` to `/ckbtc_minter.wasm.gz` (filesystem root) instead of `target/ic/ckbtc_minter.wasm.gz`. Typo from #6765; every sibling line uses `"$DIR"/...`.
