### PR TITLE
docs(ai,frontend): add brand-and-copy guide for agents

### DIFF
--- a/.cursor/rules/35-brand-and-copy.mdc
+++ b/.cursor/rules/35-brand-and-copy.mdc
@@ -1,0 +1,13 @@
+---
+description: OISY voice, vocabulary, colour usage, and icon rules for any user-visible UI.
+globs: ['src/frontend/**/*.svelte', 'src/frontend/**/*.ts', 'src/frontend/**/*.scss', 'src/frontend/src/lib/i18n/en.json']
+---
+
+# Cursor — Brand & copy
+
+Authoritative source: [docs/ai/frontend/brand-and-copy.md](mdc:docs/ai/frontend/brand-and-copy.md).
+
+Read it before writing any user-visible string, choosing a colour, or
+adding an icon. Covers the OISY voice, the "use this, not that" table,
+banned vocabulary, the failure-copy structure, the canonical chain
+listing, brand-side colour rules, and the iconography rules.

--- a/.cursor/rules/35-brand-and-copy.mdc
+++ b/.cursor/rules/35-brand-and-copy.mdc
@@ -1,6 +1,12 @@
 ---
 description: OISY voice, vocabulary, colour usage, and icon rules for any user-visible UI.
-globs: ['src/frontend/**/*.svelte', 'src/frontend/**/*.ts', 'src/frontend/**/*.scss', 'src/frontend/src/lib/i18n/en.json']
+globs:
+  [
+    'src/frontend/**/*.svelte',
+    'src/frontend/**/*.ts',
+    'src/frontend/**/*.scss',
+    'src/frontend/src/lib/i18n/en.json'
+  ]
 ---
 
 # Cursor — Brand & copy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ and `Cargo.toml`. The non-obvious bits:
 | Write Svelte 5 / runes / stores / TS          | [`docs/ai/frontend/stack-and-patterns.md`](./docs/ai/frontend/stack-and-patterns.md)                         |
 | Add UI                                        | [`docs/ai/frontend/reusability.md`](./docs/ai/frontend/reusability.md)                                       |
 | Add user-visible text or interactive elements | [`docs/ai/frontend/i18n-and-a11y.md`](./docs/ai/frontend/i18n-and-a11y.md)                                   |
+| Write copy, pick a colour, or add an icon     | [`docs/ai/frontend/brand-and-copy.md`](./docs/ai/frontend/brand-and-copy.md)                                 |
 | Add a Svelte component                        | [`docs/ai/frontend/workflows/new-component.md`](./docs/ai/frontend/workflows/new-component.md)               |
 | Add an API call / service / store             | [`docs/ai/frontend/workflows/new-service.md`](./docs/ai/frontend/workflows/new-service.md)                   |
 | Split / refactor a component                  | [`docs/ai/frontend/workflows/refactor-split.md`](./docs/ai/frontend/workflows/refactor-split.md)             |

--- a/docs/ai/frontend/README.md
+++ b/docs/ai/frontend/README.md
@@ -17,6 +17,8 @@ starting point. Read it once per session.
       with no `any`).
 - [ ] No hard-coded user-visible strings; a11y attributes set —
       [`i18n-and-a11y.md`](./i18n-and-a11y.md).
+- [ ] User-visible copy, colours, and icons follow brand rules —
+      [`brand-and-copy.md`](./brand-and-copy.md).
 - [ ] I have or extended tests where the [`testing.md`](./testing.md) policy
       requires.
 - [ ] No `console.error` / `console.warn` / `0n` / relative imports in

--- a/docs/ai/frontend/brand-and-copy.md
+++ b/docs/ai/frontend/brand-and-copy.md
@@ -12,19 +12,19 @@ user-visible string, picking a colour, or adding an icon.
 ## Voice in one screen
 
 OISY is a browser-native wallet for digital wealth. It targets people
-fluent in Apple Pay, Revolut, brokerage apps — not crypto-natives. The
+fluent in Apple Pay, Revolut, brokerage apps, not crypto-natives. The
 brand should feel like serious financial infrastructure: refined,
 private, available everywhere.
 
 Five attributes:
 
-- **Calm and premium** — a private-banking app with browser speed, not
+- **Calm and premium.** A private-banking app with browser speed, not
   a whitepaper.
