### PR TITLE
feat(backend)!: expose active user transaction endpoints

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1,3 +1,64 @@
+// In-flight high-level user operation, persisted so the FE can resume polling
+// across logout / tab close.
+type ActiveUserTransaction = record {
+	// Frontend-generated identifier (`UUIDv4`). Unique per user.
+	id : text;
+	status : ActiveUserTransactionStatus;
+	// Learned-mid-flow named references, e.g.
+	// `{ key: "tx_hash", value: "0x…" }`. See [`ActiveUserTransactionRef`]
+	// for the field layout exposed on the wire and in TS bindings.
+	external_refs : vec ActiveUserTransactionRef;
+	// Opaque to the backend; the FE writes a flow-specific step name here.
+	progress_step : opt text;
+	data : ActiveUserTransactionData;
+	updated_at_ns : nat64;
+	// Populated when `status = Failed`.
+	error : opt text;
+	created_at_ns : nat64
+};
+// Flow-specific payload, captured once at creation and immutable thereafter.
+//
+// Variants are append-only (Candid evolution rule). Learned-mid-flow values
+// (tx hashes, forwarding addresses, provider request ids, …) go in
+// `ActiveUserTransaction::external_refs` so we don't need to bump candid for
+// every new provider integration.
+type ActiveUserTransactionData = variant {
+	OneSecEvmToIcp : OneSecEvmToIcpData;
+	OneSecIcpToEvm : OneSecIcpToEvmData
+};
+type ActiveUserTransactionError = variant {
+	InvalidId;
+	NotFound;
+	TooManyActiveTransactions;
+	InvalidData : text;
+	AlreadyExists;
+	IllegalStatusTransition
+};
+// Learned-mid-flow `(key, value)` reference attached to an active transaction,
+// e.g. `{ key: "tx_hash", value: "0x…" }`. Modelled as a named record (not a
+// tuple) so the generated TS bindings expose `.key` / `.value` instead of
+// positional `[string, string]` access.
+type ActiveUserTransactionRef = record { key : text; value : text };
+// Shared result for endpoints that return a single `ActiveUserTransaction`
+// (both `create_active_user_transaction` and `update_active_user_transaction`).
+// One type because the wire shape is identical — the candid extractor would
+// dedupe twin variants anyway.
+type ActiveUserTransactionResult = variant {
+	Ok : ActiveUserTransaction;
+	Err : ActiveUserTransactionError
+};
+// Lifecycle status of an active user transaction.
+//
+// Allowed transitions are enforced by the backend:
+// `Pending` → `Pending | Executing | Succeeded | Failed`,
+// `Executing` → `Executing | Succeeded | Failed`,
+// terminal states are immutable (idempotent no-op).
+type ActiveUserTransactionStatus = variant {
+	Failed;
+	Executing;
+	Succeeded;
+	Pending
+};
 type AddDappSettingsError = variant {
 	MaxHiddenDappIds;
 	VersionMismatch;
@@ -343,6 +404,12 @@ type ContactError = variant {
 	TooManyContactsWithImages
 };
 type ContactImage = record { data : blob; mime_type : ImageMimeType };
+type CreateActiveUserTransactionRequest = record {
+	id : text;
+	external_refs : vec ActiveUserTransactionRef;
+	progress_step : opt text;
+	data : ActiveUserTransactionData
+};
 type CreateContactRequest = record { name : text; image : opt ContactImage };
 type CreateContactResult = variant {
 	// The contact was retrieved successfully.
@@ -385,6 +452,10 @@ type Delegation = record {
 	pubkey : blob;
 	targets : opt vec principal;
 	expiration : nat64
+};
+type DeleteActiveUserTransactionResult = variant {
+	Ok;
+	Err : ActiveUserTransactionError
 };
 type DeleteContactResult = variant {
 	// The contact was deleted successfully.
@@ -444,6 +515,13 @@ type ExperimentalFeaturesSettings = record {
 };
 // An EXT v2 compliant token on the Internet Computer.
 type ExtV2Token = record { canister_id : principal };
+type GetActiveUserTransactionsResponse = record {
+	transactions : vec ActiveUserTransaction
+};
+type GetActiveUserTransactionsResult = variant {
+	Ok : GetActiveUserTransactionsResponse;
+	Err : ActiveUserTransactionError
+};
 type GetAgreementHistoryError = variant { UserNotFound };
 type GetAgreementHistoryResult = variant {
 	Ok : vec AgreementHistoryEntry;
@@ -665,6 +743,18 @@ type NetworksSettings = record {
 type NotificationSettings = record {
 	dismissed_notifications : vec DismissedNotification
 };
+type OneSecEvmToIcpData = record {
+	recipient_principal : principal;
+	source_token : TokenId;
+	amount : nat;
+	dest_token : TokenId
+};
+type OneSecIcpToEvmData = record {
+	recipient_evm_address : text;
+	source_token : TokenId;
+	amount : nat;
+	dest_token : TokenId
+};
 // Outpoint.
 type Outpoint = record {
 	// Transaction ID (TxID).
@@ -879,6 +969,19 @@ type TransformArgs = record {
 	// Raw response from remote service, to be transformed
 	response : HttpRequestResult
 };
+// Partial update. `None` means "leave untouched"; `Some(value)` overwrites
+// the stored value. There is no encoding for "clear back to `None`" — this
+// is intentional: `error` is only ever set on the `Failed` terminal state
+// (immutable by lifecycle), and `progress_step` is forward-only.
+// `external_refs`, when provided, **replaces** the stored list in full —
+// the FE always knows the complete set after each poll.
+type UpdateActiveUserTransactionRequest = record {
+	id : text;
+	status : opt ActiveUserTransactionStatus;
+	external_refs : opt vec ActiveUserTransactionRef;
+	progress_step : opt text;
+	error : opt text
+};
 type UpdateAgreementsError = variant { VersionMismatch; UserNotFound };
 type UpdateExperimentalFeaturesSettingsRequest = record {
 	experimental_features : vec record {
@@ -1053,6 +1156,13 @@ service : (Arg) -> {
 	);
 	// Gets the canister configuration.
 	config : () -> (Config) query;
+	// Creates a new active user transaction record for the caller.
+	//
+	// # Errors
+	// Errors are enumerated by: `ActiveUserTransactionError`.
+	create_active_user_transaction : (CreateActiveUserTransactionRequest) -> (
+		ActiveUserTransactionResult
+	);
 	// Creates a new contact for the caller.
 	//
 	// # Errors
@@ -1069,6 +1179,15 @@ service : (Arg) -> {
 	// caller does not already have a profile. Existing users are unaffected and still receive
 	// `Ok(profile)` for idempotent calls.
 	create_user_profile : () -> (CreateUserProfileResult);
+	// Deletes one of the caller's active user transactions. Idempotent: returns
+	// `Ok(())` whether or not the record existed. This is the only path that
+	// removes records — there is no automatic pruning.
+	//
+	// # Errors
+	// Errors are enumerated by: `ActiveUserTransactionError`.
+	delete_active_user_transaction : (text) -> (
+		DeleteActiveUserTransactionResult
+	);
 	// Deletes a contact for the caller.
 	//
 	// # Errors
@@ -1081,6 +1200,10 @@ service : (Arg) -> {
 	get_account_creation_timestamps : () -> (
 		vec record { principal; nat64 }
 	) query;
+	// Returns all of the caller's active user transactions (Pending, Executing,
+	// Succeeded, Failed). Records are retained until the FE deletes them on user
+	// acknowledgement, so terminal entries remain in the list until dismissed.
+	get_active_user_transactions : () -> (GetActiveUserTransactionsResult) query;
 	// Retrieves the amount of cycles that the signer canister is allowed to spend
 	// on behalf of the current user.
 	//
@@ -1223,6 +1346,13 @@ service : (Arg) -> {
 	// Error conditions are enumerated by: `TopUpCyclesLedgerError`
 	top_up_cycles_ledger : (opt TopUpCyclesLedgerRequest) -> (
 		TopUpCyclesLedgerResult
+	);
+	// Applies a partial update to one of the caller's active user transactions.
+	//
+	// # Errors
+	// Errors are enumerated by: `ActiveUserTransactionError`.
+	update_active_user_transaction : (UpdateActiveUserTransactionRequest) -> (
+		ActiveUserTransactionResult
 	);
 	// Updates an existing contact for the caller.
 	//

--- a/src/backend/src/active_user_transactions/mod.rs
+++ b/src/backend/src/active_user_transactions/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod model;

--- a/src/backend/src/active_user_transactions/model.rs
+++ b/src/backend/src/active_user_transactions/model.rs
@@ -1,0 +1,661 @@
+use std::collections::HashSet;
+
+use candid::{Nat, Principal};
+use shared::types::active_user_transaction::{
+    ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
+    ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
+    GetActiveUserTransactionsResponse, UpdateActiveUserTransactionRequest,
+    MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_ACTIVE_USER_TRANSACTION_ERROR_LEN,
+    MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REFS, MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_KEY_LEN,
+    MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_VALUE_LEN, MAX_ACTIVE_USER_TRANSACTION_ID_LEN,
+    MAX_ACTIVE_USER_TRANSACTION_PROGRESS_STEP_LEN, MAX_EVM_ADDRESS_LEN,
+};
+
+use crate::types::{ActiveUserTransactionKey, ActiveUserTransactionsMap, Candid, StoredPrincipal};
+
+/// Create a new active transaction. Checks are ordered so callers always see
+/// the most informative error: `InvalidId` → `AlreadyExists` (idempotent
+/// retries land here even at the cap) → `InvalidData` → `TooManyActiveTransactions`.
+pub fn create(
+    map: &mut ActiveUserTransactionsMap,
+    principal: Principal,
+    request: CreateActiveUserTransactionRequest,
+    now_ns: u64,
+) -> Result<ActiveUserTransaction, ActiveUserTransactionError> {
+    validate_id(&request.id)?;
+
+    let key = key(principal, &request.id);
+    if map.contains_key(&key) {
+        return Err(ActiveUserTransactionError::AlreadyExists);
+    }
+
+    validate_data(&request.data)?;
+    validate_progress_step(request.progress_step.as_deref())?;
+    validate_external_refs(&request.external_refs)?;
+
+    if count_records(map, principal) >= MAX_ACTIVE_USER_TRANSACTIONS_PER_USER {
+        return Err(ActiveUserTransactionError::TooManyActiveTransactions);
+    }
+
+    let tx = ActiveUserTransaction {
+        id: request.id,
+        status: ActiveUserTransactionStatus::Pending,
+        data: request.data,
+        progress_step: request.progress_step,
+        external_refs: request.external_refs,
+        created_at_ns: now_ns,
+        updated_at_ns: now_ns,
+        error: None,
+    };
+
+    map.insert(key, Candid(tx.clone()));
+    Ok(tx)
+}
+
+/// Apply a partial update to an existing active transaction. Status transitions
+/// are validated; updates against missing or other-user records are rejected.
+pub fn update(
+    map: &mut ActiveUserTransactionsMap,
+    principal: Principal,
+    request: UpdateActiveUserTransactionRequest,
+    now_ns: u64,
+) -> Result<ActiveUserTransaction, ActiveUserTransactionError> {
+    validate_id(&request.id)?;
+
+    let entry_key = key(principal, &request.id);
+    let mut current = map
+        .get(&entry_key)
+        .map(|c| c.0)
+        .ok_or(ActiveUserTransactionError::NotFound)?;
+
+    if let Some(step) = request.progress_step.as_deref() {
+        validate_progress_step(Some(step))?;
+    }
+    if let Some(refs) = request.external_refs.as_ref() {
+        validate_external_refs(refs)?;
+    }
+    if let Some(err) = request.error.as_deref() {
+        validate_error(err)?;
+    }
+
+    if let Some(new_status) = request.status.as_ref() {
+        validate_transition(&current.status, new_status)?;
+        current.status = new_status.clone();
+    }
+    if let Some(step) = request.progress_step {
+        current.progress_step = Some(step);
+    }
+    if let Some(refs) = request.external_refs {
+        current.external_refs = refs;
+    }
+    if let Some(err) = request.error {
+        current.error = Some(err);
+    }
+    current.updated_at_ns = now_ns;
+
+    map.insert(entry_key, Candid(current.clone()));
+    Ok(current)
+}
+
+/// Delete an active transaction. Idempotent — returns `Ok(())` whether or not
+/// the record existed (the FE only cares that it is gone).
+pub fn delete(
+    map: &mut ActiveUserTransactionsMap,
+    principal: Principal,
+    id: String,
+) -> Result<(), ActiveUserTransactionError> {
+    validate_id(&id)?;
+    map.remove(&ActiveUserTransactionKey(StoredPrincipal(principal), id));
+    Ok(())
+}
+
+/// Build the response of active transactions visible to the caller. Records
+/// are never auto-pruned — the FE deletes them on user acknowledgement.
+pub fn list(
+    map: &ActiveUserTransactionsMap,
+    principal: Principal,
+) -> GetActiveUserTransactionsResponse {
+    let transactions: Vec<ActiveUserTransaction> =
+        scan_principal(map, principal).map(|(_, c)| c.0).collect();
+
+    GetActiveUserTransactionsResponse { transactions }
+}
+
+fn count_records(map: &ActiveUserTransactionsMap, principal: Principal) -> usize {
+    let lower = key(principal, "");
+    map.range(lower..)
+        .take_while(|entry| entry.key().0 .0 == principal)
+        .count()
+}
+
+fn scan_principal(
+    map: &ActiveUserTransactionsMap,
+    principal: Principal,
+) -> impl Iterator<Item = (ActiveUserTransactionKey, Candid<ActiveUserTransaction>)> + '_ {
+    let lower = key(principal, "");
+    // `LazyEntry::into_pair` would let us replace the closure with a method
+    // reference, but `ic_stable_structures::btreemap::iter` is a private module
+    // so the type cannot be named outside the crate.
+    #[expect(
+        clippy::redundant_closure_for_method_calls,
+        reason = "LazyEntry type path is not publicly exported by ic-stable-structures"
+    )]
+    map.range(lower..)
+        .take_while(move |entry| entry.key().0 .0 == principal)
+        .map(|entry| entry.into_pair())
+}
+
+fn key(principal: Principal, id: &str) -> ActiveUserTransactionKey {
+    ActiveUserTransactionKey(StoredPrincipal(principal), id.to_string())
+}
+
+fn validate_id(id: &str) -> Result<(), ActiveUserTransactionError> {
+    if id.is_empty() || id.len() > MAX_ACTIVE_USER_TRANSACTION_ID_LEN {
+        return Err(ActiveUserTransactionError::InvalidId);
+    }
+    if !id.chars().all(|c| c.is_ascii_graphic()) {
+        return Err(ActiveUserTransactionError::InvalidId);
+    }
+    Ok(())
+}
+
+fn validate_progress_step(step: Option<&str>) -> Result<(), ActiveUserTransactionError> {
+    if let Some(s) = step {
+        if s.len() > MAX_ACTIVE_USER_TRANSACTION_PROGRESS_STEP_LEN {
+            return Err(ActiveUserTransactionError::InvalidData(
+                "progress_step too long".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_error(error: &str) -> Result<(), ActiveUserTransactionError> {
+    if error.len() > MAX_ACTIVE_USER_TRANSACTION_ERROR_LEN {
+        return Err(ActiveUserTransactionError::InvalidData(
+            "error message too long".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_external_refs(
+    refs: &[ActiveUserTransactionRef],
+) -> Result<(), ActiveUserTransactionError> {
+    if refs.len() > MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REFS {
+        return Err(ActiveUserTransactionError::InvalidData(
+            "too many external_refs".to_string(),
+        ));
+    }
+    let mut seen = HashSet::with_capacity(refs.len());
+    for ActiveUserTransactionRef { key, value } in refs {
+        if key.is_empty() || key.len() > MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_KEY_LEN {
+            return Err(ActiveUserTransactionError::InvalidData(
+                "external_refs key invalid length".to_string(),
+            ));
+        }
+        if value.len() > MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_VALUE_LEN {
+            return Err(ActiveUserTransactionError::InvalidData(
+                "external_refs value too long".to_string(),
+            ));
+        }
+        if !seen.insert(key.as_str()) {
+            return Err(ActiveUserTransactionError::InvalidData(
+                "duplicate external_refs key".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_data(data: &ActiveUserTransactionData) -> Result<(), ActiveUserTransactionError> {
+    match data {
+        ActiveUserTransactionData::OneSecIcpToEvm(d) => {
+            require_positive_amount(&d.amount)?;
+            require_evm_address(&d.recipient_evm_address)?;
+        }
+        ActiveUserTransactionData::OneSecEvmToIcp(d) => {
+            require_positive_amount(&d.amount)?;
+            if d.recipient_principal == Principal::anonymous() {
+                return Err(ActiveUserTransactionError::InvalidData(
+                    "recipient_principal must not be anonymous".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn require_positive_amount(amount: &Nat) -> Result<(), ActiveUserTransactionError> {
+    if amount.0 == 0u32.into() {
+        return Err(ActiveUserTransactionError::InvalidData(
+            "amount must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn require_evm_address(addr: &str) -> Result<(), ActiveUserTransactionError> {
+    if addr.is_empty() || addr.len() > MAX_EVM_ADDRESS_LEN {
+        return Err(ActiveUserTransactionError::InvalidData(
+            "recipient_evm_address invalid length".to_string(),
+        ));
+    }
+    if !addr.starts_with("0x") {
+        return Err(ActiveUserTransactionError::InvalidData(
+            "recipient_evm_address must start with 0x".to_string(),
+        ));
+    }
+    if !addr[2..].chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(ActiveUserTransactionError::InvalidData(
+            "recipient_evm_address must be hex".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_transition(
+    from: &ActiveUserTransactionStatus,
+    to: &ActiveUserTransactionStatus,
+) -> Result<(), ActiveUserTransactionError> {
+    use ActiveUserTransactionStatus::{Executing, Failed, Pending, Succeeded};
+
+    let ok = matches!(
+        (from, to),
+        (Pending, Pending | Executing | Succeeded | Failed)
+            | (Executing, Executing | Succeeded | Failed)
+            | (Succeeded, Succeeded)
+            | (Failed, Failed)
+    );
+
+    if ok {
+        Ok(())
+    } else {
+        Err(ActiveUserTransactionError::IllegalStatusTransition)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use candid::{Nat, Principal};
+    use ic_stable_structures::{
+        memory_manager::{MemoryId, MemoryManager},
+        DefaultMemoryImpl,
+    };
+    use pretty_assertions::assert_eq;
+    use shared::types::{
+        active_user_transaction::{
+            ActiveUserTransactionData, ActiveUserTransactionError, ActiveUserTransactionRef,
+            ActiveUserTransactionStatus, CreateActiveUserTransactionRequest, OneSecIcpToEvmData,
+            UpdateActiveUserTransactionRequest, MAX_ACTIVE_USER_TRANSACTIONS_PER_USER,
+        },
+        token_id::TokenId,
+    };
+
+    use super::{create, delete, list, update};
+    use crate::types::maps::ActiveUserTransactionsMap;
+
+    const PRINCIPAL_TEXT: &str = "7blps-itamd-lzszp-7lbda-4nngn-fev5u-2jvpn-6y3ap-eunp7-kz57e-fqe";
+    const OTHER_PRINCIPAL_TEXT: &str =
+        "535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe";
+
+    fn setup() -> (
+        ActiveUserTransactionsMap,
+        RefCell<MemoryManager<DefaultMemoryImpl>>,
+    ) {
+        let mm = RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+        let map = ActiveUserTransactionsMap::init(mm.borrow().get(MemoryId::new(0)));
+        (map, mm)
+    }
+
+    fn principal() -> Principal {
+        Principal::from_text(PRINCIPAL_TEXT).unwrap()
+    }
+
+    fn other_principal() -> Principal {
+        Principal::from_text(OTHER_PRINCIPAL_TEXT).unwrap()
+    }
+
+    fn sample_data() -> ActiveUserTransactionData {
+        ActiveUserTransactionData::OneSecIcpToEvm(OneSecIcpToEvmData {
+            source_token: TokenId::IcpNative,
+            dest_token: TokenId::EvmNative(1),
+            amount: Nat::from(1_000_000u64),
+            recipient_evm_address: "0x0000000000000000000000000000000000000001".to_string(),
+        })
+    }
+
+    fn create_req(id: &str) -> CreateActiveUserTransactionRequest {
+        CreateActiveUserTransactionRequest {
+            id: id.to_string(),
+            data: sample_data(),
+            progress_step: None,
+            external_refs: vec![],
+        }
+    }
+
+    #[test]
+    fn create_and_get_roundtrip() {
+        let (mut map, _mm) = setup();
+        let tx = create(&mut map, principal(), create_req("id-1"), 1).expect("create");
+        assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+        assert_eq!(tx.created_at_ns, 1);
+        assert_eq!(tx.updated_at_ns, 1);
+
+        let res = list(&map, principal()).transactions;
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].id, "id-1");
+    }
+
+    #[test]
+    fn duplicate_id_rejected() {
+        let (mut map, _mm) = setup();
+        create(&mut map, principal(), create_req("id-1"), 1).expect("first");
+        let err = create(&mut map, principal(), create_req("id-1"), 2).unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::AlreadyExists);
+    }
+
+    #[test]
+    fn empty_id_rejected() {
+        let (mut map, _mm) = setup();
+        let err = create(&mut map, principal(), create_req(""), 1).unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::InvalidId);
+    }
+
+    #[test]
+    fn id_with_non_ascii_rejected() {
+        let (mut map, _mm) = setup();
+        let err = create(&mut map, principal(), create_req("naïve-id"), 1).unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::InvalidId);
+    }
+
+    #[test]
+    fn zero_amount_rejected() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("id-1");
+        req.data = ActiveUserTransactionData::OneSecIcpToEvm(OneSecIcpToEvmData {
+            source_token: TokenId::IcpNative,
+            dest_token: TokenId::EvmNative(1),
+            amount: Nat::from(0u32),
+            recipient_evm_address: "0x0000000000000000000000000000000000000001".to_string(),
+        });
+        let err = create(&mut map, principal(), req, 1).unwrap_err();
+        assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    #[test]
+    fn malformed_eth_address_rejected() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("id-1");
+        req.data = ActiveUserTransactionData::OneSecIcpToEvm(OneSecIcpToEvmData {
+            source_token: TokenId::IcpNative,
+            dest_token: TokenId::EvmNative(1),
+            amount: Nat::from(1u32),
+            recipient_evm_address: "not-an-address".to_string(),
+        });
+        let err = create(&mut map, principal(), req, 1).unwrap_err();
+        assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    #[test]
+    fn duplicate_external_ref_key_rejected() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("id-1");
+        req.external_refs = vec![
+            ActiveUserTransactionRef {
+                key: "tx_hash".to_string(),
+                value: "a".to_string(),
+            },
+            ActiveUserTransactionRef {
+                key: "tx_hash".to_string(),
+                value: "b".to_string(),
+            },
+        ];
+        let err = create(&mut map, principal(), req, 1).unwrap_err();
+        assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    #[test]
+    fn duplicate_id_at_cap_returns_already_exists() {
+        let (mut map, _mm) = setup();
+        for i in 0..MAX_ACTIVE_USER_TRANSACTIONS_PER_USER {
+            create(&mut map, principal(), create_req(&format!("id-{i}")), 1).expect("within cap");
+        }
+        // Idempotent retry of an existing id, even at the cap, must surface
+        // AlreadyExists rather than TooManyActiveTransactions.
+        let err = create(&mut map, principal(), create_req("id-0"), 2).unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::AlreadyExists);
+    }
+
+    #[test]
+    fn per_user_cap_enforced() {
+        let (mut map, _mm) = setup();
+        for i in 0..MAX_ACTIVE_USER_TRANSACTIONS_PER_USER {
+            create(&mut map, principal(), create_req(&format!("id-{i}")), 1).expect("within cap");
+        }
+        let err = create(&mut map, principal(), create_req("overflow"), 1).unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::TooManyActiveTransactions);
+
+        // Other principals are unaffected.
+        create(&mut map, other_principal(), create_req("id-1"), 1)
+            .expect("other principal not throttled");
+    }
+
+    #[test]
+    fn cap_counts_terminal_rows() {
+        let (mut map, _mm) = setup();
+        for i in 0..MAX_ACTIVE_USER_TRANSACTIONS_PER_USER {
+            let id = format!("id-{i}");
+            create(&mut map, principal(), create_req(&id), 1).expect("within cap");
+            update(
+                &mut map,
+                principal(),
+                UpdateActiveUserTransactionRequest {
+                    id,
+                    status: Some(ActiveUserTransactionStatus::Succeeded),
+                    progress_step: None,
+                    external_refs: None,
+                    error: None,
+                },
+                2,
+            )
+            .expect("succeed");
+        }
+        let err = create(&mut map, principal(), create_req("overflow"), 3).unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::TooManyActiveTransactions);
+
+        // FE acknowledges one row, freeing a slot.
+        delete(&mut map, principal(), "id-0".to_string()).expect("delete");
+        create(&mut map, principal(), create_req("after-delete"), 4)
+            .expect("slot freed after delete");
+    }
+
+    #[test]
+    fn update_partial_fields() {
+        let (mut map, _mm) = setup();
+        create(&mut map, principal(), create_req("id-1"), 1).expect("create");
+
+        let updated = update(
+            &mut map,
+            principal(),
+            UpdateActiveUserTransactionRequest {
+                id: "id-1".to_string(),
+                status: Some(ActiveUserTransactionStatus::Executing),
+                progress_step: Some("submitting".to_string()),
+                external_refs: Some(vec![ActiveUserTransactionRef {
+                    key: "tx_hash".to_string(),
+                    value: "0xabc".to_string(),
+                }]),
+                error: None,
+            },
+            5,
+        )
+        .expect("update");
+
+        assert_eq!(updated.status, ActiveUserTransactionStatus::Executing);
+        assert_eq!(updated.progress_step.as_deref(), Some("submitting"));
+        assert_eq!(updated.external_refs.len(), 1);
+        assert_eq!(updated.updated_at_ns, 5);
+        assert_eq!(updated.created_at_ns, 1);
+    }
+
+    #[test]
+    fn illegal_transition_rejected() {
+        let (mut map, _mm) = setup();
+        create(&mut map, principal(), create_req("id-1"), 1).expect("create");
+        update(
+            &mut map,
+            principal(),
+            UpdateActiveUserTransactionRequest {
+                id: "id-1".to_string(),
+                status: Some(ActiveUserTransactionStatus::Succeeded),
+                progress_step: None,
+                external_refs: None,
+                error: None,
+            },
+            2,
+        )
+        .expect("Pending -> Succeeded allowed");
+
+        let err = update(
+            &mut map,
+            principal(),
+            UpdateActiveUserTransactionRequest {
+                id: "id-1".to_string(),
+                status: Some(ActiveUserTransactionStatus::Executing),
+                progress_step: None,
+                external_refs: None,
+                error: None,
+            },
+            3,
+        )
+        .unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::IllegalStatusTransition);
+    }
+
+    #[test]
+    fn update_missing_with_invalid_payload_returns_not_found() {
+        let (mut map, _mm) = setup();
+        // Payload would fail semantic validation, but existence check must
+        // run first so the caller sees `NotFound`, not `InvalidData`.
+        let err = update(
+            &mut map,
+            principal(),
+            UpdateActiveUserTransactionRequest {
+                id: "missing".to_string(),
+                status: None,
+                progress_step: Some("x".repeat(1024)),
+                external_refs: None,
+                error: None,
+            },
+            1,
+        )
+        .unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::NotFound);
+    }
+
+    #[test]
+    fn update_missing_rejected() {
+        let (mut map, _mm) = setup();
+        let err = update(
+            &mut map,
+            principal(),
+            UpdateActiveUserTransactionRequest {
+                id: "missing".to_string(),
+                status: None,
+                progress_step: None,
+                external_refs: None,
+                error: None,
+            },
+            1,
+        )
+        .unwrap_err();
+        assert_eq!(err, ActiveUserTransactionError::NotFound);
+    }
+
+    #[test]
+    fn list_returns_all_statuses() {
+        let (mut map, _mm) = setup();
+        create(&mut map, principal(), create_req("a"), 1).expect("a");
+        create(&mut map, principal(), create_req("b"), 1).expect("b");
+        update(
+            &mut map,
+            principal(),
+            UpdateActiveUserTransactionRequest {
+                id: "b".to_string(),
+                status: Some(ActiveUserTransactionStatus::Succeeded),
+                progress_step: None,
+                external_refs: None,
+                error: None,
+            },
+            2,
+        )
+        .expect("update b");
+
+        let all = list(&map, principal()).transactions;
+        let mut ids: Vec<String> = all.iter().map(|tx| tx.id.clone()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn list_is_principal_scoped() {
+        let (mut map, _mm) = setup();
+        create(&mut map, principal(), create_req("a"), 1).expect("a");
+        create(&mut map, other_principal(), create_req("a"), 1).expect("other");
+
+        let mine = list(&map, principal()).transactions;
+        assert_eq!(mine.len(), 1);
+
+        let theirs = list(&map, other_principal()).transactions;
+        assert_eq!(theirs.len(), 1);
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let (mut map, _mm) = setup();
+        create(&mut map, principal(), create_req("a"), 1).expect("create");
+        delete(&mut map, principal(), "a".to_string()).expect("first delete");
+        delete(&mut map, principal(), "a".to_string()).expect("second delete idempotent");
+        assert!(list(&map, principal()).transactions.is_empty());
+    }
+
+    #[test]
+    fn terminal_records_are_retained_until_deleted() {
+        let (mut map, _mm) = setup();
+        create(&mut map, principal(), create_req("a"), 1).expect("create");
+        update(
+            &mut map,
+            principal(),
+            UpdateActiveUserTransactionRequest {
+                id: "a".to_string(),
+                status: Some(ActiveUserTransactionStatus::Succeeded),
+                progress_step: None,
+                external_refs: None,
+                error: None,
+            },
+            10,
+        )
+        .expect("succeed");
+
+        // No matter how far in the future we read, the terminal record stays
+        // until the FE explicitly deletes it.
+        let far_future = 10u64 + 30 * 24 * 60 * 60 * 1_000_000_000;
+        let res = list(&map, principal()).transactions;
+        assert_eq!(res.len(), 1, "terminal entry must be retained");
+
+        create(&mut map, principal(), create_req("b"), far_future).expect("create b");
+        let after_write: Vec<String> = {
+            let mut ids: Vec<String> = list(&map, principal())
+                .transactions
+                .into_iter()
+                .map(|tx| tx.id)
+                .collect();
+            ids.sort();
+            ids
+        };
+        assert_eq!(after_write, vec!["a".to_string(), "b".to_string()]);
+    }
+}

--- a/src/backend/src/api/active_user_transactions.rs
+++ b/src/backend/src/api/active_user_transactions.rs
@@ -1,0 +1,89 @@
+use ic_cdk::{
+    api::{msg_caller, time},
+    query, update,
+};
+use shared::types::{
+    active_user_transaction::{
+        CreateActiveUserTransactionRequest, UpdateActiveUserTransactionRequest,
+    },
+    result_types::{
+        ActiveUserTransactionResult, DeleteActiveUserTransactionResult,
+        GetActiveUserTransactionsResult,
+    },
+};
+
+use crate::{
+    active_user_transactions::model,
+    state::{mutate_state, read_state},
+    utils::guards::{caller_is_not_anonymous, caller_is_registered_user},
+};
+
+/// Creates a new active user transaction record for the caller.
+///
+/// # Errors
+/// Errors are enumerated by: `ActiveUserTransactionError`.
+#[update(guard = "caller_is_registered_user")]
+#[must_use]
+pub fn create_active_user_transaction(
+    request: CreateActiveUserTransactionRequest,
+) -> ActiveUserTransactionResult {
+    let principal = msg_caller();
+    let now_ns = time();
+    let result = mutate_state(|state| {
+        model::create(
+            &mut state.active_user_transactions,
+            principal,
+            request,
+            now_ns,
+        )
+    });
+    result.into()
+}
+
+/// Applies a partial update to one of the caller's active user transactions.
+///
+/// # Errors
+/// Errors are enumerated by: `ActiveUserTransactionError`.
+#[update(guard = "caller_is_registered_user")]
+#[must_use]
+pub fn update_active_user_transaction(
+    request: UpdateActiveUserTransactionRequest,
+) -> ActiveUserTransactionResult {
+    let principal = msg_caller();
+    let now_ns = time();
+    let result = mutate_state(|state| {
+        model::update(
+            &mut state.active_user_transactions,
+            principal,
+            request,
+            now_ns,
+        )
+    });
+    result.into()
+}
+
+/// Deletes one of the caller's active user transactions. Idempotent: returns
+/// `Ok(())` whether or not the record existed. This is the only path that
+/// removes records — there is no automatic pruning.
+///
+/// # Errors
+/// Errors are enumerated by: `ActiveUserTransactionError`.
+#[update(guard = "caller_is_registered_user")]
+#[must_use]
+pub fn delete_active_user_transaction(id: String) -> DeleteActiveUserTransactionResult {
+    let principal = msg_caller();
+    let result =
+        mutate_state(|state| model::delete(&mut state.active_user_transactions, principal, id));
+    result.into()
+}
+
+/// Returns all of the caller's active user transactions (Pending, Executing,
+/// Succeeded, Failed). Records are retained until the FE deletes them on user
+/// acknowledgement, so terminal entries remain in the list until dismissed.
+#[query(guard = "caller_is_not_anonymous")]
+#[must_use]
+pub fn get_active_user_transactions() -> GetActiveUserTransactionsResult {
+    let principal = msg_caller();
+    let response = read_state(|state| model::list(&state.active_user_transactions, principal));
+    GetActiveUserTransactionsResult::Ok(response)
+}

--- a/src/backend/src/api/mod.rs
+++ b/src/backend/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod active_user_transactions;
 pub mod admin;
 pub mod api_keys;
 pub mod bitcoin;

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -10,6 +10,9 @@ use shared::{
     http::{HttpRequest, HttpResponse},
     std_canister_status,
     types::{
+        active_user_transaction::{
+            CreateActiveUserTransactionRequest, UpdateActiveUserTransactionRequest,
+        },
         agreement::{UpdateProviderAgreementsRequest, UpdateUserAgreementsRequest},
         api_keys::ApiKeys,
         backend_config::{Arg, Config},
@@ -25,10 +28,11 @@ use shared::{
         network::{SaveNetworksSettingsRequest, SetShowTestnetsRequest},
         notification::AddDismissedNotificationRequest,
         result_types::{
-            AddUserDismissedNotificationResult, AddUserHiddenDappIdResult, AllowSigningResult,
-            BtcAddPendingTransactionResult, BtcGetFeePercentilesResult,
-            BtcGetPendingTransactionsResult, CreateContactResult, CreateUserProfileResult,
-            DeleteContactResult, GetAgreementHistoryResult, GetAllowedCyclesResult,
+            ActiveUserTransactionResult, AddUserDismissedNotificationResult,
+            AddUserHiddenDappIdResult, AllowSigningResult, BtcAddPendingTransactionResult,
+            BtcGetFeePercentilesResult, BtcGetPendingTransactionsResult, CreateContactResult,
+            CreateUserProfileResult, DeleteActiveUserTransactionResult, DeleteContactResult,
+            GetActiveUserTransactionsResult, GetAgreementHistoryResult, GetAllowedCyclesResult,
             GetContactResult, GetContactsResult, GetUserProfileResult, GetUserTransactionsResult,
             SaveUserTransactionsResult, SetUserShowTestnetsResult, UpdateContactResult,
             UpdateExperimentalFeaturesSettingsResult, UpdateProviderAgreementsResult,
@@ -49,6 +53,7 @@ use shared::{
 
 use crate::state::{read_state, set_config};
 
+mod active_user_transactions;
 mod api;
 mod bitcoin;
 mod contacts;

--- a/src/backend/src/types/mod.rs
+++ b/src/backend/src/types/mod.rs
@@ -3,8 +3,10 @@ pub(crate) mod storable;
 
 pub(crate) use self::{
     maps::{
-        AgreementHistoryMap, BtcUserPendingTransactionsMap, UserProfileMap, UserProfileUpdatedMap,
-        UserTransactionsMap, VMem,
+        ActiveUserTransactionsMap, AgreementHistoryMap, BtcUserPendingTransactionsMap,
+        UserProfileMap, UserProfileUpdatedMap, UserTransactionsMap, VMem,
     },
-    storable::{Candid, StoredPrincipal, StoredTokenId, UserTransactionKey},
+    storable::{
+        ActiveUserTransactionKey, Candid, StoredPrincipal, StoredTokenId, UserTransactionKey,
+    },
 };

--- a/src/backend/tests/it/active_user_transactions.rs
+++ b/src/backend/tests/it/active_user_transactions.rs
@@ -235,7 +235,7 @@ fn records_survive_canister_upgrade() {
     // install rolls out of the rate-limit window before we attempt the
     // upgrade. Mirrors the advance_time + tick-loop idiom used in
     // `tests/it/signer.rs` and `tests/it/status.rs`.
-    pic.pic.advance_time(Duration::from_secs(60));
+    pic.pic.advance_time(Duration::from_mins(1));
     for _ in 0..20 {
         pic.pic.tick();
     }

--- a/src/backend/tests/it/active_user_transactions.rs
+++ b/src/backend/tests/it/active_user_transactions.rs
@@ -1,0 +1,244 @@
+use candid::{Nat, Principal};
+use pretty_assertions::assert_eq;
+use shared::types::{
+    active_user_transaction::{
+        ActiveUserTransactionData, ActiveUserTransactionError, ActiveUserTransactionRef,
+        ActiveUserTransactionStatus, CreateActiveUserTransactionRequest, OneSecIcpToEvmData,
+        UpdateActiveUserTransactionRequest,
+    },
+    result_types::{
+        ActiveUserTransactionResult, DeleteActiveUserTransactionResult,
+        GetActiveUserTransactionsResult,
+    },
+    token_id::TokenId,
+};
+
+use crate::utils::{
+    mock::CALLER,
+    pocketic::{setup, BackendBuilder, PicBackend, PicCanisterTrait},
+};
+
+const TX_ID: &str = "11111111-1111-4111-8111-111111111111";
+const ETH_ADDR: &str = "0x0000000000000000000000000000000000000001";
+
+fn caller() -> Principal {
+    Principal::from_text(CALLER).unwrap()
+}
+
+fn other_caller() -> Principal {
+    Principal::from_text("535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe").unwrap()
+}
+
+fn sample_data() -> ActiveUserTransactionData {
+    ActiveUserTransactionData::OneSecIcpToEvm(OneSecIcpToEvmData {
+        source_token: TokenId::IcpNative,
+        dest_token: TokenId::EvmNative(1),
+        amount: Nat::from(1_000_000u64),
+        recipient_evm_address: ETH_ADDR.to_string(),
+    })
+}
+
+fn create_req(id: &str) -> CreateActiveUserTransactionRequest {
+    CreateActiveUserTransactionRequest {
+        id: id.to_string(),
+        data: sample_data(),
+        progress_step: Some("initialization".to_string()),
+        external_refs: vec![],
+    }
+}
+
+fn create_active(pic: &PicBackend, user: Principal, id: &str) -> ActiveUserTransactionResult {
+    pic.ensure_user_profile(user);
+    pic.update::<ActiveUserTransactionResult>(
+        user,
+        "create_active_user_transaction",
+        create_req(id),
+    )
+    .expect("create_active_user_transaction call should succeed")
+}
+
+#[test]
+fn create_requires_registered_user() {
+    let pic = setup();
+
+    let res = pic.update::<ActiveUserTransactionResult>(
+        Principal::anonymous(),
+        "create_active_user_transaction",
+        create_req(TX_ID),
+    );
+    assert!(
+        res.is_err(),
+        "anonymous caller must be rejected by the guard"
+    );
+}
+
+#[test]
+fn create_and_get_roundtrip() {
+    let pic = setup();
+    let user = caller();
+
+    let created = match create_active(&pic, user, TX_ID) {
+        ActiveUserTransactionResult::Ok(tx) => *tx,
+        ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    };
+    assert_eq!(created.id, TX_ID);
+    assert_eq!(created.status, ActiveUserTransactionStatus::Pending);
+
+    let listed = pic
+        .query::<GetActiveUserTransactionsResult>(user, "get_active_user_transactions", ())
+        .expect("query should succeed");
+
+    match listed {
+        GetActiveUserTransactionsResult::Ok(response) => {
+            assert_eq!(response.transactions.len(), 1);
+            assert_eq!(response.transactions[0].id, TX_ID);
+        }
+        GetActiveUserTransactionsResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+}
+
+#[test]
+fn duplicate_create_returns_already_exists() {
+    let pic = setup();
+    let user = caller();
+
+    create_active(&pic, user, TX_ID);
+    let second = create_active(&pic, user, TX_ID);
+    match second {
+        ActiveUserTransactionResult::Err(ActiveUserTransactionError::AlreadyExists) => {}
+        other => panic!("expected AlreadyExists, got {other:?}"),
+    }
+}
+
+#[test]
+fn update_transitions_and_terminal_visible() {
+    let pic = setup();
+    let user = caller();
+    create_active(&pic, user, TX_ID);
+
+    let updated = pic
+        .update::<ActiveUserTransactionResult>(
+            user,
+            "update_active_user_transaction",
+            UpdateActiveUserTransactionRequest {
+                id: TX_ID.to_string(),
+                status: Some(ActiveUserTransactionStatus::Succeeded),
+                progress_step: Some("done".to_string()),
+                external_refs: Some(vec![ActiveUserTransactionRef {
+                    key: "tx_hash".to_string(),
+                    value: "0xabc".to_string(),
+                }]),
+                error: None,
+            },
+        )
+        .expect("update call should succeed");
+    match updated {
+        ActiveUserTransactionResult::Ok(tx) => {
+            assert_eq!(tx.status, ActiveUserTransactionStatus::Succeeded);
+            assert_eq!(tx.external_refs.len(), 1);
+            assert_eq!(tx.progress_step.as_deref(), Some("done"));
+        }
+        ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+
+    let listed = pic
+        .query::<GetActiveUserTransactionsResult>(user, "get_active_user_transactions", ())
+        .expect("query should succeed");
+    match listed {
+        GetActiveUserTransactionsResult::Ok(response) => {
+            assert_eq!(response.transactions.len(), 1);
+            assert_eq!(response.transactions[0].id, TX_ID);
+            assert_eq!(
+                response.transactions[0].status,
+                ActiveUserTransactionStatus::Succeeded
+            );
+        }
+        GetActiveUserTransactionsResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+}
+
+#[test]
+fn delete_is_idempotent_and_filters_view() {
+    let pic = setup();
+    let user = caller();
+    create_active(&pic, user, TX_ID);
+
+    let first = pic
+        .update::<DeleteActiveUserTransactionResult>(
+            user,
+            "delete_active_user_transaction",
+            TX_ID.to_string(),
+        )
+        .expect("delete call should succeed");
+    assert!(matches!(first, DeleteActiveUserTransactionResult::Ok(())));
+
+    let second = pic
+        .update::<DeleteActiveUserTransactionResult>(
+            user,
+            "delete_active_user_transaction",
+            TX_ID.to_string(),
+        )
+        .expect("delete call should succeed on missing id");
+    assert!(matches!(second, DeleteActiveUserTransactionResult::Ok(())));
+
+    let listed = pic
+        .query::<GetActiveUserTransactionsResult>(user, "get_active_user_transactions", ())
+        .expect("query should succeed");
+    match listed {
+        GetActiveUserTransactionsResult::Ok(response) => assert!(response.transactions.is_empty()),
+        GetActiveUserTransactionsResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+}
+
+#[test]
+fn records_are_principal_scoped() {
+    let pic = setup();
+    let user = caller();
+    let other = other_caller();
+
+    create_active(&pic, user, TX_ID);
+    create_active(&pic, other, TX_ID); // same id, different principal — allowed
+
+    let user_listed = pic
+        .query::<GetActiveUserTransactionsResult>(user, "get_active_user_transactions", ())
+        .expect("query should succeed");
+    let other_listed = pic
+        .query::<GetActiveUserTransactionsResult>(other, "get_active_user_transactions", ())
+        .expect("query should succeed");
+
+    for (label, result) in [("caller", user_listed), ("other", other_listed)] {
+        match result {
+            GetActiveUserTransactionsResult::Ok(response) => {
+                assert_eq!(
+                    response.transactions.len(),
+                    1,
+                    "{label} should see exactly its own record"
+                );
+            }
+            GetActiveUserTransactionsResult::Err(err) => {
+                panic!("{label} query returned error: {err:?}")
+            }
+        }
+    }
+}
+
+#[test]
+fn records_survive_canister_upgrade() {
+    let pic = setup();
+    let user = caller();
+    create_active(&pic, user, TX_ID);
+
+    pic.upgrade_with_wasm(&BackendBuilder::default_wasm_path(), None)
+        .expect("canister upgrade should succeed");
+
+    let listed = pic
+        .query::<GetActiveUserTransactionsResult>(user, "get_active_user_transactions", ())
+        .expect("query should succeed");
+    match listed {
+        GetActiveUserTransactionsResult::Ok(response) => {
+            assert_eq!(response.transactions.len(), 1);
+            assert_eq!(response.transactions[0].id, TX_ID);
+        }
+        GetActiveUserTransactionsResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+}

--- a/src/backend/tests/it/active_user_transactions.rs
+++ b/src/backend/tests/it/active_user_transactions.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use candid::{Nat, Principal};
 use pretty_assertions::assert_eq;
 use shared::types::{
@@ -227,6 +229,16 @@ fn records_survive_canister_upgrade() {
     let pic = setup();
     let user = caller();
     create_active(&pic, user, TX_ID);
+
+    // PocketIC throttles install_code based on instructions used in recent
+    // rounds; advance simulated time and drive ticks so the heavy `setup()`
+    // install rolls out of the rate-limit window before we attempt the
+    // upgrade. Mirrors the advance_time + tick-loop idiom used in
+    // `tests/it/signer.rs` and `tests/it/status.rs`.
+    pic.pic.advance_time(Duration::from_secs(60));
+    for _ in 0..20 {
+        pic.pic.tick();
+    }
 
     pic.upgrade_with_wasm(&BackendBuilder::default_wasm_path(), None)
         .expect("canister upgrade should succeed");

--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -1,3 +1,4 @@
+mod active_user_transactions;
 mod agreements;
 mod bitcoin;
 mod config;

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -1,3 +1,64 @@
+// In-flight high-level user operation, persisted so the FE can resume polling
+// across logout / tab close.
+type ActiveUserTransaction = record {
+	// Frontend-generated identifier (`UUIDv4`). Unique per user.
+	id : text;
+	status : ActiveUserTransactionStatus;
+	// Learned-mid-flow named references, e.g.
+	// `{ key: "tx_hash", value: "0x…" }`. See [`ActiveUserTransactionRef`]
+	// for the field layout exposed on the wire and in TS bindings.
+	external_refs : vec ActiveUserTransactionRef;
+	// Opaque to the backend; the FE writes a flow-specific step name here.
+	progress_step : opt text;
+	data : ActiveUserTransactionData;
+	updated_at_ns : nat64;
+	// Populated when `status = Failed`.
+	error : opt text;
+	created_at_ns : nat64
+};
+// Flow-specific payload, captured once at creation and immutable thereafter.
+//
+// Variants are append-only (Candid evolution rule). Learned-mid-flow values
+// (tx hashes, forwarding addresses, provider request ids, …) go in
+// `ActiveUserTransaction::external_refs` so we don't need to bump candid for
+// every new provider integration.
+type ActiveUserTransactionData = variant {
+	OneSecEvmToIcp : OneSecEvmToIcpData;
+	OneSecIcpToEvm : OneSecIcpToEvmData
+};
+type ActiveUserTransactionError = variant {
+	InvalidId;
+	NotFound;
+	TooManyActiveTransactions;
+	InvalidData : text;
+	AlreadyExists;
+	IllegalStatusTransition
+};
+// Learned-mid-flow `(key, value)` reference attached to an active transaction,
+// e.g. `{ key: "tx_hash", value: "0x…" }`. Modelled as a named record (not a
+// tuple) so the generated TS bindings expose `.key` / `.value` instead of
+// positional `[string, string]` access.
+type ActiveUserTransactionRef = record { key : text; value : text };
+// Shared result for endpoints that return a single `ActiveUserTransaction`
+// (both `create_active_user_transaction` and `update_active_user_transaction`).
+// One type because the wire shape is identical — the candid extractor would
+// dedupe twin variants anyway.
+type ActiveUserTransactionResult = variant {
+	Ok : ActiveUserTransaction;
+	Err : ActiveUserTransactionError
+};
+// Lifecycle status of an active user transaction.
+//
+// Allowed transitions are enforced by the backend:
+// `Pending` → `Pending | Executing | Succeeded | Failed`,
+// `Executing` → `Executing | Succeeded | Failed`,
+// terminal states are immutable (idempotent no-op).
+type ActiveUserTransactionStatus = variant {
+	Failed;
+	Executing;
+	Succeeded;
+	Pending
+};
 type AddDappSettingsError = variant {
 	MaxHiddenDappIds;
 	VersionMismatch;
@@ -343,6 +404,12 @@ type ContactError = variant {
 	TooManyContactsWithImages
 };
 type ContactImage = record { data : blob; mime_type : ImageMimeType };
+type CreateActiveUserTransactionRequest = record {
+	id : text;
+	external_refs : vec ActiveUserTransactionRef;
+	progress_step : opt text;
+	data : ActiveUserTransactionData
+};
 type CreateContactRequest = record { name : text; image : opt ContactImage };
 type CreateContactResult = variant {
 	// The contact was retrieved successfully.
@@ -385,6 +452,10 @@ type Delegation = record {
 	pubkey : blob;
 	targets : opt vec principal;
 	expiration : nat64
+};
+type DeleteActiveUserTransactionResult = variant {
+	Ok;
+	Err : ActiveUserTransactionError
 };
 type DeleteContactResult = variant {
 	// The contact was deleted successfully.
@@ -444,6 +515,13 @@ type ExperimentalFeaturesSettings = record {
 };
 // An EXT v2 compliant token on the Internet Computer.
 type ExtV2Token = record { canister_id : principal };
+type GetActiveUserTransactionsResponse = record {
+	transactions : vec ActiveUserTransaction
+};
+type GetActiveUserTransactionsResult = variant {
+	Ok : GetActiveUserTransactionsResponse;
+	Err : ActiveUserTransactionError
+};
 type GetAgreementHistoryError = variant { UserNotFound };
 type GetAgreementHistoryResult = variant {
 	Ok : vec AgreementHistoryEntry;
@@ -665,6 +743,18 @@ type NetworksSettings = record {
 type NotificationSettings = record {
 	dismissed_notifications : vec DismissedNotification
 };
+type OneSecEvmToIcpData = record {
+	recipient_principal : principal;
+	source_token : TokenId;
+	amount : nat;
+	dest_token : TokenId
+};
+type OneSecIcpToEvmData = record {
+	recipient_evm_address : text;
+	source_token : TokenId;
+	amount : nat;
+	dest_token : TokenId
+};
 // Outpoint.
 type Outpoint = record {
 	// Transaction ID (TxID).
@@ -879,6 +969,19 @@ type TransformArgs = record {
 	// Raw response from remote service, to be transformed
 	response : HttpRequestResult
 };
+// Partial update. `None` means "leave untouched"; `Some(value)` overwrites
+// the stored value. There is no encoding for "clear back to `None`" — this
+// is intentional: `error` is only ever set on the `Failed` terminal state
+// (immutable by lifecycle), and `progress_step` is forward-only.
+// `external_refs`, when provided, **replaces** the stored list in full —
+// the FE always knows the complete set after each poll.
+type UpdateActiveUserTransactionRequest = record {
+	id : text;
+	status : opt ActiveUserTransactionStatus;
+	external_refs : opt vec ActiveUserTransactionRef;
+	progress_step : opt text;
+	error : opt text
+};
 type UpdateAgreementsError = variant { VersionMismatch; UserNotFound };
 type UpdateExperimentalFeaturesSettingsRequest = record {
 	experimental_features : vec record {
@@ -1053,6 +1156,13 @@ service : (Arg) -> {
 	);
 	// Gets the canister configuration.
 	config : () -> (Config) query;
+	// Creates a new active user transaction record for the caller.
+	//
+	// # Errors
+	// Errors are enumerated by: `ActiveUserTransactionError`.
+	create_active_user_transaction : (CreateActiveUserTransactionRequest) -> (
+		ActiveUserTransactionResult
+	);
 	// Creates a new contact for the caller.
 	//
 	// # Errors
@@ -1069,6 +1179,15 @@ service : (Arg) -> {
 	// caller does not already have a profile. Existing users are unaffected and still receive
 	// `Ok(profile)` for idempotent calls.
 	create_user_profile : () -> (CreateUserProfileResult);
+	// Deletes one of the caller's active user transactions. Idempotent: returns
+	// `Ok(())` whether or not the record existed. This is the only path that
+	// removes records — there is no automatic pruning.
+	//
+	// # Errors
+	// Errors are enumerated by: `ActiveUserTransactionError`.
+	delete_active_user_transaction : (text) -> (
+		DeleteActiveUserTransactionResult
+	);
 	// Deletes a contact for the caller.
 	//
 	// # Errors
@@ -1081,6 +1200,10 @@ service : (Arg) -> {
 	get_account_creation_timestamps : () -> (
 		vec record { principal; nat64 }
 	) query;
+	// Returns all of the caller's active user transactions (Pending, Executing,
+	// Succeeded, Failed). Records are retained until the FE deletes them on user
+	// acknowledgement, so terminal entries remain in the list until dismissed.
+	get_active_user_transactions : () -> (GetActiveUserTransactionsResult) query;
 	// Retrieves the amount of cycles that the signer canister is allowed to spend
 	// on behalf of the current user.
 	//
@@ -1223,6 +1346,13 @@ service : (Arg) -> {
 	// Error conditions are enumerated by: `TopUpCyclesLedgerError`
 	top_up_cycles_ledger : (opt TopUpCyclesLedgerRequest) -> (
 		TopUpCyclesLedgerResult
+	);
+	// Applies a partial update to one of the caller's active user transactions.
+	//
+	// # Errors
+	// Errors are enumerated by: `ActiveUserTransactionError`.
+	update_active_user_transaction : (UpdateActiveUserTransactionRequest) -> (
+		ActiveUserTransactionResult
 	);
 	// Updates an existing contact for the caller.
 	//

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -10,6 +10,86 @@ import type { ActorMethod } from '@icp-sdk/core/agent';
 import type { IDL } from '@icp-sdk/core/candid';
 import type { Principal } from '@icp-sdk/core/principal';
 
+/**
+ * In-flight high-level user operation, persisted so the FE can resume polling
+ * across logout / tab close.
+ */
+export interface ActiveUserTransaction {
+	/**
+	 * Frontend-generated identifier (`UUIDv4`). Unique per user.
+	 */
+	id: string;
+	status: ActiveUserTransactionStatus;
+	/**
+	 * Learned-mid-flow named references, e.g.
+	 * `{ key: "tx_hash", value: "0x…" }`. See [`ActiveUserTransactionRef`]
+	 * for the field layout exposed on the wire and in TS bindings.
+	 */
+	external_refs: Array<ActiveUserTransactionRef>;
+	/**
+	 * Opaque to the backend; the FE writes a flow-specific step name here.
+	 */
+	progress_step: [] | [string];
+	data: ActiveUserTransactionData;
+	updated_at_ns: bigint;
+	/**
+	 * Populated when `status = Failed`.
+	 */
+	error: [] | [string];
+	created_at_ns: bigint;
+}
+/**
+ * Flow-specific payload, captured once at creation and immutable thereafter.
+ *
+ * Variants are append-only (Candid evolution rule). Learned-mid-flow values
+ * (tx hashes, forwarding addresses, provider request ids, …) go in
+ * `ActiveUserTransaction::external_refs` so we don't need to bump candid for
+ * every new provider integration.
+ */
+export type ActiveUserTransactionData =
+	| {
+			OneSecEvmToIcp: OneSecEvmToIcpData;
+	  }
+	| { OneSecIcpToEvm: OneSecIcpToEvmData };
+export type ActiveUserTransactionError =
+	| { InvalidId: null }
+	| { NotFound: null }
+	| { TooManyActiveTransactions: null }
+	| { InvalidData: string }
+	| { AlreadyExists: null }
+	| { IllegalStatusTransition: null };
+/**
+ * Learned-mid-flow `(key, value)` reference attached to an active transaction,
+ * e.g. `{ key: "tx_hash", value: "0x…" }`. Modelled as a named record (not a
+ * tuple) so the generated TS bindings expose `.key` / `.value` instead of
+ * positional `[string, string]` access.
+ */
+export interface ActiveUserTransactionRef {
+	key: string;
+	value: string;
+}
+/**
+ * Shared result for endpoints that return a single `ActiveUserTransaction`
+ * (both `create_active_user_transaction` and `update_active_user_transaction`).
+ * One type because the wire shape is identical — the candid extractor would
+ * dedupe twin variants anyway.
+ */
+export type ActiveUserTransactionResult =
+	| { Ok: ActiveUserTransaction }
+	| { Err: ActiveUserTransactionError };
+/**
+ * Lifecycle status of an active user transaction.
+ *
+ * Allowed transitions are enforced by the backend:
+ * `Pending` → `Pending | Executing | Succeeded | Failed`,
+ * `Executing` → `Executing | Succeeded | Failed`,
+ * terminal states are immutable (idempotent no-op).
+ */
+export type ActiveUserTransactionStatus =
+	| { Failed: null }
+	| { Executing: null }
+	| { Succeeded: null }
+	| { Pending: null };
 export type AddDappSettingsError =
 	| { MaxHiddenDappIds: null }
 	| { VersionMismatch: null }
@@ -502,6 +582,12 @@ export interface ContactImage {
 	data: Uint8Array;
 	mime_type: ImageMimeType;
 }
+export interface CreateActiveUserTransactionRequest {
+	id: string;
+	external_refs: Array<ActiveUserTransactionRef>;
+	progress_step: [] | [string];
+	data: ActiveUserTransactionData;
+}
 export interface CreateContactRequest {
 	name: string;
 	image: [] | [ContactImage];
@@ -574,6 +660,7 @@ export interface Delegation {
 	targets: [] | [Array<Principal>];
 	expiration: bigint;
 }
+export type DeleteActiveUserTransactionResult = { Ok: null } | { Err: ActiveUserTransactionError };
 export type DeleteContactResult =
 	| {
 			/**
@@ -660,6 +747,14 @@ export interface ExperimentalFeaturesSettings {
 export interface ExtV2Token {
 	canister_id: Principal;
 }
+export interface GetActiveUserTransactionsResponse {
+	transactions: Array<ActiveUserTransaction>;
+}
+export type GetActiveUserTransactionsResult =
+	| {
+			Ok: GetActiveUserTransactionsResponse;
+	  }
+	| { Err: ActiveUserTransactionError };
 export type GetAgreementHistoryError = { UserNotFound: null };
 export type GetAgreementHistoryResult =
 	| {
@@ -1009,6 +1104,18 @@ export interface NetworksSettings {
 }
 export interface NotificationSettings {
 	dismissed_notifications: Array<DismissedNotification>;
+}
+export interface OneSecEvmToIcpData {
+	recipient_principal: Principal;
+	source_token: TokenId;
+	amount: bigint;
+	dest_token: TokenId;
+}
+export interface OneSecIcpToEvmData {
+	recipient_evm_address: string;
+	source_token: TokenId;
+	amount: bigint;
+	dest_token: TokenId;
 }
 /**
  * Outpoint.
@@ -1377,6 +1484,21 @@ export interface TransformArgs {
 	 */
 	response: HttpRequestResult;
 }
+/**
+ * Partial update. `None` means "leave untouched"; `Some(value)` overwrites
+ * the stored value. There is no encoding for "clear back to `None`" — this
+ * is intentional: `error` is only ever set on the `Failed` terminal state
+ * (immutable by lifecycle), and `progress_step` is forward-only.
+ * `external_refs`, when provided, **replaces** the stored list in full —
+ * the FE always knows the complete set after each poll.
+ */
+export interface UpdateActiveUserTransactionRequest {
+	id: string;
+	status: [] | [ActiveUserTransactionStatus];
+	external_refs: [] | [Array<ActiveUserTransactionRef>];
+	progress_step: [] | [string];
+	error: [] | [string];
+}
 export type UpdateAgreementsError = { VersionMismatch: null } | { UserNotFound: null };
 export interface UpdateExperimentalFeaturesSettingsRequest {
 	experimental_features: Array<[ExperimentalFeatureSettingsFor, ExperimentalFeatureSettings]>;
@@ -1608,6 +1730,16 @@ export interface _SERVICE {
 	 */
 	config: ActorMethod<[], Config>;
 	/**
+	 * Creates a new active user transaction record for the caller.
+	 *
+	 * # Errors
+	 * Errors are enumerated by: `ActiveUserTransactionError`.
+	 */
+	create_active_user_transaction: ActorMethod<
+		[CreateActiveUserTransactionRequest],
+		ActiveUserTransactionResult
+	>;
+	/**
 	 * Creates a new contact for the caller.
 	 *
 	 * # Errors
@@ -1628,6 +1760,15 @@ export interface _SERVICE {
 	 */
 	create_user_profile: ActorMethod<[], CreateUserProfileResult>;
 	/**
+	 * Deletes one of the caller's active user transactions. Idempotent: returns
+	 * `Ok(())` whether or not the record existed. This is the only path that
+	 * removes records — there is no automatic pruning.
+	 *
+	 * # Errors
+	 * Errors are enumerated by: `ActiveUserTransactionError`.
+	 */
+	delete_active_user_transaction: ActorMethod<[string], DeleteActiveUserTransactionResult>;
+	/**
 	 * Deletes a contact for the caller.
 	 *
 	 * # Errors
@@ -1641,6 +1782,12 @@ export interface _SERVICE {
 	 * Gets account creation timestamps.
 	 */
 	get_account_creation_timestamps: ActorMethod<[], Array<[Principal, bigint]>>;
+	/**
+	 * Returns all of the caller's active user transactions (Pending, Executing,
+	 * Succeeded, Failed). Records are retained until the FE deletes them on user
+	 * acknowledgement, so terminal entries remain in the list until dismissed.
+	 */
+	get_active_user_transactions: ActorMethod<[], GetActiveUserTransactionsResult>;
 	/**
 	 * Retrieves the amount of cycles that the signer canister is allowed to spend
 	 * on behalf of the current user.
@@ -1816,6 +1963,16 @@ export interface _SERVICE {
 	 * Error conditions are enumerated by: `TopUpCyclesLedgerError`
 	 */
 	top_up_cycles_ledger: ActorMethod<[[] | [TopUpCyclesLedgerRequest]], TopUpCyclesLedgerResult>;
+	/**
+	 * Applies a partial update to one of the caller's active user transactions.
+	 *
+	 * # Errors
+	 * Errors are enumerated by: `ActiveUserTransactionError`.
+	 */
+	update_active_user_transaction: ActorMethod<
+		[UpdateActiveUserTransactionRequest],
+		ActiveUserTransactionResult
+	>;
 	/**
 	 * Updates an existing contact for the caller.
 	 *

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -194,6 +194,79 @@ export const idlFactory = ({ IDL }) => {
 		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8)),
 		new_user_signups_allowed: IDL.Opt(IDL.Bool)
 	});
+	const ActiveUserTransactionRef = IDL.Record({
+		key: IDL.Text,
+		value: IDL.Text
+	});
+	const TokenId = IDL.Variant({
+		Erc20: IDL.Tuple(IDL.Text, IDL.Nat64),
+		ExtV2: IDL.Principal,
+		SolNativeDevnet: IDL.Null,
+		Icrc: IDL.Principal,
+		EvmNative: IDL.Nat64,
+		Icrc7: IDL.Principal,
+		BtcNativeMainnet: IDL.Null,
+		Erc721: IDL.Tuple(IDL.Text, IDL.Nat64),
+		SolNativeMainnet: IDL.Null,
+		SplDevnet: IDL.Text,
+		SplMainnet: IDL.Text,
+		IcpNative: IDL.Null,
+		IcPunks: IDL.Principal,
+		BtcNativeTestnet: IDL.Null,
+		Erc1155: IDL.Tuple(IDL.Text, IDL.Nat64),
+		Erc4626: IDL.Tuple(IDL.Text, IDL.Nat64),
+		Dip721: IDL.Principal
+	});
+	const OneSecEvmToIcpData = IDL.Record({
+		recipient_principal: IDL.Principal,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
+	const OneSecIcpToEvmData = IDL.Record({
+		recipient_evm_address: IDL.Text,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
+	const ActiveUserTransactionData = IDL.Variant({
+		OneSecEvmToIcp: OneSecEvmToIcpData,
+		OneSecIcpToEvm: OneSecIcpToEvmData
+	});
+	const CreateActiveUserTransactionRequest = IDL.Record({
+		id: IDL.Text,
+		external_refs: IDL.Vec(ActiveUserTransactionRef),
+		progress_step: IDL.Opt(IDL.Text),
+		data: ActiveUserTransactionData
+	});
+	const ActiveUserTransactionStatus = IDL.Variant({
+		Failed: IDL.Null,
+		Executing: IDL.Null,
+		Succeeded: IDL.Null,
+		Pending: IDL.Null
+	});
+	const ActiveUserTransaction = IDL.Record({
+		id: IDL.Text,
+		status: ActiveUserTransactionStatus,
+		external_refs: IDL.Vec(ActiveUserTransactionRef),
+		progress_step: IDL.Opt(IDL.Text),
+		data: ActiveUserTransactionData,
+		updated_at_ns: IDL.Nat64,
+		error: IDL.Opt(IDL.Text),
+		created_at_ns: IDL.Nat64
+	});
+	const ActiveUserTransactionError = IDL.Variant({
+		InvalidId: IDL.Null,
+		NotFound: IDL.Null,
+		TooManyActiveTransactions: IDL.Null,
+		InvalidData: IDL.Text,
+		AlreadyExists: IDL.Null,
+		IllegalStatusTransition: IDL.Null
+	});
+	const ActiveUserTransactionResult = IDL.Variant({
+		Ok: ActiveUserTransaction,
+		Err: ActiveUserTransactionError
+	});
 	const ImageMimeType = IDL.Variant({
 		'image/gif': IDL.Null,
 		'image/png': IDL.Null,
@@ -346,9 +419,20 @@ export const idlFactory = ({ IDL }) => {
 		Ok: UserProfile,
 		Err: CreateUserProfileError
 	});
+	const DeleteActiveUserTransactionResult = IDL.Variant({
+		Ok: IDL.Null,
+		Err: ActiveUserTransactionError
+	});
 	const DeleteContactResult = IDL.Variant({
 		Ok: IDL.Nat64,
 		Err: ContactError
+	});
+	const GetActiveUserTransactionsResponse = IDL.Record({
+		transactions: IDL.Vec(ActiveUserTransaction)
+	});
+	const GetActiveUserTransactionsResult = IDL.Variant({
+		Ok: GetActiveUserTransactionsResponse,
+		Err: ActiveUserTransactionError
 	});
 	const GetAllowedCyclesResponse = IDL.Record({ allowed_cycles: IDL.Nat });
 	const GetAllowedCyclesError = IDL.Variant({
@@ -397,25 +481,6 @@ export const idlFactory = ({ IDL }) => {
 	const GetContactsResult = IDL.Variant({
 		Ok: IDL.Vec(Contact),
 		Err: ContactError
-	});
-	const TokenId = IDL.Variant({
-		Erc20: IDL.Tuple(IDL.Text, IDL.Nat64),
-		ExtV2: IDL.Principal,
-		SolNativeDevnet: IDL.Null,
-		Icrc: IDL.Principal,
-		EvmNative: IDL.Nat64,
-		Icrc7: IDL.Principal,
-		BtcNativeMainnet: IDL.Null,
-		Erc721: IDL.Tuple(IDL.Text, IDL.Nat64),
-		SolNativeMainnet: IDL.Null,
-		SplDevnet: IDL.Text,
-		SplMainnet: IDL.Text,
-		IcpNative: IDL.Null,
-		IcPunks: IDL.Principal,
-		BtcNativeTestnet: IDL.Null,
-		Erc1155: IDL.Tuple(IDL.Text, IDL.Nat64),
-		Erc4626: IDL.Tuple(IDL.Text, IDL.Nat64),
-		Dip721: IDL.Principal
 	});
 	const ExchangeData = IDL.Record({
 		price_24h_change_pct: IDL.Opt(IDL.Float64),
@@ -624,6 +689,13 @@ export const idlFactory = ({ IDL }) => {
 		Ok: TopUpCyclesLedgerResponse,
 		Err: TopUpCyclesLedgerError
 	});
+	const UpdateActiveUserTransactionRequest = IDL.Record({
+		id: IDL.Text,
+		status: IDL.Opt(ActiveUserTransactionStatus),
+		external_refs: IDL.Opt(IDL.Vec(ActiveUserTransactionRef)),
+		progress_step: IDL.Opt(IDL.Text),
+		error: IDL.Opt(IDL.Text)
+	});
 	const UpdateProviderAgreementsRequest = IDL.Record({
 		current_user_version: IDL.Opt(IDL.Nat64),
 		provider_agreements: IDL.Vec(IDL.Tuple(ProviderAgreementType, UserAgreement))
@@ -670,10 +742,17 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		config: IDL.Func([], [Config]),
+		create_active_user_transaction: IDL.Func(
+			[CreateActiveUserTransactionRequest],
+			[ActiveUserTransactionResult],
+			[]
+		),
 		create_contact: IDL.Func([CreateContactRequest], [CreateContactResult], []),
 		create_user_profile: IDL.Func([], [CreateUserProfileResult], []),
+		delete_active_user_transaction: IDL.Func([IDL.Text], [DeleteActiveUserTransactionResult], []),
 		delete_contact: IDL.Func([IDL.Nat64], [DeleteContactResult], []),
 		get_account_creation_timestamps: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64))]),
+		get_active_user_transactions: IDL.Func([], [GetActiveUserTransactionsResult]),
 		get_allowed_cycles: IDL.Func([], [GetAllowedCyclesResult], []),
 		get_api_keys: IDL.Func([], [ApiKeys]),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
@@ -707,6 +786,11 @@ export const idlFactory = ({ IDL }) => {
 		top_up_cycles_ledger: IDL.Func(
 			[IDL.Opt(TopUpCyclesLedgerRequest)],
 			[TopUpCyclesLedgerResult],
+			[]
+		),
+		update_active_user_transaction: IDL.Func(
+			[UpdateActiveUserTransactionRequest],
+			[ActiveUserTransactionResult],
 			[]
 		),
 		update_contact: IDL.Func([Contact], [GetContactResult], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -194,6 +194,79 @@ export const idlFactory = ({ IDL }) => {
 		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8)),
 		new_user_signups_allowed: IDL.Opt(IDL.Bool)
 	});
+	const ActiveUserTransactionRef = IDL.Record({
+		key: IDL.Text,
+		value: IDL.Text
+	});
+	const TokenId = IDL.Variant({
+		Erc20: IDL.Tuple(IDL.Text, IDL.Nat64),
+		ExtV2: IDL.Principal,
+		SolNativeDevnet: IDL.Null,
+		Icrc: IDL.Principal,
+		EvmNative: IDL.Nat64,
+		Icrc7: IDL.Principal,
+		BtcNativeMainnet: IDL.Null,
+		Erc721: IDL.Tuple(IDL.Text, IDL.Nat64),
+		SolNativeMainnet: IDL.Null,
+		SplDevnet: IDL.Text,
+		SplMainnet: IDL.Text,
+		IcpNative: IDL.Null,
+		IcPunks: IDL.Principal,
+		BtcNativeTestnet: IDL.Null,
+		Erc1155: IDL.Tuple(IDL.Text, IDL.Nat64),
+		Erc4626: IDL.Tuple(IDL.Text, IDL.Nat64),
+		Dip721: IDL.Principal
+	});
+	const OneSecEvmToIcpData = IDL.Record({
+		recipient_principal: IDL.Principal,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
+	const OneSecIcpToEvmData = IDL.Record({
+		recipient_evm_address: IDL.Text,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
+	const ActiveUserTransactionData = IDL.Variant({
+		OneSecEvmToIcp: OneSecEvmToIcpData,
+		OneSecIcpToEvm: OneSecIcpToEvmData
+	});
+	const CreateActiveUserTransactionRequest = IDL.Record({
+		id: IDL.Text,
+		external_refs: IDL.Vec(ActiveUserTransactionRef),
+		progress_step: IDL.Opt(IDL.Text),
+		data: ActiveUserTransactionData
+	});
+	const ActiveUserTransactionStatus = IDL.Variant({
+		Failed: IDL.Null,
+		Executing: IDL.Null,
+		Succeeded: IDL.Null,
+		Pending: IDL.Null
+	});
+	const ActiveUserTransaction = IDL.Record({
+		id: IDL.Text,
+		status: ActiveUserTransactionStatus,
+		external_refs: IDL.Vec(ActiveUserTransactionRef),
+		progress_step: IDL.Opt(IDL.Text),
+		data: ActiveUserTransactionData,
+		updated_at_ns: IDL.Nat64,
+		error: IDL.Opt(IDL.Text),
+		created_at_ns: IDL.Nat64
+	});
+	const ActiveUserTransactionError = IDL.Variant({
+		InvalidId: IDL.Null,
+		NotFound: IDL.Null,
+		TooManyActiveTransactions: IDL.Null,
+		InvalidData: IDL.Text,
+		AlreadyExists: IDL.Null,
+		IllegalStatusTransition: IDL.Null
+	});
+	const ActiveUserTransactionResult = IDL.Variant({
+		Ok: ActiveUserTransaction,
+		Err: ActiveUserTransactionError
+	});
 	const ImageMimeType = IDL.Variant({
 		'image/gif': IDL.Null,
 		'image/png': IDL.Null,
@@ -346,9 +419,20 @@ export const idlFactory = ({ IDL }) => {
 		Ok: UserProfile,
 		Err: CreateUserProfileError
 	});
+	const DeleteActiveUserTransactionResult = IDL.Variant({
+		Ok: IDL.Null,
+		Err: ActiveUserTransactionError
+	});
 	const DeleteContactResult = IDL.Variant({
 		Ok: IDL.Nat64,
 		Err: ContactError
+	});
+	const GetActiveUserTransactionsResponse = IDL.Record({
+		transactions: IDL.Vec(ActiveUserTransaction)
+	});
+	const GetActiveUserTransactionsResult = IDL.Variant({
+		Ok: GetActiveUserTransactionsResponse,
+		Err: ActiveUserTransactionError
 	});
 	const GetAllowedCyclesResponse = IDL.Record({ allowed_cycles: IDL.Nat });
 	const GetAllowedCyclesError = IDL.Variant({
@@ -397,25 +481,6 @@ export const idlFactory = ({ IDL }) => {
 	const GetContactsResult = IDL.Variant({
 		Ok: IDL.Vec(Contact),
 		Err: ContactError
-	});
-	const TokenId = IDL.Variant({
-		Erc20: IDL.Tuple(IDL.Text, IDL.Nat64),
-		ExtV2: IDL.Principal,
-		SolNativeDevnet: IDL.Null,
-		Icrc: IDL.Principal,
-		EvmNative: IDL.Nat64,
-		Icrc7: IDL.Principal,
-		BtcNativeMainnet: IDL.Null,
-		Erc721: IDL.Tuple(IDL.Text, IDL.Nat64),
-		SolNativeMainnet: IDL.Null,
-		SplDevnet: IDL.Text,
-		SplMainnet: IDL.Text,
-		IcpNative: IDL.Null,
-		IcPunks: IDL.Principal,
-		BtcNativeTestnet: IDL.Null,
-		Erc1155: IDL.Tuple(IDL.Text, IDL.Nat64),
-		Erc4626: IDL.Tuple(IDL.Text, IDL.Nat64),
-		Dip721: IDL.Principal
 	});
 	const ExchangeData = IDL.Record({
 		price_24h_change_pct: IDL.Opt(IDL.Float64),
@@ -624,6 +689,13 @@ export const idlFactory = ({ IDL }) => {
 		Ok: TopUpCyclesLedgerResponse,
 		Err: TopUpCyclesLedgerError
 	});
+	const UpdateActiveUserTransactionRequest = IDL.Record({
+		id: IDL.Text,
+		status: IDL.Opt(ActiveUserTransactionStatus),
+		external_refs: IDL.Opt(IDL.Vec(ActiveUserTransactionRef)),
+		progress_step: IDL.Opt(IDL.Text),
+		error: IDL.Opt(IDL.Text)
+	});
 	const UpdateProviderAgreementsRequest = IDL.Record({
 		current_user_version: IDL.Opt(IDL.Nat64),
 		provider_agreements: IDL.Vec(IDL.Tuple(ProviderAgreementType, UserAgreement))
@@ -671,14 +743,21 @@ export const idlFactory = ({ IDL }) => {
 			[]
 		),
 		config: IDL.Func([], [Config], ['query']),
+		create_active_user_transaction: IDL.Func(
+			[CreateActiveUserTransactionRequest],
+			[ActiveUserTransactionResult],
+			[]
+		),
 		create_contact: IDL.Func([CreateContactRequest], [CreateContactResult], []),
 		create_user_profile: IDL.Func([], [CreateUserProfileResult], []),
+		delete_active_user_transaction: IDL.Func([IDL.Text], [DeleteActiveUserTransactionResult], []),
 		delete_contact: IDL.Func([IDL.Nat64], [DeleteContactResult], []),
 		get_account_creation_timestamps: IDL.Func(
 			[],
 			[IDL.Vec(IDL.Tuple(IDL.Principal, IDL.Nat64))],
 			['query']
 		),
+		get_active_user_transactions: IDL.Func([], [GetActiveUserTransactionsResult], ['query']),
 		get_allowed_cycles: IDL.Func([], [GetAllowedCyclesResult], []),
 		get_api_keys: IDL.Func([], [ApiKeys], ['query']),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
@@ -717,6 +796,11 @@ export const idlFactory = ({ IDL }) => {
 		top_up_cycles_ledger: IDL.Func(
 			[IDL.Opt(TopUpCyclesLedgerRequest)],
 			[TopUpCyclesLedgerResult],
+			[]
+		),
+		update_active_user_transaction: IDL.Func(
+			[UpdateActiveUserTransactionRequest],
+			[ActiveUserTransactionResult],
 			[]
 		),
 		update_contact: IDL.Func([Contact], [GetContactResult], []),


### PR DESCRIPTION
BREAKING CHANGE: The backend API is now incompatible with production.

# Motivation

Final slice of the `active_user_transactions` feature, after #12882 (shared types) and #12890 (stable storage). Adds the four canister endpoints (`create_active_user_transaction`, `update_active_user_transaction`, `delete_active_user_transaction`, `get_active_user_transactions`) the FE will poll to track in-flight high-level user operations (e.g. cross-chain swaps) across logout and tab close.

# Changes

- New `active_user_transactions::model` — pure CRUD on the existing map type with:
    - per-user cap enforcement (counts terminal rows; FE acknowledges via `delete` to free a slot);
    - id / data / external-refs / error validation against the `MAX_*` limits introduced in #12882;
    - status-transition matrix — `Pending → Pending|Executing|Succeeded|Failed`, `Executing → Executing|Succeeded|Failed`, terminal states immutable (idempotent no-op on self-transition).
- New `api::active_user_transactions` — four thin dispatching handlers. Mutations guarded by `caller_is_registered_user`; the `get` query uses `caller_is_not_anonymous` (matches the contacts / transactions convention).
- `src/backend/src/types/mod.rs` re-exports the `ActiveUserTransactionsMap` / `ActiveUserTransactionKey` aliases  introduced in #12890 (previously module-private, now used by the model layer).
- Regenerated candid (4 new endpoints, ≈130 new lines under `src/backend/backend.did`) and TS bindings via `npm run generate`.
 - Purely additive — no existing record, variant, or signature changes. The `backend-tests / breaking-interface` job stays green.
