### PR TITLE
feat(frontend): track transaction-filter open / close on desktop

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContacts.svelte
@@ -3,15 +3,30 @@
 	import TransactionsFilterContactsPanel from '$lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte';
 	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
 	import { TRANSACTIONS_FILTER_CONTACTS_DROPDOWN } from '$lib/constants/test-ids.constants';
+	import {
+		PLAUSIBLE_EVENT_EVENTS_KEYS,
+		PLAUSIBLE_EVENT_FILTER_MODIFIERS
+	} from '$lib/enums/plausible';
+	import { trackTransactionFilter } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.contactIds));
+
+	const onToggle = (visible: boolean) => {
+		trackTransactionFilter({
+			modifier: visible
+				? PLAUSIBLE_EVENT_FILTER_MODIFIERS.OPEN
+				: PLAUSIBLE_EVENT_FILTER_MODIFIERS.CLOSE,
+			key: PLAUSIBLE_EVENT_EVENTS_KEYS.CONTACT
+		});
+	};
 </script>
 
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.contacts_aria_label}
 	count={selectedSet.size}
+	{onToggle}
 	panelWidthClass="w-full sm:w-72"
 	testId={TRANSACTIONS_FILTER_CONTACTS_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.contacts_label}

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTokens.svelte
@@ -3,15 +3,30 @@
 	import TransactionsFilterTokensPanel from '$lib/components/transactions/filter/TransactionsFilterTokensPanel.svelte';
 	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
 	import { TRANSACTIONS_FILTER_TOKENS_DROPDOWN } from '$lib/constants/test-ids.constants';
+	import {
+		PLAUSIBLE_EVENT_EVENTS_KEYS,
+		PLAUSIBLE_EVENT_FILTER_MODIFIERS
+	} from '$lib/enums/plausible';
+	import { trackTransactionFilter } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 
 	let selectedSet = $derived(new Set<string>($transactionsFilterStore.tokenIds));
+
+	const onToggle = (visible: boolean) => {
+		trackTransactionFilter({
+			modifier: visible
+				? PLAUSIBLE_EVENT_FILTER_MODIFIERS.OPEN
+				: PLAUSIBLE_EVENT_FILTER_MODIFIERS.CLOSE,
+			key: PLAUSIBLE_EVENT_EVENTS_KEYS.TOKEN
+		});
+	};
 </script>
 
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.tokens_aria_label}
 	count={selectedSet.size}
+	{onToggle}
 	panelWidthClass="w-full sm:w-80"
 	testId={TRANSACTIONS_FILTER_TOKENS_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.tokens_label}

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterTypes.svelte
@@ -4,12 +4,27 @@
 	import MultiSelectDropdown from '$lib/components/ui/MultiSelectDropdown.svelte';
 	import { TRANSACTIONS_FILTER_TYPES_DROPDOWN } from '$lib/constants/test-ids.constants';
 	import { selectedTransactionsFilterTypesCount } from '$lib/derived/transactions-filter.derived';
+	import {
+		PLAUSIBLE_EVENT_EVENTS_KEYS,
+		PLAUSIBLE_EVENT_FILTER_MODIFIERS
+	} from '$lib/enums/plausible';
+	import { trackTransactionFilter } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	const onToggle = (visible: boolean) => {
+		trackTransactionFilter({
+			modifier: visible
+				? PLAUSIBLE_EVENT_FILTER_MODIFIERS.OPEN
+				: PLAUSIBLE_EVENT_FILTER_MODIFIERS.CLOSE,
+			key: PLAUSIBLE_EVENT_EVENTS_KEYS.TRANSACTION_TYPE
+		});
+	};
 </script>
 
 <MultiSelectDropdown
 	ariaLabel={$i18n.transaction.filter.types_aria_label}
 	count={$selectedTransactionsFilterTypesCount}
+	{onToggle}
 	panelWidthClass="w-full sm:w-64"
 	testId={TRANSACTIONS_FILTER_TYPES_DROPDOWN}
 	triggerLabel={$i18n.transaction.filter.types_label}

--- a/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
+++ b/src/frontend/src/lib/components/ui/MultiSelectDropdown.svelte
@@ -18,6 +18,10 @@
 		triggerIcon?: Snippet;
 		panel: Snippet;
 		panelWidthClass?: string;
+		// Fires whenever the panel transitions from hidden→visible or
+		// visible→hidden (including clicks outside that close the popover).
+		// Optional so existing callers stay untouched.
+		onToggle?: (visible: boolean) => void;
 	}
 
 	let {
@@ -30,7 +34,8 @@
 		testId,
 		triggerIcon,
 		panel,
-		panelWidthClass
+		panelWidthClass,
+		onToggle
 	}: Props = $props();
 
 	let visible = $state(false);
@@ -39,6 +44,20 @@
 	const onTriggerClick = () => {
 		visible = !visible;
 	};
+
+	// Surface every visibility change (trigger click, click-outside, escape)
+	// through the optional `onToggle` callback so consumers can react without
+	// wiring up `bind:visible` themselves. We skip the very first run so we
+	// don't fire a spurious "close" for the initial `visible = false`.
+	let initialised = false;
+	$effect(() => {
+		const next = visible;
+		if (!initialised) {
+			initialised = true;
+			return;
+		}
+		onToggle?.(next);
+	});
 </script>
 
 <button

