### PR TITLE
feat(frontend): detect Icrc7 in NFT-canister standard probe and form

### DIFF
--- a/src/frontend/src/icp-eth/types/add-token.ts
+++ b/src/frontend/src/icp-eth/types/add-token.ts
@@ -22,6 +22,10 @@ interface IcPunksAddTokenData {
 	icPunksCanisterId: string;
 }
 
+interface Icrc7AddTokenData {
+	icrc7CanisterId: string;
+}
+
 interface SplAddTokenData {
 	splTokenAddress: SolAddress;
 }
@@ -33,6 +37,7 @@ export type AddTokenData = OneOf<
 		ExtAddTokenData,
 		Dip721AddTokenData,
 		IcPunksAddTokenData,
+		Icrc7AddTokenData,
 		SplAddTokenData
 	]
 >;

--- a/src/frontend/src/icp/components/tokens/IcAddNftForm.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddNftForm.svelte
@@ -15,12 +15,14 @@
 		extCanisterId?: string;
 		dip721CanisterId?: string;
 		icPunksCanisterId?: string;
+		icrc7CanisterId?: string;
 	}
 
 	let {
 		extCanisterId = $bindable(),
 		dip721CanisterId = $bindable(),
-		icPunksCanisterId = $bindable()
+		icPunksCanisterId = $bindable(),
+		icrc7CanisterId = $bindable()
 	}: Props = $props();
 
 	let canisterId = $state<CanisterIdText | undefined>();
@@ -31,6 +33,7 @@
 		extCanisterId = undefined;
 		dip721CanisterId = undefined;
 		icPunksCanisterId = undefined;
