### PR TITLE
test(e2e): replace raw setTimeout waits in flow page

### DIFF
--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -177,6 +177,12 @@ abstract class Homepage {
 
 	protected async mockSelectorAll({ selector }: SelectorOperationParams): Promise<void> {
 		const elementsLocator = this.#page.locator(selector);
+
+		// Wait for the first match to render before masking. Otherwise
+		// `evaluateAll` runs against an empty NodeList (silently no-op) and
+		// the screenshot captures the un-mocked, time-sensitive content.
+		await elementsLocator.first().waitFor({ state: 'visible' });
+
 		await elementsLocator.evaluateAll((elements) => {
 			for (const element of elements) {
 				(element as HTMLElement).innerHTML = 'placeholder';

--- a/e2e/utils/pages/send-and-receive-flow.page.ts
+++ b/e2e/utils/pages/send-and-receive-flow.page.ts
@@ -92,8 +92,6 @@ export class FlowPage extends HomepageLoggedIn {
 	async navigateToActivity(): Promise<void> {
 		await this.navigateTo({ testId: NAVIGATION_ITEM_ACTIVITY, expectedPath: AppPath.Activity });
 
-		await new Promise((resolve) => setTimeout(resolve, 5000));
-
 		await this.mockSelectorAll({
 			selector: '[data-tid="receive-tokens-modal-transaction-timestamp"]'
 		});
@@ -116,8 +114,6 @@ export class FlowPage extends HomepageLoggedIn {
 			testId: this.getTokenCardTestId({ tokenSymbol, networkSymbol }),
 			expectedPath: AppPath.Transactions
 		});
-
-		await new Promise((resolve) => setTimeout(resolve, 1000));
 
 		await this.mockSelectorAll({
 			selector: '[data-tid="receive-tokens-modal-transaction-timestamp"]'


### PR DESCRIPTION
# Motivation

\`navigateToActivity()\` and \`navigateToTransactionsPage()\` slept 5 s and 1 s respectively before calling \`mockSelectorAll('…transaction-timestamp')\`. The sleeps were a hack: \`mockSelectorAll\`'s \`evaluateAll\` runs against an empty NodeList without complaining, so calling it before the rows render is a silent no-op and the screenshot then captures the un-mocked, time-sensitive timestamps.

# Changes

- \`e2e/utils/pages/homepage.page.ts\` — \`mockSelectorAll\` now waits for the first match to be visible before evaluating.
- \`e2e/utils/pages/send-and-receive-flow.page.ts\` — drop the two \`new Promise(r => setTimeout(r, …))\` sleeps.

Behavioral note: any caller that legitimately matches zero elements will now time out instead of silently no-op'ing. The only current caller (this flow page) always expects matches.
