### PR TITLE
test(e2e): drop no-op CAROUSEL_SLIDE_NAVIGATION waits

### DIFF
--- a/e2e/utils/pages/activity.page.ts
+++ b/e2e/utils/pages/activity.page.ts
@@ -1,7 +1,6 @@
 import { AppPath } from '$lib/constants/routes.constants';
 import {
 	ACTIVITY_TRANSACTION_SKELETON_PREFIX,
-	CAROUSEL_SLIDE_NAVIGATION,
 	NAVIGATION_ITEM_ACTIVITY,
 	NO_TRANSACTIONS_PLACEHOLDER
 } from '$lib/constants/test-ids.constants';
@@ -16,9 +15,6 @@ export class ActivityPage extends HomepageLoggedIn {
 
 	override async extendWaitForReady(): Promise<void> {
 		await this.navigateTo({ testId: NAVIGATION_ITEM_ACTIVITY, expectedPath: AppPath.Activity });
-		await this.getLocatorByTestId({ testId: CAROUSEL_SLIDE_NAVIGATION }).waitFor({
-			state: 'hidden'
-		});
 		await this.waitForLoadState();
 
 		await Promise.all(

--- a/e2e/utils/pages/explorer.page.ts
+++ b/e2e/utils/pages/explorer.page.ts
@@ -1,8 +1,5 @@
 import { AppPath } from '$lib/constants/routes.constants';
-import {
-	CAROUSEL_SLIDE_NAVIGATION,
-	NAVIGATION_ITEM_EXPLORER
-} from '$lib/constants/test-ids.constants';
+import { NAVIGATION_ITEM_EXPLORER } from '$lib/constants/test-ids.constants';
 import { HomepageLoggedIn, type HomepageLoggedInParams } from './homepage.page';
 
 export type ExplorerPageParams = HomepageLoggedInParams;
@@ -14,9 +11,6 @@ export class ExplorerPage extends HomepageLoggedIn {
 
 	override async extendWaitForReady(): Promise<void> {
 		await this.navigateTo({ testId: NAVIGATION_ITEM_EXPLORER, expectedPath: AppPath.Explore });
-		await this.getLocatorByTestId({ testId: CAROUSEL_SLIDE_NAVIGATION }).waitFor({
-			state: 'hidden'
-		});
 		await this.waitForLoadState();
 	}
 }

--- a/e2e/utils/pages/settings.page.ts
+++ b/e2e/utils/pages/settings.page.ts
@@ -1,6 +1,5 @@
 import { AppPath } from '$lib/constants/routes.constants';
 import {
-	CAROUSEL_SLIDE_NAVIGATION,
 	NAVIGATION_ITEM_SETTINGS,
 	SETTINGS_ADDRESS_LABEL
 } from '$lib/constants/test-ids.constants';
@@ -17,10 +16,6 @@ export class SettingsPage extends HomepageLoggedIn {
 		await this.navigateTo({ testId: NAVIGATION_ITEM_SETTINGS, expectedPath: AppPath.Settings });
 
 		await this.mockSelector({ selector: `[data-tid="${SETTINGS_ADDRESS_LABEL}"]` });
-
-		await this.getLocatorByTestId({ testId: CAROUSEL_SLIDE_NAVIGATION }).waitFor({
-			state: 'hidden'
-		});
 
 		await this.waitForLoadState();
 	}

--- a/e2e/utils/pages/transactions.page.ts
+++ b/e2e/utils/pages/transactions.page.ts
@@ -1,8 +1,4 @@
-import {
-	CAROUSEL_SLIDE_NAVIGATION,
-	NO_TRANSACTIONS_PLACEHOLDER,
-	TOKEN_CARD
-} from '$lib/constants/test-ids.constants';
+import { NO_TRANSACTIONS_PLACEHOLDER, TOKEN_CARD } from '$lib/constants/test-ids.constants';
 import { HomepageLoggedIn, type HomepageLoggedInParams } from './homepage.page';
 
 type TransactionsPageParams = HomepageLoggedInParams;
@@ -58,9 +54,6 @@ export class TransactionsPage extends HomepageLoggedIn {
 		await this.toggleNetworkSelector({ networkSymbol: networkId });
 		const testId = `${TOKEN_CARD}-${tokenSymbol}-${networkId}`;
 		await this.clickByTestId({ testId });
-		await this.getLocatorByTestId({ testId: CAROUSEL_SLIDE_NAVIGATION }).waitFor({
-			state: 'hidden'
-		});
 		if (waitForPlaceholder) {
 			await this.waitForByTestId({ testId: NO_TRANSACTIONS_PLACEHOLDER });
 		}


### PR DESCRIPTION
# Motivation

Four page objects call \`getLocatorByTestId({ testId: CAROUSEL_SLIDE_NAVIGATION }).waitFor({ state: 'hidden' })\`. The constant is \`'carousel-slide-navigation-'\` (trailing dash), so the exact-match lookup never matches the actual \`…-1\`, \`…-2\`, … indicator IDs. Even if it had, \`state: 'hidden'\` is satisfied immediately by the CSS mask in \`e2e/styles/masks.css\` (\`visibility: hidden\` counts as hidden). Result: the wait never blocks anything.

# Changes

- Drop the dead \`waitFor({ state: 'hidden' })\` line and the now-unused \`CAROUSEL_SLIDE_NAVIGATION\` import in \`activity.page.ts\`, \`explorer.page.ts\`, \`settings.page.ts\`, \`transactions.page.ts\`.

If a real "wait for carousel layout to settle" is needed later, it can be added intentionally with the correct selector and state.