+		icrc7CanisterId = undefined;
 
 		if (isNullish($authIdentity)) {
 			return;
@@ -71,6 +74,14 @@
 
 		if (standard === 'icpunks') {
 			icPunksCanisterId = canisterId;
+
+			standardNotRecognized = false;
+
+			return;
+		}
+
+		if (standard === 'icrc7') {
+			icrc7CanisterId = canisterId;
 
 			standardNotRecognized = false;
 

--- a/src/frontend/src/icp/services/ic-standard.services.ts
+++ b/src/frontend/src/icp/services/ic-standard.services.ts
@@ -12,6 +12,7 @@ import {
 	getTokensByOwner as icPunksGetTokensByOwner,
 	metadata as icPunksMetadata
 } from '$icp/api/icpunks.api';
+import { collectionMetadata as icrc7CollectionMetadata } from '$icp/api/icrc7.api';
 import { extIndexToIdentifier } from '$icp/utils/ext.utils';
 import {
 	ResolveByProbingError,
@@ -22,7 +23,7 @@ import type { TokenStandardCode } from '$lib/types/token';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 
-type AcceptedStandards = Extract<TokenStandardCode, 'ext' | 'dip721' | 'icpunks'>;
+type AcceptedStandards = Extract<TokenStandardCode, 'ext' | 'dip721' | 'icpunks' | 'icrc7'>;
 
 export const detectNftCanisterStandard = async ({
 	identity,
@@ -73,8 +74,13 @@ export const detectNftCanisterStandard = async ({
 		onResolve: () => 'icpunks'
 	};
 
+	const icrc7Canister: ResolveGroup<AcceptedStandards> = {
+		probes: [() => icrc7CollectionMetadata(baseParams)],
+		onResolve: () => 'icrc7'
+	};
+
 	try {
-		return await resolveByProbing([extCanister, dip721Canister, icPunksCanister]);
+		return await resolveByProbing([extCanister, dip721Canister, icPunksCanister, icrc7Canister]);
 	} catch (err: unknown) {
 		// If the error is caused by the probing service, we cannot identify correctly the standard.
 		if (err instanceof ResolveByProbingError) {

--- a/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetwork.svelte
@@ -61,6 +61,7 @@
 		extCanisterId,
 		dip721CanisterId,
 		icPunksCanisterId,
+		icrc7CanisterId,
 		ethContractAddress,
 		splTokenAddress
 	} = $derived(tokenData);
@@ -74,7 +75,9 @@
 					? { extCanisterId }
 					: nonNullish(dip721CanisterId)
 						? { dip721CanisterId }
-						: { icPunksCanisterId }
+						: nonNullish(icPunksCanisterId)
+							? { icPunksCanisterId }
+							: { icrc7CanisterId }
 				: {
 						ledgerCanisterId,
 						indexCanisterId:
@@ -101,7 +104,9 @@
 
 	let invalidIcPunks = $derived(isNullishOrEmpty(icPunksCanisterId));
 
-	let invalidIcNft = $derived(invalidExt && invalidDip721 && invalidIcPunks);
+	let invalidIcrc7 = $derived(isNullishOrEmpty(icrc7CanisterId));
+
+	let invalidIcNft = $derived(invalidExt && invalidDip721 && invalidIcPunks && invalidIcrc7);
 
 	let invalidSpl = $derived(isNullishOrEmpty(splTokenAddress));
 
@@ -135,7 +140,12 @@
 
 		{#if isIcpNetwork}
 			{#if isNftsPage}
-				<IcAddNftForm bind:extCanisterId bind:dip721CanisterId bind:icPunksCanisterId />
+				<IcAddNftForm
+					bind:extCanisterId
+					bind:dip721CanisterId
+					bind:icPunksCanisterId
+					bind:icrc7CanisterId
+				/>
 			{:else}
 				<IcAddIcrcTokenForm bind:ledgerCanisterId bind:indexCanisterId />
 			{/if}

--- a/src/frontend/src/tests/icp/services/ic-standard.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-standard.services.spec.ts
@@ -12,6 +12,7 @@ import {
 	getTokensByOwner as icPunksGetTokensByOwner,
 	metadata as icPunksMetadata
 } from '$icp/api/icpunks.api';
+import { collectionMetadata as icrc7CollectionMetadata } from '$icp/api/icrc7.api';
 import { detectNftCanisterStandard } from '$icp/services/ic-standard.services';
 import { extIndexToIdentifier } from '$icp/utils/ext.utils';
 import { ZERO } from '$lib/constants/app.constants';
@@ -38,6 +39,10 @@ vi.mock('$icp/api/dip721.api', () => ({
 vi.mock('$icp/api/icpunks.api', () => ({
 	getTokensByOwner: vi.fn(),
 	metadata: vi.fn(),
+	collectionMetadata: vi.fn()
+}));
+
+vi.mock('$icp/api/icrc7.api', () => ({
 	collectionMetadata: vi.fn()
 }));
 
@@ -72,6 +77,11 @@ describe('ic-standard.services', () => {
 			vi.mocked(icPunksGetTokensByOwner).mockResolvedValue([]);
 			vi.mocked(icPunksMetadata).mockResolvedValue(mockIcPunksMetadata);
 			vi.mocked(icPunksCollectionMetadata).mockResolvedValue(mockIcPunksCollectionMetadata);
+
+			vi.mocked(icrc7CollectionMetadata).mockResolvedValue([
+				['icrc7:name', { Text: 'Mock Icrc7 Collection' }],
+				['icrc7:symbol', { Text: 'MOCK7' }]
+			]);
 		});
 
 		it('should detect an EXT canister', async () => {
@@ -98,6 +108,18 @@ describe('ic-standard.services', () => {
 			expect(icPunksGetTokensByOwner).not.toHaveBeenCalled();
 			expect(icPunksMetadata).not.toHaveBeenCalled();
 			expect(icPunksCollectionMetadata).not.toHaveBeenCalled();
+
+			expect(icrc7CollectionMetadata).not.toHaveBeenCalled();
+		});
+
+		it('should detect an Icrc7 canister', async () => {
+			vi.mocked(extBalance).mockRejectedValue(new Error('Not an EXT canister'));
+			vi.mocked(dip721Balance).mockRejectedValue(new Error('Not a DIP721 canister'));
+			vi.mocked(icPunksGetTokensByOwner).mockRejectedValue(new Error('Not an ICPunks canister'));
+
+			await expect(detectNftCanisterStandard(params)).resolves.toBe('icrc7');
+
+			expect(icrc7CollectionMetadata).toHaveBeenCalledExactlyOnceWith(expected);
 		});
 
 		it('should detect a DIP721 canister', async () => {
@@ -127,6 +149,8 @@ describe('ic-standard.services', () => {
 			expect(icPunksGetTokensByOwner).not.toHaveBeenCalled();
 			expect(icPunksMetadata).not.toHaveBeenCalled();
 			expect(icPunksCollectionMetadata).not.toHaveBeenCalled();
+
+			expect(icrc7CollectionMetadata).not.toHaveBeenCalled();
 		});
 
 		it('should detect an ICPunks canister', async () => {
@@ -163,12 +187,15 @@ describe('ic-standard.services', () => {
 				tokenIdentifier: 1n
 			});
 			expect(icPunksCollectionMetadata).toHaveBeenCalledExactlyOnceWith(expected);
+
+			expect(icrc7CollectionMetadata).not.toHaveBeenCalled();
 		});
 
 		it('should return undefined for unrecognized canisters', async () => {
 			vi.mocked(extBalance).mockRejectedValue(new Error('Not an EXT canister'));
 			vi.mocked(dip721Balance).mockRejectedValue(new Error('Not a DIP721 canister'));
 			vi.mocked(icPunksGetTokensByOwner).mockRejectedValue(new Error('Not an ICPunks canister'));
+			vi.mocked(icrc7CollectionMetadata).mockRejectedValue(new Error('Not an ICRC-7 canister'));
 
 			await expect(detectNftCanisterStandard(params)).resolves.toBeUndefined();
 
@@ -200,6 +227,8 @@ describe('ic-standard.services', () => {
 				tokenIdentifier: 1n
 			});
 			expect(icPunksCollectionMetadata).toHaveBeenCalledExactlyOnceWith(expected);
+
+			expect(icrc7CollectionMetadata).toHaveBeenCalledExactlyOnceWith(expected);
 		});
 
 		it('should throw any other error from the service', async () => {
@@ -219,6 +248,8 @@ describe('ic-standard.services', () => {
 			expect(icPunksGetTokensByOwner).not.toHaveBeenCalled();
 			expect(icPunksMetadata).not.toHaveBeenCalled();
 			expect(icPunksCollectionMetadata).not.toHaveBeenCalled();
+
+			expect(icrc7CollectionMetadata).not.toHaveBeenCalled();
 		});
 
 		it('should prioritize EXT over any other standard', async () => {
@@ -243,6 +274,8 @@ describe('ic-standard.services', () => {
 			expect(icPunksGetTokensByOwner).not.toHaveBeenCalled();
 			expect(icPunksMetadata).not.toHaveBeenCalled();
 			expect(icPunksCollectionMetadata).not.toHaveBeenCalled();
+
+			expect(icrc7CollectionMetadata).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Lets the custom-NFT import wizard recognise an ICRC-7 collection canister id and bind it to the form's `icrc7CanisterId` slot, so the upcoming review screen has data to consume. Mirrors the EXT / DIP721 / IcPunks branches already in `IcAddNftForm.svelte`.
