### PR TITLE
fix(frontend): preserve Solana token account owners

### DIFF
--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -96,10 +96,10 @@ const extractBalances = ({
 	};
 };
 
-type SolTokenAccountMetadata = {
+interface SolTokenAccountMetadata {
 	addressToOwner: Record<SolAddress, SolAddress>;
 	addressToToken: Record<SolAddress, SplTokenAddress>;
-};
+}
 
 const emptySolTokenAccountMetadata: SolTokenAccountMetadata = {
 	addressToOwner: {},
@@ -120,7 +120,11 @@ const extractTokenAccountMetadata = (instruction: SolRpcInstruction): SolTokenAc
 	}
 
 	if (type === 'create' || type === 'createIdempotent') {
-		const { account, wallet: owner, mint } = info as Partial<{
+		const {
+			account,
+			wallet: owner,
+			mint
+		} = info as Partial<{
 			account: SolAddress;
 			wallet: SolAddress;
 			mint: SplTokenAddress;
@@ -134,7 +138,11 @@ const extractTokenAccountMetadata = (instruction: SolRpcInstruction): SolTokenAc
 		}
 	}
 
-	if (type === 'initializeAccount' || type === 'initializeAccount2' || type === 'initializeAccount3') {
+	if (
+		type === 'initializeAccount' ||
+		type === 'initializeAccount2' ||
+		type === 'initializeAccount3'
+	) {
 		const { account, owner, mint } = info as Partial<{
 			account: SolAddress;
 			owner: SolAddress;

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -22,6 +22,7 @@ import {
 import type { SolAddress } from '$sol/types/address';
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { LoadNextSolTransactionsParams, LoadSolTransactionsParams } from '$sol/types/sol-api';
+import type { SolRpcInstruction } from '$sol/types/sol-instructions';
 import type {
 	ParsedAccount,
 	SolMappedTransaction,
@@ -93,6 +94,62 @@ const extractBalances = ({
 		preBalance: accountIndex < preBalances.length ? preBalances[accountIndex] : lamports(ZERO),
 		postBalance: accountIndex < postBalances.length ? postBalances[accountIndex] : lamports(ZERO)
 	};
+};
+
+type SolTokenAccountMetadata = {
+	addressToOwner: Record<SolAddress, SolAddress>;
+	addressToToken: Record<SolAddress, SplTokenAddress>;
+};
+
+const emptySolTokenAccountMetadata: SolTokenAccountMetadata = {
+	addressToOwner: {},
+	addressToToken: {}
+};
+
+const extractTokenAccountMetadata = (instruction: SolRpcInstruction): SolTokenAccountMetadata => {
+	if (!('parsed' in instruction)) {
+		return emptySolTokenAccountMetadata;
+	}
+
+	const {
+		parsed: { type, info }
+	} = instruction;
+
+	if (isNullish(info)) {
+		return emptySolTokenAccountMetadata;
+	}
+
+	if (type === 'create' || type === 'createIdempotent') {
+		const { account, wallet: owner, mint } = info as Partial<{
+			account: SolAddress;
+			wallet: SolAddress;
+			mint: SplTokenAddress;
+		}>;
+
+		if (nonNullish(account) && nonNullish(owner) && nonNullish(mint)) {
+			return {
+				addressToOwner: { [account]: owner },
+				addressToToken: { [account]: mint }
+			};
+		}
+	}
+
+	if (type === 'initializeAccount' || type === 'initializeAccount2' || type === 'initializeAccount3') {
+		const { account, owner, mint } = info as Partial<{
+			account: SolAddress;
+			owner: SolAddress;
+			mint: SplTokenAddress;
+		}>;
+
+		if (nonNullish(account) && nonNullish(owner) && nonNullish(mint)) {
+			return {
+				addressToOwner: { [account]: owner },
+				addressToToken: { [account]: mint }
+			};
+		}
+	}
+
+	return emptySolTokenAccountMetadata;
 };
 
 export const fetchSolTransactionsForSignature = async ({
@@ -170,28 +227,50 @@ export const fetchSolTransactionsForSignature = async ({
 			parsedTransactions: SolTransactionUi[];
 			cumulativeBalances: Record<SolAddress, SolMappedTransaction['value']>;
 			addressToToken: Record<SolAddress, SplTokenAddress>;
+			addressToOwner: Record<SolAddress, SolAddress>;
 		}>
 	>(
 		async (acc, instruction, idx) => {
 			const {
 				parsedTransactions,
 				cumulativeBalances: accCumulativeBalances,
-				addressToToken: accAddressToToken
+				addressToToken: accAddressToToken,
+				addressToOwner: accAddressToOwner
 			} = await acc;
+
+			const instructionWithProgramAddress = {
+				...instruction,
+				programAddress: instruction.programId
+			};
+			const {
+				addressToToken: instructionAddressToToken,
+				addressToOwner: instructionAddressToOwner
+			} = extractTokenAccountMetadata(instructionWithProgramAddress);
+
+			const addressToOwner = {
+				...accAddressToOwner,
+				...instructionAddressToOwner
+			};
+			const addressToTokenFromInstruction = {
+				...accAddressToToken,
+				...instructionAddressToToken
+			};
 
 			const mappedTransaction = await mapSolParsedInstruction({
 				identity,
-				instruction: {
-					...instruction,
-					programAddress: instruction.programId
-				},
+				instruction: instructionWithProgramAddress,
 				network,
 				cumulativeBalances: accCumulativeBalances,
-				addressToToken: accAddressToToken
+				addressToToken: addressToTokenFromInstruction
 			});
 
 			if (isNullish(mappedTransaction)) {
-				return acc;
+				return {
+					parsedTransactions,
+					cumulativeBalances: accCumulativeBalances,
+					addressToToken: addressToTokenFromInstruction,
+					addressToOwner
+				};
 			}
 
 			const { value, from, to, tokenAddress: mappedTokenAddress } = mappedTransaction;
@@ -200,7 +279,7 @@ export const fetchSolTransactionsForSignature = async ({
 			// associated with a certain address. This way, we can skip the call to request the account info
 			// for mapping a certain transaction to its specific token.
 			const addressToToken = {
-				...accAddressToToken,
+				...addressToTokenFromInstruction,
 				...(nonNullish(mappedTokenAddress) && {
 					[from]: mappedTokenAddress,
 					[to]: mappedTokenAddress
@@ -220,24 +299,32 @@ export const fetchSolTransactionsForSignature = async ({
 				})
 			};
 
+			const instructionFromOwner = addressToOwner[from];
+			const instructionToOwner = addressToOwner[to];
+
 			// Ignoring the instruction if the transaction is not related to the address or its associated token account.
-			if (from !== address && to !== address && from !== ataAddress && to !== ataAddress) {
-				return { parsedTransactions, cumulativeBalances, addressToToken };
+			if (
+				from !== address &&
+				to !== address &&
+				from !== ataAddress &&
+				to !== ataAddress &&
+				instructionFromOwner !== address &&
+				instructionToOwner !== address
+			) {
+				return { parsedTransactions, cumulativeBalances, addressToToken, addressToOwner };
 			}
 
 			// If the token address is not the one we are looking for, we can skip this instruction.
 			// In the case of Solana native tokens, the token address is undefined.
 			if (mappedTokenAddress !== tokenAddress) {
-				return { parsedTransactions, cumulativeBalances, addressToToken };
+				return { parsedTransactions, cumulativeBalances, addressToToken, addressToOwner };
 			}
 
-			const fromOwner: SolTransactionUi['fromOwner'] = await getAccountOwner({
-				address: from,
-				network
-			});
+			const fromOwner: SolTransactionUi['fromOwner'] =
+				instructionFromOwner ?? (await getAccountOwner({ address: from, network }));
 
 			const toOwner: SolTransactionUi['toOwner'] = nonNullish(to)
-				? await getAccountOwner({ address: to, network })
+				? (instructionToOwner ?? (await getAccountOwner({ address: to, network })))
 				: undefined;
 
 			const newTransaction: SolTransactionUi = {
@@ -246,7 +333,7 @@ export const fetchSolTransactionsForSignature = async ({
 				blockNumber: Number(slot),
 				timestamp: blockTime ?? ZERO,
 				value,
-				type: address === from || ataAddress === from ? 'send' : 'receive',
+				type: address === from || ataAddress === from || address === fromOwner ? 'send' : 'receive',
 				from,
 				...(nonNullish(fromOwner) && { fromOwner }),
 				to,
@@ -273,13 +360,15 @@ export const fetchSolTransactionsForSignature = async ({
 						: [])
 				],
 				cumulativeBalances,
-				addressToToken
+				addressToToken,
+				addressToOwner
 			};
 		},
 		Promise.resolve({
 			parsedTransactions: [],
 			cumulativeBalances: initialCumulativeBalances,
-			addressToToken: {}
+			addressToToken: {},
+			addressToOwner: {}
 		})
 	);
 

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -48,6 +48,7 @@ import {
 	mockSplAddress
 } from '$tests/mocks/sol.mock';
 import * as solProgramToken from '@solana-program/token';
+import { address as solAddress } from '@solana/kit';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
 
@@ -161,6 +162,23 @@ describe('sol-transactions.services', () => {
 		};
 
 		const indexStartAtaMapping = Math.floor(mockAllInstructions.length / 3);
+		const mockInitializedTokenAccount = 'F5Qu5Lx2aDwis6KwtpXBuHWHh2VGWewQAVEaatAKfir3';
+		const mockInitializedTokenAddress = 'So11111111111111111111111111111111111111112';
+		const expectedInstructionAddressToToken = ({
+			instructions,
+			index
+		}: {
+			instructions: ReadonlyArray<(typeof mockAllInstructions)[number]>;
+			index: number;
+		}): Record<string, string> => {
+			const indexStartInstructionTokenMapping = instructions.findIndex(
+				(instruction) => 'parsed' in instruction && instruction.parsed.type === 'initializeAccount3'
+			);
+
+			return indexStartInstructionTokenMapping >= 0 && index >= indexStartInstructionTokenMapping
+				? { [mockInitializedTokenAccount]: mockInitializedTokenAddress }
+				: {};
+		};
 
 		const expectedResults: SolTransactionUi[] = Array.from(
 			{ length: nInstructions },
@@ -224,7 +242,10 @@ describe('sol-transactions.services', () => {
 									[mockSolAddress]: initialBalance - mockValue * BigInt(index),
 									[mockSolAddress2]: mockValue * BigInt(index)
 								},
-					addressToToken: {}
+					addressToToken: expectedInstructionAddressToToken({
+						instructions: mockAllInstructions,
+						index
+					})
 				});
 			});
 		});
@@ -263,7 +284,10 @@ describe('sol-transactions.services', () => {
 									[mockSolAddress]: initialBalance - mockValue * BigInt(index),
 									[mockSolAddress2]: mockValue * BigInt(index)
 								},
-					addressToToken: {}
+					addressToToken: expectedInstructionAddressToToken({
+						instructions: innerInstructions,
+						index
+					})
 				});
 			});
 		});
@@ -400,13 +424,16 @@ describe('sol-transactions.services', () => {
 									[mockSolAddress2]:
 										mockValue * BigInt(index >= indexStartAtaMapping ? index - 1 : index)
 								},
-					addressToToken:
-						index >= indexStartAtaMapping
-							? {
-									[mockAtaAddress]: mockSplAddress,
-									[mockAtaAddress2]: mockSplAddress
-								}
-							: {}
+					addressToToken: {
+						...expectedInstructionAddressToToken({
+							instructions: mockAllInstructions,
+							index
+						}),
+						...(index >= indexStartAtaMapping && {
+							[mockAtaAddress]: mockSplAddress,
+							[mockAtaAddress2]: mockSplAddress
+						})
+					}
 				});
 			});
 		});
@@ -444,7 +471,7 @@ describe('sol-transactions.services', () => {
 									type: 'createIdempotent'
 								},
 								program: 'spl-associated-token-account',
-								programId: ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
+								programId: solAddress(ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS),
 								stackHeight: undefined
 							},
 							{
@@ -458,7 +485,7 @@ describe('sol-transactions.services', () => {
 									type: 'transfer'
 								},
 								program: 'spl-token',
-								programId: TOKEN_PROGRAM_ADDRESS,
+								programId: solAddress(TOKEN_PROGRAM_ADDRESS),
 								stackHeight: undefined
 							},
 							{
@@ -472,7 +499,7 @@ describe('sol-transactions.services', () => {
 									type: 'transfer'
 								},
 								program: 'spl-token',
-								programId: TOKEN_PROGRAM_ADDRESS,
+								programId: solAddress(TOKEN_PROGRAM_ADDRESS),
 								stackHeight: undefined
 							}
 						]
@@ -482,7 +509,7 @@ describe('sol-transactions.services', () => {
 					...mockTransactionDetail.meta,
 					innerInstructions: []
 				}
-			} as SolRpcTransaction;
+			};
 
 			spyFetchTransactionDetailForSignature.mockResolvedValue(mockTransactionDetailWithClosedAta);
 			spyFindAssociatedTokenPda.mockResolvedValue([mockAtaAddress]);
@@ -505,7 +532,11 @@ describe('sol-transactions.services', () => {
 						return Promise.resolve(undefined);
 					}
 
-					const { amount, source: from, destination: to } = info as {
+					const {
+						amount,
+						source: from,
+						destination: to
+					} = info as {
 						amount: string;
 						source: SolMappedTransaction['from'];
 						destination: SolMappedTransaction['to'];
@@ -544,7 +575,7 @@ describe('sol-transactions.services', () => {
 			]);
 			expect(
 				vi.mocked(getAccountOwner).mock.calls.some(([{ address }]) => address === mockAtaAddress)
-			).toBe(false);
+			).toBeFalsy();
 
 			const [outboundTransaction] = transactions;
 			const cachedOutboundTransaction = mapUserTransactionToSolTransaction({

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -5,7 +5,10 @@ import { ZERO } from '$lib/constants/app.constants';
 import { solAddressDevnetStore, solAddressMainnetStore } from '$lib/stores/address.store';
 import * as solanaApi from '$sol/api/solana.api';
 import { getAccountOwner } from '$sol/api/solana.api';
-import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
+import {
+	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
+	TOKEN_PROGRAM_ADDRESS
+} from '$sol/constants/sol.constants';
 import * as solSignaturesServices from '$sol/services/sol-signatures.services';
 import {
 	fetchSolTransactionsForSignature,
@@ -26,6 +29,10 @@ import type {
 	SolTransactionUi
 } from '$sol/types/sol-transaction';
 import * as solInstructionsUtils from '$sol/utils/sol-instructions.utils';
+import {
+	mapSolTransactionToUserTransaction,
+	mapUserTransactionToSolTransaction
+} from '$sol/utils/user-transactions.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockSolSignature, mockSolSignatureResponse } from '$tests/mocks/sol-signatures.mock';
@@ -414,6 +421,139 @@ describe('sol-transactions.services', () => {
 					toOwner: 'mock-owner-address'
 				}))
 			);
+		});
+
+		it('should preserve instruction-derived ATA owners for cached SPL transfers', async () => {
+			const usdtAmount = 39974n;
+			const mockTransactionDetailWithClosedAta = {
+				...mockTransactionDetail,
+				transaction: {
+					...mockTransactionDetail.transaction,
+					message: {
+						...mockTransactionDetail.transaction.message,
+						instructions: [
+							{
+								parsed: {
+									info: {
+										account: mockAtaAddress,
+										mint: mockSplAddress,
+										source: mockSolAddress,
+										tokenProgram: TOKEN_PROGRAM_ADDRESS,
+										wallet: mockSolAddress
+									},
+									type: 'createIdempotent'
+								},
+								program: 'spl-associated-token-account',
+								programId: ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
+								stackHeight: undefined
+							},
+							{
+								parsed: {
+									info: {
+										amount: usdtAmount.toString(),
+										authority: mockSolAddress2,
+										destination: mockAtaAddress,
+										source: mockSolAddress2
+									},
+									type: 'transfer'
+								},
+								program: 'spl-token',
+								programId: TOKEN_PROGRAM_ADDRESS,
+								stackHeight: undefined
+							},
+							{
+								parsed: {
+									info: {
+										amount: usdtAmount.toString(),
+										authority: mockSolAddress,
+										destination: mockSolAddress2,
+										source: mockAtaAddress
+									},
+									type: 'transfer'
+								},
+								program: 'spl-token',
+								programId: TOKEN_PROGRAM_ADDRESS,
+								stackHeight: undefined
+							}
+						]
+					}
+				},
+				meta: {
+					...mockTransactionDetail.meta,
+					innerInstructions: []
+				}
+			} as SolRpcTransaction;
+
+			spyFetchTransactionDetailForSignature.mockResolvedValue(mockTransactionDetailWithClosedAta);
+			spyFindAssociatedTokenPda.mockResolvedValue([mockAtaAddress]);
+			vi.mocked(getAccountOwner).mockResolvedValue(undefined);
+			spyMapSolParsedInstruction.mockImplementation(
+				({
+					instruction
+				}: Parameters<typeof solInstructionsUtils.mapSolParsedInstruction>[0]): Promise<
+					SolMappedTransaction | undefined
+				> => {
+					if (!('parsed' in instruction)) {
+						return Promise.resolve(undefined);
+					}
+
+					const {
+						parsed: { type, info }
+					} = instruction;
+
+					if (type !== 'transfer') {
+						return Promise.resolve(undefined);
+					}
+
+					const { amount, source: from, destination: to } = info as {
+						amount: string;
+						source: SolMappedTransaction['from'];
+						destination: SolMappedTransaction['to'];
+					};
+
+					return Promise.resolve({
+						value: BigInt(amount),
+						from,
+						to,
+						tokenAddress: mockSplAddress
+					});
+				}
+			);
+
+			const transactions = await fetchSolTransactionsForSignature({
+				...mockParams,
+				tokenAddress: mockSplAddress,
+				tokenOwnerAddress: TOKEN_PROGRAM_ADDRESS
+			});
+
+			expect(transactions).toEqual([
+				expect.objectContaining({
+					type: 'send',
+					value: usdtAmount,
+					from: mockAtaAddress,
+					fromOwner: mockSolAddress,
+					to: mockSolAddress2
+				}),
+				expect.objectContaining({
+					type: 'receive',
+					value: usdtAmount,
+					from: mockSolAddress2,
+					to: mockAtaAddress,
+					toOwner: mockSolAddress
+				})
+			]);
+			expect(
+				vi.mocked(getAccountOwner).mock.calls.some(([{ address }]) => address === mockAtaAddress)
+			).toBe(false);
+
+			const [outboundTransaction] = transactions;
+			const cachedOutboundTransaction = mapUserTransactionToSolTransaction({
+				transaction: mapSolTransactionToUserTransaction(outboundTransaction),
+				address: mockSolAddress
+			});
+
+			expect(cachedOutboundTransaction.type).toBe('send');
+			expect(cachedOutboundTransaction.fromOwner).toBe(mockSolAddress);
 		});
 	});
 

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -505,7 +505,11 @@ describe('sol-transactions.services', () => {
 						return Promise.resolve(undefined);
 					}
 
-					const { amount, source: from, destination: to } = info as {
+					const {
+						amount,
+						source: from,
+						destination: to
+					} = info as {
 						amount: string;
 						source: SolMappedTransaction['from'];
 						destination: SolMappedTransaction['to'];
@@ -544,7 +548,7 @@ describe('sol-transactions.services', () => {
 			]);
 			expect(
 				vi.mocked(getAccountOwner).mock.calls.some(([{ address }]) => address === mockAtaAddress)
-			).toBe(false);
+			).toBeFalsy();
 
 			const [outboundTransaction] = transactions;
 			const cachedOutboundTransaction = mapUserTransactionToSolTransaction({


### PR DESCRIPTION
# Motivation

Closed Solana token accounts can lose owner context during transaction parsing, causing outbound SPL transfers to display with the wrong direction.

# Changes

- Preserve token account owner metadata from parsed transaction instructions.
- Use that owner metadata when classifying Solana SPL transfer direction.

# Tests

Adjusted tests.

