### PR TITLE
fix(frontend): reset IC balance scheduler in-memory store after error

### DIFF
--- a/src/frontend/src/icp/schedulers/ic-wallet-balance.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance.scheduler.ts
@@ -51,7 +51,11 @@ export class IcWalletBalanceScheduler<
 		await this.queryAndUpdateWithWarmup<bigint>({
 			request: ({ identity: _, certified }) => this.getBalance({ ...data, identity, certified }),
 			onLoad: ({ certified, ...rest }) => this.syncBalance({ certified, ...rest }),
-			onUpdateError: ({ error }) => this.postMessageWalletError({ msg: this.msg, error }),
+			onUpdateError: ({ error }) => {
+				// Mirror the listener-side UI reset; otherwise the next sync only emits deltas and the UI stays empty.
+				this.store = { balance: undefined };
+				this.postMessageWalletError({ msg: this.msg, error });
+			},
 			identity
 		});
 	};

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
@@ -298,7 +298,10 @@ describe('ic-wallet-balance.worker', () => {
 				});
 
 				if (nonNullish(initSuccessMock)) {
-					it('should reset the internal store after an error so the next successful sync re-emits the balance', async () => {
+					// Implicitly covers the in-memory store reset on error: a successful sync after
+					// a fatal error can only re-emit the balance payload (rather than just status
+					// messages) when the scheduler's internal store was cleared.
+					it('should re-emit the balance payload on the next successful sync after an error', async () => {
 						const err = new Error('Failed to fetch');
 						initErrorMock(err);
 
@@ -312,12 +315,6 @@ describe('ic-wallet-balance.worker', () => {
 							data: { error: err }
 						});
 
-						// After the fatal error, the in-memory store must be cleared so the next tick
-						// behaves like an initial sync (mirroring the listener-side UI reset).
-						expect(scheduler['store']).toEqual({ balance: undefined });
-
-						// Recovery: the next successful sync must emit the balance payload again
-						// (not just status messages), so the previously reset UI store is repopulated.
 						initSuccessMock();
 						postMessageMock.mockClear();
 

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
@@ -9,7 +9,7 @@ import type {
 } from '$lib/types/post-message';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import type { TestUtil } from '$tests/types/utils';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import { IcrcLedgerCanister } from '@icp-sdk/canisters/ledger/icrc';
 import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
@@ -245,6 +245,7 @@ describe('ic-wallet-balance.worker', () => {
 		initScheduler,
 		startData = undefined,
 		initErrorMock,
+		initSuccessMock,
 		msg
 	}: {
 		initScheduler: (
@@ -252,9 +253,18 @@ describe('ic-wallet-balance.worker', () => {
 		) => IcWalletScheduler<PostMessageDataRequest>;
 		startData?: PostMessageDataRequest | undefined;
 		initErrorMock: (err: Error) => void;
+		initSuccessMock?: () => void;
 		msg: 'syncIcpWallet' | 'syncIcrcWallet' | 'syncDip20Wallet';
 	}): TestUtil => {
 		let scheduler: IcWalletScheduler<PostMessageDataRequest>;
+
+		const ref = isNullish(startData)
+			? undefined
+			: 'ledgerCanisterId' in startData
+				? startData.ledgerCanisterId
+				: 'indexCanisterId' in startData
+					? startData.indexCanisterId
+					: startData.canisterId;
 
 		return {
 			setup: () => {
@@ -279,19 +289,47 @@ describe('ic-wallet-balance.worker', () => {
 					expect(postMessageMock).toHaveBeenCalledTimes(3);
 
 					expect(postMessageMock).toHaveBeenCalledWith({
-						ref: isNullish(startData)
-							? undefined
-							: 'ledgerCanisterId' in startData
-								? startData.ledgerCanisterId
-								: 'indexCanisterId' in startData
-									? startData.indexCanisterId
-									: startData.canisterId,
+						ref,
 						msg: `${msg}Error`,
 						data: {
 							error: err
 						}
 					});
 				});
+
+				if (nonNullish(initSuccessMock)) {
+					it('should reset the internal store after an error so the next successful sync re-emits the balance', async () => {
+						const err = new Error('Failed to fetch');
+						initErrorMock(err);
+
+						await scheduler.start(startData);
+
+						await awaitJobExecution();
+
+						expect(postMessageMock).toHaveBeenCalledWith({
+							ref,
+							msg: `${msg}Error`,
+							data: { error: err }
+						});
+
+						// After the fatal error, the in-memory store must be cleared so the next tick
+						// behaves like an initial sync (mirroring the listener-side UI reset).
+						expect(scheduler['store']).toEqual({ balance: undefined });
+
+						// Recovery: the next successful sync must emit the balance payload again
+						// (not just status messages), so the previously reset UI store is repopulated.
+						initSuccessMock();
+						postMessageMock.mockClear();
+
+						await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+						expect(postMessageMock).toHaveBeenCalledWith({
+							ref,
+							msg,
+							data: mockPostMessageData({ certified: false })
+						});
+					});
+				}
 			}
 		};
 	};
@@ -328,11 +366,13 @@ describe('ic-wallet-balance.worker', () => {
 
 		describe('other scenarios', () => {
 			const initErrorMock = (err: Error) => ledgerCanisterMock.balance.mockRejectedValue(err);
+			const initSuccessMock = () => ledgerCanisterMock.balance.mockResolvedValue(mockBalance);
 
 			const { setup, teardown, tests } = initOtherScenarios({
 				initScheduler: initIcrcWalletScheduler,
 				startData,
 				initErrorMock,
+				initSuccessMock,
 				msg: 'syncIcrcWallet'
 			});
 


### PR DESCRIPTION
# Motivation

When `IcWalletBalanceScheduler` hits an update error it posts a `{msg}Error` message and the listener resets the UI stores via `onLoadTransactionsError` (clears both `icTransactionsStore` and `balancesStore` for that token). The scheduler's own in-memory `this.store.balance` is left intact, so on the next successful tick `syncBalance` sees `newBalance` is false and short-circuits without posting — the UI's balance stays empty until the worker is re-created.

Same shape of bug as the Solana one (see #12802). Used by ICRC and DIP20 ledgers without an index canister.

# Changes

- `ic-wallet-balance.scheduler.ts`: clear `this.store` (`{ balance: undefined }`) inside `onUpdateError`, before posting the error.

# Tests

Adapted tests.

