### PR TITLE
fix(frontend): discover Icrc7 NFTs on reload

### DIFF
--- a/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderCollections.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, toNullable } from '@dfinity/utils';
 	import type { Identity } from '@icp-sdk/core/agent';
 	import { page } from '$app/state';
 	import type { CustomToken } from '$declarations/backend/backend.did';
 	import { EXT_BUILTIN_TOKENS } from '$env/tokens/tokens-ext/tokens.ext.env';
+	import { ICRC7_BUILTIN_TOKENS } from '$env/tokens/tokens-icrc7/tokens.icrc7.env';
 	import { enabledEthereumNetworks } from '$eth/derived/networks.derived';
 	import { alchemyProviders } from '$eth/providers/alchemy.providers';
 	import { buildNewErcTokens } from '$eth/services/erc-custom-tokens.services';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import { enabledEvmNetworks } from '$evm/derived/networks.derived';
 	import { getTokensByOwner } from '$icp/api/ext-v2-token.api';
+	import { getTokensByOwner as getIcrc7TokensByOwner } from '$icp/api/icrc7.api';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import {
 		COLLECTION_TIMER_INTERVAL_MILLIS,
@@ -25,7 +27,8 @@
 	import type {
 		SaveCustomErc1155Variant,
 		SaveCustomErc721Variant,
-		SaveCustomExtVariant
+		SaveCustomExtVariant,
+		SaveCustomIcrc7Variant
 	} from '$lib/types/custom-token';
 	import type { OwnedContract } from '$lib/types/nft';
 	import type { NonEmptyArray } from '$lib/types/utils';
@@ -122,7 +125,55 @@
 		});
 	};
 
