### PR TITLE
feat(backend): add ActiveUserTransaction types

### DIFF
--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -5,6 +5,7 @@ use candid::{CandidType, Deserialize};
 pub type Timestamp = u64;
 
 pub mod account;
+pub mod active_user_transaction;
 pub mod agreement;
 pub mod api_keys;
 pub mod backend_config;

--- a/src/shared/src/types/active_user_transaction.rs
+++ b/src/shared/src/types/active_user_transaction.rs
@@ -1,6 +1,7 @@
 use candid::{CandidType, Deserialize, Nat, Principal};
 
 use super::token_id::TokenId;
+use crate::types::Timestamp;
 
 /// Maximum number of active user transactions kept per user. Counts every
 /// stored row regardless of status; the FE must delete acknowledged rows to
@@ -76,7 +77,7 @@ pub struct OneSecIcpToEvmData {
     pub source_token: TokenId,
     pub dest_token: TokenId,
     pub amount: Nat,
-    pub recipient_eth_address: String,
+    pub recipient_evm_address: String,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -97,10 +98,12 @@ pub struct ActiveUserTransaction {
     pub data: ActiveUserTransactionData,
     /// Opaque to the backend; the FE writes a flow-specific step name here.
     pub progress_step: Option<String>,
-    /// Learned-mid-flow `(key, value)` references, e.g. `("tx_hash", "0x…")`.
+    /// Learned-mid-flow named references, e.g.
+    /// `{ key: "tx_hash", value: "0x…" }`. See [`ActiveUserTransactionRef`]
+    /// for the field layout exposed on the wire and in TS bindings.
     pub external_refs: Vec<ActiveUserTransactionRef>,
-    pub created_at_ns: u64,
-    pub updated_at_ns: u64,
+    pub created_at_ns: Timestamp,
+    pub updated_at_ns: Timestamp,
     /// Populated when `status = Failed`.
     pub error: Option<String>,
 }
@@ -113,9 +116,12 @@ pub struct CreateActiveUserTransactionRequest {
     pub external_refs: Vec<ActiveUserTransactionRef>,
 }
 
-/// Partial update. Only fields that are `Some` are applied; everything else is
-/// left untouched. `external_refs`, when provided, **replaces** the stored list
-/// in full — the FE always knows the complete set after each poll.
+/// Partial update. `None` means "leave untouched"; `Some(value)` overwrites
+/// the stored value. There is no encoding for "clear back to `None`" — this
+/// is intentional: `error` is only ever set on the `Failed` terminal state
+/// (immutable by lifecycle), and `progress_step` is forward-only.
+/// `external_refs`, when provided, **replaces** the stored list in full —
+/// the FE always knows the complete set after each poll.
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UpdateActiveUserTransactionRequest {
     pub id: String,
@@ -161,7 +167,7 @@ mod tests {
                 source_token: TokenId::IcpNative,
                 dest_token: TokenId::EvmNative(1),
                 amount: Nat::from(1_000_000u64),
-                recipient_eth_address: "0x0000000000000000000000000000000000000001".to_string(),
+                recipient_evm_address: "0x0000000000000000000000000000000000000001".to_string(),
             }),
             progress_step: Some("submitting".to_string()),
             external_refs: vec![ActiveUserTransactionRef {

--- a/src/shared/src/types/active_user_transaction.rs
+++ b/src/shared/src/types/active_user_transaction.rs
@@ -147,9 +147,9 @@ mod tests {
 
     use super::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
-        ActiveUserTransactionRef, ActiveUserTransactionStatus,
-        CreateActiveUserTransactionRequest, GetActiveUserTransactionsResponse,
-        OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
+        ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
+        GetActiveUserTransactionsResponse, OneSecEvmToIcpData, OneSecIcpToEvmData,
+        UpdateActiveUserTransactionRequest,
     };
     use crate::types::token_id::TokenId;
 

--- a/src/shared/src/types/active_user_transaction.rs
+++ b/src/shared/src/types/active_user_transaction.rs
@@ -1,0 +1,251 @@
+use candid::{CandidType, Deserialize, Nat, Principal};
+
+use super::token_id::TokenId;
+
+/// Maximum number of active user transactions kept per user. Counts every
+/// stored row regardless of status; the FE must delete acknowledged rows to
+/// free room for new ones.
+pub const MAX_ACTIVE_USER_TRANSACTIONS_PER_USER: usize = 100;
+
+/// Maximum length of the `id` field (`UUIDv4` is 36 ASCII characters).
+pub const MAX_ACTIVE_USER_TRANSACTION_ID_LEN: usize = 64;
+
+/// Maximum length of the opaque `progress_step` field.
+pub const MAX_ACTIVE_USER_TRANSACTION_PROGRESS_STEP_LEN: usize = 64;
+
+/// Maximum length of the optional `error` field.
+pub const MAX_ACTIVE_USER_TRANSACTION_ERROR_LEN: usize = 512;
+
+/// Maximum number of `(key, value)` external references per active transaction.
+pub const MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REFS: usize = 16;
+
+/// Maximum length of an `external_refs` key.
+pub const MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_KEY_LEN: usize = 32;
+
+/// Maximum length of an `external_refs` value.
+pub const MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_VALUE_LEN: usize = 256;
+
+/// Maximum length of a recipient EVM address (`0x` + 40 hex characters).
+pub const MAX_EVM_ADDRESS_LEN: usize = 42;
+
+/// Learned-mid-flow `(key, value)` reference attached to an active transaction,
+/// e.g. `{ key: "tx_hash", value: "0x…" }`. Modelled as a named record (not a
+/// tuple) so the generated TS bindings expose `.key` / `.value` instead of
+/// positional `[string, string]` access.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct ActiveUserTransactionRef {
+    pub key: String,
+    pub value: String,
+}
+
+/// Lifecycle status of an active user transaction.
+///
+/// Allowed transitions are enforced by the backend:
+/// `Pending` → `Pending | Executing | Succeeded | Failed`,
+/// `Executing` → `Executing | Succeeded | Failed`,
+/// terminal states are immutable (idempotent no-op).
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum ActiveUserTransactionStatus {
+    Pending,
+    Executing,
+    Succeeded,
+    Failed,
+}
+
+impl ActiveUserTransactionStatus {
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed)
+    }
+}
+
+/// Flow-specific payload, captured once at creation and immutable thereafter.
+///
+/// Variants are append-only (Candid evolution rule). Learned-mid-flow values
+/// (tx hashes, forwarding addresses, provider request ids, …) go in
+/// `ActiveUserTransaction::external_refs` so we don't need to bump candid for
+/// every new provider integration.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum ActiveUserTransactionData {
+    OneSecIcpToEvm(OneSecIcpToEvmData),
+    OneSecEvmToIcp(OneSecEvmToIcpData),
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct OneSecIcpToEvmData {
+    pub source_token: TokenId,
+    pub dest_token: TokenId,
+    pub amount: Nat,
+    pub recipient_eth_address: String,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct OneSecEvmToIcpData {
+    pub source_token: TokenId,
+    pub dest_token: TokenId,
+    pub amount: Nat,
+    pub recipient_principal: Principal,
+}
+
+/// In-flight high-level user operation, persisted so the FE can resume polling
+/// across logout / tab close.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct ActiveUserTransaction {
+    /// Frontend-generated identifier (`UUIDv4`). Unique per user.
+    pub id: String,
+    pub status: ActiveUserTransactionStatus,
+    pub data: ActiveUserTransactionData,
+    /// Opaque to the backend; the FE writes a flow-specific step name here.
+    pub progress_step: Option<String>,
+    /// Learned-mid-flow `(key, value)` references, e.g. `("tx_hash", "0x…")`.
+    pub external_refs: Vec<ActiveUserTransactionRef>,
+    pub created_at_ns: u64,
+    pub updated_at_ns: u64,
+    /// Populated when `status = Failed`.
+    pub error: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct CreateActiveUserTransactionRequest {
+    pub id: String,
+    pub data: ActiveUserTransactionData,
+    pub progress_step: Option<String>,
+    pub external_refs: Vec<ActiveUserTransactionRef>,
+}
+
+/// Partial update. Only fields that are `Some` are applied; everything else is
+/// left untouched. `external_refs`, when provided, **replaces** the stored list
+/// in full — the FE always knows the complete set after each poll.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct UpdateActiveUserTransactionRequest {
+    pub id: String,
+    pub status: Option<ActiveUserTransactionStatus>,
+    pub progress_step: Option<String>,
+    pub external_refs: Option<Vec<ActiveUserTransactionRef>>,
+    pub error: Option<String>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct GetActiveUserTransactionsResponse {
+    pub transactions: Vec<ActiveUserTransaction>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum ActiveUserTransactionError {
+    NotFound,
+    AlreadyExists,
+    TooManyActiveTransactions,
+    InvalidId,
+    InvalidData(String),
+    IllegalStatusTransition,
+}
+
+#[cfg(test)]
+mod tests {
+    use candid::{decode_one, encode_one, Nat, Principal};
+    use pretty_assertions::assert_eq;
+
+    use super::{
+        ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
+        ActiveUserTransactionRef, ActiveUserTransactionStatus,
+        CreateActiveUserTransactionRequest, GetActiveUserTransactionsResponse,
+        OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
+    };
+    use crate::types::token_id::TokenId;
+
+    fn sample_record() -> ActiveUserTransaction {
+        ActiveUserTransaction {
+            id: "11111111-1111-4111-8111-111111111111".to_string(),
+            status: ActiveUserTransactionStatus::Pending,
+            data: ActiveUserTransactionData::OneSecIcpToEvm(OneSecIcpToEvmData {
+                source_token: TokenId::IcpNative,
+                dest_token: TokenId::EvmNative(1),
+                amount: Nat::from(1_000_000u64),
+                recipient_eth_address: "0x0000000000000000000000000000000000000001".to_string(),
+            }),
+            progress_step: Some("submitting".to_string()),
+            external_refs: vec![ActiveUserTransactionRef {
+                key: "tx_hash".to_string(),
+                value: "0xabc".to_string(),
+            }],
+            created_at_ns: 1,
+            updated_at_ns: 2,
+            error: None,
+        }
+    }
+
+    fn roundtrip<T>(value: &T) -> T
+    where
+        T: candid::CandidType + for<'de> serde::Deserialize<'de>,
+    {
+        let bytes = encode_one(value).expect("encode");
+        decode_one(&bytes).expect("decode")
+    }
+
+    #[test]
+    fn record_roundtrips_through_candid() {
+        let original = sample_record();
+        assert_eq!(roundtrip(&original), original);
+    }
+
+    #[test]
+    fn evm_to_icp_variant_roundtrips() {
+        let original = ActiveUserTransactionData::OneSecEvmToIcp(OneSecEvmToIcpData {
+            source_token: TokenId::EvmNative(1),
+            dest_token: TokenId::IcpNative,
+            amount: Nat::from(42u64),
+            recipient_principal: Principal::from_text(
+                "7blps-itamd-lzszp-7lbda-4nngn-fev5u-2jvpn-6y3ap-eunp7-kz57e-fqe",
+            )
+            .unwrap(),
+        });
+        assert_eq!(roundtrip(&original), original);
+    }
+
+    #[test]
+    fn requests_and_responses_roundtrip() {
+        let create = CreateActiveUserTransactionRequest {
+            id: "abc".to_string(),
+            data: sample_record().data,
+            progress_step: None,
+            external_refs: vec![],
+        };
+        assert_eq!(roundtrip(&create), create);
+
+        let update = UpdateActiveUserTransactionRequest {
+            id: "abc".to_string(),
+            status: Some(ActiveUserTransactionStatus::Executing),
+            progress_step: Some("step".to_string()),
+            external_refs: Some(vec![]),
+            error: None,
+        };
+        assert_eq!(roundtrip(&update), update);
+
+        let list = GetActiveUserTransactionsResponse {
+            transactions: vec![sample_record()],
+        };
+        assert_eq!(roundtrip(&list), list);
+    }
+
+    #[test]
+    fn error_variants_roundtrip() {
+        for err in [
+            ActiveUserTransactionError::NotFound,
+            ActiveUserTransactionError::AlreadyExists,
+            ActiveUserTransactionError::TooManyActiveTransactions,
+            ActiveUserTransactionError::InvalidId,
+            ActiveUserTransactionError::InvalidData("bad".to_string()),
+            ActiveUserTransactionError::IllegalStatusTransition,
+        ] {
+            assert_eq!(roundtrip(&err), err);
+        }
+    }
+
+    #[test]
+    fn is_terminal_matches_status_kind() {
+        assert!(!ActiveUserTransactionStatus::Pending.is_terminal());
+        assert!(!ActiveUserTransactionStatus::Executing.is_terminal());
+        assert!(ActiveUserTransactionStatus::Succeeded.is_terminal());
+        assert!(ActiveUserTransactionStatus::Failed.is_terminal());
+    }
+}

--- a/src/shared/src/types/result_types.rs
+++ b/src/shared/src/types/result_types.rs
@@ -13,6 +13,9 @@ use super::{
     user_profile::{CreateUserProfileError, GetUserProfileError, UserProfile},
 };
 use crate::types::{
+    active_user_transaction::{
+        ActiveUserTransaction, ActiveUserTransactionError, GetActiveUserTransactionsResponse,
+    },
     agreement::{AgreementHistoryEntry, GetAgreementHistoryError, UpdateAgreementsError},
     bitcoin::{BtcGetFeePercentilesError, BtcGetFeePercentilesResponse},
     contact::{Contact, ContactError},
@@ -390,6 +393,56 @@ impl From<Result<Vec<AgreementHistoryEntry>, GetAgreementHistoryError>>
         match result {
             Ok(entries) => GetAgreementHistoryResult::Ok(entries),
             Err(err) => GetAgreementHistoryResult::Err(err),
+        }
+    }
+}
+
+/// Shared result for endpoints that return a single `ActiveUserTransaction`
+/// (both `create_active_user_transaction` and `update_active_user_transaction`).
+/// One type because the wire shape is identical — the candid extractor would
+/// dedupe twin variants anyway.
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum ActiveUserTransactionResult {
+    Ok(Box<ActiveUserTransaction>),
+    Err(ActiveUserTransactionError),
+}
+impl From<Result<ActiveUserTransaction, ActiveUserTransactionError>>
+    for ActiveUserTransactionResult
+{
+    fn from(result: Result<ActiveUserTransaction, ActiveUserTransactionError>) -> Self {
+        match result {
+            Ok(tx) => ActiveUserTransactionResult::Ok(Box::new(tx)),
+            Err(err) => ActiveUserTransactionResult::Err(err),
+        }
+    }
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum GetActiveUserTransactionsResult {
+    Ok(GetActiveUserTransactionsResponse),
+    Err(ActiveUserTransactionError),
+}
+impl From<Result<GetActiveUserTransactionsResponse, ActiveUserTransactionError>>
+    for GetActiveUserTransactionsResult
+{
+    fn from(result: Result<GetActiveUserTransactionsResponse, ActiveUserTransactionError>) -> Self {
+        match result {
+            Ok(response) => GetActiveUserTransactionsResult::Ok(response),
+            Err(err) => GetActiveUserTransactionsResult::Err(err),
+        }
+    }
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum DeleteActiveUserTransactionResult {
+    Ok(()),
+    Err(ActiveUserTransactionError),
+}
+impl From<Result<(), ActiveUserTransactionError>> for DeleteActiveUserTransactionResult {
+    fn from(result: Result<(), ActiveUserTransactionError>) -> Self {
+        match result {
+            Ok(()) => DeleteActiveUserTransactionResult::Ok(()),
+            Err(err) => DeleteActiveUserTransactionResult::Err(err),
         }
     }
 }


### PR DESCRIPTION
# Motivation

First slice of the upcoming `active_user_transactions` feature (in-flight high-level user operation tracking, persisted backend-side). Lands the shared types alone so the storage layer (PR 2) and the canister endpoints (PR 3) can be reviewed in isolation.

# Changes

- New `shared::types::active_user_transaction` module: `ActiveUserTransaction`, `ActiveUserTransactionStatus`, `ActiveUserTransactionData` (variants for the two initial 1-second-bridge flows), request/response/error types, and shared `MAX_*` size limits.
 - Three new entries in `shared::types::result_types` for the future endpoints: `ActiveUserTransactionResult`, `GetActiveUserTransactionsResult`, `DeleteActiveUserTransactionResult`.
