### PR TITLE
ci(e2e): pre-build frontend once and share across shards

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -65,6 +65,53 @@ jobs:
         with:
           network: local
 
+  oisy-frontend-build:
+    runs-on: ubuntu-24.04
+    if: ${{(github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+      ((github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.check-e2e-changes.outputs.e2e-or-config-changed == 'true' || contains(github.event.pull_request.labels.*.name, 'run-e2e-snapshots')))}}
+    needs: check-e2e-changes
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout for pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        run: |
+          echo "VITE_ETHERSCAN_API_KEY=${{ secrets.VITE_ETHERSCAN_API_KEY_E2E }}" >> $GITHUB_ENV
+          echo "VITE_ALCHEMY_API_KEY=${{ secrets.VITE_ALCHEMY_API_KEY_E2E }}" >> $GITHUB_ENV
+
+      - name: Prepare
+        uses: ./.github/actions/prepare
+
+      - name: Build frontend
+        shell: bash
+        # `vite build` doesn't auto-load `.env.e2e`. Source it manually so the
+        # build sees the same env the per-shard preview server saw before.
+        run: |
+          set -a
+          source .env.e2e
+          set +a
+          npm run build
+
+      - name: Upload frontend build
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: frontend-build
+          path: build/
+          retention-days: 1
+
   define-matrix:
     runs-on: ubuntu-24.04
     permissions:
@@ -87,7 +134,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-    needs: ['oisy-backend-wasm', 'check-e2e-changes', 'define-matrix']
+    needs: ['oisy-backend-wasm', 'oisy-frontend-build', 'check-e2e-changes', 'define-matrix']
     strategy:
       matrix:
         os: ${{ fromJson(needs.define-matrix.outputs.os-matrix) }}
@@ -128,6 +175,12 @@ jobs:
           name: backend.wasm.gz
           path: out/
 
+      - name: Download frontend build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: frontend-build
+          path: build/
+
       - name: Prepare macOS
         if: runner.os == 'macOS'
         uses: ./.github/actions/prepare-macos
@@ -144,6 +197,13 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Test
+        env:
+          # The frontend was built once in `oisy-frontend-build` and downloaded
+          # via `actions/download-artifact`; the per-shard preview server can
+          # serve `build/` directly. Skip the inline `npm run build` that
+          # `playwright.config.ts` would otherwise prepend to the web-server
+          # command.
+          OISY_E2E_SKIP_BUILD: 'true'
         run: npm run e2e:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload Playwright Report

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -109,7 +109,14 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: frontend-build
-          path: build/
+          # `build/` holds the static-adapter output served at runtime, but
+          # `vite preview` (invoked by `npm run preview`) refuses to start
+          # without `.svelte-kit/output/server`, so ship both. The latter is
+          # a hidden directory hence `include-hidden-files: true`.
+          path: |
+            build/
+            .svelte-kit/output/
+          include-hidden-files: true
           retention-days: 1
 
   define-matrix:
@@ -179,7 +186,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: frontend-build
-          path: build/
+          # Restore `build/` and `.svelte-kit/output/` at workspace root (the
+          # paths that the upload preserved).
+          path: .
 
       - name: Prepare macOS
         if: runner.os == 'macOS'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,12 @@ dotenv.populate(
 
 const DEV = (process.env.NODE_ENV ?? 'production') === 'development';
 
+// CI sets this to skip the in-server `npm run build` because a pre-built
+// `build/` is downloaded from a dedicated `oisy-frontend-build` job and the
+// preview server can serve it directly. Local invocations of `npm run e2e`
+// keep the build step so a fresh clone still works without extra setup.
+const SKIP_BUILD = process.env.OISY_E2E_SKIP_BUILD === 'true';
+
 const port = DEV ? 5173 : 4173;
 
 const MATRIX_OS = process.env.MATRIX_OS ?? '';
@@ -89,7 +95,11 @@ export default defineConfig({
 		}
 	},
 	webServer: {
-		command: DEV ? 'npm run dev' : 'npm run build && npm run preview',
+		command: DEV
+			? 'npm run dev'
+			: SKIP_BUILD
+				? 'npm run preview'
+				: 'npm run build && npm run preview',
 		reuseExistingServer: true,
 		port,
 		timeout: TIMEOUT


### PR DESCRIPTION
# Motivation

The Playwright \`webServer.command\` runs \`npm run build && npm run preview\` inside every shard's preview server, so the frontend is rebuilt up to 20× per full e2e run (10 shards × 2 OSes). Mirror the \`oisy-backend-wasm\` artifact pattern: build once, share via artifact.

Depends on #12799 (pins \`specified_id\` for \`backend\` and \`rewards\` in \`dfx.json\`) which makes the canister IDs baked into the bundle deterministic across shards.

# Changes

- \`.github/workflows/e2e-tests.yml\`:
  - New \`oisy-frontend-build\` job (Ubuntu only) that sources \`.env.e2e\`, runs \`npm run build\`, and uploads \`build/\` as a 1-day artifact.
  - \`e2e\` job: depend on the new job, download \`build/\`, set \`OISY_E2E_SKIP_BUILD=true\` so the per-shard preview server skips the rebuild.
- \`playwright.config.ts\`: when \`OISY_E2E_SKIP_BUILD=true\`, \`webServer.command\` becomes \`npm run preview\` only. Local \`npm run e2e\` keeps the build prefix so a fresh clone still works.
