### PR TITLE
fix(frontend): move ICP transactions info box below the Transactions header

### DIFF
--- a/src/frontend/src/btc/components/transactions/BtcTransactionsHeader.svelte
+++ b/src/frontend/src/btc/components/transactions/BtcTransactionsHeader.svelte
@@ -13,7 +13,7 @@
 	let isNetworkMainnet = $derived(isNetworkIdBTCMainnet($networkId));
 </script>
 
-<div class="mb-6">
+<div class="mb-4">
 	<div class="flex items-center">
 		<h2 class="text-base">{$i18n.transactions.text.title}</h2>
 

--- a/src/frontend/src/icp/components/transactions/IcTransactions.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactions.svelte
@@ -70,10 +70,6 @@
 
 <Info />
 
-{#if !noTransactions}
-	<HiddenMicroTransactionsInfoBox />
-{/if}
-
 <Header>
 	{$i18n.transactions.text.title}
 
@@ -87,6 +83,10 @@
 		</IcIndexCanisterStatus>
 	{/snippet}
 </Header>
+
+{#if !noTransactions}
+	<HiddenMicroTransactionsInfoBox />
+{/if}
 
 <IcTransactionsSkeletons>
 	{#if filteredTransactions.length > 0}

--- a/src/frontend/src/lib/components/ui/Header.svelte
+++ b/src/frontend/src/lib/components/ui/Header.svelte
@@ -9,7 +9,7 @@
 	let { children, end }: Props = $props();
 </script>
 
-<div class="mb-6 flex items-center justify-between pb-1">
+<div class="mb-4 flex items-center justify-between">
 	<h2 class="text-base">{@render children()}</h2>
 
 	{@render end?.()}


### PR DESCRIPTION
# Motivation

Two small, related fixes to the per-token transactions view (`/transactions/...`):

1. The hidden-micro-transactions info box renders **above** the "Transactions" header for ICP/ICRC tokens, but **below** the header for BTC, ETH and SOL. Below reads better (header first, then the hint that qualifies the list under it) and matches what every other token type already does.
2. Once the box is moved below the header it becomes visually bottom-heavy: the shared `Header` had `mb-6` + an inner `pb-1` (~28px below the title text) while `MessageBox` has `mb-4` (16px). `BtcTransactionsHeader` had the same `mb-6` asymmetry. Centering the box at 16/16 reads better.

|IC|EVM|BTC|
|---|---|---|
|<img width="607" height="773" alt="image" src="https://github.com/user-attachments/assets/310d004f-a86a-474e-95fc-5e122731b016" />|<img width="607" height="773" alt="image" src="https://github.com/user-attachments/assets/dbe3b529-28e2-4901-b477-9b0a4da12f2a" />|<img width="607" height="773" alt="image" src="https://github.com/user-attachments/assets/3fdb6855-db6d-4b9c-a7ff-7c7fd556cbd1" />|
|<img width="607" height="773" alt="image" src="https://github.com/user-attachments/assets/d5c11444-8cc3-4c77-a3bc-ca282bfa48a3" />|


# Changes

- `IcTransactions.svelte`: moved `<HiddenMicroTransactionsInfoBox />` (with its `{#if !noTransactions}` guard) from above the `<Header>` to below it. No behavior change.
- `lib/components/ui/Header.svelte`: outer wrapper `mb-6` → `mb-4`, and dropped the inner `pb-1`. The flex row already uses `items-center`, so the inner padding was only nudging the container, not affecting the title text. Shared component is only imported by `IcTransactions` / `EthTransactions` / `SolTransactions`, so the change stays within the per-token transactions views.
- `btc/components/transactions/BtcTransactionsHeader.svelte`: outer wrapper `mb-6` → `mb-4` for the same symmetry on BTC. Inner collapsible info text is unchanged.

# Tests

- All 9 transaction-view test files pass (56/56):
  ```
  npx vitest run \
    src/frontend/src/tests/icp/components/transactions/IcTransactions.spec.ts \
    src/frontend/src/tests/eth/components/transactions/ \
    src/frontend/src/tests/sol/components/transactions/ \
    src/frontend/src/tests/btc/components/transactions/
  ```
- `npx vitest run src/frontend/src/tests/lib/components/transactions/HiddenMicroTransactionsInfoBox.spec.ts` → 5/5 pass
- `npm run format:file` clean on all three touched files
- `npm run check`: only failures are 9 pre-existing TS errors in `src/frontend/src/sol/utils/sol-instructions-token.utils.ts` from the recent `@solana-program/token` 0.12 → 0.13 bump on `main` (commit 1ce6d21ac, #12710), unrelated to this change.
- Deployed to `test_fe_3` (https://dxvmu-wiaaa-aaaah-aqzaa-cai.icp0.io) for visual verification.

|IC|EVM|BTC|
|---|---|---|
|<img width="607" height="773" alt="image" src="https://github.com/user-attachments/assets/057ee477-74cf-47cd-9b6d-0fc11bc73fca" />|<img width="607" height="773" alt="image" src="https://github.com/user-attachments/assets/1cd27805-4046-44de-8508-fc7398f89c1d" />|<img width="607" height="773" alt="image" src="https://github.com/user-attachments/assets/dfbf7319-dcde-459f-b226-4b47c32599c9" />|
|<img width="607" height="773" alt="image" src="https://github.com/user-attachments/assets/48a7216f-aec7-4636-8adb-07df84759a45" />|

🤖 Claude Opus 4.7