### PR TITLE
feat(frontend): add Icrc7-add-custom-tokens service

### DIFF
--- a/src/frontend/src/icp/services/icrc7-add-custom-tokens.service.ts
+++ b/src/frontend/src/icp/services/icrc7-add-custom-tokens.service.ts
@@ -1,0 +1,119 @@
+import { collectionMetadata } from '$icp/api/icrc7.api';
+import type { Icrc7CanistersSchema } from '$icp/schema/icrc7-token.schema';
+import type { Icrc7Token, Icrc7TokenWithoutId } from '$icp/types/icrc7-token';
+import { mapIcrc7CollectionMetadata, mapIcrc7Token } from '$icp/utils/icrc7.utils';
+import { i18n } from '$lib/stores/i18n.store';
+import { toastsError } from '$lib/stores/toasts.store';
+import type { NullishIdentity } from '$lib/types/identity';
+import { assertExistingTokens } from '$lib/utils/tokens.utils';
+import { assertNonNullish, isNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { get } from 'svelte/store';
+import type * as z from 'zod';
+
+type Icrc7Canisters = z.infer<typeof Icrc7CanistersSchema>;
+
+export interface ValidateTokenData {
+	token: Icrc7TokenWithoutId;
+}
+
+export const loadAndAssertAddCustomToken = async ({
+	identity,
+	icrc7Tokens,
+	canisterId
+}: Partial<Icrc7Canisters> & {
+	identity: NullishIdentity;
+	icrc7Tokens: Icrc7Token[];
+}): Promise<{
+	result: 'success' | 'error';
+	data?: ValidateTokenData;
+}> => {
+	assertNonNullish(identity);
+
+	if (isNullish(canisterId)) {
+		toastsError({
+			msg: { text: get(i18n).tokens.import.error.missing_canister_id }
+		});
+		return { result: 'error' };
+	}
+
+	const canisterIds = { canisterId };
+
+	const { alreadyAvailable } = assertAlreadyAvailable({
+		icrc7Tokens,
+		...canisterIds
+	});
+
+	if (alreadyAvailable) {
+		return { result: 'error' };
+	}
+
+	try {
+		const params = { identity, ...canisterIds };
+
+		const token = await loadMetadata(params);
+
+		if (isNullish(token)) {
+			toastsError({
+				msg: { text: get(i18n).tokens.import.error.no_metadata }
+			});
+
+			return { result: 'error' };
+		}
+
+		const { valid } = assertExistingTokens({
+			existingTokens: icrc7Tokens,
+			token,
+			errorMsg: get(i18n).tokens.error.duplicate_metadata
+		});
+
+		if (!valid) {
+			return { result: 'error' };
+		}
+
+		return { result: 'success', data: { token } };
+	} catch (_err: unknown) {
+		return { result: 'error' };
+	}
+};
+
+const assertAlreadyAvailable = ({
+	icrc7Tokens,
+	canisterId
+}: {
+	icrc7Tokens: Icrc7Token[];
+} & Icrc7Canisters): { alreadyAvailable: boolean } => {
+	if (icrc7Tokens?.find(({ canisterId: id }) => id === canisterId) !== undefined) {
+		toastsError({
+			msg: { text: get(i18n).tokens.error.already_available }
+		});
+
+		return { alreadyAvailable: true };
+	}
+
+	return { alreadyAvailable: false };
+};
+
+const loadMetadata = async ({
+	identity,
+	canisterId
+}: Icrc7Canisters & { identity: Identity }): Promise<Icrc7TokenWithoutId | undefined> => {
+	try {
+		const entries = await collectionMetadata({ canisterId, identity, certified: true });
+
+		const metadata = mapIcrc7CollectionMetadata(entries);
+
+		if (isNullish(metadata)) {
+			return undefined;
+		}
+
+		return mapIcrc7Token({
+			canisterId,
+			metadata: { name: metadata.name, symbol: metadata.symbol }
+		});
+	} catch (err: unknown) {
+		toastsError({ msg: { text: get(i18n).tokens.import.error.loading_metadata } });
+
+		throw err;
+	}
+};

--- a/src/frontend/src/tests/icp/services/icrc7-add-custom-tokens.service.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc7-add-custom-tokens.service.spec.ts
@@ -1,0 +1,156 @@
+import type { Value } from '$declarations/icrc7/icrc7.did';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { collectionMetadata } from '$icp/api/icrc7.api';
+import { loadAndAssertAddCustomToken } from '$icp/services/icrc7-add-custom-tokens.service';
+import type { Icrc7TokenWithoutId } from '$icp/types/icrc7-token';
+import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
+import { i18n } from '$lib/stores/i18n.store';
+import * as toastsStore from '$lib/stores/toasts.store';
+import { parseTokenId } from '$lib/validation/token.validation';
+import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { get } from 'svelte/store';
+import type { MockInstance } from 'vitest';
+
+vi.mock('$icp/api/icrc7.api', () => ({
+	collectionMetadata: vi.fn()
+}));
+
+const mockOtherCanisterId = 'qcg3w-tyaaa-aaaah-qakea-cai';
+
+describe('icrc7-add-custom-tokens.service', () => {
+	describe('loadAndAssertAddCustomToken', () => {
+		const mockCanisterId = mockIcrc7CanisterId;
+
+		const mockFetchedEntries: Array<[string, Value]> = [
+			['icrc7:name', { Text: 'Mock Collection' }],
+			['icrc7:symbol', { Text: 'MOCK' }],
+			['icrc7:description', { Text: 'Mock Description' }],
+			['icrc7:logo', { Text: 'https://example.com/icon.png' }]
+		];
+
+		let spyToastsError: MockInstance;
+
+		const validParams = {
+			identity: mockIdentity,
+			icrc7Tokens: [],
+			canisterId: mockCanisterId
+		};
+
+		const expectedToken: Icrc7TokenWithoutId = {
+			canisterId: mockCanisterId,
+			standard: { code: 'icrc7' },
+			category: 'custom',
+			tags: [{ type: TokenTagType.CATEGORY, value: TokenCategoryTagValue.CRYPTO }],
+			name: 'Mock Collection',
+			symbol: 'MOCK',
+			decimals: 0,
+			network: ICP_NETWORK
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			spyToastsError = vi.spyOn(toastsStore, 'toastsError');
+
+			vi.mocked(collectionMetadata).mockResolvedValue(mockFetchedEntries);
+		});
+
+		it('should throw if identity is missing', async () => {
+			await expect(
+				loadAndAssertAddCustomToken({
+					...validParams,
+					identity: undefined
+				})
+			).rejects.toThrow();
+		});
+
+		it('should return error if canisterId is missing', async () => {
+			const { canisterId: _, ...params } = validParams;
+
+			const result = await loadAndAssertAddCustomToken(params);
+
+			expect(result).toEqual({ result: 'error' });
+
+			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
+				msg: { text: get(i18n).tokens.import.error.missing_canister_id }
+			});
+		});
+
+		it('should return error if token is already available', async () => {
+			const result = await loadAndAssertAddCustomToken({
+				...validParams,
+				icrc7Tokens: [
+					{
+						...expectedToken,
+						id: parseTokenId('test')
+					}
+				]
+			});
+
+			expect(result).toEqual({ result: 'error' });
+
+			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
+				msg: { text: get(i18n).tokens.error.already_available }
+			});
+		});
+
+		it('should return error if a token with the same metadata already exists', async () => {
+			const result = await loadAndAssertAddCustomToken({
+				identity: mockIdentity,
+				icrc7Tokens: [
+					{
+						...expectedToken,
+						id: parseTokenId('test'),
+						canisterId: mockOtherCanisterId
+					}
+				],
+				canisterId: mockCanisterId
+			});
+
+			expect(result).toEqual({ result: 'error' });
+
+			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
+				msg: { text: get(i18n).tokens.error.duplicate_metadata }
+			});
+		});
+
+		it('should return error if mapped collection metadata is missing required keys', async () => {
+			vi.mocked(collectionMetadata).mockResolvedValue([
+				['icrc7:name', { Text: 'Only name, no symbol' }]
+			]);
+
+			const result = await loadAndAssertAddCustomToken(validParams);
+
+			expect(result).toEqual({ result: 'error' });
+
+			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
+				msg: { text: get(i18n).tokens.import.error.no_metadata }
+			});
+		});
+
+		it('should successfully load a new token', async () => {
+			const result = await loadAndAssertAddCustomToken(validParams);
+
+			expect(result).toStrictEqual({ result: 'success', data: { token: expectedToken } });
+		});
+
+		it('should return error if loading metadata fails', async () => {
+			vi.mocked(collectionMetadata).mockRejectedValue(new Error('Failed to fetch'));
+
+			const result = await loadAndAssertAddCustomToken(validParams);
+
+			expect(result).toEqual({ result: 'error' });
+
+			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
+				msg: { text: get(i18n).tokens.import.error.loading_metadata }
+			});
+
+			expect(collectionMetadata).toHaveBeenCalledExactlyOnceWith({
+				canisterId: mockCanisterId,
+				identity: mockIdentity,
+				certified: true
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Adds the validation + metadata-prefill helper used by the upcoming `IcAddIcrc7TokenReview` screen, mirroring `icpunks-add-custom-tokens.service`. Centralises the import-flow guards (already-imported, duplicate metadata, missing required ICRC-7 keys) so the review component stays presentational.
