### PR TITLE
feat(backend)!: persist active user transactions in stable storage

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -752,6 +752,7 @@ type SplToken = record {
 	symbol : opt text
 };
 type Stats = record {
+	active_user_transactions_count : nat64;
 	user_profile_count : nat64;
 	user_transactions_count : nat64;
 	custom_token_count : nat64;

--- a/src/backend/src/state/memory.rs
+++ b/src/backend/src/state/memory.rs
@@ -23,6 +23,7 @@ pub(crate) const API_KEYS_MEMORY_ID: MemoryId = MemoryId::new(9);
 pub(crate) const EXCHANGE_RATE_MEMORY_ID: MemoryId = MemoryId::new(10);
 pub(crate) const USER_TRANSACTIONS_MEMORY_ID: MemoryId = MemoryId::new(11);
 pub(crate) const AGREEMENT_HISTORY_MEMORY_ID: MemoryId = MemoryId::new(12);
+pub(crate) const ACTIVE_USER_TRANSACTIONS_MEMORY_ID: MemoryId = MemoryId::new(13);
 
 thread_local! {
     pub(crate) static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(

--- a/src/backend/src/state/mod.rs
+++ b/src/backend/src/state/mod.rs
@@ -8,16 +8,18 @@ use shared::types::{
 
 use crate::{
     state::memory::{
-        AGREEMENT_HISTORY_MEMORY_ID, API_KEYS_MEMORY_ID, BTC_USER_PENDING_TRANSACTIONS_MEMORY_ID,
-        CONFIG_MEMORY_ID, CONTACT_MEMORY_ID, EXCHANGE_RATE_MEMORY_ID, MEMORY_MANAGER,
-        TOKEN_ACTIVITY_MEMORY_ID, USER_CUSTOM_TOKEN_MEMORY_ID, USER_PROFILE_MEMORY_ID,
-        USER_PROFILE_UPDATED_MEMORY_ID, USER_TOKEN_MEMORY_ID, USER_TRANSACTIONS_MEMORY_ID,
+        ACTIVE_USER_TRANSACTIONS_MEMORY_ID, AGREEMENT_HISTORY_MEMORY_ID, API_KEYS_MEMORY_ID,
+        BTC_USER_PENDING_TRANSACTIONS_MEMORY_ID, CONFIG_MEMORY_ID, CONTACT_MEMORY_ID,
+        EXCHANGE_RATE_MEMORY_ID, MEMORY_MANAGER, TOKEN_ACTIVITY_MEMORY_ID,
+        USER_CUSTOM_TOKEN_MEMORY_ID, USER_PROFILE_MEMORY_ID, USER_PROFILE_UPDATED_MEMORY_ID,
+        USER_TOKEN_MEMORY_ID, USER_TRANSACTIONS_MEMORY_ID,
     },
     types::{
         maps::{
-            AgreementHistoryMap, ApiKeysCell, BtcUserPendingTransactionsMap, ConfigCell,
-            ContactMap, CustomTokenMap, ExchangeRateMap, TokenActivityMap, UserProfileMap,
-            UserProfileUpdatedMap, UserTokenMap, UserTransactionsMap,
+            ActiveUserTransactionsMap, AgreementHistoryMap, ApiKeysCell,
+            BtcUserPendingTransactionsMap, ConfigCell, ContactMap, CustomTokenMap, ExchangeRateMap,
+            TokenActivityMap, UserProfileMap, UserProfileUpdatedMap, UserTokenMap,
+            UserTransactionsMap,
         },
         storable::Candid,
     },
@@ -44,6 +46,9 @@ pub(crate) struct State {
     pub(crate) user_transactions: UserTransactionsMap,
     /// Per-user audit trail of agreement consent/rejection events.
     pub(crate) agreement_history: AgreementHistoryMap,
+    /// Per-user in-flight high-level operations (swaps, converts, …). Survives
+    /// canister upgrades; the FE polls and updates these records.
+    pub(crate) active_user_transactions: ActiveUserTransactionsMap,
 }
 
 impl From<&State> for Stats {
@@ -57,6 +62,7 @@ impl From<&State> for Stats {
             exchange_rates_count: state.exchange_rates.len(),
             user_transactions_count: state.user_transactions.len(),
             agreement_history_count: state.agreement_history.len(),
+            active_user_transactions_count: state.active_user_transactions.len(),
         }
     }
 }
@@ -79,6 +85,7 @@ thread_local! {
             exchange_rates: ExchangeRateMap::init(mm.borrow().get(EXCHANGE_RATE_MEMORY_ID)),
             user_transactions: UserTransactionsMap::init(mm.borrow().get(USER_TRANSACTIONS_MEMORY_ID)),
             agreement_history: AgreementHistoryMap::init(mm.borrow().get(AGREEMENT_HISTORY_MEMORY_ID)),
+            active_user_transactions: ActiveUserTransactionsMap::init(mm.borrow().get(ACTIVE_USER_TRANSACTIONS_MEMORY_ID)),
         })
     );
 }

--- a/src/backend/src/types/maps.rs
+++ b/src/backend/src/types/maps.rs
@@ -4,13 +4,15 @@ use ic_stable_structures::{
     memory_manager::VirtualMemory, DefaultMemoryImpl, StableBTreeMap, StableCell,
 };
 use shared::types::{
-    agreement::AgreementHistoryEntry, api_keys::ApiKeys, backend_config::Config,
-    bitcoin::StoredPendingTransaction, contact::StoredContacts, custom_token::CustomToken,
-    exchange::ExchangeRate, token::UserToken, user_profile::StoredUserProfile,
-    user_transaction::UserTransaction, Timestamp,
+    active_user_transaction::ActiveUserTransaction, agreement::AgreementHistoryEntry,
+    api_keys::ApiKeys, backend_config::Config, bitcoin::StoredPendingTransaction,
+    contact::StoredContacts, custom_token::CustomToken, exchange::ExchangeRate, token::UserToken,
+    user_profile::StoredUserProfile, user_transaction::UserTransaction, Timestamp,
 };
 
-use crate::types::storable::{Candid, StoredPrincipal, StoredTokenId, UserTransactionKey};
+use crate::types::storable::{
+    ActiveUserTransactionKey, Candid, StoredPrincipal, StoredTokenId, UserTransactionKey,
+};
 
 pub type VMem = VirtualMemory<DefaultMemoryImpl>;
 
@@ -49,3 +51,9 @@ pub type UserTransactionsMap =
 /// Per-user audit trail of agreement consent/rejection events.
 pub type AgreementHistoryMap =
     StableBTreeMap<StoredPrincipal, Candid<Vec<AgreementHistoryEntry>>, VMem>;
+
+/// Per-record storage of in-flight user transactions (Active Transactions).
+/// Key: `(principal, frontend-generated UUID)`. One row per operation so that
+/// partial updates during polling do not rewrite a whole `Vec`.
+pub type ActiveUserTransactionsMap =
+    StableBTreeMap<ActiveUserTransactionKey, Candid<ActiveUserTransaction>, VMem>;

--- a/src/backend/src/types/storable.rs
+++ b/src/backend/src/types/storable.rs
@@ -121,3 +121,45 @@ impl Storable for UserTransactionKey {
         Self(principal, token_id)
     }
 }
