### PR TITLE
feat(frontend): finish Icrc7 NFT integration

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransaction.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransaction.svelte
@@ -27,7 +27,8 @@
 		to,
 		from,
 		fee,
-		approveSpender
+		approveSpender,
+		tokenId
 	} = $derived(transaction);
 
 	let pending = $derived(transaction?.status === 'pending');
@@ -78,6 +79,7 @@
 	{timestamp}
 	to={listTo}
 	{token}
+	{tokenId}
 	{type}
 >
 	<IcTransactionLabel amount={value} label={transactionTypeLabel} {token} {type} />

--- a/src/frontend/src/icp/services/ic-transactions.services.ts
+++ b/src/frontend/src/icp/services/ic-transactions.services.ts
@@ -1,15 +1,20 @@
 import { getTransactions as getTransactionsIcp } from '$icp/api/icp-index.api';
 import { getTransactions as getTransactionsIcrc } from '$icp/api/icrc-index-ng.api';
+import { loadIcrc3BlockLog } from '$icp/services/icrc3.services';
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import type { IcCanistersStrict, IcToken } from '$icp/types/ic-token';
 import type { IcTransaction, IcTransactionUi } from '$icp/types/ic-transaction';
+import type { Icrc7Token } from '$icp/types/icrc7-token';
 import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
 import { mapIcTransaction } from '$icp/utils/ic-transactions.utils';
 import { mapTransactionIcpToSelf } from '$icp/utils/icp-transactions.utils';
 import { mapTransactionIcrcToSelf } from '$icp/utils/icrc-transactions.utils';
 import { isTokenIcrc } from '$icp/utils/icrc.utils';
+import { mapIcrc7BlockToTransactions } from '$icp/utils/icrc7-transactions.utils';
+import { isTokenIcrc7 } from '$icp/utils/icrc7.utils';
 import { isNotIcToken, isNotIcTokenCanistersStrict } from '$icp/validation/ic-token.validation';
 import { TRACK_COUNT_IC_LOADING_TRANSACTIONS_ERROR } from '$lib/constants/analytics.constants';
