### PR TITLE
feat(frontend): track token_manage for enable and disable saves

### DIFF
--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -1,3 +1,10 @@
+import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
+import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import {
+	SOLANA_DEVNET_NETWORK_ID,
+	SOLANA_MAINNET_NETWORK_ID
+} from '$env/networks/networks.sol.env';
 import type { SaveErc1155CustomToken } from '$eth/types/erc1155-custom-token';
 import type { SaveErc20CustomToken } from '$eth/types/erc20-custom-token';
 import type { SaveErc4626CustomToken } from '$eth/types/erc4626-custom-token';
@@ -15,7 +22,10 @@ import {
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import { trackEvent } from '$lib/services/analytics.services';
 import { saveCustomTokens } from '$lib/services/save-custom-tokens.services';
-import { trackTokenManage } from '$lib/services/token-manage-analytics.services';
+import {
+	trackTokenManage,
+	type TokenManageEventToken
+} from '$lib/services/token-manage-analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
@@ -52,6 +62,55 @@ type SaveTokensToken =
 	| SaveErc4626CustomToken
 	| TokenToggleable<Token>;
 
+const mapTokenManageNetwork = <T extends SaveTokensToken>({
+	token,
+	network
+}: {
+	token: T;
+	network?: Token['network'];
+}): string | undefined => {
+	if (nonNullish(network)) {
+		return network.id.description;
+	}
+
+	if (!('networkKey' in token)) {
+		return;
+	}
+
+	if (
+		token.networkKey === 'Icrc' ||
+		token.networkKey === 'ExtV2' ||
+		token.networkKey === 'Dip721' ||
+		token.networkKey === 'IcPunks' ||
+		token.networkKey === 'Icrc7'
+	) {
+		return ICP_NETWORK_ID.description;
+	}
+
+	if (token.networkKey === 'SplMainnet') {
+		return SOLANA_MAINNET_NETWORK_ID.description;
+	}
+
+	if (token.networkKey === 'SplDevnet') {
+		return SOLANA_DEVNET_NETWORK_ID.description;
+	}
+
+	if (
+		token.networkKey !== 'Erc20' &&
+		token.networkKey !== 'Erc721' &&
+		token.networkKey !== 'Erc1155' &&
+		token.networkKey !== 'Erc4626'
+	) {
+		return;
+	}
+
+	const evmNetwork = [...SUPPORTED_ETHEREUM_NETWORKS, ...SUPPORTED_EVM_NETWORKS].find(
+		({ chainId }) => chainId === token.chainId
+	);
+
+	return evmNetwork?.id.description;
+};
+
 const mapTokenManageToken = <T extends SaveTokensToken>({
 	token,
 	tokenId,
@@ -60,14 +119,7 @@ const mapTokenManageToken = <T extends SaveTokensToken>({
 	token: T;
 	tokenId?: Token['id'];
 	network?: Token['network'];
-}):
-	| {
-			network: string;
-			address: string;
-			symbol?: string;
-			name?: string;
-	  }
-	| undefined => {
+}): TokenManageEventToken | undefined => {
 	const address =
 		'address' in token
 			? token.address
@@ -77,11 +129,7 @@ const mapTokenManageToken = <T extends SaveTokensToken>({
 					? token.canisterId
 					: tokenId?.description;
 
-	const tokenNetwork = nonNullish(network)
-		? network.id.description
-		: 'networkKey' in token
-			? token.networkKey
-			: undefined;
+	const tokenNetwork = mapTokenManageNetwork({ token, network });
 
 	if (isNullish(address) || isNullish(tokenNetwork)) {
 		return;

--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -8,9 +8,14 @@ import {
 	TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS,
 	TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR
 } from '$lib/constants/analytics.constants';
+import {
+	PLAUSIBLE_EVENT_RESULT_STATUSES,
+	PLAUSIBLE_EVENT_SOURCE_LOCATIONS
+} from '$lib/enums/plausible';
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import { trackEvent } from '$lib/services/analytics.services';
 import { saveCustomTokens } from '$lib/services/save-custom-tokens.services';
+import { trackTokenManage } from '$lib/services/token-manage-analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
@@ -37,6 +42,58 @@ export interface SaveTokensParams<T> {
 	identity: Identity;
 	tokens: NonEmptyArray<T>;
 }
+
+type SaveTokensToken =
+	| SaveCustomTokenWithKey
+	| SaveErc20CustomToken
+	| SaveSplCustomToken
+	| SaveErc721CustomToken
+	| SaveErc1155CustomToken
+	| SaveErc4626CustomToken
+	| TokenToggleable<Token>;
+
+const mapTokenManageToken = <T extends SaveTokensToken>({
+	token,
+	tokenId,
+	network
+}: {
+	token: T;
+	tokenId?: Token['id'];
+	network?: Token['network'];
+}):
+	| {
+			network: string;
+			address: string;
+			symbol?: string;
+			name?: string;
+	  }
+	| undefined => {
+	const address =
+		'address' in token
+			? token.address
+			: 'ledgerCanisterId' in token
+				? token.ledgerCanisterId
+				: 'canisterId' in token
+					? token.canisterId
+					: tokenId?.description;
+
+	const tokenNetwork = nonNullish(network)
+		? network.id.description
+		: 'networkKey' in token
+			? token.networkKey
+			: undefined;
+
+	if (isNullish(address) || isNullish(tokenNetwork)) {
+		return;
+	}
+
+	return {
+		network: tokenNetwork,
+		address,
+		...('symbol' in token && nonNullish(token.symbol) && { symbol: token.symbol }),
+		...('name' in token && nonNullish(token.name) && { name: token.name })
+	};
+};
 
 export const saveTokens = async <
 	T extends
@@ -110,6 +167,17 @@ export const saveTokens = async <
 					...{ source: MANAGE_TOKENS_MODAL_ROUTE }
 				}
 			});
+
+			const tokenManageToken = mapTokenManageToken({ token, tokenId, network });
+
+			if (nonNullish(tokenManageToken)) {
+				trackTokenManage({
+					modifier: enabled ? 'enable' : 'disable',
+					token: tokenManageToken,
+					sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS,
+					resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+				});
+			}
 		});
 	} catch (err: unknown) {
 		const versionMismatch = isVersionMismatchError(err);

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -1,3 +1,5 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.usdc.env';
 import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
@@ -16,7 +18,10 @@ import { saveTokens } from '$lib/services/manage-tokens.services';
 import { trackTokenManage } from '$lib/services/token-manage-analytics.services';
 import * as toastsStore from '$lib/stores/toasts.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
+import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
 import en from '$tests/mocks/i18n.mock';
+import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 
 vi.mock('$lib/services/analytics.services', () => ({
@@ -130,6 +135,45 @@ describe('manage-tokens.services', () => {
 					sourceLocation: 'manage_tokens',
 					resultStatus: 'success'
 				});
+			});
+		});
+
+		it('should derive token_manage network fields for backend custom-token variants', async () => {
+			const customTokens: SaveCustomTokenWithKey[] = [
+				{
+					enabled: true,
+					networkKey: 'Icrc7',
+					canisterId: mockIcrc7CanisterId
+				},
+				{
+					enabled: false,
+					networkKey: 'Erc20',
+					address: mockEthAddress,
+					chainId: ETHEREUM_NETWORK.chainId
+				}
+			];
+
+			mockSave.mockResolvedValueOnce(undefined);
+
+			await saveTokens({ ...params, tokens: customTokens });
+
+			expect(trackTokenManage).toHaveBeenNthCalledWith(1, {
+				modifier: 'enable',
+				token: {
+					network: ICP_NETWORK_ID.description,
+					address: mockIcrc7CanisterId
+				},
+				sourceLocation: 'manage_tokens',
+				resultStatus: 'success'
+			});
+			expect(trackTokenManage).toHaveBeenNthCalledWith(2, {
+				modifier: 'disable',
+				token: {
+					network: ETHEREUM_NETWORK.id.description,
+					address: mockEthAddress
+				},
+				sourceLocation: 'manage_tokens',
+				resultStatus: 'success'
 			});
 		});
 

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -13,6 +13,7 @@ import {
 import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 import { trackEvent } from '$lib/services/analytics.services';
 import { saveTokens } from '$lib/services/manage-tokens.services';
+import { trackTokenManage } from '$lib/services/token-manage-analytics.services';
 import * as toastsStore from '$lib/stores/toasts.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 import en from '$tests/mocks/i18n.mock';
@@ -20,6 +21,10 @@ import { mockIdentity } from '$tests/mocks/identity.mock';
 
 vi.mock('$lib/services/analytics.services', () => ({
 	trackEvent: vi.fn()
+}));
+
+vi.mock('$lib/services/token-manage-analytics.services', () => ({
+	trackTokenManage: vi.fn()
 }));
 
 describe('manage-tokens.services', () => {
@@ -107,6 +112,23 @@ describe('manage-tokens.services', () => {
 						networkId: token.network?.id.description,
 						source: MANAGE_TOKENS_MODAL_ROUTE
 					}
+				});
+
+				expect(trackTokenManage).toHaveBeenNthCalledWith(index + 1, {
+					modifier: token.enabled ? 'enable' : 'disable',
+					token: {
+						network: token.network.id.description,
+						address:
+							'address' in token
+								? token.address
+								: 'ledgerCanisterId' in token
+									? token.ledgerCanisterId
+									: token.id.description,
+						symbol: token.symbol,
+						name: token.name
+					},
+					sourceLocation: 'manage_tokens',
+					resultStatus: 'success'
 				});
 			});
 		});


### PR DESCRIPTION
# Motivation

Start instrumenting the cross-standard `token_manage` event by emitting it from the existing manage-token save flow whenever a token is successfully enabled or disabled. Legacy manage-token success events are left intact for dashboard continuity; this PR only adds the new typed event in parallel.

# Changes

- `manage-tokens.services.ts`: map each saved token to the token_manage payload (network, address, symbol, name when available) and call `trackTokenManage` with `event_modifier` `enable` / `disable`, `source_location` `manage_tokens`, and `result_status` `success` after successful saves.

# Tests

Adapted tests.
