### PR TITLE
test(frontend): assert loadCustomErc4626Tokens in reloadAllCustomTokens helper

### DIFF
--- a/src/frontend/src/tests/lib/services/save-custom-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/save-custom-tokens.services.spec.ts
@@ -2,6 +2,7 @@ import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
 import { loadCustomTokens as loadCustomErc1155Tokens } from '$eth/services/erc1155.services';
 import { loadCustomTokens as loadCustomErc20Tokens } from '$eth/services/erc20.services';
+import { loadCustomErc4626Tokens } from '$eth/services/erc4626.services';
 import { loadCustomTokens as loadCustomErc721Tokens } from '$eth/services/erc721.services';
 import { erc1155CustomTokensStore } from '$eth/stores/erc1155-custom-tokens.store';
 import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
@@ -160,6 +161,9 @@ describe('save-custom-tokens.services', () => {
 			expect(loadCustomErc20Tokens).toHaveBeenCalledExactlyOnceWith({ identity: mockIdentity });
 			expect(loadCustomErc721Tokens).toHaveBeenCalledExactlyOnceWith({ identity: mockIdentity });
 			expect(loadCustomErc1155Tokens).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity
+			});
+			expect(loadCustomErc4626Tokens).toHaveBeenCalledExactlyOnceWith({
 				identity: mockIdentity
 			});
 			expect(loadCustomIcrcTokens).toHaveBeenCalledExactlyOnceWith({ identity: mockIdentity });


### PR DESCRIPTION
# Motivation

Pre-existing gap surfaced by Copilot during the #12842 review: `reloadAllCustomTokens` in `save-custom-tokens.services.ts` calls `loadCustomErc4626Tokens` (since #11430), but the spec's `expectAllCustomTokensReloaded` helper has been silent about it on `main` ever since. Without this assertion, the helper claims the full reload chain is exercised when in fact ERC-4626 reload could silently regress.
