### PR TITLE
feat(frontend): register Icrc7 in custom-token discriminator chain

### DIFF
--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -2,12 +2,17 @@ import type { Value } from '$declarations/icrc7/icrc7.did';
 import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import type { EnvIcrc7Token } from '$env/types/env-icrc7-token';
 import type { IcToken } from '$icp/types/ic-token';
+import type { Icrc7CustomToken } from '$icp/types/icrc7-custom-token';
 import type { Icrc7Token, Icrc7TokenWithoutId } from '$icp/types/icrc7-token';
 import { DEFAULT_TOKEN_TAGS } from '$lib/constants/token-tag.constants';
-import type { TokenMetadata } from '$lib/types/token';
+import type { Token, TokenMetadata } from '$lib/types/token';
+import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
 
 export const isTokenIcrc7 = (token: Partial<IcToken>): token is Icrc7Token =>
 	token.standard?.code === 'icrc7';
+
+export const isTokenIcrc7CustomToken = (token: Token): token is Icrc7CustomToken =>
+	isTokenIcrc7(token) && isTokenToggleable(token);
 
 export const mapIcrc7Token = ({
 	canisterId,

--- a/src/frontend/src/lib/components/tokens/EnableTokenToggle.svelte
+++ b/src/frontend/src/lib/components/tokens/EnableTokenToggle.svelte
@@ -10,6 +10,7 @@
 	import { isTokenExtCustomToken } from '$icp/utils/ext.utils';
 	import { isTokenIcPunksCustomToken } from '$icp/utils/icpunks.utils';
 	import { isTokenIcrcCustomToken } from '$icp/utils/icrc.utils';
+	import { isTokenIcrc7CustomToken } from '$icp/utils/icrc7.utils';
 	import ManageTokenToggle from '$lib/components/tokens/ManageTokenToggle.svelte';
 	import type { Token } from '$lib/types/token';
 	import SolManageTokenToggle from '$sol/components/tokens/SolManageTokenToggle.svelte';
@@ -26,7 +27,7 @@
 
 {#if isTokenIcrcCustomToken(token)}
 	<IcManageTokenToggle onIcToken={(t) => onToggle(t)} {token} />
-{:else if isTokenErc20CustomToken(token) || isTokenSplCustomToken(token) || isTokenErc721CustomToken(token) || isTokenErc1155CustomToken(token) || isTokenExtCustomToken(token) || isTokenDip721CustomToken(token) || isTokenIcPunksCustomToken(token) || isTokenErc4626CustomToken(token)}
+{:else if isTokenErc20CustomToken(token) || isTokenSplCustomToken(token) || isTokenErc721CustomToken(token) || isTokenErc1155CustomToken(token) || isTokenExtCustomToken(token) || isTokenDip721CustomToken(token) || isTokenIcPunksCustomToken(token) || isTokenIcrc7CustomToken(token) || isTokenErc4626CustomToken(token)}
 	<ManageTokenToggle onShowOrHideToken={(t) => onToggle(t)} {token} />
 {:else if isBitcoinToken(token)}
 	<BtcManageTokenToggle />

--- a/src/frontend/src/lib/services/nft.services.ts
+++ b/src/frontend/src/lib/services/nft.services.ts
@@ -8,6 +8,7 @@ import type { IcNonFungibleToken } from '$icp/types/nft';
 import { isTokenDip721CustomToken } from '$icp/utils/dip721.utils';
 import { isTokenExtCustomToken } from '$icp/utils/ext.utils';
 import { isTokenIcPunksCustomToken } from '$icp/utils/icpunks.utils';
+import { isTokenIcrc7CustomToken } from '$icp/utils/icrc7.utils';
 import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import { saveCustomTokens } from '$lib/services/save-custom-tokens.services';
 import { nftStore } from '$lib/stores/nft.store';
@@ -114,7 +115,8 @@ export const saveNftCustomToken = async ({
 	} else if (
 		isTokenExtCustomToken(token) ||
 		isTokenDip721CustomToken(token) ||
-		isTokenIcPunksCustomToken(token)
+		isTokenIcPunksCustomToken(token) ||
+		isTokenIcrc7CustomToken(token)
 	) {
 		await saveCustomTokens({
 			identity,
@@ -125,7 +127,9 @@ export const saveNftCustomToken = async ({
 						? 'ExtV2'
 						: isTokenDip721CustomToken(token)
 							? 'Dip721'
-							: 'IcPunks'
+							: isTokenIcPunksCustomToken(token)
+								? 'IcPunks'
+								: 'Icrc7'
 				}
 			]
 		});

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -12,6 +12,7 @@ import {
 	isTokenIcrc,
 	isTokenIcrcCustomToken
 } from '$icp/utils/icrc.utils';
+import { isTokenIcrc7CustomToken } from '$icp/utils/icrc7.utils';
 import { isIcCkToken } from '$icp/validation/ic-token.validation';
 import { LOCAL, ZERO } from '$lib/constants/app.constants';
 import type { ProgressStepsAddToken } from '$lib/enums/progress-steps';
@@ -558,6 +559,10 @@ const normaliseTokenForSave = (token: Token): SaveCustomTokenWithKey | undefined
 
 	if (isTokenIcPunksCustomToken(token)) {
 		return { ...token, networkKey: 'IcPunks' };
+	}
+
+	if (isTokenIcrc7CustomToken(token)) {
+		return { ...token, networkKey: 'Icrc7' };
 	}
 
 	if (isTokenErc20CustomToken(token)) {

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -1,6 +1,11 @@
 import type { Value } from '$declarations/icrc7/icrc7.did';
 import { ICP_NETWORK } from '$env/networks/networks.icp.env';
-import { isTokenIcrc7, mapIcrc7CollectionMetadata, mapIcrc7Token } from '$icp/utils/icrc7.utils';
+import {
+	isTokenIcrc7,
+	isTokenIcrc7CustomToken,
+	mapIcrc7CollectionMetadata,
+	mapIcrc7Token
+} from '$icp/utils/icrc7.utils';
 import { DEFAULT_TOKEN_TAGS } from '$lib/constants/token-tag.constants';
 import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIcrc7CanisterId, mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
@@ -17,6 +22,32 @@ describe('icrc7.utils', () => {
 
 		it('should return false when standard is missing', () => {
 			expect(isTokenIcrc7({})).toBeFalsy();
+		});
+	});
+
+	describe('isTokenIcrc7CustomToken', () => {
+		it('should return true for a toggleable ICRC-7 token (has `enabled`)', () => {
+			expect(
+				isTokenIcrc7CustomToken({
+					...mockValidIcrc7Token,
+					version: undefined,
+					enabled: true
+				})
+			).toBeTruthy();
+		});
+
+		it('should return false for a non-toggleable ICRC-7 token (no `enabled`)', () => {
+			expect(isTokenIcrc7CustomToken(mockValidIcrc7Token)).toBeFalsy();
+		});
+
+		it('should return false for a non-ICRC-7 toggleable token', () => {
+			expect(
+				isTokenIcrc7CustomToken({
+					...mockValidIcPunksToken,
+					version: undefined,
+					enabled: true
+				})
+			).toBeFalsy();
 		});
 	});
 

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -26,14 +26,11 @@ describe('icrc7.utils', () => {
 	});
 
 	describe('isTokenIcrc7CustomToken', () => {
+		const toggleableIcrc7Token = { ...mockValidIcrc7Token, enabled: true };
+		const toggleableIcPunksToken = { ...mockValidIcPunksToken, enabled: true };
+
 		it('should return true for a toggleable ICRC-7 token (has `enabled`)', () => {
-			expect(
-				isTokenIcrc7CustomToken({
-					...mockValidIcrc7Token,
-					version: undefined,
-					enabled: true
-				})
-			).toBeTruthy();
+			expect(isTokenIcrc7CustomToken(toggleableIcrc7Token)).toBeTruthy();
 		});
 
 		it('should return false for a non-toggleable ICRC-7 token (no `enabled`)', () => {
@@ -41,13 +38,7 @@ describe('icrc7.utils', () => {
 		});
 
 		it('should return false for a non-ICRC-7 toggleable token', () => {
-			expect(
-				isTokenIcrc7CustomToken({
-					...mockValidIcPunksToken,
-					version: undefined,
-					enabled: true
-				})
-			).toBeFalsy();
+			expect(isTokenIcrc7CustomToken(toggleableIcPunksToken)).toBeFalsy();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Wires `Icrc7CustomToken` into the three custom-token discriminator switch sites that already gate `Ext` / `Dip721` / `IcPunks`, so an enabled ICRC-7 token survives save / display flows the same way the other IC NFT standards do.

# Changes

- `icp/utils/icrc7.utils.ts`: new `isTokenIcrc7CustomToken` (mirrors `isTokenIcPunksCustomToken`).
- `lib/utils/tokens.utils.ts::normaliseTokenForSave`: new `Icrc7` arm — a user-enabled ICRC-7 token round-trips with `networkKey: 'Icrc7'`.
- `lib/services/nft.services.ts::saveNftCustomTokens`: import-token clicks reach `saveCustomTokens` for ICRC-7.
- `lib/components/tokens/EnableTokenToggle.svelte`: manage-tokens row renders the toggle for ICRC-7.
- `tests/icp/utils/icrc7.utils.spec.ts`: 3 new cases for `isTokenIcrc7CustomToken`.

