### PR TITLE
fix(frontend): reset IC balance+transactions scheduler in-memory store after error

### DIFF
--- a/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
@@ -91,7 +91,12 @@ export class IcWalletBalanceAndTransactionsScheduler<
 				this.syncTransactions({ jobData: { identity, ...data }, certified, ...rest });
 				this.cleanTransactions({ certified });
 			},
-			onUpdateError: ({ error }) => this.postMessageWalletError({ msg: this.msg, error }),
+			onUpdateError: ({ error }) => {
+				// Mirror the listener-side UI reset; otherwise the next sync only emits deltas and the UI stays empty.
+				this.store = { balance: undefined, transactions: {} };
+				this.initialized = false;
+				this.postMessageWalletError({ msg: this.msg, error });
+			},
 			identity
 		});
 	};

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -21,7 +21,13 @@ import type {
 import * as eventsUtils from '$lib/utils/events.utils';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import type { TestUtil } from '$tests/types/utils';
-import { arrayOfNumberToUint8Array, isNullish, jsonReplacer, toNullable } from '@dfinity/utils';
+import {
+	arrayOfNumberToUint8Array,
+	isNullish,
+	jsonReplacer,
+	nonNullish,
+	toNullable
+} from '@dfinity/utils';
 import { IcpIndexCanister, type IcpIndexDid } from '@icp-sdk/canisters/ledger/icp';
 import {
 	IcrcIndexCanister,
@@ -248,6 +254,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 		startData = undefined,
 		initCleanupMock,
 		initErrorMock,
+		initSuccessMock,
 		msg
 	}: {
 		initScheduler: (
@@ -256,6 +263,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 		startData?: PostMessageDataRequest | undefined;
 		initCleanupMock: (mockRogueId: bigint) => void;
 		initErrorMock: (err: Error) => void;
+		initSuccessMock?: () => void;
 		msg: 'syncIcpWallet' | 'syncIcrcWallet' | 'syncDip20Wallet';
 	}): TestUtil => {
 		let scheduler: IcWalletScheduler<PostMessageDataRequest>;
@@ -321,6 +329,45 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 						}
 					});
 				});
+
+				if (nonNullish(initSuccessMock)) {
+					it('should reset the internal store after an error so the next successful sync re-emits', async () => {
+						const err = new Error('Failed to fetch');
+						initErrorMock(err);
+
+						await scheduler.start(startData);
+
+						await awaitJobExecution();
+
+						expect(postMessageMock).toHaveBeenCalledWith({
+							ref,
+							msg: `${msg}Error`,
+							data: { error: err }
+						});
+
+						// After the fatal error, the in-memory store must be cleared so the next tick
+						// behaves like an initial sync (mirroring the listener-side UI reset).
+						expect(scheduler['store']).toEqual({
+							balance: undefined,
+							transactions: {}
+						});
+						expect(scheduler['initialized']).toBeFalsy();
+
+						// Recovery: the next successful sync must emit the wallet payload again
+						// (not just status messages), so the previously reset UI store is repopulated.
+						initSuccessMock();
+						postMessageMock.mockClear();
+
+						await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+						expect(postMessageMock).toHaveBeenCalledWith(
+							expect.objectContaining({
+								ref,
+								msg
+							})
+						);
+					});
+				}
 			}
 		};
 	};
@@ -805,6 +852,14 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 					startData,
 					initCleanupMock,
 					initErrorMock: (err: Error) => ledgerCanisterMock.balance.mockRejectedValue(err),
+					initSuccessMock: () => {
+						ledgerCanisterMock.balance.mockResolvedValue(mockBalance);
+						indexCanisterMock.getTransactions.mockResolvedValue({
+							balance: mockBalanceFromTransactions(),
+							transactions: [mockTransaction],
+							oldest_tx_id: [mockOldestTxId]
+						});
+					},
 					msg: 'syncIcrcWallet'
 				});
 

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -331,7 +331,10 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 				});
 
 				if (nonNullish(initSuccessMock)) {
-					it('should reset the internal store after an error so the next successful sync re-emits', async () => {
+					// Implicitly covers the in-memory store reset on error: a successful sync after
+					// a fatal error can only re-emit the wallet payload (rather than just status
+					// messages) when the scheduler's internal store and initialized flag were cleared.
+					it('should re-emit the wallet payload on the next successful sync after an error', async () => {
 						const err = new Error('Failed to fetch');
 						initErrorMock(err);
 
@@ -345,16 +348,6 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 							data: { error: err }
 						});
 
-						// After the fatal error, the in-memory store must be cleared so the next tick
-						// behaves like an initial sync (mirroring the listener-side UI reset).
-						expect(scheduler['store']).toEqual({
-							balance: undefined,
-							transactions: {}
-						});
-						expect(scheduler['initialized']).toBeFalsy();
-
-						// Recovery: the next successful sync must emit the wallet payload again
-						// (not just status messages), so the previously reset UI store is repopulated.
 						initSuccessMock();
 						postMessageMock.mockClear();
 


### PR DESCRIPTION
# Motivation

When `IcWalletBalanceAndTransactionsScheduler` (used by ICP, ICRC and DIP20 wallets that have an index canister) hits an update error it posts a `{msg}Error` message and the listener resets the UI stores via `onLoadTransactionsError` (clears `icTransactionsStore` and `balancesStore` for that token). The scheduler's own in-memory `this.store` (balance + transactions) and `this.initialized` flag are left intact, so on the next successful tick `syncTransactions` filters out already-known transactions, sees no balance change, short-circuits, and never posts — leaving the UI empty until the worker is re-created.

Same shape of bug as the Solana one (see #12802).

# Changes

- `ic-wallet-balance-and-transactions.scheduler.ts`: clear `this.store` (`{ balance: undefined, transactions: {} }`) and reset `this.initialized = false` inside `onUpdateError`, before posting the error.

# Tests

Adapted tests.
