### PR TITLE
feat(frontend): add token_manage analytics helper

### DIFF
--- a/src/frontend/src/lib/enums/plausible.ts
+++ b/src/frontend/src/lib/enums/plausible.ts
@@ -17,7 +17,8 @@ export enum PLAUSIBLE_EVENTS {
 	SIGNER_INTERACTION = 'signer_interaction',
 	NETWORK_FILTER = 'network_filter',
 	NETWORK_MANAGE = 'network_manage',
-	TRANSACTION_FILTER = 'transaction_filter'
+	TRANSACTION_FILTER = 'transaction_filter',
+	TOKEN_MANAGE = 'token_manage'
 }
 
 export enum PLAUSIBLE_EVENT_CONTEXTS {
@@ -83,7 +84,9 @@ export enum PLAUSIBLE_EVENT_SOURCES {
 }
 
 export enum PLAUSIBLE_EVENT_SOURCE_LOCATIONS {
-	ACTIVITY_PAGE = 'activity_page'
+	ACTIVITY_PAGE = 'activity_page',
+	MANAGE_TOKENS = 'manage_tokens',
+	TOKEN_DETAILS = 'token_details'
 }
 
 export enum PLAUSIBLE_EVENT_EVENTS_KEYS {

--- a/src/frontend/src/lib/services/token-manage-analytics.services.ts
+++ b/src/frontend/src/lib/services/token-manage-analytics.services.ts
@@ -1,0 +1,61 @@
+import {
+	PLAUSIBLE_EVENTS,
+	type PLAUSIBLE_EVENT_RESULT_STATUSES,
+	type PLAUSIBLE_EVENT_SOURCE_LOCATIONS
+} from '$lib/enums/plausible';
+import { trackEvent } from '$lib/services/analytics.services';
+import { nonNullish } from '@dfinity/utils';
+
+export type TokenManageEventModifier = 'import' | 'delete' | 'enable' | 'disable' | 'edit';
+
+export type TokenManageEventKey = 'index_canister';
+
+export type TokenManageSourceLocation =
+	| PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS
+	| PLAUSIBLE_EVENT_SOURCE_LOCATIONS.TOKEN_DETAILS;
+
+export interface TokenManageEventToken {
+	network: string;
+	address: string;
+	symbol?: string;
+	name?: string;
+}
+
+export interface TrackTokenManageParams {
+	modifier: TokenManageEventModifier;
+	token: TokenManageEventToken;
+	sourceLocation: TokenManageSourceLocation;
+	resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
+	key?: TokenManageEventKey;
+	value?: string;
+	error?: string;
+	errorCode?: string;
+}
+
+export const trackTokenManage = ({
+	modifier,
+	key,
+	value,
+	token,
+	sourceLocation,
+	resultStatus,
+	error,
+	errorCode
+}: TrackTokenManageParams) => {
+	trackEvent({
+		name: PLAUSIBLE_EVENTS.TOKEN_MANAGE,
+		metadata: {
+			event_modifier: modifier,
+			...(nonNullish(key) && { event_key: key }),
+			...(nonNullish(value) && { event_value: value }),
+			token_network: token.network,
+			token_address: token.address,
+			...(nonNullish(token.symbol) && { token_symbol: token.symbol }),
+			...(nonNullish(token.name) && { token_name: token.name }),
+			source_location: sourceLocation,
+			result_status: resultStatus,
+			...(nonNullish(error) && { result_error: error }),
+			...(nonNullish(errorCode) && { result_error_code: errorCode })
+		}
+	});
+};

--- a/src/frontend/src/tests/lib/services/token-manage-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/token-manage-analytics.services.spec.ts
@@ -1,8 +1,9 @@
-import { trackEvent } from '$lib/services/analytics.services';
 import {
-	trackTokenManage,
-	type TrackTokenManageParams
-} from '$lib/services/token-manage-analytics.services';
+	PLAUSIBLE_EVENT_RESULT_STATUSES,
+	PLAUSIBLE_EVENT_SOURCE_LOCATIONS
+} from '$lib/enums/plausible';
+import { trackEvent } from '$lib/services/analytics.services';
+import { trackTokenManage } from '$lib/services/token-manage-analytics.services';
 
 vi.mock('$lib/services/analytics.services', () => ({
 	trackEvent: vi.fn()
@@ -17,8 +18,8 @@ describe('token-manage-analytics.services', () => {
 		it('should track a token_manage success event with token metadata', () => {
 			trackTokenManage({
 				modifier: 'import',
-				sourceLocation: 'manage_tokens' as TrackTokenManageParams['sourceLocation'],
-				resultStatus: 'success' as TrackTokenManageParams['resultStatus'],
+				sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
 				token: {
 					network: 'ICP',
 					address: 'sey3i-jyaaa-aaaap-quo3q-cai',
@@ -46,8 +47,8 @@ describe('token-manage-analytics.services', () => {
 				modifier: 'edit',
 				key: 'index_canister',
 				value: 'index-canister-id',
-				sourceLocation: 'token_details' as TrackTokenManageParams['sourceLocation'],
-				resultStatus: 'error' as TrackTokenManageParams['resultStatus'],
+				sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.TOKEN_DETAILS,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 				error: 'Version mismatch',
 				errorCode: 'version_mismatch',
 				token: {

--- a/src/frontend/src/tests/lib/services/token-manage-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/token-manage-analytics.services.spec.ts
@@ -1,0 +1,75 @@
+import { trackEvent } from '$lib/services/analytics.services';
+import {
+	trackTokenManage,
+	type TrackTokenManageParams
+} from '$lib/services/token-manage-analytics.services';
+
+vi.mock('$lib/services/analytics.services', () => ({
+	trackEvent: vi.fn()
+}));
+
+describe('token-manage-analytics.services', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('trackTokenManage', () => {
+		it('should track a token_manage success event with token metadata', () => {
+			trackTokenManage({
+				modifier: 'import',
+				sourceLocation: 'manage_tokens' as TrackTokenManageParams['sourceLocation'],
+				resultStatus: 'success' as TrackTokenManageParams['resultStatus'],
+				token: {
+					network: 'ICP',
+					address: 'sey3i-jyaaa-aaaap-quo3q-cai',
+					symbol: 'CCC',
+					name: 'CCC NFT Platform'
+				}
+			});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: 'token_manage',
+				metadata: {
+					event_modifier: 'import',
+					token_network: 'ICP',
+					token_address: 'sey3i-jyaaa-aaaap-quo3q-cai',
+					token_symbol: 'CCC',
+					token_name: 'CCC NFT Platform',
+					source_location: 'manage_tokens',
+					result_status: 'success'
+				}
+			});
+		});
+
+		it('should track edit-specific fields and errors when provided', () => {
+			trackTokenManage({
+				modifier: 'edit',
+				key: 'index_canister',
+				value: 'index-canister-id',
+				sourceLocation: 'token_details' as TrackTokenManageParams['sourceLocation'],
+				resultStatus: 'error' as TrackTokenManageParams['resultStatus'],
+				error: 'Version mismatch',
+				errorCode: 'version_mismatch',
+				token: {
+					network: 'ICP',
+					address: 'ledger-canister-id'
+				}
+			});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: 'token_manage',
+				metadata: {
+					event_modifier: 'edit',
+					event_key: 'index_canister',
+					event_value: 'index-canister-id',
+					token_network: 'ICP',
+					token_address: 'ledger-canister-id',
+					source_location: 'token_details',
+					result_status: 'error',
+					result_error: 'Version mismatch',
+					result_error_code: 'version_mismatch'
+				}
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Add the typed analytics foundation for the cross-standard `token_manage` event. This is intentionally just the helper and enum wiring; actual import/delete/enable/disable/edit instrumentation will land in follow-up PRs so each flow can be reviewed independently.

# Changes

- Add `PLAUSIBLE_EVENTS.TOKEN_MANAGE`.
- Add `manage_tokens` and `token_details` source locations.
- Add `trackTokenManage` with the requested fields: modifier, optional edit key/value, token network/address/symbol/name, source location, result status, and optional error fields.

# Tests

Added tests.
