### PR TITLE
docs(ai): note BTC UTXO selection lives on the frontend

### DIFF
--- a/docs/ai/backend/structure.md
+++ b/docs/ai/backend/structure.md
@@ -52,7 +52,11 @@ src/backend/src/
 │   ├── canister_ids.rs CYCLES_LEDGER + SIGNER canister principals
 │   └── service.rs      allow_signing, get_allowed_cycles, top-up flow
 │
-├── bitcoin/            BTC domain logic (fee cache, pending transactions, UTXO selection)
+├── bitcoin/            BTC domain logic: fee-percentiles cache + pending-tx
+│                       reservations. UTXO selection lives on the frontend
+│                       (`prepareBtcSend` in `$btc/services/btc-utxos.service.ts`
+│                       orchestrates the flow; `calculateUtxoSelection` in
+│                       `$btc/utils/btc-utxos.utils.ts` picks the UTXOs).
 ├── contacts/           Contact-book domain
 ├── exchange/           Exchange-rate domain (timer + provider plumbing)
 ├── transactions/       User-transaction storage / queries


### PR DESCRIPTION
# Motivation

After #12779 removed `btc_select_user_utxos_fee`, the backend structure doc still described the `bitcoin/` module as owning "UTXO selection", which is no longer true and could mislead a future contributor into re-introducing a backend selection endpoint instead of extending the frontend `prepareBtcSend` / `calculateUtxoSelection` helpers.
