### PR TITLE
feat(frontend): add Icrc7 review screen for NFT custom import

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcAddIcrc7TokenReview.svelte
+++ b/src/frontend/src/icp/components/tokens/IcAddIcrc7TokenReview.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
+	import { blur, fade } from 'svelte/transition';
+	import { icrc7Tokens } from '$icp/derived/icrc7.derived';
+	import {
+		loadAndAssertAddCustomToken,
+		type ValidateTokenData
+	} from '$icp/services/icrc7-add-custom-tokens.service';
+	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
+	import AddTokenWarning from '$lib/components/tokens/AddTokenWarning.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import Card from '$lib/components/ui/Card.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import SkeletonCardWithoutAmount from '$lib/components/ui/SkeletonCardWithoutAmount.svelte';
+	import Value from '$lib/components/ui/Value.svelte';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		icrc7CanisterId?: string;
+		metadata?: ValidateTokenData;
+		onBack: () => void;
+		onSave: () => void;
+	}
+
+	let { icrc7CanisterId, metadata = $bindable(), onBack, onSave }: Props = $props();
+
+	let invalid = $derived(isNullish(metadata));
+
+	const back = () => onBack();
+
+	onMount(async () => {
+		const { result, data } = await loadAndAssertAddCustomToken({
+			canisterId: icrc7CanisterId,
+			identity: $authIdentity,
+			icrc7Tokens: $icrc7Tokens
+		});
+
+		if (result === 'error' || isNullish(data)) {
+			back();
+			return;
+		}
+
+		metadata = data;
+	});
+</script>
+
+<ContentWithToolbar>
+	<div class="mb-4 rounded-lg bg-brand-subtle-20 p-4">
+		{#if isNullish(metadata)}
+			<SkeletonCardWithoutAmount>{$i18n.tokens.import.text.verifying}</SkeletonCardWithoutAmount>
+		{:else}
+			<div in:blur>
+				<Card noMargin>
+					{metadata.token.name}
+
+					{#snippet icon()}
+						{#if nonNullish(metadata)}
+							<Logo
+								alt={replacePlaceholders($i18n.core.alt.logo, { $name: metadata.token.name })}
+								color="white"
+								size="lg"
+								src={metadata.token.icon}
+							/>
+						{/if}
+					{/snippet}
+
+					{#snippet description()}
+						{#if nonNullish(metadata)}
+							<span class="break-all">
+								{metadata.token.symbol}
+							</span>
+						{/if}
+					{/snippet}
+				</Card>
+			</div>
+		{/if}
+	</div>
+
+	{#if nonNullish(metadata)}
+		{@const { network: safeNetwork, canisterId: safeCanisterId } = metadata.token}
+		<div in:fade>
+			<Value element="div" ref="network">
+				{#snippet label()}
+					{$i18n.tokens.manage.text.network}
+				{/snippet}
+				{#snippet content()}
+					<NetworkWithLogo network={safeNetwork} />
+				{/snippet}
+			</Value>
+
+			<Value element="div" ref="canisterId">
+				{#snippet label()}{$i18n.tokens.import.text.canister_id}{/snippet}
+				{#snippet content()}
+					{safeCanisterId}
+				{/snippet}
+			</Value>
+
+			<AddTokenWarning />
+		</div>
+	{/if}
+
+	{#snippet toolbar()}
+		<div in:fade>
+			{#if nonNullish(metadata)}
+				<ButtonGroup>
+					<ButtonBack onclick={back} />
+					<Button disabled={invalid} onclick={onSave}>
+						{$i18n.tokens.import.text.add_the_token}
+					</Button>
+				</ButtonGroup>
+			{/if}
+		</div>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
@@ -9,10 +9,12 @@
 	import type { Erc721Metadata } from '$eth/types/erc721';
 	import IcAddExtTokenReview from '$icp/components/tokens/IcAddExtTokenReview.svelte';
 	import IcAddIcPunksTokenReview from '$icp/components/tokens/IcAddIcPunksTokenReview.svelte';
+	import IcAddIcrc7TokenReview from '$icp/components/tokens/IcAddIcrc7TokenReview.svelte';
 	import IcAddIcrcTokenReview from '$icp/components/tokens/IcAddIcrcTokenReview.svelte';
 	import type { ValidateTokenData as ValidateExtTokenData } from '$icp/services/ext-add-custom-tokens.service';
 	import type { ValidateTokenData as ValidateIcrcTokenData } from '$icp/services/ic-add-custom-tokens.service';
 	import type { ValidateTokenData as ValidateIcPunksTokenData } from '$icp/services/icpunks-add-custom-tokens.service';
+	import type { ValidateTokenData as ValidateIcrc7TokenData } from '$icp/services/icrc7-add-custom-tokens.service';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import { TRACK_UNRECOGNISED_ERC_INTERFACE } from '$lib/constants/analytics.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -107,6 +109,23 @@
 				enabled: true,
 				networkKey: 'IcPunks',
 				canisterId: icPunksCanisterId
+			}
+		]);
+	};
+
+	const addIcrc7Token = async () => {
+		if (isNullish(icrc7CanisterId)) {
+			toastsError({
+				msg: { text: $i18n.tokens.import.error.missing_canister_id }
+			});
+			return;
+		}
+
+		await saveTokens([
+			{
+				enabled: true,
+				networkKey: 'Icrc7',
+				canisterId: icrc7CanisterId
 			}
 		]);
 	};
@@ -234,6 +253,8 @@
 
 	let icPunksMetadata: ValidateIcPunksTokenData | undefined = $state();
 
+	let icrc7Metadata: ValidateIcrc7TokenData | undefined = $state();
+
 	let ethMetadata: Erc20Metadata | Erc721Metadata | undefined = $state();
 
 	let splMetadata: TokenMetadata | undefined = $state();
@@ -243,6 +264,7 @@
 		indexCanisterId,
 		extCanisterId,
 		icPunksCanisterId,
+		icrc7CanisterId,
 		ethContractAddress,
 		splTokenAddress
 	} = $derived(tokenData);
@@ -263,6 +285,13 @@
 				{onBack}
 				onSave={addIcPunksToken}
 				bind:metadata={icPunksMetadata}
+			/>
+		{:else if nonNullish(icrc7CanisterId)}
+			<IcAddIcrc7TokenReview
+				{icrc7CanisterId}
+				{onBack}
+				onSave={addIcrc7Token}
+				bind:metadata={icrc7Metadata}
 			/>
 		{/if}
 	{:else}


### PR DESCRIPTION
# Motivation

Final piece of the ICRC-7 import flow: when the form (#12847) detects an ICRC-7 canister id and binds it to `tokenData.icrc7CanisterId`, the review step now renders a dedicated review component that pre-fills metadata via `loadAndAssertAddCustomToken` from the service in #12848 and on confirmation calls `saveTokens([{ networkKey: 'Icrc7', canisterId, enabled: true }])`. After this PR, the import wizard works end-to-end for ICRC-7 collections.
