### PR TITLE
feat(frontend): resolve Icrc7 deep link actions

### DIFF
--- a/src/frontend/src/icp/services/icrc7-deep-link.services.ts
+++ b/src/frontend/src/icp/services/icrc7-deep-link.services.ts
@@ -1,12 +1,19 @@
 import { ICP_NETWORK_ID, ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
+import type { Icrc7CustomToken } from '$icp/types/icrc7-custom-token';
 import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
 import { CanisterIdTextSchema, type CanisterIdText } from '$lib/types/canister';
 import type { NetworkId } from '$lib/types/network';
+import { isNullish } from '@dfinity/utils';
 
 export interface Icrc7CollectionDeepLink {
 	canisterId: CanisterIdText;
 	networkId: NetworkId;
 }
+
+export type Icrc7CollectionDeepLinkAction =
+	| ({ type: 'import' } & Icrc7CollectionDeepLink)
+	| ({ type: 'enable'; token: Icrc7CustomToken } & Icrc7CollectionDeepLink)
+	| ({ type: 'ready'; token: Icrc7CustomToken } & Icrc7CollectionDeepLink);
 
 export const parseIcrc7CollectionDeepLink = ({
 	url
@@ -30,4 +37,26 @@ export const parseIcrc7CollectionDeepLink = ({
 		canisterId: parsedCollection.data,
 		networkId: ICP_NETWORK_ID
 	};
+};
+
+export const resolveIcrc7CollectionDeepLinkAction = ({
+	url,
+	tokens
+}: {
+	url: URL;
+	tokens: Icrc7CustomToken[];
+}): Icrc7CollectionDeepLinkAction | undefined => {
+	const deepLink = parseIcrc7CollectionDeepLink({ url });
+
+	if (isNullish(deepLink)) {
+		return;
+	}
+
+	const token = tokens.find(({ canisterId }) => canisterId === deepLink.canisterId);
+
+	if (isNullish(token)) {
+		return { type: 'import', ...deepLink };
+	}
+
+	return { type: token.enabled ? 'ready' : 'enable', token, ...deepLink };
 };

--- a/src/frontend/src/tests/icp/services/icrc7-deep-link.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc7-deep-link.services.spec.ts
@@ -1,31 +1,34 @@
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
-import { parseIcrc7CollectionDeepLink } from '$icp/services/icrc7-deep-link.services';
+import {
+	parseIcrc7CollectionDeepLink,
+	resolveIcrc7CollectionDeepLinkAction
+} from '$icp/services/icrc7-deep-link.services';
 import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
-import { mockIcrc7CanisterId } from '$tests/mocks/icrc7-tokens.mock';
+import { mockIcrc7CanisterId, mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 import { nonNullish } from '@dfinity/utils';
 
 describe('icrc7-deep-link.services', () => {
+	const urlWithParams = ({
+		collection,
+		network
+	}: {
+		collection?: string;
+		network?: string;
+	}): URL => {
+		const url = new URL('https://oisy.com/nfts/');
+
+		if (nonNullish(collection)) {
+			url.searchParams.set(COLLECTION_PARAM, collection);
+		}
+
+		if (nonNullish(network)) {
+			url.searchParams.set(NETWORK_PARAM, network);
+		}
+
+		return url;
+	};
+
 	describe('parseIcrc7CollectionDeepLink', () => {
-		const urlWithParams = ({
-			collection,
-			network
-		}: {
-			collection?: string;
-			network?: string;
-		}): URL => {
-			const url = new URL('https://oisy.com/nfts/');
-
-			if (nonNullish(collection)) {
-				url.searchParams.set(COLLECTION_PARAM, collection);
-			}
-
-			if (nonNullish(network)) {
-				url.searchParams.set(NETWORK_PARAM, network);
-			}
-
-			return url;
-		};
-
 		it('should parse a valid ICP collection deep link', () => {
 			expect(
 				parseIcrc7CollectionDeepLink({
@@ -63,6 +66,61 @@ describe('icrc7-deep-link.services', () => {
 			expect(
 				parseIcrc7CollectionDeepLink({
 					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ETH' })
+				})
+			).toBeUndefined();
+		});
+	});
+
+	describe('resolveIcrc7CollectionDeepLinkAction', () => {
+		const enabledToken = { ...mockValidIcrc7Token, enabled: true };
+		const disabledToken = { ...mockValidIcrc7Token, enabled: false };
+
+		it('should return import action when collection is unknown', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: []
+				})
+			).toEqual({
+				type: 'import',
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
+		});
+
+		it('should return enable action when collection is known but disabled', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: [disabledToken]
+				})
+			).toEqual({
+				type: 'enable',
+				token: disabledToken,
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
+		});
+
+		it('should return ready action when collection is already enabled', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ICP' }),
+					tokens: [enabledToken]
+				})
+			).toEqual({
+				type: 'ready',
+				token: enabledToken,
+				canisterId: mockIcrc7CanisterId,
+				networkId: ICP_NETWORK_ID
+			});
+		});
+
+		it('should return undefined for invalid deep links', () => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ETH' }),
+					tokens: [enabledToken]
 				})
 			).toBeUndefined();
 		});


### PR DESCRIPTION
# Motivation

ICRC-7 collection links need a small service-level decision layer before any UI can decide whether to import, enable, or ignore a collection.

# Changes

- Add `resolveIcrc7CollectionDeepLinkAction` for import, enable, and ready states.

# Tests

Added tests.