+
+/// Composite key for per-user active-transaction storage.
+///
+/// Encoding mirrors [`UserTransactionKey`]: `[u32 BE principal_len][principal_bytes][id_bytes]`.
+/// The length-prefixed principal lets us range-scan all entries belonging to
+/// a given principal by starting at `(principal, "")` and stopping when the
+/// principal component changes.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ActiveUserTransactionKey(pub StoredPrincipal, pub String);
+
+impl Storable for ActiveUserTransactionKey {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        let principal_bytes = self.0.to_bytes();
+        let id_bytes = self.1.as_bytes();
+        let principal_len =
+            u32::try_from(principal_bytes.len()).expect("principal length should fit in u32");
+        let mut buf = Vec::with_capacity(4 + principal_bytes.len() + id_bytes.len());
+        buf.extend_from_slice(&principal_len.to_be_bytes());
+        buf.extend_from_slice(&principal_bytes);
+        buf.extend_from_slice(id_bytes);
+        Cow::Owned(buf)
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.to_bytes().to_vec()
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        let principal_len = u32::from_be_bytes(
+            bytes[..4]
+                .try_into()
+                .expect("failed to decode principal length"),
+        ) as usize;
+        let principal = StoredPrincipal::from_bytes(Cow::Borrowed(&bytes[4..4 + principal_len]));
+        let id = std::str::from_utf8(&bytes[4 + principal_len..])
+            .expect("active user transaction id should be valid UTF-8")
+            .to_owned();
+        Self(principal, id)
+    }
+}

