### PR TITLE
feat(frontend): support NFT data URL media checks

### DIFF
--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -67,6 +67,26 @@ const adaptMetadataResourceUrl = (url: URL): URL | undefined => {
 	return new URL(parsedNewUrl.data);
 };
 
+const dataUrlMediaStatus = ({ url }: { url: URL }): MediaStatusEnum | undefined => {
+	if (url.protocol !== 'data:') {
+		return;
+	}
+
+	const [metadata, data = ''] = url.href.split(',', 2);
+	const [mediaType] = metadata.slice('data:'.length).split(';', 1);
+
+	if (!(mediaType.startsWith('image/') || mediaType.startsWith('video/'))) {
+		return MediaStatusEnum.NON_SUPPORTED_MEDIA_TYPE;
+	}
+
+	const isBase64 = metadata.endsWith(';base64');
+	const size = isBase64 ? Math.ceil((data.length * 3) / 4) : decodeURIComponent(data).length;
+
+	return size > NFT_MAX_FILESIZE_LIMIT
+		? MediaStatusEnum.FILESIZE_LIMIT_EXCEEDED
+		: MediaStatusEnum.OK;
+};
+
 export const parseMetadataResourceUrl = ({ url, error }: { url: string; error: NftError }): URL => {
 	const parsedUrl = UrlSchema.safeParse(url);
 
@@ -298,6 +318,12 @@ export const getMediaStatus = async (mediaUrl?: string): Promise<MediaStatusEnum
 
 		if (isNullish(url)) {
 			return MediaStatusEnum.INVALID_DATA;
+		}
+
+		const dataUrlStatus = dataUrlMediaStatus({ url });
+
+		if (nonNullish(dataUrlStatus)) {
+			return dataUrlStatus;
 		}
 
 		const { type, size } = await extractMediaTypeAndSize(url.href);

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -80,11 +80,20 @@ const dataUrlMediaStatus = ({ url }: { url: URL }): MediaStatusEnum | undefined 
 	}
 
 	const isBase64 = metadata.endsWith(';base64');
-	const size = isBase64 ? Math.ceil((data.length * 3) / 4) : decodeURIComponent(data).length;
+	const size = isBase64
+		? base64ByteLength({ data })
+		: new TextEncoder().encode(decodeURIComponent(data)).length;
 
 	return size > NFT_MAX_FILESIZE_LIMIT
 		? MediaStatusEnum.FILESIZE_LIMIT_EXCEEDED
 		: MediaStatusEnum.OK;
+};
+
+const base64ByteLength = ({ data }: { data: string }): number => {
+	const sanitizedData = data.replaceAll(/\s/g, '');
+	const padding = sanitizedData.endsWith('==') ? 2 : sanitizedData.endsWith('=') ? 1 : 0;
+
+	return Math.floor((sanitizedData.length * 3) / 4) - padding;
 };
 
 export const parseMetadataResourceUrl = ({ url, error }: { url: string; error: NftError }): URL => {

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -812,12 +812,32 @@ describe('nfts.utils', () => {
 			expect(global.fetch).not.toHaveBeenCalled();
 		});
 
+		it('returns OK for padded base64 data image URLs without overcounting size', async () => {
+			global.fetch = vi.fn();
+
+			const result = await getMediaStatus('data:image/png;base64,TQ==');
+
+			expect(result).toBe(MediaStatusEnum.OK);
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
 		it('returns NON_SUPPORTED_MEDIA_TYPE for non-media data URLs', async () => {
 			global.fetch = vi.fn();
 
 			const result = await getMediaStatus('data:text/html;base64,PGgxPkhlbGxvPC9oMT4=');
 
 			expect(result).toBe(MediaStatusEnum.NON_SUPPORTED_MEDIA_TYPE);
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
+		it('returns FILESIZE_LIMIT_EXCEEDED for oversized data media URLs without fetching', async () => {
+			global.fetch = vi.fn();
+
+			const result = await getMediaStatus(
+				`data:image/png,${'a'.repeat(NFT_MAX_FILESIZE_LIMIT + 1)}`
+			);
+
+			expect(result).toBe(MediaStatusEnum.FILESIZE_LIMIT_EXCEEDED);
 			expect(global.fetch).not.toHaveBeenCalled();
 		});
 

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -803,6 +803,24 @@ describe('nfts.utils', () => {
 			expect(result).toBe(MediaStatusEnum.OK);
 		});
 
+		it('returns OK for data image URLs without fetching', async () => {
+			global.fetch = vi.fn();
+
+			const result = await getMediaStatus('data:image/png;base64,iVBORw0KGgo=');
+
+			expect(result).toBe(MediaStatusEnum.OK);
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
+		it('returns NON_SUPPORTED_MEDIA_TYPE for non-media data URLs', async () => {
+			global.fetch = vi.fn();
+
+			const result = await getMediaStatus('data:text/html;base64,PGgxPkhlbGxvPC9oMT4=');
+
+			expect(result).toBe(MediaStatusEnum.NON_SUPPORTED_MEDIA_TYPE);
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
 		it('returns INVALID_DATA for invalid URL', async () => {
 			const result = await getMediaStatus('not-a-url');
 


### PR DESCRIPTION
# Motivation

Avoid network requests for NFT media that is already embedded as a data URL.

# Changes

- Detect image and video `data:` URLs directly in NFT media status checks.
- Return unsupported media or filesize statuses without calling `fetch`.

# Tests

Added tests.
