### PR TITLE
fix(frontend): correct BTC transaction value via net-flow algorithm

### DIFF
--- a/src/frontend/src/btc/types/btc.ts
+++ b/src/frontend/src/btc/types/btc.ts
@@ -8,6 +8,7 @@ export interface BtcTransactionUi extends Omit<TransactionUiCommon, 'to'> {
 	type: BtcTransactionType;
 	status: BtcTransactionStatus;
 	value?: bigint;
+	fee?: bigint;
 	confirmations?: number;
 
 	// BTC transaction can have multiple recipients

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -67,7 +67,11 @@ export const mapBtcTransaction = ({
 			inputs[0].prev_out.addr)
 		: btcAddress;
 
-	const to = isReceive ? [btcAddress] : recipients;
+	// On a send with zero non-user outputs (consolidation), fall back to the user's
+	// own address so the list row has a counterparty to render. Every output in
+	// this branch literally has `addr === btcAddress`, so this is the true
+	// destination, not a guess.
+	const to = isReceive || recipients.length === 0 ? [btcAddress] : recipients;
 
 	return {
 		id: hash,

--- a/src/frontend/src/btc/utils/btc-transactions.utils.ts
+++ b/src/frontend/src/btc/utils/btc-transactions.utils.ts
@@ -13,88 +13,72 @@ export const mapBtcTransaction = ({
 	btcAddress: BtcAddress;
 	latestBitcoinBlockHeight: number;
 }): BtcTransactionUi => {
-	// Step 1: Calculate total input value and determine if the transaction is a "send"
-	const { totalInputValue, isTypeSend } = inputs.reduce<{
-		totalInputValue: number;
-		isTypeSend: boolean;
-	}>(
-		(acc, { prev_out: { value, addr } }) => ({
-			totalInputValue: acc.totalInputValue + value,
-			isTypeSend: acc.isTypeSend ? acc.isTypeSend : addr === btcAddress
-		}),
-		{
-			totalInputValue: 0,
-			isTypeSend: false
-		}
+	// Step 1: Aggregate input/output values split by user vs. others.
+	const inputsFromUser = inputs.reduce(
+		(acc, { prev_out: { addr, value } }) => acc + (addr === btcAddress ? value : 0),
+		0
 	);
 
-	// Step 2: Analyse outputs to determine total value, destination addresses, and whether it's a self-transaction
-	const { totalOutputValue, totalValue, to, selfTransaction } = out.reduce<{
-		to: string[];
-		totalValue: number | undefined;
-		totalOutputValue: number;
-		selfTransaction: boolean;
+	const { outputsToUser, outputsToOthers, recipients } = out.reduce<{
+		outputsToUser: number;
+		outputsToOthers: number;
+		recipients: string[];
 	}>(
-		(acc, output) => {
-			const { addr, value } = output;
-
-			// For 'send' tx: include outputs not to the sender
-			// For 'receive' tx: include only outputs to the user
-			const isValidOutput =
-				(isTypeSend && addr !== btcAddress) || (!isTypeSend && addr === btcAddress);
-
-			return {
-				...acc,
-				totalValue: isValidOutput ? (acc.totalValue ?? 0) + value : acc.totalValue,
-				to: isValidOutput ? [...acc.to, addr] : acc.to,
-				totalOutputValue: acc.totalOutputValue + value,
-				// If all outputs are to the sender, it's a self-transaction
-				selfTransaction: acc.selfTransaction && addr === btcAddress
-			};
-		},
-		{
-			totalOutputValue: 0,
-			totalValue: undefined,
-			to: [],
-			selfTransaction: true
-		}
+		(acc, { addr, value }) =>
+			addr === btcAddress
+				? { ...acc, outputsToUser: acc.outputsToUser + value }
+				: {
+						...acc,
+						outputsToOthers: acc.outputsToOthers + value,
+						recipients: [...acc.recipients, addr]
+					},
+		{ outputsToUser: 0, outputsToOthers: 0, recipients: [] }
 	);
 
-	// Step 3: Calculate the transaction fee from the difference between input and output values
-	const utxosFee = totalInputValue - totalOutputValue;
+	// Step 2: Classify by net flow. The user "received" if more BTC came into their
+	// address than left it. Otherwise it's a send (including the zero-net consolidation case).
+	const isReceive = outputsToUser > inputsFromUser;
 
-	// Step 4: Compute the number of confirmations
-	// +1 is needed to account for the block where the transaction was first included
+	// Step 3: Derive the displayable amount and the fee attributable to the user.
+	// For a send, the user's net spend (rawNet) is capped at what actually went to
+	// other recipients; any excess is the user's share of the network fee.
+	const rawNet = inputsFromUser - outputsToUser;
+	const sendAmount = Math.min(rawNet, outputsToOthers);
+	const value = BigInt(isReceive ? outputsToUser - inputsFromUser : sendAmount);
+	const fee = isReceive ? undefined : BigInt(rawNet - sendAmount);
+
+	// Step 4: Resolve confirmations / status from the latest block height.
+	// +1 accounts for the block where the transaction was first included.
 	const confirmations = nonNullish(block_index)
 		? latestBitcoinBlockHeight - block_index + 1
 		: undefined;
 
-	// Step 5: Derive transaction status based on confirmations thresholds
 	const status = isNullish(confirmations)
 		? 'pending'
 		: confirmations >= CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 			? 'confirmed'
 			: 'unconfirmed';
 
-	// Step 6: Determine the value of the transaction
-	const value = selfTransaction
-		? // For self-transactions, we consider the total output value plus the fee, since that is logically the value spent for the presumable 'send' transaction
-			BigInt(totalOutputValue + utxosFee)
-		: nonNullish(totalValue)
-			? // For 'send' transactions, we consider the total value sent plus the fee, since that is logically the value spent for the transaction
-				BigInt(isTypeSend ? totalValue + utxosFee : totalValue)
-			: undefined;
+	// Step 5: Pick a sensible counterparty for from/to. For a receive, prefer the
+	// first non-user input as the sender (falls back to inputs[0] when all inputs
+	// happen to be user-owned, which shouldn't occur for an isReceive transaction).
+	const from = isReceive
+		? (inputs.find(({ prev_out: { addr } }) => addr !== btcAddress)?.prev_out.addr ??
+			inputs[0].prev_out.addr)
+		: btcAddress;
 
-	// Step 7: Compose the final structured BTC transaction object for the UI
+	const to = isReceive ? [btcAddress] : recipients;
+
 	return {
 		id: hash,
 		timestamp: BigInt(time),
 		value,
+		fee,
 		status,
 		blockNumber: block_index ?? undefined,
-		type: isTypeSend ? 'send' : 'receive',
-		from: isTypeSend ? btcAddress : inputs[0].prev_out.addr,
-		to: selfTransaction ? [btcAddress] : to,
+		type: isReceive ? 'receive' : 'send',
+		from,
+		to,
 		confirmations
 	};
 };

--- a/src/frontend/src/lib/types/blockchain.ts
+++ b/src/frontend/src/lib/types/blockchain.ts
@@ -27,7 +27,7 @@ interface BitcoinPrevOut {
 	addr: string;
 }
 
-interface BitcoinInput {
+export interface BitcoinInput {
 	sequence: number;
 	witness: string;
 	script: string;

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -321,7 +321,7 @@ describe('mapBtcTransaction', () => {
 			expect(result.to).toEqual([otherAddress]);
 		});
 
-		it('returns to = [] for a pure self-consolidation', () => {
+		it('returns to = [self] for a pure self-consolidation', () => {
 			const transaction = buildTransaction({ inMe: 10, outMe: 9 });
 
 			const result = mapBtcTransaction({
@@ -331,7 +331,7 @@ describe('mapBtcTransaction', () => {
 			});
 
 			expect(result.from).toBe(mockBtcAddress);
-			expect(result.to).toEqual([]);
+			expect(result.to).toEqual([mockBtcAddress]);
 		});
 	});
 });

--- a/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-transactions.utils.spec.ts
@@ -4,14 +4,18 @@ import {
 } from '$btc/constants/btc.constants';
 import type { BtcTransactionStatus } from '$btc/types/btc';
 import { mapBtcTransaction, sortBtcTransactions } from '$btc/utils/btc-transactions.utils';
-import type { BitcoinTransaction } from '$lib/types/blockchain';
+import { ZERO } from '$lib/constants/app.constants';
+import type { BitcoinInput, BitcoinOutput, BitcoinTransaction } from '$lib/types/blockchain';
 import {
 	mockBtcTransaction,
 	mockBtcTransactionUi
 } from '$tests/mocks/blockchain-transactions.mock';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
+import { nonNullish } from '@dfinity/utils';
 
 describe('mapBtcTransaction', () => {
+	const otherAddress = 'bc1q3jlulk7pw9p5tjqcrwdec9a6vdaw9pqhw0wg4g';
+
 	const sendTransaction = {
 		...mockBtcTransaction,
 		inputs: [
@@ -24,179 +28,311 @@ describe('mapBtcTransaction', () => {
 			}
 		]
 	} as BitcoinTransaction;
-	const sendTransactionValue = 202174416n;
-	const to = mockBtcTransaction.out
+
+	// Under the net-flow algorithm: value is what actually went to other recipients,
+	// fee is the user's share of the network fee (rawNet - sendAmount).
+	const sendTransactionValue = 202173397n;
+	const sendTransactionFee = 1019n;
+	const sendRecipients = mockBtcTransaction.out
 		.map(({ addr }) => addr)
 		.filter((addr) => addr !== mockBtcAddress);
 
-	it('should map correctly when receive transaction is pending', () => {
-		const result = mapBtcTransaction({
-			transaction: mockBtcTransaction,
-			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight: 1
-		});
-		const expectedResult = {
-			...mockBtcTransactionUi,
-			blockNumber: undefined,
-			confirmations: undefined,
-			status: 'pending'
-		};
+	describe('status / confirmations', () => {
+		it('marks the transaction as pending when there is no block_index', () => {
+			const result = mapBtcTransaction({
+				transaction: mockBtcTransaction,
+				btcAddress: mockBtcAddress,
+				latestBitcoinBlockHeight: 1
+			});
 
-		expect(result).toEqual(expectedResult);
+			expect(result).toEqual({
+				...mockBtcTransactionUi,
+				blockNumber: undefined,
+				confirmations: undefined,
+				status: 'pending'
+			});
+		});
+
+		it('marks the transaction as unconfirmed below the confirmation threshold', () => {
+			const transaction = {
+				...mockBtcTransaction,
+				block_index: mockBtcTransactionUi.blockNumber
+			} as BitcoinTransaction;
+			const result = mapBtcTransaction({
+				transaction,
+				btcAddress: mockBtcAddress,
+				latestBitcoinBlockHeight:
+					(mockBtcTransactionUi.blockNumber ?? 0) + UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+			});
+
+			expect(result).toEqual({
+				...mockBtcTransactionUi,
+				status: 'unconfirmed',
+				confirmations: UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
+			});
+		});
+
+		it('marks the transaction as confirmed at or above the confirmation threshold', () => {
+			const transaction = {
+				...mockBtcTransaction,
+				block_index: mockBtcTransactionUi.blockNumber
+			} as BitcoinTransaction;
+			const result = mapBtcTransaction({
+				transaction,
+				btcAddress: mockBtcAddress,
+				latestBitcoinBlockHeight:
+					(mockBtcTransactionUi.blockNumber ?? 0) + CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+			});
+
+			expect(result).toEqual({
+				...mockBtcTransactionUi,
+				confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
+			});
+		});
+
+		it('maps a send transaction with the user as the sole input', () => {
+			const transaction = {
+				...sendTransaction,
+				block_index: mockBtcTransactionUi.blockNumber
+			} as BitcoinTransaction;
+			const result = mapBtcTransaction({
+				transaction,
+				btcAddress: mockBtcAddress,
+				latestBitcoinBlockHeight:
+					(mockBtcTransactionUi.blockNumber ?? 0) + CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
+			});
+
+			expect(result).toEqual({
+				...mockBtcTransactionUi,
+				from: mockBtcAddress,
+				to: sendRecipients,
+				value: sendTransactionValue,
+				fee: sendTransactionFee,
+				type: 'send',
+				confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
+			});
+		});
 	});
 
-	it('should map correctly when receive transaction is unconfirmed', () => {
-		const transaction = {
+	describe('net-flow value / fee', () => {
+		const [baseInput] = mockBtcTransaction.inputs;
+		const [baseOutput] = mockBtcTransaction.out;
+
+		const isPositive = (n: number | undefined): n is number => nonNullish(n) && n > 0;
+
+		const makeInput = ({ value, addr }: { value: number; addr: string }): BitcoinInput => ({
+			...baseInput,
+			prev_out: { ...baseInput.prev_out, addr, value }
+		});
+
+		const makeOutput = ({ value, addr }: { value: number; addr: string }): BitcoinOutput => ({
+			...baseOutput,
+			addr,
+			value
+		});
+
+		const buildTransaction = ({
+			inOthers,
+			inMe,
+			outOthers,
+			outMe
+		}: {
+			inOthers?: number;
+			inMe?: number;
+			outOthers?: number;
+			outMe?: number;
+		}): BitcoinTransaction => ({
 			...mockBtcTransaction,
-			block_index: mockBtcTransactionUi.blockNumber
-		} as BitcoinTransaction;
-		const result = mapBtcTransaction({
-			transaction,
-			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight:
-				(mockBtcTransactionUi.blockNumber ?? 0) + UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
-		});
-		const expectedResult = {
-			...mockBtcTransactionUi,
-			status: 'unconfirmed',
-			confirmations: UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
-		};
-
-		expect(result).toEqual(expectedResult);
-	});
-
-	it('should map correctly when receive transaction is confirmed', () => {
-		const transaction = {
-			...mockBtcTransaction,
-			block_index: mockBtcTransactionUi.blockNumber
-		} as BitcoinTransaction;
-		const result = mapBtcTransaction({
-			transaction,
-			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight:
-				(mockBtcTransactionUi.blockNumber ?? 0) + CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
-		});
-
-		const expectedResult = {
-			...mockBtcTransactionUi,
-			confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
-		};
-
-		expect(result).toEqual(expectedResult);
-	});
-
-	it('should map correctly when send transaction is pending', () => {
-		const result = mapBtcTransaction({
-			transaction: sendTransaction,
-			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight: 1
-		});
-		const expectedResult = {
-			...mockBtcTransactionUi,
-			from: mockBtcAddress,
-			to,
-			value: sendTransactionValue,
-			type: 'send',
-			blockNumber: undefined,
-			confirmations: undefined,
-			status: 'pending'
-		};
-
-		expect(result).toEqual(expectedResult);
-	});
-
-	it('should map correctly when send transaction is unconfirmed', () => {
-		const transaction = {
-			...sendTransaction,
-			block_index: mockBtcTransactionUi.blockNumber
-		} as BitcoinTransaction;
-		const result = mapBtcTransaction({
-			transaction,
-			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight:
-				(mockBtcTransactionUi.blockNumber ?? 0) + UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
-		});
-		const expectedResult = {
-			...mockBtcTransactionUi,
-			status: 'unconfirmed',
-			from: mockBtcAddress,
-			to,
-			value: sendTransactionValue,
-			type: 'send',
-			confirmations: UNCONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
-		};
-
-		expect(result).toEqual(expectedResult);
-	});
-
-	it('should map correctly when send transaction is confirmed', () => {
-		const transaction = {
-			...sendTransaction,
-			block_index: mockBtcTransactionUi.blockNumber
-		} as BitcoinTransaction;
-		const result = mapBtcTransaction({
-			transaction,
-			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight:
-				(mockBtcTransactionUi.blockNumber ?? 0) + CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
-		});
-		const expectedResult = {
-			...mockBtcTransactionUi,
-			from: mockBtcAddress,
-			to,
-			value: sendTransactionValue,
-			type: 'send',
-			confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
-		};
-
-		expect(result).toEqual(expectedResult);
-	});
-
-	it('should map correctly a self-transaction', () => {
-		const transaction = {
-			...sendTransaction,
-			block_index: mockBtcTransactionUi.blockNumber,
 			inputs: [
-				{
-					...mockBtcTransaction.inputs[0],
-					prev_out: {
-						...mockBtcTransaction.inputs[0].prev_out,
-						addr: mockBtcAddress,
-						value: 45_235
-					}
-				}
+				...(isPositive(inOthers) ? [makeInput({ value: inOthers, addr: otherAddress })] : []),
+				...(isPositive(inMe) ? [makeInput({ value: inMe, addr: mockBtcAddress })] : [])
 			],
 			out: [
-				{
-					...mockBtcTransaction.out[0],
-					addr: mockBtcAddress,
-					spent: false,
-					value: 1_000
-				},
-				{
-					...mockBtcTransaction.out[1],
-					addr: mockBtcAddress,
-					spent: true,
-					value: 43_955
-				}
+				...(isPositive(outOthers) ? [makeOutput({ value: outOthers, addr: otherAddress })] : []),
+				...(isPositive(outMe) ? [makeOutput({ value: outMe, addr: mockBtcAddress })] : [])
 			]
-		} as BitcoinTransaction;
-		const result = mapBtcTransaction({
-			transaction,
-			btcAddress: mockBtcAddress,
-			latestBitcoinBlockHeight:
-				(mockBtcTransactionUi.blockNumber ?? 0) + CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS
 		});
-		const expectedResult = {
-			...mockBtcTransactionUi,
-			from: mockBtcAddress,
-			to: [mockBtcAddress],
-			value: BigInt(transaction.inputs[0].prev_out.value),
-			type: 'send',
-			confirmations: CONFIRMED_BTC_TRANSACTION_MIN_CONFIRMATIONS + 1
-		};
 
-		expect(result).toEqual(expectedResult);
+		// Test matrix from the algorithm specification.
+		// Each row: { name, inputs, outputs, expected type/value/fee }.
+		// `value` is BTC the user "sent" (for send) or "received" (for receive).
+		// `fee` is the user's share of the network fee; undefined on receive.
+		const cases: {
+			name: string;
+			inOthers?: number;
+			inMe?: number;
+			outOthers?: number;
+			outMe?: number;
+			type: 'send' | 'receive';
+			value: bigint;
+			fee?: bigint;
+		}[] = [
+			{ name: 'Receive', inOthers: 10, outOthers: 7, outMe: 2, type: 'receive', value: 2n },
+			{ name: 'Send', inMe: 10, outOthers: 9, type: 'send', value: 9n, fee: 1n },
+			{
+				name: 'Multi Send (send with return)',
+				inMe: 10,
+				outOthers: 2,
+				outMe: 5,
+				type: 'send',
+				value: 2n,
+				fee: 3n
+			},
+			{ name: 'Self Send', inMe: 10, outMe: 9, type: 'send', value: ZERO, fee: 1n },
+			{
+				name: 'Combi Send',
+				inOthers: 5,
+				inMe: 5,
+				outOthers: 9,
+				type: 'send',
+				value: 5n,
+				fee: ZERO
+			},
+			{
+				name: 'Combi Send (cap)',
+				inOthers: 5,
+				inMe: 5,
+				outOthers: 1,
+				type: 'send',
+				value: 1n,
+				fee: 4n
+			},
+			{
+				name: 'Combi Self Send (<)',
+				inOthers: 5,
+				inMe: 5,
+				outMe: 3,
+				type: 'send',
+				value: ZERO,
+				fee: 2n
+			},
+			{
+				name: 'Combi Self Send (=)',
+				inOthers: 5,
+				inMe: 5,
+				outMe: 5,
+				type: 'send',
+				value: ZERO,
+				fee: ZERO
+			},
+			{
+				name: 'Combi Self Send (>)',
+				inOthers: 5,
+				inMe: 5,
+				outMe: 7,
+				type: 'receive',
+				value: 2n
+			},
+			{
+				name: 'Combi Multi Send (<)',
+				inOthers: 5,
+				inMe: 5,
+				outOthers: 4,
+				outMe: 4,
+				type: 'send',
+				value: 1n,
+				fee: ZERO
+			},
+			{
+				name: 'Combi Multi Send (<, cap)',
+				inOthers: 5,
+				inMe: 5,
+				outOthers: 1,
+				outMe: 3,
+				type: 'send',
+				value: 1n,
+				fee: 1n
+			},
+			{
+				name: 'Combi Multi Send (=)',
+				inOthers: 5,
+				inMe: 5,
+				outOthers: 3,
+				outMe: 5,
+				type: 'send',
+				value: ZERO,
+				fee: ZERO
+			},
+			{
+				name: 'Combi Multi Send (>)',
+				inOthers: 5,
+				inMe: 5,
+				outOthers: 1,
+				outMe: 8,
+				type: 'receive',
+				value: 3n
+			},
+			{
+				name: 'Receive with sender change',
+				inOthers: 5,
+				outOthers: 1,
+				outMe: 4,
+				type: 'receive',
+				value: 4n
+			},
+			{
+				name: 'Send with return (alt amounts)',
+				inMe: 10,
+				outOthers: 4,
+				outMe: 5,
+				type: 'send',
+				value: 4n,
+				fee: 1n
+			}
+		];
+
+		it.each(cases)('$name', ({ inOthers, inMe, outOthers, outMe, type, value, fee }) => {
+			const transaction = buildTransaction({ inOthers, inMe, outOthers, outMe });
+
+			const result = mapBtcTransaction({
+				transaction,
+				btcAddress: mockBtcAddress,
+				latestBitcoinBlockHeight: 1
+			});
+
+			expect(result.type).toBe(type);
+			expect(result.value).toBe(value);
+			expect(result.fee).toBe(fee);
+		});
+
+		it('sets to = [user] and from = sender on a receive', () => {
+			const transaction = buildTransaction({ inOthers: 10, outMe: 10 });
+
+			const result = mapBtcTransaction({
+				transaction,
+				btcAddress: mockBtcAddress,
+				latestBitcoinBlockHeight: 1
+			});
+
+			expect(result.from).toBe(otherAddress);
+			expect(result.to).toEqual([mockBtcAddress]);
+		});
+
+		it('sets from = user and to = recipients on a send', () => {
+			const transaction = buildTransaction({ inMe: 10, outOthers: 9 });
+
+			const result = mapBtcTransaction({
+				transaction,
+				btcAddress: mockBtcAddress,
+				latestBitcoinBlockHeight: 1
+			});
+
+			expect(result.from).toBe(mockBtcAddress);
+			expect(result.to).toEqual([otherAddress]);
+		});
+
+		it('returns to = [] for a pure self-consolidation', () => {
+			const transaction = buildTransaction({ inMe: 10, outMe: 9 });
+
+			const result = mapBtcTransaction({
+				transaction,
+				btcAddress: mockBtcAddress,
+				latestBitcoinBlockHeight: 1
+			});
+
+			expect(result.from).toBe(mockBtcAddress);
+			expect(result.to).toEqual([]);
+		});
 	});
 });
 


### PR DESCRIPTION
# Motivation

`mapBtcTransaction` mis-reported the displayed amount for any BTC transaction whose outputs all landed on the user's own address. The `selfTransaction` flag was meant to mean *"input and all outputs to the same address"* but checked only outputs, so a normal receive with no sender change (common for exchange withdrawals) was misclassified and shown inflated by the fee.

Beyond fixing that case, the surrounding "last output is change" model required guessing the user's intent. Switching to a deterministic net-flow model removes the heuristic.

