### PR TITLE
chore(deps): bump @dfinity/internet-identity-playwright to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
 			},
 			"devDependencies": {
 				"@dfinity/eslint-config-oisy-wallet": "^0.3.0",
-				"@dfinity/internet-identity-playwright": "^0.0.5",
+				"@dfinity/internet-identity-playwright": "^2.0.0",
 				"@icp-sdk/bindgen": "^0.2.0",
 				"@playwright/test": "^1.58.2",
 				"@rollup/plugin-inject": "^5.0.5",
@@ -540,16 +540,16 @@
 			}
 		},
 		"node_modules/@dfinity/internet-identity-playwright": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@dfinity/internet-identity-playwright/-/internet-identity-playwright-0.0.5.tgz",
-			"integrity": "sha512-tCmjsX7ui4Qw2s7Ufoh1xJayLUHFbXaSsybrTfYtv3uZlYtMM+dU24lnNv1IPKh19dalXMxi+IWuY5ePGR9KZQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/internet-identity-playwright/-/internet-identity-playwright-2.0.0.tgz",
+			"integrity": "sha512-8dqxxKEqNhM+dozEHFB3Dn54lXsFMjuDKy4qT4ALWypWDM61Ey1KFfvI34gyn70xWLLTLxEiWb6CrDnzJu3NGQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=22"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.44.1"
+				"@playwright/test": "^1.52.0"
 			}
 		},
 		"node_modules/@dfinity/oisy-wallet-signer": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 	},
 	"devDependencies": {
 		"@dfinity/eslint-config-oisy-wallet": "^0.3.0",
-		"@dfinity/internet-identity-playwright": "^0.0.5",
+		"@dfinity/internet-identity-playwright": "^2.0.0",
 		"@icp-sdk/bindgen": "^0.2.0",
 		"@playwright/test": "^1.58.2",
 		"@rollup/plugin-inject": "^5.0.5",


### PR DESCRIPTION
# Motivation

Pinned at v0.0.5 forever. v3 is breaking (new id.ai UI) but `dfx.json` still ships II `release-2024-10-25`, so jumping to v3 would break login.

v2.0.0 keeps the same `signInWithNewIdentity()` API and selectors → zero code change. v3 + II canister bump is a follow-up.

First of several small atomic PRs to revive the e2e suite.

# Changes

- Bump `@dfinity/internet-identity-playwright` `^0.0.5` → `^2.0.0`.