### PR TITLE
feat(frontend): track token management actions

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenReviewByNetwork.svelte
@@ -244,7 +244,8 @@
 			modalNext,
 			onSuccess,
 			onError,
-			identity: $authIdentity
+			identity: $authIdentity,
+			tokenManageModifier: 'import'
 		});
 
 	let icrcMetadata: ValidateIcrcTokenData | undefined = $state();

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { isNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { page } from '$app/state';
 	import type { AddTokenData } from '$icp-eth/types/add-token';
@@ -11,8 +12,13 @@
 	import { MANAGE_TOKENS_MODAL } from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
+	import {
+		PLAUSIBLE_EVENT_RESULT_STATUSES,
+		PLAUSIBLE_EVENT_SOURCE_LOCATIONS
+	} from '$lib/enums/plausible';
 	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 	import { WizardStepsManageTokens } from '$lib/enums/wizard-steps';
+	import { trackTokenManage } from '$lib/services/token-manage-analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Network } from '$lib/types/network';
@@ -68,7 +74,42 @@
 
 	const progress = (step: ProgressStepsAddToken) => (saveProgressStep = step);
 
+	const trackImportCancel = () => {
+		if (
+			currentStep?.name !== WizardStepsManageTokens.IMPORT &&
+			currentStep?.name !== WizardStepsManageTokens.REVIEW
+		) {
+			return;
+		}
+
+		const address =
+			tokenData.ledgerCanisterId ??
+			tokenData.extCanisterId ??
+			tokenData.dip721CanisterId ??
+			tokenData.icPunksCanisterId ??
+			tokenData.icrc7CanisterId ??
+			tokenData.ethContractAddress ??
+			tokenData.splTokenAddress;
+		const tokenNetwork = network?.id.description;
+
+		if (isNullish(address) || isNullish(tokenNetwork)) {
+			return;
+		}
+
+		trackTokenManage({
+			modifier: 'import',
+			token: {
+				network: tokenNetwork,
+				address
+			},
+			sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.CANCEL
+		});
+	};
+
 	const close = () => {
+		trackImportCancel();
+
 		modalStore.close();
 
 		saveProgressStep = ProgressStepsAddToken.INITIALIZATION;

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -23,6 +23,7 @@
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Network } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
+	import { isNullishOrEmpty } from '$lib/utils/input.utils';
 	import { isRouteNfts } from '$lib/utils/nav.utils';
 	import { saveAllCustomTokens } from '$lib/utils/tokens.utils';
 
@@ -93,7 +94,7 @@
 
 		const tokenNetwork = network?.id.description;
 
-		if (isNullish(address) || isNullish(tokenNetwork)) {
+		if (isNullishOrEmpty(address) || isNullish(tokenNetwork)) {
 			return;
 		}
 

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -90,6 +90,7 @@
 			tokenData.icrc7CanisterId ??
 			tokenData.ethContractAddress ??
 			tokenData.splTokenAddress;
+			
 		const tokenNetwork = network?.id.description;
 
 		if (isNullish(address) || isNullish(tokenNetwork)) {

--- a/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokensModal.svelte
@@ -90,7 +90,7 @@
 			tokenData.icrc7CanisterId ??
 			tokenData.ethContractAddress ??
 			tokenData.splTokenAddress;
-			
+
 		const tokenNetwork = network?.id.description;
 
 		if (isNullish(address) || isNullish(tokenNetwork)) {

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
+	import { assertNonNullish, isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import type { Snippet } from 'svelte';
 	import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
@@ -29,14 +29,25 @@
 	import { addTokenSteps } from '$lib/constants/steps.constants';
 	import { TOKEN_MODAL_SAVE_BUTTON } from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import {
+		PLAUSIBLE_EVENT_RESULT_STATUSES,
+		PLAUSIBLE_EVENT_SOURCE_LOCATIONS
+	} from '$lib/enums/plausible';
 	import { ProgressStepsAddToken } from '$lib/enums/progress-steps';
 	import { TokenModalSteps } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
+	import {
+		trackTokenManage,
+		type TokenManageEventKey,
+		type TokenManageEventModifier,
+		type TokenManageEventToken
+	} from '$lib/services/token-manage-analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 	import type { OptionToken, Token } from '$lib/types/token';
 	import { toCustomToken } from '$lib/utils/custom-token.utils';
+	import { errorDetailToString } from '$lib/utils/error.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { back, gotoReplaceRoot } from '$lib/utils/nav.utils';
 	import { isNetworkIdSOLDevnet } from '$lib/utils/network.utils';
@@ -110,6 +121,66 @@
 		nonNullish(fromRoute) ? await back({ pop: nonNullish(fromRoute) }) : await gotoReplaceRoot();
 	};
 
+	const mapTokenManageToken = (token: Token): TokenManageEventToken => {
+		const tokenAddress = 'address' in token ? (token.address as string | undefined) : undefined;
+		const network = token.network.id.description;
+		const address =
+			tokenAddress ?? (isTokenIcrc(token) ? token.ledgerCanisterId : token.id.description);
+
+		assertNonNullish(network);
+		assertNonNullish(address);
+
+		return {
+			network,
+			address,
+			...(nonNullish(token.symbol) && { symbol: token.symbol }),
+			...(nonNullish(token.name) && { name: token.name })
+		};
+	};
+
+	const trackTokenManageDetails = ({
+		modifier,
+		token,
+		resultStatus,
+		key,
+		value,
+		error
+	}: {
+		modifier: TokenManageEventModifier;
+		token: Token;
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
+		key?: TokenManageEventKey;
+		value?: string;
+		error?: string;
+	}) =>
+		trackTokenManage({
+			modifier,
+			token: mapTokenManageToken(token),
+			sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.TOKEN_DETAILS,
+			resultStatus,
+			...(nonNullish(key) && { key }),
+			...(nonNullish(value) && { value }),
+			...(nonNullish(error) && { error })
+		});
+
+	const trackTokenManageEdit = ({
+		tokenToEdit,
+		resultStatus,
+		error
+	}: {
+		tokenToEdit: Token;
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
+		error?: string;
+	}) =>
+		trackTokenManageDetails({
+			modifier: 'edit',
+			token: tokenToEdit,
+			resultStatus,
+			key: 'index_canister',
+			value: icrcTokenIndexCanisterId,
+			...(nonNullish(error) && { error })
+		});
+
 	const onTokenDeleteSuccess = async (deletedToken: Token) => {
 		loading = false;
 
@@ -125,6 +196,12 @@
 				...(nonNullish(address) && { address: `${address}` }),
 				networkId: `${deletedToken.network.id.description}`
 			}
+		});
+
+		trackTokenManageDetails({
+			modifier: 'delete',
+			token: deletedToken,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 		});
 
 		toastsShow({
@@ -206,6 +283,13 @@
 				await onTokenDeleteSuccess(tokenToDelete);
 			}
 		} catch (err: unknown) {
+			trackTokenManageDetails({
+				modifier: 'delete',
+				token: tokenToDelete,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+				error: errorDetailToString(err)
+			});
+
 			toastsError({
 				msg: { text: $i18n.tokens.error.unexpected_error_on_token_delete },
 				err
@@ -215,6 +299,19 @@
 			showBottomSheetDeleteConfirmation = false;
 			loading = false;
 		}
+	};
+
+	const onTokenDeleteCancel = (tokenToDelete: OptionToken) => {
+		if (nonNullish(tokenToDelete)) {
+			trackTokenManageDetails({
+				modifier: 'delete',
+				token: tokenToDelete,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.CANCEL
+			});
+		}
+
+		showBottomSheetDeleteConfirmation = false;
+		gotoStep(TokenModalSteps.CONTENT);
 	};
 
 	const onTokenEdit = async (tokenToEdit: OptionToken) => {
@@ -241,6 +338,11 @@
 					: { valid: true };
 
 				if (!valid) {
+					trackTokenManageEdit({
+						tokenToEdit,
+						resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR
+					});
+
 					loading = false;
 					icrcTokenIndexCanisterId = tokenToEdit.indexCanisterId ?? '';
 					progress(ProgressStepsAddToken.INITIALIZATION);
@@ -287,6 +389,11 @@
 							}
 						});
 
+						trackTokenManageEdit({
+							tokenToEdit,
+							resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+						});
+
 						toastsShow({
 							text: replacePlaceholders($i18n.tokens.details.update_confirmation, {
 								$token: getTokenDisplaySymbol(tokenToEdit)
@@ -297,7 +404,13 @@
 					}
 				});
 			}
-		} catch (err) {
+		} catch (err: unknown) {
+			trackTokenManageEdit({
+				tokenToEdit,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+				error: errorDetailToString(err)
+			});
+
 			toastsError({
 				msg: { text: $i18n.tokens.error.unexpected_error_on_token_update },
 				err
@@ -310,6 +423,15 @@
 			progress(ProgressStepsAddToken.INITIALIZATION);
 			gotoStep(TokenModalSteps.CONTENT);
 		}
+	};
+
+	const onTokenEditCancel = (tokenToEdit: Token) => {
+		trackTokenManageEdit({
+			tokenToEdit,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.CANCEL
+		});
+
+		gotoStep(TokenModalSteps.CONTENT);
 	};
 </script>
 
@@ -349,7 +471,7 @@
 		{:else if currentStepName === TokenModalSteps.DELETE_CONFIRMATION}
 			<TokenModalDeleteConfirmation
 				{loading}
-				onCancel={() => gotoStep(TokenModalSteps.CONTENT)}
+				onCancel={() => onTokenDeleteCancel(token)}
 				onConfirm={() => onTokenDelete(token)}
 				{token}
 			/>
@@ -369,7 +491,7 @@
 
 				{#snippet toolbar()}
 					<ButtonGroup>
-						<ButtonBack onclick={() => gotoStep(TokenModalSteps.CONTENT)} />
+						<ButtonBack onclick={() => onTokenEditCancel(token)} />
 
 						<Button
 							disabled={icrcTokenIndexCanisterId === (token.indexCanisterId ?? '')}
@@ -388,10 +510,7 @@
 </WizardModal>
 
 {#if currentStepName === TokenModalSteps.CONTENT && showBottomSheetDeleteConfirmation}
-	<BottomSheetConfirmationPopup
-		disabled={loading}
-		onCancel={() => (showBottomSheetDeleteConfirmation = false)}
-	>
+	<BottomSheetConfirmationPopup disabled={loading} onCancel={() => onTokenDeleteCancel(token)}>
 		{#snippet title()}
 			{$i18n.tokens.text.delete_token}
 		{/snippet}
@@ -399,7 +518,7 @@
 		{#snippet content()}
 			<TokenModalDeleteConfirmation
 				{loading}
-				onCancel={() => (showBottomSheetDeleteConfirmation = false)}
+				onCancel={() => onTokenDeleteCancel(token)}
 				onConfirm={() => onTokenDelete(token)}
 				{token}
 			/>

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -159,7 +159,7 @@
 			sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.TOKEN_DETAILS,
 			resultStatus,
 			...(nonNullish(key) && { key }),
-			...(nonNullish(value) && { value }),
+			...(notEmptyString(value) && { value }),
 			...(nonNullish(error) && { error })
 		});
 

--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -24,7 +24,9 @@ import { trackEvent } from '$lib/services/analytics.services';
 import { saveCustomTokens } from '$lib/services/save-custom-tokens.services';
 import {
 	trackTokenManage,
-	type TokenManageEventToken
+	type TokenManageEventModifier,
+	type TokenManageEventToken,
+	type TokenManageSourceLocation
 } from '$lib/services/token-manage-analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
@@ -33,7 +35,11 @@ import type { NullishIdentity } from '$lib/types/identity';
 import type { Token } from '$lib/types/token';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { NonEmptyArray } from '$lib/types/utils';
-import { isVersionMismatchError, mapIcErrorMetadata } from '$lib/utils/error.utils';
+import {
+	errorDetailToString,
+	isVersionMismatchError,
+	mapIcErrorMetadata
+} from '$lib/utils/error.utils';
 import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -45,6 +51,8 @@ interface ManageTokensSaveParams {
 	onSuccess?: () => void;
 	onError?: () => void;
 	identity: NullishIdentity;
+	tokenManageModifier?: TokenManageEventModifier;
+	tokenManageSourceLocation?: TokenManageSourceLocation;
 }
 
 export interface SaveTokensParams<T> {
@@ -143,6 +151,49 @@ const mapTokenManageToken = <T extends SaveTokensToken>({
 	};
 };
 
+const tokenManageModifier = <T extends SaveTokensToken>({
+	token,
+	modifier
+}: {
+	token: T;
+	modifier?: TokenManageEventModifier;
+}): TokenManageEventModifier => modifier ?? (token.enabled ? 'enable' : 'disable');
+
+const trackTokenManageResults = <T extends SaveTokensToken>({
+	tokens,
+	modifier,
+	sourceLocation,
+	resultStatus,
+	error,
+	errorCode
+}: {
+	tokens: T[];
+	modifier?: TokenManageEventModifier;
+	sourceLocation: TokenManageSourceLocation;
+	resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
+	error?: string;
+	errorCode?: string;
+}) => {
+	tokens.forEach((token) => {
+		const tokenId = 'id' in token ? token.id : undefined;
+		const network = 'network' in token ? token.network : undefined;
+		const tokenManageToken = mapTokenManageToken({ token, tokenId, network });
+
+		if (isNullish(tokenManageToken)) {
+			return;
+		}
+
+		trackTokenManage({
+			modifier: tokenManageModifier({ token, modifier }),
+			token: tokenManageToken,
+			sourceLocation,
+			resultStatus,
+			...(nonNullish(error) && { error }),
+			...(nonNullish(errorCode) && { errorCode })
+		});
+	});
+};
+
 export const saveTokens = async <
 	T extends
 		| SaveCustomTokenWithKey
@@ -159,7 +210,9 @@ export const saveTokens = async <
 	modalNext,
 	onSuccess,
 	onError,
-	identity
+	identity,
+	tokenManageModifier: modifier,
+	tokenManageSourceLocation = PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS
 }: {
 	tokens: T[];
 	save: (params: SaveTokensParams<T>) => Promise<void>;
@@ -216,16 +269,12 @@ export const saveTokens = async <
 				}
 			});
 
-			const tokenManageToken = mapTokenManageToken({ token, tokenId, network });
-
-			if (nonNullish(tokenManageToken)) {
-				trackTokenManage({
-					modifier: enabled ? 'enable' : 'disable',
-					token: tokenManageToken,
-					sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS,
-					resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
-				});
-			}
+			trackTokenManageResults({
+				tokens: [token],
+				modifier,
+				sourceLocation: tokenManageSourceLocation,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+			});
 		});
 	} catch (err: unknown) {
 		const versionMismatch = isVersionMismatchError(err);
@@ -247,6 +296,15 @@ export const saveTokens = async <
 		trackEvent({
 			name: TRACK_COUNT_MANAGE_TOKENS_SAVE_ERROR,
 			metadata: mapIcErrorMetadata(err)
+		});
+
+		trackTokenManageResults({
+			tokens,
+			modifier,
+			sourceLocation: tokenManageSourceLocation,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+			error: errorDetailToString(err),
+			...(versionMismatch && { errorCode: 'version_mismatch' })
 		});
 	}
 };

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -177,6 +177,30 @@ describe('manage-tokens.services', () => {
 			});
 		});
 
