### PR TITLE
feat(frontend): support Icrc7 blob image metadata

### DIFF
--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -143,8 +143,11 @@ const blobImageMimeType = (value: Uint8Array): string | undefined => {
 	}
 
 	const text = new TextDecoder().decode(value.slice(0, 256)).trimStart().toLowerCase();
+	const normalizedText = text
+		.replace(/^(?:<\?xml[\s\S]*?\?>\s*|<!doctype\s+svg[^>]*>\s*|<!--[\s\S]*?-->\s*)*/u, '')
+		.trimStart();
 
-	if (text.startsWith('<svg')) {
+	if (normalizedText.startsWith('<svg')) {
 		return 'image/svg+xml';
 	}
 };

--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -9,7 +9,7 @@ import type { NftMetadataWithoutId } from '$lib/types/nft';
 import type { Token, TokenMetadata } from '$lib/types/token';
 import { mapNftAttributes } from '$lib/utils/nft.utils';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
-import { isNullish, nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish, uint8ArrayToBase64 } from '@dfinity/utils';
 
 export const isTokenIcrc7 = (token: Partial<IcToken>): token is Icrc7Token =>
 	token.standard?.code === 'icrc7';
@@ -96,17 +96,6 @@ const valueToString = ({ value }: { value: Value }): string | undefined => {
 	if ('Int' in value) {
 		return value.Int.toString();
 	}
-};
-
-const uint8ArrayToBase64 = (value: Uint8Array): string => {
-	let binary = '';
-	const chunkSize = 0x8000;
-
-	for (let i = 0; i < value.length; i += chunkSize) {
-		binary += String.fromCharCode(...value.slice(i, i + chunkSize));
-	}
-
-	return btoa(binary);
 };
 
 const blobImageMimeType = (value: Uint8Array): string | undefined => {

--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -56,6 +56,14 @@ const ICRC7_TOKEN_IMAGE_KEYS = [
 	'image',
 	'image_url'
 ];
+const ICRC7_TOKEN_THUMBNAIL_KEYS = [
+	'icrc7:thumbnail',
+	'icrc7:metadata:thumbnail',
+	'icrc7:thumbnail_url',
+	'icrc7:metadata:thumbnail_url',
+	'thumbnail',
+	'thumbnail_url'
+];
 const ICRC7_TOKEN_ATTRIBUTES_KEYS = ['icrc7:attributes', 'icrc7:metadata:attributes', 'attributes'];
 
 const lookupText = ({
@@ -88,6 +96,86 @@ const valueToString = ({ value }: { value: Value }): string | undefined => {
 	if ('Int' in value) {
 		return value.Int.toString();
 	}
+};
+
+const uint8ArrayToBase64 = (value: Uint8Array): string => {
+	let binary = '';
+	const chunkSize = 0x8000;
+
+	for (let i = 0; i < value.length; i += chunkSize) {
+		binary += String.fromCharCode(...value.slice(i, i + chunkSize));
+	}
+
+	return btoa(binary);
+};
+
+const blobImageMimeType = (value: Uint8Array): string | undefined => {
+	const [first, second, third, fourth, ...rest] = value;
+
+	if (first === 0xff && second === 0xd8 && third === 0xff) {
+		return 'image/jpeg';
+	}
+
+	if (
+		first === 0x89 &&
+		second === 0x50 &&
+		third === 0x4e &&
+		fourth === 0x47 &&
+		rest[0] === 0x0d &&
+		rest[1] === 0x0a &&
+		rest[2] === 0x1a &&
+		rest[3] === 0x0a
+	) {
+		return 'image/png';
+	}
+
+	if (
+		first === 0x47 &&
+		second === 0x49 &&
+		third === 0x46 &&
+		fourth === 0x38 &&
+		(rest[0] === 0x37 || rest[0] === 0x39) &&
+		rest[1] === 0x61
+	) {
+		return 'image/gif';
+	}
+
+	if (
+		first === 0x52 &&
+		second === 0x49 &&
+		third === 0x46 &&
+		fourth === 0x46 &&
+		rest[4] === 0x57 &&
+		rest[5] === 0x45 &&
+		rest[6] === 0x42 &&
+		rest[7] === 0x50
+	) {
+		return 'image/webp';
+	}
+
+	const text = new TextDecoder().decode(value.slice(0, 256)).trimStart().toLowerCase();
+
+	if (text.startsWith('<svg')) {
+		return 'image/svg+xml';
+	}
+};
+
+const blobToImageDataUrl = ({ value }: { value: Uint8Array }): string | undefined => {
+	const mimeType = blobImageMimeType(value);
+
+	if (isNullish(mimeType)) {
+		return;
+	}
+
+	return `data:${mimeType};base64,${uint8ArrayToBase64(value)}`;
+};
+
+const valueToImageUrl = ({ value }: { value: Value }): string | undefined => {
+	if ('Blob' in value) {
+		return blobToImageDataUrl({ value: value.Blob });
+	}
+
+	return valueToString({ value });
 };
 
 const lookupStringByKeys = ({
@@ -215,13 +303,19 @@ export const mapIcrc7CollectionMetadata = (
 export const mapIcrc7TokenMetadata = (entries: Array<[string, Value]>): NftMetadataWithoutId => {
 	const name = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_NAME_KEYS });
 	const description = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_DESCRIPTION_KEYS });
-	const imageUrl = lookupStringByKeys({ entries, keys: ICRC7_TOKEN_IMAGE_KEYS });
+	const imageEntry = entries.find(([key]) => ICRC7_TOKEN_IMAGE_KEYS.includes(key));
+	const thumbnailEntry = entries.find(([key]) => ICRC7_TOKEN_THUMBNAIL_KEYS.includes(key));
+	const imageUrl = nonNullish(imageEntry) ? valueToImageUrl({ value: imageEntry[1] }) : undefined;
+	const thumbnailUrl = nonNullish(thumbnailEntry)
+		? valueToImageUrl({ value: thumbnailEntry[1] })
+		: undefined;
 	const attributes = lookupAttributesByKeys({ entries, keys: ICRC7_TOKEN_ATTRIBUTES_KEYS });
 
 	return {
 		...(nonNullish(name) && { name }),
 		...(nonNullish(description) && { description }),
 		...(nonNullish(imageUrl) && { imageUrl }),
+		...(nonNullish(thumbnailUrl) && { thumbnailUrl }),
 		...(nonNullish(attributes) && { attributes })
 	};
 };

--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -144,9 +144,23 @@ const mapIcrc7Collection = ({ canisterId, ...rest }: Icrc7Token): NftCollection 
 	address: canisterId
 });
 
