### PR TITLE
feat(frontend): use get_my_exchange_rates in exchange worker

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -284,6 +284,14 @@ export const getExchangeRates = async ({
 	return getExchangeRates(params);
 };
 
+export const getMyExchangeRates = async ({
+	identity
+}: CanisterApiFunctionParams): Promise<Array<[TokenId, BackendExchangeRate | undefined]>> => {
+	const { getMyExchangeRates } = await backendCanister({ identity });
+
+	return getMyExchangeRates();
+};
+
 export const getUserTransactions = async ({
 	identity,
 	...params

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -448,6 +448,16 @@ export class BackendCanister extends Canister<BackendService> {
 		}, new Map());
 	};
 
+	getMyExchangeRates = async (): Promise<Array<[TokenId, BackendExchangeRate | undefined]>> => {
+		// `get_my_exchange_rates` is an update on the backend (mutates token_activity, may issue
+		// HTTP outcalls), so it always goes through the certified service.
+		const { get_my_exchange_rates } = this.caller({ certified: true });
+
+		const results = await get_my_exchange_rates();
+
+		return results.map(([id, rate]) => [id, this.mapExchangeRate(fromNullable(rate))]);
+	};
+
 	getUserTransactions = async ({
 		tokenId,
 		start,

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -8,7 +8,7 @@ import { ICPSWAP_PROVIDER_ENABLED } from '$env/rest/icpswap.env';
 import { KONGSWAP_PROVIDER_ENABLED } from '$env/rest/kongswap.env';
 import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
-import { getExchangeRates } from '$lib/api/backend.api';
+import { getExchangeRates, getMyExchangeRates } from '$lib/api/backend.api';
 import { NANO_SECONDS_IN_MILLISECOND } from '$lib/constants/app.constants';
 import { Currency } from '$lib/enums/currency';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/coingecko.rest';
@@ -429,6 +429,79 @@ export const fetchAllExchangeRatesFromBackend = async ({
 			normalizeId: lower
 		}),
 		currentSplPrices: buildPriceMap({ pairs: spl.pairs, rates: coingeckoRates })
+	};
+};
+
+/**
+ * Caller-aware variant of `fetchAllExchangeRatesFromBackend`.
+ *
+ * Calls the per-caller `get_my_exchange_rates` endpoint, which derives the
+ * relevant token list server-side (native + the caller's custom tokens,
+ * filtered to priceable variants) and guarantees the response is at most
+ * ~2 minutes stale. The frontend therefore no longer has to assemble the
+ * token list itself, and no longer has to keep `erc20Addresses /
+ * icrcCanisterIds / splTokenAddresses` in sync with whatever the backend
+ * considers "the user's tokens".
+ *
+ * The shape of the returned object is identical to
+ * `fetchAllExchangeRatesFromBackend` so the worker doesn't care which
+ * source produced it.
+ */
+export const fetchMyExchangeRatesFromBackend = async ({
+	identity
+}: {
+	identity: Identity;
+}): Promise<{
+	currentEthPrice: CoingeckoSimplePriceResponse | undefined;
+	currentBtcPrice: CoingeckoSimplePriceResponse | undefined;
+	currentIcpPrice: CoingeckoSimplePriceResponse | undefined;
+	currentSolPrice: CoingeckoSimplePriceResponse | undefined;
+	currentBnbPrice: CoingeckoSimplePriceResponse | undefined;
+	currentPolPrice: CoingeckoSimplePriceResponse | undefined;
+	currentArbitrumEthPrice: CoingeckoSimplePriceResponse | undefined;
+	currentBaseEthPrice: CoingeckoSimplePriceResponse | undefined;
+	currentErc20Prices: CoingeckoSimpleTokenPriceResponse;
+	currentIcrcPrices: CoingeckoSimpleTokenPriceResponse;
+	currentSplPrices: CoingeckoSimpleTokenPriceResponse;
+}> => {
+	const rates = await getMyExchangeRates({ identity });
+
+	const coingeckoRates = new Map<string, CoingeckoSimpleTokenPrice>();
+	const currentErc20Prices: CoingeckoSimpleTokenPriceResponse = {};
+	const currentIcrcPrices: CoingeckoSimpleTokenPriceResponse = {};
+	const currentSplPrices: CoingeckoSimpleTokenPriceResponse = {};
+
+	for (const [tokenId, rate] of rates) {
+		const mapped = mapExchangeRateToCoingecko(rate);
+		if (nonNullish(mapped)) {
+			const key = tokenIdKey(tokenId);
+			if (nonNullish(key)) {
+				coingeckoRates.set(key, mapped);
+			}
+
+			if ('Erc20' in tokenId) {
+				const [address] = tokenId.Erc20;
+				currentErc20Prices[address.toLowerCase()] = mapped;
+			} else if ('Icrc' in tokenId) {
+				currentIcrcPrices[tokenId.Icrc.toText().toLowerCase()] = mapped;
+			} else if ('SplMainnet' in tokenId) {
+				currentSplPrices[tokenId.SplMainnet] = mapped;
+			}
+		}
+	}
+
+	return {
+		currentEthPrice: nativePrice({ ...ETH_NATIVE_ENTRY, coingeckoRates }),
+		currentBtcPrice: nativePrice({ ...BTC_NATIVE_ENTRY, coingeckoRates }),
+		currentIcpPrice: nativePrice({ ...ICP_NATIVE_ENTRY, coingeckoRates }),
+		currentSolPrice: nativePrice({ ...SOL_NATIVE_ENTRY, coingeckoRates }),
+		currentBnbPrice: nativePrice({ ...BNB_NATIVE_ENTRY, coingeckoRates }),
+		currentPolPrice: nativePrice({ ...POL_NATIVE_ENTRY, coingeckoRates }),
+		currentArbitrumEthPrice: nativePrice({ ...ARBITRUM_ETH_NATIVE_ENTRY, coingeckoRates }),
+		currentBaseEthPrice: nativePrice({ ...BASE_ETH_NATIVE_ENTRY, coingeckoRates }),
+		currentErc20Prices,
+		currentIcrcPrices,
+		currentSplPrices
 	};
 };
 

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -17,7 +17,7 @@ import {
 	exchangeRateSOLToUsd,
 	exchangeRateSPLToUsd,
 	exchangeRateUsdToCurrency,
-	fetchAllExchangeRatesFromBackend
+	fetchMyExchangeRatesFromBackend
 } from '$lib/services/exchange.services';
 import type { CoingeckoPlatformId, CoingeckoSimpleTokenPriceResponse } from '$lib/types/coingecko';
 import type { CoingeckoErc20PriceParams } from '$lib/types/coingecko-erc20';
@@ -130,9 +130,6 @@ const buildErc20PriceParams = (
 
 const syncExchangeFromBackend = async ({
 	currentCurrency,
-	erc20ContractAddresses,
-	icrcLedgerCanisterIds,
-	splTokenAddresses,
 	erc4626TokensExchangeData
 }: SyncExchangeParams): Promise<PostMessageDataResponseExchange> => {
 	const identity = await AuthClientProvider.getInstance().loadIdentity();
@@ -164,12 +161,7 @@ const syncExchangeFromBackend = async ({
 
 	const [currentExchangeRate, backendPrices] = await Promise.all([
 		exchangeRateUsdToCurrency(currentCurrency),
-		fetchAllExchangeRatesFromBackend({
-			identity,
-			erc20Addresses: erc20ContractAddresses,
-			icrcCanisterIds: icrcLedgerCanisterIds,
-			splTokenAddresses
-		})
+		fetchMyExchangeRatesFromBackend({ identity })
 	]);
 
 	const {

--- a/src/frontend/src/tests/lib/api/backend.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/backend.api.spec.ts
@@ -6,6 +6,7 @@ import {
 	createUserProfile,
 	getExchangeRate,
 	getExchangeRates,
+	getMyExchangeRates,
 	getPendingBtcTransactions,
 	getUserProfile,
 	getUserTransactions,
@@ -721,6 +722,42 @@ describe('backend.api', () => {
 			await expect(
 				getExchangeRates({ ...baseParams, token_ids: tokenIds, certified: false })
 			).rejects.toThrow();
+		});
+	});
+
+	describe('getMyExchangeRates', () => {
+		const tokenId: TokenId = { Icrc: Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai') };
+		const mockRate: BackendExchangeRate = {
+			usd: {
+				price: 42000,
+				price24hChangePct: 1.5,
+				marketCap: 800_000_000_000,
+				timestampNs: 1_000_000_000n
+			}
+		};
+		const mockResponse: Array<[TokenId, BackendExchangeRate | undefined]> = [[tokenId, mockRate]];
+
+		beforeEach(() => {
+			backendCanisterMock.getMyExchangeRates.mockResolvedValue(mockResponse);
+		});
+
+		it('should successfully call getMyExchangeRates endpoint', async () => {
+			const result = await getMyExchangeRates({ ...baseParams });
+
+			expect(result).toEqual(mockResponse);
+			expect(backendCanisterMock.getMyExchangeRates).toHaveBeenCalledExactlyOnceWith();
+		});
+
+		it('should throw an error if identity is undefined', async () => {
+			await expect(getMyExchangeRates({ identity: undefined })).rejects.toThrow();
+		});
+
+		it('should throw an error if getMyExchangeRates throws', async () => {
+			backendCanisterMock.getMyExchangeRates.mockImplementation(() => {
+				throw new Error('mock-error');
+			});
+
+			await expect(getMyExchangeRates({ ...baseParams })).rejects.toThrow();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -1745,4 +1745,68 @@ describe('backend.canister', () => {
 			);
 		});
 	});
+
+	describe('getMyExchangeRates', () => {
+		const tokenIds = [{ Icrc: mockPrincipal }, { Erc20: ['0xabc', 1n] as [string, bigint] }];
+		const mockCandidRate = {
+			usd: {
+				price: [42000] as [] | [number],
+				price_24h_change_pct: [1.5] as [] | [number],
+				market_cap: [800_000_000_000] as [] | [number],
+				timestamp_ns: 1_000_000_000n
+			}
+		};
+		const expectedUnwrapped = {
+			usd: {
+				price: 42000,
+				price24hChangePct: 1.5,
+				marketCap: 800_000_000_000,
+				timestampNs: 1_000_000_000n
+			}
+		};
+
+		it('should return the response paired with unwrapped rates', async () => {
+			const rawResponse = tokenIds.map(
+				(id) => [id, [mockCandidRate]] as [typeof id, [typeof mockCandidRate]]
+			);
+			service.get_my_exchange_rates.mockResolvedValue(rawResponse);
+
+			const { getMyExchangeRates } = await createBackendCanister({ serviceOverride: service });
+
+			const result = await getMyExchangeRates();
+
+			expect(result).toEqual([
+				[tokenIds[0], expectedUnwrapped],
+				[tokenIds[1], expectedUnwrapped]
+			]);
+			expect(service.get_my_exchange_rates).toHaveBeenCalledExactlyOnceWith();
+		});
+
+		it('should map empty rates to undefined', async () => {
+			service.get_my_exchange_rates.mockResolvedValue([
+				[tokenIds[0], [mockCandidRate]],
+				[tokenIds[1], []]
+			]);
+
+			const { getMyExchangeRates } = await createBackendCanister({ serviceOverride: service });
+
+			const result = await getMyExchangeRates();
+
+			expect(result).toEqual([
+				[tokenIds[0], expectedUnwrapped],
+				[tokenIds[1], undefined]
+			]);
+		});
+
+		it('should throw an error if the service throws', async () => {
+			service.get_my_exchange_rates.mockImplementation(async () => {
+				await Promise.resolve();
+				throw mockResponseError;
+			});
+
+			const { getMyExchangeRates } = await createBackendCanister({ serviceOverride: service });
+
+			await expect(getMyExchangeRates()).rejects.toThrow(mockResponseError);
+		});
+	});
 });

--- a/src/frontend/src/tests/lib/services/exchange.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/exchange.services.spec.ts
@@ -1,5 +1,5 @@
 import type { TokenId } from '$declarations/backend/backend.did';
-import { getExchangeRates } from '$lib/api/backend.api';
+import { getExchangeRates, getMyExchangeRates } from '$lib/api/backend.api';
 import { Currency } from '$lib/enums/currency';
 import { simplePrice, simpleTokenPrice } from '$lib/rest/coingecko.rest';
 import { fetchBatchIcpSwapPrices } from '$lib/rest/icpswap.rest';
@@ -8,6 +8,7 @@ import {
 	exchangeRateICRCToUsd,
 	exchangeRateUsdToCurrency,
 	fetchAllExchangeRatesFromBackend,
+	fetchMyExchangeRatesFromBackend,
 	syncExchange
 } from '$lib/services/exchange.services';
 import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
@@ -46,7 +47,8 @@ vi.mock('$lib/utils/exchange.utils', () => ({
 	findMissingLedgerCanisterIds: vi.fn()
 }));
 vi.mock('$lib/api/backend.api', () => ({
-	getExchangeRates: vi.fn()
+	getExchangeRates: vi.fn(),
+	getMyExchangeRates: vi.fn()
 }));
 vi.mock('$env/rest/icpswap.env', () => ({
 	ICPSWAP_PROVIDER_ENABLED: true
@@ -508,6 +510,122 @@ describe('exchange.services', () => {
 					last_updated_at: 0
 				}
 			});
+		});
+	});
+
+	describe('fetchMyExchangeRatesFromBackend', () => {
+		const mockExchangeRate: BackendExchangeRate = {
+			usd: {
+				price: 42000,
+				price24hChangePct: 1.5,
+				marketCap: 800_000_000_000,
+				timestampNs: 1_000_000_000n
+			}
+		};
+
+		const expectedPrice = {
+			usd: 42000,
+			usd_24h_change: 1.5,
+			usd_market_cap: 800_000_000_000,
+			last_updated_at: 1000
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should call getMyExchangeRates with no arguments other than identity', async () => {
+			vi.mocked(getMyExchangeRates).mockResolvedValue([]);
+
+			await fetchMyExchangeRatesFromBackend({ identity: mockIdentity });
+
+			expect(getMyExchangeRates).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity
+			});
+		});
+
+		it('should bucket the backend response by token variant', async () => {
+			const erc20TokenId: TokenId = { Erc20: ['0xABC', 1n] };
+			const icrcTokenId: TokenId = {
+				Icrc: Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai')
+			};
+			const splTokenId: TokenId = { SplMainnet: 'SoLaddr1' };
+
+			vi.mocked(getMyExchangeRates).mockResolvedValue([
+				[erc20TokenId, mockExchangeRate],
+				[icrcTokenId, mockExchangeRate],
+				[splTokenId, mockExchangeRate]
+			]);
+
+			const result = await fetchMyExchangeRatesFromBackend({ identity: mockIdentity });
+
+			expect(result.currentErc20Prices).toEqual({ '0xabc': expectedPrice });
+			expect(result.currentIcrcPrices).toEqual({
+				'ryjl3-tyaaa-aaaaa-aaaba-cai': expectedPrice
+			});
+			expect(result.currentSplPrices).toEqual({ SoLaddr1: expectedPrice });
+		});
+
+		it('should return undefined native prices and empty maps when the backend returns nothing', async () => {
+			vi.mocked(getMyExchangeRates).mockResolvedValue([]);
+
+			const result = await fetchMyExchangeRatesFromBackend({ identity: mockIdentity });
+
+			expect(result.currentEthPrice).toBeUndefined();
+			expect(result.currentBtcPrice).toBeUndefined();
+			expect(result.currentIcpPrice).toBeUndefined();
+			expect(result.currentSolPrice).toBeUndefined();
+			expect(result.currentBnbPrice).toBeUndefined();
+			expect(result.currentPolPrice).toBeUndefined();
+			expect(result.currentArbitrumEthPrice).toBeUndefined();
+			expect(result.currentBaseEthPrice).toBeUndefined();
+			expect(result.currentErc20Prices).toEqual({});
+			expect(result.currentIcrcPrices).toEqual({});
+			expect(result.currentSplPrices).toEqual({});
+		});
+
+		it('should expose native token prices when the backend provides them', async () => {
+			vi.mocked(getMyExchangeRates).mockResolvedValue([
+				[{ EvmNative: 1n }, mockExchangeRate],
+				[{ BtcNativeMainnet: null }, mockExchangeRate],
+				[{ IcpNative: null }, mockExchangeRate],
+				[{ SolNativeMainnet: null }, mockExchangeRate],
+				[{ EvmNative: 56n }, mockExchangeRate],
+				[{ EvmNative: 137n }, mockExchangeRate],
+				[{ EvmNative: 42161n }, mockExchangeRate],
+				[{ EvmNative: 8453n }, mockExchangeRate]
+			]);
+
+			const result = await fetchMyExchangeRatesFromBackend({ identity: mockIdentity });
+
+			expect(result.currentEthPrice).toEqual({ ethereum: expectedPrice });
+			expect(result.currentBtcPrice).toEqual({ bitcoin: expectedPrice });
+			expect(result.currentIcpPrice).toEqual({ 'internet-computer': expectedPrice });
+			expect(result.currentSolPrice).toEqual({ solana: expectedPrice });
+			expect(result.currentBnbPrice).toEqual({ binancecoin: expectedPrice });
+			expect(result.currentPolPrice).toEqual({ 'polygon-ecosystem-token': expectedPrice });
+			expect(result.currentArbitrumEthPrice).toEqual({ ethereum: expectedPrice });
+			expect(result.currentBaseEthPrice).toEqual({ ethereum: expectedPrice });
+		});
+
+		it('should skip entries whose price is missing', async () => {
+			const noPriceRate: BackendExchangeRate = {
+				usd: {
+					price: undefined,
+					price24hChangePct: 1.5,
+					marketCap: 100,
+					timestampNs: 1n
+				}
+			};
+
+			vi.mocked(getMyExchangeRates).mockResolvedValue([
+				[{ Erc20: ['0xabc', 1n] }, noPriceRate],
+				[{ Erc20: ['0xdef', 1n] }, undefined]
+			]);
+
+			const result = await fetchMyExchangeRatesFromBackend({ identity: mockIdentity });
+
+			expect(result.currentErc20Prices).toEqual({});
 		});
 	});
 

