### PR TITLE
fix(frontend): page Solana history from backend first

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -62,9 +62,7 @@ const setSolBackendPaginationCursor = ({
 	solBackendPaginationCursors.delete(tokenId);
 };
 
-const mapSolCertifiedTransactions = (
-	transactions: SolTransactionUi[]
-): SolCertifiedTransaction[] =>
+const mapSolCertifiedTransactions = (transactions: SolTransactionUi[]): SolCertifiedTransaction[] =>
 	transactions.map((transaction) => ({
 		data: transaction,
 		certified: false

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -4,7 +4,7 @@ import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import { solAddressDevnet, solAddressLocal, solAddressMainnet } from '$lib/derived/address.derived';
 import type { NullishIdentity } from '$lib/types/identity';
-import type { Token } from '$lib/types/token';
+import type { Token, TokenId } from '$lib/types/token';
 import type { ResultSuccess } from '$lib/types/utils';
 import { consoleError } from '$lib/utils/console.utils';
 import { isNetworkIdSOLDevnet, isNetworkIdSOLLocal } from '$lib/utils/network.utils';
@@ -44,6 +44,31 @@ import { get } from 'svelte/store';
 // https://solana.com/docs/core/fees#base-transaction-fee
 export const extractFeePayer = (accountKeys: ParsedAccount[]): ParsedAccount | undefined =>
 	accountKeys.length > 0 ? accountKeys.filter(({ signer }) => signer)[0] : undefined;
+
+const solBackendPaginationCursors = new Map<TokenId, bigint>();
+
+const setSolBackendPaginationCursor = ({
+	tokenId,
+	nextStart
+}: {
+	tokenId: TokenId;
+	nextStart: bigint | undefined;
+}) => {
+	if (nonNullish(nextStart)) {
+		solBackendPaginationCursors.set(tokenId, nextStart);
+		return;
+	}
+
+	solBackendPaginationCursors.delete(tokenId);
+};
+
+const mapSolCertifiedTransactions = (
+	transactions: SolTransactionUi[]
+): SolCertifiedTransaction[] =>
+	transactions.map((transaction) => ({
+		data: transaction,
+		certified: false
+	}));
 
 const extractBalances = ({
 	address,
@@ -320,6 +345,29 @@ const loadSolTransactions = async ({
 	try {
 		const backendTokenId = solBackendTokenId({ network, tokenAddress });
 		const isHeadLoad = isNullish(before);
+		const backendCursor = solBackendPaginationCursors.get(tokenId);
+
+		if (USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED && !isHeadLoad && nonNullish(backendCursor)) {
+			const storedPage = await loadSolUserTransactions({
+				identity,
+				tokenId: backendTokenId,
+				address,
+				start: backendCursor
+			});
+
+			setSolBackendPaginationCursor({ tokenId, nextStart: storedPage?.nextStart });
+
+			if (nonNullish(storedPage) && storedPage.transactions.length > 0) {
+				const certifiedTransactions = mapSolCertifiedTransactions(storedPage.transactions);
+
+				solTransactionsStore.append({
+					tokenId,
+					transactions: certifiedTransactions
+				});
+
+				return certifiedTransactions;
+			}
+		}
 
 		const stored =
 			USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED && isHeadLoad
@@ -329,6 +377,10 @@ const loadSolTransactions = async ({
 						address
 					})
 				: undefined;
+
+		if (isHeadLoad) {
+			setSolBackendPaginationCursor({ tokenId, nextStart: stored?.nextStart });
+		}
 
 		const storedTransactions = stored?.transactions ?? [];
 
@@ -364,10 +416,7 @@ const loadSolTransactions = async ({
 			? [...freshTransactions, ...storedTransactions]
 			: freshTransactions;
 
-		const certifiedTransactions = allTransactions.map((transaction) => ({
-			data: transaction,
-			certified: false
-		}));
+		const certifiedTransactions = mapSolCertifiedTransactions(allTransactions);
 
 		solTransactionsStore.append({
 			tokenId,
@@ -382,10 +431,7 @@ const loadSolTransactions = async ({
 			}).catch((err) => consoleError('Background save of finalized SOL transactions failed:', err));
 		}
 
-		return freshTransactions.map((transaction) => ({
-			data: transaction,
-			certified: false
-		}));
+		return mapSolCertifiedTransactions(freshTransactions);
 	} catch (error: unknown) {
 		solTransactionsStore.reset(tokenId);
 

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -716,6 +716,54 @@ describe('sol-transactions.services', () => {
 			});
 		});
 
+		it('should load backend pages before RPC when paginating with before', async () => {
+			const storedTransactions = createMockSolTransactionsUi(2).map((tx, i) => ({
+				...tx,
+				id: `stored-${i}`
+			}));
+			const nextStoredTransactions = createMockSolTransactionsUi(2).map((tx, i) => ({
+				...tx,
+				id: `next-stored-${i}`
+			}));
+			const before = mockSolSignature();
+
+			vi.mocked(loadSolUserTransactions)
+				.mockResolvedValueOnce({
+					transactions: storedTransactions,
+					newestBlockIndex: 100n,
+					oldestBlockIndex: 50n,
+					nextStart: 2n,
+					totalStored: 4n
+				})
+				.mockResolvedValueOnce({
+					transactions: nextStoredTransactions,
+					newestBlockIndex: 100n,
+					oldestBlockIndex: 10n,
+					nextStart: undefined,
+					totalStored: 4n
+				});
+
+			spyGetTransactions.mockResolvedValueOnce([]);
+
+			await loadNextSolTransactions(mockParams);
+			await loadNextSolTransactions({ ...mockParams, before });
+
+			expect(loadSolUserTransactions).toHaveBeenNthCalledWith(2, {
+				identity: mockIdentity,
+				tokenId: { SolNativeMainnet: null },
+				address: mockSolAddress,
+				start: 2n
+			});
+			expect(spyGetTransactions).toHaveBeenCalledOnce();
+			expect(get(solTransactionsStore)?.[mockToken.id]).toEqual(
+				[...storedTransactions, ...nextStoredTransactions].map((data) => ({
+					data,
+					certified: false
+				}))
+			);
+			expect(saveSolFinalizedTransactions).not.toHaveBeenCalled();
+		});
+
 		it('should set only new transactions when no stored transactions exist', async () => {
 			vi.mocked(loadSolUserTransactions).mockResolvedValue(undefined);
 


### PR DESCRIPTION
# Motivation

Solana older-history pagination should use cached finalized backend pages before asking RPC providers again.

# Changes

Track Solana backend pagination cursors and append backend pages before falling back to RPC pagination.

# Tests

Adapted tests.
