### PR TITLE
feat(frontend): expose parsed Icrc7 NFT metadata API

### DIFF
--- a/src/frontend/src/icp/api/icrc7.api.ts
+++ b/src/frontend/src/icp/api/icrc7.api.ts
@@ -1,6 +1,7 @@
 import type { Account, Value } from '$declarations/icrc7/icrc7.did';
 import { Icrc7Canister } from '$icp/canisters/icrc7.canister';
 import type { CanisterApiFunctionParamsWithCanisterId } from '$lib/types/canister';
+import type { NftMetadataWithoutId } from '$lib/types/nft';
 import { assertNonNullish, isNullish, type QueryParams } from '@dfinity/utils';
 import { Principal } from '@icp-sdk/core/principal';
 
@@ -77,6 +78,24 @@ export const tokenMetadata = async ({
 	});
 
 	return await tokenMetadata({ certified, tokenIds });
+};
+
+export const metadata = async ({
+	certified,
+	identity,
+	canisterId,
+	tokenId,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<{ tokenId: bigint } & QueryParams>): Promise<
+	NftMetadataWithoutId | undefined
+> => {
+	const { metadata } = await icrc7Canister({
+		identity,
+		canisterId,
+		...rest
+	});
+
+	return await metadata({ certified, tokenId });
 };
 
 export const transfer = async ({

--- a/src/frontend/src/icp/canisters/icrc7.canister.ts
+++ b/src/frontend/src/icp/canisters/icrc7.canister.ts
@@ -2,10 +2,19 @@ import type { Account, _SERVICE as Icrc7Service, Value } from '$declarations/icr
 import { idlFactory as idlCertifiedFactoryIcrc7 } from '$declarations/icrc7/icrc7.factory.certified.did';
 import { idlFactory as idlFactoryIcrc7 } from '$declarations/icrc7/icrc7.factory.did';
 import { mapIcrc7TransferError } from '$icp/canisters/icrc7.errors';
+import { mapIcrc7TokenMetadata } from '$icp/utils/icrc7.utils';
 import { getAgent } from '$lib/actors/agents.ic';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import type { CreateCanisterOptions } from '$lib/types/canister';
-import { Canister, createServices, toNullable, type QueryParams } from '@dfinity/utils';
+import type { NftMetadataWithoutId } from '$lib/types/nft';
+import {
+	Canister,
+	createServices,
+	fromNullable,
+	isNullish,
+	toNullable,
+	type QueryParams
+} from '@dfinity/utils';
 
 // Wrapper around an ICRC-7 NFT collection canister.
 // Reference: https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-7/ICRC-7.md
@@ -65,6 +74,20 @@ export class Icrc7Canister extends Canister<Icrc7Service> {
 		const { icrc7_token_metadata } = this.caller({ certified });
 
 		return await icrc7_token_metadata(tokenIds);
+	};
+
+	metadata = async ({
+		tokenId,
+		certified
+	}: { tokenId: bigint } & QueryParams): Promise<NftMetadataWithoutId | undefined> => {
+		const [metadata] = await this.tokenMetadata({ tokenIds: [tokenId], certified });
+		const entries = fromNullable(metadata);
+
+		if (isNullish(entries)) {
+			return;
+		}
+
+		return mapIcrc7TokenMetadata(entries);
 	};
 
 	/**

--- a/src/frontend/src/tests/icp/api/icrc7.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc7.api.spec.ts
@@ -2,6 +2,7 @@ import {
 	collectionMetadata,
 	getOwnersOf,
 	getTokensByOwner,
+	metadata,
 	tokenMetadata,
 	transfer
 } from '$icp/api/icrc7.api';
@@ -158,6 +159,37 @@ describe('icrc7.api', () => {
 			tokenCanisterMock.tokenMetadata.mockRejectedValueOnce(mockError);
 
 			await expect(tokenMetadata(params)).rejects.toThrow(mockError);
+		});
+	});
+
+	describe('metadata', () => {
+		const mockTokenId = 1n;
+		const mockResponse = { name: 'Mock ICRC-7 NFT #1' };
+
+		const params = {
+			identity: mockIdentity,
+			canisterId: mockIcrc7CanisterId,
+			tokenId: mockTokenId
+		};
+
+		beforeEach(() => {
+			tokenCanisterMock.metadata.mockResolvedValue(mockResponse);
+		});
+
+		it('should call metadata successfully', async () => {
+			const result = await metadata(params);
+
+			expect(result).toStrictEqual(mockResponse);
+			expect(tokenCanisterMock.metadata).toHaveBeenCalledExactlyOnceWith({
+				tokenId: mockTokenId
+			});
+		});
+
+		it('should throw if metadata fails', async () => {
+			const mockError = new CanisterInternalError('Generic error');
+			tokenCanisterMock.metadata.mockRejectedValueOnce(mockError);
+
+			await expect(metadata(params)).rejects.toThrow(mockError);
 		});
 	});
 

--- a/src/frontend/src/tests/icp/canisters/icrc7.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/icrc7.canister.spec.ts
@@ -147,6 +147,31 @@ describe('icrc7.canister', () => {
 		});
 	});
 
+	describe('metadata', () => {
+		const mockTokenId = 1n;
+
+		it('should map the first icrc7_token_metadata result', async () => {
+			service.icrc7_token_metadata.mockResolvedValue([[mockIcrc7TokenMetadata]]);
+
+			const { metadata } = await createIcrc7Canister({ serviceOverride: service });
+
+			const res = await metadata({ certified, tokenId: mockTokenId });
+
+			expect(res).toEqual({
+				name: 'Mock ICRC-7 NFT #1'
+			});
+			expect(service.icrc7_token_metadata).toHaveBeenCalledExactlyOnceWith([mockTokenId]);
+		});
+
+		it('should return undefined when metadata is missing', async () => {
+			service.icrc7_token_metadata.mockResolvedValue([[]]);
+
+			const { metadata } = await createIcrc7Canister({ serviceOverride: service });
+
+			await expect(metadata({ certified, tokenId: mockTokenId })).resolves.toBeUndefined();
+		});
+	});
+
 	describe('transfer', () => {
 		const mockTokenId = 12345n;
 		const mockBlockIndex = 7n;


### PR DESCRIPTION
# Motivation

Build on `mapIcrc7TokenMetadata` by exposing a parsed single-token metadata method from the ICRC-7 canister wrapper and API. The raw batch `tokenMetadata` method remains available, while the upcoming `mapIcrc7Nft` flow can consume the parsed shape directly.

