### PR TITLE
fix(frontend): keep older Solana history pages

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -321,13 +321,14 @@ const loadSolTransactions = async ({
 		const backendTokenId = solBackendTokenId({ network, tokenAddress });
 		const isHeadLoad = isNullish(before);
 
-		const stored = USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED && isHeadLoad
-			? await loadSolUserTransactions({
-					identity,
-					tokenId: backendTokenId,
-					address
-				})
-			: undefined;
+		const stored =
+			USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED && isHeadLoad
+				? await loadSolUserTransactions({
+						identity,
+						tokenId: backendTokenId,
+						address
+					})
+				: undefined;
 
 		const storedTransactions = stored?.transactions ?? [];
 

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -319,8 +319,9 @@ const loadSolTransactions = async ({
 }: LoadSolTransactionsParams): Promise<SolCertifiedTransaction[]> => {
 	try {
 		const backendTokenId = solBackendTokenId({ network, tokenAddress });
+		const isHeadLoad = isNullish(before);
 
-		const stored = USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED
+		const stored = USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED && isHeadLoad
 			? await loadSolUserTransactions({
 					identity,
 					tokenId: backendTokenId,
@@ -348,7 +349,6 @@ const loadSolTransactions = async ({
 			...rest
 		});
 		const newestStoredSlot = stored?.newestBlockIndex;
-		const isHeadLoad = isNullish(before);
 
 		// Filter RPC results to only include transactions from slots newer than the stored data.
 		// This avoids overlap by range-partitioning.

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -350,8 +350,8 @@ const loadSolTransactions = async ({
 		});
 		const newestStoredSlot = stored?.newestBlockIndex;
 
-		// Filter RPC results to only include transactions from slots newer than the stored data.
-		// This avoids overlap by range-partitioning.
+		// On head loads, keep only RPC transactions newer than the backend cache.
+		// Cursor pagination already asks RPC for older transactions, so those pages must not use this filter.
 		const freshTransactions =
 			nonNullish(newestStoredSlot) && isHeadLoad
 				? newTransactions.filter(

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -348,16 +348,20 @@ const loadSolTransactions = async ({
 			...rest
 		});
 		const newestStoredSlot = stored?.newestBlockIndex;
+		const isHeadLoad = isNullish(before);
 
 		// Filter RPC results to only include transactions from slots newer than the stored data.
 		// This avoids overlap by range-partitioning.
-		const freshTransactions = nonNullish(newestStoredSlot)
-			? newTransactions.filter(
-					({ blockNumber }) => isNullish(blockNumber) || blockNumber > Number(newestStoredSlot)
-				)
-			: newTransactions;
+		const freshTransactions =
+			nonNullish(newestStoredSlot) && isHeadLoad
+				? newTransactions.filter(
+						({ blockNumber }) => isNullish(blockNumber) || blockNumber > Number(newestStoredSlot)
+					)
+				: newTransactions;
 
-		const allTransactions = [...freshTransactions, ...storedTransactions];
+		const allTransactions = isHeadLoad
+			? [...freshTransactions, ...storedTransactions]
+			: freshTransactions;
 
 		const certifiedTransactions = allTransactions.map((transaction) => ({
 			data: transaction,

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -631,6 +631,86 @@ describe('sol-transactions.services', () => {
 			);
 		});
 
+		it('should filter non-newer RPC transactions when loading head with backend-stored transactions', async () => {
+			const storedTransactions = createMockSolTransactionsUi(2).map((tx, i) => ({
+				...tx,
+				id: `stored-${i}`
+			}));
+
+			vi.mocked(loadSolUserTransactions).mockResolvedValue({
+				transactions: storedTransactions,
+				newestBlockIndex: 100n,
+				oldestBlockIndex: 50n,
+				nextStart: undefined,
+				totalStored: 2n
+			});
+
+			const olderRpcTransaction = {
+				...createMockSolTransactionsUi(1)[0],
+				id: 'older-rpc',
+				blockNumber: 99
+			};
+			const newerRpcTransaction = {
+				...createMockSolTransactionsUi(1)[0],
+				id: 'newer-rpc',
+				blockNumber: 101
+			};
+
+			spyGetTransactions.mockResolvedValue([olderRpcTransaction, newerRpcTransaction]);
+
+			await loadNextSolTransactions(mockParams);
+
+			expect(get(solTransactionsStore)?.[mockToken.id]).toEqual(
+				[newerRpcTransaction, ...storedTransactions].map((data) => ({
+					data,
+					certified: false
+				}))
+			);
+			expect(saveSolFinalizedTransactions).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				tokenId: { SolNativeMainnet: null },
+				transactions: [newerRpcTransaction]
+			});
+		});
+
+		it('should keep older RPC transactions when paginating with before and backend-stored transactions', async () => {
+			const storedTransactions = createMockSolTransactionsUi(2).map((tx, i) => ({
+				...tx,
+				id: `stored-${i}`
+			}));
+
+			vi.mocked(loadSolUserTransactions).mockResolvedValue({
+				transactions: storedTransactions,
+				newestBlockIndex: 100n,
+				oldestBlockIndex: 50n,
+				nextStart: undefined,
+				totalStored: 2n
+			});
+
+			const olderRpcTransaction = {
+				...createMockSolTransactionsUi(1)[0],
+				id: 'older-rpc',
+				blockNumber: 40
+			};
+			const before = mockSolSignature();
+
+			spyGetTransactions.mockResolvedValue([olderRpcTransaction]);
+
+			await loadNextSolTransactions({ ...mockParams, before });
+
+			expect(get(solTransactionsStore)?.[mockToken.id]).toEqual([
+				{
+					data: olderRpcTransaction,
+					certified: false
+				}
+			]);
+			expect(saveSolFinalizedTransactions).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				tokenId: { SolNativeMainnet: null },
+				transactions: [olderRpcTransaction]
+			});
+		});
+
 		it('should set only new transactions when no stored transactions exist', async () => {
 			vi.mocked(loadSolUserTransactions).mockResolvedValue(undefined);
 

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -695,16 +695,20 @@ describe('sol-transactions.services', () => {
 			};
 			const before = mockSolSignature();
 
-			spyGetTransactions.mockResolvedValue([olderRpcTransaction]);
+			spyGetTransactions.mockResolvedValueOnce([]);
 
+			await loadNextSolTransactions(mockParams);
+
+			spyGetTransactions.mockResolvedValueOnce([olderRpcTransaction]);
 			await loadNextSolTransactions({ ...mockParams, before });
 
-			expect(get(solTransactionsStore)?.[mockToken.id]).toEqual([
-				{
-					data: olderRpcTransaction,
+			expect(loadSolUserTransactions).toHaveBeenCalledOnce();
+			expect(get(solTransactionsStore)?.[mockToken.id]).toEqual(
+				[...storedTransactions, olderRpcTransaction].map((data) => ({
+					data,
 					certified: false
-				}
-			]);
+				}))
+			);
 			expect(saveSolFinalizedTransactions).toHaveBeenCalledExactlyOnceWith({
 				identity: mockIdentity,
 				tokenId: { SolNativeMainnet: null },

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -599,6 +599,7 @@ describe('sol-transactions.services', () => {
 
 			expect(callArg.exitIfFirstSignatureMatches).toBeUndefined();
 			expect(callArg.before).toBe(before);
+			expect(loadSolUserTransactions).not.toHaveBeenCalled();
 		});
 
 		it('should combine stored and new transactions in the store', async () => {


### PR DESCRIPTION
# Motivation

Solana token history can stop too early when older RPC pages are loaded after backend-cached transactions.

# Changes

Only apply the backend newest-slot filter on the initial Solana history load, not on `before` cursor pagination.

# Tests

Added tests.
