### PR TITLE
feat(frontend): wire Icrc7 collection deep links

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcIcrc7DeepLinkHandler.svelte
+++ b/src/frontend/src/icp/components/tokens/IcIcrc7DeepLinkHandler.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import { SvelteSet } from 'svelte/reactivity';
+	import { page } from '$app/state';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+	import { icrc7CustomTokensNotInitialized, icrc7Tokens } from '$icp/derived/icrc7.derived';
+	import { resolveIcrc7CollectionDeepLinkAction } from '$icp/services/icrc7-deep-link.services';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { WizardStepsManageTokens } from '$lib/enums/wizard-steps';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+
+	const icrc7DeepLinkManageTokensId = Symbol();
+	const handledIcrc7DeepLinkCanisterIds = new SvelteSet<string>();
+
+	const icrc7DeepLinkAction = $derived.by(() => {
+		if (isNullish($authIdentity) || $icrc7CustomTokensNotInitialized) {
+			return undefined;
+		}
+
+		return resolveIcrc7CollectionDeepLinkAction({
+			url: page.url,
+			tokens: $icrc7Tokens
+		});
+	});
+
+	$effect(() => {
+		const action = icrc7DeepLinkAction;
+
+		if (
+			isNullish(action) ||
+			action.type === 'ready' ||
+			handledIcrc7DeepLinkCanisterIds.has(action.canisterId)
+		) {
+			return;
+		}
+
+		handledIcrc7DeepLinkCanisterIds.add(action.canisterId);
+
+		if (action.type === 'import') {
+			const data = {
+				initialNetwork: ICP_NETWORK,
+				initialTokenData: { icrc7CanisterId: action.canisterId },
+				initialSearch: action.canisterId,
+				initialStep: WizardStepsManageTokens.REVIEW
+			};
+
+			modalStore.openManageTokens({
+				id: icrc7DeepLinkManageTokensId,
+				data
+			});
+			return;
+		}
+
+		const data = {
+			initialSearch: action.token.name,
+			message: $i18n.transactions.text.token_needs_enabling
+		};
+
+		modalStore.openManageTokens({
+			id: icrc7DeepLinkManageTokensId,
+			data
+		});
+	});
+</script>

--- a/src/frontend/src/icp/services/icrc7-deep-link.services.ts
+++ b/src/frontend/src/icp/services/icrc7-deep-link.services.ts
@@ -3,6 +3,7 @@ import type { Icrc7CustomToken } from '$icp/types/icrc7-custom-token';
 import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
 import { CanisterIdTextSchema, type CanisterIdText } from '$lib/types/canister';
 import type { NetworkId } from '$lib/types/network';
