### PR TITLE
fix(frontend): keep latest exchange sync payload

### DIFF
--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -94,8 +94,7 @@ const stopTimer = () => {
 };
 
 let syncInProgress = false;
-let syncQueued = false;
-let queuedGeneration: number | undefined = undefined;
+let queuedSyncGeneration: number | undefined = undefined;
 let activeSyncGeneration: number | undefined = undefined;
 
 interface SyncExchangeParams {
@@ -335,28 +334,29 @@ const syncLatestExchange = async (generation: number) => {
 	}
 
 	if (syncInProgress) {
-		syncQueued = true;
-		queuedGeneration = generation;
+		queuedSyncGeneration = generation;
 		return;
 	}
 
-	do {
-		syncQueued = false;
-		queuedGeneration = undefined;
+	syncInProgress = true;
+	activeSyncGeneration = generation;
 
-		syncInProgress = true;
-		activeSyncGeneration = generation;
+	await syncExchange(paramsFromTimerData(latestTimerData)).finally(() => {
+		syncInProgress = false;
+		if (activeSyncGeneration === generation) {
+			activeSyncGeneration = undefined;
+		}
+	});
 
-		await syncExchange(paramsFromTimerData(latestTimerData)).finally(() => {
-			syncInProgress = false;
-			if (activeSyncGeneration === generation) {
-				activeSyncGeneration = undefined;
-			}
-		});
-	} while (syncQueued && generation === timerGeneration);
+	const nextGeneration = queuedSyncGeneration;
+	queuedSyncGeneration = undefined;
 
-	if (syncQueued && queuedGeneration === timerGeneration) {
-		void syncLatestExchange(queuedGeneration);
+	if (
+		nonNullish(nextGeneration) &&
+		nextGeneration !== generation &&
+		nextGeneration === timerGeneration
+	) {
+		void syncLatestExchange(nextGeneration);
 	}
 };
 

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -55,6 +55,10 @@ const startExchangeTimer = async (data: PostMessageDataRequestExchangeTimer | un
 		return;
 	}
 
+	if (syncInProgress && activeSyncGeneration === timerGeneration) {
+		return;
+	}
+
 	latestTimerData = data;
 	const generation = ++timerGeneration;
 
@@ -91,7 +95,8 @@ const stopTimer = () => {
 
 let syncInProgress = false;
 let syncQueued = false;
-let syncCompletion: Promise<void> | undefined = undefined;
+let queuedGeneration: number | undefined = undefined;
+let activeSyncGeneration: number | undefined = undefined;
 
 interface SyncExchangeParams {
 	currentCurrency: Currency;
@@ -325,27 +330,34 @@ const paramsFromTimerData = (
 });
 
 const syncLatestExchange = async (generation: number) => {
-	if (syncInProgress) {
-		syncQueued = true;
-		await syncCompletion;
+	if (generation !== timerGeneration) {
+		return;
 	}
 
-	if (generation !== timerGeneration) {
+	if (syncInProgress) {
+		syncQueued = true;
+		queuedGeneration = generation;
 		return;
 	}
 
 	do {
 		syncQueued = false;
+		queuedGeneration = undefined;
 
 		syncInProgress = true;
+		activeSyncGeneration = generation;
 
-		syncCompletion = syncExchange(paramsFromTimerData(latestTimerData)).finally(() => {
+		await syncExchange(paramsFromTimerData(latestTimerData)).finally(() => {
 			syncInProgress = false;
-			syncCompletion = undefined;
+			if (activeSyncGeneration === generation) {
+				activeSyncGeneration = undefined;
+			}
 		});
-
-		await syncCompletion;
 	} while (syncQueued && generation === timerGeneration);
+
+	if (syncQueued && queuedGeneration === timerGeneration) {
+		void syncLatestExchange(queuedGeneration);
+	}
 };
 
 const syncExchange = async (params: SyncExchangeParams) => {

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -46,6 +46,8 @@ export const onExchangeMessage = async ({
 };
 
 let timer: NodeJS.Timeout | undefined = undefined;
+let timerGeneration = 0;
+let latestTimerData: PostMessageDataRequestExchangeTimer | undefined = undefined;
 
 const startExchangeTimer = async (data: PostMessageDataRequestExchangeTimer | undefined) => {
 	// This worker has already been started
@@ -53,23 +55,21 @@ const startExchangeTimer = async (data: PostMessageDataRequestExchangeTimer | un
 		return;
 	}
 
-	const sync = async () =>
-		await syncExchange({
-			currentCurrency: data?.currentCurrency ?? Currency.USD,
-			erc20ContractAddresses: data?.erc20Addresses ?? [],
-			icrcLedgerCanisterIds: data?.icrcCanisterIds ?? [],
-			splTokenAddresses: data?.splAddresses ?? [],
-			erc4626TokensExchangeData: data?.erc4626TokensExchangeData ?? []
-		});
+	latestTimerData = data;
+	const generation = ++timerGeneration;
 
 	// We sync now but also schedule the update afterward
-	await sync();
+	await syncLatestExchange(generation);
+
+	if (generation !== timerGeneration) {
+		return;
+	}
 
 	const scheduleNext = (): void => {
 		timer = setTimeout(async () => {
-			await sync();
+			await syncLatestExchange(generation);
 
-			if (nonNullish(timer)) {
+			if (generation === timerGeneration) {
 				scheduleNext();
 			}
 		}, SYNC_EXCHANGE_TIMER_INTERVAL);
@@ -79,6 +79,8 @@ const startExchangeTimer = async (data: PostMessageDataRequestExchangeTimer | un
 };
 
 const stopTimer = () => {
+	timerGeneration++;
+
 	if (isNullish(timer)) {
 		return;
 	}
@@ -88,6 +90,8 @@ const stopTimer = () => {
 };
 
 let syncInProgress = false;
+let syncQueued = false;
+let syncCompletion: Promise<void> | undefined = undefined;
 
 interface SyncExchangeParams {
 	currentCurrency: Currency;
@@ -310,14 +314,41 @@ const syncExchangeFromProviders = async ({
 	};
 };
 
-const syncExchange = async (params: SyncExchangeParams) => {
-	// Avoid duplicating the sync if already in progress and not yet finished
+const paramsFromTimerData = (
+	data: PostMessageDataRequestExchangeTimer | undefined
+): SyncExchangeParams => ({
+	currentCurrency: data?.currentCurrency ?? Currency.USD,
+	erc20ContractAddresses: data?.erc20Addresses ?? [],
+	icrcLedgerCanisterIds: data?.icrcCanisterIds ?? [],
+	splTokenAddresses: data?.splAddresses ?? [],
+	erc4626TokensExchangeData: data?.erc4626TokensExchangeData ?? []
+});
+
+const syncLatestExchange = async (generation: number) => {
 	if (syncInProgress) {
+		syncQueued = true;
+		await syncCompletion;
+	}
+
+	if (generation !== timerGeneration) {
 		return;
 	}
 
-	syncInProgress = true;
+	do {
+		syncQueued = false;
 
+		syncInProgress = true;
+
+		syncCompletion = syncExchange(paramsFromTimerData(latestTimerData)).finally(() => {
+			syncInProgress = false;
+			syncCompletion = undefined;
+		});
+
+		await syncCompletion;
+	} while (syncQueued && generation === timerGeneration);
+};
+
+const syncExchange = async (params: SyncExchangeParams) => {
 	try {
 		const data = BACKEND_EXCHANGE_ENABLED
 			? await syncExchangeFromBackend(params)
@@ -337,6 +368,4 @@ const syncExchange = async (params: SyncExchangeParams) => {
 			}
 		});
 	}
-
-	syncInProgress = false;
 };

--- a/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
+++ b/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
@@ -240,6 +240,66 @@ describe('exchange.worker', () => {
 				expect(postMessageMock).toHaveBeenCalledOnce();
 			});
 
+			it('should sync the latest payload when restarted during the immediate sync', async () => {
+				let resolveFirstSync: ((v: CoingeckoSimpleErc4626TokenPriceResponse) => void) | undefined;
+				vi.mocked(calculateErc4626Prices)
+					.mockImplementationOnce(
+						() =>
+							new Promise((resolve) => {
+								resolveFirstSync = resolve;
+							})
+					)
+					.mockResolvedValue({});
+
+				const firstEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
+					...createEvent(msg),
+					data: {
+						msg,
+						data: {
+							currentCurrency: Currency.USD,
+							erc20Addresses: [],
+							icrcCanisterIds: [],
+							splAddresses: [],
+							erc4626TokensExchangeData: []
+						}
+					}
+				};
+
+				const latestEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
+					...createEvent(msg),
+					data: {
+						msg,
+						data: {
+							currentCurrency: Currency.USD,
+							erc20Addresses: [],
+							icrcCanisterIds: ['icrc1'],
+							splAddresses: [],
+							erc4626TokensExchangeData: []
+						}
+					}
+				};
+
+				const firstStart = onExchangeMessage(firstEvent);
+				await vi.advanceTimersByTimeAsync(0);
+
+				expect(resolveFirstSync).toBeDefined();
+
+				await onExchangeMessage(createEvent('stopExchangeTimer'));
+				const latestStart = onExchangeMessage(latestEvent);
+
+				resolveFirstSync?.({});
+
+				await Promise.all([firstStart, latestStart]);
+
+				expect(simpleTokenPrice).toHaveBeenCalledWith({
+					id: 'internet-computer',
+					vs_currencies: Currency.USD,
+					contract_addresses: ['icrc1'],
+					include_market_cap: true,
+					include_24hr_change: true
+				});
+			});
+
 			it('should sync prices at the correct interval', async () => {
 				await onExchangeMessage(event);
 

--- a/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
+++ b/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
@@ -291,12 +291,14 @@ describe('exchange.worker', () => {
 
 				await Promise.all([firstStart, latestStart]);
 
-				expect(simpleTokenPrice).toHaveBeenCalledWith({
-					id: 'internet-computer',
-					vs_currencies: Currency.USD,
-					contract_addresses: ['icrc1'],
-					include_market_cap: true,
-					include_24hr_change: true
+				await vi.waitFor(() => {
+					expect(simpleTokenPrice).toHaveBeenCalledWith({
+						id: 'internet-computer',
+						vs_currencies: Currency.USD,
+						contract_addresses: ['icrc1'],
+						include_market_cap: true,
+						include_24hr_change: true
+					});
 				});
 			});
 


### PR DESCRIPTION
# Motivation

Ensure exchange price refreshes use the latest token payload when the worker is restarted during an in-flight sync.

# Changes

- Track the latest exchange timer payload and invalidate stale timer generations.
- Queue a single follow-up sync generation when a restart arrives while another sync is still running.
- Preserve no-op behavior for duplicate starts that are not restarts.

# Tests

Added tests.