--- a/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
+++ b/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
@@ -2,7 +2,7 @@ import type { TokenId } from '$declarations/backend/backend.did';
 import { calculateErc4626Prices } from '$eth/services/erc4626-exchange.services';
 import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
-import { getExchangeRates } from '$lib/api/backend.api';
+import { getMyExchangeRates } from '$lib/api/backend.api';
 import { SYNC_EXCHANGE_TIMER_INTERVAL } from '$lib/constants/exchange.constants';
 import { Currency } from '$lib/enums/currency';
 import { AuthClientProvider } from '$lib/providers/auth-client.providers';
@@ -18,13 +18,11 @@ import type {
 } from '$lib/types/coingecko';
 import type { BackendExchangeRate } from '$lib/types/exchange';
 import type { PostMessage, PostMessageDataRequestExchangeTimer } from '$lib/types/post-message';
-import { tokenIdKey } from '$lib/utils/token-id.utils';
 import { onExchangeMessage } from '$lib/workers/exchange.worker';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { createMockEvent, excludeValidMessageEvents } from '$tests/mocks/workers.mock';
 import { Principal } from '@dfinity/principal';
-import { nonNullish } from '@dfinity/utils';
 
 const { backendExchangeEnabled } = vi.hoisted(() => ({
 	backendExchangeEnabled: { current: false }
@@ -63,7 +61,7 @@ vi.mock('$eth/services/erc4626-exchange.services', () => ({
 }));
 
 vi.mock('$lib/api/backend.api', () => ({
-	getExchangeRates: vi.fn()
+	getMyExchangeRates: vi.fn()
 }));
 
 vi.mock('$lib/providers/auth-client.providers', async (importActual) => {
@@ -1093,15 +1091,9 @@ describe('exchange.worker', () => {
 				}
 			};
 
-			const mockRatesMap = (
+			const mockMyRates = (
 				...entries: [TokenId, BackendExchangeRate][]
-			): Map<string, BackendExchangeRate> =>
-				new Map(
-					entries.reduce<[string, BackendExchangeRate][]>((acc, [id, rate]) => {
-						const key = tokenIdKey(id);
-						return nonNullish(key) ? [...acc, [key, rate]] : acc;
-					}, [])
-				);
+			): Array<[TokenId, BackendExchangeRate | undefined]> => entries;
 
 			beforeEach(() => {
 				backendExchangeEnabled.current = true;
@@ -1112,7 +1104,7 @@ describe('exchange.worker', () => {
 			});
 
 			it('should fetch prices from backend instead of CoinGecko', async () => {
-				vi.mocked(getExchangeRates).mockResolvedValue(new Map());
+				vi.mocked(getMyExchangeRates).mockResolvedValue([]);
 
 				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
 					...createEvent(msg),
@@ -1130,7 +1122,7 @@ describe('exchange.worker', () => {
 
 				await onExchangeMessage(mockEvent);
 
-				expect(getExchangeRates).toHaveBeenCalledOnce();
+				expect(getMyExchangeRates).toHaveBeenCalledOnce();
 				expect(simpleTokenPrice).not.toHaveBeenCalled();
 			});
 
@@ -1140,8 +1132,8 @@ describe('exchange.worker', () => {
 					Icrc: Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai')
 				};
 
-				vi.mocked(getExchangeRates).mockResolvedValue(
-					mockRatesMap([erc20TokenId, mockExchangeRate], [icrcTokenId, mockExchangeRate])
+				vi.mocked(getMyExchangeRates).mockResolvedValue(
+					mockMyRates([erc20TokenId, mockExchangeRate], [icrcTokenId, mockExchangeRate])
 				);
 
 				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
@@ -1181,7 +1173,7 @@ describe('exchange.worker', () => {
 			});
 
 			it('should return native prices as undefined when backend has no data for them', async () => {
-				vi.mocked(getExchangeRates).mockResolvedValue(new Map());
+				vi.mocked(getMyExchangeRates).mockResolvedValue([]);
 
 				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
 					...createEvent(msg),
@@ -1210,8 +1202,8 @@ describe('exchange.worker', () => {
 			});
 
 			it('should include native token prices when backend provides them', async () => {
-				vi.mocked(getExchangeRates).mockResolvedValue(
-					mockRatesMap(
+				vi.mocked(getMyExchangeRates).mockResolvedValue(
+					mockMyRates(
 						[{ EvmNative: 1n }, mockExchangeRate],
 						[{ BtcNativeMainnet: null }, mockExchangeRate],
 						[{ IcpNative: null }, mockExchangeRate],
@@ -1256,7 +1248,7 @@ describe('exchange.worker', () => {
 			});
 
 			it('should still fetch currency exchange rate from CoinGecko for non-USD currencies', async () => {
-				vi.mocked(getExchangeRates).mockResolvedValue(new Map());
+				vi.mocked(getMyExchangeRates).mockResolvedValue([]);
 				vi.mocked(simplePrice).mockResolvedValue({
 					bitcoin: { usd: 60000, eur: 55000, usd_24h_change: 2, eur_24h_change: 1.5 }
 				});
@@ -1295,7 +1287,7 @@ describe('exchange.worker', () => {
 			});
 
 			it('should post syncExchangeError when backend call fails', async () => {
-				vi.mocked(getExchangeRates).mockRejectedValue(new Error('Backend unavailable'));
+				vi.mocked(getMyExchangeRates).mockRejectedValue(new Error('Backend unavailable'));
 				vi.mocked(calculateErc4626Prices).mockResolvedValue({});
 
 				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
@@ -1367,7 +1359,7 @@ describe('exchange.worker', () => {
 					'Cannot fetch backend exchange rates without an authenticated identity.'
 				);
 
-				expect(getExchangeRates).not.toHaveBeenCalled();
+				expect(getMyExchangeRates).not.toHaveBeenCalled();
 			});
 		});
 	});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

Step 2 of the per-caller backend exchange flow (depends on the BE PR that adds `get_my_exchange_rates`). Switches the `BACKEND_EXCHANGE_ENABLED` branch of the exchange worker to the new endpoint so the FE no longer has to assemble the user's token list itself, and so the response carries the backend's 2-minute freshness guarantee.

# Changes

- `BackendCanister.getMyExchangeRates` (canister wrapper): thin wrapper over the new update method; returns `Array<[TokenId, BackendExchangeRate | undefined]>` with rates already unwrapped via `mapExchangeRate`.
- `backend.api.getMyExchangeRates({ identity })`: matching API export.
- `fetchMyExchangeRatesFromBackend` in `exchange.services.ts`: new service that iterates over the response, buckets entries by token variant (`Erc20`, `Icrc`, `SplMainnet`, native), and produces the same `PostMessageDataResponseExchange`-shaped object the worker already consumes, so `syncExchange` and the rest of the pipeline are unchanged.
- `exchange.worker.ts`: `syncExchangeFromBackend` calls `fetchMyExchangeRatesFromBackend` instead of `fetchAllExchangeRatesFromBackend`. The post-message payload still carries `erc20Addresses` / `icrcCanisterIds` / `splAddresses` because the providers branch (used outside production) still needs them.
- The legacy `fetchAllExchangeRatesFromBackend` and the underlying `getExchangeRates` API are intentionally kept for now so their existing test coverage stays in place; they will be cleaned up in a follow-up once the providers branch is fully retired.

# Tests

- `BackendCanister.getMyExchangeRates`: new tests for success (full unwrap), missing-rate → `undefined`, and throw-propagation.
- `backend.api.getMyExchangeRates`: new tests for success, missing identity, and throw-propagation.
- `fetchMyExchangeRatesFromBackend`: new tests for the no-args call shape, variant bucketing (Erc20 / Icrc / Spl), native token mapping, empty / missing-price handling.
- Existing `exchange.worker` `BACKEND_EXCHANGE_ENABLED` tests rewired to mock `getMyExchangeRates` and assert against the new `Array<[TokenId, BackendExchangeRate | undefined]>` shape.
- Locally: `prettier --check`, `eslint --max-warnings 0`, `svelte-check` (app + spec configs) all clean. The 4 affected specs run 242 / 242 passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f6a7779-2c46-4ba7-9b31-0aa6cc3f2bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f6a7779-2c46-4ba7-9b31-0aa6cc3f2bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

