### PR TITLE
feat(frontend): add mapIcrc7Nft utility

### DIFF
--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -12,6 +12,7 @@ import type { Nft, NftCollection } from '$lib/types/nft';
 import { mapNftAttributes } from '$lib/utils/nft.utils';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
+import { UrlSchema } from '$lib/validation/url.validation';
 import { nonNullish, notEmptyString, type QueryParams } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
@@ -143,6 +144,16 @@ const mapIcrc7Collection = ({ canisterId, ...rest }: Icrc7Token): NftCollection 
 	address: canisterId
 });
 
+const mapIcrc7MetadataUrl = (url: string | undefined): string | undefined => {
+	if (!notEmptyString(url)) {
+		return;
+	}
+
+	const parsedUrl = UrlSchema.safeParse(url);
+
+	return parsedUrl.success ? parsedUrl.data : undefined;
+};
+
 export const mapIcrc7Nft = async ({
 	index: tokenId,
 	token,
@@ -163,17 +174,23 @@ export const mapIcrc7Nft = async ({
 			certified
 		})) ?? {};
 
+	const { imageUrl: rawImageUrl, thumbnailUrl: rawThumbnailUrl, ...metadataRest } = metadata;
+	const imageUrl = mapIcrc7MetadataUrl(rawImageUrl);
+	const thumbnailUrl = mapIcrc7MetadataUrl(rawThumbnailUrl);
+
 	const mediaStatus = {
-		image: nonNullish(metadata.imageUrl)
-			? await getMediaStatusOrCache(metadata.imageUrl)
+		image: nonNullish(imageUrl)
+			? await getMediaStatusOrCache(imageUrl)
 			: MediaStatusEnum.INVALID_DATA,
-		thumbnail: nonNullish(metadata.thumbnailUrl)
-			? await getMediaStatusOrCache(metadata.thumbnailUrl)
+		thumbnail: nonNullish(thumbnailUrl)
+			? await getMediaStatusOrCache(thumbnailUrl)
 			: MediaStatusEnum.INVALID_DATA
 	};
 
 	return {
-		...metadata,
+		...metadataRest,
+		...(nonNullish(imageUrl) && { imageUrl }),
+		...(nonNullish(thumbnailUrl) && { thumbnailUrl }),
 		id: parseNftId(tokenId.toString()),
 		mediaStatus,
 		collection: mapIcrc7Collection(token)

--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -1,16 +1,18 @@
 import type { TokenIndex } from '$declarations/ext_v2_token/ext_v2_token.did';
 import { metadata as getIcPunksMetadata } from '$icp/api/icpunks.api';
+import { metadata as getIcrc7Metadata } from '$icp/api/icrc7.api';
 import { getExtMetadata } from '$icp/services/ext-metadata.services';
 import type { Dip721Token } from '$icp/types/dip721-token';
 import type { ExtToken } from '$icp/types/ext-token';
 import type { IcPunksToken } from '$icp/types/icpunks-token';
+import type { Icrc7Token } from '$icp/types/icrc7-token';
 import { extIndexToIdentifier, parseExtTokenIndex } from '$icp/utils/ext.utils';
 import { MediaStatusEnum } from '$lib/enums/media-status';
 import type { Nft, NftCollection } from '$lib/types/nft';
 import { mapNftAttributes } from '$lib/utils/nft.utils';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
-import { notEmptyString, type QueryParams } from '@dfinity/utils';
+import { nonNullish, notEmptyString, type QueryParams } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 
@@ -133,5 +135,47 @@ export const mapIcPunksNft = async ({
 			attributes.map(({ name: trait_type, value }) => ({ trait_type, value }))
 		),
 		collection: mapIcPunksCollection(token)
+	};
+};
+
+const mapIcrc7Collection = ({ canisterId, ...rest }: Icrc7Token): NftCollection => ({
+	...rest,
+	address: canisterId
+});
+
+export const mapIcrc7Nft = async ({
+	index: tokenId,
+	token,
+	identity,
+	certified
+}: {
+	index: bigint;
+	token: Icrc7Token;
+	identity: Identity;
+} & QueryParams): Promise<Nft> => {
+	const { canisterId } = token;
+
+	const metadata =
+		(await getIcrc7Metadata({
+			canisterId,
+			tokenId,
+			identity,
+			certified
+		})) ?? {};
+
+	const mediaStatus = {
+		image: nonNullish(metadata.imageUrl)
+			? await getMediaStatusOrCache(metadata.imageUrl)
+			: MediaStatusEnum.INVALID_DATA,
+		thumbnail: nonNullish(metadata.thumbnailUrl)
+			? await getMediaStatusOrCache(metadata.thumbnailUrl)
+			: MediaStatusEnum.INVALID_DATA
+	};
+
+	return {
+		...metadata,
+		id: parseNftId(tokenId.toString()),
+		mediaStatus,
+		collection: mapIcrc7Collection(token)
 	};
 };

--- a/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
@@ -1,7 +1,8 @@
 import { metadata as getIcPunksMetadata } from '$icp/api/icpunks.api';
+import { metadata as getIcrc7Metadata } from '$icp/api/icrc7.api';
 import { getExtMetadata } from '$icp/services/ext-metadata.services';
 import { extIndexToIdentifier } from '$icp/utils/ext.utils';
-import { mapDip721Nft, mapExtNft, mapIcPunksNft } from '$icp/utils/nft.utils';
+import { mapDip721Nft, mapExtNft, mapIcPunksNft, mapIcrc7Nft } from '$icp/utils/nft.utils';
 import { MediaStatusEnum } from '$lib/enums/media-status';
 import type { NftMetadataWithoutId } from '$lib/types/nft';
 import { mapNftAttributes } from '$lib/utils/nft.utils';
@@ -9,6 +10,7 @@ import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
 import { mockIcPunksMetadata } from '$tests/mocks/icpunks-token.mock';
 import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
+import { mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { Principal } from '@icp-sdk/core/principal';
 import { SvelteMap } from 'svelte/reactivity';
@@ -22,6 +24,14 @@ vi.mock(import('$icp/services/ext-metadata.services'), async (importOriginal) =>
 });
 
 vi.mock(import('$icp/api/icpunks.api'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		metadata: vi.fn()
+	};
+});
+
+vi.mock(import('$icp/api/icrc7.api'), async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
 		...actual,
@@ -217,6 +227,102 @@ describe('nft.utils', () => {
 				collection: {
 					...rest,
 					address: mockValidIcPunksToken.canisterId
+				}
+			});
+		});
+	});
+
+	describe('mapIcrc7Nft', () => {
+		const mockIndex = 50n;
+		const mockMetadata: NftMetadataWithoutId = {
+			name: 'ICRC-7 NFT #50',
+			description: 'A byte-stream-backed NFT',
+			imageUrl:
+				'https://blob.caffeine.ai/v1/blob/?blob_hash=sha256%3A3dafe45&owner_id=sey3i-jyaaa-aaaap-quo3q-cai',
+			attributes: [{ traitType: 'Level', value: '50' }]
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(SvelteMap.prototype, 'get').mockReturnValue(undefined); // invalidate cache
+
+			global.fetch = vi.fn().mockResolvedValue({
+				headers: {
+					get: () => null
+				}
+			});
+
+			vi.mocked(getIcrc7Metadata).mockResolvedValue(mockMetadata);
+		});
+
+		it('should map correctly an ICRC-7 NFT', async () => {
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			const { canisterId: _, ...rest } = mockValidIcrc7Token;
+
+			expect(result).toStrictEqual({
+				id: result.id,
+				...mockMetadata,
+				mediaStatus: {
+					image: MediaStatusEnum.OK,
+					thumbnail: MediaStatusEnum.INVALID_DATA
+				},
+				collection: {
+					...rest,
+					address: mockValidIcrc7Token.canisterId
+				}
+			});
+
+			expect(getIcrc7Metadata).toHaveBeenCalledExactlyOnceWith({
+				canisterId: mockValidIcrc7Token.canisterId,
+				tokenId: mockIndex,
+				identity: mockIdentity,
+				certified: undefined
+			});
+		});
+
+		it('should use invalid media statuses when metadata has no image URLs', async () => {
+			vi.mocked(getIcrc7Metadata).mockResolvedValue({
+				name: 'ICRC-7 NFT #50'
+			});
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			expect(result.mediaStatus).toStrictEqual({
+				image: MediaStatusEnum.INVALID_DATA,
+				thumbnail: MediaStatusEnum.INVALID_DATA
+			});
+		});
+
+		it('should handle missing metadata from the service', async () => {
+			vi.mocked(getIcrc7Metadata).mockResolvedValue(undefined);
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			const { canisterId: _, ...rest } = mockValidIcrc7Token;
+
+			expect(result).toStrictEqual({
+				id: result.id,
+				mediaStatus: {
+					image: MediaStatusEnum.INVALID_DATA,
+					thumbnail: MediaStatusEnum.INVALID_DATA
+				},
+				collection: {
+					...rest,
+					address: mockValidIcrc7Token.canisterId
 				}
 			});
 		});

--- a/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
@@ -303,6 +303,37 @@ describe('nft.utils', () => {
 			});
 		});
 
+		it('should omit invalid metadata URLs and avoid fetching them', async () => {
+			vi.mocked(getIcrc7Metadata).mockResolvedValue({
+				name: 'ICRC-7 NFT #50',
+				imageUrl: '',
+				thumbnailUrl: 'http://localhost/token-50.png'
+			});
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			const { canisterId: _, ...rest } = mockValidIcrc7Token;
+
+			expect(result).toStrictEqual({
+				id: result.id,
+				name: 'ICRC-7 NFT #50',
+				mediaStatus: {
+					image: MediaStatusEnum.INVALID_DATA,
+					thumbnail: MediaStatusEnum.INVALID_DATA
+				},
+				collection: {
+					...rest,
+					address: mockValidIcrc7Token.canisterId
+				}
+			});
+
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
 		it('should handle missing metadata from the service', async () => {
 			vi.mocked(getIcrc7Metadata).mockResolvedValue(undefined);
 


### PR DESCRIPTION
# Motivation

Add the pure mapper needed before ICRC-7 collections can render owned NFTs in the NFT grid. This consumes the parsed `metadata({ tokenId })` API from #12859 and follows the existing EXT / ICPunks mapper shape without wiring the load dispatch yet.
