### PR TITLE
fix(frontend): reset BTC scheduler in-memory store after fatal sync error

### DIFF
--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -305,6 +305,12 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 			onUpdateError: ({ error }) => {
 				this.failedSyncCounter++;
 				if (FAILURE_THRESHOLD <= this.failedSyncCounter) {
+					// Mirror the listener-side UI reset; otherwise the next sync only emits deltas and the UI stays empty.
+					this.store = {
+						balance: undefined,
+						transactions: {},
+						latestBitcoinBlockHeight: undefined
+					};
 					this.postMessageWalletError({ error });
 				}
 			}

--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
@@ -287,6 +287,39 @@ describe('btc-wallet.worker', () => {
 						}
 					});
 				});
+
+				it('should reset the internal store when emitting an error so the next successful sync re-emits', async () => {
+					await scheduler.start(startData);
+
+					await awaitJobExecution();
+
+					// Sanity check: the first sync populated the internal store.
+					expect(scheduler['store'].balance).toBeDefined();
+
+					// Force three consecutive update failures to cross the FAILURE_THRESHOLD.
+					const err = new Error('Failed to fetch');
+					signerCanisterMock.getBtcBalance.mockRejectedValue(err);
+
+					await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+					await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+					await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+					expect(postMessageMock).toHaveBeenCalledWith({
+						ref,
+						msg: 'syncBtcWalletError',
+						data: {
+							error: err
+						}
+					});
+
+					// After the fatal error, the in-memory store must be cleared so the next tick
+					// behaves like an initial sync (mirroring the listener-side UI reset).
+					expect(scheduler['store']).toEqual({
+						balance: undefined,
+						transactions: {},
+						latestBitcoinBlockHeight: undefined
+					});
+				});
 			}
 		};
 	};


### PR DESCRIPTION
# Motivation

After `FAILURE_THRESHOLD` consecutive update failures, `BtcWalletScheduler` posts `syncBtcWalletError` and the listener resets the UI stores (`balancesStore`, `btcTransactionsStore`). The scheduler's own in-memory `this.store` is left intact, so on the next successful tick `syncWalletData` sees neither `newBalance` nor `newTransactions` and short-circuits without posting — leaving the UI empty until the worker is re-created.

Same shape of bug as the Solana one (see #12802) — split into a separate atomic PR per AGENTS.md.

# Changes

- `btc-wallet.scheduler.ts`: clear `this.store` (`balance`, `transactions`, `latestBitcoinBlockHeight`) inside `onUpdateError` once `FAILURE_THRESHOLD` is crossed, before posting the error.

# Tests

Adapt tests.