+		it('should support token_manage import modifier override', async () => {
+			const customTokens: SaveCustomTokenWithKey[] = [
+				{
+					enabled: true,
+					networkKey: 'Icrc7',
+					canisterId: mockIcrc7CanisterId
+				}
+			];
+
+			mockSave.mockResolvedValueOnce(undefined);
+
+			await saveTokens({ ...params, tokens: customTokens, tokenManageModifier: 'import' });
+
+			expect(trackTokenManage).toHaveBeenCalledExactlyOnceWith({
+				modifier: 'import',
+				token: {
+					network: ICP_NETWORK_ID.description,
+					address: mockIcrc7CanisterId
+				},
+				sourceLocation: 'manage_tokens',
+				resultStatus: 'success'
+			});
+		});
+
 		it('should handle errors from save', async () => {
 			mockSave.mockRejectedValueOnce(new Error('Save failed'));
 
@@ -197,6 +221,28 @@ describe('manage-tokens.services', () => {
 					error: 'Save failed'
 				}
 			});
+
+			expect(trackTokenManage).toHaveBeenCalledTimes(tokens.length);
+
+			tokens.forEach((token, index) => {
+				expect(trackTokenManage).toHaveBeenNthCalledWith(index + 1, {
+					modifier: token.enabled ? 'enable' : 'disable',
+					token: {
+						network: token.network.id.description,
+						address:
+							'address' in token
+								? token.address
+								: 'ledgerCanisterId' in token
+									? token.ledgerCanisterId
+									: token.id.description,
+						symbol: token.symbol,
+						name: token.name
+					},
+					sourceLocation: 'manage_tokens',
+					resultStatus: 'error',
+					error: 'Save failed'
+				});
+			});
 		});
 
 		it('should show a warning toast on version mismatch error', async () => {
@@ -216,6 +262,29 @@ describe('manage-tokens.services', () => {
 				metadata: {
 					error: 'Version mismatch, token update not allowed'
 				}
+			});
+
+			expect(trackTokenManage).toHaveBeenCalledTimes(tokens.length);
+
+			tokens.forEach((token, index) => {
+				expect(trackTokenManage).toHaveBeenNthCalledWith(index + 1, {
+					modifier: token.enabled ? 'enable' : 'disable',
+					token: {
+						network: token.network.id.description,
+						address:
+							'address' in token
+								? token.address
+								: 'ledgerCanisterId' in token
+									? token.ledgerCanisterId
+									: token.id.description,
+						symbol: token.symbol,
+						name: token.name
+					},
+					sourceLocation: 'manage_tokens',
+					resultStatus: 'error',
+					error: 'Version mismatch, token update not allowed',
+					errorCode: 'version_mismatch'
+				});
 			});
 		});
 


### PR DESCRIPTION
# Motivation

Token management actions should emit consistent analytics for imports, edits, deletes, cancellations, and errors.

# Changes

- Centralize token_manage result tracking for save paths.
- Track import, edit, delete, cancel, and error outcomes from the manage-token UI.

# Tests

Added tests.
