### PR TITLE
feat(frontend): skip Solana tx detail fetch when head signature unchanged

### DIFF
--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -148,12 +148,18 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 			}
 		}
 
+		const exitIfFirstSignatureMatches =
+			storedTransactions.length > 0 && nonNullish(storedTransactions[0]?.data.signature)
+				? String(storedTransactions[0].data.signature)
+				: undefined;
+
 		const rpcTransactions = await getSolTransactions({
 			network,
 			identity,
 			address,
 			tokenAddress,
-			tokenOwnerAddress
+			tokenOwnerAddress,
+			exitIfFirstSignatureMatches
 		});
 
 		const rpcCertified = rpcTransactions.map((transaction) => ({

--- a/src/frontend/src/sol/services/sol-signatures.services.ts
+++ b/src/frontend/src/sol/services/sol-signatures.services.ts
@@ -116,6 +116,7 @@ export const getSolTransactions = async ({
 	});
 
 	if (
+		isNullish(before) &&
 		nonNullish(exitIfFirstSignatureMatches) &&
 		signatures.length > 0 &&
 		String(signatures[0].signature) === exitIfFirstSignatureMatches

--- a/src/frontend/src/sol/services/sol-signatures.services.ts
+++ b/src/frontend/src/sol/services/sol-signatures.services.ts
@@ -84,7 +84,8 @@ export const getSolTransactions = async ({
 	tokenAddress,
 	tokenOwnerAddress,
 	before,
-	limit = Number(WALLET_PAGINATION)
+	limit = Number(WALLET_PAGINATION),
+	exitIfFirstSignatureMatches
 }: GetSolTransactionsParams): Promise<SolTransactionUi[]> => {
 	if (nonNullish(tokenAddress)) {
 		assertIsAddress(tokenAddress);
@@ -113,6 +114,14 @@ export const getSolTransactions = async ({
 		before: beforeSignature,
 		limit
 	});
+
+	if (
+		nonNullish(exitIfFirstSignatureMatches) &&
+		signatures.length > 0 &&
+		String(signatures[0].signature) === exitIfFirstSignatureMatches
+	) {
+		return [];
+	}
 
 	return await signatures.reduce(
 		async (accPromise, signature) => {

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -314,6 +314,7 @@ const loadSolTransactions = async ({
 	identity,
 	address,
 	tokenAddress,
+	before,
 	...rest
 }: LoadSolTransactionsParams): Promise<SolCertifiedTransaction[]> => {
 	try {
@@ -327,15 +328,25 @@ const loadSolTransactions = async ({
 				})
 			: undefined;
 
+		const storedTransactions = stored?.transactions ?? [];
+
+		const exitIfFirstSignatureMatches =
+			USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED &&
+			isNullish(before) &&
+			storedTransactions.length > 0 &&
+			nonNullish(storedTransactions[0]?.signature)
+				? String(storedTransactions[0].signature)
+				: undefined;
+
 		const newTransactions = await getSolTransactions({
 			network,
 			identity,
 			address,
 			tokenAddress,
+			before,
+			exitIfFirstSignatureMatches,
 			...rest
 		});
-
-		const storedTransactions = stored?.transactions ?? [];
 		const newestStoredSlot = stored?.newestBlockIndex;
 
 		// Filter RPC results to only include transactions from slots newer than the stored data.

--- a/src/frontend/src/sol/types/sol-api.ts
+++ b/src/frontend/src/sol/types/sol-api.ts
@@ -13,8 +13,9 @@ export interface GetSolTransactionsParams {
 	before?: string;
 	limit?: number;
 	/**
-	 * When set, compares this to the newest RPC signature after `fetchSignatures`.
-	 * If they match, skips parsing transaction details (no new activity at the head of history).
+	 * Head loads only (`before` unset): when set, compares to the first signature returned by
+	 * `fetchSignatures` (the newest page item). If they match, skips per-signature detail fetches.
+	 * Ignored when `before` is set — paginated pages are not global chain head.
 	 */
 	exitIfFirstSignatureMatches?: string;
 }

--- a/src/frontend/src/sol/types/sol-api.ts
+++ b/src/frontend/src/sol/types/sol-api.ts
@@ -12,6 +12,11 @@ export interface GetSolTransactionsParams {
 	tokenOwnerAddress?: SolAddress;
 	before?: string;
 	limit?: number;
+	/**
+	 * When set, compares this to the newest RPC signature after `fetchSignatures`.
+	 * If they match, skips parsing transaction details (no new activity at the head of history).
+	 */
+	exitIfFirstSignatureMatches?: string;
 }
 
 export type LoadSolTransactionsParams = GetSolTransactionsParams & {

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -331,6 +331,22 @@ describe('sol-signatures.services', () => {
 			expect(spyFetchTransactionsForSignature).not.toHaveBeenCalled();
 		});
 
+		it('should not skip parsing when before is set even if exitIfFirstSignatureMatches matches the page head', async () => {
+			const [pageHead] = mockSignatures;
+			const before = mockSolSignature();
+
+			const transactions = await getSolTransactions({
+				identity: mockIdentity,
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				before,
+				exitIfFirstSignatureMatches: String(pageHead.signature)
+			});
+
+			expect(transactions).toHaveLength(mockSignatures.length * mockSolTransactions.length);
+			expect(spyFetchTransactionsForSignature).toHaveBeenCalledTimes(mockSignatures.length);
+		});
+
 		it('should handle empty transactions responses', async () => {
 			spyFetchSignatures.mockReturnValue([mockSolSignatureResponse()]);
 			spyFetchTransactionsForSignature.mockReturnValue([]);

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -316,6 +316,21 @@ describe('sol-signatures.services', () => {
 			expect(spyFetchTransactionsForSignature).not.toHaveBeenCalled();
 		});
 
+		it('should skip parsing when exitIfFirstSignatureMatches equals the newest RPC signature', async () => {
+			const head = mockSignatures[0];
+
+			const transactions = await getSolTransactions({
+				identity: mockIdentity,
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				exitIfFirstSignatureMatches: String(head.signature)
+			});
+
+			expect(transactions).toEqual([]);
+			expect(spyFetchSignatures).toHaveBeenCalledOnce();
+			expect(spyFetchTransactionsForSignature).not.toHaveBeenCalled();
+		});
+
 		it('should handle empty transactions responses', async () => {
 			spyFetchSignatures.mockReturnValue([mockSolSignatureResponse()]);
 			spyFetchTransactionsForSignature.mockReturnValue([]);

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -317,7 +317,7 @@ describe('sol-signatures.services', () => {
 		});
 
 		it('should skip parsing when exitIfFirstSignatureMatches equals the newest RPC signature', async () => {
-			const head = mockSignatures[0];
+			const [head] = mockSignatures;
 
 			const transactions = await getSolTransactions({
 				identity: mockIdentity,

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -554,6 +554,51 @@ describe('sol-transactions.services', () => {
 			});
 		});
 
+		it('should pass exitIfFirstSignatureMatches when loading head with backend-stored transactions', async () => {
+			const storedTransactions = createMockSolTransactionsUi(2).map((tx, i) => ({
+				...tx,
+				id: `stored-${i}`
+			}));
+
+			vi.mocked(loadSolUserTransactions).mockResolvedValue({
+				transactions: storedTransactions,
+				newestBlockIndex: 100n,
+				oldestBlockIndex: 50n,
+				nextStart: undefined,
+				totalStored: 2n
+			});
+			spyGetTransactions.mockResolvedValueOnce([]);
+
+			await loadNextSolTransactions(mockParams);
+
+			expect(spyGetTransactions).toHaveBeenCalledWith(
+				expect.objectContaining({
+					exitIfFirstSignatureMatches: String(storedTransactions[0].signature)
+				})
+			);
+		});
+
+		it('should not pass exitIfFirstSignatureMatches when paginating with before', async () => {
+			const storedTransactions = createMockSolTransactionsUi(2);
+
+			vi.mocked(loadSolUserTransactions).mockResolvedValue({
+				transactions: storedTransactions,
+				newestBlockIndex: 100n,
+				oldestBlockIndex: 50n,
+				nextStart: undefined,
+				totalStored: 2n
+			});
+
+			const before = mockSolSignature();
+			spyGetTransactions.mockResolvedValueOnce([]);
+
+			await loadNextSolTransactions({ ...mockParams, before, limit: 10 });
+
+			const [callArg] = spyGetTransactions.mock.calls[0];
+			expect(callArg.exitIfFirstSignatureMatches).toBeUndefined();
+			expect(callArg.before).toBe(before);
+		});
+
 		it('should combine stored and new transactions in the store', async () => {
 			const storedTransactions = createMockSolTransactionsUi(2).map((tx, i) => ({
 				...tx,

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -559,6 +559,7 @@ describe('sol-transactions.services', () => {
 				...tx,
 				id: `stored-${i}`
 			}));
+			const [firstStored] = storedTransactions;
 
 			vi.mocked(loadSolUserTransactions).mockResolvedValue({
 				transactions: storedTransactions,
@@ -573,7 +574,7 @@ describe('sol-transactions.services', () => {
 
 			expect(spyGetTransactions).toHaveBeenCalledWith(
 				expect.objectContaining({
-					exitIfFirstSignatureMatches: String(storedTransactions[0].signature)
+					exitIfFirstSignatureMatches: String(firstStored.signature)
 				})
 			);
 		});
@@ -594,7 +595,8 @@ describe('sol-transactions.services', () => {
 
 			await loadNextSolTransactions({ ...mockParams, before, limit: 10 });
 
-			const [callArg] = spyGetTransactions.mock.calls[0];
+			const [[callArg]] = spyGetTransactions.mock.calls;
+
 			expect(callArg.exitIfFirstSignatureMatches).toBeUndefined();
 			expect(callArg.before).toBe(before);
 		});


### PR DESCRIPTION
# Motivation

Reduce redundant Solana RPC work when reloading transactions and the newest on-chain signature matches what we already have from the backend.