--- a/src/backend/tests/it/stats.rs
+++ b/src/backend/tests/it/stats.rs
@@ -62,6 +62,7 @@ fn stats_returns_correct_number_of_users() {
         exchange_rates_count: 0,
         user_transactions_count: 0,
         agreement_history_count: 0,
+        active_user_transactions_count: 0,
     };
 
     let caller = controller();

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -752,6 +752,7 @@ type SplToken = record {
 	symbol : opt text
 };
 type Stats = record {
+	active_user_transactions_count : nat64;
 	user_profile_count : nat64;
 	user_transactions_count : nat64;
 	custom_token_count : nat64;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -1136,6 +1136,7 @@ export interface SplToken {
 	symbol: [] | [string];
 }
 export interface Stats {
+	active_user_transactions_count: bigint;
 	user_profile_count: bigint;
 	user_transactions_count: bigint;
 	custom_token_count: bigint;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -588,6 +588,7 @@ export const idlFactory = ({ IDL }) => {
 		Err: UpdateAgreementsError
 	});
 	const Stats = IDL.Record({
+		active_user_transactions_count: IDL.Nat64,
 		user_profile_count: IDL.Nat64,
 		user_transactions_count: IDL.Nat64,
 		custom_token_count: IDL.Nat64,

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -588,6 +588,7 @@ export const idlFactory = ({ IDL }) => {
 		Err: UpdateAgreementsError
 	});
 	const Stats = IDL.Record({
+		active_user_transactions_count: IDL.Nat64,
 		user_profile_count: IDL.Nat64,
 		user_transactions_count: IDL.Nat64,
 		custom_token_count: IDL.Nat64,

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -62,4 +62,5 @@ pub struct Stats {
     pub exchange_rates_count: u64,
     pub user_transactions_count: u64,
     pub agreement_history_count: u64,
+    pub active_user_transactions_count: u64,
 }


### PR DESCRIPTION
BREAKING CHANGE: The backend API is now incompatible with production.

# Motivation

Second slice of the upcoming `active_user_transactions` feature (after #12882 which landed the shared types). This PR wires the storage layer so the canister can persist in-flight high-level user operations across upgrades. Public endpoints land separately in a follow-up.

# Changes

- New `MemoryId(13)` (`ACTIVE_USER_TRANSACTIONS_MEMORY_ID`) — slot 5 stays reserved as before. a length-prefixed `Storable` encoding (mirrors `UserTransactionKey`) so we can range-scan all of a principal's rows.
- New `ActiveUserTransactionsMap` alias — per-record `StableBTreeMap<…, Candid<ActiveUserTransaction>>` rather than `Candid<Vec<…>>`, so partial updates during polling don't rewrite a whole `Vec`.
- New field on `State` + matching `Stats` counter so `/stats` reflects per-canister volume.

# Tests

- `./scripts/test.backend.sh stats` — existing stats integration tests pass against the regenerated candid (`stats_returns_correct_number_of_users` now also asserts the new counter starts at 0).

