### PR TITLE
test(e2e): tighten Playwright timeouts and retries

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,11 +71,29 @@ const nonAppleProjects = [
 	}
 ];
 
-const TIMEOUT = 5 * 60 * 1000;
+// Per-test wall-clock cap. Anything longer than this is almost always a hang
+// rather than a slow test — fail fast so the retry (or the next shard) gets
+// a chance to surface a useful trace.
+const TEST_TIMEOUT = 60_000;
+
+// Per-action cap (click, fill, etc.). 15s is generous for any single DOM
+// interaction; if we need longer, we should `expect.poll` instead of letting
+// the action retry silently.
+const ACTION_TIMEOUT = 15_000;
+
+// Per-navigation cap. Slightly more generous because login + Internet
+// Identity popups can legitimately take a few seconds.
+const NAVIGATION_TIMEOUT = 30_000;
+
+// Web server boot can include `npm run build` (≈2 min on cold caches), so it
+// gets the most generous budget — kept independent from the per-test cap.
+const WEB_SERVER_TIMEOUT = 5 * 60 * 1000;
 
 export default defineConfig({
-	retries: 3,
-	timeout: TIMEOUT,
+	// One retry in any environment: that buys us the trace for the second run
+	// without burning ×4 the wall-clock when a whole shard is genuinely broken.
+	retries: 1,
+	timeout: TEST_TIMEOUT,
 	workers: 5,
 	expect: {
 		toHaveScreenshot: {
@@ -92,7 +110,7 @@ export default defineConfig({
 		command: DEV ? 'npm run dev' : 'npm run build && npm run preview',
 		reuseExistingServer: true,
 		port,
-		timeout: TIMEOUT
+		timeout: WEB_SERVER_TIMEOUT
 	},
 	testDir: 'e2e',
 	testMatch: ['**/*.e2e.ts', '**/*.spec.ts'],
@@ -100,8 +118,8 @@ export default defineConfig({
 	use: {
 		testIdAttribute: 'data-tid',
 		trace: 'on',
-		actionTimeout: TIMEOUT,
-		navigationTimeout: TIMEOUT,
+		actionTimeout: ACTION_TIMEOUT,
+		navigationTimeout: NAVIGATION_TIMEOUT,
 		...(DEV && { headless: false })
 	},
 	projects: [


### PR DESCRIPTION
# Motivation

A single 5 min \`TIMEOUT\` constant covers per-test, per-action, per-navigation **and** web-server boot. With \`retries: 3\`, a hung test burns ~20 min/shard and the trace shows "eventually succeeded" instead of where it actually hung.

# Changes

- Split into 4 named constants: \`TEST_TIMEOUT = 60s\`, \`ACTION_TIMEOUT = 15s\`, \`NAVIGATION_TIMEOUT = 30s\`, \`WEB_SERVER_TIMEOUT = 5 min\` (unchanged — \`npm run build\` is slow).
- \`retries: 3\` → \`retries: 1\`.