### PR TITLE
ci(e2e): cache Playwright browsers between shards

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -143,6 +143,30 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
 
+      - name: Get Playwright version
+        id: playwright-version
+        shell: bash
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: npx playwright install --with-deps
+
+      - name: Install Playwright system deps (cache hit, Linux only)
+        if: steps.playwright-cache.outputs.cache-hit == 'true' && runner.os == 'Linux'
+        shell: bash
+        run: npx playwright install-deps
+
       - name: Test
         run: npm run e2e:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"playwright:install": "playwright install --with-deps",
 		"e2e": "npm run playwright:install && playwright test",
 		"e2e:dev": "npm run playwright:install && NODE_ENV=development playwright test",
-		"e2e:ci": "npm run playwright:install && playwright test --update-snapshots=changed --reporter=html,list",
+		"e2e:ci": "playwright test --update-snapshots=changed --reporter=html,list",
 		"e2e:snapshots": "npm run playwright:install && npx playwright test --update-snapshots=changed --reporter=list",
 		"e2e:snapshots:dev": "npm run playwright:install && NODE_ENV=development npx playwright test --update-snapshots=changed --reporter=list",
 		"e2e:report": "npx playwright show-report",


### PR DESCRIPTION
# Motivation

\`playwright install --with-deps\` runs on every shard via the npm script — 20× per full run.

# Changes

- \`.github/workflows/e2e-tests.yml\`: cache \`~/.cache/ms-playwright\` (Linux) and \`~/Library/Caches/ms-playwright\` (macOS), keyed on \`@playwright/test\` version. Install browsers on cache miss; install apt deps only on cache hit + Linux.
- \`package.json\`: drop \`npm run playwright:install &&\` prefix from \`e2e:ci\`. Local scripts unchanged.
