### PR TITLE
fix(frontend): reset Solana scheduler in-memory store after fatal sync error

### DIFF
--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -217,6 +217,15 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 				maxRetries: 10
 			});
 		} catch (error: unknown) {
+			// On a fatal sync failure, the listener (main thread) resets the UI stores for this token.
+			// We must mirror that on the scheduler side, otherwise the next successful run only emits
+			// deltas (no `newBalance` / `newTransactions`) and the UI stays empty until the worker is
+			// re-created. Clearing the in-memory store forces the next run to behave like an initial
+			// sync, re-loading from the backend cache and re-emitting the full state.
+			this.store = {
+				balance: undefined,
+				transactions: {}
+			};
 			this.postMessageWalletError({ error });
 		}
 	};

--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -217,11 +217,7 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 				maxRetries: 10
 			});
 		} catch (error: unknown) {
-			// On a fatal sync failure, the listener (main thread) resets the UI stores for this token.
-			// We must mirror that on the scheduler side, otherwise the next successful run only emits
-			// deltas (no `newBalance` / `newTransactions`) and the UI stays empty until the worker is
-			// re-created. Clearing the in-memory store forces the next run to behave like an initial
-			// sync, re-loading from the backend cache and re-emitting the full state.
+			// Mirror the listener-side UI reset; otherwise the next sync only emits deltas and the UI stays empty.
 			this.store = {
 				balance: undefined,
 				transactions: {}

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -272,6 +272,56 @@ describe('sol-wallet.scheduler', () => {
 					});
 				});
 
+				it('should reset the internal store after a fatal error so the next successful sync re-emits the full state', async () => {
+					await scheduler.start(startData);
+
+					await awaitJobExecution();
+
+					// Sanity check: the first sync populated the internal store.
+					expect(scheduler['store'].transactions).toEqual(
+						expectedSoLTransactions.reduce(
+							(acc, transaction) => ({
+								...acc,
+								[transaction.data.id]: transaction
+							}),
+							{}
+						)
+					);
+					expect(scheduler['store'].balance).toBeDefined();
+
+					// Force the next iteration to fail and exhaust retries.
+					const err = new Error('Failed to fetch');
+					spyLoadBalance.mockRejectedValue(err);
+
+					await vi.advanceTimersByTimeAsync(SOL_WALLET_TIMER_INTERVAL_MILLIS);
+
+					expect(postMessageMock).toHaveBeenCalledWith({
+						msg: 'syncSolWalletError',
+						ref,
+						data: {
+							error: err
+						}
+					});
+
+					// After the fatal error, the in-memory store must be cleared so the worker
+					// can start fresh on the next tick (mirroring the listener-side UI reset).
+					expect(scheduler['store']).toEqual({
+						balance: undefined,
+						transactions: {}
+					});
+
+					// Recovery: the next successful sync must emit the wallet payload again,
+					// not just status messages, so the previously reset UI store is repopulated.
+					spyLoadBalance.mockResolvedValue(isSpl ? mockSplBalance : mockSolBalance);
+					postMessageMock.mockClear();
+
+					await vi.advanceTimersByTimeAsync(SOL_WALLET_TIMER_INTERVAL_MILLIS);
+
+					expect(postMessageMock).toHaveBeenCalledWith(
+						mockPostMessage({ withTransactions: true, isSpl, ref })
+					);
+				});
+
 				it('should not post message when no new transactions or balance changes', async () => {
 					await scheduler.start(startData);
 


### PR DESCRIPTION
# Motivation

When the Solana RPC hiccups (`TypeError: Failed to fetch`), the activity feed can stop loading and never recover until the worker is re-created. After `retryWithDelay` exhausts its retries, the scheduler posts `syncSolWalletError` and the listener resets the UI stores — but the scheduler's own `this.store` keeps the backend-cached transactions from the initial sync, so on the next tick `isInitialSync` is `false`, no backend reload happens, and `syncWalletData` short-circuits with no `newBalance` / `newTransactions` to emit.

# Changes

- `sol-wallet.scheduler.ts`: clear `this.store` in `syncWallet`'s catch branch so the next tick behaves like an initial sync.

# Tests

Adapted tests.
