### PR TITLE
feat(frontend): active transactions API methods

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -1,4 +1,5 @@
 import type {
+	ActiveUserTransaction,
 	BtcGetFeePercentilesResponse,
 	Contact,
 	CustomToken,
@@ -17,6 +18,7 @@ import type {
 	BtcAddPendingTransactionParams,
 	BtcGetFeePercentilesParams,
 	BtcGetPendingTransactionParams,
+	CreateActiveUserTransactionParams,
 	CreateContactParams,
 	CreateUserProfileResponse,
 	DeleteContactParams,
@@ -30,6 +32,7 @@ import type {
 	SaveUserNetworksSettings,
 	SaveUserTransactionsParams,
 	SetUserShowTestnetsParams,
+	UpdateActiveUserTransactionParams,
 	UpdateContactParams,
 	UpdateUserExperimentalFeatureSettings,
 	UpdateUserTransactionFilterSettings
@@ -300,6 +303,41 @@ export const saveUserTransactions = async ({
 	const { saveUserTransactions } = await backendCanister({ identity });
 
 	return saveUserTransactions(params);
+};
+
+export const createActiveUserTransaction = async ({
+	identity,
+	...params
+}: CanisterApiFunctionParams<CreateActiveUserTransactionParams>): Promise<ActiveUserTransaction> => {
+	const { createActiveUserTransaction } = await backendCanister({ identity });
+
+	return createActiveUserTransaction(params);
+};
+
+export const updateActiveUserTransaction = async ({
+	identity,
+	...params
+}: CanisterApiFunctionParams<UpdateActiveUserTransactionParams>): Promise<ActiveUserTransaction> => {
+	const { updateActiveUserTransaction } = await backendCanister({ identity });
+
+	return updateActiveUserTransaction(params);
+};
+
+export const deleteActiveUserTransaction = async ({
+	identity,
+	id
+}: CanisterApiFunctionParams<{ id: string }>): Promise<void> => {
+	const { deleteActiveUserTransaction } = await backendCanister({ identity });
+
+	return deleteActiveUserTransaction(id);
+};
+
+export const getActiveUserTransactions = async ({
+	identity
+}: CanisterApiFunctionParams): Promise<ActiveUserTransaction[]> => {
+	const { getActiveUserTransactions } = await backendCanister({ identity });
+
+	return getActiveUserTransactions();
 };
 
 const backendCanister = async ({

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -1,4 +1,5 @@
 import type {
+	ActiveUserTransaction,
 	_SERVICE as BackendService,
 	BtcGetFeePercentilesResponse,
 	Contact,
@@ -27,6 +28,7 @@ import type {
 	BtcAddPendingTransactionParams,
 	BtcGetFeePercentilesParams,
 	BtcGetPendingTransactionParams,
+	CreateActiveUserTransactionParams,
 	CreateUserProfileResponse,
 	GetPendingTransactionsOutcome,
 	GetUserProfileResponse,
@@ -37,6 +39,7 @@ import type {
 	SaveUserNetworksSettings,
 	SaveUserTransactionsParams,
 	SetUserShowTestnetsParams,
+	UpdateActiveUserTransactionParams,
 	UpdateUserExperimentalFeatureSettings,
 	UpdateUserTransactionFilterSettings
 } from '$lib/types/api';
@@ -490,6 +493,76 @@ export class BackendCanister extends Canister<BackendService> {
 
 		if ('Ok' in response) {
 			return;
+		}
+
+		throw response.Err;
+	};
+
+	createActiveUserTransaction = async ({
+		id,
+		data,
+		progressStep,
+		externalRefs
+	}: CreateActiveUserTransactionParams): Promise<ActiveUserTransaction> => {
+		const { create_active_user_transaction } = this.caller({ certified: true });
+
+		const response = await create_active_user_transaction({
+			id,
+			data,
+			progress_step: toNullable(progressStep),
+			external_refs: externalRefs
+		});
+
+		if ('Ok' in response) {
+			return response.Ok;
+		}
+
+		throw response.Err;
+	};
+
+	updateActiveUserTransaction = async ({
+		id,
+		status,
+		progressStep,
+		externalRefs,
+		error
+	}: UpdateActiveUserTransactionParams): Promise<ActiveUserTransaction> => {
+		const { update_active_user_transaction } = this.caller({ certified: true });
+
+		const response = await update_active_user_transaction({
+			id,
+			status: toNullable(status),
+			progress_step: toNullable(progressStep),
+			external_refs: toNullable(externalRefs),
+			error: toNullable(error)
+		});
+
+		if ('Ok' in response) {
+			return response.Ok;
+		}
+
+		throw response.Err;
+	};
+
+	deleteActiveUserTransaction = async (id: string): Promise<void> => {
+		const { delete_active_user_transaction } = this.caller({ certified: true });
+
+		const response = await delete_active_user_transaction(id);
+
+		if ('Ok' in response) {
+			return;
+		}
+
+		throw response.Err;
+	};
+
+	getActiveUserTransactions = async (): Promise<ActiveUserTransaction[]> => {
+		const { get_active_user_transactions } = this.caller({ certified: false });
+
+		const response = await get_active_user_transactions();
+
+		if ('Ok' in response) {
+			return response.Ok.transactions;
 		}
 
 		throw response.Err;

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -1,5 +1,8 @@
 import type { BtcAddress } from '$btc/types/address';
 import type {
+	ActiveUserTransactionData,
+	ActiveUserTransactionRef,
+	ActiveUserTransactionStatus,
 	AllowSigningResponse,
 	TokenId as BackendTokenId,
 	Network as BitcoinNetwork,
@@ -229,4 +232,19 @@ export interface GetUserTransactionsResponse {
 export interface SaveUserTransactionsParams {
 	tokenId: BackendTokenId;
 	transactions: UserTransaction[];
+}
+
+export interface CreateActiveUserTransactionParams {
+	id: string;
+	data: ActiveUserTransactionData;
+	progressStep?: string;
+	externalRefs: ActiveUserTransactionRef[];
+}
+
+export interface UpdateActiveUserTransactionParams {
+	id: string;
+	status?: ActiveUserTransactionStatus;
+	progressStep?: string;
+	externalRefs?: ActiveUserTransactionRef[];
+	error?: string;
 }

--- a/src/frontend/src/tests/lib/api/backend.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/backend.api.spec.ts
@@ -3,7 +3,10 @@ import {
 	addPendingBtcTransaction,
 	addUserDismissedNotification,
 	allowSigning,
+	createActiveUserTransaction,
 	createUserProfile,
+	deleteActiveUserTransaction,
+	getActiveUserTransactions,
 	getExchangeRate,
 	getExchangeRates,
 	getPendingBtcTransactions,
@@ -15,6 +18,7 @@ import {
 	saveUserTransactions,
 	setCustomToken,
 	setManyCustomTokens,
+	updateActiveUserTransaction,
 	updateUserExperimentalFeatureSettings,
 	updateUserTransactionFilterSettings
 } from '$lib/api/backend.api';
@@ -26,15 +30,23 @@ import type {
 	AllowSigningParams,
 	BtcAddPendingTransactionParams,
 	BtcGetPendingTransactionParams,
+	CreateActiveUserTransactionParams,
 	CreateUserProfileResponse,
 	GetUserProfileResponse,
 	GetUserTransactionsParams,
 	SaveUserTransactionsParams,
+	UpdateActiveUserTransactionParams,
 	UpdateUserExperimentalFeatureSettings,
 	UpdateUserTransactionFilterSettings
 } from '$lib/types/api';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';
 import type { BackendExchangeRate } from '$lib/types/exchange';
+import {
+	mockActiveUserTransaction,
+	mockActiveUserTransactionId,
+	mockCreateActiveUserTransactionParams,
+	mockUpdateActiveUserTransactionParams
+} from '$tests/mocks/active-user-transactions.mock';
 import { mockUtxo } from '$tests/mocks/btc.mock';
 import { mockCustomTokens } from '$tests/mocks/custom-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -721,6 +733,137 @@ describe('backend.api', () => {
 			await expect(
 				getExchangeRates({ ...baseParams, token_ids: tokenIds, certified: false })
 			).rejects.toThrow();
+		});
+	});
+
+	describe('createActiveUserTransaction', () => {
+		const mockParams: CanisterApiFunctionParams<CreateActiveUserTransactionParams> = {
+			...baseParams,
+			...mockCreateActiveUserTransactionParams
+		};
+
+		beforeEach(() => {
+			backendCanisterMock.createActiveUserTransaction.mockResolvedValue(mockActiveUserTransaction);
+		});
+
+		it('should successfully call createActiveUserTransaction endpoint', async () => {
+			const result = await createActiveUserTransaction(mockParams);
+
+			expect(result).toEqual(mockActiveUserTransaction);
+			expect(backendCanisterMock.createActiveUserTransaction).toHaveBeenCalledExactlyOnceWith(
+				mockCreateActiveUserTransactionParams
+			);
+		});
+
+		it('should throw an error if identity is undefined', async () => {
+			await expect(
+				createActiveUserTransaction({ ...mockParams, identity: undefined })
+			).rejects.toThrow();
+		});
+
+		it('should throw an error if createActiveUserTransaction throws', async () => {
+			backendCanisterMock.createActiveUserTransaction.mockImplementation(() => {
+				throw new Error('mock-error');
+			});
+
+			await expect(createActiveUserTransaction(mockParams)).rejects.toThrow();
+		});
+	});
+
+	describe('updateActiveUserTransaction', () => {
+		const mockParams: CanisterApiFunctionParams<UpdateActiveUserTransactionParams> = {
+			...baseParams,
+			...mockUpdateActiveUserTransactionParams
+		};
+
+		beforeEach(() => {
+			backendCanisterMock.updateActiveUserTransaction.mockResolvedValue(mockActiveUserTransaction);
+		});
+
+		it('should successfully call updateActiveUserTransaction endpoint', async () => {
+			const result = await updateActiveUserTransaction(mockParams);
+
+			expect(result).toEqual(mockActiveUserTransaction);
+			expect(backendCanisterMock.updateActiveUserTransaction).toHaveBeenCalledExactlyOnceWith(
+				mockUpdateActiveUserTransactionParams
+			);
+		});
+
+		it('should throw an error if identity is undefined', async () => {
+			await expect(
+				updateActiveUserTransaction({ ...mockParams, identity: undefined })
+			).rejects.toThrow();
+		});
+
+		it('should throw an error if updateActiveUserTransaction throws', async () => {
+			backendCanisterMock.updateActiveUserTransaction.mockImplementation(() => {
+				throw new Error('mock-error');
+			});
+
+			await expect(updateActiveUserTransaction(mockParams)).rejects.toThrow();
+		});
+	});
+
+	describe('deleteActiveUserTransaction', () => {
+		const mockParams: CanisterApiFunctionParams<{ id: string }> = {
+			...baseParams,
+			id: mockActiveUserTransactionId
+		};
+
+		beforeEach(() => {
+			backendCanisterMock.deleteActiveUserTransaction.mockResolvedValue();
+		});
+
+		it('should successfully call deleteActiveUserTransaction endpoint', async () => {
+			const result = await deleteActiveUserTransaction(mockParams);
+
+			expect(result).toBeUndefined();
+			expect(backendCanisterMock.deleteActiveUserTransaction).toHaveBeenCalledExactlyOnceWith(
+				mockActiveUserTransactionId
+			);
+		});
+
+		it('should throw an error if identity is undefined', async () => {
+			await expect(
+				deleteActiveUserTransaction({ ...mockParams, identity: undefined })
+			).rejects.toThrow();
+		});
+
+		it('should throw an error if deleteActiveUserTransaction throws', async () => {
+			backendCanisterMock.deleteActiveUserTransaction.mockImplementation(() => {
+				throw new Error('mock-error');
+			});
+
+			await expect(deleteActiveUserTransaction(mockParams)).rejects.toThrow();
+		});
+	});
+
+	describe('getActiveUserTransactions', () => {
+		const mockParams: CanisterApiFunctionParams = baseParams;
+
+		beforeEach(() => {
+			backendCanisterMock.getActiveUserTransactions.mockResolvedValue([mockActiveUserTransaction]);
+		});
+
+		it('should successfully call getActiveUserTransactions endpoint', async () => {
+			const result = await getActiveUserTransactions(mockParams);
+
+			expect(result).toEqual([mockActiveUserTransaction]);
+			expect(backendCanisterMock.getActiveUserTransactions).toHaveBeenCalledExactlyOnceWith();
+		});
+
+		it('should throw an error if identity is undefined', async () => {
+			await expect(
+				getActiveUserTransactions({ ...mockParams, identity: undefined })
+			).rejects.toThrow();
+		});
+
+		it('should throw an error if getActiveUserTransactions throws', async () => {
+			backendCanisterMock.getActiveUserTransactions.mockImplementation(() => {
+				throw new Error('mock-error');
+			});
+
+			await expect(getActiveUserTransactions(mockParams)).rejects.toThrow();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -13,6 +13,15 @@ import { CanisterInternalError } from '$lib/canisters/errors';
 import { ZERO } from '$lib/constants/app.constants';
 import type { BtcAddPendingTransactionParams } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
+import {
+	mockActiveUserTransaction,
+	mockActiveUserTransactionData,
+	mockActiveUserTransactionErrorNotFound,
+	mockActiveUserTransactionId,
+	mockActiveUserTransactionRef,
+	mockCreateActiveUserTransactionParams,
+	mockUpdateActiveUserTransactionParams
+} from '$tests/mocks/active-user-transactions.mock';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { getMockContacts } from '$tests/mocks/contacts.mock';
 import { mockIdentity, mockPrincipal } from '$tests/mocks/identity.mock';
@@ -1743,6 +1752,211 @@ describe('backend.canister', () => {
 			await expect(getExchangeRates({ token_ids: tokenIds, certified: false })).rejects.toThrow(
 				mockResponseError
 			);
+		});
+	});
+
+	describe('createActiveUserTransaction', () => {
+		const errorResponse = { Err: mockActiveUserTransactionErrorNotFound };
+
+		it('should create the record and return the unwrapped value', async () => {
+			service.create_active_user_transaction.mockResolvedValue({
+				Ok: mockActiveUserTransaction
+			});
+
+			const { createActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await createActiveUserTransaction(mockCreateActiveUserTransactionParams);
+
+			expect(service.create_active_user_transaction).toHaveBeenCalledExactlyOnceWith({
+				id: mockActiveUserTransactionId,
+				data: mockActiveUserTransactionData,
+				progress_step: ['submitting'],
+				external_refs: []
+			});
+			expect(res).toEqual(mockActiveUserTransaction);
+		});
+
+		it('should pass empty array for progress_step when undefined', async () => {
+			service.create_active_user_transaction.mockResolvedValue({
+				Ok: mockActiveUserTransaction
+			});
+
+			const { createActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			await createActiveUserTransaction({
+				id: mockActiveUserTransactionId,
+				data: mockActiveUserTransactionData,
+				externalRefs: []
+			});
+
+			expect(service.create_active_user_transaction).toHaveBeenCalledExactlyOnceWith({
+				id: mockActiveUserTransactionId,
+				data: mockActiveUserTransactionData,
+				progress_step: [],
+				external_refs: []
+			});
+		});
+
+		it('should throw if the canister returns Err', async () => {
+			service.create_active_user_transaction.mockResolvedValue(errorResponse);
+
+			const { createActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			await expect(
+				createActiveUserTransaction(mockCreateActiveUserTransactionParams)
+			).rejects.toEqual(errorResponse.Err);
+		});
+
+		it('should rethrow if the canister call throws', async () => {
+			service.create_active_user_transaction.mockImplementation(async () => {
+				await Promise.resolve();
+				throw mockResponseError;
+			});
+
+			const { createActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			await expect(
+				createActiveUserTransaction(mockCreateActiveUserTransactionParams)
+			).rejects.toThrow(mockResponseError);
+		});
+	});
+
+	describe('updateActiveUserTransaction', () => {
+		const errorResponse = { Err: mockActiveUserTransactionErrorNotFound };
+
+		it('should pass populated optionals through to the canister', async () => {
+			service.update_active_user_transaction.mockResolvedValue({
+				Ok: mockActiveUserTransaction
+			});
+
+			const { updateActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await updateActiveUserTransaction(mockUpdateActiveUserTransactionParams);
+
+			expect(service.update_active_user_transaction).toHaveBeenCalledExactlyOnceWith({
+				id: mockActiveUserTransactionId,
+				status: [{ Executing: null }],
+				progress_step: ['settling'],
+				external_refs: [[mockActiveUserTransactionRef]],
+				error: []
+			});
+			expect(res).toEqual(mockActiveUserTransaction);
+		});
+
+		it('should pass empty arrays for all unset partial fields', async () => {
+			service.update_active_user_transaction.mockResolvedValue({
+				Ok: mockActiveUserTransaction
+			});
+
+			const { updateActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			await updateActiveUserTransaction({ id: mockActiveUserTransactionId });
+
+			expect(service.update_active_user_transaction).toHaveBeenCalledExactlyOnceWith({
+				id: mockActiveUserTransactionId,
+				status: [],
+				progress_step: [],
+				external_refs: [],
+				error: []
+			});
+		});
+
+		it('should throw if the canister returns Err', async () => {
+			service.update_active_user_transaction.mockResolvedValue(errorResponse);
+
+			const { updateActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			await expect(
+				updateActiveUserTransaction(mockUpdateActiveUserTransactionParams)
+			).rejects.toEqual(errorResponse.Err);
+		});
+	});
+
+	describe('deleteActiveUserTransaction', () => {
+		const errorResponse = { Err: mockActiveUserTransactionErrorNotFound };
+
+		it('should resolve to void on Ok', async () => {
+			service.delete_active_user_transaction.mockResolvedValue({ Ok: null });
+
+			const { deleteActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await deleteActiveUserTransaction(mockActiveUserTransactionId);
+
+			expect(service.delete_active_user_transaction).toHaveBeenCalledExactlyOnceWith(
+				mockActiveUserTransactionId
+			);
+			expect(res).toBeUndefined();
+		});
+
+		it('should throw if the canister returns Err', async () => {
+			service.delete_active_user_transaction.mockResolvedValue(errorResponse);
+
+			const { deleteActiveUserTransaction } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			await expect(deleteActiveUserTransaction(mockActiveUserTransactionId)).rejects.toEqual(
+				errorResponse.Err
+			);
+		});
+	});
+
+	describe('getActiveUserTransactions', () => {
+		const errorResponse = { Err: mockActiveUserTransactionErrorNotFound };
+
+		it('should return the unwrapped list of transactions', async () => {
+			service.get_active_user_transactions.mockResolvedValue({
+				Ok: { transactions: [mockActiveUserTransaction] }
+			});
+
+			const { getActiveUserTransactions } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await getActiveUserTransactions();
+
+			expect(service.get_active_user_transactions).toHaveBeenCalledExactlyOnceWith();
+			expect(res).toEqual([mockActiveUserTransaction]);
+		});
+
+		it('should return an empty array when the user has no records', async () => {
+			service.get_active_user_transactions.mockResolvedValue({
+				Ok: { transactions: [] }
+			});
+
+			const { getActiveUserTransactions } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			const res = await getActiveUserTransactions();
+
+			expect(res).toEqual([]);
+		});
+
+		it('should throw if the canister returns Err', async () => {
+			service.get_active_user_transactions.mockResolvedValue(errorResponse);
+
+			const { getActiveUserTransactions } = await createBackendCanister({
+				serviceOverride: service
+			});
+
+			await expect(getActiveUserTransactions()).rejects.toEqual(errorResponse.Err);
 		});
 	});
 });

--- a/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
@@ -1,0 +1,61 @@
+import type {
+	ActiveUserTransaction,
+	ActiveUserTransactionData,
+	ActiveUserTransactionError,
+	ActiveUserTransactionRef,
+	OneSecIcpToEvmData
+} from '$declarations/backend/backend.did';
+import type {
+	CreateActiveUserTransactionParams,
+	UpdateActiveUserTransactionParams
+} from '$lib/types/api';
+import { mockPrincipal } from '$tests/mocks/identity.mock';
+
+export const mockActiveUserTransactionId = '11111111-1111-4111-8111-111111111111';
+
+export const mockRecipientEvmAddress = '0x0000000000000000000000000000000000000001';
+
+export const mockOneSecIcpToEvmData: OneSecIcpToEvmData = {
+	source_token: { Icrc: mockPrincipal },
+	dest_token: { EvmNative: 1n },
+	amount: 1_000_000n,
+	recipient_evm_address: mockRecipientEvmAddress
+};
+
+export const mockActiveUserTransactionData: ActiveUserTransactionData = {
+	OneSecIcpToEvm: mockOneSecIcpToEvmData
+};
+
+export const mockActiveUserTransactionRef: ActiveUserTransactionRef = {
+	key: 'tx_hash',
+	value: '0xabc'
+};
+
+export const mockActiveUserTransaction: ActiveUserTransaction = {
+	id: mockActiveUserTransactionId,
+	status: { Pending: null },
+	data: mockActiveUserTransactionData,
+	progress_step: ['submitting'],
+	external_refs: [],
+	created_at_ns: 1n,
+	updated_at_ns: 1n,
+	error: []
+};
+
+export const mockCreateActiveUserTransactionParams: CreateActiveUserTransactionParams = {
+	id: mockActiveUserTransactionId,
+	data: mockActiveUserTransactionData,
+	progressStep: 'submitting',
+	externalRefs: []
+};
+
+export const mockUpdateActiveUserTransactionParams: UpdateActiveUserTransactionParams = {
+	id: mockActiveUserTransactionId,
+	status: { Executing: null },
+	progressStep: 'settling',
+	externalRefs: [mockActiveUserTransactionRef]
+};
+
+export const mockActiveUserTransactionErrorNotFound: ActiveUserTransactionError = {
+	NotFound: null
+};


### PR DESCRIPTION
# Motivation

We can now expose the new BE endpoints via `backend.api` methods.