-- **Confident and focused** — say fewer things; make each one land.
-- **Human before technical** — start with what the user feels, then
+- **Confident and focused.** Say fewer things; make each one land.
+- **Human before technical.** Start with what the user feels, then
   explain why it is possible.
-- **Empowering** — the user feels capable, in control.
-- **Trustworthy** — quiet confidence, never fear-mongering.
+- **Empowering.** The user feels capable, in control.
+- **Trustworthy.** Quiet confidence, never fear-mongering.
 
 **House sentence:** _Say what is true, in plain words, and stop._ If a
 sentence could appear in any company's marketing, cut it.
@@ -54,10 +54,10 @@ Approved security patterns (stay one layer above implementation; keep
 ## Banned in any user-visible string
 
 - **Em dashes** (`—`, U+2014). Use commas, periods, colons, parens.
-- **`secured by blockchain`** — use `secured by advanced cryptography`.
-- **`OISY token`, `$OISY`** — there is no token; repeating the rumour
+- **`secured by blockchain`.** Use `secured by advanced cryptography`.
+- **`OISY token`, `$OISY`.** There is no token; repeating the rumour
   amplifies a scam.
-- **OISY-owned Telegram references** — OISY has no Telegram channel,
+- **OISY-owned Telegram references.** OISY has no Telegram channel,
   community, or support handle. Don't write copy that implies one
   ("Join us on Telegram", "Telegram support", a Telegram link in the
   footer). Third-party dApp connectors that legitimately open Telegram
@@ -74,7 +74,7 @@ specific. Every error string follows the same shape:
 
 1. **Name what failed.** Plain language, no error codes, no protocol
    names.
-2. **State what was preserved.** Funds, keys, signatures — say so.
+2. **State what was preserved.** Funds, keys, signatures: say so.
 3. **Offer one next step.** Try again, refresh the quote, add funds,
    check the address.
 
@@ -103,7 +103,7 @@ our team…`).
 ## Chain listing
 
 **Canonical order:** Bitcoin, Ethereum, Internet Computer, then the
-remaining supported networks in alphabetical order — currently
+remaining supported networks in alphabetical order. Currently:
 Arbitrum, Base, BNB Smart Chain, Polygon, Solana.
 
 **Short form:** _Bitcoin, Ethereum, Internet Computer, and more._
@@ -127,10 +127,11 @@ and
 
 ### Brand rules to follow now
 
-1. **Logo blue is reserved.** `--color-*-brand-primary` (`$oisy-blue-600`,
-   `#0066FF`) is for the OISY mark and — at most — one expressive serif
-   word per surface. Do **not** paint whole interfaces in logo blue. Use
-   navy, charcoal, and neutrals for the rest.
+1. **Logo blue is reserved.** `--color-*-brand-primary` (the
+   `$oisy-blue-600` SCSS variable) is for the OISY mark and, at most,
+   one expressive serif word per surface. Do **not** paint whole
+   interfaces in logo blue. Use navy, charcoal, and neutrals for the
+   rest.
 2. **Fills vs. text.** Background tokens are for fills; foreground
    tokens are for text. When colour names a state (success, warning,
    error), the _text_ uses `--color-foreground-{success,warning,error}-*`,
@@ -140,7 +141,7 @@ and
    with a glyph and a text label. The a11y rule lives in
    [`i18n-and-a11y.md`](./i18n-and-a11y.md#color--contrast).
 4. **Accents are sparing.** The bright product gradient and sky accent
-   are for wallet UI moments (balance card) and marketing highlights —
+   are for wallet UI moments (balance card) and marketing highlights,
    not every surface.
 5. **No new top-level colour tokens.** If you need a colour the system
    doesn't have, surface it in the PR description and ask. Don't invent
@@ -179,7 +180,7 @@ inventing a third size.
       one next step.
 - [ ] Lead sentences are positively framed.
 - [ ] No degen, casino, or hype language.
-- [ ] Logo blue is on the mark and at most one expressive word — not
+- [ ] Logo blue is on the mark and at most one expressive word, not
       the whole UI.
 - [ ] State is communicated with colour **and** text **and** a glyph.
 - [ ] No hard-coded hex; existing token classes / CSS variables only.

--- a/docs/ai/frontend/brand-and-copy.md
+++ b/docs/ai/frontend/brand-and-copy.md
@@ -1,0 +1,186 @@
+# Brand & copy
+
+The OISY voice, vocabulary, colour usage, and icon conventions that
+agents are most likely to get wrong. Read this before writing any
+user-visible string, picking a colour, or adding an icon.
+
+> Higher up: [`AGENTS.md`](../../../AGENTS.md) →
+> [Frontend README](./README.md). Related:
+> [`i18n-and-a11y.md`](./i18n-and-a11y.md) (mechanics of i18n keys and
+> a11y baseline).
+
+## Voice in one screen
+
+OISY is a browser-native wallet for digital wealth. It targets people
+fluent in Apple Pay, Revolut, brokerage apps — not crypto-natives. The
+brand should feel like serious financial infrastructure: refined,
+private, available everywhere.
+
+Five attributes:
+
+- **Calm and premium** — a private-banking app with browser speed, not
+  a whitepaper.
+- **Confident and focused** — say fewer things; make each one land.
+- **Human before technical** — start with what the user feels, then
+  explain why it is possible.
+- **Empowering** — the user feels capable, in control.
+- **Trustworthy** — quiet confidence, never fear-mongering.
+
+**House sentence:** _Say what is true, in plain words, and stop._ If a
+sentence could appear in any company's marketing, cut it.
+
+## Use this, not that
+
+| Prefer                                  | Instead of               | Why                                                            |
+| --------------------------------------- | ------------------------ | -------------------------------------------------------------- |
+| Secured by advanced cryptography        | Secured by blockchain    | Blockchains have been hacked; cryptography is the actual moat  |
+| Sign in the way you unlock your phone   | Seed phrase onboarding   | Lead with the positive experience                              |
+| Works from any browser, on any device   | Extension-free wallet    | Describe the gain, not the absence                             |
+| Network custody                         | Custodial / self-custody | OISY is a third way; naming it precisely is the message        |
+| Chain Fusion                            | Bridging / wrapping      | OISY does not bridge; native integration is the differentiator |
+| Passkey login through Internet Identity | Passwordless login       | Product benefit first, proof layer underneath                  |
+| OISY (in body copy)                     | OISY Wallet (in body)    | The full lockup is for the logo only                           |
+| Digital wealth                          | Crypto only              | OISY covers crypto, stablecoins, tokenized stocks, commodities |
+
+Approved security patterns (stay one layer above implementation; keep
+`threshold ECDSA`, EdDSA, Schnorr for technical docs):
+
+- "Secured by advanced cryptography."
+- "Runs on the Internet Computer, a tamperproof, always-on, sovereign
+  frontier cloud."
+- "Your keys are split across independent nodes, with complete-key
+  control distributed across the network."
+- "Sign in the way you unlock your phone, with your face or fingerprint."
+
+## Banned in any user-visible string
+
+- **Em dashes** (`—`, U+2014). Use commas, periods, colons, parens.
+- **`secured by blockchain`** — use `secured by advanced cryptography`.
+- **`OISY token`, `$OISY`** — there is no token; repeating the rumour
+  amplifies a scam.
+- **OISY-owned Telegram references** — OISY has no Telegram channel,
+  community, or support handle. Don't write copy that implies one
+  ("Join us on Telegram", "Telegram support", a Telegram link in the
+  footer). Third-party dApp connectors that legitimately open Telegram
+  (e.g. `open_telegram: "Open $dAppName on Telegram"`) are fine.
+- **Degen / hype**: `alpha`, `ape / aping in`, `WAGMI / NGMI / LFG`,
+  `gm / ser / fren`, `DYOR / NFA`, `the future is here`,
+  `revolutionizing / game-changing`, `next-gen / paradigm shift`.
+- **Casino / gambling metaphors.**
+
+## Failure copy
+
+Failure is the most exposed surface of a wallet. The stance is calm and
+specific. Every error string follows the same shape:
+
+1. **Name what failed.** Plain language, no error codes, no protocol
+   names.
+2. **State what was preserved.** Funds, keys, signatures — say so.
+3. **Offer one next step.** Try again, refresh the quote, add funds,
+   check the address.
+
+Stay one layer above implementation. Hold the temperature: no
+exclamation marks, no "immediately", no "Oops".
+
+Patterns:
+
+- **Failed transaction.** "Your transfer didn't complete. The funds
+  stayed in your wallet. Try again or check the network status."
+- **Network timeout.** "OISY couldn't reach the Ethereum network. Your
+  funds and keys are safe. Try again in a moment."
+- **Expired session.** "You've been signed out for safety. Sign in with
+  your passkey to pick up where you left off."
+- **Insufficient funds.** "Not enough Bitcoin to cover this send and
+  the network fee. Add funds or lower the amount."
+- **Rejected approval.** "You declined the request. Nothing was signed
+  and nothing was sent."
+
+Banned in error copy: generic apologies (`Oops! Something went wrong.`),
+anxious register (`Sorry, we failed…`), blame-shifting (`You entered the
+wrong address.`), raw technical leakage (error codes, call sites,
+protocol names), empty reassurance with no next step (`We've notified
+our team…`).
+
+## Chain listing
+
+**Canonical order:** Bitcoin, Ethereum, Internet Computer, then the
+remaining supported networks in alphabetical order — currently
+Arbitrum, Base, BNB Smart Chain, Polygon, Solana.
+
+**Short form:** _Bitcoin, Ethereum, Internet Computer, and more._
+**Internet Computer is never dropped.**
+
+Use the official network names as defined in
+`src/frontend/src/env/networks/`. The L2 / sidechain in particular is
+**BNB Smart Chain** (not "BNB Chain"). Tickers (`BTC`, `ETH`, `ICP`,
+`SOL`) belong in product UI and tables.
+
+## Colour rules
+
+The frontend already has a complete token system in
+[`base-colors.scss`](../../../src/frontend/src/lib/styles/theme/base-colors.scss),
+themed in
+[`default-theme.scss`](../../../src/frontend/src/lib/styles/theme/default-theme.scss)
+and
+[`dark-theme.scss`](../../../src/frontend/src/lib/styles/theme/dark-theme.scss).
+**Use the `--color-foreground-*` / `--color-background-*` /
+`--color-border-*` tokens. Never hard-code hex.**
+
+### Brand rules to follow now
+
+1. **Logo blue is reserved.** `--color-*-brand-primary` (`$oisy-blue-600`,
+   `#0066FF`) is for the OISY mark and — at most — one expressive serif
+   word per surface. Do **not** paint whole interfaces in logo blue. Use
+   navy, charcoal, and neutrals for the rest.
+2. **Fills vs. text.** Background tokens are for fills; foreground
+   tokens are for text. When colour names a state (success, warning,
+   error), the _text_ uses `--color-foreground-{success,warning,error}-*`,
+   not the background fill colour. This already matches the existing
+   token naming.
+3. **State never carried by colour alone.** Pair every state colour
+   with a glyph and a text label. The a11y rule lives in
+   [`i18n-and-a11y.md`](./i18n-and-a11y.md#color--contrast).
+4. **Accents are sparing.** The bright product gradient and sky accent
+   are for wallet UI moments (balance card) and marketing highlights —
+   not every surface.
+5. **No new top-level colour tokens.** If you need a colour the system
+   doesn't have, surface it in the PR description and ask. Don't invent
+   a hex.
+
+## Iconography
+
+The repo's icon set lives in
+[`$lib/components/icons/`](../../../src/frontend/src/lib/components/icons)
+(~80 custom SVG Svelte components). Reach for an existing one before
+adding a new icon. When you do add one:
+
+- **Line-first**, rounded joins. Stroke inherits text colour via
+  `stroke: currentColor` so the icon recolours with the surrounding
+  text. Use a semantic colour only when the icon encodes state.
+- **No emoji** in product or marketing copy. No PNG icons. No icon
+  fonts.
+- Every icon answers a "what does this do" question. Decorative icons
+  get `aria-hidden="true"` (see
+  [`i18n-and-a11y.md`](./i18n-and-a11y.md#icons)).
+
+The codebase has mixed historical sizes and stroke widths. Aspirational
+defaults for _new_ additions: 24px square in product, 1.5px stroke
+weight. If you deviate, match the immediate neighbours rather than
+inventing a third size.
+
+## Pre-ship copy checklist (every UI change)
+
+- [ ] No em dashes (`—`) in any visible string.
+- [ ] Internet Computer appears in every chain list, in the canonical
+      order.
+- [ ] No reference to a Telegram channel.
+- [ ] No claim or implication of an OISY token.
+- [ ] Security copy uses "advanced cryptography", never "blockchain".
+- [ ] Failure copy names what failed, states what was preserved, offers
+      one next step.
+- [ ] Lead sentences are positively framed.
+- [ ] No degen, casino, or hype language.
+- [ ] Logo blue is on the mark and at most one expressive word — not
+      the whole UI.
+- [ ] State is communicated with colour **and** text **and** a glyph.
+- [ ] No hard-coded hex; existing token classes / CSS variables only.

--- a/docs/ai/frontend/brand-and-copy.md
+++ b/docs/ai/frontend/brand-and-copy.md
@@ -37,7 +37,6 @@ sentence could appear in any company's marketing, cut it.
 | Sign in the way you unlock your phone   | Seed phrase onboarding   | Lead with the positive experience                              |
 | Works from any browser, on any device   | Extension-free wallet    | Describe the gain, not the absence                             |
 | Network custody                         | Custodial / self-custody | OISY is a third way; naming it precisely is the message        |
-| Chain Fusion                            | Bridging / wrapping      | OISY does not bridge; native integration is the differentiator |
 | Passkey login through Internet Identity | Passwordless login       | Product benefit first, proof layer underneath                  |
 | OISY (in body copy)                     | OISY Wallet (in body)    | The full lockup is for the logo only                           |
 | Digital wealth                          | Crypto only              | OISY covers crypto, stablecoins, tokenized stocks, commodities |

--- a/docs/ai/frontend/i18n-and-a11y.md
+++ b/docs/ai/frontend/i18n-and-a11y.md
@@ -4,6 +4,11 @@ These two are non-negotiable. CI catches some violations
 (`svelte-check`, ESLint a11y rules, `frontend-remove-unused-components`)
 but most are on you. This page is the contract.
 
+> Brand voice, vocabulary, banned phrases, failure-copy structure, and
+> the colour / icon rules live in
+> [`brand-and-copy.md`](./brand-and-copy.md). Read it together with
+> this page whenever you add user-visible strings.
+
 ## i18n
 
 ### Single source of truth — `en.json` only
@@ -138,6 +143,9 @@ Baseline rules; ESLint a11y rules and `svelte-check` catch some violations.
   or shape.
 - Use the project's design tokens / utility classes. Search the closest
   neighbour and follow it; don't hard-code hex.
+- Brand-side rules (logo-blue restraint, accent usage, fill-vs-text
+  semantics) live in
+  [`brand-and-copy.md`](./brand-and-copy.md#colour-rules).
 
 ### Images / media
 

--- a/src/frontend/src/lib/constants/ai-assistant.constants.ts
+++ b/src/frontend/src/lib/constants/ai-assistant.constants.ts
@@ -15,13 +15,13 @@ export const getAiAssistantSystemPrompt = ({
 	`GENERAL:
 	- You are OISY Wallet, the world's first fully on-chain digital asset wallet, consolidating chains, identities, and primitives into a single immutable DeFi terminal.
 	- Powered by ICP's Chain Fusion technology, OISY delivers security, transparency, and scalability by default.
-	- You support Bitcoin, Ethereum, Internet Computer, Arbitrum, Base, BNB Smart Chain, Polygon, and Solana without bridges.
+	- You support BTC, ETH, SOL, ICP, Polygon, Arbitrum, BNB Chain & Base without bridges.
 	- Core Identity: Browser-based wallet requiring no downloads. Uses network custody - private keys distributed across ICP nodes via threshold ECDSA, never controlled by a single entity.
 	
 	KEY FEATURES:
 	- Internet Identity authentication (passkeys), privacy mode, address book, WalletConnect integration, in-wallet swaps.
 	- Each saved contact can contain multiple labeled addresses (ETH, BTC, IC principals and account IDs, Sol).
-	- ETH addresses saved in contacts can be used for sending on Ethereum, Arbitrum, Base, BNB Smart Chain, and Polygon.
+	- ETH addresses saved in contacts can be used for sending ETH, Polygon, Arbitrum, BNB and Base.
 	- Fully decentralized - entire app served from blockchain.
 	
 	TOOL USAGE RULES:

--- a/src/frontend/src/lib/constants/ai-assistant.constants.ts
+++ b/src/frontend/src/lib/constants/ai-assistant.constants.ts
@@ -15,13 +15,13 @@ export const getAiAssistantSystemPrompt = ({
 	`GENERAL:
 	- You are OISY Wallet, the world's first fully on-chain digital asset wallet, consolidating chains, identities, and primitives into a single immutable DeFi terminal.
 	- Powered by ICP's Chain Fusion technology, OISY delivers security, transparency, and scalability by default.
-	- You support BTC, ETH, SOL, ICP, Polygon, Arbitrum, BNB Chain & Base without bridges.
+	- You support Bitcoin, Ethereum, Internet Computer, Arbitrum, Base, BNB Smart Chain, Polygon, and Solana without bridges.
 	- Core Identity: Browser-based wallet requiring no downloads. Uses network custody - private keys distributed across ICP nodes via threshold ECDSA, never controlled by a single entity.
 	
 	KEY FEATURES:
 	- Internet Identity authentication (passkeys), privacy mode, address book, WalletConnect integration, in-wallet swaps.
 	- Each saved contact can contain multiple labeled addresses (ETH, BTC, IC principals and account IDs, Sol).
-	- ETH addresses saved in contacts can be used for sending ETH, Polygon, Arbitrum, BNB and Base.
+	- ETH addresses saved in contacts can be used for sending on Ethereum, Arbitrum, Base, BNB Smart Chain, and Polygon.
 	- Fully decentralized - entire app served from blockchain.
 	
 	TOOL USAGE RULES:


### PR DESCRIPTION
# Motivation

Agents writing user-visible OISY copy (and humans reviewing it) need a single, agent-readable contract for the OISY voice, vocabulary, colour usage, and icon conventions. Without one, easy-to-miss brand violations land in PRs: em dashes, "secured by blockchain", inconsistent chain naming, hard-coded hex. The OISY Brand Book is the source of truth but lives outside the repo; this PR distills the developer-actionable parts into `docs/ai/frontend/brand-and-copy.md` so every agent (Claude, Cursor, Copilot) reads it on every change, matching the repo's existing thin-pointer-to-docs pattern.

Fonts are deliberately out of scope (not finalised yet). Colour variables are also untouched — the existing `--color-foreground-*` / `--color-background-*` / `--color-border-*` token system already maps cleanly to the brand's fill-vs-text split, so the guide points at it rather than introducing new tokens.

The AI assistant system prompt (`ai-assistant.constants.ts`) is deliberately excluded — its chain references are tickers (`BTC`, `ETH`, `ICP`, `BNB`) that match the tool-call enum schemas the LLM must emit. Brand-side naming applies to user-visible UI strings, not LLM-facing technical interfaces.

# Changes

- **New doc — `docs/ai/frontend/brand-and-copy.md`** — voice in one screen, "use this, not that" table, banned vocabulary, failure-copy structure (name what failed → state what was preserved → offer one next step), canonical chain listing (Bitcoin, Ethereum, Internet Computer, then alphabetical, with BNB Smart Chain rather than "BNB Chain"), brand-side colour rules pointing at the existing token system, iconography rules, pre-ship checklist.
- **New Cursor rule — `.cursor/rules/35-brand-and-copy.mdc`** — thin pointer matching the existing pattern; globs cover `.svelte`, `.ts`, `.scss`, and `en.json`.
- **`AGENTS.md`** — added a row to §3 ("Write copy, pick a colour, or add an icon → brand-and-copy.md").
- **`docs/ai/frontend/README.md`** — added the brand-and-copy item to the pre-flight checklist.
- **`docs/ai/frontend/i18n-and-a11y.md`** — top callout + cross-link from the Color & contrast section.

The branch has a second `revert(ai)` commit that undoes an exploratory edit to the AI assistant prompt; squash-merge will fold it into the net diff, which is docs-only.

Meta-update rule applied: this PR introduces new agent guidance, so `docs/ai/**` is updated together with the rule pointer.

# Tests

- Documentation-only change after the revert. No new code paths, no schema changes, no behaviour change in shipped UI.
- `npx prettier --check` on every touched file: clean.
- CI will run the full frontend gate.