### PR TITLE
refactor(frontend): share stored SPL owner refresh check

### DIFF
--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -23,9 +23,11 @@ import type { SolAddress } from '$sol/types/address';
 import type { SolanaNetworkType } from '$sol/types/network';
 import type { SolBalance } from '$sol/types/sol-balance';
 import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-message';
-import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import type { SplTokenAddress } from '$sol/types/spl';
-import { solBackendTokenId } from '$sol/utils/user-transactions.utils';
+import {
+	requiresStoredSplOwnerRefresh,
+	solBackendTokenId
+} from '$sol/utils/user-transactions.utils';
 import { assertNonNullish, isNullish, jsonReplacer, nonNullish } from '@dfinity/utils';
 import type { Nullish } from '@dfinity/zod-schemas';
 
@@ -46,21 +48,6 @@ interface SolWalletData {
 	balance: CertifiedData<SolBalance | null>;
 	transactions: SolCertifiedTransaction[];
 }
-
-const requiresStoredSplOwnerRefresh = ({
-	transaction: { from, fromOwner, to, toOwner },
-	address,
-	tokenAddress
-}: {
-	transaction: SolTransactionUi;
-	address: SolAddress;
-	tokenAddress?: SplTokenAddress;
-}): boolean =>
-	nonNullish(tokenAddress) &&
-	from !== address &&
-	fromOwner !== address &&
-	to !== address &&
-	toOwner !== address;
 
 export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> {
 	#ref: PostMessageCommon['ref'] | undefined;

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -34,7 +34,10 @@ import type { SplTokenAddress } from '$sol/types/spl';
 import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
 import { mapSolParsedInstruction } from '$sol/utils/sol-instructions.utils';
 import { isTokenSpl } from '$sol/utils/spl.utils';
-import { solBackendTokenId } from '$sol/utils/user-transactions.utils';
+import {
+	requiresStoredSplOwnerRefresh,
+	solBackendTokenId
+} from '$sol/utils/user-transactions.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import { findAssociatedTokenPda } from '@solana-program/token';
 import { lamports, address as solAddress } from '@solana/kit';
@@ -68,21 +71,6 @@ const mapSolCertifiedTransactions = (transactions: SolTransactionUi[]): SolCerti
 		data: transaction,
 		certified: false
 	}));
-
-const requiresStoredSplOwnerRefresh = ({
-	transaction: { from, fromOwner, to, toOwner },
-	address,
-	tokenAddress
-}: {
-	transaction: SolTransactionUi;
-	address: SolAddress;
-	tokenAddress?: SplTokenAddress;
-}): boolean =>
-	nonNullish(tokenAddress) &&
-	from !== address &&
-	fromOwner !== address &&
-	to !== address &&
-	toOwner !== address;
 
 const extractBalances = ({
 	address,

--- a/src/frontend/src/sol/utils/user-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/user-transactions.utils.ts
@@ -79,6 +79,21 @@ export const mapUserTransactionToSolTransaction = ({
 export const isSolTransactionFinalized = (tx: SolTransactionUi): boolean =>
 	tx.status === 'finalized';
 
+export const requiresStoredSplOwnerRefresh = ({
+	transaction: { from, fromOwner, to, toOwner },
+	address,
+	tokenAddress
+}: {
+	transaction: SolTransactionUi;
+	address: SolAddress;
+	tokenAddress?: SplTokenAddress;
+}): boolean =>
+	nonNullish(tokenAddress) &&
+	from !== address &&
+	fromOwner !== address &&
+	to !== address &&
+	toOwner !== address;
+
 /**
  * Derives the backend `TokenId` from the Solana network type and optional SPL token address.
  */

--- a/src/frontend/src/tests/sol/utils/user-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/user-transactions.utils.spec.ts
@@ -5,6 +5,7 @@ import {
 	isSolTransactionFinalized,
 	mapSolTransactionToUserTransaction,
 	mapUserTransactionToSolTransaction,
+	requiresStoredSplOwnerRefresh,
 	solBackendTokenId
 } from '$sol/utils/user-transactions.utils';
 import { mockSignature } from '$tests/mocks/sol-transactions.mock';
@@ -12,7 +13,7 @@ import {
 	mockSolBackendUserTransaction,
 	mockSolUserTransactionUi
 } from '$tests/mocks/sol-user-transactions.mock';
-import { mockSolAddress } from '$tests/mocks/sol.mock';
+import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
 import { toNullable } from '@dfinity/utils';
 import { signature } from '@solana/kit';
 
@@ -273,6 +274,80 @@ describe('user-transactions.utils', () => {
 
 		it('should return false when status is null', () => {
 			expect(isSolTransactionFinalized({ ...mockSolUserTransactionUi, status: null })).toBeFalsy();
+		});
+	});
+
+	describe('requiresStoredSplOwnerRefresh', () => {
+		const mockTokenAddress = 'mock-token-address';
+		const ownerlessSplTransaction: SolTransactionUi = {
+			...mockSolUserTransactionUi,
+			from: 'mock-source-token-account',
+			to: 'mock-destination-token-account',
+			fromOwner: undefined,
+			toOwner: undefined
+		};
+
+		it('should request a refresh for SPL transactions without wallet address or owner context', () => {
+			expect(
+				requiresStoredSplOwnerRefresh({
+					transaction: ownerlessSplTransaction,
+					address: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				})
+			).toBeTruthy();
+		});
+
+		it('should not request a refresh for native SOL transactions', () => {
+			expect(
+				requiresStoredSplOwnerRefresh({
+					transaction: ownerlessSplTransaction,
+					address: mockSolAddress
+				})
+			).toBeFalsy();
+		});
+
+		it('should not request a refresh when the wallet address matches the source address', () => {
+			expect(
+				requiresStoredSplOwnerRefresh({
+					transaction: { ...ownerlessSplTransaction, from: mockSolAddress },
+					address: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				})
+			).toBeFalsy();
+		});
+
+		it('should not request a refresh when the wallet address matches the source owner', () => {
+			expect(
+				requiresStoredSplOwnerRefresh({
+					transaction: { ...ownerlessSplTransaction, fromOwner: mockSolAddress },
+					address: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				})
+			).toBeFalsy();
+		});
+
+		it('should not request a refresh when the wallet address matches the destination address', () => {
+			expect(
+				requiresStoredSplOwnerRefresh({
+					transaction: { ...ownerlessSplTransaction, to: mockSolAddress },
+					address: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				})
+			).toBeFalsy();
+		});
+
+		it('should not request a refresh when the wallet address matches the destination owner', () => {
+			expect(
+				requiresStoredSplOwnerRefresh({
+					transaction: {
+						...ownerlessSplTransaction,
+						to: mockSolAddress2,
+						toOwner: mockSolAddress
+					},
+					address: mockSolAddress,
+					tokenAddress: mockTokenAddress
+				})
+			).toBeFalsy();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

PR #12897 introduced the same stored SPL owner refresh predicate in two Solana transaction-loading paths. Sharing it keeps the refresh logic aligned and avoids future drift.
