### PR TITLE
refactor(frontend): extract contacts filter empty state into its own component

### DIFF
--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsEmptyState.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsEmptyState.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import IconAddressBook from '$lib/components/icons/IconAddressBook.svelte';
+	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA } from '$lib/constants/test-ids.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+
+	const openAddressBook = () => {
+		modalStore.openAddressBook({ id: Symbol() });
+	};
+</script>
+
+<div class="flex flex-col items-center gap-3 px-2 py-4 text-center">
+	<div class="w-16 text-brand-primary [&_svg]:h-auto [&_svg]:w-full" aria-hidden="true">
+		<IconAddressBook />
+	</div>
+
+	<p class="text-sm text-secondary">{$i18n.transaction.filter.contacts_empty_title}</p>
+
+	<p class="text-sm text-tertiary">
+		<strong
+			><span class="relative -top-px mr-1 inline-block align-middle text-success-primary"
+				><IconShieldCheck size="16" /></span
+			>{`${replaceOisyPlaceholders($i18n.core.text.oisy_protects_you)} `}</strong
+		>{$i18n.transaction.filter.contacts_empty_description}<br />
+		<a
+			class="blue-link no-underline"
+			href="https://docs.oisy.com/introduction/oisy-keeps-you-protected#contacts"
+			rel="noopener noreferrer"
+			target="_blank">{$i18n.core.text.learn_more}</a
+		>
+	</p>
+
+	<Button
+		colorStyle="primary"
+		fullWidth
+		onclick={openAddressBook}
+		testId={TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA}
+		type="button"
+	>
+		{$i18n.transaction.filter.contacts_empty_cta}
+	</Button>
+</div>

--- a/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte
+++ b/src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
 	import { Checkbox } from '@dfinity/gix-components';
 	import Avatar from '$lib/components/contact/Avatar.svelte';
-	import IconAddressBook from '$lib/components/icons/IconAddressBook.svelte';
-	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
+	import TransactionsFilterContactsEmptyState from '$lib/components/transactions/filter/TransactionsFilterContactsEmptyState.svelte';
 	import InputSearch from '$lib/components/ui/InputSearch.svelte';
-	import { TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA } from '$lib/constants/test-ids.constants';
 	import { contacts } from '$lib/derived/contacts.derived';
 	import {
 		PLAUSIBLE_EVENT_EVENTS_KEYS,
@@ -13,10 +10,9 @@
 	} from '$lib/enums/plausible';
 	import { trackTransactionFilter } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
 	import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 	import { matchesContactByText } from '$lib/utils/contact.utils';
-	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	interface Props {
 		// When the panel is rendered inside a desktop dropdown popover the
@@ -65,45 +61,11 @@
 
 		transactionsFilterStore.toggleContactId(id);
 	};