+const isImageDataUrl = (url: string): boolean => {
+	try {
+		const { protocol, pathname } = new URL(url);
+
+		return protocol === 'data:' && pathname.startsWith('image/');
+	} catch (_: unknown) {
+		return false;
+	}
+};
+
 const mapIcrc7MetadataUrl = (url: string | undefined): string | undefined => {
 	if (!notEmptyString(url)) {
 		return;
+	}
+
+	if (isImageDataUrl(url)) {
+		return url;
 	}
 
 	const parsedUrl = UrlSchema.safeParse(url);

--- a/src/frontend/src/icp/utils/nft.utils.ts
+++ b/src/frontend/src/icp/utils/nft.utils.ts
@@ -144,11 +144,25 @@ const mapIcrc7Collection = ({ canisterId, ...rest }: Icrc7Token): NftCollection 
 	address: canisterId
 });
 
-const isImageDataUrl = (url: string): boolean => {
-	try {
-		const { protocol, pathname } = new URL(url);
+const BASE64_DATA_REGEX = /^[A-Za-z0-9+/]*={0,2}$/;
 
-		return protocol === 'data:' && pathname.startsWith('image/');
+const isBase64ImageDataUrl = (url: string): boolean => {
+	try {
+		const { protocol } = new URL(url);
+
+		if (protocol !== 'data:') {
+			return false;
+		}
+
+		const [metadata, data = ''] = url.split(',', 2);
+		const [mediaType, ...parameters] = metadata.slice('data:'.length).toLowerCase().split(';');
+
+		return (
+			mediaType.startsWith('image/') &&
+			parameters.includes('base64') &&
+			data.length % 4 === 0 &&
+			BASE64_DATA_REGEX.test(data)
+		);
 	} catch (_: unknown) {
 		return false;
 	}
@@ -159,7 +173,7 @@ const mapIcrc7MetadataUrl = (url: string | undefined): string | undefined => {
 		return;
 	}
 
-	if (isImageDataUrl(url)) {
+	if (isBase64ImageDataUrl(url)) {
 		return url;
 	}
 

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -10,6 +10,7 @@ import {
 import { DEFAULT_TOKEN_TAGS } from '$lib/constants/token-tag.constants';
 import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIcrc7CanisterId, mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
+import { uint8ArrayToBase64 } from '@dfinity/utils';
 
 describe('icrc7.utils', () => {
 	describe('isTokenIcrc7', () => {
@@ -182,6 +183,16 @@ describe('icrc7.utils', () => {
 				])
 			).toEqual({
 				imageUrl: 'data:image/png;base64,iVBORw0KGgo='
+			});
+		});
+
+		it('should map SVG blobs with XML and comments into data URLs', () => {
+			const blob = new TextEncoder().encode(
+				'<?xml version="1.0"?>\n<!-- icon -->\n<svg xmlns="http://www.w3.org/2000/svg"/>'
+			);
+
+			expect(mapIcrc7TokenMetadata([['icrc7:image', { Blob: blob }]])).toEqual({
+				imageUrl: `data:image/svg+xml;base64,${uint8ArrayToBase64(blob)}`
 			});
 		});
 

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -161,12 +161,27 @@ describe('icrc7.utils', () => {
 				mapIcrc7TokenMetadata([
 					['icrc7:metadata:name', { Text: 'Namespaced token' }],
 					['icrc7:metadata:description', { Text: 'Namespaced description' }],
-					['icrc7:metadata:image_url', { Text: 'https://example.com/token.png' }]
+					['icrc7:metadata:image_url', { Text: 'https://example.com/token.png' }],
+					['icrc7:metadata:thumbnail_url', { Text: 'https://example.com/token-thumb.png' }]
 				])
 			).toEqual({
 				name: 'Namespaced token',
 				description: 'Namespaced description',
-				imageUrl: 'https://example.com/token.png'
+				imageUrl: 'https://example.com/token.png',
+				thumbnailUrl: 'https://example.com/token-thumb.png'
+			});
+		});
+
+		it('should map image blobs into data URLs', () => {
+			expect(
+				mapIcrc7TokenMetadata([
+					[
+						'icrc7:image',
+						{ Blob: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]) }
+					]
+				])
+			).toEqual({
+				imageUrl: 'data:image/png;base64,iVBORw0KGgo='
 			});
 		});
 

--- a/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
@@ -324,6 +324,26 @@ describe('nft.utils', () => {
 			expect(global.fetch).not.toHaveBeenCalled();
 		});
 
+		it('should omit non-base64 data image URLs and avoid fetching them', async () => {
+			vi.mocked(getIcrc7Metadata).mockResolvedValue({
+				name: 'ICRC-7 NFT #50',
+				imageUrl: 'data:image/svg+xml;utf8,<svg/>'
+			});
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			expect(result.imageUrl).toBeUndefined();
+			expect(result.mediaStatus).toStrictEqual({
+				image: MediaStatusEnum.INVALID_DATA,
+				thumbnail: MediaStatusEnum.INVALID_DATA
+			});
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
 		it('should omit invalid metadata URLs and avoid fetching them', async () => {
 			vi.mocked(getIcrc7Metadata).mockResolvedValue({
 				name: 'ICRC-7 NFT #50',

--- a/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/nft.utils.spec.ts
@@ -303,6 +303,27 @@ describe('nft.utils', () => {
 			});
 		});
 
+		it('should map data image URLs without fetching them for validation', async () => {
+			const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
+			vi.mocked(getIcrc7Metadata).mockResolvedValue({
+				name: 'ICRC-7 NFT #50',
+				imageUrl
+			});
+
+			const result = await mapIcrc7Nft({
+				index: mockIndex,
+				token: mockValidIcrc7Token,
+				identity: mockIdentity
+			});
+
+			expect(result.imageUrl).toBe(imageUrl);
+			expect(result.mediaStatus).toStrictEqual({
+				image: MediaStatusEnum.OK,
+				thumbnail: MediaStatusEnum.INVALID_DATA
+			});
+			expect(global.fetch).not.toHaveBeenCalled();
+		});
+
 		it('should omit invalid metadata URLs and avoid fetching them', async () => {
 			vi.mocked(getIcrc7Metadata).mockResolvedValue({
 				name: 'ICRC-7 NFT #50',


### PR DESCRIPTION
# Motivation

ICRC-7 token metadata can provide image bytes directly instead of an external URL.

# Changes

- Convert recognized image blobs from ICRC-7 metadata into `data:image/...` URLs.
- Map thumbnail metadata keys alongside full image keys.
- Allow ICRC-7 NFT mapping to keep image data URLs and add focused tests.

# Tests

Added tests.

