### PR TITLE
test(e2e): cap getStableViewportHeight polling

### DIFF
--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -469,16 +469,27 @@ abstract class Homepage {
 	}
 
 	async getStableViewportHeight(): Promise<number> {
+		// Hard cap so a page with an animation, polling worker, or streaming
+		// content that never settles can't burn the entire test timeout. If
+		// the page hasn't stabilised after `MAX_POLLS * POLL_INTERVAL_MS`,
+		// fall back to the latest sample and let the snapshot diff surface
+		// any layout drift instead of hanging.
+		const POLL_INTERVAL_MS = 1_000;
+		const MAX_POLLS = 10;
+
 		let previousHeight: number;
 		let currentHeight: number = await this.#page.evaluate(
 			() => document.documentElement.scrollHeight
 		);
 
-		do {
+		for (let i = 0; i < MAX_POLLS; i++) {
 			previousHeight = currentHeight;
-			await this.#page.waitForTimeout(1000);
+			await this.#page.waitForTimeout(POLL_INTERVAL_MS);
 			currentHeight = await this.#page.evaluate(() => document.documentElement.scrollHeight);
-		} while (currentHeight !== previousHeight);
+			if (currentHeight === previousHeight) {
+				return currentHeight;
+			}
+		}
 
 		return currentHeight;
 	}


### PR DESCRIPTION
# Motivation

\`getStableViewportHeight()\` polled \`document.documentElement.scrollHeight\` every 1 s until two consecutive samples matched, with no upper cap. A page that never quiesces (animation, polling worker, streaming content) burns the entire per-test timeout in this loop and the test fails with no useful trace.

# Changes

- \`e2e/utils/pages/homepage.page.ts\`: bound the loop at 10 polls (~10 s, named \`MAX_POLLS\` / \`POLL_INTERVAL_MS\`). On exhaustion, return the latest sample so the snapshot diff surfaces any layout drift instead of hanging.
