### PR TITLE
refactor(frontend): drop unused btcSelectUserUtxosFee wrapper

### DIFF
--- a/src/frontend/src/btc/services/btc-utxos.service.ts
+++ b/src/frontend/src/btc/services/btc-utxos.service.ts
@@ -20,8 +20,9 @@ export interface BtcReviewServiceParams {
 }
 
 /**
- * Main orchestrator function that replaces the backend btc_select_user_utxos_fee call
- * This function coordinates all the steps needed to select UTXOs and calculate fees
+ * Selects UTXOs and calculates the fee for a BTC send on the frontend:
+ * filters out pending-reserved and under-confirmed UTXOs, picks the
+ * smallest-sufficient set, and returns the estimated fee.
  */
 export const prepareBtcSend = ({
 	amount,

--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -17,7 +17,6 @@ import type {
 	BtcAddPendingTransactionParams,
 	BtcGetFeePercentilesParams,
 	BtcGetPendingTransactionParams,
-	BtcSelectUserUtxosFeeParams,
 	CreateContactParams,
 	CreateUserProfileResponse,
 	DeleteContactParams,
@@ -30,7 +29,6 @@ import type {
 	SaveUserAgreements,
 	SaveUserNetworksSettings,
 	SaveUserTransactionsParams,
-	SelectedUtxosFeeOutcome,
 	SetUserShowTestnetsParams,
 	UpdateContactParams,
 	UpdateUserExperimentalFeatureSettings,
@@ -123,15 +121,6 @@ export const getPendingBtcTransactions = async ({
 	const { btcGetPendingTransactions } = await backendCanister({ identity });
 
 	return btcGetPendingTransactions(params);
-};
-
-export const selectUserUtxosFee = async ({
-	identity,
-	...params
-}: CanisterApiFunctionParams<BtcSelectUserUtxosFeeParams>): Promise<SelectedUtxosFeeOutcome> => {
-	const { btcSelectUserUtxosFee } = await backendCanister({ identity });
-
-	return btcSelectUserUtxosFee(params);
 };
 
 export const getCurrentBtcFeePercentiles = async ({

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -27,7 +27,6 @@ import type {
 	BtcAddPendingTransactionParams,
 	BtcGetFeePercentilesParams,
 	BtcGetPendingTransactionParams,
-	BtcSelectUserUtxosFeeParams,
 	CreateUserProfileResponse,
 	GetPendingTransactionsOutcome,
 	GetUserProfileResponse,
@@ -37,7 +36,6 @@ import type {
 	SaveUserAgreements,
 	SaveUserNetworksSettings,
 	SaveUserTransactionsParams,
-	SelectedUtxosFeeOutcome,
 	SetUserShowTestnetsParams,
 	UpdateUserExperimentalFeatureSettings,
 	UpdateUserTransactionFilterSettings
@@ -191,43 +189,6 @@ export class BackendCanister extends Canister<BackendService> {
 		}
 
 		throw mapBtcGetPendingTransactionsError(response.Err);
-	};
-
-	btcSelectUserUtxosFee = async ({
-		network,
-		minConfirmations,
-		amountSatoshis,
-		iiDelegationChain
-	}: BtcSelectUserUtxosFeeParams): Promise<SelectedUtxosFeeOutcome> => {
-		const { btc_select_user_utxos_fee } = this.caller({ certified: true });
-
-		const response = await btc_select_user_utxos_fee({
-			network,
-			min_confirmations: minConfirmations,
-			amount_satoshis: amountSatoshis,
-			ii_delegation_chain: iiDelegationChain
-		});
-
-		if ('Ok' in response) {
-			return { response: response.Ok };
-		}
-
-		// In case of rate limit reached, we ignore the error and let the user continue (for now).
-		// TODO: improve placeholder with significant data, for now we do not use them
-		if ('RateLimited' in response.Err) {
-			return {
-				response: {
-					fee_satoshis: ZERO,
-					utxos: []
-				},
-				rateLimitInfo: {
-					endpoint: 'btc_select_user_utxos_fee',
-					limiter: 'BTC_SELECT_UTXOS_FEE_RATE_LIMITER'
-				}
-			};
-		}
-
-		throw mapBtcSelectUserUtxosFeeError(response.Err);
 	};
 
 	btcGetCurrentFeePercentiles = async ({

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -9,7 +9,6 @@ import type {
 	GetUserProfileError,
 	IIDelegationChain,
 	PendingTransaction,
-	SelectedUtxosFeeResponse,
 	UserProfile,
 	UserTransaction,
 	Utxo
@@ -51,11 +50,6 @@ export interface GetPendingTransactionsOutcome {
 	rateLimitInfo?: RateLimitInfo;
 }
 
-export interface SelectedUtxosFeeOutcome {
-	response: SelectedUtxosFeeResponse;
-	rateLimitInfo?: RateLimitInfo;
-}
-
 export interface AllowSigningParams {
 	iiDelegationChain: Nullable<IIDelegationChain>;
 }
@@ -63,13 +57,6 @@ export interface AllowSigningParams {
 export interface AllowSigningOutcome {
 	response: AllowSigningResponse;
 	rateLimitInfo?: RateLimitInfo;
-}
-
-export interface BtcSelectUserUtxosFeeParams {
-	network: BitcoinNetwork;
-	amountSatoshis: bigint;
-	minConfirmations: [number];
-	iiDelegationChain: Nullable<IIDelegationChain>;
 }
 
 export interface BtcGetPendingTransactionParams {

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -4,7 +4,6 @@ import type {
 	_SERVICE as BackendService,
 	BtcAddPendingTransactionResult,
 	BtcGetPendingTransactionsResult,
-	BtcSelectUserUtxosFeeResult,
 	CustomToken,
 	IcrcToken,
 	UserProfile
@@ -12,7 +11,7 @@ import type {
 import { BackendCanister } from '$lib/canisters/backend.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { ZERO } from '$lib/constants/app.constants';
-import type { BtcAddPendingTransactionParams, BtcSelectUserUtxosFeeParams } from '$lib/types/api';
+import type { BtcAddPendingTransactionParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { getMockContacts } from '$tests/mocks/contacts.mock';
@@ -100,19 +99,6 @@ describe('backend.canister', () => {
 		network: btcGetPendingTransactionParams.network,
 		address: btcGetPendingTransactionParams.address,
 		ii_delegation_chain: btcGetPendingTransactionParams.iiDelegationChain
-	};
-
-	const btcSelectUserUtxosFeeParams = {
-		network: btcAddPendingTransactionParams.network,
-		minConfirmations: [100],
-		amountSatoshis: 100n,
-		iiDelegationChain: mockIIDelegationChain
-	} as BtcSelectUserUtxosFeeParams;
-	const btcSelectUserUtxosFeeEndpointParams = {
-		network: btcSelectUserUtxosFeeParams.network,
-		min_confirmations: btcSelectUserUtxosFeeParams.minConfirmations,
-		amount_satoshis: btcSelectUserUtxosFeeParams.amountSatoshis,
-		ii_delegation_chain: btcSelectUserUtxosFeeParams.iiDelegationChain
 	};
 
 	const mockedUserProfile = {
@@ -531,151 +517,6 @@ describe('backend.canister', () => {
 
 			await expect(btcGetPendingTransactions(btcGetPendingTransactionParams)).rejects.toThrow(
 				new CanisterInternalError('II delegation chain verification failed: chain expired')
-			);
-		});
-	});
-
-	describe('btc_select_user_utxos_fee', () => {
-		it('should return user utxos fee with success response', async () => {
-			const response = {
-				Ok: {
-					fee_satoshis: 1n,
-					utxos: btcAddPendingTransactionParams.utxos
-				}
-			};
-
-			service.btc_select_user_utxos_fee.mockResolvedValue(response);
-
-			const { btcSelectUserUtxosFee } = await createBackendCanister({
-				serviceOverride: service
-			});
-
-			const res = await btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
-
-			expect(service.btc_select_user_utxos_fee).toHaveBeenCalledWith(
-				btcSelectUserUtxosFeeEndpointParams
-			);
-			expect(res).toEqual({ response: response.Ok });
-		});
-
-		it('should throw an error if btc_select_user_utxos_fee returns an internal error', async () => {
-			service.btc_select_user_utxos_fee.mockResolvedValue(errorResponse);
-
-			const { btcSelectUserUtxosFee } = await createBackendCanister({
-				serviceOverride: service
-			});
-
-			const res = btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
-
-			await expect(res).rejects.toThrow(
-				new CanisterInternalError(errorResponse.Err.InternalError.msg)
-			);
-		});
-
-		it('should throw an error if btc_select_user_utxos_fee returns a pending-transactions error', async () => {
-			service.btc_select_user_utxos_fee.mockResolvedValue({ Err: { PendingTransactions: null } });
-
-			const { btcSelectUserUtxosFee } = await createBackendCanister({
-				serviceOverride: service
-			});
-
-			const res = btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
-
-			await expect(res).rejects.toThrow(
-				new CanisterInternalError(
-					'Selecting utxos fee is not possible - pending transactions found.'
-				)
-			);
-		});
-
-		it('should throw an error if btc_select_user_utxos_fee returns a generic canister error', async () => {
-			// @ts-expect-error we test this in purposes
-			service.btc_select_user_utxos_fee.mockResolvedValue({ Err: { CanisterError: null } });
-
-			const { btcSelectUserUtxosFee } = await createBackendCanister({
-				serviceOverride: service
-			});
-
-			const res = btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
-
-			await expect(res).rejects.toThrow(
-				new CanisterInternalError('Unknown BtcSelectUserUtxosFeeError')
-			);
-		});
-
-		it('should throw an error if btc_select_user_utxos_fee throws', async () => {
-			service.btc_select_user_utxos_fee.mockImplementation(async () => {
-				await Promise.resolve();
-				throw mockResponseError;
-			});
-
-			const { btcSelectUserUtxosFee } = await createBackendCanister({
-				serviceOverride: service
-			});
-
-			const res = btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
-
-			await expect(res).rejects.toThrow(mockResponseError);
-		});
-
-		it('should throw an error if btc_select_user_utxos_fee returns an unexpected response', async () => {
-			// @ts-expect-error we test this in purposes
-			service.btc_select_user_utxos_fee.mockResolvedValue({ test: 'unexpected' });
-
-			const { btcSelectUserUtxosFee } = await createBackendCanister({
-				serviceOverride: service
-			});
-
-			const res = btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
-
-			await expect(res).rejects.toThrow();
-		});
-
-		it('should return rateLimitInfo if RateLimited error is returned', async () => {
-			const response = {
-				Err: { RateLimited: { max_calls: 5, window_ns: 60_000_000_000n, caller: mockPrincipal } }
-			};
-
-			service.btc_select_user_utxos_fee.mockResolvedValue(
-				response as unknown as BtcSelectUserUtxosFeeResult
-			);
-
-			const { btcSelectUserUtxosFee } = await createBackendCanister({
-				serviceOverride: service
-			});
-
-			const res = await btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams);
-
-			expect(service.btc_select_user_utxos_fee).toHaveBeenCalledWith(
-				btcSelectUserUtxosFeeEndpointParams
-			);
-			expect(res).toStrictEqual({
-				response: {
-					fee_satoshis: ZERO,
-					utxos: []
-				},
-				rateLimitInfo: {
-					endpoint: 'btc_select_user_utxos_fee',
-					limiter: 'BTC_SELECT_UTXOS_FEE_RATE_LIMITER'
-				}
-			});
-		});
-
-		it('should throw a CanisterInternalError if InvalidDelegationChain error is returned', async () => {
-			const response = {
-				Err: { InvalidDelegationChain: { msg: 'unknown canister' } }
-			};
-
-			service.btc_select_user_utxos_fee.mockResolvedValue(
-				response as unknown as BtcSelectUserUtxosFeeResult
-			);
-
-			const { btcSelectUserUtxosFee } = await createBackendCanister({
-				serviceOverride: service
-			});
-
-			await expect(btcSelectUserUtxosFee(btcSelectUserUtxosFeeParams)).rejects.toThrow(
-				new CanisterInternalError('II delegation chain verification failed: unknown canister')
 			);
 		});
 	});


### PR DESCRIPTION
# Motivation

Since #12657 (smallest-sufficient greedy UTXO selection on the frontend) and #12706 (outpoint-based pending-UTXO matching), the frontend no longer calls the backend `btc_select_user_utxos_fee` endpoint — the BTC send and parallel-send flows compute the selection and fee entirely on the client via `prepareBtcSend` / `calculateUtxoSelection`.

The TypeScript wrapper around the endpoint (`selectUserUtxosFee` API function, `btcSelectUserUtxosFee` canister method, the matching params / outcome types, and ~150 lines of spec) is therefore dead on the frontend. This PR removes that frontend surface as a non-breaking, isolated first step.

The backend endpoint itself (and its supporting helpers, types, integration tests, and rate limiter) is still in place and will be  removed in a follow-up breaking-interface PR — kept separate to keep the candid change atomic and easy to review.