### PR TITLE
feat(frontend): show network fee in BTC transaction modal

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionModal.svelte
@@ -32,7 +32,7 @@
 
 	const { transaction, token }: Props = $props();
 
-	let { from, value, timestamp, id, blockNumber, to, type, status, confirmations } =
+	let { from, value, fee, timestamp, id, blockNumber, to, type, status, confirmations } =
 		$derived(transaction);
 
 	let explorerUrl: string | undefined = $derived(
@@ -150,6 +150,22 @@
 						{$i18n.transaction.text.confirmations}
 					</span>
 					<span>{confirmations}</span>
+				</ListItem>
+			{/if}
+
+			{#if nonNullish(fee) && nonNullish(token)}
+				<ListItem>
+					<span>
+						{$i18n.fee.text.fee}
+					</span>
+					<output>
+						{formatToken({
+							value: fee,
+							unitName: token.decimals,
+							displayDecimals: token.decimals
+						})}
+						{token.symbol}
+					</output>
 				</ListItem>
 			{/if}
 

--- a/src/frontend/src/tests/btc/components/transactions/BtcTransactionModal.spec.ts
+++ b/src/frontend/src/tests/btc/components/transactions/BtcTransactionModal.spec.ts
@@ -81,4 +81,30 @@ describe('BtcTransactionModal', () => {
 		expect(getByText(get(i18n).networks.network)).toBeInTheDocument();
 		expect(getByText(BTC_MAINNET_TOKEN.network.name)).toBeInTheDocument();
 	});
+
+	it('should display fee when present', () => {
+		const fee = 1019n;
+		const { getByText } = render(BtcTransactionModal, {
+			transaction: { ...mockBtcTransactionUi, type: 'send', fee },
+			token: BTC_MAINNET_TOKEN
+		});
+
+		const formattedFee = `${formatToken({
+			value: fee,
+			unitName: BTC_MAINNET_TOKEN.decimals,
+			displayDecimals: BTC_MAINNET_TOKEN.decimals
+		})} ${BTC_MAINNET_TOKEN.symbol}`;
+
+		expect(getByText(get(i18n).fee.text.fee)).toBeInTheDocument();
+		expect(getByText(formattedFee)).toBeInTheDocument();
+	});
+
+	it('should not display fee when nullish', () => {
+		const { queryByText } = render(BtcTransactionModal, {
+			transaction: { ...mockBtcTransactionUi, fee: undefined },
+			token: BTC_MAINNET_TOKEN
+		});
+
+		expect(queryByText(get(i18n).fee.text.fee)).not.toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
# Motivation

Now that `mapBtcTransaction` exposes the user's share of the network fee as a dedicated `fee` field, surface it in the transaction details modal. Previously the fee was implicitly bundled into the `value` of a send, which both masked the real send amount and prevented the modal from showing the fee at all.