### PR TITLE
test(e2e): re-implement QR decoder via in-browser jsQR

### DIFF
--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -35,7 +35,7 @@ import { isNullish, nonNullish } from '@dfinity/utils';
 import { expect, type Locator, type Page, type ViewportSize } from '@playwright/test';
 import { PromotionCarousel } from '../components/promotion-carousel.component';
 import { HOMEPAGE_URL, LOCAL_REPLICA_URL } from '../constants/e2e.constants';
-import { getQRCodeValueFromDataURL } from '../qr-code.utils';
+import { getQRCodeValueFromCanvas } from '../qr-code.utils';
 import {
 	getReceiveTokensModalAddressLabelSelector,
 	getReceiveTokensModalQrCodeButtonSelector
@@ -202,28 +202,9 @@ abstract class Homepage {
 		await this.waitForByTestId({ testId: LOGIN_BUTTON, options });
 	}
 
-	private async getCanvasAsDataURL({
-		selector
-	}: SelectorOperationParams): Promise<string | undefined> {
-		return await this.#page.evaluate<string | undefined, { selector: string }>(
-			({ selector }) => {
-				const canvas = document.querySelector<HTMLCanvasElement>(selector);
-				return canvas?.toDataURL();
-			},
-			{
-				selector
-			}
-		);
-	}
-
 	protected async readQRCode({ selector }: SelectorOperationParams): Promise<string | undefined> {
 		await this.#page.locator(selector).waitFor();
-
-		const dataUrl = await this.getCanvasAsDataURL({ selector });
-
-		if (nonNullish(dataUrl)) {
-			return getQRCodeValueFromDataURL({ dataUrl });
-		}
+		return await getQRCodeValueFromCanvas({ page: this.#page, selector });
 	}
 
 	protected async waitForModal({

--- a/e2e/utils/qr-code.utils.ts
+++ b/e2e/utils/qr-code.utils.ts
@@ -1,24 +1,41 @@
-// TODO: uncomment and replace Jimp with native functions, unless the library bumps its dependency to zod to v4
-export const getQRCodeValueFromDataURL = async ({
-	dataUrl: _
-}: {
-	dataUrl: string;
-	// eslint-disable-next-line arrow-body-style,require-await
-}): Promise<string | undefined> => {
-	return Promise.reject(new Error('Function `getQRCodeValueFromDataURL` not implemented'));
+import type { Page } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
 
-	// const qrBuffer = Buffer.from(dataUrl.replace(/^data:image\/[a-z]+;base64,/, ''), 'base64');
-	// const image = await Jimp.read(qrBuffer);
-	//
-	// const imageData = {
-	// 	data: new Uint8ClampedArray(image.bitmap.data),
-	// 	width: image.bitmap.width,
-	// 	height: image.bitmap.height
-	// };
-	//
-	// const decodedQR = jsQR(imageData.data, imageData.width, imageData.height);
-	//
-	// if (nonNullish(decodedQR)) {
-	// 	return decodedQR.data;
-	// }
+declare global {
+	interface Window {
+		jsQR?: (data: Uint8ClampedArray, width: number, height: number) => { data: string } | null;
+	}
+}
+
+// Path to the bundled jsQR UMD build. Injected into the page so we can decode
+// the QR straight from the canvas's `ImageData`, avoiding the
+// canvas → PNG → decode round-trip that previously needed a Node-side PNG
+// decoder (Jimp, removed in #9165).
+const JSQR_BUNDLE_PATH = fileURLToPath(
+	new URL('../../node_modules/jsqr/dist/jsQR.js', import.meta.url)
+);
+
+export const getQRCodeValueFromCanvas = async ({
+	page,
+	selector
+}: {
+	page: Page;
+	selector: string;
+}): Promise<string | undefined> => {
+	await page.addScriptTag({ path: JSQR_BUNDLE_PATH });
+
+	return await page.evaluate((sel) => {
+		const canvas = document.querySelector<HTMLCanvasElement>(sel);
+		if (canvas === null) {
+			return undefined;
+		}
+
+		const ctx = canvas.getContext('2d');
+		if (ctx === null || window.jsQR === undefined) {
+			return undefined;
+		}
+
+		const { data, width, height } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+		return window.jsQR(data, width, height)?.data;
+	}, selector);
 };


### PR DESCRIPTION
# Motivation

\`getQRCodeValueFromDataURL\` has been throwing \`Function getQRCodeValueFromDataURL not implemented\` since #9165 removed \`jimp\` (its PNG decoder), silently breaking the five \`should display correct QR codes for receiving …\` specs in \`receive-tokens-modal.spec.ts\`.

Restore decoding **without bringing back a Node-side PNG decoder**: run \`jsQR\` (already a dep) directly inside the page context. The canvas's \`ImageData\` is already available via the browser's 2D context, so the canvas → PNG → decode round-trip is no longer needed.

# Changes

- \`e2e/utils/qr-code.utils.ts\`: rewrite as \`getQRCodeValueFromCanvas({ page, selector })\`. Injects the bundled \`node_modules/jsqr/dist/jsQR.js\` UMD via \`page.addScriptTag\` and decodes from \`ctx.getImageData\`.
- \`e2e/utils/pages/homepage.page.ts\`: \`readQRCode()\` becomes a thin wrapper that just passes \`this.#page\`; \`getCanvasAsDataURL()\` is removed (no longer needed).
- No new dependencies. \`jsqr\` was already in \`package.json\`.

# Tests

- \`npx tsc --noEmit -p e2e/tsconfig.json\` ✓
- \`npx prettier --check e2e/\` ✓
- \`npx eslint e2e/ --max-warnings 0\` ✓
- The 5 QR specs stay \`testWithII.skip(...)\` for now (consistent with the rest of the e2e suite); they'll be un-skipped one-by-one in Phase 3.