--- a/src/frontend/src/lib/enums/plausible.ts
+++ b/src/frontend/src/lib/enums/plausible.ts
@@ -102,7 +102,9 @@ export enum PLAUSIBLE_EVENT_EVENTS_KEYS {
 export enum PLAUSIBLE_EVENT_FILTER_MODIFIERS {
 	SET = 'set',
 	UNSET = 'unset',
-	CLEAR = 'clear'
+	CLEAR = 'clear',
+	OPEN = 'open',
+	CLOSE = 'close'
 }
 
 export enum PLAUSIBLE_EVENT_RESULT_STATUSES {

--- a/src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MultiSelectDropdown.spec.ts
@@ -92,4 +92,32 @@ describe('MultiSelectDropdown', () => {
 			expect(shell.className).not.toContain('min-w-60');
 		});
 	});
+
+	it('does not invoke onToggle on initial mount', () => {
+		const onToggle = vi.fn();
+
+		render(MultiSelectDropdownTest, { props: { onToggle } });
+
+		expect(onToggle).not.toHaveBeenCalled();
+	});
+
+	it('invokes onToggle(true) when the panel opens and onToggle(false) when it closes', async () => {
+		const onToggle = vi.fn();
+
+		const { getByTestId } = render(MultiSelectDropdownTest, { props: { onToggle } });
+
+		await fireEvent.click(getByTestId('multi-select-dropdown'));
+
+		await waitFor(() => {
+			expect(onToggle).toHaveBeenLastCalledWith(true);
+		});
+
+		await fireEvent.click(getByTestId('multi-select-dropdown'));
+
+		await waitFor(() => {
+			expect(onToggle).toHaveBeenLastCalledWith(false);
+		});
+
+		expect(onToggle).toHaveBeenCalledTimes(2);
+	});
 });

--- a/src/frontend/src/tests/lib/components/ui/MultiSelectDropdownTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/MultiSelectDropdownTest.svelte
@@ -5,14 +5,16 @@
 		count?: number;
 		searchable?: boolean;
 		panelWidthClass?: string;
+		onToggle?: (visible: boolean) => void;
 	}
 
-	let { count = 0, searchable = false, panelWidthClass }: Props = $props();
+	let { count = 0, searchable = false, panelWidthClass, onToggle }: Props = $props();
 </script>
 
 <MultiSelectDropdown
 	ariaLabel="Filter"
 	{count}
+	{onToggle}
 	{panelWidthClass}
 	searchPlaceholder="Search items"
 	{searchable}

--- a/src/frontend/src/tests/lib/services/analytics.service.spec.ts
+++ b/src/frontend/src/tests/lib/services/analytics.service.spec.ts
@@ -352,6 +352,52 @@ describe('plausible analytics service', () => {
 				}
 			});
 		});
+
+		it('emits an open event with only event_key when a filter is opened', async () => {
+			const { trackTransactionFilter, initPlausibleAnalytics } =
+				await import('$lib/services/analytics.services');
+			const { PLAUSIBLE_EVENT_EVENTS_KEYS, PLAUSIBLE_EVENT_FILTER_MODIFIERS } =
+				await import('$lib/enums/plausible');
+
+			await initPlausibleAnalytics();
+
+			trackTransactionFilter({
+				modifier: PLAUSIBLE_EVENT_FILTER_MODIFIERS.OPEN,
+				key: PLAUSIBLE_EVENT_EVENTS_KEYS.TOKEN
+			});
+
+			expect(trackMock).toHaveBeenCalledWith('transaction_filter', {
+				props: {
+					event_modifier: 'open',
+					event_key: 'token',
+					source_location: 'activity_page',
+					result_status: 'success'
+				}
+			});
+		});
+
+		it('emits a close event with only event_key when a filter is closed', async () => {
+			const { trackTransactionFilter, initPlausibleAnalytics } =
+				await import('$lib/services/analytics.services');
+			const { PLAUSIBLE_EVENT_EVENTS_KEYS, PLAUSIBLE_EVENT_FILTER_MODIFIERS } =
+				await import('$lib/enums/plausible');
+
+			await initPlausibleAnalytics();
+
+			trackTransactionFilter({
+				modifier: PLAUSIBLE_EVENT_FILTER_MODIFIERS.CLOSE,
+				key: PLAUSIBLE_EVENT_EVENTS_KEYS.CONTACT
+			});
+
+			expect(trackMock).toHaveBeenCalledWith('transaction_filter', {
+				props: {
+					event_modifier: 'close',
+					event_key: 'contact',
+					source_location: 'activity_page',
+					result_status: 'success'
+				}
+			});
+		});
 	});
 
 	it('should console.debug the error in STAGING when tracker.track throws', async () => {


### PR DESCRIPTION
# Motivation

Track when a desktop filter dropdown is opened / closed.

Stacks on #12780.

# Changes

- Add `OPEN` / `CLOSE` to `PLAUSIBLE_EVENT_FILTER_MODIFIERS`.
- `MultiSelectDropdown`: optional `onToggle(visible)` callback (skips initial mount).
- `TransactionsFilterTypes` / `Tokens` / `Contacts` wire it.

# Tests

Tests for the callback and for the open / close payload.