### PR TITLE
fix(frontend): show approval steps in stepper for Velora Delta swaps

### DIFF
--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -190,6 +190,12 @@
 			isNotDefaultEthereumToken($sourceToken)
 	);
 
+	const swapEmitsApprovalSteps = $derived(
+		!isNearIntentsProvider &&
+			$swapAmountsStore?.selectedProvider?.provider === SwapProvider.VELORA &&
+			isNotDefaultEthereumToken($sourceToken)
+	);
+
 	const isTransferNeeded = $derived(isNearIntentsProvider);
 
 	const isGasless = $derived(
@@ -451,7 +457,7 @@
 				</SwapReview>
 			{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
 				<SwapProgress
-					sendWithApproval={isApproveNeeded}
+					sendWithApproval={swapEmitsApprovalSteps}
 					sendWithTransfer={isTransferNeeded}
 					{swapProgressStep}
 					swapWithBridging={$swapAmountsStore?.selectedProvider?.provider === SwapProvider.ONE_SEC}


### PR DESCRIPTION
# Motivation

When swapping an ERC20 token via Velora, the progress stepper briefly highlighted "Initialization" in green and then went fully blank - every step grey, nothing moving - until the swap reached the on-chain swap phase, at which point highlighting resumed normally.

Root cause: the stepper omitted `SIGN_APPROVE` / `APPROVE` for Velora **Delta** swaps, but the Delta service code path emits those progress events:
  - gasless Delta emits `APPROVE` (the permit signature)
  - non-gasless Delta calls `approveToken`, which emits `SIGN_APPROVE`
    then `APPROVE`