-
-	const openAddressBook = () => {
-		modalStore.openAddressBook({ id: Symbol() });
-	};
 </script>
 
 <div class="flex flex-col gap-3">
 	{#if isEmpty}
-		<div class="flex flex-col items-center gap-3 px-2 py-4 text-center">
-			<div class="w-16 text-brand-primary [&_svg]:h-auto [&_svg]:w-full" aria-hidden="true">
-				<IconAddressBook />
-			</div>
-
-			<p class="text-sm text-secondary">{$i18n.transaction.filter.contacts_empty_title}</p>
-
-			<p class="text-sm text-tertiary">
-				<strong
-					><span class="relative -top-px mr-1 inline-block align-middle text-success-primary"
-						><IconShieldCheck size="16" /></span
-					>{`${replaceOisyPlaceholders($i18n.core.text.oisy_protects_you)} `}</strong
-				>{$i18n.transaction.filter.contacts_empty_description}<br />
-				<a
-					class="blue-link no-underline"
-					href="https://docs.oisy.com/introduction/oisy-keeps-you-protected#contacts"
-					rel="noopener noreferrer"
-					target="_blank">{$i18n.core.text.learn_more}</a
-				>
-			</p>
-
-			<Button
-				colorStyle="primary"
-				fullWidth
-				onclick={openAddressBook}
-				testId={TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA}
-				type="button"
-			>
-				{$i18n.transaction.filter.contacts_empty_cta}
-			</Button>
-		</div>
+		<TransactionsFilterContactsEmptyState />
 	{:else}
 		<InputSearch
 			{autofocus}

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterContactsEmptyState.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterContactsEmptyState.spec.ts
@@ -1,0 +1,61 @@
+import TransactionsFilterContactsEmptyState from '$lib/components/transactions/filter/TransactionsFilterContactsEmptyState.svelte';
+import { TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA } from '$lib/constants/test-ids.constants';
+import { i18n } from '$lib/stores/i18n.store';
+import { modalStore } from '$lib/stores/modal.store';
+import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+import { fireEvent, render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+
+describe('TransactionsFilterContactsEmptyState', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('renders the no-contacts-yet line', () => {
+		const { getByText } = render(TransactionsFilterContactsEmptyState);
+
+		expect(getByText(get(i18n).transaction.filter.contacts_empty_title)).toBeInTheDocument();
+	});
+
+	it('renders the OISY-protects-you lockup and description', () => {
+		const { getByText } = render(TransactionsFilterContactsEmptyState);
+
+		expect(
+			getByText(replaceOisyPlaceholders(get(i18n).core.text.oisy_protects_you))
+		).toBeInTheDocument();
+		// The description sits between the OISY-protects-you <strong> and the
+		// Learn more <a> inside the same <p>, so the paragraph's full text is
+		// "<oisy lockup> <description> <learn more>". Use a partial match
+		// against the i18n value so the test stays in sync with the copy.
+		expect(
+			getByText(get(i18n).transaction.filter.contacts_empty_description, { exact: false })
+		).toBeInTheDocument();
+	});
+
+	it('renders a Learn more link pointing to the protected-contacts docs', () => {
+		const { getByRole } = render(TransactionsFilterContactsEmptyState);
+
+		const link = getByRole('link', { name: get(i18n).core.text.learn_more });
+
+		expect(link).toHaveAttribute(
+			'href',
+			'https://docs.oisy.com/introduction/oisy-keeps-you-protected#contacts'
+		);
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+	});
+
+	it('renders the CTA button that opens the address book', async () => {
+		const openSpy = vi.spyOn(modalStore, 'openAddressBook');
+
+		const { getByTestId } = render(TransactionsFilterContactsEmptyState);
+
+		const cta = getByTestId(TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA);
+
+		expect(cta).toHaveTextContent(get(i18n).transaction.filter.contacts_empty_cta);
+
+		await fireEvent.click(cta);
+
+		expect(openSpy).toHaveBeenCalledOnce();
+	});
+});

--- a/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterContactsPanel.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/filter/TransactionsFilterContactsPanel.spec.ts
@@ -1,5 +1,4 @@
 import TransactionsFilterContactsPanel from '$lib/components/transactions/filter/TransactionsFilterContactsPanel.svelte';
-import { TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA } from '$lib/constants/test-ids.constants';
 import * as contactsDerived from '$lib/derived/contacts.derived';
 import {
 	PLAUSIBLE_EVENT_EVENTS_KEYS,
@@ -7,10 +6,9 @@ import {
 } from '$lib/enums/plausible';
 import * as analyticsServices from '$lib/services/analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
-import { modalStore } from '$lib/stores/modal.store';
 import { transactionsFilterStore } from '$lib/stores/transactions-filter.store';
 import type { ContactUi } from '$lib/types/contact';
-import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { getMockContactsUi, mockContactEthAddressUi } from '$tests/mocks/contacts.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
@@ -134,52 +132,15 @@ describe('TransactionsFilterContactsPanel', () => {
 			).toBeNull();
 		});
 
-		it('renders the no-contacts-yet line above the OISY-protects-you block', () => {
+		// The contents of the empty state itself (icon, OISY lockup, Learn
+		// more link, CTA, etc.) are covered by
+		// `TransactionsFilterContactsEmptyState.spec.ts`. The panel spec just
+		// asserts the branching: an empty contact list switches the panel
+		// from the list view to the empty-state component.
+		it('renders the empty-state component', () => {
 			const { getByText } = render(TransactionsFilterContactsPanel);
 
 			expect(getByText(get(i18n).transaction.filter.contacts_empty_title)).toBeInTheDocument();
-		});
-
-		it('renders the OISY-protects-you lockup and description', () => {
-			const { getByText } = render(TransactionsFilterContactsPanel);
-
-			expect(
-				getByText(replaceOisyPlaceholders(get(i18n).core.text.oisy_protects_you))
-			).toBeInTheDocument();
-			// The description sits between the OISY-protects-you <strong> and the
-			// Learn more <a> inside the same <p>, so the paragraph's full text is
-			// "<oisy lockup> <description> <learn more>". Use a partial match
-			// against the i18n value so the test stays in sync with the copy.
-			expect(
-				getByText(get(i18n).transaction.filter.contacts_empty_description, { exact: false })
-			).toBeInTheDocument();
-		});
-
-		it('renders a Learn more link pointing to the protected-contacts docs', () => {
-			const { getByRole } = render(TransactionsFilterContactsPanel);
-
-			const link = getByRole('link', { name: get(i18n).core.text.learn_more });
-
-			expect(link).toHaveAttribute(
-				'href',
-				'https://docs.oisy.com/introduction/oisy-keeps-you-protected#contacts'
-			);
-			expect(link).toHaveAttribute('target', '_blank');
-			expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-		});
-
-		it('renders the CTA button that opens the address book', async () => {
-			const openSpy = vi.spyOn(modalStore, 'openAddressBook');
-
-			const { getByTestId } = render(TransactionsFilterContactsPanel);
-
-			const cta = getByTestId(TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA);
-
-			expect(cta).toHaveTextContent(get(i18n).transaction.filter.contacts_empty_cta);
-
-			await fireEvent.click(cta);
-
-			expect(openSpy).toHaveBeenCalledOnce();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Follow-up to [#12778](https://github.com/dfinity/oisy-wallet/pull/12778). [@AntonioVentilii suggested](https://github.com/dfinity/oisy-wallet/pull/12778#discussion_r3246471664-ish) extracting the empty-state block out of `TransactionsFilterContactsPanel` for better maintainability — the panel currently mixes search/list/tracking logic with a self-contained empty-state UI.

# Changes

- New component [`TransactionsFilterContactsEmptyState.svelte`](src/frontend/src/lib/components/transactions/filter/TransactionsFilterContactsEmptyState.svelte) owns the illustration, the "You haven't added contacts yet" line, the OISY-protects-you lockup, the Learn more link, the "Add your first contact" CTA, and the `openAddressBook` handler.
- `TransactionsFilterContactsPanel` now only branches on `$contacts.length === 0` and renders `<TransactionsFilterContactsEmptyState />` for the empty case. Its import list drops `IconAddressBook`, `IconShieldCheck`, `Button`, the `TRANSACTIONS_FILTER_CONTACTS_EMPTY_CTA` test id, `modalStore`, and `replaceOisyPlaceholders` — none of those concern the list/search/tracking responsibility the panel keeps.

# Tests

- New `TransactionsFilterContactsEmptyState.spec.ts` covers the title, the OISY lockup + description, the Learn more link's `href` / `target` / `rel`, and that clicking the CTA calls `modalStore.openAddressBook`.
- `TransactionsFilterContactsPanel.spec.ts` keeps a single branching assertion under `when the user has no contacts` (the empty-state component is rendered) and drops the per-element tests that are now owned by the new spec.

🤖 Claude Opus 4.7