### PR TITLE
perf(backend): tighten exchange refresh + activity to 1m / 10m

### DIFF
--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -23,12 +23,12 @@ use crate::{
     types::storable::{Candid, StoredTokenId},
 };
 
-/// How often exchange rates are refreshed (5 minutes).
-const PRICE_REFRESH_INTERVAL_SEC: u64 = 5 * 60;
+/// How often exchange rates are refreshed (1 minute).
+const PRICE_REFRESH_INTERVAL_SEC: u64 = 60;
 
 /// Tokens that haven't been queried within this window are considered inactive
-/// and skipped during price refreshes (1 hour).
-pub const PRICE_ACTIVITY_THRESHOLD_SEC: u64 = 60 * 60;
+/// and skipped during price refreshes (10 minutes).
+pub const PRICE_ACTIVITY_THRESHOLD_SEC: u64 = 10 * 60;
 
 /// A token's cached price is considered "fresh enough" if its
 /// [`ExchangeData::timestamp_ns`] (the provider-reported `last_updated_at`,

--- a/src/backend/src/token/activity.rs
+++ b/src/backend/src/token/activity.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 
 /// How long an inactive token's activity record is kept before housekeeping
-/// evicts it (24 hours).
+/// evicts it (30 minutes).
 ///
-/// Generously larger than `PRICE_ACTIVITY_THRESHOLD_SEC` so any token that is
-/// still being refreshed is never accidentally removed; the goal here is just
-/// to bound the on-disk size of `token_activity` over time, not to gate
-/// refreshes.
-pub(crate) const TOKEN_ACTIVITY_RETENTION_SEC: u64 = 24 * 60 * 60;
+/// Comfortably larger than `PRICE_ACTIVITY_THRESHOLD_SEC` (10 minutes) so any
+/// token that is still being refreshed is never accidentally removed; the
+/// goal here is just to bound the on-disk size of `token_activity` over
+/// time, not to gate refreshes.
+pub(crate) const TOKEN_ACTIVITY_RETENTION_SEC: u64 = 30 * 60;
 
 fn add_to_token_activity(
     token_id: StoredTokenId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

Step 3 of the per-caller backend exchange flow. Tightens the timer cadence and activity window so the timer keeps the cache hot for whatever the worker is polling. Independent from the new endpoint PR — can land before, after, or alongside it.

# Changes

- `PRICE_REFRESH_INTERVAL_SEC`: 5 min → 1 min.
- `PRICE_ACTIVITY_THRESHOLD_SEC`: 60 min → 10 min.
- `TOKEN_ACTIVITY_RETENTION_SEC`: 24 h → 30 min (still well above the 10-minute activity threshold so tokens still being refreshed are never accidentally pruned; the goal is just to bound the on-disk size of `token_activity`).
- `PRICE_FRESHNESS_GRACE_NS` is derived from `PRICE_REFRESH_INTERVAL_SEC`, so it correspondingly drops to 30 s — still useful as a duplicate-call guard inside `refresh_exchange_rates`, well under the 2-minute freshness contract that `stale_or_missing_tokens` enforces.

# Tests

- `cargo clippy` (wasm32 + native + tests): clean.
- `cargo test --lib exchange::`: 19 / 19 pass.
- `./scripts/lint.did.sh`: clean.

These are pure constant changes — no behaviour change beyond the cadence itself, no candid surface delta. The recurring timer just runs five times more often, against an order-of-magnitude smaller active set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f6a7779-2c46-4ba7-9b31-0aa6cc3f2bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f6a7779-2c46-4ba7-9b31-0aa6cc3f2bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

