### PR TITLE
refactor(frontend): use isNotDefaultEthereumToken helper

### DIFF
--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -7,7 +7,7 @@ import { swap } from '$eth/services/swap.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import { getCompactSignature, getSignParamsEIP712 } from '$eth/utils/eip712.utils';
 import { isTokenErc } from '$eth/utils/erc.utils';
-import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
+import { isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { setCustomToken as setCustomIcrcToken } from '$icp-eth/services/icrc-token.services';
 import { approve } from '$icp/api/icrc-ledger.api';
 import { sendIcp, sendIcrc } from '$icp/services/ic-send.services';
@@ -1280,7 +1280,7 @@ export const fetchVeloraMarketSwap = async ({
 
 	const TokenTransferProxy = await sdk.swap.getSpender();
 
-	if (!isDefaultEthereumToken(sourceToken)) {
+	if (isNotDefaultEthereumToken(sourceToken)) {
 		await approveToken({
 			token: sourceToken,
 			from: userAddress,

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -154,7 +154,7 @@ vi.mock('$eth/utils/eip712.utils', () => ({
 }));
 
 vi.mock('$eth/utils/eth.utils', () => ({
-	isDefaultEthereumToken: vi.fn(() => false)
+	isNotDefaultEthereumToken: vi.fn(() => true)
 }));
 
 vi.mock('$lib/api/signer.api', () => ({
@@ -1132,7 +1132,7 @@ describe('swap.services', () => {
 		});
 
 		it('should execute market swap successfully with default Ethereum token', async () => {
-			vi.mocked(ethUtils.isDefaultEthereumToken).mockReturnValue(true);
+			vi.mocked(ethUtils.isNotDefaultEthereumToken).mockReturnValue(false);
 
 			await fetchVeloraMarketSwap({
 				identity: mockIdentity,


### PR DESCRIPTION
# Motivation

`fetchVeloraMarketSwap` in `swap.services.ts` was negating `isDefaultEthereumToken` inline (`!isDefaultEthereumToken(...)`) while the rest of the codebase already uses the dedicated `isNotDefaultEthereumToken` helper from `$eth/utils/eth.utils` (see `SwapEthWizard.svelte` and `page-token.derived.ts`). Aligning this call site with the existing convention makes the check easier to read and keeps the `is*` / `isNot*` pairing consistent across the Ethereum utils.

