### PR TITLE
feat(frontend): add Icrc3 canister wrapper and API

### DIFF
--- a/src/frontend/src/icp/api/icrc3.api.ts
+++ b/src/frontend/src/icp/api/icrc3.api.ts
@@ -1,0 +1,75 @@
+import type {
+	DataCertificate,
+	GetArchivesResult,
+	GetBlocksArgs,
+	GetBlocksResult
+} from '$declarations/icrc3/icrc3.did';
+import { Icrc3Canister } from '$icp/canisters/icrc3.canister';
+import type { CanisterApiFunctionParamsWithCanisterId } from '$lib/types/canister';
+import { assertNonNullish, type QueryParams } from '@dfinity/utils';
+import { Principal } from '@icp-sdk/core/principal';
+
+export const getArchives = async ({
+	certified,
+	identity,
+	canisterId,
+	from,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<
+	{ from?: Principal } & QueryParams
+>): Promise<GetArchivesResult> => {
+	const { getArchives } = await icrc3Canister({ identity, canisterId, ...rest });
+
+	return await getArchives({ certified, from });
+};
+
+export const getBlocks = async ({
+	certified,
+	identity,
+	canisterId,
+	args,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<
+	{ args: GetBlocksArgs } & QueryParams
+>): Promise<GetBlocksResult> => {
+	const { getBlocks } = await icrc3Canister({ identity, canisterId, ...rest });
+
+	return await getBlocks({ certified, args });
+};
+
+export const getTipCertificate = async ({
+	certified,
+	identity,
+	canisterId,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<QueryParams>): Promise<DataCertificate | undefined> => {
+	const { getTipCertificate } = await icrc3Canister({ identity, canisterId, ...rest });
+
+	return await getTipCertificate({ certified });
+};
+
+export const supportedBlockTypes = async ({
+	certified,
+	identity,
+	canisterId,
+	...rest
+}: CanisterApiFunctionParamsWithCanisterId<QueryParams>): Promise<
+	Array<{ url: string; block_type: string }>
+> => {
+	const { supportedBlockTypes } = await icrc3Canister({ identity, canisterId, ...rest });
+
+	return await supportedBlockTypes({ certified });
+};
+
+const icrc3Canister = async ({
+	identity,
+	nullishIdentityErrorMessage,
+	canisterId
+}: CanisterApiFunctionParamsWithCanisterId): Promise<Icrc3Canister> => {
+	assertNonNullish(identity, nullishIdentityErrorMessage);
+
+	return await Icrc3Canister.create({
+		identity,
+		canisterId: Principal.fromText(canisterId)
+	});
+};

--- a/src/frontend/src/icp/canisters/icrc3.canister.ts
+++ b/src/frontend/src/icp/canisters/icrc3.canister.ts
@@ -1,0 +1,71 @@
+import type {
+	DataCertificate,
+	GetArchivesResult,
+	GetBlocksArgs,
+	GetBlocksResult,
+	_SERVICE as Icrc3Service
+} from '$declarations/icrc3/icrc3.did';
+import { idlFactory as idlCertifiedFactoryIcrc3 } from '$declarations/icrc3/icrc3.factory.certified.did';
+import { idlFactory as idlFactoryIcrc3 } from '$declarations/icrc3/icrc3.factory.did';
+import { getAgent } from '$lib/actors/agents.ic';
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import {
+	Canister,
+	createServices,
+	fromNullable,
+	toNullable,
+	type QueryParams
+} from '@dfinity/utils';
+import type { Principal } from '@icp-sdk/core/principal';
+
+export class Icrc3Canister extends Canister<Icrc3Service> {
+	static async create({
+		identity,
+		...options
+	}: CreateCanisterOptions<Icrc3Service>): Promise<Icrc3Canister> {
+		const agent = await getAgent({ identity });
+
+		const { service, certifiedService, canisterId } = createServices<Icrc3Service>({
+			options: {
+				...options,
+				agent
+			},
+			idlFactory: idlFactoryIcrc3,
+			certifiedIdlFactory: idlCertifiedFactoryIcrc3
+		});
+
+		return new Icrc3Canister(canisterId, service, certifiedService);
+	}
+
+	getArchives = async ({
+		from,
+		certified
+	}: { from?: Principal } & QueryParams): Promise<GetArchivesResult> => {
+		const { icrc3_get_archives } = this.caller({ certified });
+
+		return await icrc3_get_archives({ from: toNullable(from) });
+	};
+
+	getBlocks = async ({
+		args,
+		certified
+	}: { args: GetBlocksArgs } & QueryParams): Promise<GetBlocksResult> => {
+		const { icrc3_get_blocks } = this.caller({ certified });
+
+		return await icrc3_get_blocks(args);
+	};
+
+	getTipCertificate = async ({ certified }: QueryParams): Promise<DataCertificate | undefined> => {
+		const { icrc3_get_tip_certificate } = this.caller({ certified });
+
+		return fromNullable(await icrc3_get_tip_certificate());
+	};
+
+	supportedBlockTypes = async ({
+		certified
+	}: QueryParams): Promise<Array<{ url: string; block_type: string }>> => {
+		const { icrc3_supported_block_types } = this.caller({ certified });
+
+		return await icrc3_supported_block_types();
+	};
+}

--- a/src/frontend/src/tests/icp/api/icrc3.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc3.api.spec.ts
@@ -1,0 +1,75 @@
+import { getArchives, getBlocks, getTipCertificate, supportedBlockTypes } from '$icp/api/icrc3.api';
+import { Icrc3Canister } from '$icp/canisters/icrc3.canister';
+import { CanisterInternalError } from '$lib/canisters/errors';
+import { ZERO } from '$lib/constants/app.constants';
+import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
+import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+import { mock } from 'vitest-mock-extended';
+
+describe('icrc3.api', () => {
+	const canisterMock = mock<Icrc3Canister>();
+
+	const params = {
+		identity: mockIdentity,
+		canisterId: mockIcrc7CanisterId
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		vi.spyOn(Icrc3Canister, 'create').mockResolvedValue(canisterMock);
+	});
+
+	describe('getArchives', () => {
+		it('should call getArchives successfully', async () => {
+			const archives = [{ canister_id: mockPrincipal, start: ZERO, end: 10n }];
+			canisterMock.getArchives.mockResolvedValue(archives);
+
+			await expect(getArchives({ ...params, from: mockPrincipal })).resolves.toEqual(archives);
+			expect(canisterMock.getArchives).toHaveBeenCalledExactlyOnceWith({
+				from: mockPrincipal
+			});
+		});
+	});
+
+	describe('getBlocks', () => {
+		it('should call getBlocks successfully', async () => {
+			const args = [{ start: ZERO, length: 1n }];
+			const response = { log_length: 1n, blocks: [], archived_blocks: [] };
+			canisterMock.getBlocks.mockResolvedValue(response);
+
+			await expect(getBlocks({ ...params, args })).resolves.toEqual(response);
+			expect(canisterMock.getBlocks).toHaveBeenCalledExactlyOnceWith({ args });
+		});
+	});
+
+	describe('getTipCertificate', () => {
+		it('should call getTipCertificate successfully', async () => {
+			const certificate = {
+				certificate: new Uint8Array([1]),
+				hash_tree: new Uint8Array([2])
+			};
+			canisterMock.getTipCertificate.mockResolvedValue(certificate);
+
+			await expect(getTipCertificate(params)).resolves.toEqual(certificate);
+			expect(canisterMock.getTipCertificate).toHaveBeenCalledExactlyOnceWith({});
+		});
+	});
+
+	describe('supportedBlockTypes', () => {
+		it('should call supportedBlockTypes successfully', async () => {
+			const blockTypes = [{ block_type: '7xfer', url: 'https://github.com/dfinity/ICRC' }];
+			canisterMock.supportedBlockTypes.mockResolvedValue(blockTypes);
+
+			await expect(supportedBlockTypes(params)).resolves.toEqual(blockTypes);
+			expect(canisterMock.supportedBlockTypes).toHaveBeenCalledExactlyOnceWith({});
+		});
+
+		it('should throw when the canister call fails', async () => {
+			const err = new CanisterInternalError('Failed');
+			canisterMock.supportedBlockTypes.mockRejectedValue(err);
+
+			await expect(supportedBlockTypes(params)).rejects.toThrow(err);
+		});
+	});
+});

--- a/src/frontend/src/tests/icp/api/icrc3.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icrc3.api.spec.ts
@@ -2,7 +2,7 @@ import { getArchives, getBlocks, getTipCertificate, supportedBlockTypes } from '
 import { Icrc3Canister } from '$icp/canisters/icrc3.canister';
 import { CanisterInternalError } from '$lib/canisters/errors';
 import { ZERO } from '$lib/constants/app.constants';
-import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
+import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import { mock } from 'vitest-mock-extended';
 
@@ -11,7 +11,7 @@ describe('icrc3.api', () => {
 
 	const params = {
 		identity: mockIdentity,
-		canisterId: mockIcrc7CanisterId
+		canisterId: mockLedgerCanisterId
 	};
 
 	beforeEach(() => {

--- a/src/frontend/src/tests/icp/canisters/icrc3.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/icrc3.canister.spec.ts
@@ -2,7 +2,7 @@ import type { _SERVICE as Icrc3Service } from '$declarations/icrc3/icrc3.did';
 import { Icrc3Canister } from '$icp/canisters/icrc3.canister';
 import { ZERO } from '$lib/constants/app.constants';
 import type { CreateCanisterOptions } from '$lib/types/canister';
-import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
+import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
@@ -15,7 +15,7 @@ describe('icrc3.canister', () => {
 		serviceOverride
 	}: Pick<CreateCanisterOptions<Icrc3Service>, 'serviceOverride'>): Promise<Icrc3Canister> =>
 		Icrc3Canister.create({
-			canisterId: Principal.fromText(mockIcrc7CanisterId),
+			canisterId: Principal.fromText(mockLedgerCanisterId),
 			identity: mockIdentity,
 			certifiedServiceOverride: serviceOverride,
 			serviceOverride

--- a/src/frontend/src/tests/icp/canisters/icrc3.canister.spec.ts
+++ b/src/frontend/src/tests/icp/canisters/icrc3.canister.spec.ts
@@ -1,0 +1,105 @@
+import type { _SERVICE as Icrc3Service } from '$declarations/icrc3/icrc3.did';
+import { Icrc3Canister } from '$icp/canisters/icrc3.canister';
+import { ZERO } from '$lib/constants/app.constants';
+import type { CreateCanisterOptions } from '$lib/types/canister';
+import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
+import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
+import { Principal } from '@icp-sdk/core/principal';
+import { mock } from 'vitest-mock-extended';
+
+describe('icrc3.canister', () => {
+	const certified = false;
+
+	const createIcrc3Canister = ({
+		serviceOverride
+	}: Pick<CreateCanisterOptions<Icrc3Service>, 'serviceOverride'>): Promise<Icrc3Canister> =>
+		Icrc3Canister.create({
+			canisterId: Principal.fromText(mockIcrc7CanisterId),
+			identity: mockIdentity,
+			certifiedServiceOverride: serviceOverride,
+			serviceOverride
+		});
+
+	const service = mock<ActorSubclass<Icrc3Service>>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('getArchives', () => {
+		it('should call icrc3_get_archives without a cursor', async () => {
+			const archives = [{ canister_id: mockPrincipal, start: ZERO, end: 10n }];
+			service.icrc3_get_archives.mockResolvedValue(archives);
+
+			const { getArchives } = await createIcrc3Canister({ serviceOverride: service });
+
+			await expect(getArchives({ certified })).resolves.toEqual(archives);
+			expect(service.icrc3_get_archives).toHaveBeenCalledExactlyOnceWith({ from: [] });
+		});
+
+		it('should pass the archive cursor when provided', async () => {
+			service.icrc3_get_archives.mockResolvedValue([]);
+
+			const { getArchives } = await createIcrc3Canister({ serviceOverride: service });
+
+			await getArchives({ certified, from: mockPrincipal });
+
+			expect(service.icrc3_get_archives).toHaveBeenCalledExactlyOnceWith({
+				from: [mockPrincipal]
+			});
+		});
+	});
+
+	describe('getBlocks', () => {
+		it('should call icrc3_get_blocks with the provided block ranges', async () => {
+			const args = [{ start: ZERO, length: 2n }];
+			const response = {
+				log_length: 2n,
+				blocks: [{ id: ZERO, block: { Map: [] } }],
+				archived_blocks: []
+			};
+			service.icrc3_get_blocks.mockResolvedValue(response);
+
+			const { getBlocks } = await createIcrc3Canister({ serviceOverride: service });
+
+			await expect(getBlocks({ certified, args })).resolves.toEqual(response);
+			expect(service.icrc3_get_blocks).toHaveBeenCalledExactlyOnceWith(args);
+		});
+	});
+
+	describe('getTipCertificate', () => {
+		it('should return the optional tip certificate when present', async () => {
+			const certificate = {
+				certificate: new Uint8Array([1, 2, 3]),
+				hash_tree: new Uint8Array([4, 5, 6])
+			};
+			service.icrc3_get_tip_certificate.mockResolvedValue([certificate]);
+
+			const { getTipCertificate } = await createIcrc3Canister({ serviceOverride: service });
+
+			await expect(getTipCertificate({ certified })).resolves.toEqual(certificate);
+			expect(service.icrc3_get_tip_certificate).toHaveBeenCalledExactlyOnceWith();
+		});
+
+		it('should return undefined when the tip certificate is absent', async () => {
+			service.icrc3_get_tip_certificate.mockResolvedValue([]);
+
+			const { getTipCertificate } = await createIcrc3Canister({ serviceOverride: service });
+
+			await expect(getTipCertificate({ certified })).resolves.toBeUndefined();
+		});
+	});
+
+	describe('supportedBlockTypes', () => {
+		it('should call icrc3_supported_block_types', async () => {
+			const blockTypes = [{ block_type: '7xfer', url: 'https://github.com/dfinity/ICRC' }];
+			service.icrc3_supported_block_types.mockResolvedValue(blockTypes);
+
+			const { supportedBlockTypes } = await createIcrc3Canister({ serviceOverride: service });
+
+			await expect(supportedBlockTypes({ certified })).resolves.toEqual(blockTypes);
+			expect(service.icrc3_supported_block_types).toHaveBeenCalledExactlyOnceWith();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Build on the generated ICRC-3 declarations by exposing a typed canister wrapper and API surface for the four standard block-log endpoints. This is the API foundation for the future ICRC-7 transaction-history work; no activity UI is wired yet.
