### PR TITLE
feat(frontend): wire Icrc7 env tokens through mapIcrc7Token

### DIFF
--- a/src/frontend/src/env/tokens/tokens-icrc7/tokens.icrc7.env.ts
+++ b/src/frontend/src/env/tokens/tokens-icrc7/tokens.icrc7.env.ts
@@ -1,0 +1,10 @@
+import { EnvIcrc7TokensSchema } from '$env/schema/env-icrc7-token.schema';
+import icrc7Tokens from '$env/tokens/tokens-icrc7/tokens.icrc7.json';
+import { mapIcrc7Token } from '$icp/utils/icrc7.utils';
+
+// Just to be safe, we want to raise an error at build time if the tokens.icrc7.json file is not valid.
+export const ICRC7_BUILTIN_TOKENS = EnvIcrc7TokensSchema.parse(icrc7Tokens).map(mapIcrc7Token);
+
+export const ICRC7_BUILTIN_TOKENS_INDEXED = new Map(
+	ICRC7_BUILTIN_TOKENS.map((token) => [token.canisterId, token])
+);

--- a/src/frontend/src/icp/schema/icrc7-token.schema.ts
+++ b/src/frontend/src/icp/schema/icrc7-token.schema.ts
@@ -16,3 +16,5 @@ export const Icrc7TokenSchema = z.object({
 	...NonFungibleTokenAppearanceSchema.shape,
 	...Icrc7InterfaceSchema.shape
 });
+
+export const Icrc7TokenWithoutIdSchema = Icrc7TokenSchema.omit({ id: true }).strict();

--- a/src/frontend/src/icp/types/icrc7-custom-token.ts
+++ b/src/frontend/src/icp/types/icrc7-custom-token.ts
@@ -1,0 +1,4 @@
+import type { Icrc7Token } from '$icp/types/icrc7-token';
+import type { CustomToken } from '$lib/types/custom-token';
+
+export type Icrc7CustomToken = CustomToken<Icrc7Token>;

--- a/src/frontend/src/icp/types/icrc7-token.ts
+++ b/src/frontend/src/icp/types/icrc7-token.ts
@@ -1,4 +1,6 @@
-import type { Icrc7TokenSchema } from '$icp/schema/icrc7-token.schema';
+import type { Icrc7TokenSchema, Icrc7TokenWithoutIdSchema } from '$icp/schema/icrc7-token.schema';
 import type * as z from 'zod';
 
 export type Icrc7Token = z.infer<typeof Icrc7TokenSchema>;
+
+export type Icrc7TokenWithoutId = z.infer<typeof Icrc7TokenWithoutIdSchema>;

--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -1,10 +1,31 @@
 import type { Value } from '$declarations/icrc7/icrc7.did';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import type { EnvIcrc7Token } from '$env/types/env-icrc7-token';
 import type { IcToken } from '$icp/types/ic-token';
-import type { Icrc7Token } from '$icp/types/icrc7-token';
+import type { Icrc7Token, Icrc7TokenWithoutId } from '$icp/types/icrc7-token';
+import { DEFAULT_TOKEN_TAGS } from '$lib/constants/token-tag.constants';
 import type { TokenMetadata } from '$lib/types/token';
 
 export const isTokenIcrc7 = (token: Partial<IcToken>): token is Icrc7Token =>
 	token.standard?.code === 'icrc7';
+
+export const mapIcrc7Token = ({
+	canisterId,
+	metadata: { name, symbol }
+}: EnvIcrc7Token): Icrc7TokenWithoutId => ({
+	canisterId,
+	network: ICP_NETWORK,
+	name,
+	symbol,
+	// ICRC-7 collections do not have a meaningful `decimals` (NFTs); kept at 0 to satisfy
+	// the shared `TokenSchema` shape — same convention as `mapIcPunksToken` / `mapDip721Token`.
+	decimals: 0,
+	standard: {
+		code: 'icrc7'
+	},
+	category: 'custom',
+	tags: DEFAULT_TOKEN_TAGS
+});
 
 // Standard collection-level metadata keys defined in ICRC-7.
 // Reference: https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-7/ICRC-7.md#icrc7_collection_metadata

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -1,7 +1,9 @@
 import type { Value } from '$declarations/icrc7/icrc7.did';
-import { isTokenIcrc7, mapIcrc7CollectionMetadata } from '$icp/utils/icrc7.utils';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { isTokenIcrc7, mapIcrc7CollectionMetadata, mapIcrc7Token } from '$icp/utils/icrc7.utils';
+import { DEFAULT_TOKEN_TAGS } from '$lib/constants/token-tag.constants';
 import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
-import { mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
+import { mockIcrc7CanisterId, mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 
 describe('icrc7.utils', () => {
 	describe('isTokenIcrc7', () => {
@@ -85,6 +87,26 @@ describe('icrc7.utils', () => {
 
 		it('should return undefined for an empty entries array', () => {
 			expect(mapIcrc7CollectionMetadata([])).toBeUndefined();
+		});
+	});
+
+	describe('mapIcrc7Token', () => {
+		it('should map an EnvIcrc7Token into an Icrc7TokenWithoutId', () => {
+			expect(
+				mapIcrc7Token({
+					canisterId: mockIcrc7CanisterId,
+					metadata: { name: 'Cosmicrafts', symbol: 'CCC' }
+				})
+			).toEqual({
+				canisterId: mockIcrc7CanisterId,
+				network: ICP_NETWORK,
+				name: 'Cosmicrafts',
+				symbol: 'CCC',
+				decimals: 0,
+				standard: { code: 'icrc7' },
+				category: 'custom',
+				tags: DEFAULT_TOKEN_TAGS
+			});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Stacked on #12830 + #12831. Adds the env→token bridge so the upcoming ICRC-7 loader can populate the default-tokens store from the curated JSON list, mirroring `mapIcPunksToken` / `tokens.icpunks.env.ts`.

# Changes

- `icp/schema/icrc7-token.schema.ts`: new `Icrc7TokenWithoutIdSchema` (omits `id`, strict).
- `icp/types/icrc7-token.ts`: new `Icrc7TokenWithoutId` type.
- `icp/types/icrc7-custom-token.ts`: new `Icrc7CustomToken = CustomToken<Icrc7Token>` alias.
- `icp/utils/icrc7.utils.ts`: new `mapIcrc7Token` (`EnvIcrc7Token` → `Icrc7TokenWithoutId`).
- `env/tokens/tokens-icrc7/tokens.icrc7.env.ts`: new file exposing `ICRC7_BUILTIN_TOKENS` (+ `_INDEXED`). Curated list is empty for now.

# Tests

- `npm run check` clean.
- `npm run lint -- --max-warnings 0` clean.
- `npx vitest run` for `icrc7.utils.spec.ts` — 11 cases pass (1 new for `mapIcrc7Token`).