### PR TITLE
feat(frontend): skip Etherscan when ETH incremental window is empty

### DIFF
--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -80,7 +80,7 @@ export const reloadEthereumTransactions = (params: {
 
 const maxEthNativeBlockNumberInStore = (tokenId: TokenId): number | undefined => {
 	const rows = get(ethTransactionsStore)?.[tokenId];
-	
+
 	if (isNullish(rows) || rows.length === 0) {
 		return;
 	}
@@ -95,8 +95,8 @@ const maxEthNativeBlockNumberInStore = (tokenId: TokenId): number | undefined =>
 };
 
 /**
-* Next Etherscan `startBlock` after the newest known height; backend cursor wins over the store. 
-*/
+ * Next Etherscan `startBlock` after the newest known height; backend cursor wins over the store.
+ */
 const resolveEthIncrementalStartBlock = ({
 	newestStoredBlockIndex,
 	maxBlockFromTransactionsStore
@@ -107,11 +107,11 @@ const resolveEthIncrementalStartBlock = ({
 	if (nonNullish(newestStoredBlockIndex)) {
 		return Number(newestStoredBlockIndex) + 1;
 	}
-	
+
 	if (nonNullish(maxBlockFromTransactionsStore)) {
 		return maxBlockFromTransactionsStore + 1;
 	}
-	
+
 	return 0;
 };
 
@@ -137,9 +137,9 @@ const loadNewEthNativeTransactionsAfterStartBlock = async ({
 	const tipReachesStartBlock = await (async (): Promise<boolean> => {
 		try {
 			const { getBlockNumber } = infuraProviders(networkId);
-			
+
 			const latestBlockNumber = await getBlockNumber();
-			
+
 			return latestBlockNumber >= startBlock;
 		} catch (_: unknown) {
 			// If we cannot read the tip, still query Etherscan rather than leave the UI stale.

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -80,20 +80,23 @@ export const reloadEthereumTransactions = (params: {
 
 const maxEthNativeBlockNumberInStore = (tokenId: TokenId): number | undefined => {
 	const rows = get(ethTransactionsStore)?.[tokenId];
+	
 	if (isNullish(rows) || rows.length === 0) {
-		return undefined;
+		return;
 	}
 
 	const blocks = rows.map(({ data }) => data.blockNumber).filter(nonNullish);
 
 	if (blocks.length === 0) {
-		return undefined;
+		return;
 	}
 
 	return Math.max(...blocks);
 };
 
-/** Next Etherscan `startBlock` after the newest known height; backend cursor wins over the store. */
+/**
+* Next Etherscan `startBlock` after the newest known height; backend cursor wins over the store. 
+*/
 const resolveEthIncrementalStartBlock = ({
 	newestStoredBlockIndex,
 	maxBlockFromTransactionsStore
@@ -104,9 +107,11 @@ const resolveEthIncrementalStartBlock = ({
 	if (nonNullish(newestStoredBlockIndex)) {
 		return Number(newestStoredBlockIndex) + 1;
 	}
+	
 	if (nonNullish(maxBlockFromTransactionsStore)) {
 		return maxBlockFromTransactionsStore + 1;
 	}
+	
 	return 0;
 };
 
@@ -132,7 +137,9 @@ const loadNewEthNativeTransactionsAfterStartBlock = async ({
 	const tipReachesStartBlock = await (async (): Promise<boolean> => {
 		try {
 			const { getBlockNumber } = infuraProviders(networkId);
+			
 			const latestBlockNumber = await getBlockNumber();
+			
 			return latestBlockNumber >= startBlock;
 		} catch (_: unknown) {
 			// If we cannot read the tip, still query Etherscan rather than leave the UI stale.

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -78,6 +78,75 @@ export const reloadEthereumTransactions = (params: {
 	silent?: boolean;
 }): Promise<ResultSuccess> => loadEthereumTransactions({ ...params, updateOnly: true });
 
+const maxEthNativeBlockNumberInStore = (tokenId: TokenId): number | undefined => {
+	const rows = get(ethTransactionsStore)?.[tokenId];
+	if (isNullish(rows) || rows.length === 0) {
+		return undefined;
+	}
+
+	const blocks = rows.map(({ data }) => data.blockNumber).filter(nonNullish);
+
+	if (blocks.length === 0) {
+		return undefined;
+	}
+
+	return Math.max(...blocks);
+};
+
+/** Next Etherscan `startBlock` after the newest known height; backend cursor wins over the store. */
+const resolveEthIncrementalStartBlock = ({
+	newestStoredBlockIndex,
+	maxBlockFromTransactionsStore
+}: {
+	newestStoredBlockIndex: bigint | undefined;
+	maxBlockFromTransactionsStore: number | undefined;
+}): number => {
+	if (nonNullish(newestStoredBlockIndex)) {
+		return Number(newestStoredBlockIndex) + 1;
+	}
+	if (nonNullish(maxBlockFromTransactionsStore)) {
+		return maxBlockFromTransactionsStore + 1;
+	}
+	return 0;
+};
+
+/**
+ * Fetches native ETH history from Etherscan after `startBlock` (exclusive lower bound in API terms).
+ * For incremental loads, skips the request when Infura reports the chain tip is still below `startBlock`.
+ */
+const loadNewEthNativeTransactionsAfterStartBlock = async ({
+	networkId,
+	address,
+	startBlock
+}: {
+	networkId: NetworkId;
+	address: Address;
+	startBlock: number;
+}): Promise<Transaction[]> => {
+	const { transactions: transactionsProvider } = etherscanProviders(networkId);
+
+	if (startBlock === 0) {
+		return transactionsProvider({ address, startBlock: 0, sort: 'desc' });
+	}
+
+	const tipReachesStartBlock = await (async (): Promise<boolean> => {
+		try {
+			const { getBlockNumber } = infuraProviders(networkId);
+			const latestBlockNumber = await getBlockNumber();
+			return latestBlockNumber >= startBlock;
+		} catch (_: unknown) {
+			// If we cannot read the tip, still query Etherscan rather than leave the UI stale.
+			return true;
+		}
+	})();
+
+	if (!tipReachesStartBlock) {
+		return [];
+	}
+
+	return transactionsProvider({ address, startBlock, sort: 'desc' });
+};
+
 const loadEthTransactions = async ({
 	identity,
 	networkId,
@@ -106,38 +175,18 @@ const loadEthTransactions = async ({
 			? await loadEthUserTransactions({ identity, tokenId: transactionTokenId })
 			: undefined;
 
-		// Fetch from Etherscan starting after the newest stored block (incremental loading).
-		// When the backend has no cursor yet, reuse the highest block already shown in the store so
-		// production (backend persistence disabled) still avoids `startBlock: 0` full-history pulls on refresh.
-		let startBlock = nonNullish(stored?.newestBlockIndex) ? Number(stored.newestBlockIndex) + 1 : 0;
+		const startBlock = resolveEthIncrementalStartBlock({
+			newestStoredBlockIndex: stored?.newestBlockIndex,
+			maxBlockFromTransactionsStore: nonNullish(stored?.newestBlockIndex)
+				? undefined
+				: maxEthNativeBlockNumberInStore(tokenId)
+		});
 
-		if (startBlock === 0) {
-			const maxBlockFromStore = maxEthNativeBlockNumberInStore(tokenId);
-			if (nonNullish(maxBlockFromStore)) {
-				startBlock = maxBlockFromStore + 1;
-			}
-		}
-
-		const { transactions: transactionsProvider } = etherscanProviders(networkId);
-
-		let newTransactions: Transaction[];
-
-		if (startBlock > 0) {
-			try {
-				const { getBlockNumber } = infuraProviders(networkId);
-				const latestBlockNumber = await getBlockNumber();
-
-				if (latestBlockNumber < startBlock) {
-					newTransactions = [];
-				} else {
-					newTransactions = await transactionsProvider({ address, startBlock, sort: 'desc' });
-				}
-			} catch (_: unknown) {
-				newTransactions = await transactionsProvider({ address, startBlock, sort: 'desc' });
-			}
-		} else {
-			newTransactions = await transactionsProvider({ address, startBlock: 0, sort: 'desc' });
-		}
+		const newTransactions = await loadNewEthNativeTransactionsAfterStartBlock({
+			networkId,
+			address,
+			startBlock
+		});
 
 		// Combine newest-first: new transactions (desc) then stored (desc from backend)
 		const allTransactions = [...newTransactions, ...(stored?.transactions ?? [])];
@@ -370,21 +419,6 @@ const loadErc721Transactions = async ({
 	return await retryWithDelay({
 		request: async () => await erc721Transactions({ contract: token, address })
 	});
-};
-
-const maxEthNativeBlockNumberInStore = (tokenId: TokenId): number | undefined => {
-	const rows = get(ethTransactionsStore)?.[tokenId];
-	if (isNullish(rows) || rows.length === 0) {
-		return undefined;
-	}
-
-	const blocks = rows.map(({ data }) => data.blockNumber).filter(nonNullish);
-
-	if (blocks.length === 0) {
-		return undefined;
-	}
-
-	return Math.max(...blocks);
 };
 
 const loadErc1155Transactions = async ({

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -7,6 +7,7 @@ import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import { enabledErc721Tokens } from '$eth/derived/erc721.derived';
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
 import { etherscanProviders } from '$eth/providers/etherscan.providers';
+import { infuraProviders } from '$eth/providers/infura.providers';
 import {
 	loadEthUserTransactions,
 	saveEthFinalizedTransactions
@@ -105,13 +106,38 @@ const loadEthTransactions = async ({
 			? await loadEthUserTransactions({ identity, tokenId: transactionTokenId })
 			: undefined;
 
-		// Fetch from Etherscan starting after the newest stored block (incremental loading)
-		const startBlock = nonNullish(stored?.newestBlockIndex)
-			? Number(stored.newestBlockIndex) + 1
-			: 0;
+		// Fetch from Etherscan starting after the newest stored block (incremental loading).
+		// When the backend has no cursor yet, reuse the highest block already shown in the store so
+		// production (backend persistence disabled) still avoids `startBlock: 0` full-history pulls on refresh.
+		let startBlock = nonNullish(stored?.newestBlockIndex) ? Number(stored.newestBlockIndex) + 1 : 0;
+
+		if (startBlock === 0) {
+			const maxBlockFromStore = maxEthNativeBlockNumberInStore(tokenId);
+			if (nonNullish(maxBlockFromStore)) {
+				startBlock = maxBlockFromStore + 1;
+			}
+		}
 
 		const { transactions: transactionsProvider } = etherscanProviders(networkId);
-		const newTransactions = await transactionsProvider({ address, startBlock, sort: 'desc' });
+
+		let newTransactions: Transaction[];
+
+		if (startBlock > 0) {
+			try {
+				const { getBlockNumber } = infuraProviders(networkId);
+				const latestBlockNumber = await getBlockNumber();
+
+				if (latestBlockNumber < startBlock) {
+					newTransactions = [];
+				} else {
+					newTransactions = await transactionsProvider({ address, startBlock, sort: 'desc' });
+				}
+			} catch (_: unknown) {
+				newTransactions = await transactionsProvider({ address, startBlock, sort: 'desc' });
+			}
+		} else {
+			newTransactions = await transactionsProvider({ address, startBlock: 0, sort: 'desc' });
+		}
 
 		// Combine newest-first: new transactions (desc) then stored (desc from backend)
 		const allTransactions = [...newTransactions, ...(stored?.transactions ?? [])];
@@ -344,6 +370,21 @@ const loadErc721Transactions = async ({
 	return await retryWithDelay({
 		request: async () => await erc721Transactions({ contract: token, address })
 	});
+};
+
+const maxEthNativeBlockNumberInStore = (tokenId: TokenId): number | undefined => {
+	const rows = get(ethTransactionsStore)?.[tokenId];
+	if (isNullish(rows) || rows.length === 0) {
+		return undefined;
+	}
+
+	const blocks = rows.map(({ data }) => data.blockNumber).filter(nonNullish);
+
+	if (blocks.length === 0) {
+		return undefined;
+	}
+
+	return Math.max(...blocks);
 };
 
 const loadErc1155Transactions = async ({

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -56,6 +56,16 @@ vi.mock('$env/user-transactions.env', () => ({
 	USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED: true
 }));
 
+const infuraMocks = vi.hoisted(() => ({
+	mockInfuraGetBlockNumber: vi.fn().mockResolvedValue(99_999_999)
+}));
+
+vi.mock('$eth/providers/infura.providers', () => ({
+	infuraProviders: vi.fn(() => ({
+		getBlockNumber: infuraMocks.mockInfuraGetBlockNumber
+	}))
+}));
+
 describe('eth-transactions.services', () => {
 	const mockErc20CustomTokens = [USDC_TOKEN, LINK_TOKEN, PEPE_TOKEN].map((token) => ({
 		data: { ...token, enabled: true },
@@ -303,6 +313,14 @@ describe('eth-transactions.services', () => {
 
 				vi.mocked(loadEthUserTransactions).mockResolvedValue(undefined);
 				vi.mocked(saveEthFinalizedTransactions).mockResolvedValue({ success: true });
+
+				infuraMocks.mockInfuraGetBlockNumber.mockReset();
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValue(99_999_999);
+
+				mockEthTransactionsProvider.mockReset();
+				mockEthTransactionsProvider.mockResolvedValue([]);
+
+				ethTransactionsStore.nullify(mockTokenId);
 			});
 
 			it('should return false if address store is empty', async () => {
@@ -356,6 +374,8 @@ describe('eth-transactions.services', () => {
 					startBlock: 0,
 					sort: 'desc'
 				});
+
+				expect(infuraMocks.mockInfuraGetBlockNumber).not.toHaveBeenCalled();
 			});
 
 			it('should fetch incrementally from Etherscan using newestBlockIndex + 1', async () => {
@@ -369,6 +389,7 @@ describe('eth-transactions.services', () => {
 					totalStored: 2n
 				});
 
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(150);
 				mockEthTransactionsProvider.mockResolvedValueOnce([]);
 
 				await loadEthereumTransactions({
@@ -386,6 +407,65 @@ describe('eth-transactions.services', () => {
 				});
 			});
 
+			it('should skip Etherscan when the chain tip is still before the incremental start block', async () => {
+				const storedTransactions = createMockEthTransactions(2);
+
+				vi.mocked(loadEthUserTransactions).mockResolvedValue({
+					transactions: storedTransactions,
+					newestBlockIndex: 100n,
+					oldestBlockIndex: 50n,
+					nextStart: undefined,
+					totalStored: 2n
+				});
+
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(100);
+				mockEthTransactionsProvider.mockResolvedValueOnce([]);
+
+				await loadEthereumTransactions({
+					identity: mockIdentity,
+					networkId: mockNetworkId,
+					tokenId: mockTokenId,
+					chainId: mockChainId,
+					standard: mockStandard
+				});
+
+				expect(mockEthTransactionsProvider).not.toHaveBeenCalled();
+			});
+
+			it('should use max block from the store when the backend has no cursor', async () => {
+				vi.mocked(loadEthUserTransactions).mockResolvedValue(undefined);
+
+				const existingTransactions = createMockEthTransactions(2).map((tx, i) => ({
+					...tx,
+					blockNumber: 300 + i
+				}));
+
+				ethTransactionsStore.set({
+					tokenId: mockTokenId,
+					transactions: existingTransactions.map((data) => ({
+						data,
+						certified: false
+					}))
+				});
+
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(400);
+				mockEthTransactionsProvider.mockResolvedValueOnce([]);
+
+				await loadEthereumTransactions({
+					identity: mockIdentity,
+					networkId: mockNetworkId,
+					tokenId: mockTokenId,
+					chainId: mockChainId,
+					standard: mockStandard
+				});
+
+				expect(mockEthTransactionsProvider).toHaveBeenCalledWith({
+					address: mockEthAddress,
+					startBlock: 302,
+					sort: 'desc'
+				});
+			});
+
 			it('should combine stored and new transactions in the store', async () => {
 				const storedTransactions = createMockEthTransactions(2);
 				const newTransactions = createMockEthTransactions(3);
@@ -398,6 +478,7 @@ describe('eth-transactions.services', () => {
 					totalStored: 2n
 				});
 
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(150);
 				mockEthTransactionsProvider.mockResolvedValueOnce(newTransactions);
 
 				const result = await loadEthereumTransactions({
@@ -521,6 +602,7 @@ describe('eth-transactions.services', () => {
 					totalStored: 2n
 				});
 
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(100);
 				mockEthTransactionsProvider.mockResolvedValueOnce([]);
 
 				await loadEthereumTransactions({
@@ -531,6 +613,7 @@ describe('eth-transactions.services', () => {
 					standard: mockStandard
 				});
 
+				expect(mockEthTransactionsProvider).not.toHaveBeenCalled();
 				expect(saveEthFinalizedTransactions).not.toHaveBeenCalled();
 			});
 


### PR DESCRIPTION
# Motivation

Reduce redundant Etherscan calls when refreshing native ETH transaction lists and the chain has not advanced past the incremental cursor.

# Changes

- Derive incremental `startBlock` from `ethTransactionsStore` when the backend has no newest block.
- When `startBlock > 0`, compare Infura latest block to the cursor and skip Etherscan if there is nothing new to fetch.

# Tests

New tests.
