### PR TITLE
chore(build): pin specified_id for backend and rewards on local

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -101,6 +101,7 @@
 			"wasm": "out/backend.wasm.gz",
 			"init_arg_file": "out/backend.args.did",
 			"build": "scripts/build.backend.sh",
+			"specified_id": "d3nvo-aaaaa-aaaar-qagzq-cai",
 			"remote": {
 				"id": {
 					"test_fe_1": "d3nvo-aaaaa-aaaar-qagzq-cai",
@@ -522,6 +523,7 @@
 			"type": "custom",
 			"candid": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.5.10/rewards.did",
 			"wasm": "https://github.com/dfinity/oisy-wallet/releases/download/rc0.5.10/rewards.wasm.gz",
+			"specified_id": "vi6cu-aiaaa-aaaad-aad7q-cai",
 			"remote": {
 				"id": {
 					"ic": "nynz6-haaaa-aaaan-qzqda-cai",


### PR DESCRIPTION
# Motivation

\`backend\` and \`rewards\` are the only two FE-baked canisters in \`dfx.json\` without a local \`specified_id\`, so dfx allocates them dynamically per replica. That blocks pre-building the FE bundle once and reusing it across e2e shards (the build needs deterministic IDs).

Values match what \`canister_e2e_ids.json\` already lists for the \`local\` network and the \`e2e\` / \`staging\` remote IDs — and bring these two in line with every other canister in \`dfx.json\` that already has a \`specified_id\`.

Precursor for the upcoming \`ci(e2e): pre-build frontend once and share across shards\` PR.

# Changes

- \`dfx.json\` \`backend\`: add \`"specified_id": "d3nvo-aaaaa-aaaar-qagzq-cai"\`.
- \`dfx.json\` \`rewards\`: add \`"specified_id": "vi6cu-aiaaa-aaaad-aad7q-cai"\`.