+import { isNullish } from '@dfinity/utils';
 
 export interface Icrc7CollectionDeepLink {
 	canisterId: CanisterIdText;
@@ -47,13 +48,13 @@ export const resolveIcrc7CollectionDeepLinkAction = ({
 }): Icrc7CollectionDeepLinkAction | undefined => {
 	const deepLink = parseIcrc7CollectionDeepLink({ url });
 
-	if (deepLink === undefined) {
+	if (isNullish(deepLink)) {
 		return;
 	}
 
 	const token = tokens.find(({ canisterId }) => canisterId === deepLink.canisterId);
 
-	if (token === undefined) {
+	if (isNullish(token)) {
 		return { type: 'import', ...deepLink };
 	}
 

--- a/src/frontend/src/icp/services/icrc7-deep-link.services.ts
+++ b/src/frontend/src/icp/services/icrc7-deep-link.services.ts
@@ -1,4 +1,5 @@
 import { ICP_NETWORK_ID, ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
+import type { Icrc7CustomToken } from '$icp/types/icrc7-custom-token';
 import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
 import { CanisterIdTextSchema, type CanisterIdText } from '$lib/types/canister';
 import type { NetworkId } from '$lib/types/network';
@@ -7,6 +8,11 @@ export interface Icrc7CollectionDeepLink {
 	canisterId: CanisterIdText;
 	networkId: NetworkId;
 }
+
+export type Icrc7CollectionDeepLinkAction =
+	| ({ type: 'import' } & Icrc7CollectionDeepLink)
+	| ({ type: 'enable'; token: Icrc7CustomToken } & Icrc7CollectionDeepLink)
+	| ({ type: 'ready'; token: Icrc7CustomToken } & Icrc7CollectionDeepLink);
 
 export const parseIcrc7CollectionDeepLink = ({
 	url
@@ -30,4 +36,26 @@ export const parseIcrc7CollectionDeepLink = ({
 		canisterId: parsedCollection.data,
 		networkId: ICP_NETWORK_ID
 	};
+};
+
+export const resolveIcrc7CollectionDeepLinkAction = ({
+	url,
+	tokens
+}: {
+	url: URL;
+	tokens: Icrc7CustomToken[];
+}): Icrc7CollectionDeepLinkAction | undefined => {
+	const deepLink = parseIcrc7CollectionDeepLink({ url });
+
+	if (deepLink === undefined) {
+		return;
+	}
+
+	const token = tokens.find(({ canisterId }) => canisterId === deepLink.canisterId);
+
+	if (token === undefined) {
+		return { type: 'import', ...deepLink };
+	}
+
+	return { type: token.enabled ? 'ready' : 'enable', token, ...deepLink };
 };

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -2,6 +2,7 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import type { Snippet } from 'svelte';
 	import { page } from '$app/state';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import AddTokenByNetwork from '$lib/components/manage/AddTokenByNetwork.svelte';
 	import AddTokenReviewByNetwork from '$lib/components/manage/AddTokenReviewByNetwork.svelte';
@@ -22,11 +23,12 @@
 
 	interface Props {
 		initialSearch?: string;
+		icrc7CanisterId?: string;
 		onClose?: () => void;
 		infoElement?: Snippet;
 	}
 
-	let { initialSearch, onClose = () => {}, infoElement }: Props = $props();
+	let { initialSearch, icrc7CanisterId, onClose = () => {}, infoElement }: Props = $props();
 
 	const isNftsPage = $derived(isRouteNfts(page));
 
@@ -53,6 +55,7 @@
 
 	let currentStep: WizardStep<WizardStepsManageTokens> | undefined = $state();
 	let modal: WizardModal<WizardStepsManageTokens> | undefined = $state();
+	let initializedIcrc7ReviewStep = false;
 
 	const saveTokens = async (tokens: Token[]) => {
 		await saveAllCustomTokens({
@@ -75,8 +78,23 @@
 		onClose();
 	};
 
-	let network: Network | undefined = $state($selectedNetwork);
-	let tokenData: Partial<AddTokenData> = $state({});
+	const initialNetwork = (): Network | undefined =>
+		icrc7CanisterId === undefined ? $selectedNetwork : ICP_NETWORK;
+
+	const initialTokenData = (): Partial<AddTokenData> =>
+		icrc7CanisterId === undefined ? {} : { icrc7CanisterId };
+
+	let network: Network | undefined = $state(initialNetwork());
+	let tokenData: Partial<AddTokenData> = $state(initialTokenData());
+
+	$effect(() => {
+		if (initializedIcrc7ReviewStep || icrc7CanisterId === undefined || modal === undefined) {
+			return;
+		}
+
+		initializedIcrc7ReviewStep = true;
+		modal.set(2);
+	});
 </script>
 
 <WizardModal

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -3,7 +3,6 @@
 	import { isNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { page } from '$app/state';
-	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import AddTokenByNetwork from '$lib/components/manage/AddTokenByNetwork.svelte';
 	import AddTokenReviewByNetwork from '$lib/components/manage/AddTokenReviewByNetwork.svelte';
@@ -24,12 +23,21 @@
 
 	interface Props {
 		initialSearch?: string;
-		icrc7CanisterId?: string;
+		initialNetwork?: Network;
+		initialTokenData?: Partial<AddTokenData>;
+		initialStep?: WizardStepsManageTokens;
 		onClose?: () => void;
 		infoElement?: Snippet;
 	}
 
-	let { initialSearch, icrc7CanisterId, onClose = () => {}, infoElement }: Props = $props();
+	let {
+		initialSearch,
+		initialNetwork,
+		initialTokenData,
+		initialStep,
+		onClose = () => {},
+		infoElement
+	}: Props = $props();
 
 	const isNftsPage = $derived(isRouteNfts(page));
 
@@ -56,7 +64,7 @@
 
 	let currentStep: WizardStep<WizardStepsManageTokens> | undefined = $state();
 	let modal: WizardModal<WizardStepsManageTokens> | undefined = $state();
-	let initializedIcrc7ReviewStep = false;
+	let initializedInitialStep = false;
 
 	const saveTokens = async (tokens: Token[]) => {
 		await saveAllCustomTokens({
@@ -79,22 +87,25 @@
 		onClose();
 	};
 
-	const initialNetwork = (): Network | undefined =>
-		isNullish(icrc7CanisterId) ? $selectedNetwork : ICP_NETWORK;
+	const initialModalNetwork = (): Network | undefined => initialNetwork ?? $selectedNetwork;
 
-	const initialTokenData = (): Partial<AddTokenData> =>
-		isNullish(icrc7CanisterId) ? {} : { icrc7CanisterId };
+	const initialModalTokenData = (): Partial<AddTokenData> => initialTokenData ?? {};
 
-	let network: Network | undefined = $state(initialNetwork());
-	let tokenData: Partial<AddTokenData> = $state(initialTokenData());
+	let network: Network | undefined = $state(initialModalNetwork());
+	let tokenData: Partial<AddTokenData> = $state(initialModalTokenData());
 
 	$effect(() => {
-		if (initializedIcrc7ReviewStep || isNullish(icrc7CanisterId) || isNullish(modal)) {
+		if (initializedInitialStep || isNullish(initialStep) || isNullish(modal)) {
 			return;
 		}
 
-		initializedIcrc7ReviewStep = true;
-		modal.set(2);
+		initializedInitialStep = true;
+
+		const stepIndex = steps.findIndex(({ name }) => name === initialStep);
+
+		if (stepIndex >= 0) {
+			modal.set(stepIndex);
+		}
 	});
 </script>
 

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { isNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { page } from '$app/state';
 	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
@@ -79,16 +80,16 @@
 	};
 
 	const initialNetwork = (): Network | undefined =>
-		icrc7CanisterId === undefined ? $selectedNetwork : ICP_NETWORK;
+		isNullish(icrc7CanisterId) ? $selectedNetwork : ICP_NETWORK;
 
 	const initialTokenData = (): Partial<AddTokenData> =>
-		icrc7CanisterId === undefined ? {} : { icrc7CanisterId };
+		isNullish(icrc7CanisterId) ? {} : { icrc7CanisterId };
 
 	let network: Network | undefined = $state(initialNetwork());
 	let tokenData: Partial<AddTokenData> = $state(initialTokenData());
 
 	$effect(() => {
-		if (initializedIcrc7ReviewStep || icrc7CanisterId === undefined || modal === undefined) {
+		if (initializedIcrc7ReviewStep || isNullish(icrc7CanisterId) || isNullish(modal)) {
 			return;
 		}
 

--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -72,7 +72,7 @@
 		const action = icrc7DeepLinkAction;
 
 		if (
-			action === undefined ||
+			isNullish(action) ||
 			action.type === 'ready' ||
 			handledIcrc7DeepLinkCanisterIds.has(action.canisterId)
 		) {

--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { SvelteSet } from 'svelte/reactivity';
+	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import { page } from '$app/state';
 	import { EARNING_ENABLED } from '$env/earning';
-	import { icrc7CustomTokensNotInitialized, icrc7Tokens } from '$icp/derived/icrc7.derived';
-	import { resolveIcrc7CollectionDeepLinkAction } from '$icp/services/icrc7-deep-link.services';
 	import EarningsList from '$lib/components/earning/EarningsList.svelte';
 	import GoToEarnButton from '$lib/components/earning/GoToEarnButton.svelte';
 	import ManageTokensModal from '$lib/components/manage/ManageTokensModal.svelte';
@@ -24,14 +21,13 @@
 	import StickyHeader from '$lib/components/ui/StickyHeader.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
-	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalManageTokens, modalManageTokensData } from '$lib/derived/modal.derived';
 	import { routeCollection, routeNetwork, routeNft } from '$lib/derived/nav.derived';
 	import { PLAUSIBLE_EVENTS } from '$lib/enums/plausible';
 	import { TokenTypes } from '$lib/enums/token-types';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
 	import { activeAssetsTabStore } from '$lib/stores/settings.store';
+	import type { ManageTokensData } from '$lib/types/manage-tokens';
 
 	interface Props {
 		tab: TokenTypes;
@@ -44,61 +40,12 @@
 	// svelte-ignore state_referenced_locally -- we want to get only the initial value
 	let activeTab = $state(tab);
 
-	const icrc7DeepLinkManageTokensId = Symbol();
-	const handledIcrc7DeepLinkCanisterIds = new SvelteSet<string>();
-
-	let { icrc7CanisterId, initialSearch, message } = $derived(
-		nonNullish($modalManageTokensData)
-			? $modalManageTokensData
-			: { icrc7CanisterId: undefined, initialSearch: undefined, message: undefined }
+	let { initialSearch, message, initialNetwork, initialTokenData, initialStep } = $derived(
+		nonNullish($modalManageTokensData) ? $modalManageTokensData : ({} as ManageTokensData)
 	);
-
-	const icrc7DeepLinkAction = $derived.by(() => {
-		if (tab !== TokenTypes.NFTS || isNullish($authIdentity) || $icrc7CustomTokensNotInitialized) {
-			return undefined;
-		}
-
-		return resolveIcrc7CollectionDeepLinkAction({
-			url: page.url,
-			tokens: $icrc7Tokens
-		});
-	});
 
 	$effect(() => {
 		activeAssetsTabStore.set({ key: 'active-assets-tab', value: activeTab });
-	});
-
-	$effect(() => {
-		const action = icrc7DeepLinkAction;
-
-		if (
-			isNullish(action) ||
-			action.type === 'ready' ||
-			handledIcrc7DeepLinkCanisterIds.has(action.canisterId)
-		) {
-			return;
-		}
-
-		handledIcrc7DeepLinkCanisterIds.add(action.canisterId);
-
-		if (action.type === 'import') {
-			modalStore.openManageTokens({
-				id: icrc7DeepLinkManageTokensId,
-				data: {
-					icrc7CanisterId: action.canisterId,
-					initialSearch: action.canisterId
-				}
-			});
-			return;
-		}
-
-		modalStore.openManageTokens({
-			id: icrc7DeepLinkManageTokensId,
-			data: {
-				initialSearch: action.token.name,
-				message: $i18n.transactions.text.token_needs_enabling
-			}
-		});
 	});
 </script>
 
@@ -193,7 +140,7 @@
 {/if}
 
 {#if $modalManageTokens}
-	<ManageTokensModal {icrc7CanisterId} {initialSearch}>
+	<ManageTokensModal {initialNetwork} {initialSearch} {initialStep} {initialTokenData}>
 		{#snippet infoElement()}
 			{#if nonNullish(message)}
 				<MessageBox level="info">

--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { fade } from 'svelte/transition';
 	import { page } from '$app/state';
 	import { EARNING_ENABLED } from '$env/earning';
+	import { icrc7CustomTokensNotInitialized, icrc7Tokens } from '$icp/derived/icrc7.derived';
+	import { resolveIcrc7CollectionDeepLinkAction } from '$icp/services/icrc7-deep-link.services';
 	import EarningsList from '$lib/components/earning/EarningsList.svelte';
 	import GoToEarnButton from '$lib/components/earning/GoToEarnButton.svelte';
 	import ManageTokensModal from '$lib/components/manage/ManageTokensModal.svelte';
@@ -21,11 +24,13 @@
 	import StickyHeader from '$lib/components/ui/StickyHeader.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalManageTokens, modalManageTokensData } from '$lib/derived/modal.derived';
 	import { routeCollection, routeNetwork, routeNft } from '$lib/derived/nav.derived';
 	import { PLAUSIBLE_EVENTS } from '$lib/enums/plausible';
 	import { TokenTypes } from '$lib/enums/token-types';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
 	import { activeAssetsTabStore } from '$lib/stores/settings.store';
 
 	interface Props {
@@ -39,14 +44,61 @@
 	// svelte-ignore state_referenced_locally -- we want to get only the initial value
 	let activeTab = $state(tab);
 
-	let { initialSearch, message } = $derived(
+	const icrc7DeepLinkManageTokensId = Symbol();
+	const handledIcrc7DeepLinkCanisterIds = new SvelteSet<string>();
+
+	let { icrc7CanisterId, initialSearch, message } = $derived(
 		nonNullish($modalManageTokensData)
 			? $modalManageTokensData
-			: { initialSearch: undefined, message: undefined }
+			: { icrc7CanisterId: undefined, initialSearch: undefined, message: undefined }
 	);
+
+	const icrc7DeepLinkAction = $derived.by(() => {
+		if (tab !== TokenTypes.NFTS || isNullish($authIdentity) || $icrc7CustomTokensNotInitialized) {
+			return undefined;
+		}
+
+		return resolveIcrc7CollectionDeepLinkAction({
+			url: page.url,
+			tokens: $icrc7Tokens
+		});
+	});
 
 	$effect(() => {
 		activeAssetsTabStore.set({ key: 'active-assets-tab', value: activeTab });
+	});
+
+	$effect(() => {
+		const action = icrc7DeepLinkAction;
+
+		if (
+			action === undefined ||
+			action.type === 'ready' ||
+			handledIcrc7DeepLinkCanisterIds.has(action.canisterId)
+		) {
+			return;
+		}
+
+		handledIcrc7DeepLinkCanisterIds.add(action.canisterId);
+
+		if (action.type === 'import') {
+			modalStore.openManageTokens({
+				id: icrc7DeepLinkManageTokensId,
+				data: {
+					icrc7CanisterId: action.canisterId,
+					initialSearch: action.canisterId
+				}
+			});
+			return;
+		}
+
+		modalStore.openManageTokens({
+			id: icrc7DeepLinkManageTokensId,
+			data: {
+				initialSearch: action.token.name,
+				message: $i18n.transactions.text.token_needs_enabling
+			}
+		});
 	});
 </script>
 
@@ -138,16 +190,16 @@
 			{/if}
 		</div>
 	</div>
+{/if}
 
-	{#if $modalManageTokens}
-		<ManageTokensModal {initialSearch}>
-			{#snippet infoElement()}
-				{#if nonNullish(message)}
-					<MessageBox level="info">
-						{message}
-					</MessageBox>
-				{/if}
-			{/snippet}
-		</ManageTokensModal>
-	{/if}
+{#if $modalManageTokens}
+	<ManageTokensModal {icrc7CanisterId} {initialSearch}>
+		{#snippet infoElement()}
+			{#if nonNullish(message)}
+				<MessageBox level="info">
+					{message}
+				</MessageBox>
+			{/if}
+		{/snippet}
+	</ManageTokensModal>
 {/if}

--- a/src/frontend/src/lib/types/manage-tokens.ts
+++ b/src/frontend/src/lib/types/manage-tokens.ts
@@ -1,5 +1,11 @@
+import type { AddTokenData } from '$icp-eth/types/add-token';
+import type { WizardStepsManageTokens } from '$lib/enums/wizard-steps';
+import type { Network } from '$lib/types/network';
+
 export interface ManageTokensData {
 	initialSearch?: string;
 	message?: string;
-	icrc7CanisterId?: string;
+	initialNetwork?: Network;
+	initialTokenData?: Partial<AddTokenData>;
+	initialStep?: WizardStepsManageTokens;
 }

--- a/src/frontend/src/lib/types/manage-tokens.ts
+++ b/src/frontend/src/lib/types/manage-tokens.ts
@@ -1,4 +1,5 @@
 export interface ManageTokensData {
-	initialSearch: string;
+	initialSearch?: string;
 	message?: string;
+	icrc7CanisterId?: string;
 }

--- a/src/frontend/src/routes/(app)/nfts/+page.svelte
+++ b/src/frontend/src/routes/(app)/nfts/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import IcIcrc7DeepLinkHandler from '$icp/components/tokens/IcIcrc7DeepLinkHandler.svelte';
 	import Assets from '$lib/components/tokens/Assets.svelte';
 	import { TokenTypes } from '$lib/enums/token-types';
 </script>
 
+<IcIcrc7DeepLinkHandler />
 <Assets tab={TokenTypes.NFTS} />

--- a/src/frontend/src/tests/icp/services/icrc7-deep-link.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc7-deep-link.services.spec.ts
@@ -1,31 +1,34 @@
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
-import { parseIcrc7CollectionDeepLink } from '$icp/services/icrc7-deep-link.services';
+import {
+	parseIcrc7CollectionDeepLink,
+	resolveIcrc7CollectionDeepLinkAction
+} from '$icp/services/icrc7-deep-link.services';
 import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
-import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
+import { mockIcrc7CanisterId, mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 import { nonNullish } from '@dfinity/utils';
 
 describe('icrc7-deep-link.services', () => {
+	const urlWithParams = ({
+		collection,
+		network
+	}: {
+		collection?: string;
+		network?: string;
+	}): URL => {
+		const url = new URL('https://oisy.com/nfts/');
+
+		if (nonNullish(collection)) {
+			url.searchParams.set(COLLECTION_PARAM, collection);
+		}
+
+		if (nonNullish(network)) {
+			url.searchParams.set(NETWORK_PARAM, network);
+		}
+
+		return url;
+	};
+
 	describe('parseIcrc7CollectionDeepLink', () => {
-		const urlWithParams = ({
-			collection,
-			network
-		}: {
-			collection?: string;
-			network?: string;
-		}): URL => {
-			const url = new URL('https://oisy.com/nfts/');
-
-			if (nonNullish(collection)) {
-				url.searchParams.set(COLLECTION_PARAM, collection);
-			}
-
-			if (nonNullish(network)) {
-				url.searchParams.set(NETWORK_PARAM, network);
-			}
-
-			return url;
-		};
-
 		it('should parse a valid ICP collection deep link', () => {
 			expect(
 				parseIcrc7CollectionDeepLink({
@@ -63,6 +66,61 @@ describe('icrc7-deep-link.services', () => {
 			expect(
 				parseIcrc7CollectionDeepLink({
 					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ETH' })
+				})
+			).toBeUndefined();
+		});
+	});
+
+	describe('resolveIcrc7CollectionDeepLinkAction', () => {
+		const enabledToken = { ...mockValidIcrc7Token, enabled: true };
+		const disabledToken = { ...mockValidIcrc7Token, enabled: false };
+
+		it('should return import action when collection is unknown', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: []
+				})
+			).toEqual({
+				type: 'import',
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
+		});
+
+		it('should return enable action when collection is known but disabled', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: [disabledToken]
+				})
+			).toEqual({
+				type: 'enable',
+				token: disabledToken,
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
+		});
+
+		it('should return ready action when collection is already enabled', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: [enabledToken]
+				})
+			).toEqual({
+				type: 'ready',
+				token: enabledToken,
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
+		});
+
+		it('should return undefined for invalid deep links', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ETH' }),
+					tokens: [enabledToken]
 				})
 			).toBeUndefined();
 		});


### PR DESCRIPTION
# Motivation

Let `/nfts/?collection=<canister>&network=ICP` continue into the existing ICRC-7 NFT collection enable/import flow instead of landing on an unloaded collection screen.

# Changes

- Resolve ICRC-7 collection deep links into ready, enable, or import actions.
- Open the NFT manage modal from collection routes, filtering known disabled collections or preloading unknown collections into the ICRC-7 review step.

# Tests

Added tests.
