### PR TITLE
test(e2e): wait for login button instead of 15s sleep in warmup

### DIFF
--- a/e2e/warmup.setup.ts
+++ b/e2e/warmup.setup.ts
@@ -1,10 +1,20 @@
+import { LOGIN_BUTTON } from '$lib/constants/test-ids.constants';
 import { test as setup } from '@playwright/test';
 
-const WARMUP_TIMEOUT = 15_000;
+// In dev mode (`npm run dev`) Vite triggers a dependency-optimization reload
+// on the very first navigation; if the first real test happens to land
+// during that reload the Internet Identity popup connection breaks and login
+// fails. Pre-warm by loading the home page once and waiting for the
+// post-reload login button to render before any actual test runs.
+//
+// Allow up to 60 s for the post-reload render — the actual wait is typically
+// a few seconds, but the cap protects against a Vite optimization that
+// genuinely hangs.
+const WARMUP_TIMEOUT = 60_000;
 
 setup('warm up the app to trigger initial reload', async ({ page }) => {
 	setup.setTimeout(WARMUP_TIMEOUT + 30_000);
 
 	await page.goto('/');
-	await page.waitForTimeout(WARMUP_TIMEOUT);
+	await page.getByTestId(LOGIN_BUTTON).waitFor({ state: 'visible', timeout: WARMUP_TIMEOUT });
 });


### PR DESCRIPTION
# Motivation

\`warmup.setup.ts\` did \`page.goto('/')\` then \`page.waitForTimeout(15_000)\`. The sleep is paid in full on every shard × every project, regardless of whether Vite's dev-mode dep-optimization reload actually happened, and gives no signal that the app rendered after the reload.

# Changes

- \`e2e/warmup.setup.ts\`: replace the 15 s blind sleep with \`page.getByTestId(LOGIN_BUTTON).waitFor({ state: 'visible', timeout: 60_000 })\`. Typical wait is a few seconds; the 60 s cap is a safety net for a Vite optimization that genuinely hangs.
