### PR TITLE
feat(frontend): track transaction-filter open / close on mobile

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterMobileSheet.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterMobileSheet.svelte
@@ -16,6 +16,11 @@
 		selectedTransactionsFilterTokensCount,
 		selectedTransactionsFilterTypesCount
 	} from '$lib/derived/transactions-filter.derived';
+	import {
+		PLAUSIBLE_EVENT_EVENTS_KEYS,
+		PLAUSIBLE_EVENT_FILTER_MODIFIERS
+	} from '$lib/enums/plausible';
+	import { trackTransactionFilter } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {
@@ -26,11 +31,46 @@
 
 	type FilterStep = 'root' | 'types' | 'tokens' | 'contacts';
 
+	const FILTER_KEY_BY_STEP: Record<Exclude<FilterStep, 'root'>, PLAUSIBLE_EVENT_EVENTS_KEYS> = {
+		types: PLAUSIBLE_EVENT_EVENTS_KEYS.TRANSACTION_TYPE,
+		tokens: PLAUSIBLE_EVENT_EVENTS_KEYS.TOKEN,
+		contacts: PLAUSIBLE_EVENT_EVENTS_KEYS.CONTACT
+	};
+
+	const trackStepOpen = (next: Exclude<FilterStep, 'root'>) => {
+		trackTransactionFilter({
+			modifier: PLAUSIBLE_EVENT_FILTER_MODIFIERS.OPEN,
+			key: FILTER_KEY_BY_STEP[next]
+		});
+	};
+
+	const trackStepClose = (previous: Exclude<FilterStep, 'root'>) => {
+		trackTransactionFilter({
+			modifier: PLAUSIBLE_EVENT_FILTER_MODIFIERS.CLOSE,
+			key: FILTER_KEY_BY_STEP[previous]
+		});
+	};
+
 	let step = $state<FilterStep>('root');
 
-	const goToRoot = () => (step = 'root');
+	const enterStep = (next: Exclude<FilterStep, 'root'>) => {
+		trackStepOpen(next);
+		step = next;
+	};
+
+	const goToRoot = () => {
+		if (step !== 'root') {
+			trackStepClose(step);
+		}
+		step = 'root';
+	};
 
 	const onClose = () => {
+		// Sheet dismissed: if the user was inside a sub-step, we still emit
+		// the matching close event so dashboards see balanced open/close pairs.
+		if (step !== 'root') {
+			trackStepClose(step);
+		}
 		step = 'root';
 	};
 
@@ -86,7 +126,7 @@
 						<li>
 							<button
 								class="flex w-full items-center justify-between rounded-md px-3 py-3 text-left transition hover:bg-brand-subtle-10"
-								onclick={() => (step = rowStep)}
+								onclick={() => enterStep(rowStep)}
 								type="button"
 							>
 								<span class="flex items-center gap-3 text-sm">

--- a/src/frontend/src/lib/enums/plausible.ts
+++ b/src/frontend/src/lib/enums/plausible.ts
@@ -102,7 +102,9 @@ export enum PLAUSIBLE_EVENT_EVENTS_KEYS {
 export enum PLAUSIBLE_EVENT_FILTER_MODIFIERS {
 	SET = 'set',
 	UNSET = 'unset',
-	CLEAR = 'clear'
+	CLEAR = 'clear',
+	OPEN = 'open',
+	CLOSE = 'close'
 }
 
 export enum PLAUSIBLE_EVENT_RESULT_STATUSES {

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterMobileSheet.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterMobileSheet.spec.ts
@@ -1,6 +1,11 @@
 import TransactionsFilterMobileSheet from '$lib/components/transactions/filter/TransactionsFilterMobileSheet.svelte';
 import * as contactsDerived from '$lib/derived/contacts.derived';
 import * as networkTokensDerived from '$lib/derived/network-tokens.derived';
+import {
+	PLAUSIBLE_EVENT_EVENTS_KEYS,
+	PLAUSIBLE_EVENT_FILTER_MODIFIERS
+} from '$lib/enums/plausible';
+import * as analyticsServices from '$lib/services/analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 import { fireEvent, render } from '@testing-library/svelte';
@@ -86,6 +91,39 @@ describe('TransactionsFilterMobileSheet', () => {
 		expect(container.querySelector('input[id="transactions-filter-type-send"]')).toBeNull();
 		expect(getByText(get(i18n).transaction.filter.tokens_label)).toBeInTheDocument();
 		expect(getByText(get(i18n).transaction.filter.contacts_label)).toBeInTheDocument();
+	});
+
+	it('tracks an open event when entering a filter step from the root', async () => {
+		const trackSpy = vi
+			.spyOn(analyticsServices, 'trackTransactionFilter')
+			.mockImplementation(() => {});
+
+		const { getByText } = render(TransactionsFilterMobileSheet, { props: { visible: true } });
+
+		await fireEvent.click(getByText(get(i18n).transaction.filter.tokens_label));
+
+		expect(trackSpy).toHaveBeenCalledWith({
+			modifier: PLAUSIBLE_EVENT_FILTER_MODIFIERS.OPEN,
+			key: PLAUSIBLE_EVENT_EVENTS_KEYS.TOKEN
+		});
+	});
+
+	it('tracks a close event when navigating back to the root step', async () => {
+		const trackSpy = vi
+			.spyOn(analyticsServices, 'trackTransactionFilter')
+			.mockImplementation(() => {});
+
+		const { getByText, getByLabelText } = render(TransactionsFilterMobileSheet, {
+			props: { visible: true }
+		});
+
+		await fireEvent.click(getByText(get(i18n).transaction.filter.types_label));
+		await fireEvent.click(getByLabelText(get(i18n).core.text.back));
+
+		expect(trackSpy).toHaveBeenCalledWith({
+			modifier: PLAUSIBLE_EVENT_FILTER_MODIFIERS.CLOSE,
+			key: PLAUSIBLE_EVENT_EVENTS_KEYS.TRANSACTION_TYPE
+		});
 	});
 
 	it('resets to the root step when the sheet is closed', async () => {


### PR DESCRIPTION
# Motivation

Track when a mobile filter sub-step is opened / closed.

Stacks on #12780. Sibling of #12790.

# Changes

- Add `OPEN` / `CLOSE` to `PLAUSIBLE_EVENT_FILTER_MODIFIERS`.
- `TransactionsFilterMobileSheet` emits `open` on step enter and `close` on back / dismissal from a sub-step.

# Tests

Tests for open on step enter and close on back.