-	const load = async ({ extTokens }: { extTokens: boolean }) => {
+	const loadIcrc7Tokens = async ({ identity, customTokens }: LoadTokensParams) => {
+		const icrc7EnabledCustomToken = customTokens.reduce<CanisterIdText[]>(
+			(acc, { token, enabled }) =>
+				'Icrc7' in token && enabled ? [...acc, token.Icrc7.canister_id.toText()] : acc,
+			[]
+		);
+
+		const owner = { owner: identity.getPrincipal(), subaccount: toNullable<Uint8Array>() };
+
+		const canisterIdPromises = ICRC7_BUILTIN_TOKENS.map(async ({ canisterId }) => {
+			if (icrc7EnabledCustomToken.includes(canisterId)) {
+				return [];
+			}
+
+			try {
+				const tokens = await getIcrc7TokensByOwner({
+					identity,
+					owner,
+					canisterId,
+					certified: false
+				});
+
+				return tokens.length > 0 ? [canisterId] : [];
+			} catch (error: unknown) {
+				consoleWarn(`Error fetching ICRC-7 tokens from canister ${canisterId}:`, error);
+
+				return [];
+			}
+		});
+
+		const canisterIds = (await Promise.all(canisterIdPromises)).flat();
+
+		if (canisterIds.length === 0) {
+			return;
+		}
+
+		const icrc7Tokens: SaveCustomIcrc7Variant[] = canisterIds.map((canisterId) => ({
+			canisterId,
+			networkKey: 'Icrc7',
+			enabled: true
+		}));
+
+		await saveCustomTokens({
+			tokens: icrc7Tokens as NonEmptyArray<SaveCustomIcrc7Variant>,
+			identity
+		});
+	};
+
+	const load = async ({ reloadCollections }: { reloadCollections: boolean }) => {
 		if (isNullish($authIdentity)) {
 			return;
 		}
@@ -135,7 +186,8 @@
 		try {
 			await Promise.all([
 				loadErcTokens(params),
-				extTokens ? loadExtTokens(params) : Promise.resolve()
+				reloadCollections ? loadExtTokens(params) : Promise.resolve(),
+				reloadCollections ? loadIcrc7Tokens(params) : Promise.resolve()
 			]);
 		} catch (_: unknown) {
 			// no need to raise the error, but we should reload the custom tokens, just to avoid that it is caused by outdated tokens
@@ -147,11 +199,11 @@
 	};
 
 	const onLoad = async () => {
-		await load({ extTokens: false });
+		await load({ reloadCollections: false });
 	};
 
 	const reload = async (event?: CustomEvent<OisyReloadCollectionsEvent>) => {
-		await load({ extTokens: true });
+		await load({ reloadCollections: true });
 
 		event?.detail.callback?.();
 	};

--- a/src/frontend/src/lib/types/custom-token.ts
+++ b/src/frontend/src/lib/types/custom-token.ts
@@ -64,6 +64,7 @@ export type SaveCustomErc721Variant = CustomTokenState & TokenVariant<'Erc721', 
 export type SaveCustomErc1155Variant = CustomTokenState &
 	TokenVariant<'Erc1155', ErcSaveCustomToken>;
 export type SaveCustomExtVariant = CustomTokenState & TokenVariant<'ExtV2', ExtSaveCustomToken>;
+export type SaveCustomIcrc7Variant = CustomTokenState & TokenVariant<'Icrc7', Icrc7SaveCustomToken>;
 
 export type CustomToken<T extends Token> = TokenToggleable<T>;
 

--- a/src/frontend/src/tests/lib/components/loaders/LoaderCollections.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderCollections.spec.ts
@@ -2,9 +2,11 @@ import type { CustomToken } from '$declarations/backend/backend.did';
 import { SUPPORTED_EVM_MAINNET_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
 import { SUPPORTED_ETHEREUM_MAINNET_NETWORKS } from '$env/networks/networks.eth.env';
 import { EXT_BUILTIN_TOKENS } from '$env/tokens/tokens-ext/tokens.ext.env';
+import { ICRC7_BUILTIN_TOKENS } from '$env/tokens/tokens-icrc7/tokens.icrc7.env';
 import type { AlchemyProvider } from '$eth/providers/alchemy.providers';
 import * as alchemyProvidersModule from '$eth/providers/alchemy.providers';
 import * as extTokenApi from '$icp/api/ext-v2-token.api';
+import * as icrc7Api from '$icp/api/icrc7.api';
 import LoaderCollections from '$lib/components/loaders/LoaderCollections.svelte';
 import * as saveCustomTokens from '$lib/services/save-custom-tokens.services';
 import { ethAddressStore } from '$lib/stores/address.store';
@@ -21,6 +23,7 @@ import type { MockInstance } from 'vitest';
 describe('LoaderCollections', () => {
 	let alchemyProvidersSpy: MockInstance;
 	let extGetTokensByOwnerSpy: MockInstance;
+	let icrc7GetTokensByOwnerSpy: MockInstance;
 	let saveCustomTokensSpy: MockInstance;
 
 	const mockGetTokensForOwner = vi.fn();
@@ -37,6 +40,9 @@ describe('LoaderCollections', () => {
 
 		extGetTokensByOwnerSpy = vi.spyOn(extTokenApi, 'getTokensByOwner');
 		extGetTokensByOwnerSpy.mockResolvedValue([]);
+
+		icrc7GetTokensByOwnerSpy = vi.spyOn(icrc7Api, 'getTokensByOwner');
+		icrc7GetTokensByOwnerSpy.mockResolvedValue([]);
 
 		saveCustomTokensSpy = vi.spyOn(saveCustomTokens, 'saveCustomTokens');
 		saveCustomTokensSpy.mockResolvedValue(undefined);
@@ -84,8 +90,6 @@ describe('LoaderCollections', () => {
 	});
 
 	it('should not add new EXT collections by default', async () => {
-		extGetTokensByOwnerSpy.mockReset().mockResolvedValueOnce([1, 2, 3]);
-
 		render(LoaderCollections);
 
 		await waitFor(() => {
@@ -94,8 +98,17 @@ describe('LoaderCollections', () => {
 		});
 	});
 
+	it('should not add new ICRC-7 collections by default', async () => {
+		render(LoaderCollections);
+
+		await waitFor(() => {
+			expect(icrc7GetTokensByOwnerSpy).not.toHaveBeenCalled();
+			expect(saveCustomTokensSpy).not.toHaveBeenCalled();
+		});
+	});
+
 	it('should add new EXT collections if the event is triggered', async () => {
-		extGetTokensByOwnerSpy.mockReset().mockResolvedValueOnce([1, 2, 3]);
+		extGetTokensByOwnerSpy.mockResolvedValueOnce([1, 2, 3]);
 
 		render(LoaderCollections);
 
@@ -128,6 +141,40 @@ describe('LoaderCollections', () => {
 		});
 	});
 
+	it('should add new ICRC-7 collections if the event is triggered', async () => {
+		icrc7GetTokensByOwnerSpy.mockResolvedValueOnce([1n, 2n, 3n]);
+
+		render(LoaderCollections);
+
+		emit({ message: 'oisyReloadCollections', detail: { callback: mockEventCallback } });
+
+		await waitFor(() => {
+			expect(icrc7GetTokensByOwnerSpy).toHaveBeenCalledTimes(ICRC7_BUILTIN_TOKENS.length);
+
+			ICRC7_BUILTIN_TOKENS.forEach(({ canisterId }, index) => {
+				expect(icrc7GetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
+					identity: mockIdentity,
+					owner: { owner: mockPrincipal, subaccount: [] },
+					canisterId,
+					certified: false
+				});
+			});
+
+			expect(saveCustomTokensSpy).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				tokens: [
+					{
+						canisterId: ICRC7_BUILTIN_TOKENS[0].canisterId,
+						networkKey: 'Icrc7',
+						enabled: true
+					}
+				]
+			});
+
+			expect(mockEventCallback).toHaveBeenCalledExactlyOnceWith();
+		});
+	});
+
 	it('should not add ERC collections if there are no new collections', async () => {
 		const networks = [...SUPPORTED_EVM_MAINNET_NETWORKS, ...SUPPORTED_ETHEREUM_MAINNET_NETWORKS];
 
@@ -143,8 +190,6 @@ describe('LoaderCollections', () => {
 	});
 
 	it('should not add EXT collections if there are no new collections', async () => {
-		extGetTokensByOwnerSpy.mockReset().mockResolvedValueOnce([]);
-
 		render(LoaderCollections);
 
 		emit({ message: 'oisyReloadCollections', detail: { callback: mockEventCallback } });
@@ -156,6 +201,29 @@ describe('LoaderCollections', () => {
 				expect(extGetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
 					identity: mockIdentity,
 					owner: mockPrincipal,
+					canisterId,
+					certified: false
+				});
+			});
+
+			expect(saveCustomTokensSpy).not.toHaveBeenCalled();
+
+			expect(mockEventCallback).toHaveBeenCalledExactlyOnceWith();
+		});
+	});
+
+	it('should not add ICRC-7 collections if there are no new collections', async () => {
+		render(LoaderCollections);
+
+		emit({ message: 'oisyReloadCollections', detail: { callback: mockEventCallback } });
+
+		await waitFor(() => {
+			expect(icrc7GetTokensByOwnerSpy).toHaveBeenCalledTimes(ICRC7_BUILTIN_TOKENS.length);
+
+			ICRC7_BUILTIN_TOKENS.forEach(({ canisterId }, index) => {
+				expect(icrc7GetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
+					identity: mockIdentity,
+					owner: { owner: mockPrincipal, subaccount: [] },
 					canisterId,
 					certified: false
 				});
@@ -248,6 +316,43 @@ describe('LoaderCollections', () => {
 		});
 	});
 
+	it('should not add existing ICRC-7 collections', async () => {
+		const existingIcrc7CustomToken: CustomToken = {
+			token: {
+				Icrc7: {
+					canister_id: Principal.fromText(ICRC7_BUILTIN_TOKENS[0].canisterId)
+				}
+			},
+			version: toNullable(1n),
+			enabled: true,
+			section: toNullable(),
+			allow_external_content_source: toNullable(false)
+		};
+
+		backendCustomTokens.set([existingIcrc7CustomToken]);
+
+		render(LoaderCollections);
+
+		emit({ message: 'oisyReloadCollections', detail: { callback: mockEventCallback } });
+
+		await waitFor(() => {
+			expect(icrc7GetTokensByOwnerSpy).toHaveBeenCalledTimes(ICRC7_BUILTIN_TOKENS.length - 1);
+
+			ICRC7_BUILTIN_TOKENS.slice(1).forEach(({ canisterId }, index) => {
+				expect(icrc7GetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
+					identity: mockIdentity,
+					owner: { owner: mockPrincipal, subaccount: [] },
+					canisterId,
+					certified: false
+				});
+			});
+
+			expect(saveCustomTokensSpy).not.toHaveBeenCalled();
+
+			expect(mockEventCallback).toHaveBeenCalledExactlyOnceWith();
+		});
+	});
+
 	it('should handle EXT error gracefully', async () => {
 		const mockError = new Error('EXT error');
 		extGetTokensByOwnerSpy.mockRejectedValueOnce(mockError);
@@ -272,6 +377,37 @@ describe('LoaderCollections', () => {
 
 			expect(console.warn).toHaveBeenCalledExactlyOnceWith(
 				`Error fetching EXT tokens from canister ${EXT_BUILTIN_TOKENS[0].canisterId}:`,
+				mockError
+			);
+
+			expect(mockEventCallback).toHaveBeenCalledExactlyOnceWith();
+		});
+	});
+
+	it('should handle ICRC-7 error gracefully', async () => {
+		const mockError = new Error('ICRC-7 error');
+		icrc7GetTokensByOwnerSpy.mockRejectedValueOnce(mockError);
+
+		render(LoaderCollections);
+
+		emit({ message: 'oisyReloadCollections', detail: { callback: mockEventCallback } });
+
+		await waitFor(() => {
+			expect(icrc7GetTokensByOwnerSpy).toHaveBeenCalledTimes(ICRC7_BUILTIN_TOKENS.length);
+
+			ICRC7_BUILTIN_TOKENS.forEach(({ canisterId }, index) => {
+				expect(icrc7GetTokensByOwnerSpy).toHaveBeenNthCalledWith(index + 1, {
+					identity: mockIdentity,
+					owner: { owner: mockPrincipal, subaccount: [] },
+					canisterId,
+					certified: false
+				});
+			});
+
+			expect(saveCustomTokensSpy).not.toHaveBeenCalled();
+
+			expect(console.warn).toHaveBeenCalledExactlyOnceWith(
+				`Error fetching ICRC-7 tokens from canister ${ICRC7_BUILTIN_TOKENS[0].canisterId}:`,
 				mockError
 			);
 


### PR DESCRIPTION
# Motivation

NFT reload should discover newly received ICRC-7 collection NFTs, matching the existing IC collection reload behavior.

# Changes

- Scan built-in ICRC-7 NFT collections during manual collection reload.
- Save discovered ICRC-7 collections as enabled custom NFT tokens.

# Tests

Added tests.
