### PR TITLE
fix(frontend): expose sign-out button on signer pages

### DIFF
--- a/src/frontend/src/lib/components/signer/SignerLogout.svelte
+++ b/src/frontend/src/lib/components/signer/SignerLogout.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import IconLogout from '$lib/components/icons/IconLogout.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { SIGNER_LOGOUT_BUTTON } from '$lib/constants/test-ids.constants';
+	import { signOut } from '$lib/services/auth.services';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	const handleLogout = async () => {
+		await signOut({
+			resetUrl: true,
+			source: 'signer-page'
+		});
+	};
+</script>
+
+<Button
+	ariaLabel={$i18n.auth.text.logout}
+	colorStyle="tertiary"
+	innerStyleClass="items-center justify-center"
+	onclick={handleLogout}
+	paddingSmall
+	styleClass="rounded-lg py-2"
+	testId={SIGNER_LOGOUT_BUTTON}
+	type="button"
+>
+	{$i18n.auth.text.logout}
+	<IconLogout />
+</Button>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -19,6 +19,7 @@ export const CURRENCY_SWITCHER_DROPDOWN = 'currency-switcher-dropdown';
 export const CURRENCY_SWITCHER_DROPDOWN_BUTTON = 'currency-switcher-dropdown-button';
 
 export const LOGOUT_BUTTON = 'logout-button';
+export const SIGNER_LOGOUT_BUTTON = 'signer-logout-button';
 export const LOGIN_BUTTON = 'login-button';
 export const LOGIN_BUTTON_GOOGLE = 'login-button-google';
 export const LOGIN_BUTTON_APPLE = 'login-button-apple';

--- a/src/frontend/src/routes/(sign)/sign/+layout.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+layout.svelte
@@ -3,6 +3,8 @@
 	import Modals from '$lib/components/core/Modals.svelte';
 	import OisyWalletLogoLink from '$lib/components/core/OisyWalletLogoLink.svelte';
 	import PwaBanner from '$lib/components/core/PwaBanner.svelte';
+	import SignerLogout from '$lib/components/signer/SignerLogout.svelte';
+	import { authSignedIn } from '$lib/derived/auth.derived';
 
 	interface Props {
 		children: Snippet;
@@ -12,7 +14,15 @@
 </script>
 
 <main class="mx-auto flex w-full max-w-[576px] flex-col gap-y-6 px-5 pt-10">
-	<div class="hidden justify-center 1.5xs:flex"><OisyWalletLogoLink /></div>
+	<div class="relative flex min-h-10 items-center justify-center">
+		<div class="hidden 1.5xs:block"><OisyWalletLogoLink /></div>
+
+		{#if $authSignedIn}
+			<div class="absolute inset-y-0 right-0 flex items-center">
+				<SignerLogout />
+			</div>
+		{/if}
+	</div>
 
 	{@render children()}
 </main>


### PR DESCRIPTION
# Motivation

After the signer-URL split, `signer.oisy.com` / `legacy-signer.oisy.com` no longer share IndexedDB with `oisy.com`, so logging out on the main wallet no longer clears the signer's delegation. The `(sign)` layout had no logout affordance, so users could only clear a stale signer session via devtools.

# Changes

- Add `SignerLogout.svelte` and render it in `(sign)/+layout.svelte` when `$authSignedIn`, wired to the shared `signOut({ source: 'signer-page' })`.
- Add `SIGNER_LOGOUT_BUTTON` test id.

# Tests

Adapted tests.
