### PR TITLE
feat(frontend): add Icrc7 token metadata parser

### DIFF
--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -9,6 +9,7 @@ import type { NftMetadataWithoutId } from '$lib/types/nft';
 import type { Token, TokenMetadata } from '$lib/types/token';
 import { mapNftAttributes } from '$lib/utils/nft.utils';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const isTokenIcrc7 = (token: Partial<IcToken>): token is Icrc7Token =>
 	token.standard?.code === 'icrc7';
@@ -66,8 +67,8 @@ const lookupText = ({
 }): string | undefined => {
 	const entry = entries.find(([k]) => k === key);
 
-	if (entry === undefined) {
-		return undefined;
+	if (isNullish(entry)) {
+		return;
 	}
 
 	const [, value] = entry;
@@ -87,8 +88,6 @@ const valueToString = ({ value }: { value: Value }): string | undefined => {
 	if ('Int' in value) {
 		return value.Int.toString();
 	}
-
-	return undefined;
 };
 
 const lookupStringByKeys = ({
@@ -100,7 +99,11 @@ const lookupStringByKeys = ({
 }): string | undefined => {
 	const entry = entries.find(([key]) => keys.includes(key));
 
-	return entry === undefined ? undefined : valueToString({ value: entry[1] });
+	if (isNullish(entry)) {
+		return;
+	}
+
+	return valueToString({ value: entry[1] });
 };
 
 const valueToAttributeValue = ({
@@ -115,7 +118,7 @@ const valueToAttributeRecord = ({
 	value: Value;
 }): { trait_type: string; value?: string | number | boolean } | undefined => {
 	if (!('Map' in value)) {
-		return undefined;
+		return;
 	}
 
 	const traitType = lookupStringByKeys({
@@ -123,15 +126,15 @@ const valueToAttributeRecord = ({
 		keys: ['trait_type', 'traitType', 'name']
 	});
 
-	if (traitType === undefined) {
-		return undefined;
+	if (isNullish(traitType)) {
+		return;
 	}
 
 	const rawValue = value.Map.find(([key]) => key === 'value')?.[1];
 
 	return {
 		trait_type: traitType,
-		...(rawValue !== undefined && { value: valueToAttributeValue({ value: rawValue }) })
+		...(nonNullish(rawValue) && { value: valueToAttributeValue({ value: rawValue }) })
 	};
 };
 
@@ -144,8 +147,8 @@ const lookupAttributesByKeys = ({
 }): NftMetadataWithoutId['attributes'] | undefined => {
 	const entry = entries.find(([key]) => keys.includes(key));
 
-	if (entry === undefined) {
-		return undefined;
+	if (isNullish(entry)) {
+		return;
 	}
 
 	const [, value] = entry;
@@ -165,12 +168,10 @@ const lookupAttributesByKeys = ({
 		return mapNftAttributes(
 			value.Array.map((attributeValue) => valueToAttributeRecord({ value: attributeValue })).filter(
 				(attribute): attribute is { trait_type: string; value?: string | number | boolean } =>
-					attribute !== undefined
+					nonNullish(attribute)
 			)
 		);
 	}
-
-	return undefined;
 };
 
 /**
@@ -189,8 +190,8 @@ export const mapIcrc7CollectionMetadata = (
 	const name = lookupText({ entries, key: ICRC7_NAME_KEY });
 	const symbol = lookupText({ entries, key: ICRC7_SYMBOL_KEY });
 
-	if (name === undefined || symbol === undefined) {
-		return undefined;
+	if (isNullish(name) || isNullish(symbol)) {
+		return;
 	}
 
 	const description = lookupText({ entries, key: ICRC7_DESCRIPTION_KEY });
@@ -199,8 +200,8 @@ export const mapIcrc7CollectionMetadata = (
 	return {
 		name,
 		symbol,
-		...(description !== undefined && { description }),
-		...(icon !== undefined && { icon })
+		...(nonNullish(description) && { description }),
+		...(nonNullish(icon) && { icon })
 	};
 };
 
@@ -220,9 +221,9 @@ export const mapIcrc7TokenMetadata = (
 	const attributes = lookupAttributesByKeys({ entries, keys: ICRC7_TOKEN_ATTRIBUTES_KEYS });
 
 	return {
-		...(name !== undefined && { name }),
-		...(description !== undefined && { description }),
-		...(imageUrl !== undefined && { imageUrl }),
-		...(attributes !== undefined && { attributes })
+		...(nonNullish(name) && { name }),
+		...(nonNullish(description) && { description }),
+		...(nonNullish(imageUrl) && { imageUrl }),
+		...(nonNullish(attributes) && { attributes })
 	};
 };

--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -5,7 +5,9 @@ import type { IcToken } from '$icp/types/ic-token';
 import type { Icrc7CustomToken } from '$icp/types/icrc7-custom-token';
 import type { Icrc7Token, Icrc7TokenWithoutId } from '$icp/types/icrc7-token';
 import { DEFAULT_TOKEN_TAGS } from '$lib/constants/token-tag.constants';
+import type { NftMetadataWithoutId } from '$lib/types/nft';
 import type { Token, TokenMetadata } from '$lib/types/token';
+import { mapNftAttributes } from '$lib/utils/nft.utils';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
 
 export const isTokenIcrc7 = (token: Partial<IcToken>): token is Icrc7Token =>
@@ -39,6 +41,22 @@ const ICRC7_SYMBOL_KEY = 'icrc7:symbol';
 const ICRC7_DESCRIPTION_KEY = 'icrc7:description';
 const ICRC7_LOGO_KEY = 'icrc7:logo';
 
+const ICRC7_TOKEN_NAME_KEYS = ['icrc7:name', 'icrc7:metadata:name', 'name'];
+const ICRC7_TOKEN_DESCRIPTION_KEYS = [
+	'icrc7:description',
+	'icrc7:metadata:description',
+	'description'
+];
+const ICRC7_TOKEN_IMAGE_KEYS = [
+	'icrc7:image',
+	'icrc7:metadata:image',
+	'icrc7:image_url',
+	'icrc7:metadata:image_url',
+	'image',
+	'image_url'
+];
+const ICRC7_TOKEN_ATTRIBUTES_KEYS = ['icrc7:attributes', 'icrc7:metadata:attributes', 'attributes'];
+
 const lookupText = ({
 	entries,
 	key
@@ -55,6 +73,104 @@ const lookupText = ({
 	const [, value] = entry;
 
 	return 'Text' in value ? value.Text : undefined;
+};
+
+const valueToString = ({ value }: { value: Value }): string | undefined => {
+	if ('Text' in value) {
+		return value.Text;
+	}
+
+	if ('Nat' in value) {
+		return value.Nat.toString();
+	}
+
+	if ('Int' in value) {
+		return value.Int.toString();
+	}
+
+	return undefined;
+};
+
+const lookupStringByKeys = ({
+	entries,
+	keys
+}: {
+	entries: Array<[string, Value]>;
+	keys: string[];
+}): string | undefined => {
+	const entry = entries.find(([key]) => keys.includes(key));
+
+	return entry === undefined ? undefined : valueToString({ value: entry[1] });
+};
+
+const valueToAttributeValue = ({
+	value
+}: {
+	value: Value;
+}): string | number | boolean | undefined => valueToString({ value });
+
+const valueToAttributeRecord = ({
+	value
+}: {
+	value: Value;
+}): { trait_type: string; value?: string | number | boolean } | undefined => {
+	if (!('Map' in value)) {
+		return undefined;
+	}
+
+	const traitType = lookupStringByKeys({
+		entries: value.Map,
+		keys: ['trait_type', 'traitType', 'name']
+	});
+
+	if (traitType === undefined) {
+		return undefined;
+	}
+
+	const rawValue = value.Map.find(([key]) => key === 'value')?.[1];
+
+	return {
+		trait_type: traitType,
+		...(rawValue !== undefined && { value: valueToAttributeValue({ value: rawValue }) })
+	};
+};
+
+const lookupAttributesByKeys = ({
+	entries,
+	keys
+}: {
+	entries: Array<[string, Value]>;
+	keys: string[];
+}): NftMetadataWithoutId['attributes'] | undefined => {
+	const entry = entries.find(([key]) => keys.includes(key));
+
+	if (entry === undefined) {
+		return undefined;
+	}
+
+	const [, value] = entry;
+
+	if ('Map' in value) {
+		return mapNftAttributes(
+			Object.fromEntries(
+				value.Map.map(([traitType, traitValue]) => [
+					traitType,
+					valueToAttributeValue({ value: traitValue })
+				])
+			)
+		);
+	}
+
+	if ('Array' in value) {
+		return mapNftAttributes(
+			value.Array.map((attributeValue) => valueToAttributeRecord({ value: attributeValue })).filter(
+				(attribute): attribute is { trait_type: string; value?: string | number | boolean } =>
+					attribute !== undefined
+			)
+		);
+	}
+
+	return undefined;
 };
 
 /**
@@ -85,5 +201,28 @@ export const mapIcrc7CollectionMetadata = (
 		symbol,
 		...(description !== undefined && { description }),
 		...(icon !== undefined && { icon })
+	};
+};
+
+/**
+ * Maps an ICRC-7 `icrc7_token_metadata` response for a single token into the NFT metadata shape
+ * consumed by the NFT grid.
+ *
+ * Real collections are not fully consistent about key names, so this accepts the standard
+ * `icrc7:*` keys, the `icrc7:metadata:*` namespace and common unprefixed fallbacks.
+ */
+export const mapIcrc7TokenMetadata = (
+	entries: Array<[string, Value]>
+): Omit<NftMetadataWithoutId, 'id'> => {
+	const name = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_NAME_KEYS });
+	const description = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_DESCRIPTION_KEYS });
+	const imageUrl = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_IMAGE_KEYS });
+	const attributes = lookupAttributesByKeys({ entries, keys: ICRC7_TOKEN_ATTRIBUTES_KEYS });
+
+	return {
+		...(name !== undefined && { name }),
+		...(description !== undefined && { description }),
+		...(imageUrl !== undefined && { imageUrl }),
+		...(attributes !== undefined && { attributes })
 	};
 };

--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -212,9 +212,7 @@ export const mapIcrc7CollectionMetadata = (
  * Real collections are not fully consistent about key names, so this accepts the standard
  * `icrc7:*` keys, the `icrc7:metadata:*` namespace and common unprefixed fallbacks.
  */
-export const mapIcrc7TokenMetadata = (
-	entries: Array<[string, Value]>
-): Omit<NftMetadataWithoutId, 'id'> => {
+export const mapIcrc7TokenMetadata = (entries: Array<[string, Value]>): NftMetadataWithoutId => {
 	const name = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_NAME_KEYS });
 	const description = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_DESCRIPTION_KEYS });
 	const imageUrl = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_IMAGE_KEYS });

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -4,7 +4,8 @@ import {
 	isTokenIcrc7,
 	isTokenIcrc7CustomToken,
 	mapIcrc7CollectionMetadata,
-	mapIcrc7Token
+	mapIcrc7Token,
+	mapIcrc7TokenMetadata
 } from '$icp/utils/icrc7.utils';
 import { DEFAULT_TOKEN_TAGS } from '$lib/constants/token-tag.constants';
 import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
@@ -129,6 +130,80 @@ describe('icrc7.utils', () => {
 				category: 'custom',
 				tags: DEFAULT_TOKEN_TAGS
 			});
+		});
+	});
+
+	describe('mapIcrc7TokenMetadata', () => {
+		it('should map prefixed token metadata keys', () => {
+			expect(
+				mapIcrc7TokenMetadata([
+					['icrc7:name', { Text: 'Token #50' }],
+					['icrc7:description', { Text: 'The test NFT' }],
+					[
+						'icrc7:image',
+						{
+							Text: 'https://blob.caffeine.ai/v1/blob/?blob_hash=sha256%3A3dafe45&owner_id=sey3i-jyaaa-aaaap-quo3q-cai'
+						}
+					],
+					['icrc7:attributes', { Map: [['Background', { Text: 'Blue' }]] }]
+				])
+			).toEqual({
+				name: 'Token #50',
+				description: 'The test NFT',
+				imageUrl:
+					'https://blob.caffeine.ai/v1/blob/?blob_hash=sha256%3A3dafe45&owner_id=sey3i-jyaaa-aaaap-quo3q-cai',
+				attributes: [{ traitType: 'Background', value: 'Blue' }]
+			});
+		});
+
+		it('should map icrc7:metadata namespace keys', () => {
+			expect(
+				mapIcrc7TokenMetadata([
+					['icrc7:metadata:name', { Text: 'Namespaced token' }],
+					['icrc7:metadata:description', { Text: 'Namespaced description' }],
+					['icrc7:metadata:image_url', { Text: 'https://example.com/token.png' }]
+				])
+			).toEqual({
+				name: 'Namespaced token',
+				description: 'Namespaced description',
+				imageUrl: 'https://example.com/token.png'
+			});
+		});
+
+		it('should map unprefixed fallback keys and array attributes', () => {
+			expect(
+				mapIcrc7TokenMetadata([
+					['name', { Text: 'Fallback token' }],
+					['image', { Text: 'https://example.com/fallback.png' }],
+					[
+						'attributes',
+						{
+							Array: [
+								{
+									Map: [
+										['trait_type', { Text: 'Level' }],
+										['value', { Nat: 50n }]
+									]
+								}
+							]
+						}
+					]
+				])
+			).toEqual({
+				name: 'Fallback token',
+				imageUrl: 'https://example.com/fallback.png',
+				attributes: [{ traitType: 'Level', value: '50' }]
+			});
+		});
+
+		it('should ignore unsupported metadata values without throwing', () => {
+			expect(
+				mapIcrc7TokenMetadata([
+					['icrc7:name', { Blob: new Uint8Array([1, 2, 3]) }],
+					['icrc7:image', { Blob: new Uint8Array([4, 5, 6]) }],
+					['icrc7:attributes', { Text: 'not an attributes structure' }]
+				])
+			).toEqual({});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Add the parser needed before wiring ICRC-7 NFTs into the NFT grid. This converts one `icrc7_token_metadata` response into the NFT metadata shape without touching the load/display pipeline yet.

# Changes

- Add `mapIcrc7TokenMetadata` to `icrc7.utils.ts`.
- Support standard `icrc7:*` keys, `icrc7:metadata:*` keys, and common unprefixed fallbacks.
- Parse map and array-style attributes through the existing `mapNftAttributes` helper.

# Tests

Added tests.