+import { WALLET_PAGINATION, ZERO } from '$lib/constants/app.constants';
 import {
 	PLAUSIBLE_EVENT_CONTEXTS,
 	PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS,
@@ -96,6 +101,106 @@ const loadNextIcTransactionsRequest = ({
 		identity
 	});
 
+const loadIcrc7TransactionsPage = async ({
+	token,
+	identity,
+	certified,
+	lastId,
+	maxResults
+}: {
+	token: Icrc7Token;
+	identity: NullishIdentity;
+	certified?: boolean;
+	lastId?: string;
+	maxResults?: bigint;
+}): Promise<{ transactions: IcTransactionUi[]; reachedStart: boolean }> => {
+	const length = maxResults ?? WALLET_PAGINATION;
+	let cursorEnd: bigint;
+
+	if (nonNullish(lastId)) {
+		cursorEnd = BigInt(lastId);
+	} else {
+		const { logLength } = await loadIcrc3BlockLog({
+			identity,
+			canisterId: token.canisterId,
+			start: ZERO,
+			length: ZERO,
+			certified
+		});
+		cursorEnd = logLength;
+	}
+
+	while (cursorEnd > ZERO) {
+		const start = cursorEnd > length ? cursorEnd - length : ZERO;
+		const { blocks } = await loadIcrc3BlockLog({
+			identity,
+			canisterId: token.canisterId,
+			start,
+			length: cursorEnd - start,
+			certified
+		});
+
+		const transactions = blocks
+			.toReversed()
+			.flatMap((block) => mapIcrc7BlockToTransactions({ block, identity }));
+
+		if (transactions.length > 0 || start === ZERO) {
+			return { transactions, reachedStart: start === ZERO };
+		}
+
+		cursorEnd = start;
+	}
+
+	return { transactions: [], reachedStart: true };
+};
+
+const loadNextIcrc7TransactionsRequest = ({
+	token,
+	identity,
+	signalEnd,
+	lastId,
+	maxResults
+}: {
+	identity: NullishIdentity;
+	lastId?: string;
+	maxResults?: bigint;
+	token: Icrc7Token;
+	signalEnd: () => void;
+}): Promise<void> =>
+	queryAndUpdate<{ transactions: IcTransactionUi[]; reachedStart: boolean }>({
+		request: ({ certified }) =>
+			loadIcrc7TransactionsPage({
+				token,
+				identity,
+				lastId,
+				maxResults,
+				certified
+			}),
+		onLoad: ({ response: { transactions, reachedStart }, certified }) => {
+			if (transactions.length === 0) {
+				if (reachedStart) {
+					signalEnd();
+				}
+				return;
+			}
+
+			icTransactionsStore.append({
+				tokenId: token.id,
+				transactions: transactions.map((transaction) => ({ data: transaction, certified }))
+			});
+
+			if (reachedStart) {
+				signalEnd();
+			}
+		},
+		onUpdateError: ({ error }) => {
+			onLoadTransactionsError({ tokenId: token.id, error });
+
+			signalEnd();
+		},
+		identity
+	});
+
 export const onLoadTransactionsError = ({
 	tokenId,
 	error: err
@@ -166,7 +271,20 @@ export const loadNextIcTransactions = async ({
 		return;
 	}
 
-	if (isNotIcToken(token) || isNotIcTokenCanistersStrict(token)) {
+	if (isTokenIcrc7(token)) {
+		await loadNextIcrc7TransactionsRequest({
+			lastId: lastIdCleaned,
+			token,
+			...rest
+		});
+		return;
+	}
+
+	if (isNotIcToken(token)) {
+		return;
+	}
+
+	if (isNotIcTokenCanistersStrict(token)) {
 		// On one hand, we assume that the parent component does not mount this component if no transactions can be fetched; on the other hand, we want to avoid displaying an error toast that could potentially appear multiple times.
 		// Therefore, we do not particularly display a visual error. In any case, we cannot load transactions without an Index canister.
 		return;

--- a/src/frontend/src/icp/services/icrc3.services.ts
+++ b/src/frontend/src/icp/services/icrc3.services.ts
@@ -1,0 +1,80 @@
+import type { GetBlocksResult, Value } from '$declarations/icrc3/icrc3.did';
+import { getBlocks } from '$icp/api/icrc3.api';
+import type { CanisterIdText } from '$lib/types/canister';
+import type { NullishIdentity } from '$lib/types/identity';
+import { nonNullish, type QueryParams } from '@dfinity/utils';
+
+export interface Icrc3Block {
+	id: bigint;
+	block: Value;
+}
+
+export interface LoadIcrc3BlockLogParams extends QueryParams {
+	identity: NullishIdentity;
+	canisterId: CanisterIdText;
+	start: bigint;
+	length: bigint;
+}
+
+export interface LoadIcrc3BlockLogResult {
+	logLength: bigint;
+	blocks: Icrc3Block[];
+}
+
+const compareIcrc3BlockIds = ({ a, b }: { a: Icrc3Block; b: Icrc3Block }): number =>
+	a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+
+const loadArchivedBlocks = async ({
+	identity,
+	certified,
+	archivedBlocks
+}: {
+	identity: NullishIdentity;
+	certified?: boolean;
+	archivedBlocks: GetBlocksResult['archived_blocks'];
+}): Promise<Icrc3Block[]> => {
+	const responses = await Promise.all(
+		archivedBlocks
+			.filter(({ callback: [, method] }) => method === 'icrc3_get_blocks')
+			.map(async ({ callback: [archiveCanisterId], args }) => {
+				const { blocks } = await getBlocks({
+					identity,
+					canisterId: archiveCanisterId.toText(),
+					certified,
+					args
+				});
+
+				return blocks;
+			})
+	);
+
+	return responses.flat();
+};
+
+export const loadIcrc3BlockLog = async ({
+	identity,
+	canisterId,
+	start,
+	length,
+	certified
+}: LoadIcrc3BlockLogParams): Promise<LoadIcrc3BlockLogResult> => {
+	const {
+		blocks,
+		archived_blocks: archivedBlocks,
+		log_length: logLength
+	} = await getBlocks({
+		identity,
+		canisterId,
+		certified,
+		args: [{ start, length }]
+	});
+
+	const archived = nonNullish(archivedBlocks)
+		? await loadArchivedBlocks({ identity, certified, archivedBlocks })
+		: [];
+
+	return {
+		logLength,
+		blocks: [...blocks, ...archived].sort((a, b) => compareIcrc3BlockIds({ a, b }))
+	};
+};

--- a/src/frontend/src/icp/services/icrc7-deep-link.services.ts
+++ b/src/frontend/src/icp/services/icrc7-deep-link.services.ts
@@ -3,6 +3,7 @@ import type { Icrc7CustomToken } from '$icp/types/icrc7-custom-token';
 import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
 import { CanisterIdTextSchema, type CanisterIdText } from '$lib/types/canister';
 import type { NetworkId } from '$lib/types/network';
+import { isNullish } from '@dfinity/utils';
 
 export interface Icrc7CollectionDeepLink {
 	canisterId: CanisterIdText;
@@ -47,13 +48,13 @@ export const resolveIcrc7CollectionDeepLinkAction = ({
 }): Icrc7CollectionDeepLinkAction | undefined => {
 	const deepLink = parseIcrc7CollectionDeepLink({ url });
 
-	if (deepLink === undefined) {
+	if (isNullish(deepLink)) {
 		return;
 	}
 
 	const token = tokens.find(({ canisterId }) => canisterId === deepLink.canisterId);
 
-	if (token === undefined) {
+	if (isNullish(token)) {
 		return { type: 'import', ...deepLink };
 	}
 

--- a/src/frontend/src/icp/services/icrc7-deep-link.services.ts
+++ b/src/frontend/src/icp/services/icrc7-deep-link.services.ts
@@ -1,4 +1,5 @@
 import { ICP_NETWORK_ID, ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
+import type { Icrc7CustomToken } from '$icp/types/icrc7-custom-token';
 import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
 import { CanisterIdTextSchema, type CanisterIdText } from '$lib/types/canister';
 import type { NetworkId } from '$lib/types/network';
@@ -7,6 +8,11 @@ export interface Icrc7CollectionDeepLink {
 	canisterId: CanisterIdText;
 	networkId: NetworkId;
 }
+
+export type Icrc7CollectionDeepLinkAction =
+	| ({ type: 'import' } & Icrc7CollectionDeepLink)
+	| ({ type: 'enable'; token: Icrc7CustomToken } & Icrc7CollectionDeepLink)
+	| ({ type: 'ready'; token: Icrc7CustomToken } & Icrc7CollectionDeepLink);
 
 export const parseIcrc7CollectionDeepLink = ({
 	url
@@ -30,4 +36,26 @@ export const parseIcrc7CollectionDeepLink = ({
 		canisterId: parsedCollection.data,
 		networkId: ICP_NETWORK_ID
 	};
+};
+
+export const resolveIcrc7CollectionDeepLinkAction = ({
+	url,
+	tokens
+}: {
+	url: URL;
+	tokens: Icrc7CustomToken[];
+}): Icrc7CollectionDeepLinkAction | undefined => {
+	const deepLink = parseIcrc7CollectionDeepLink({ url });
+
+	if (deepLink === undefined) {
+		return;
+	}
+
+	const token = tokens.find(({ canisterId }) => canisterId === deepLink.canisterId);
+
+	if (token === undefined) {
+		return { type: 'import', ...deepLink };
+	}
+
+	return { type: token.enabled ? 'ready' : 'enable', token, ...deepLink };
 };

--- a/src/frontend/src/icp/services/nft.services.ts
+++ b/src/frontend/src/icp/services/nft.services.ts
@@ -1,21 +1,24 @@
 import { getTokensByOwner as getDip721TokensByOwner } from '$icp/api/dip721.api';
 import { getTokensByOwner as getExtTokensByOwner } from '$icp/api/ext-v2-token.api';
 import { getTokensByOwner as getIcPunksTokensByOwner } from '$icp/api/icpunks.api';
+import { getTokensByOwner as getIcrc7TokensByOwner } from '$icp/api/icrc7.api';
 import type { Dip721Token } from '$icp/types/dip721-token';
 import type { ExtToken } from '$icp/types/ext-token';
 import type { IcPunksToken } from '$icp/types/icpunks-token';
+import type { Icrc7Token } from '$icp/types/icrc7-token';
 import type { IcNonFungibleToken } from '$icp/types/nft';
 import { isTokenDip721 } from '$icp/utils/dip721.utils';
 import { isTokenExt } from '$icp/utils/ext.utils';
 import { isTokenIcPunks } from '$icp/utils/icpunks.utils';
-import { mapDip721Nft, mapExtNft, mapIcPunksNft } from '$icp/utils/nft.utils';
+import { isTokenIcrc7 } from '$icp/utils/icrc7.utils';
+import { mapDip721Nft, mapExtNft, mapIcPunksNft, mapIcrc7Nft } from '$icp/utils/nft.utils';
 import { TRACK_COUNT_IC_LOADING_NFTS_FROM_COLLECTION_ERROR } from '$lib/constants/analytics.constants';
 import { trackEvent } from '$lib/services/analytics.services';
 import type { NullishIdentity } from '$lib/types/identity';
 import type { Nft } from '$lib/types/nft';
 import type { Token } from '$lib/types/token';
 import { mapIcErrorMetadata } from '$lib/utils/error.utils';
-import { assertNever, isNullish, type QueryParams } from '@dfinity/utils';
+import { assertNever, isNullish, toNullable, type QueryParams } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 
 const loadExtNfts = async ({
@@ -126,6 +129,44 @@ const loadIcPunksNfts = async ({
 	}
 };
 
+const loadIcrc7Nfts = async ({
+	token,
+	identity,
+	certified
+}: {
+	token: Icrc7Token;
+	identity: Identity;
+} & QueryParams) => {
+	const {
+		canisterId,
+		standard: { code: standard }
+	} = token;
+
+	const owner = { owner: identity.getPrincipal(), subaccount: toNullable<Uint8Array>() };
+
+	try {
+		const tokenIndices = await getIcrc7TokensByOwner({
+			identity,
+			owner,
+			canisterId,
+			certified
+		});
+
+		const promises = tokenIndices.map(
+			async (index) => await mapIcrc7Nft({ index, token, identity, certified })
+		);
+
+		return await Promise.all(promises);
+	} catch (err: unknown) {
+		trackEvent({
+			name: TRACK_COUNT_IC_LOADING_NFTS_FROM_COLLECTION_ERROR,
+			metadata: { ...(mapIcErrorMetadata(err) ?? {}), canisterId, standard }
+		});
+
+		return [];
+	}
+};
+
 export const loadNfts = async ({
 	tokens,
 	identity,
@@ -149,6 +190,10 @@ export const loadNfts = async ({
 
 		if (isTokenIcPunks(token)) {
 			return await loadIcPunksNfts({ token, identity, certified });
+		}
+
+		if (isTokenIcrc7(token)) {
+			return await loadIcrc7Nfts({ token, identity, certified });
 		}
 
 		assertNever(token, `Unsupported NFT IC token ${(token as Token).standard.code}`);

--- a/src/frontend/src/icp/types/ic-transaction.ts
+++ b/src/frontend/src/icp/types/ic-transaction.ts
@@ -50,6 +50,7 @@ export interface IcTransactionUi {
 	timestamp?: bigint;
 	status: IcTransactionStatus;
 	txExplorerUrl?: string;
+	tokenId?: bigint;
 	approveSpender?: string;
 	approveSpenderExplorerUrl?: string;
 	approveExpiresAt?: bigint;

--- a/src/frontend/src/icp/utils/icrc7-transactions.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7-transactions.utils.ts
@@ -1,0 +1,221 @@
+import type { Value } from '$declarations/icrc3/icrc3.did';
+import type { Icrc3Block } from '$icp/services/icrc3.services';
+import type { IcTransactionUi } from '$icp/types/ic-transaction';
+import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
+import type { NullishIdentity } from '$lib/types/identity';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import {
+	encodeIcrcAccount,
+	fromCandidAccount,
+	type IcrcIndexDid
+} from '@icp-sdk/canisters/ledger/icrc';
+import { Principal } from '@icp-sdk/core/principal';
+
+type Icrc7BlockType = '7mint' | '7burn' | '7xfer';
+
+interface ParsedIcrc7Block {
+	id: bigint;
+	type: Icrc7BlockType;
+	timestamp?: bigint;
+	tokenId: bigint;
+	from?: string;
+	to?: string;
+}
+
+const lookupMapValue = ({
+	map,
+	key
+}: {
+	map: Array<[string, Value]>;
+	key: string;
+}): Value | undefined => map.find(([entryKey]) => entryKey === key)?.[1];
+
+const valueAsMap = ({ value }: { value: Value | undefined }): Array<[string, Value]> | undefined =>
+	nonNullish(value) && 'Map' in value ? value.Map : undefined;
+
+const valueAsNat = ({ value }: { value: Value | undefined }): bigint | undefined =>
+	nonNullish(value) && 'Nat' in value ? value.Nat : undefined;
+
+const valueAsText = ({ value }: { value: Value | undefined }): string | undefined =>
+	nonNullish(value) && 'Text' in value ? value.Text : undefined;
+
+const valueAsBlob = ({ value }: { value: Value | undefined }): Uint8Array | undefined =>
+	nonNullish(value) && 'Blob' in value ? value.Blob : undefined;
+
+const valueAsIcrc7BlockType = ({
+	value
+}: {
+	value: Value | undefined;
+}): Icrc7BlockType | undefined => {
+	const text = valueAsText({ value });
+
+	return text === '7mint' || text === '7burn' || text === '7xfer' ? text : undefined;
+};
+
+const valueAsPrincipal = ({ value }: { value: Value | undefined }): Principal | undefined => {
+	const text = valueAsText({ value });
+
+	if (nonNullish(text)) {
+		try {
+			return Principal.fromText(text);
+		} catch (_: unknown) {
+			return;
+		}
+	}
+
+	const blob = valueAsBlob({ value });
+
+	return nonNullish(blob) ? Principal.fromUint8Array(blob) : undefined;
+};
+
+const valueAsAccount = ({ value }: { value: Value | undefined }): string | undefined => {
+	const map = valueAsMap({ value });
+
+	if (isNullish(map)) {
+		return valueAsText({ value });
+	}
+
+	const owner = valueAsPrincipal({ value: lookupMapValue({ map, key: 'owner' }) });
+
+	if (isNullish(owner)) {
+		return;
+	}
+
+	const subaccount = valueAsBlob({ value: lookupMapValue({ map, key: 'subaccount' }) });
+	const account: IcrcIndexDid.Account = {
+		owner,
+		subaccount: nonNullish(subaccount) ? [subaccount] : []
+	};
+
+	return encodeIcrcAccount(fromCandidAccount(account));
+};
+
+const parseIcrc7Block = ({ id, block }: Icrc3Block): ParsedIcrc7Block | undefined => {
+	const blockMap = valueAsMap({ value: block });
+
+	if (isNullish(blockMap)) {
+		return;
+	}
+
+	const type = valueAsIcrc7BlockType({ value: lookupMapValue({ map: blockMap, key: 'btype' }) });
+	const txMap = valueAsMap({ value: lookupMapValue({ map: blockMap, key: 'tx' }) });
+
+	if (isNullish(type) || isNullish(txMap)) {
+		return;
+	}
+
+	const tokenId =
+		valueAsNat({ value: lookupMapValue({ map: txMap, key: 'tid' }) }) ??
+		valueAsNat({ value: lookupMapValue({ map: txMap, key: 'token_id' }) });
+
+	if (isNullish(tokenId)) {
+		return;
+	}
+
+	return {
+		id,
+		type,
+		timestamp: valueAsNat({ value: lookupMapValue({ map: blockMap, key: 'ts' }) }),
+		tokenId,
+		from: valueAsAccount({ value: lookupMapValue({ map: txMap, key: 'from' }) }),
+		to: valueAsAccount({ value: lookupMapValue({ map: txMap, key: 'to' }) })
+	};
+};
+
+const mapIcrc7Transfer = ({
+	transaction,
+	accountIdentifier
+}: {
+	transaction: ParsedIcrc7Block;
+	accountIdentifier: string;
+}): IcTransactionUi[] => {
+	const { id, timestamp, tokenId, from, to } = transaction;
+	const isSender = from?.toLowerCase() === accountIdentifier.toLowerCase();
+	const isReceiver = to?.toLowerCase() === accountIdentifier.toLowerCase();
+
+	return [
+		...(isSender
+			? [
+					{
+						id: id.toString(),
+						type: 'send' as const,
+						from,
+						to,
+						incoming: false,
+						timestamp,
+						status: 'executed' as const,
+						tokenId
+					}
+				]
+			: []),
+		...(isReceiver
+			? [
+					{
+						id: `${id.toString()}${isSender ? '-self' : ''}`,
+						type: 'receive' as const,
+						from,
+						to,
+						incoming: true,
+						timestamp,
+						status: 'executed' as const,
+						tokenId
+					}
+				]
+			: [])
+	];
+};
+
+export const mapIcrc7BlockToTransactions = ({
+	block,
+	identity
+}: {
+	block: Icrc3Block;
+	identity: NullishIdentity;
+}): IcTransactionUi[] => {
+	if (isNullish(identity)) {
+		return [];
+	}
+
+	const transaction = parseIcrc7Block(block);
+
+	if (isNullish(transaction)) {
+		return [];
+	}
+
+	const accountIdentifier = encodeIcrcAccount(getIcrcAccount(identity.getPrincipal()));
+	const { id, type, timestamp, tokenId, from, to } = transaction;
+
+	if (type === '7xfer') {
+		return mapIcrc7Transfer({ transaction, accountIdentifier });
+	}
+
+	if (type === '7mint' && to?.toLowerCase() === accountIdentifier.toLowerCase()) {
+		return [
+			{
+				id: id.toString(),
+				type: 'mint',
+				to,
+				incoming: true,
+				timestamp,
+				status: 'executed',
+				tokenId
+			}
+		];
+	}
+
+	if (type === '7burn' && from?.toLowerCase() === accountIdentifier.toLowerCase()) {
+		return [
+			{
+				id: id.toString(),
+				type: 'burn',
+				from,
+				incoming: false,
+				timestamp,
+				status: 'executed',
+				tokenId
+			}
+		];
+	}
+
+	return [];
+};

--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -56,6 +56,14 @@ const ICRC7_TOKEN_IMAGE_KEYS = [
 	'image',
 	'image_url'
 ];
+const ICRC7_TOKEN_THUMBNAIL_KEYS = [
+	'icrc7:thumbnail',
+	'icrc7:metadata:thumbnail',
+	'icrc7:thumbnail_url',
+	'icrc7:metadata:thumbnail_url',
+	'thumbnail',
+	'thumbnail_url'
+];
 const ICRC7_TOKEN_ATTRIBUTES_KEYS = ['icrc7:attributes', 'icrc7:metadata:attributes', 'attributes'];
 
 const lookupText = ({
@@ -88,6 +96,86 @@ const valueToString = ({ value }: { value: Value }): string | undefined => {
 	if ('Int' in value) {
 		return value.Int.toString();
 	}
+};
+
+const uint8ArrayToBase64 = (value: Uint8Array): string => {
+	let binary = '';
+	const chunkSize = 0x8000;
+
+	for (let i = 0; i < value.length; i += chunkSize) {
+		binary += String.fromCharCode(...value.slice(i, i + chunkSize));
+	}
+
+	return btoa(binary);
+};
+
+const blobImageMimeType = (value: Uint8Array): string | undefined => {
+	const [first, second, third, fourth, ...rest] = value;
+
+	if (first === 0xff && second === 0xd8 && third === 0xff) {
+		return 'image/jpeg';
+	}
+
+	if (
+		first === 0x89 &&
+		second === 0x50 &&
+		third === 0x4e &&
+		fourth === 0x47 &&
+		rest[0] === 0x0d &&
+		rest[1] === 0x0a &&
+		rest[2] === 0x1a &&
+		rest[3] === 0x0a
+	) {
+		return 'image/png';
+	}
+
+	if (
+		first === 0x47 &&
+		second === 0x49 &&
+		third === 0x46 &&
+		fourth === 0x38 &&
+		(rest[0] === 0x37 || rest[0] === 0x39) &&
+		rest[1] === 0x61
+	) {
+		return 'image/gif';
+	}
+
+	if (
+		first === 0x52 &&
+		second === 0x49 &&
+		third === 0x46 &&
+		fourth === 0x46 &&
+		rest[4] === 0x57 &&
+		rest[5] === 0x45 &&
+		rest[6] === 0x42 &&
+		rest[7] === 0x50
+	) {
+		return 'image/webp';
+	}
+
+	const text = new TextDecoder().decode(value.slice(0, 256)).trimStart().toLowerCase();
+
+	if (text.startsWith('<svg')) {
+		return 'image/svg+xml';
+	}
+};
+
+const blobToImageDataUrl = ({ value }: { value: Uint8Array }): string | undefined => {
+	const mimeType = blobImageMimeType(value);
+
+	if (isNullish(mimeType)) {
+		return;
+	}
+
+	return `data:${mimeType};base64,${uint8ArrayToBase64(value)}`;
+};
+
+const valueToImageUrl = ({ value }: { value: Value }): string | undefined => {
+	if ('Blob' in value) {
+		return blobToImageDataUrl({ value: value.Blob });
+	}
+
+	return valueToString({ value });
 };
 
 const lookupStringByKeys = ({
@@ -215,13 +303,19 @@ export const mapIcrc7CollectionMetadata = (
 export const mapIcrc7TokenMetadata = (entries: Array<[string, Value]>): NftMetadataWithoutId => {
 	const name = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_NAME_KEYS });
 	const description = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_DESCRIPTION_KEYS });
-	const imageUrl = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_IMAGE_KEYS });
+	const imageEntry = entries.find(([key]) => ICRC7_TOKEN_IMAGE_KEYS.includes(key));
+	const thumbnailEntry = entries.find(([key]) => ICRC7_TOKEN_THUMBNAIL_KEYS.includes(key));
+	const imageUrl = nonNullish(imageEntry) ? valueToImageUrl({ value: imageEntry[1] }) : undefined;
+	const thumbnailUrl = nonNullish(thumbnailEntry)
+		? valueToImageUrl({ value: thumbnailEntry[1] })
+		: undefined;
 	const attributes = lookupAttributesByKeys({ entries, keys: ICRC7_TOKEN_ATTRIBUTES_KEYS });
 
 	return {
 		...(nonNullish(name) && { name }),
 		...(nonNullish(description) && { description }),
 		...(nonNullish(imageUrl) && { imageUrl }),
+		...(nonNullish(thumbnailUrl) && { thumbnailUrl }),
 		...(nonNullish(attributes) && { attributes })
 	};
 };

--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -1,16 +1,19 @@
 import type { TokenIndex } from '$declarations/ext_v2_token/ext_v2_token.did';
 import { metadata as getIcPunksMetadata } from '$icp/api/icpunks.api';
+import { metadata as getIcrc7Metadata } from '$icp/api/icrc7.api';
 import { getExtMetadata } from '$icp/services/ext-metadata.services';
 import type { Dip721Token } from '$icp/types/dip721-token';
 import type { ExtToken } from '$icp/types/ext-token';
 import type { IcPunksToken } from '$icp/types/icpunks-token';
+import type { Icrc7Token } from '$icp/types/icrc7-token';
 import { extIndexToIdentifier, parseExtTokenIndex } from '$icp/utils/ext.utils';
 import { MediaStatusEnum } from '$lib/enums/media-status';
 import type { Nft, NftCollection } from '$lib/types/nft';
 import { mapNftAttributes } from '$lib/utils/nft.utils';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
-import { notEmptyString, type QueryParams } from '@dfinity/utils';
+import { UrlSchema } from '$lib/validation/url.validation';
+import { nonNullish, notEmptyString, type QueryParams } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 
@@ -133,5 +136,77 @@ export const mapIcPunksNft = async ({
 			attributes.map(({ name: trait_type, value }) => ({ trait_type, value }))
 		),
 		collection: mapIcPunksCollection(token)
+	};
+};
+
+const mapIcrc7Collection = ({ canisterId, ...rest }: Icrc7Token): NftCollection => ({
+	...rest,
+	address: canisterId
+});
+
+const isImageDataUrl = (url: string): boolean => {
+	try {
+		const { protocol, pathname } = new URL(url);
+
+		return protocol === 'data:' && pathname.startsWith('image/');
+	} catch (_: unknown) {
+		return false;
+	}
+};
+
+const mapIcrc7MetadataUrl = (url: string | undefined): string | undefined => {
+	if (!notEmptyString(url)) {
+		return;
+	}
+
+	if (isImageDataUrl(url)) {
+		return url;
+	}
+
+	const parsedUrl = UrlSchema.safeParse(url);
+
+	return parsedUrl.success ? parsedUrl.data : undefined;
+};
+
+export const mapIcrc7Nft = async ({
+	index: tokenId,
+	token,
+	identity,
+	certified
+}: {
+	index: bigint;
+	token: Icrc7Token;
+	identity: Identity;
+} & QueryParams): Promise<Nft> => {
+	const { canisterId } = token;
+
+	const metadata =
+		(await getIcrc7Metadata({
+			canisterId,
+			tokenId,
+			identity,
+			certified
+		})) ?? {};
+
+	const { imageUrl: rawImageUrl, thumbnailUrl: rawThumbnailUrl, ...metadataRest } = metadata;
+	const imageUrl = mapIcrc7MetadataUrl(rawImageUrl);
+	const thumbnailUrl = mapIcrc7MetadataUrl(rawThumbnailUrl);
+
+	const mediaStatus = {
+		image: nonNullish(imageUrl)
+			? await getMediaStatusOrCache(imageUrl)
+			: MediaStatusEnum.INVALID_DATA,
+		thumbnail: nonNullish(thumbnailUrl)
+			? await getMediaStatusOrCache(thumbnailUrl)
+			: MediaStatusEnum.INVALID_DATA
+	};
+
+	return {
+		...metadataRest,
+		...(nonNullish(imageUrl) && { imageUrl }),
+		...(nonNullish(thumbnailUrl) && { thumbnailUrl }),
+		id: parseNftId(tokenId.toString()),
+		mediaStatus,
+		collection: mapIcrc7Collection(token)
 	};
 };

--- a/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
@@ -244,7 +244,8 @@
 			modalNext,
 			onSuccess,
 			onError,
-			identity: $authIdentity
+			identity: $authIdentity,
+			tokenManageModifier: 'import'
 		});
 
 	let icrcMetadata: ValidateIcrcTokenData | undefined = $state();

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -120,16 +120,16 @@
 	};
 
 	const initialNetwork = (): Network | undefined =>
-		icrc7CanisterId === undefined ? $selectedNetwork : ICP_NETWORK;
+		isNullish(icrc7CanisterId) ? $selectedNetwork : ICP_NETWORK;
 
 	const initialTokenData = (): Partial<AddTokenData> =>
-		icrc7CanisterId === undefined ? {} : { icrc7CanisterId };
+		isNullish(icrc7CanisterId) ? {} : { icrc7CanisterId };
 
 	let network: Network | undefined = $state(initialNetwork());
 	let tokenData: Partial<AddTokenData> = $state(initialTokenData());
 
 	$effect(() => {
-		if (initializedIcrc7ReviewStep || icrc7CanisterId === undefined || modal === undefined) {
+		if (initializedIcrc7ReviewStep || isNullish(icrc7CanisterId) || isNullish(modal)) {
 			return;
 		}
 

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { isNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { page } from '$app/state';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
 	import AddTokenByNetwork from '$lib/components/manage/AddTokenByNetwork.svelte';
 	import AddTokenReviewByNetwork from '$lib/components/manage/AddTokenReviewByNetwork.svelte';
@@ -11,8 +13,13 @@
 	import { MANAGE_TOKENS_MODAL } from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
+	import {
+		PLAUSIBLE_EVENT_RESULT_STATUSES,
+		PLAUSIBLE_EVENT_SOURCE_LOCATIONS
+	} from '$lib/enums/plausible';
 	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 	import { WizardStepsManageTokens } from '$lib/enums/wizard-steps';
+	import { trackTokenManage } from '$lib/services/token-manage-analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Network } from '$lib/types/network';
@@ -22,11 +29,12 @@
 
 	interface Props {
 		initialSearch?: string;
+		icrc7CanisterId?: string;
 		onClose?: () => void;
 		infoElement?: Snippet;
 	}
 
-	let { initialSearch, onClose = () => {}, infoElement }: Props = $props();
+	let { initialSearch, icrc7CanisterId, onClose = () => {}, infoElement }: Props = $props();
 
 	const isNftsPage = $derived(isRouteNfts(page));
 
@@ -53,6 +61,7 @@
 
 	let currentStep: WizardStep<WizardStepsManageTokens> | undefined = $state();
 	let modal: WizardModal<WizardStepsManageTokens> | undefined = $state();
+	let initializedIcrc7ReviewStep = false;
 
 	const saveTokens = async (tokens: Token[]) => {
 		await saveAllCustomTokens({
@@ -68,15 +77,65 @@
 
 	const progress = (step: ProgressStepsAddToken) => (saveProgressStep = step);
 
+	const trackImportCancel = () => {
+		if (
+			currentStep?.name !== WizardStepsManageTokens.IMPORT &&
+			currentStep?.name !== WizardStepsManageTokens.REVIEW
+		) {
+			return;
+		}
+
+		const address =
+			tokenData.ledgerCanisterId ??
+			tokenData.extCanisterId ??
+			tokenData.dip721CanisterId ??
+			tokenData.icPunksCanisterId ??
+			tokenData.icrc7CanisterId ??
+			tokenData.ethContractAddress ??
+			tokenData.splTokenAddress;
+		const tokenNetwork = network?.id.description;
+
+		if (isNullish(address) || isNullish(tokenNetwork)) {
+			return;
+		}
+
+		trackTokenManage({
+			modifier: 'import',
+			token: {
+				network: tokenNetwork,
+				address
+			},
+			sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.CANCEL
+		});
+	};
+
 	const close = () => {
+		trackImportCancel();
+
 		modalStore.close();
 
 		saveProgressStep = ProgressStepsAddToken.INITIALIZATION;
 		onClose();
 	};
 
-	let network: Network | undefined = $state($selectedNetwork);
-	let tokenData: Partial<AddTokenData> = $state({});
+	const initialNetwork = (): Network | undefined =>
+		icrc7CanisterId === undefined ? $selectedNetwork : ICP_NETWORK;
+
+	const initialTokenData = (): Partial<AddTokenData> =>
+		icrc7CanisterId === undefined ? {} : { icrc7CanisterId };
+
+	let network: Network | undefined = $state(initialNetwork());
+	let tokenData: Partial<AddTokenData> = $state(initialTokenData());
+
+	$effect(() => {
+		if (initializedIcrc7ReviewStep || icrc7CanisterId === undefined || modal === undefined) {
+			return;
+		}
+
+		initializedIcrc7ReviewStep = true;
+		modal.set(2);
+	});
 </script>
 
 <WizardModal

--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -72,7 +72,7 @@
 		const action = icrc7DeepLinkAction;
 
 		if (
-			action === undefined ||
+			isNullish(action) ||
 			action.type === 'ready' ||
 			handledIcrc7DeepLinkCanisterIds.has(action.canisterId)
 		) {

--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { fade } from 'svelte/transition';
 	import { page } from '$app/state';
 	import { EARNING_ENABLED } from '$env/earning';
+	import { icrc7CustomTokensNotInitialized, icrc7Tokens } from '$icp/derived/icrc7.derived';
+	import { resolveIcrc7CollectionDeepLinkAction } from '$icp/services/icrc7-deep-link.services';
 	import EarningsList from '$lib/components/earning/EarningsList.svelte';
 	import GoToEarnButton from '$lib/components/earning/GoToEarnButton.svelte';
 	import ManageTokensModal from '$lib/components/manage/ManageTokensModal.svelte';
@@ -21,11 +24,13 @@
 	import StickyHeader from '$lib/components/ui/StickyHeader.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalManageTokens, modalManageTokensData } from '$lib/derived/modal.derived';
 	import { routeCollection, routeNetwork, routeNft } from '$lib/derived/nav.derived';
 	import { PLAUSIBLE_EVENTS } from '$lib/enums/plausible';
 	import { TokenTypes } from '$lib/enums/token-types';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
 	import { activeAssetsTabStore } from '$lib/stores/settings.store';
 
 	interface Props {
@@ -39,14 +44,61 @@
 	// svelte-ignore state_referenced_locally -- we want to get only the initial value
 	let activeTab = $state(tab);
 
-	let { initialSearch, message } = $derived(
+	const icrc7DeepLinkManageTokensId = Symbol();
+	const handledIcrc7DeepLinkCanisterIds = new SvelteSet<string>();
+
+	let { icrc7CanisterId, initialSearch, message } = $derived(
 		nonNullish($modalManageTokensData)
 			? $modalManageTokensData
-			: { initialSearch: undefined, message: undefined }
+			: { icrc7CanisterId: undefined, initialSearch: undefined, message: undefined }
 	);
+
+	const icrc7DeepLinkAction = $derived.by(() => {
+		if (tab !== TokenTypes.NFTS || isNullish($authIdentity) || $icrc7CustomTokensNotInitialized) {
+			return undefined;
+		}
+
+		return resolveIcrc7CollectionDeepLinkAction({
+			url: page.url,
+			tokens: $icrc7Tokens
+		});
+	});
 
 	$effect(() => {
 		activeAssetsTabStore.set({ key: 'active-assets-tab', value: activeTab });
+	});
+
+	$effect(() => {
+		const action = icrc7DeepLinkAction;
+
+		if (
+			action === undefined ||
+			action.type === 'ready' ||
+			handledIcrc7DeepLinkCanisterIds.has(action.canisterId)
+		) {
+			return;
+		}
+
+		handledIcrc7DeepLinkCanisterIds.add(action.canisterId);
+
+		if (action.type === 'import') {
+			modalStore.openManageTokens({
+				id: icrc7DeepLinkManageTokensId,
+				data: {
+					icrc7CanisterId: action.canisterId,
+					initialSearch: action.canisterId
+				}
+			});
+			return;
+		}
+
+		modalStore.openManageTokens({
+			id: icrc7DeepLinkManageTokensId,
+			data: {
+				initialSearch: action.token.name,
+				message: $i18n.transactions.text.token_needs_enabling
+			}
+		});
 	});
 </script>
 
@@ -138,16 +190,16 @@
 			{/if}
 		</div>
 	</div>
+{/if}
 
-	{#if $modalManageTokens}
-		<ManageTokensModal {initialSearch}>
-			{#snippet infoElement()}
-				{#if nonNullish(message)}
-					<MessageBox level="info">
-						{message}
-					</MessageBox>
-				{/if}
-			{/snippet}
-		</ManageTokensModal>
-	{/if}
+{#if $modalManageTokens}
+	<ManageTokensModal {icrc7CanisterId} {initialSearch}>
+		{#snippet infoElement()}
+			{#if nonNullish(message)}
+				<MessageBox level="info">
+					{message}
+				</MessageBox>
+			{/if}
+		{/snippet}
+	</ManageTokensModal>
 {/if}

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
+	import { assertNonNullish, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import type { Snippet } from 'svelte';
 	import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
@@ -29,14 +29,25 @@
 	import { addTokenSteps } from '$lib/constants/steps.constants';
 	import { TOKEN_MODAL_SAVE_BUTTON } from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import {
+		PLAUSIBLE_EVENT_RESULT_STATUSES,
+		PLAUSIBLE_EVENT_SOURCE_LOCATIONS
+	} from '$lib/enums/plausible';
 	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 	import { TokenModalSteps } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
+	import {
+		trackTokenManage,
+		type TokenManageEventKey,
+		type TokenManageEventModifier,
+		type TokenManageEventToken
+	} from '$lib/services/token-manage-analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 	import type { OptionToken, Token } from '$lib/types/token';
 	import { toCustomToken } from '$lib/utils/custom-token.utils';
+	import { errorDetailToString } from '$lib/utils/error.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { back, gotoReplaceRoot } from '$lib/utils/nav.utils';
 	import { isNetworkIdSOLDevnet } from '$lib/utils/network.utils';
@@ -110,6 +121,66 @@
 		nonNullish(fromRoute) ? await back({ pop: nonNullish(fromRoute) }) : await gotoReplaceRoot();
 	};
 
+	const mapTokenManageToken = (token: Token): TokenManageEventToken => {
+		const tokenAddress = 'address' in token ? (token.address as string | undefined) : undefined;
+		const network = token.network.id.description;
+		const address =
+			tokenAddress ?? (isTokenIcrc(token) ? token.ledgerCanisterId : token.id.description);
+
+		assertNonNullish(network);
+		assertNonNullish(address);
+
+		return {
+			network,
+			address,
+			...(nonNullish(token.symbol) && { symbol: token.symbol }),
+			...(nonNullish(token.name) && { name: token.name })
+		};
+	};
+
+	const trackTokenManageDetails = ({
+		modifier,
+		token,
+		resultStatus,
+		key,
+		value,
+		error
+	}: {
+		modifier: TokenManageEventModifier;
+		token: Token;
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
+		key?: TokenManageEventKey;
+		value?: string;
+		error?: string;
+	}) =>
+		trackTokenManage({
+			modifier,
+			token: mapTokenManageToken(token),
+			sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.TOKEN_DETAILS,
+			resultStatus,
+			...(nonNullish(key) && { key }),
+			...(nonNullish(value) && { value }),
+			...(nonNullish(error) && { error })
+		});
+
+	const trackTokenManageEdit = ({
+		tokenToEdit,
+		resultStatus,
+		error
+	}: {
+		tokenToEdit: Token;
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
+		error?: string;
+	}) =>
+		trackTokenManageDetails({
+			modifier: 'edit',
+			token: tokenToEdit,
+			resultStatus,
+			key: 'index_canister',
+			value: icrcTokenIndexCanisterId,
+			...(nonNullish(error) && { error })
+		});
+
 	const onTokenDeleteSuccess = async (deletedToken: Token) => {
 		loading = false;
 
@@ -125,6 +196,12 @@
 				...(nonNullish(address) && { address: `${address}` }),
 				networkId: `${deletedToken.network.id.description}`
 			}
+		});
+
+		trackTokenManageDetails({
+			modifier: 'delete',
+			token: deletedToken,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 		});
 
 		toastsShow({
@@ -206,6 +283,13 @@
 				await onTokenDeleteSuccess(tokenToDelete);
 			}
 		} catch (err: unknown) {
+			trackTokenManageDetails({
+				modifier: 'delete',
+				token: tokenToDelete,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+				error: errorDetailToString(err)
+			});
+
 			toastsError({
 				msg: { text: $i18n.tokens.error.unexpected_error_on_token_delete },
 				err
@@ -215,6 +299,19 @@
 			showBottomSheetDeleteConfirmation = false;
 			loading = false;
 		}
+	};
+
+	const onTokenDeleteCancel = (tokenToDelete: OptionToken) => {
+		if (nonNullish(tokenToDelete)) {
+			trackTokenManageDetails({
+				modifier: 'delete',
+				token: tokenToDelete,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.CANCEL
+			});
+		}
+
+		showBottomSheetDeleteConfirmation = false;
+		gotoStep(TokenModalSteps.CONTENT);
 	};
 
 	const onTokenEdit = async (tokenToEdit: OptionToken) => {
@@ -241,6 +338,11 @@
 					: { valid: true };
 
 				if (!valid) {
+					trackTokenManageEdit({
+						tokenToEdit,
+						resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR
+					});
+
 					loading = false;
 					icrcTokenIndexCanisterId = tokenToEdit.indexCanisterId ?? '';
 					progress(ProgressStepsAddToken.INITIALIZATION);
@@ -287,6 +389,11 @@
 							}
 						});
 
+						trackTokenManageEdit({
+							tokenToEdit,
+							resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+						});
+
 						toastsShow({
 							text: replacePlaceholders($i18n.tokens.details.update_confirmation, {
 								$token: getTokenDisplaySymbol(tokenToEdit)
@@ -297,7 +404,13 @@
 					}
 				});
 			}
-		} catch (err) {
+		} catch (err: unknown) {
+			trackTokenManageEdit({
+				tokenToEdit,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+				error: errorDetailToString(err)
+			});
+
 			toastsError({
 				msg: { text: $i18n.tokens.error.unexpected_error_on_token_update },
 				err
@@ -310,6 +423,15 @@
 			progress(ProgressStepsAddToken.INITIALIZATION);
 			gotoStep(TokenModalSteps.CONTENT);
 		}
+	};
+
+	const onTokenEditCancel = (tokenToEdit: Token) => {
+		trackTokenManageEdit({
+			tokenToEdit,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.CANCEL
+		});
+
+		gotoStep(TokenModalSteps.CONTENT);
 	};
 </script>
 
@@ -349,7 +471,7 @@
 		{:else if currentStepName === TokenModalSteps.DELETE_CONFIRMATION}
 			<TokenModalDeleteConfirmation
 				{loading}
-				onCancel={() => gotoStep(TokenModalSteps.CONTENT)}
+				onCancel={() => onTokenDeleteCancel(token)}
 				onConfirm={() => onTokenDelete(token)}
 				{token}
 			/>
@@ -369,7 +491,7 @@
 
 				{#snippet toolbar()}
 					<ButtonGroup>
-						<ButtonBack onclick={() => gotoStep(TokenModalSteps.CONTENT)} />
+						<ButtonBack onclick={() => onTokenEditCancel(token)} />
 
 						<Button
 							disabled={icrcTokenIndexCanisterId === (token.indexCanisterId ?? '')}
@@ -388,10 +510,7 @@
 </WizardModal>
 
 {#if currentStepName === TokenModalSteps.CONTENT && showBottomSheetDeleteConfirmation}
-	<BottomSheetConfirmationPopup
-		disabled={loading}
-		onCancel={() => (showBottomSheetDeleteConfirmation = false)}
-	>
+	<BottomSheetConfirmationPopup disabled={loading} onCancel={() => onTokenDeleteCancel(token)}>
 		{#snippet title()}
 			{$i18n.tokens.text.delete_token}
 		{/snippet}
@@ -399,7 +518,7 @@
 		{#snippet content()}
 			<TokenModalDeleteConfirmation
 				{loading}
-				onCancel={() => (showBottomSheetDeleteConfirmation = false)}
+				onCancel={() => onTokenDeleteCancel(token)}
 				onConfirm={() => onTokenDelete(token)}
 				{token}
 			/>

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -39,7 +39,7 @@
 		iconType: 'token' | 'transaction';
 		to?: string;
 		from?: string;
-		tokenId?: number;
+		tokenId?: number | bigint | string;
 		children: Snippet;
 		onClick?: () => void;
 		approveSpender?: string;

--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -24,7 +24,9 @@ import { trackEvent } from '$lib/services/analytics.services';
 import { saveCustomTokens } from '$lib/services/save-custom-tokens.services';
 import {
 	trackTokenManage,
-	type TokenManageEventToken
+	type TokenManageEventModifier,
+	type TokenManageEventToken,
+	type TokenManageSourceLocation
 } from '$lib/services/token-manage-analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
@@ -33,7 +35,11 @@ import type { NullishIdentity } from '$lib/types/identity';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { NonEmptyArray } from '$lib/types/utils';
-import { isVersionMismatchError, mapIcErrorMetadata } from '$lib/utils/error.utils';
+import {
+	errorDetailToString,
+	isVersionMismatchError,
+	mapIcErrorMetadata
+} from '$lib/utils/error.utils';
 import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -45,6 +51,8 @@ interface ManageTokensSaveParams {
 	onSuccess?: () => void;
 	onError?: () => void;
 	identity: NullishIdentity;
+	tokenManageModifier?: TokenManageEventModifier;
+	tokenManageSourceLocation?: TokenManageSourceLocation;
 }
 
 export interface SaveTokensParams<T> {
@@ -143,6 +151,49 @@ const mapTokenManageToken = <T extends SaveTokensToken>({
 	};
 };
 
+const tokenManageModifier = <T extends SaveTokensToken>({
+	token,
+	modifier
+}: {
+	token: T;
+	modifier?: TokenManageEventModifier;
+}): TokenManageEventModifier => modifier ?? (token.enabled ? 'enable' : 'disable');
+
+const trackTokenManageResults = <T extends SaveTokensToken>({
+	tokens,
+	modifier,
+	sourceLocation,
+	resultStatus,
+	error,
+	errorCode
+}: {
+	tokens: T[];
+	modifier?: TokenManageEventModifier;
+	sourceLocation: TokenManageSourceLocation;
+	resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
+	error?: string;
+	errorCode?: string;
+}) => {
+	tokens.forEach((token) => {
+		const tokenId = 'id' in token ? token.id : undefined;
+		const network = 'network' in token ? token.network : undefined;
+		const tokenManageToken = mapTokenManageToken({ token, tokenId, network });
+
+		if (isNullish(tokenManageToken)) {
+			return;
+		}
+
+		trackTokenManage({
+			modifier: tokenManageModifier({ token, modifier }),
+			token: tokenManageToken,
+			sourceLocation,
+			resultStatus,
+			...(nonNullish(error) && { error }),
+			...(nonNullish(errorCode) && { errorCode })
+		});
+	});
+};
+
 export const saveTokens = async <
 	T extends
 		| SaveCustomTokenWithKey
@@ -159,7 +210,9 @@ export const saveTokens = async <
 	modalNext,
 	onSuccess,
 	onError,
-	identity
+	identity,
+	tokenManageModifier: modifier,
+	tokenManageSourceLocation = PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS
 }: {
 	tokens: T[];
 	save: (params: SaveTokensParams<T>) => Promise<void>;
@@ -216,16 +269,12 @@ export const saveTokens = async <
 				}
 			});
 
-			const tokenManageToken = mapTokenManageToken({ token, tokenId, network });
-
-			if (nonNullish(tokenManageToken)) {
-				trackTokenManage({
-					modifier: enabled ? 'enable' : 'disable',
-					token: tokenManageToken,
-					sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS,
-					resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
-				});
-			}
+			trackTokenManageResults({
+				tokens: [token],
+				modifier,
+				sourceLocation: tokenManageSourceLocation,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+			});
 		});
 	} catch (err: unknown) {
 		const versionMismatch = isVersionMismatchError(err);
@@ -247,6 +296,15 @@ export const saveTokens = async <
 		trackEvent({
 			name: TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR,
 			metadata: mapIcErrorMetadata(err)
+		});
+
+		trackTokenManageResults({
+			tokens,
+			modifier,
+			sourceLocation: tokenManageSourceLocation,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+			error: errorDetailToString(err),
+			...(versionMismatch && { errorCode: 'version_mismatch' })
 		});
 	}
 };

--- a/src/frontend/src/lib/types/manage-tokens.ts
+++ b/src/frontend/src/lib/types/manage-tokens.ts
@@ -1,4 +1,5 @@
 export interface ManageTokensData {
-	initialSearch: string;
+	initialSearch?: string;
 	message?: string;
+	icrc7CanisterId?: string;
 }

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -67,6 +67,26 @@ const adaptMetadataResourceUrl = (url: URL): URL | undefined => {
 	return new URL(parsedNewUrl.data);
 };
 
+const dataUrlMediaStatus = ({ url }: { url: URL }): MediaStatusEnum | undefined => {
+	if (url.protocol !== 'data:') {
+		return;
+	}
+
+	const [metadata, data = ''] = url.href.split(',', 2);
+	const [mediaType] = metadata.slice('data:'.length).split(';', 1);
+
+	if (!(mediaType.startsWith('image/') || mediaType.startsWith('video/'))) {
+		return MediaStatusEnum.NON_SUPPORTED_MEDIA_TYPE;
+	}
+
+	const isBase64 = metadata.endsWith(';base64');
+	const size = isBase64 ? Math.ceil((data.length * 3) / 4) : decodeURIComponent(data).length;
+
+	return size > NFT_MAX_FILESIZE_LIMIT
+		? MediaStatusEnum.FILESIZE_LIMIT_EXCEEDED
+		: MediaStatusEnum.OK;
+};
+
 export const parseMetadataResourceUrl = ({ url, error }: { url: string; error: NftError }): URL => {
 	const parsedUrl = UrlSchema.safeParse(url);
 
@@ -298,6 +318,12 @@ export const getMediaStatus = async (mediaUrl?: string): Promise<MediaStatusEnum
 
 		if (isNullish(url)) {
 			return MediaStatusEnum.INVALID_DATA;
+		}
+
+		const dataUrlStatus = dataUrlMediaStatus({ url });
+
+		if (nonNullish(dataUrlStatus)) {
+			return dataUrlStatus;
 		}
 
 		const { type, size } = await extractMediaTypeAndSize(url.href);

--- a/src/frontend/src/tests/icp/services/ic-transactions.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/ic-transactions.services.spec.ts
@@ -1,3 +1,4 @@
+import type { Value } from '$declarations/icrc3/icrc3.did';
 import { ICP_EXPLORER_URL } from '$env/explorers.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN, ICP_TOKEN_ID } from '$env/tokens/tokens.icp.env';
@@ -10,6 +11,7 @@ import {
 	onLoadTransactionsError,
 	onTransactionsCleanUp
 } from '$icp/services/ic-transactions.services';
+import { loadIcrc3BlockLog, type Icrc3Block } from '$icp/services/icrc3.services';
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import type { IcToken } from '$icp/types/ic-token';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
@@ -25,7 +27,8 @@ import { balancesStore } from '$lib/stores/balances.store';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { bn1Bi } from '$tests/mocks/balances.mock';
 import { createMockIcTransactionsUi } from '$tests/mocks/ic-transactions.mock';
-import { mockIdentity } from '$tests/mocks/identity.mock';
+import { mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
+import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
 import type { IcpIndexDid } from '@icp-sdk/canisters/ledger/icp';
 import { get } from 'svelte/store';
@@ -37,6 +40,10 @@ vi.mock('$icp/api/icp-index.api', () => ({
 
 vi.mock('$icp/api/icrc-index-ng.api', () => ({
 	getTransactions: vi.fn()
+}));
+
+vi.mock('$icp/services/icrc3.services', () => ({
+	loadIcrc3BlockLog: vi.fn()
 }));
 
 describe('ic-transactions.services', () => {
@@ -174,6 +181,29 @@ describe('ic-transactions.services', () => {
 			certified: false
 		}));
 
+		const accountValue = (principal: typeof mockPrincipal): Value => ({
+			Map: [['owner', { Text: principal.toText() }]]
+		});
+
+		const icrc7Block = ({
+			id,
+			btype,
+			tx
+		}: {
+			id: bigint;
+			btype: '7mint' | '7burn' | '7xfer';
+			tx: Array<[string, Value]>;
+		}): Icrc3Block => ({
+			id,
+			block: {
+				Map: [
+					['btype', { Text: btype }],
+					['ts', { Nat: 1_700_000_000_000_000_000n }],
+					['tx', { Map: [['tid', { Nat: 50n }] as [string, Value], ...tx] }]
+				]
+			}
+		});
+
 		beforeEach(() => {
 			vi.clearAllMocks();
 
@@ -239,6 +269,67 @@ describe('ic-transactions.services', () => {
 
 			expect(getTransactionsIcp).not.toHaveBeenCalled();
 			expect(getTransactionsIcrc).not.toHaveBeenCalled();
+		});
+
+		it('should load transactions from ICRC-3 blocks for ICRC-7 tokens', async () => {
+			const blocks = [
+				icrc7Block({
+					id: 1n,
+					btype: '7mint',
+					tx: [['to', accountValue(mockPrincipal2)]]
+				}),
+				icrc7Block({
+					id: 2n,
+					btype: '7xfer',
+					tx: [
+						['from', accountValue(mockPrincipal2)],
+						['to', accountValue(mockPrincipal)]
+					]
+				})
+			];
+
+			vi.mocked(loadIcrc3BlockLog)
+				.mockResolvedValueOnce({ logLength: 3n, blocks: [] })
+				.mockResolvedValueOnce({ logLength: 3n, blocks })
+				.mockResolvedValueOnce({ logLength: 3n, blocks: [] })
+				.mockResolvedValueOnce({ logLength: 3n, blocks });
+
+			icTransactionsStore.reset(mockValidIcrc7Token.id);
+
+			await loadNextIcTransactions({
+				...mockParams,
+				lastId: undefined,
+				token: mockValidIcrc7Token
+			});
+
+			expect(getTransactionsIcp).not.toHaveBeenCalled();
+			expect(getTransactionsIcrc).not.toHaveBeenCalled();
+			expect(loadIcrc3BlockLog).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				canisterId: mockValidIcrc7Token.canisterId,
+				start: ZERO,
+				length: ZERO,
+				certified: expect.any(Boolean)
+			});
+			expect(loadIcrc3BlockLog).toHaveBeenCalledWith({
+				identity: mockIdentity,
+				canisterId: mockValidIcrc7Token.canisterId,
+				start: ZERO,
+				length: 3n,
+				certified: expect.any(Boolean)
+			});
+
+			expect(get(icTransactionsStore)?.[mockValidIcrc7Token.id]).toEqual([
+				{
+					data: expect.objectContaining({
+						id: '2',
+						type: 'receive',
+						incoming: true,
+						tokenId: 50n
+					}),
+					certified: true
+				}
+			]);
 		});
 
 		it('should load transactions with the correct parameters for ICP token', async () => {

--- a/src/frontend/src/tests/icp/services/icrc3.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc3.services.spec.ts
@@ -1,0 +1,129 @@
+import { getBlocks } from '$icp/api/icrc3.api';
+import { loadIcrc3BlockLog } from '$icp/services/icrc3.services';
+import { ZERO } from '$lib/constants/app.constants';
+import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
+
+vi.mock('$icp/api/icrc3.api', () => ({
+	getBlocks: vi.fn()
+}));
+
+describe('icrc3.services', () => {
+	describe('loadIcrc3BlockLog', () => {
+		const params = {
+			identity: mockIdentity,
+			canisterId: mockLedgerCanisterId,
+			start: ZERO,
+			length: 10n
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should load local blocks from the ledger canister', async () => {
+			vi.mocked(getBlocks).mockResolvedValue({
+				log_length: 2n,
+				blocks: [
+					{ id: 1n, block: { Map: [['btype', { Text: '7xfer' }]] } },
+					{ id: ZERO, block: { Map: [['btype', { Text: '7mint' }]] } }
+				],
+				archived_blocks: []
+			});
+
+			await expect(loadIcrc3BlockLog(params)).resolves.toEqual({
+				logLength: 2n,
+				blocks: [
+					{ id: ZERO, block: { Map: [['btype', { Text: '7mint' }]] } },
+					{ id: 1n, block: { Map: [['btype', { Text: '7xfer' }]] } }
+				]
+			});
+
+			expect(getBlocks).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				canisterId: mockLedgerCanisterId,
+				certified: undefined,
+				args: [{ start: ZERO, length: 10n }]
+			});
+		});
+
+		it('should sort block ids without number coercion', async () => {
+			const largeBlockId = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+
+			vi.mocked(getBlocks).mockResolvedValue({
+				log_length: 2n,
+				blocks: [
+					{ id: largeBlockId + 1n, block: { Map: [['btype', { Text: '7burn' }]] } },
+					{ id: largeBlockId, block: { Map: [['btype', { Text: '7mint' }]] } }
+				],
+				archived_blocks: []
+			});
+
+			await expect(loadIcrc3BlockLog(params)).resolves.toEqual({
+				logLength: 2n,
+				blocks: [
+					{ id: largeBlockId, block: { Map: [['btype', { Text: '7mint' }]] } },
+					{ id: largeBlockId + 1n, block: { Map: [['btype', { Text: '7burn' }]] } }
+				]
+			});
+		});
+
+		it('should load archived block ranges when callback method is icrc3_get_blocks', async () => {
+			vi.mocked(getBlocks)
+				.mockResolvedValueOnce({
+					log_length: 3n,
+					blocks: [{ id: 2n, block: { Map: [['btype', { Text: '7burn' }]] } }],
+					archived_blocks: [
+						{
+							args: [{ start: ZERO, length: 2n }],
+							callback: [mockPrincipal, 'icrc3_get_blocks']
+						}
+					]
+				})
+				.mockResolvedValueOnce({
+					log_length: 2n,
+					blocks: [
+						{ id: ZERO, block: { Map: [['btype', { Text: '7mint' }]] } },
+						{ id: 1n, block: { Map: [['btype', { Text: '7xfer' }]] } }
+					],
+					archived_blocks: []
+				});
+
+			await expect(loadIcrc3BlockLog(params)).resolves.toEqual({
+				logLength: 3n,
+				blocks: [
+					{ id: ZERO, block: { Map: [['btype', { Text: '7mint' }]] } },
+					{ id: 1n, block: { Map: [['btype', { Text: '7xfer' }]] } },
+					{ id: 2n, block: { Map: [['btype', { Text: '7burn' }]] } }
+				]
+			});
+
+			expect(getBlocks).toHaveBeenNthCalledWith(2, {
+				identity: mockIdentity,
+				canisterId: mockPrincipal.toText(),
+				certified: undefined,
+				args: [{ start: ZERO, length: 2n }]
+			});
+		});
+
+		it('should ignore unsupported archive callback methods', async () => {
+			vi.mocked(getBlocks).mockResolvedValue({
+				log_length: 1n,
+				blocks: [{ id: ZERO, block: { Map: [] } }],
+				archived_blocks: [
+					{
+						args: [{ start: ZERO, length: 1n }],
+						callback: [mockPrincipal, 'custom_get_blocks']
+					}
+				]
+			});
+
+			await expect(loadIcrc3BlockLog(params)).resolves.toEqual({
+				logLength: 1n,
+				blocks: [{ id: ZERO, block: { Map: [] } }]
+			});
+
+			expect(getBlocks).toHaveBeenCalledOnce();
+		});
+	});
+});

--- a/src/frontend/src/tests/icp/services/icrc7-deep-link.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc7-deep-link.services.spec.ts
@@ -1,31 +1,34 @@
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
-import { parseIcrc7CollectionDeepLink } from '$icp/services/icrc7-deep-link.services';
+import {
+	parseIcrc7CollectionDeepLink,
+	resolveIcrc7CollectionDeepLinkAction
+} from '$icp/services/icrc7-deep-link.services';
 import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
-import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
+import { mockIcrc7CanisterId, mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 import { nonNullish } from '@dfinity/utils';
 
 describe('icrc7-deep-link.services', () => {
+	const urlWithParams = ({
+		collection,
+		network
+	}: {
+		collection?: string;
+		network?: string;
+	}): URL => {
+		const url = new URL('https://oisy.com/nfts/');
+
+		if (nonNullish(collection)) {
+			url.searchParams.set(COLLECTION_PARAM, collection);
+		}
+
+		if (nonNullish(network)) {
+			url.searchParams.set(NETWORK_PARAM, network);
+		}
+
+		return url;
+	};
+
 	describe('parseIcrc7CollectionDeepLink', () => {
-		const urlWithParams = ({
-			collection,
-			network
-		}: {
-			collection?: string;
-			network?: string;
-		}): URL => {
-			const url = new URL('https://oisy.com/nfts/');
-
-			if (nonNullish(collection)) {
-				url.searchParams.set(COLLECTION_PARAM, collection);
-			}
-
-			if (nonNullish(network)) {
-				url.searchParams.set(NETWORK_PARAM, network);
-			}
-
-			return url;
-		};
-
 		it('should parse a valid ICP collection deep link', () => {
 			expect(
 				parseIcrc7CollectionDeepLink({
@@ -65,6 +68,52 @@ describe('icrc7-deep-link.services', () => {
 					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ETH' })
 				})
 			).toBeUndefined();
+		});
+	});
+
+	describe('resolveIcrc7CollectionDeepLinkAction', () => {
+		const enabledToken = { ...mockValidIcrc7Token, enabled: true };
+		const disabledToken = { ...mockValidIcrc7Token, enabled: false };
+
+		it('should return import action when collection is unknown', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: []
+				})
+			).toEqual({
+				type: 'import',
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
+		});
+
+		it('should return enable action when collection is known but disabled', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: [disabledToken]
+				})
+			).toEqual({
+				type: 'enable',
+				token: disabledToken,
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
+		});
+
+		it('should return ready action when collection is already enabled', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: [enabledToken]
+				})
+			).toEqual({
+				type: 'ready',
+				token: enabledToken,
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/icp/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/nft.services.spec.ts
@@ -4,14 +4,17 @@ import * as extTokenApi from '$icp/api/ext-v2-token.api';
 import { getTokensByOwner as getExtTokensByOwner } from '$icp/api/ext-v2-token.api';
 import * as icPunksApi from '$icp/api/icpunks.api';
 import { getTokensByOwner as getIcPunksTokensByOwner } from '$icp/api/icpunks.api';
+import * as icrc7Api from '$icp/api/icrc7.api';
+import { getTokensByOwner as getIcrc7TokensByOwner } from '$icp/api/icrc7.api';
 import { loadNfts } from '$icp/services/nft.services';
-import { mapDip721Nft, mapExtNft, mapIcPunksNft } from '$icp/utils/nft.utils';
+import { mapDip721Nft, mapExtNft, mapIcPunksNft, mapIcrc7Nft } from '$icp/utils/nft.utils';
 import { TRACK_COUNT_IC_LOADING_NFTS_FROM_COLLECTION_ERROR } from '$lib/constants/analytics.constants';
 import { trackEvent } from '$lib/services/analytics.services';
 import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidExtV2Token, mockValidExtV2Token2 } from '$tests/mocks/ext-tokens.mock';
 import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
+import { mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
 
 vi.mock(import('$icp/api/icpunks.api'), async (importOriginal) => {
@@ -25,6 +28,15 @@ vi.mock(import('$icp/api/icpunks.api'), async (importOriginal) => {
 	};
 });
 
+vi.mock(import('$icp/api/icrc7.api'), async (importOriginal) => {
+	const actual = await importOriginal();
+
+	return {
+		...actual,
+		metadata: vi.fn().mockResolvedValue({ name: 'Mock ICRC-7 NFT' })
+	};
+});
+
 vi.mock('$lib/services/analytics.services', () => ({
 	trackEvent: vi.fn()
 }));
@@ -34,9 +46,10 @@ describe('nft.services', () => {
 		const mockExtTokens = [mockValidExtV2Token, mockValidExtV2Token2];
 		const mockDip721Tokens = [mockValidDip721Token];
 		const mockIcPunksTokens = [mockValidIcPunksToken];
+		const mockIcrc7Tokens = [mockValidIcrc7Token];
 
 		const mockParams = {
-			tokens: [...mockExtTokens, ...mockDip721Tokens, ...mockIcPunksTokens],
+			tokens: [...mockExtTokens, ...mockDip721Tokens, ...mockIcPunksTokens, ...mockIcrc7Tokens],
 			identity: mockIdentity
 		};
 
@@ -44,6 +57,7 @@ describe('nft.services', () => {
 		const mockTokenIndices2 = [4, 5];
 		const mockTokenIndices3 = [6n, 7n, 8n];
 		const mockTokenIndices4 = [9n];
+		const mockTokenIndices5 = [10n, 11n];
 
 		const expected1 = await Promise.all(
 			mockTokenIndices1.map((index) =>
@@ -63,7 +77,12 @@ describe('nft.services', () => {
 				mapIcPunksNft({ index, token: mockValidIcPunksToken, identity: mockIdentity })
 			)
 		);
-		const expected = [...expected1, ...expected2, ...expected3, ...expected4];
+		const expected5 = await Promise.all(
+			mockTokenIndices5.map((index) =>
+				mapIcrc7Nft({ index, token: mockValidIcrc7Token, identity: mockIdentity })
+			)
+		);
+		const expected = [...expected1, ...expected2, ...expected3, ...expected4, ...expected5];
 
 		beforeEach(() => {
 			vi.clearAllMocks();
@@ -98,6 +117,15 @@ describe('nft.services', () => {
 
 				return [];
 			});
+
+			// @ts-expect-error This is a mocked implementation that is not asynchronous as the original method is.
+			vi.spyOn(icrc7Api, 'getTokensByOwner').mockImplementation(({ canisterId }) => {
+				if (canisterId === mockValidIcrc7Token.canisterId) {
+					return mockTokenIndices5;
+				}
+
+				return [];
+			});
 		});
 
 		it('should return an empty array if the identity is nullish', async () => {
@@ -108,6 +136,7 @@ describe('nft.services', () => {
 			expect(getExtTokensByOwner).not.toHaveBeenCalled();
 			expect(getDip721TokensByOwner).not.toHaveBeenCalled();
 			expect(getIcPunksTokensByOwner).not.toHaveBeenCalled();
+			expect(getIcrc7TokensByOwner).not.toHaveBeenCalled();
 		});
 
 		it('should return an empty array if the tokens list is empty', async () => {
@@ -116,12 +145,14 @@ describe('nft.services', () => {
 			expect(getExtTokensByOwner).not.toHaveBeenCalled();
 			expect(getDip721TokensByOwner).not.toHaveBeenCalled();
 			expect(getIcPunksTokensByOwner).not.toHaveBeenCalled();
+			expect(getIcrc7TokensByOwner).not.toHaveBeenCalled();
 		});
 
 		it('should return an empty array if there are not tokens owned by the user', async () => {
 			vi.spyOn(extTokenApi, 'getTokensByOwner').mockResolvedValue([]);
 			vi.spyOn(dip721Api, 'getTokensByOwner').mockResolvedValue([]);
 			vi.spyOn(icPunksApi, 'getTokensByOwner').mockResolvedValue([]);
+			vi.spyOn(icrc7Api, 'getTokensByOwner').mockResolvedValue([]);
 
 			await expect(loadNfts(mockParams)).resolves.toEqual([]);
 
@@ -151,6 +182,16 @@ describe('nft.services', () => {
 				expect(getIcPunksTokensByOwner).toHaveBeenCalledWith({
 					identity: mockIdentity,
 					owner: mockPrincipal,
+					canisterId
+				});
+			});
+
+			expect(getIcrc7TokensByOwner).toHaveBeenCalledTimes(mockIcrc7Tokens.length);
+
+			mockIcrc7Tokens.forEach(({ canisterId }) => {
+				expect(getIcrc7TokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: { owner: mockPrincipal, subaccount: [] },
 					canisterId
 				});
 			});
@@ -188,6 +229,16 @@ describe('nft.services', () => {
 					canisterId
 				});
 			});
+
+			expect(getIcrc7TokensByOwner).toHaveBeenCalledTimes(mockIcrc7Tokens.length);
+
+			mockIcrc7Tokens.forEach(({ canisterId }) => {
+				expect(getIcrc7TokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: { owner: mockPrincipal, subaccount: [] },
+					canisterId
+				});
+			});
 		});
 
 		it('should handle EXT service errors gracefully', async () => {
@@ -197,7 +248,8 @@ describe('nft.services', () => {
 			await expect(loadNfts(mockParams)).resolves.toEqual([
 				...expected2,
 				...expected3,
-				...expected4
+				...expected4,
+				...expected5
 			]);
 
 			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
@@ -247,7 +299,8 @@ describe('nft.services', () => {
 			await expect(loadNfts(mockParams)).resolves.toEqual([
 				...expected1,
 				...expected2,
-				...expected4
+				...expected4,
+				...expected5
 			]);
 
 			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
@@ -297,7 +350,8 @@ describe('nft.services', () => {
 			await expect(loadNfts(mockParams)).resolves.toEqual([
 				...expected1,
 				...expected2,
-				...expected3
+				...expected3,
+				...expected5
 			]);
 
 			expect(getExtTokensByOwner).toHaveBeenCalledTimes(mockExtTokens.length);
@@ -340,6 +394,37 @@ describe('nft.services', () => {
 			});
 		});
 
+		it('should handle ICRC-7 service errors gracefully', async () => {
+			const mockError = new Error('Mock ICRC-7 error');
+			vi.spyOn(icrc7Api, 'getTokensByOwner').mockRejectedValueOnce(mockError);
+
+			await expect(loadNfts(mockParams)).resolves.toEqual([
+				...expected1,
+				...expected2,
+				...expected3,
+				...expected4
+			]);
+
+			expect(getIcrc7TokensByOwner).toHaveBeenCalledTimes(mockIcrc7Tokens.length);
+
+			mockIcrc7Tokens.forEach(({ canisterId }) => {
+				expect(getIcrc7TokensByOwner).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					owner: { owner: mockPrincipal, subaccount: [] },
+					canisterId
+				});
+			});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_IC_LOADING_NFTS_FROM_COLLECTION_ERROR,
+				metadata: {
+					error: mockError.message,
+					canisterId: mockValidIcrc7Token.canisterId,
+					standard: mockValidIcrc7Token.standard.code
+				}
+			});
+		});
+
 		it("should raise an error if the token's standard is not supported", async () => {
 			// @ts-expect-error we test this on purpose
 			await expect(loadNfts({ ...mockParams, tokens: [mockValidIcrcToken] })).rejects.toThrow(
@@ -349,6 +434,7 @@ describe('nft.services', () => {
 			expect(getExtTokensByOwner).not.toHaveBeenCalled();
 			expect(getDip721TokensByOwner).not.toHaveBeenCalled();
 			expect(getIcPunksTokensByOwner).not.toHaveBeenCalled();
+			expect(getIcrc7TokensByOwner).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/frontend/src/tests/icp/utils/icrc7-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7-transactions.utils.spec.ts
@@ -1,0 +1,185 @@
+import type { Value } from '$declarations/icrc3/icrc3.did';
+import type { Icrc3Block } from '$icp/services/icrc3.services';
+import { getIcrcAccount } from '$icp/utils/icrc-account.utils';
+import { mapIcrc7BlockToTransactions } from '$icp/utils/icrc7-transactions.utils';
+import { mockIdentity, mockPrincipal, mockPrincipal2 } from '$tests/mocks/identity.mock';
+import { encodeIcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
+import type { Principal } from '@icp-sdk/core/principal';
+
+describe('icrc7-transactions.utils', () => {
+	const timestamp = 1_700_000_000_000_000_000n;
+	const tokenId = 50n;
+	const selfAccount = encodeIcrcAccount(getIcrcAccount(mockPrincipal));
+	const otherAccount = encodeIcrcAccount(getIcrcAccount(mockPrincipal2));
+
+	const accountValue = (principal: Principal): Value => ({
+		Map: [['owner', { Text: principal.toText() }]]
+	});
+
+	const block = ({
+		id = 42n,
+		btype,
+		tx
+	}: {
+		id?: bigint;
+		btype: '7mint' | '7burn' | '7xfer' | '1xfer';
+		tx: Array<[string, Value]>;
+	}): Icrc3Block => ({
+		id,
+		block: {
+			Map: [
+				['btype', { Text: btype }],
+				['ts', { Nat: timestamp }],
+				['tx', { Map: [['tid', { Nat: tokenId }], ...tx] }]
+			]
+		}
+	});
+
+	it('should map incoming mint blocks for the signed-in account', () => {
+		expect(
+			mapIcrc7BlockToTransactions({
+				block: block({ btype: '7mint', tx: [['to', accountValue(mockPrincipal)]] }),
+				identity: mockIdentity
+			})
+		).toEqual([
+			{
+				id: '42',
+				type: 'mint',
+				to: selfAccount,
+				incoming: true,
+				timestamp,
+				status: 'executed',
+				tokenId
+			}
+		]);
+	});
+
+	it('should map outgoing burn blocks for the signed-in account', () => {
+		expect(
+			mapIcrc7BlockToTransactions({
+				block: block({ btype: '7burn', tx: [['from', accountValue(mockPrincipal)]] }),
+				identity: mockIdentity
+			})
+		).toEqual([
+			{
+				id: '42',
+				type: 'burn',
+				from: selfAccount,
+				incoming: false,
+				timestamp,
+				status: 'executed',
+				tokenId
+			}
+		]);
+	});
+
+	it('should map send and receive transfer blocks by direction', () => {
+		expect(
+			mapIcrc7BlockToTransactions({
+				block: block({
+					btype: '7xfer',
+					tx: [
+						['from', accountValue(mockPrincipal)],
+						['to', accountValue(mockPrincipal2)]
+					]
+				}),
+				identity: mockIdentity
+			})
+		).toEqual([
+			{
+				id: '42',
+				type: 'send',
+				from: selfAccount,
+				to: otherAccount,
+				incoming: false,
+				timestamp,
+				status: 'executed',
+				tokenId
+			}
+		]);
+
+		expect(
+			mapIcrc7BlockToTransactions({
+				block: block({
+					id: 43n,
+					btype: '7xfer',
+					tx: [
+						['from', accountValue(mockPrincipal2)],
+						['to', accountValue(mockPrincipal)]
+					]
+				}),
+				identity: mockIdentity
+			})
+		).toEqual([
+			{
+				id: '43',
+				type: 'receive',
+				from: otherAccount,
+				to: selfAccount,
+				incoming: true,
+				timestamp,
+				status: 'executed',
+				tokenId
+			}
+		]);
+	});
+
+	it('should duplicate self-transfers as send and receive rows', () => {
+		expect(
+			mapIcrc7BlockToTransactions({
+				block: block({
+					btype: '7xfer',
+					tx: [
+						['from', accountValue(mockPrincipal)],
+						['to', accountValue(mockPrincipal)]
+					]
+				}),
+				identity: mockIdentity
+			})
+		).toEqual([
+			{
+				id: '42',
+				type: 'send',
+				from: selfAccount,
+				to: selfAccount,
+				incoming: false,
+				timestamp,
+				status: 'executed',
+				tokenId
+			},
+			{
+				id: '42-self',
+				type: 'receive',
+				from: selfAccount,
+				to: selfAccount,
+				incoming: true,
+				timestamp,
+				status: 'executed',
+				tokenId
+			}
+		]);
+	});
+
+	it('should ignore unsupported, malformed, or unrelated blocks', () => {
+		expect(
+			mapIcrc7BlockToTransactions({
+				block: block({ btype: '1xfer', tx: [['to', accountValue(mockPrincipal)]] }),
+				identity: mockIdentity
+			})
+		).toEqual([]);
+
+		expect(
+			mapIcrc7BlockToTransactions({
+				block: { id: 1n, block: { Map: [['btype', { Text: '7mint' }]] } },
+				identity: mockIdentity
+			})
+		).toEqual([]);
+
+		expect(
+			mapIcrc7BlockToTransactions({
+				block: block({ btype: '7mint', tx: [['to', accountValue(mockPrincipal2)]] }),
+				identity: mockIdentity
+			})
+		).toEqual([]);
+	});
+});

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -161,12 +161,27 @@ describe('icrc7.utils', () => {
 				mapIcrc7TokenMetadata([
 					['icrc7:metadata:name', { Text: 'Namespaced token' }],
 					['icrc7:metadata:description', { Text: 'Namespaced description' }],
-					['icrc7:metadata:image_url', { Text: 'https://example.com/token.png' }]
+					['icrc7:metadata:image_url', { Text: 'https://example.com/token.png' }],
+					['icrc7:metadata:thumbnail_url', { Text: 'https://example.com/token-thumb.png' }]
 				])
 			).toEqual({
 				name: 'Namespaced token',
 				description: 'Namespaced description',
-				imageUrl: 'https://example.com/token.png'
+				imageUrl: 'https://example.com/token.png',
+				thumbnailUrl: 'https://example.com/token-thumb.png'
+			});
+		});
+
+		it('should map image blobs into data URLs', () => {
+			expect(
+				mapIcrc7TokenMetadata([
+					[
+						'icrc7:image',
+						{ Blob: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) }
+					]
+				])
+			).toEqual({
+				imageUrl: 'data:image/png;base64,iVBORw0KGgo='
 			});
 		});
 

--- a/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
@@ -1,7 +1,8 @@
 import { metadata as getIcPunksMetadata } from '$icp/api/icpunks.api';
+import { metadata as getIcrc7Metadata } from '$icp/api/icrc7.api';
 import { getExtMetadata } from '$icp/services/ext-metadata.services';
 import { extIndexToIdentifier } from '$icp/utils/ext.utils';
-import { mapDip721Nft, mapExtNft, mapIcPunksNft } from '$icp/utils/nft.utils';
+import { mapDip721Nft, mapExtNft, mapIcPunksNft, mapIcrc7Nft } from '$icp/utils/nft.utils';
 import { MediaStatusEnum } from '$lib/enums/media-status';
 import type { NftMetadataWithoutId } from '$lib/types/nft';
 import { mapNftAttributes } from '$lib/utils/nft.utils';
@@ -9,6 +10,7 @@ import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
 import { mockIcPunksMetadata } from '$tests/mocks/icpunks-token.mock';
 import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
+import { mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { Principal } from '@icp-sdk/core/principal';
 import { SvelteMap } from 'svelte/reactivity';
@@ -22,6 +24,14 @@ vi.mock(import('$icp/services/ext-metadata.services'), async (importOriginal) =>
 });
 
 vi.mock(import('$icp/api/icpunks.api'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		metadata: vi.fn()
+	};
+});
+
+vi.mock(import('$icp/api/icrc7.api'), async (importOriginal) => {
 	const actual = await importOriginal();
 	return {
 		...actual,
@@ -217,6 +227,154 @@ describe('nft.utils', () => {
 				collection: {
 					...rest,
 					address: mockValidIcPunksToken.canisterId
+				}
+			});
+		});
+	});
+
+	describe('mapIcrc7Nft', () => {
+		const mockIndex = 50n;
+		const mockMetadata: NftMetadataWithoutId = {
+			name: 'ICRC-7 NFT #50',
+			description: 'A byte-stream-backed NFT',
+			imageUrl:
+				'https://blob.caffeine.ai/v1/blob/?blob_hash=sha256%3A3dafe45&owner_id=sey3i-jyaaa-aaaap-quo3q-cai',
+			attributes: [{ traitType: 'Level', value: '50' }]
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(SvelteMap.prototype, 'get').mockReturnValue(undefined); // invalidate cache
+
+			global.fetch = vi.fn().mockResolvedValue({
+				headers: {
+					get: () => null
+				}
+			});
+
+			vi.mocked(getIcrc7Metadata).mockResolvedValue(mockMetadata);
+		});
+
+		it('should map correctly an ICRC-7 NFT', async () => {
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			const { canisterId: _, ...rest } = mockValidIcrc7Token;
+
+			expect(result).toStrictEqual({
+				id: result.id,
+				...mockMetadata,
+				mediaStatus: {
+					image: MediaStatusEnum.OK,
+					thumbnail: MediaStatusEnum.INVALID_DATA
+				},
+				collection: {
+					...rest,
+					address: mockValidIcrc7Token.canisterId
+				}
+			});
+
+			expect(getIcrc7Metadata).toHaveBeenCalledExactlyOnceWith({
+				canisterId: mockValidIcrc7Token.canisterId,
+				tokenId: mockIndex,
+				identity: mockIdentity,
+				certified: undefined
+			});
+		});
+
+		it('should use invalid media statuses when metadata has no image URLs', async () => {
+			vi.mocked(getIcrc7Metadata).mockResolvedValue({
+				name: 'ICRC-7 NFT #50'
+			});
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			expect(result.mediaStatus).toStrictEqual({
+				image: MediaStatusEnum.INVALID_DATA,
+				thumbnail: MediaStatusEnum.INVALID_DATA
+			});
+		});
+
+		it('should map data image URLs without fetching them for validation', async () => {
+			const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
+			vi.mocked(getIcrc7Metadata).mockResolvedValue({
+				name: 'ICRC-7 NFT #50',
+				imageUrl
+			});
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			expect(result.imageUrl).toBe(imageUrl);
+			expect(result.mediaStatus).toStrictEqual({
+				image: MediaStatusEnum.OK,
+				thumbnail: MediaStatusEnum.INVALID_DATA
+			});
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
+		it('should omit invalid metadata URLs and avoid fetching them', async () => {
+			vi.mocked(getIcrc7Metadata).mockResolvedValue({
+				name: 'ICRC-7 NFT #50',
+				imageUrl: '',
+				thumbnailUrl: 'http://localhost/token-50.png'
+			});
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			const { canisterId: _, ...rest } = mockValidIcrc7Token;
+
+			expect(result).toStrictEqual({
+				id: result.id,
+				name: 'ICRC-7 NFT #50',
+				mediaStatus: {
+					image: MediaStatusEnum.INVALID_DATA,
+					thumbnail: MediaStatusEnum.INVALID_DATA
+				},
+				collection: {
+					...rest,
+					address: mockValidIcrc7Token.canisterId
+				}
+			});
+
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
+		it('should handle missing metadata from the service', async () => {
+			vi.mocked(getIcrc7Metadata).mockResolvedValue(undefined);
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			const { canisterId: _, ...rest } = mockValidIcrc7Token;
+
+			expect(result).toStrictEqual({
+				id: result.id,
+				mediaStatus: {
+					image: MediaStatusEnum.INVALID_DATA,
+					thumbnail: MediaStatusEnum.INVALID_DATA
+				},
+				collection: {
+					...rest,
+					address: mockValidIcrc7Token.canisterId
 				}
 			});
 		});

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -177,6 +177,30 @@ describe('manage-tokens.services', () => {
 			});
 		});
 
+		it('should support token_manage import modifier override', async () => {
+			const customTokens: SaveCustomTokenWithKey[] = [
+				{
+					enabled: true,
+					networkKey: 'Icrc7',
+					canisterId: mockIcrc7CanisterId
+				}
+			];
+
+			mockSave.mockResolvedValueOnce(undefined);
+
+			await saveTokens({ ...params, tokens: customTokens, tokenManageModifier: 'import' });
+
+			expect(trackTokenManage).toHaveBeenCalledExactlyOnceWith({
+				modifier: 'import',
+				token: {
+					network: ICP_NETWORK_ID.description,
+					address: mockIcrc7CanisterId
+				},
+				sourceLocation: 'manage_tokens',
+				resultStatus: 'success'
+			});
+		});
+
 		it('should handle errors from save', async () => {
 			mockSave.mockRejectedValueOnce(new Error('Save failed'));
 
@@ -197,6 +221,28 @@ describe('manage-tokens.services', () => {
 					error: 'Save failed'
 				}
 			});
+
+			expect(trackTokenManage).toHaveBeenCalledTimes(tokens.length);
+
+			tokens.forEach((token, index) => {
+				expect(trackTokenManage).toHaveBeenNthCalledWith(index + 1, {
+					modifier: token.enabled ? 'enable' : 'disable',
+					token: {
+						network: token.network.id.description,
+						address:
+							'address' in token
+								? token.address
+								: 'ledgerCanisterId' in token
+									? token.ledgerCanisterId
+									: token.id.description,
+						symbol: token.symbol,
+						name: token.name
+					},
+					sourceLocation: 'manage_tokens',
+					resultStatus: 'error',
+					error: 'Save failed'
+				});
+			});
 		});
 
 		it('should show a warning toast on version mismatch error', async () => {
@@ -216,6 +262,29 @@ describe('manage-tokens.services', () => {
 				metadata: {
 					error: 'Version mismatch, token update not allowed'
 				}
+			});
+
+			expect(trackTokenManage).toHaveBeenCalledTimes(tokens.length);
+
+			tokens.forEach((token, index) => {
+				expect(trackTokenManage).toHaveBeenNthCalledWith(index + 1, {
+					modifier: token.enabled ? 'enable' : 'disable',
+					token: {
+						network: token.network.id.description,
+						address:
+							'address' in token
+								? token.address
+								: 'ledgerCanisterId' in token
+									? token.ledgerCanisterId
+									: token.id.description,
+						symbol: token.symbol,
+						name: token.name
+					},
+					sourceLocation: 'manage_tokens',
+					resultStatus: 'error',
+					error: 'Version mismatch, token update not allowed',
+					errorCode: 'version_mismatch'
+				});
 			});
 		});
 

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -803,6 +803,24 @@ describe('nfts.utils', () => {
 			expect(result).toBe(MediaStatusEnum.OK);
 		});
 
+		it('returns OK for data image URLs without fetching', async () => {
+			global.fetch = vi.fn();
+
+			const result = await getMediaStatus('data:image/png;base64,iVBORw0KGgo=');
+
+			expect(result).toBe(MediaStatusEnum.OK);
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
+		it('returns NON_SUPPORTED_MEDIA_TYPE for non-media data URLs', async () => {
+			global.fetch = vi.fn();
+
+			const result = await getMediaStatus('data:text/html;base64,PGgxPkhlbGxvPC9oMT4=');
+
+			expect(result).toBe(MediaStatusEnum.NON_SUPPORTED_MEDIA_TYPE);
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
 		it('returns INVALID_DATA for invalid URL', async () => {
 			const result = await getMediaStatus('not-a-url');
 


### PR DESCRIPTION
# Motivation

Finish the remaining ICRC-7 NFT MVP frontend pieces in a draft PR so the integration can be reviewed without marking it ready prematurely.

# Changes

- Wire ICRC-7 NFT loading, deep-link import/enable handling, and token_manage analytics paths.
- Support blob/data-backed NFT image metadata and safe media validation.
- Add ICRC-3 block-log loading plus ICRC-7 mint, burn, and transfer transaction mapping with NFT token id passthrough.

# Tests

- npm run format
- npm run lint -- --max-warnings 0
- npm run check
- npm run test
- Focused ICRC-7 integration Vitest suites passed before the full test run.