### PR TITLE
feat(frontend): treat octet-stream NFT media as displayable

### DIFF
--- a/src/frontend/src/lib/services/url.services.ts
+++ b/src/frontend/src/lib/services/url.services.ts
@@ -114,12 +114,19 @@ export const extractMediaUrls = async (url: string): Promise<string[]> => {
 };
 
 const getMediaType = (type: string): MediaType => {
-	if (type.startsWith('image/') || type.startsWith('.gif')) {
+	const normalizedType = type.split(';', 1)[0].trim().toLowerCase();
+
+	if (normalizedType.startsWith('image/') || normalizedType.startsWith('.gif')) {
 		return MediaType.Img;
 	}
 
-	if (type.startsWith('video/')) {
+	if (normalizedType.startsWith('video/')) {
 		return MediaType.Video;
+	}
+
+	// Byte-stream blob hosts (e.g. Caffeine) often serve valid JPEG/PNG as octet-stream.
+	if (normalizedType === 'application/octet-stream') {
+		return MediaType.Img;
 	}
 
 	return MediaType.Other;

--- a/src/frontend/src/tests/lib/services/url.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/url.services.spec.ts
@@ -161,6 +161,24 @@ describe('url.services', () => {
 			});
 		});
 
+		it('should treat application/octet-stream as image media', async () => {
+			global.fetch = vi.fn().mockResolvedValueOnce({
+				headers: {
+					get: (h: string) =>
+						h === 'Content-Type'
+							? 'application/octet-stream'
+							: h === 'Content-Length'
+								? mockSize.toString()
+								: null
+				}
+			});
+
+			await expect(extractMediaTypeAndSize(mockUrl)).resolves.toStrictEqual({
+				type: MediaType.Img,
+				size: mockSize
+			});
+		});
+
 		it('should handle a missing content size', async () => {
 			global.fetch = vi.fn().mockResolvedValueOnce({
 				headers: {

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -865,6 +865,25 @@ describe('nfts.utils', () => {
 			expect(result).toBe(MediaStatusEnum.OK);
 		});
 
+		it('returns OK for application/octet-stream byte-stream assets under the size limit', async () => {
+			global.fetch = vi.fn().mockResolvedValueOnce({
+				headers: {
+					get: (h: string) =>
+						h === 'Content-Type'
+							? 'application/octet-stream'
+							: h === 'Content-Length'
+								? (NFT_MAX_FILESIZE_LIMIT - 100).toString()
+								: null
+				}
+			});
+
+			const result = await getMediaStatus(
+				'https://blob.caffeine.ai/v1/blob/?blob_hash=sha256%3Aabc&owner_id=sey3i-jyaaa-aaaap-quo3q-cai&project_id=019de6f2-675c-775e-9eda-2adf4341566c'
+			);
+
+			expect(result).toBe(MediaStatusEnum.OK);
+		});
+
 		it('returns NON_SUPPORTED_MEDIA_TYPE for non-image and non-video type', async () => {
 			global.fetch = vi.fn().mockResolvedValueOnce({
 				headers: {


### PR DESCRIPTION
# Motivation

ICRC-7 test NFTs from Caffeine expose image metadata as `https://blob.caffeine.ai/...` Text URLs. The assets are valid JPEGs but are served with `Content-Type: application/octet-stream`. OISY classified that as unsupported media, so images stayed hidden even after the user enabled collection media.

# Changes

- Classify `application/octet-stream` as image media in `getMediaType` (with charset stripped from the header).

# Tests

Added tests.

