### PR TITLE
feat(backend)!: replace exchange rates endpoint

### DIFF
--- a/docs/ai/backend/patterns.md
+++ b/docs/ai/backend/patterns.md
@@ -150,6 +150,15 @@ pub fn create_contact(req: CreateContactRequest) -> CreateContactResult {
   refreshes run when `coingecko_api_key` is set and `exchange_rate_enabled` is not
   `opt false`. See
   [`shared::types::api_keys::ApiKeys`](../../../src/shared/src/types/api_keys.rs).
+  - `get_my_exchange_rates` is the per-caller fetch endpoint: it returns the
+    USD price for each of the caller's priceable tokens (native + custom,
+    minus testnets / NFTs / ERC-4626), re-marks them as active so the timer
+    keeps them warm, and awaits a one-shot refresh for any token whose
+    cache is older than `PRICE_STALENESS_THRESHOLD_SEC` (2 min) or missing.
+    It's an `update` (mutates `token_activity`, may issue HTTP outcalls).
+  - The legacy `get_exchange_rates(vec TokenId)` and `get_exchange_rate(TokenId)`
+    queries are kept for now but should be considered deprecated in favour
+    of `get_my_exchange_rates` for client-driven price fetches.
 
 ## Workspace dependencies — root or nothing
 

--- a/docs/ai/backend/patterns.md
+++ b/docs/ai/backend/patterns.md
@@ -150,15 +150,14 @@ pub fn create_contact(req: CreateContactRequest) -> CreateContactResult {
   refreshes run when `coingecko_api_key` is set and `exchange_rate_enabled` is not
   `opt false`. See
   [`shared::types::api_keys::ApiKeys`](../../../src/shared/src/types/api_keys.rs).
-  - `get_my_exchange_rates` is the per-caller fetch endpoint: it returns the
+  - `get_exchange_rates` is the per-caller fetch endpoint: it returns the
     USD price for each of the caller's priceable tokens (native + custom,
     minus testnets / NFTs / ERC-4626), re-marks them as active so the timer
     keeps them warm, and awaits a one-shot refresh for any token whose
     cache is older than `PRICE_STALENESS_THRESHOLD_SEC` (2 min) or missing.
     It's an `update` (mutates `token_activity`, may issue HTTP outcalls).
-  - The legacy `get_exchange_rates(vec TokenId)` and `get_exchange_rate(TokenId)`
-    queries are kept for now but should be considered deprecated in favour
-    of `get_my_exchange_rates` for client-driven price fetches.
+  - `get_exchange_rate(TokenId)` is a legacy cache-only query for callers
+    that already know the token ID and do not need activation or freshness.
 
 ## Workspace dependencies — root or nothing
 

--- a/docs/ai/backend/patterns.md
+++ b/docs/ai/backend/patterns.md
@@ -155,6 +155,8 @@ pub fn create_contact(req: CreateContactRequest) -> CreateContactResult {
     minus testnets / NFTs / ERC-4626), re-marks them as active so the timer
     keeps them warm, and awaits a one-shot refresh for any token whose
     cache is older than `PRICE_STALENESS_THRESHOLD_SEC` (2 min) or missing.
+    Entries that remain stale or missing after the refresh attempt are
+    returned as `None`, so returned prices never exceed the freshness window.
     It's an `update` (mutates `token_activity`, may issue HTTP outcalls).
   - `get_exchange_rate(TokenId)` is a legacy cache-only query for callers
     that already know the token ID and do not need activation or freshness.

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1237,9 +1237,6 @@ service : (Arg) -> {
 	// * `Ok(Vec<Contact>)` - A vector of the user's contacts.
 	get_contacts : () -> (GetContactsResult) query;
 	get_exchange_rate : (TokenId) -> (opt ExchangeRate) query;
-	get_exchange_rates : (vec TokenId) -> (
-		vec record { TokenId; opt ExchangeRate }
-	) query;
 	// Returns the latest USD prices for the caller's priceable tokens.
 	//
 	// "Priceable" means the union of:
@@ -1255,7 +1252,7 @@ service : (Arg) -> {
 	//
 	// This is an `update` (rather than a `query`) because it mutates state
 	// (`token_activity`) and may issue HTTP outcalls.
-	get_my_exchange_rates : () -> (vec record { TokenId; opt ExchangeRate });
+	get_exchange_rates : () -> (vec record { TokenId; opt ExchangeRate });
 	// Returns the full agreement consent/rejection history for the caller.
 	//
 	// # Returns

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1240,6 +1240,22 @@ service : (Arg) -> {
 	get_exchange_rates : (vec TokenId) -> (
 		vec record { TokenId; opt ExchangeRate }
 	) query;
+	// Returns the latest USD prices for the caller's priceable tokens.
+	//
+	// "Priceable" means the union of:
+	// - the always-on native tokens (BTC, ICP, SOL, ETH on the supported EVM mainnets), and
+	// - the caller's custom tokens, filtered to variants the configured providers can actually price
+	// (testnets, NFTs and ERC-4626 vaults are excluded).
+	//
+	// The endpoint also re-marks the returned tokens as active so the
+	// background refresh timer keeps them warm, and — if any cached price is
+	// older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
+	// missing — awaits a one-shot fetch for that subset before responding, so
+	// the response always honours the freshness contract.
+	//
+	// This is an `update` (rather than a `query`) because it mutates state
+	// (`token_activity`) and may issue HTTP outcalls.
+	get_my_exchange_rates : () -> (vec record { TokenId; opt ExchangeRate });
 	// Returns the full agreement consent/rejection history for the caller.
 	//
 	// # Returns

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1246,10 +1246,10 @@ service : (Arg) -> {
 	//
 	// The endpoint also re-marks the returned tokens as active so the
 	// background refresh timer keeps them warm. If any cached price is older
-	// than PRICE_STALENESS_THRESHOLD_SEC seconds or missing, the endpoint
-	// awaits a one-shot fetch for that subset before responding. Entries that
-	// remain stale or missing after that attempt are returned as `None` so
-	// returned prices honour the freshness contract.
+	// than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
+	// missing, the endpoint awaits a one-shot fetch for that subset before
+	// responding. Entries that remain stale or missing after that attempt are
+	// returned as `None` so returned prices honour the freshness contract.
 	//
 	// This is an `update` (rather than a `query`) because it mutates state
 	// (`token_activity`) and may issue HTTP outcalls.

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1245,10 +1245,11 @@ service : (Arg) -> {
 	// (testnets, NFTs and ERC-4626 vaults are excluded).
 	//
 	// The endpoint also re-marks the returned tokens as active so the
-	// background refresh timer keeps them warm, and — if any cached price is
-	// older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
-	// missing — awaits a one-shot fetch for that subset before responding, so
-	// the response always honours the freshness contract.
+	// background refresh timer keeps them warm. If any cached price is older
+	// than PRICE_STALENESS_THRESHOLD_SEC seconds or missing, the endpoint
+	// awaits a one-shot fetch for that subset before responding. Entries that
+	// remain stale or missing after that attempt are returned as `None` so
+	// returned prices honour the freshness contract.
 	//
 	// This is an `update` (rather than a `query`) because it mutates state
 	// (`token_activity`) and may issue HTTP outcalls.

--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -1,7 +1,16 @@
-use ic_cdk::query;
+use ic_cdk::{api::msg_caller, query, update};
 use shared::types::{exchange::ExchangeRate, token_id::TokenId};
 
-use crate::{state::read_state, types::StoredTokenId, utils::guards::caller_is_not_anonymous};
+use crate::{
+    exchange::{
+        cached_rates_snapshot, fetch_and_update_prices, priceable_tokens_for_caller,
+        stale_or_missing_tokens,
+    },
+    state::read_state,
+    token,
+    types::{StoredPrincipal, StoredTokenId},
+    utils::guards::caller_is_not_anonymous,
+};
 
 const MAX_TOKEN_LIST_LENGTH: usize = 1_000;
 
@@ -34,4 +43,43 @@ pub fn get_exchange_rates(token_ids: Vec<TokenId>) -> Vec<(TokenId, Option<Excha
 #[must_use]
 pub fn get_exchange_rate(token_id: TokenId) -> Option<ExchangeRate> {
     read_state(|s| s.exchange_rates.get(&StoredTokenId(token_id)).map(|c| c.0))
+}
+
+/// Returns the latest USD prices for the caller's priceable tokens.
+///
+/// "Priceable" means the union of:
+/// - the always-on native tokens (BTC, ICP, SOL, ETH on the supported EVM mainnets), and
+/// - the caller's custom tokens, filtered to variants the configured providers can actually price
+///   (testnets, NFTs and ERC-4626 vaults are excluded).
+///
+/// The endpoint also re-marks the returned tokens as active so the
+/// background refresh timer keeps them warm, and — if any cached price is
+/// older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
+/// missing — awaits a one-shot fetch for that subset before responding, so
+/// the response always honours the freshness contract.
+///
+/// This is an `update` (rather than a `query`) because it mutates state
+/// (`token_activity`) and may issue HTTP outcalls.
+#[update(guard = "caller_is_not_anonymous")]
+#[must_use]
+pub async fn get_my_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
+    let caller = StoredPrincipal(msg_caller());
+
+    let tokens = priceable_tokens_for_caller(caller);
+
+    if tokens.is_empty() {
+        return Vec::new();
+    }
+
+    let active_ids: Vec<TokenId> = tokens.iter().map(|s| s.0.clone()).collect();
+    token::mark_tokens_active(&active_ids);
+
+    let stale = stale_or_missing_tokens(&tokens);
+    if !stale.is_empty() {
+        if let Err(err) = fetch_and_update_prices(&stale).await {
+            ic_cdk::println!("get_my_exchange_rates fetch failed: {err:?}");
+        }
+    }
+
+    cached_rates_snapshot(tokens)
 }

--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -12,12 +12,6 @@ use crate::{
     utils::guards::caller_is_not_anonymous,
 };
 
-#[query(guard = "caller_is_not_anonymous")]
-#[must_use]
-pub fn get_exchange_rate(token_id: TokenId) -> Option<ExchangeRate> {
-    read_state(|s| s.exchange_rates.get(&StoredTokenId(token_id)).map(|c| c.0))
-}
-
 /// Returns the latest USD prices for the caller's priceable tokens.
 ///
 /// "Priceable" means the union of:
@@ -55,4 +49,10 @@ pub async fn get_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
     }
 
     cached_rates_snapshot(tokens)
+}
+
+#[query(guard = "caller_is_not_anonymous")]
+#[must_use]
+pub fn get_exchange_rate(token_id: TokenId) -> Option<ExchangeRate> {
+    read_state(|s| s.exchange_rates.get(&StoredTokenId(token_id)).map(|c| c.0))
 }

--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -20,10 +20,11 @@ use crate::{
 ///   (testnets, NFTs and ERC-4626 vaults are excluded).
 ///
 /// The endpoint also re-marks the returned tokens as active so the
-/// background refresh timer keeps them warm, and — if any cached price is
-/// older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
-/// missing — awaits a one-shot fetch for that subset before responding, so
-/// the response always honours the freshness contract.
+/// background refresh timer keeps them warm. If any cached price is older
+/// than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
+/// missing, the endpoint awaits a one-shot fetch for that subset before
+/// responding. Entries that remain stale or missing after that attempt are
+/// returned as `None` so returned prices honour the freshness contract.
 ///
 /// This is an `update` (rather than a `query`) because it mutates state
 /// (`token_activity`) and may issue HTTP outcalls.

--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -12,33 +12,6 @@ use crate::{
     utils::guards::caller_is_not_anonymous,
 };
 
-const MAX_TOKEN_LIST_LENGTH: usize = 1_000;
-
-#[query(guard = "caller_is_not_anonymous")]
-#[must_use]
-pub fn get_exchange_rates(token_ids: Vec<TokenId>) -> Vec<(TokenId, Option<ExchangeRate>)> {
-    if token_ids.len() > MAX_TOKEN_LIST_LENGTH {
-        ic_cdk::trap(format!(
-            "Maximum number of token_ids exceeded: {} > {}",
-            token_ids.len(),
-            MAX_TOKEN_LIST_LENGTH
-        ));
-    }
-
-    read_state(|s| {
-        token_ids
-            .into_iter()
-            .map(|id| {
-                let rate = s
-                    .exchange_rates
-                    .get(&StoredTokenId(id.clone()))
-                    .map(|c| c.0);
-                (id, rate)
-            })
-            .collect()
-    })
-}
-
 #[query(guard = "caller_is_not_anonymous")]
 #[must_use]
 pub fn get_exchange_rate(token_id: TokenId) -> Option<ExchangeRate> {
@@ -62,7 +35,7 @@ pub fn get_exchange_rate(token_id: TokenId) -> Option<ExchangeRate> {
 /// (`token_activity`) and may issue HTTP outcalls.
 #[update(guard = "caller_is_not_anonymous")]
 #[must_use]
-pub async fn get_my_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
+pub async fn get_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
     let caller = StoredPrincipal(msg_caller());
 
     let tokens = priceable_tokens_for_caller(caller);
@@ -77,7 +50,7 @@ pub async fn get_my_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
     let stale = stale_or_missing_tokens(&tokens);
     if !stale.is_empty() {
         if let Err(err) = fetch_and_update_prices(&stale).await {
-            ic_cdk::println!("get_my_exchange_rates fetch failed: {err:?}");
+            ic_cdk::println!("get_exchange_rates fetch failed: {err:?}");
         }
     }
 

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -217,15 +217,20 @@ pub(crate) fn stale_or_missing_tokens(token_ids: &[StoredTokenId]) -> Vec<Stored
 
 /// Reads the on-canister exchange rate cache for the supplied tokens and
 /// returns one `(TokenId, Option<ExchangeRate>)` entry per input id, in the
-/// same order. `None` means the cache has no entry for that token.
+/// same order. `None` means the cache has no fresh entry for that token.
 pub(crate) fn cached_rates_snapshot(
     token_ids: Vec<StoredTokenId>,
 ) -> Vec<(TokenId, Option<ExchangeRate>)> {
+    let freshness_floor_ns = time().saturating_sub(PRICE_STALENESS_THRESHOLD_SEC * 1_000_000_000);
+
     read_state(|s| {
         token_ids
             .into_iter()
             .map(|stored| {
-                let rate = s.exchange_rates.get(&stored).map(|c| c.0);
+                let rate = s
+                    .exchange_rates
+                    .get(&stored)
+                    .and_then(|c| (c.0.usd.timestamp_ns >= freshness_floor_ns).then_some(c.0));
                 (stored.0, rate)
             })
             .collect()

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -15,12 +15,18 @@ use shared::types::{
 use crate::{
     exchange::{
         composite::fetch_all_prices,
-        providers::{coingecko::CoinGeckoProvider, icpswap::IcpSwapProvider},
+        providers::{
+            coingecko::{is_priceable_token_id, CoinGeckoProvider},
+            icpswap::IcpSwapProvider,
+        },
         supplemental::SupplementalPriceProvider,
     },
     read_state,
     state::{mutate_state, with_api_keys},
-    types::storable::{Candid, StoredTokenId},
+    types::{
+        storable::{Candid, StoredTokenId},
+        StoredPrincipal,
+    },
 };
 
 /// How often exchange rates are refreshed (5 minutes).
@@ -38,6 +44,15 @@ pub const PRICE_ACTIVITY_THRESHOLD_SEC: u64 = 60 * 60;
 /// bootstrap or a manual refresh has just populated the cache with a price
 /// the provider also reports as recent.
 const PRICE_FRESHNESS_GRACE_NS: u64 = (PRICE_REFRESH_INTERVAL_SEC / 2) * 1_000_000_000;
+
+/// Maximum age of a cached price, in seconds, that the per-caller
+/// [`get_my_exchange_rates`] endpoint will accept without triggering a
+/// blocking refresh for the token.
+///
+/// Anything older — or missing — causes the endpoint to await a one-shot
+/// fetch for that subset before returning, so the caller's response always
+/// honours the contract that prices are at most this many seconds old.
+pub const PRICE_STALENESS_THRESHOLD_SEC: u64 = 2 * 60;
 
 /// Native tokens whose prices are always fetched, regardless of user activity.
 fn native_token_ids() -> Vec<StoredTokenId> {
@@ -99,7 +114,26 @@ fn supplemental_price_providers() -> Vec<Box<dyn SupplementalPriceProvider>> {
     vec![Box::new(IcpSwapProvider::default())]
 }
 
-pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
+/// Fetches USD prices for `token_ids` from the configured providers and
+/// writes the results into the on-canister cache.
+///
+/// Used by both the recurring refresh timer ([`refresh_exchange_rates`]) and
+/// on-demand caller-driven refreshes (e.g. [`get_my_exchange_rates`]). The
+/// caller is expected to have already filtered `token_ids` down to the
+/// subset that actually needs a fresh fetch; this function makes no
+/// staleness or activity decisions of its own.
+///
+/// Returns:
+/// - `Ok(())` once the (possibly empty) set of fresh prices has been written.
+/// - `Err(ExchangeError::Disabled)` if `exchange_rate_enabled` is `Some(false)`.
+/// - `Err(ExchangeError::ApiKeyNotSet)` if no `CoinGecko` API key is configured.
+pub(crate) async fn fetch_and_update_prices(
+    token_ids: &[StoredTokenId],
+) -> Result<(), ExchangeError> {
+    if token_ids.is_empty() {
+        return Ok(());
+    }
+
     let enabled = with_api_keys(|keys| {
         keys.coingecko_api_key.is_some() && keys.exchange_rate_enabled != Some(false)
     });
@@ -112,7 +146,93 @@ pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
         with_api_keys(|keys| keys.coingecko_api_key.clone()).ok_or(ExchangeError::ApiKeyNotSet)?;
 
     let provider = CoinGeckoProvider::new(api_key);
+    let supplementals = supplemental_price_providers();
 
+    let prices = fetch_all_prices(&provider, &supplementals, token_ids).await;
+
+    for (token_id, exchange_data) in prices {
+        update_price(&token_id, &exchange_data);
+    }
+
+    Ok(())
+}
+
+/// Returns the deduplicated set of priceable tokens associated with `caller`,
+/// in the form expected by the price-fetch helpers.
+///
+/// "Priceable" means: the token variant + chain combination is something we
+/// can ever fetch a USD rate for via the configured providers. NFT
+/// standards, ERC-4626 vaults, testnets, and EVM chains we don't have a
+/// `CoinGecko` mapping for are filtered out so they don't bloat the request
+/// payload or the activity map. The result is the union of:
+///
+/// - the always-on native tokens ([`native_token_ids`]), and
+/// - the caller's custom tokens stored in `s.custom_token`, mapped via [`TokenId::from`] and
+///   filtered through [`is_priceable_token_id`].
+pub(crate) fn priceable_tokens_for_caller(caller: StoredPrincipal) -> Vec<StoredTokenId> {
+    let mut tokens: Vec<StoredTokenId> = native_token_ids();
+
+    let caller_custom_tokens: Vec<StoredTokenId> = read_state(|s| {
+        s.custom_token
+            .get(&caller)
+            .map(|tokens| {
+                tokens
+                    .0
+                    .iter()
+                    .map(|ct| TokenId::from(&ct.token))
+                    .filter(is_priceable_token_id)
+                    .map(StoredTokenId)
+                    .collect()
+            })
+            .unwrap_or_default()
+    });
+
+    tokens.extend(caller_custom_tokens);
+    tokens.sort_unstable();
+    tokens.dedup();
+    tokens
+}
+
+/// Returns the subset of `token_ids` whose cached USD price is either
+/// missing or older than [`PRICE_STALENESS_THRESHOLD_SEC`] seconds.
+///
+/// Used by [`get_my_exchange_rates`] to decide which tokens require a
+/// blocking outcall before the response can satisfy its freshness contract.
+pub(crate) fn stale_or_missing_tokens(token_ids: &[StoredTokenId]) -> Vec<StoredTokenId> {
+    let now = time();
+    let staleness_floor_ns = now.saturating_sub(PRICE_STALENESS_THRESHOLD_SEC * 1_000_000_000);
+
+    read_state(|s| {
+        token_ids
+            .iter()
+            .filter(|t| {
+                s.exchange_rates
+                    .get(t)
+                    .is_none_or(|r| r.0.usd.timestamp_ns < staleness_floor_ns)
+            })
+            .cloned()
+            .collect()
+    })
+}
+
+/// Reads the on-canister exchange rate cache for the supplied tokens and
+/// returns one `(TokenId, Option<ExchangeRate>)` entry per input id, in the
+/// same order. `None` means the cache has no entry for that token.
+pub(crate) fn cached_rates_snapshot(
+    token_ids: Vec<StoredTokenId>,
+) -> Vec<(TokenId, Option<ExchangeRate>)> {
+    read_state(|s| {
+        token_ids
+            .into_iter()
+            .map(|stored| {
+                let rate = s.exchange_rates.get(&stored).map(|c| c.0);
+                (stored.0, rate)
+            })
+            .collect()
+    })
+}
+
+pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
     let now = time();
     let threshold = now.saturating_sub(PRICE_ACTIVITY_THRESHOLD_SEC * 1_000_000_000);
 
@@ -139,16 +259,5 @@ pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
         });
     });
 
-    if tokens_to_fetch.is_empty() {
-        return Ok(());
-    }
-
-    let supplementals = supplemental_price_providers();
-    let prices = fetch_all_prices(&provider, &supplementals, &tokens_to_fetch).await;
-
-    for (token_id, exchange_data) in prices {
-        update_price(&token_id, &exchange_data);
-    }
-
-    Ok(())
+    fetch_and_update_prices(&tokens_to_fetch).await
 }

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -46,8 +46,8 @@ pub const PRICE_ACTIVITY_THRESHOLD_SEC: u64 = 60 * 60;
 const PRICE_FRESHNESS_GRACE_NS: u64 = (PRICE_REFRESH_INTERVAL_SEC / 2) * 1_000_000_000;
 
 /// Maximum age of a cached price, in seconds, that the per-caller
-/// [`get_my_exchange_rates`] endpoint will accept without triggering a
-/// blocking refresh for the token.
+/// `get_exchange_rates` endpoint will accept without triggering a blocking
+/// refresh for the token.
 ///
 /// Anything older — or missing — causes the endpoint to await a one-shot
 /// fetch for that subset before returning, so the caller's response always
@@ -118,7 +118,7 @@ fn supplemental_price_providers() -> Vec<Box<dyn SupplementalPriceProvider>> {
 /// writes the results into the on-canister cache.
 ///
 /// Used by both the recurring refresh timer ([`refresh_exchange_rates`]) and
-/// on-demand caller-driven refreshes (e.g. [`get_my_exchange_rates`]). The
+/// on-demand caller-driven refreshes. The
 /// caller is expected to have already filtered `token_ids` down to the
 /// subset that actually needs a fresh fetch; this function makes no
 /// staleness or activity decisions of its own.
@@ -196,7 +196,7 @@ pub(crate) fn priceable_tokens_for_caller(caller: StoredPrincipal) -> Vec<Stored
 /// Returns the subset of `token_ids` whose cached USD price is either
 /// missing or older than [`PRICE_STALENESS_THRESHOLD_SEC`] seconds.
 ///
-/// Used by [`get_my_exchange_rates`] to decide which tokens require a
+/// Used by `get_exchange_rates` to decide which tokens require a
 /// blocking outcall before the response can satisfy its freshness contract.
 pub(crate) fn stale_or_missing_tokens(token_ids: &[StoredTokenId]) -> Vec<StoredTokenId> {
     let now = time();

--- a/src/backend/src/exchange/providers/coingecko/mod.rs
+++ b/src/backend/src/exchange/providers/coingecko/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use shared::types::{exchange::ExchangeData, token_id::TokenId};
 
+pub(crate) use self::platform::is_priceable_token_id;
 use self::{
     client::CoinGeckoClient,
     platform::{coingecko_native_coin, coingecko_platform},

--- a/src/backend/src/exchange/providers/coingecko/platform.rs
+++ b/src/backend/src/exchange/providers/coingecko/platform.rs
@@ -1,3 +1,5 @@
+use shared::types::token_id::TokenId;
+
 /// Maps an EVM chain ID to the corresponding `CoinGecko` platform identifier
 /// used in the `/simple/token_price` endpoint for contract-based tokens.
 pub fn coingecko_platform(chain_id: u64) -> Option<&'static str> {
@@ -22,9 +24,43 @@ pub fn coingecko_native_coin(chain_id: u64) -> Option<&'static str> {
     }
 }
 
+/// Whether this `TokenId` is something we can ever fetch a USD price for via
+/// the configured providers (`CoinGecko` primary, `ICPSwap` supplemental for
+/// ICRC).
+///
+/// Returns `false` for testnet variants, NFT standards (ERC-721/1155, EXT,
+/// DIP-721, `ICPunks`, ICRC-7), ERC-4626 vault tokens (priced FE-side from
+/// their underlying ERC-20), and EVM/ERC-20 tokens on chains we don't have
+/// a `CoinGecko` mapping for.
+#[must_use]
+pub fn is_priceable_token_id(token_id: &TokenId) -> bool {
+    match token_id {
+        TokenId::EvmNative(chain_id) => coingecko_native_coin(*chain_id).is_some(),
+        TokenId::Erc20(_, chain_id) => coingecko_platform(*chain_id).is_some(),
+        TokenId::Icrc(_)
+        | TokenId::IcpNative
+        | TokenId::SolNativeMainnet
+        | TokenId::BtcNativeMainnet
+        | TokenId::SplMainnet(_) => true,
+        TokenId::Erc721(..)
+        | TokenId::Erc1155(..)
+        | TokenId::Erc4626(..)
+        | TokenId::SplDevnet(_)
+        | TokenId::SolNativeDevnet
+        | TokenId::BtcNativeTestnet
+        | TokenId::ExtV2(_)
+        | TokenId::Dip721(_)
+        | TokenId::IcPunks(_)
+        | TokenId::Icrc7(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{coingecko_native_coin, coingecko_platform};
+    use candid::Principal;
+    use shared::types::custom_token::ChainId;
+
+    use super::{coingecko_native_coin, coingecko_platform, is_priceable_token_id, TokenId};
 
     #[test]
     fn test_known_platforms() {
@@ -57,5 +93,71 @@ mod tests {
     #[test]
     fn test_native_coin_unknown_returns_none() {
         assert_eq!(coingecko_native_coin(999), None);
+    }
+
+    fn erc(addr: &str, chain_id: ChainId) -> TokenId {
+        TokenId::Erc20(
+            shared::types::custom_token::ErcTokenId(addr.to_string()),
+            chain_id,
+        )
+    }
+
+    #[test]
+    fn priceable_includes_supported_native_and_contract_chains() {
+        assert!(is_priceable_token_id(&TokenId::EvmNative(1)));
+        assert!(is_priceable_token_id(&TokenId::EvmNative(56)));
+        assert!(is_priceable_token_id(&TokenId::EvmNative(137)));
+        assert!(is_priceable_token_id(&TokenId::EvmNative(8453)));
+        assert!(is_priceable_token_id(&TokenId::EvmNative(42161)));
+        assert!(is_priceable_token_id(&erc("0xabc", 1)));
+        assert!(is_priceable_token_id(&erc("0xabc", 42161)));
+        assert!(is_priceable_token_id(&TokenId::IcpNative));
+        assert!(is_priceable_token_id(&TokenId::SolNativeMainnet));
+        assert!(is_priceable_token_id(&TokenId::BtcNativeMainnet));
+        assert!(is_priceable_token_id(
+            &TokenId::Icrc(Principal::anonymous())
+        ));
+        assert!(is_priceable_token_id(&TokenId::SplMainnet(
+            shared::types::custom_token::SplTokenId("So111".to_string())
+        )));
+    }
+
+    #[test]
+    fn priceable_excludes_unsupported_chains_and_testnets() {
+        assert!(!is_priceable_token_id(&TokenId::EvmNative(999)));
+        assert!(!is_priceable_token_id(&erc("0xabc", 999)));
+        assert!(!is_priceable_token_id(&TokenId::SolNativeDevnet));
+        assert!(!is_priceable_token_id(&TokenId::BtcNativeTestnet));
+        assert!(!is_priceable_token_id(&TokenId::SplDevnet(
+            shared::types::custom_token::SplTokenId("dev".to_string())
+        )));
+    }
+
+    #[test]
+    fn priceable_excludes_nft_and_vault_standards() {
+        assert!(!is_priceable_token_id(&TokenId::Erc721(
+            shared::types::custom_token::ErcTokenId("0xabc".to_string()),
+            1
+        )));
+        assert!(!is_priceable_token_id(&TokenId::Erc1155(
+            shared::types::custom_token::ErcTokenId("0xabc".to_string()),
+            1
+        )));
+        assert!(!is_priceable_token_id(&TokenId::Erc4626(
+            shared::types::custom_token::ErcTokenId("0xabc".to_string()),
+            1
+        )));
+        assert!(!is_priceable_token_id(&TokenId::ExtV2(
+            Principal::anonymous()
+        )));
+        assert!(!is_priceable_token_id(&TokenId::Dip721(
+            Principal::anonymous()
+        )));
+        assert!(!is_priceable_token_id(&TokenId::IcPunks(
+            Principal::anonymous()
+        )));
+        assert!(!is_priceable_token_id(&TokenId::Icrc7(
+            Principal::anonymous()
+        )));
     }
 }

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -1237,9 +1237,6 @@ service : (Arg) -> {
 	// * `Ok(Vec<Contact>)` - A vector of the user's contacts.
 	get_contacts : () -> (GetContactsResult) query;
 	get_exchange_rate : (TokenId) -> (opt ExchangeRate) query;
-	get_exchange_rates : (vec TokenId) -> (
-		vec record { TokenId; opt ExchangeRate }
-	) query;
 	// Returns the latest USD prices for the caller's priceable tokens.
 	//
 	// "Priceable" means the union of:
@@ -1255,7 +1252,7 @@ service : (Arg) -> {
 	//
 	// This is an `update` (rather than a `query`) because it mutates state
 	// (`token_activity`) and may issue HTTP outcalls.
-	get_my_exchange_rates : () -> (vec record { TokenId; opt ExchangeRate });
+	get_exchange_rates : () -> (vec record { TokenId; opt ExchangeRate });
 	// Returns the full agreement consent/rejection history for the caller.
 	//
 	// # Returns

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -1240,6 +1240,22 @@ service : (Arg) -> {
 	get_exchange_rates : (vec TokenId) -> (
 		vec record { TokenId; opt ExchangeRate }
 	) query;
+	// Returns the latest USD prices for the caller's priceable tokens.
+	//
+	// "Priceable" means the union of:
+	// - the always-on native tokens (BTC, ICP, SOL, ETH on the supported EVM mainnets), and
+	// - the caller's custom tokens, filtered to variants the configured providers can actually price
+	// (testnets, NFTs and ERC-4626 vaults are excluded).
+	//
+	// The endpoint also re-marks the returned tokens as active so the
+	// background refresh timer keeps them warm, and — if any cached price is
+	// older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
+	// missing — awaits a one-shot fetch for that subset before responding, so
+	// the response always honours the freshness contract.
+	//
+	// This is an `update` (rather than a `query`) because it mutates state
+	// (`token_activity`) and may issue HTTP outcalls.
+	get_my_exchange_rates : () -> (vec record { TokenId; opt ExchangeRate });
 	// Returns the full agreement consent/rejection history for the caller.
 	//
 	// # Returns

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -1246,10 +1246,10 @@ service : (Arg) -> {
 	//
 	// The endpoint also re-marks the returned tokens as active so the
 	// background refresh timer keeps them warm. If any cached price is older
-	// than PRICE_STALENESS_THRESHOLD_SEC seconds or missing, the endpoint
-	// awaits a one-shot fetch for that subset before responding. Entries that
-	// remain stale or missing after that attempt are returned as `None` so
-	// returned prices honour the freshness contract.
+	// than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
+	// missing, the endpoint awaits a one-shot fetch for that subset before
+	// responding. Entries that remain stale or missing after that attempt are
+	// returned as `None` so returned prices honour the freshness contract.
 	//
 	// This is an `update` (rather than a `query`) because it mutates state
 	// (`token_activity`) and may issue HTTP outcalls.

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -1245,10 +1245,11 @@ service : (Arg) -> {
 	// (testnets, NFTs and ERC-4626 vaults are excluded).
 	//
 	// The endpoint also re-marks the returned tokens as active so the
-	// background refresh timer keeps them warm, and — if any cached price is
-	// older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
-	// missing — awaits a one-shot fetch for that subset before responding, so
-	// the response always honours the freshness contract.
+	// background refresh timer keeps them warm. If any cached price is older
+	// than PRICE_STALENESS_THRESHOLD_SEC seconds or missing, the endpoint
+	// awaits a one-shot fetch for that subset before responding. Entries that
+	// remain stale or missing after that attempt are returned as `None` so
+	// returned prices honour the freshness contract.
 	//
 	// This is an `update` (rather than a `query`) because it mutates state
 	// (`token_activity`) and may issue HTTP outcalls.

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -1831,7 +1831,6 @@ export interface _SERVICE {
 	 */
 	get_contacts: ActorMethod<[], GetContactsResult>;
 	get_exchange_rate: ActorMethod<[TokenId], [] | [ExchangeRate]>;
-	get_exchange_rates: ActorMethod<[Array<TokenId>], Array<[TokenId, [] | [ExchangeRate]]>>;
 	/**
 	 * Returns the latest USD prices for the caller's priceable tokens.
 	 *
@@ -1849,7 +1848,7 @@ export interface _SERVICE {
 	 * This is an `update` (rather than a `query`) because it mutates state
 	 * (`token_activity`) and may issue HTTP outcalls.
 	 */
-	get_my_exchange_rates: ActorMethod<[], Array<[TokenId, [] | [ExchangeRate]]>>;
+	get_exchange_rates: ActorMethod<[], Array<[TokenId, [] | [ExchangeRate]]>>;
 	/**
 	 * Returns the full agreement consent/rejection history for the caller.
 	 *

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -1840,10 +1840,11 @@ export interface _SERVICE {
 	 * (testnets, NFTs and ERC-4626 vaults are excluded).
 	 *
 	 * The endpoint also re-marks the returned tokens as active so the
-	 * background refresh timer keeps them warm, and — if any cached price is
-	 * older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
-	 * missing — awaits a one-shot fetch for that subset before responding, so
-	 * the response always honours the freshness contract.
+	 * background refresh timer keeps them warm. If any cached price is older
+	 * than PRICE_STALENESS_THRESHOLD_SEC seconds or missing, the endpoint
+	 * awaits a one-shot fetch for that subset before responding. Entries that
+	 * remain stale or missing after that attempt are returned as `None` so
+	 * returned prices honour the freshness contract.
 	 *
 	 * This is an `update` (rather than a `query`) because it mutates state
 	 * (`token_activity`) and may issue HTTP outcalls.

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -1833,6 +1833,24 @@ export interface _SERVICE {
 	get_exchange_rate: ActorMethod<[TokenId], [] | [ExchangeRate]>;
 	get_exchange_rates: ActorMethod<[Array<TokenId>], Array<[TokenId, [] | [ExchangeRate]]>>;
 	/**
+	 * Returns the latest USD prices for the caller's priceable tokens.
+	 *
+	 * "Priceable" means the union of:
+	 * - the always-on native tokens (BTC, ICP, SOL, ETH on the supported EVM mainnets), and
+	 * - the caller's custom tokens, filtered to variants the configured providers can actually price
+	 * (testnets, NFTs and ERC-4626 vaults are excluded).
+	 *
+	 * The endpoint also re-marks the returned tokens as active so the
+	 * background refresh timer keeps them warm, and — if any cached price is
+	 * older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
+	 * missing — awaits a one-shot fetch for that subset before responding, so
+	 * the response always honours the freshness contract.
+	 *
+	 * This is an `update` (rather than a `query`) because it mutates state
+	 * (`token_activity`) and may issue HTTP outcalls.
+	 */
+	get_my_exchange_rates: ActorMethod<[], Array<[TokenId, [] | [ExchangeRate]]>>;
+	/**
 	 * Returns the full agreement consent/rejection history for the caller.
 	 *
 	 * # Returns

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -1841,10 +1841,10 @@ export interface _SERVICE {
 	 *
 	 * The endpoint also re-marks the returned tokens as active so the
 	 * background refresh timer keeps them warm. If any cached price is older
-	 * than PRICE_STALENESS_THRESHOLD_SEC seconds or missing, the endpoint
-	 * awaits a one-shot fetch for that subset before responding. Entries that
-	 * remain stale or missing after that attempt are returned as `None` so
-	 * returned prices honour the freshness contract.
+	 * than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
+	 * missing, the endpoint awaits a one-shot fetch for that subset before
+	 * responding. Entries that remain stale or missing after that attempt are
+	 * returned as `None` so returned prices honour the freshness contract.
 	 *
 	 * This is an `update` (rather than a `query`) because it mutates state
 	 * (`token_activity`) and may issue HTTP outcalls.

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -759,11 +759,7 @@ export const idlFactory = ({ IDL }) => {
 		get_contact: IDL.Func([IDL.Nat64], [GetContactResult]),
 		get_contacts: IDL.Func([], [GetContactsResult]),
 		get_exchange_rate: IDL.Func([TokenId], [IDL.Opt(ExchangeRate)]),
-		get_exchange_rates: IDL.Func(
-			[IDL.Vec(TokenId)],
-			[IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))]
-		),
-		get_my_exchange_rates: IDL.Func([], [IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))], []),
+		get_exchange_rates: IDL.Func([], [IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))], []),
 		get_user_agreement_history: IDL.Func([], [GetAgreementHistoryResult]),
 		get_user_profile: IDL.Func([], [GetUserProfileResult]),
 		get_user_transactions: IDL.Func([GetUserTransactionsRequest], [GetUserTransactionsResult]),

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -763,6 +763,7 @@ export const idlFactory = ({ IDL }) => {
 			[IDL.Vec(TokenId)],
 			[IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))]
 		),
+		get_my_exchange_rates: IDL.Func([], [IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))], []),
 		get_user_agreement_history: IDL.Func([], [GetAgreementHistoryResult]),
 		get_user_profile: IDL.Func([], [GetUserProfileResult]),
 		get_user_transactions: IDL.Func([GetUserTransactionsRequest], [GetUserTransactionsResult]),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -769,6 +769,7 @@ export const idlFactory = ({ IDL }) => {
 			[IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))],
 			['query']
 		),
+		get_my_exchange_rates: IDL.Func([], [IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))], []),
 		get_user_agreement_history: IDL.Func([], [GetAgreementHistoryResult], ['query']),
 		get_user_profile: IDL.Func([], [GetUserProfileResult], ['query']),
 		get_user_transactions: IDL.Func(

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -764,12 +764,7 @@ export const idlFactory = ({ IDL }) => {
 		get_contact: IDL.Func([IDL.Nat64], [GetContactResult], ['query']),
 		get_contacts: IDL.Func([], [GetContactsResult], ['query']),
 		get_exchange_rate: IDL.Func([TokenId], [IDL.Opt(ExchangeRate)], ['query']),
-		get_exchange_rates: IDL.Func(
-			[IDL.Vec(TokenId)],
-			[IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))],
-			['query']
-		),
-		get_my_exchange_rates: IDL.Func([], [IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))], []),
+		get_exchange_rates: IDL.Func([], [IDL.Vec(IDL.Tuple(TokenId, IDL.Opt(ExchangeRate)))], []),
 		get_user_agreement_history: IDL.Func([], [GetAgreementHistoryResult], ['query']),
 		get_user_profile: IDL.Func([], [GetUserProfileResult], ['query']),
 		get_user_transactions: IDL.Func(

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -431,12 +431,11 @@ export class BackendCanister extends Canister<BackendService> {
 	};
 
 	getExchangeRates = async ({
-		token_ids,
 		certified
 	}: { token_ids: TokenId[] } & QueryParams): Promise<Map<string, BackendExchangeRate>> => {
 		const { get_exchange_rates } = this.caller({ certified });
 
-		const results = await get_exchange_rates(token_ids);
+		const results = await get_exchange_rates();
 
 		return results.reduce<Map<string, BackendExchangeRate>>((acc, [id, rate]) => {
 			const unwrapped = this.mapExchangeRate(fromNullable(rate));

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -430,10 +430,10 @@ export class BackendCanister extends Canister<BackendService> {
 		return this.mapExchangeRate(fromNullable(response));
 	};
 
-	getExchangeRates = async ({
-		certified
-	}: { token_ids: TokenId[] } & QueryParams): Promise<Map<string, BackendExchangeRate>> => {
-		const { get_exchange_rates } = this.caller({ certified });
+	getExchangeRates = async (
+		_params: { token_ids: TokenId[] } & QueryParams
+	): Promise<Map<string, BackendExchangeRate>> => {
+		const { get_exchange_rates } = this.caller({ certified: true });
 
 		const results = await get_exchange_rates();
 

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -430,7 +430,9 @@ export class BackendCanister extends Canister<BackendService> {
 		return this.mapExchangeRate(fromNullable(response));
 	};
 
-	getExchangeRates = async (	_params: { token_ids: TokenId[] } & QueryParams	): Promise<Map<string, BackendExchangeRate>> => {
+	getExchangeRates = async (
+		_params: { token_ids: TokenId[] } & QueryParams
+	): Promise<Map<string, BackendExchangeRate>> => {
 		const { get_exchange_rates } = this.caller({ certified: true });
 
 		const results = await get_exchange_rates();

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -430,9 +430,7 @@ export class BackendCanister extends Canister<BackendService> {
 		return this.mapExchangeRate(fromNullable(response));
 	};
 
-	getExchangeRates = async (
-		_params: { token_ids: TokenId[] } & QueryParams
-	): Promise<Map<string, BackendExchangeRate>> => {
+	getExchangeRates = async (	_params: { token_ids: TokenId[] } & QueryParams	): Promise<Map<string, BackendExchangeRate>> => {
 		const { get_exchange_rates } = this.caller({ certified: true });
 
 		const results = await get_exchange_rates();

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -1724,7 +1724,7 @@ describe('backend.canister', () => {
 				expect(rate).toEqual(expectedUnwrapped);
 			}
 
-			expect(service.get_exchange_rates).toHaveBeenCalledExactlyOnceWith(tokenIds);
+			expect(service.get_exchange_rates).toHaveBeenCalledExactlyOnceWith();
 		});
 
 		it('should omit entries with no rate from the Map', async () => {


### PR DESCRIPTION
# Motivation

Move the backend exchange-rate API to the cleaner caller-scoped shape before wiring the remaining stack. The frontend should no longer pass an explicit token list; the backend owns token resolution, activation, and the 2-minute freshness contract.

BREAKING CHANGE: `get_exchange_rates` no longer accepts `vec TokenId` and is now an update method returning prices for the caller's priceable tokens. Frontend callers must switch to the no-arg update call in the follow-up PR.

# Changes

- Replace `get_exchange_rates(vec TokenId) query` with `get_exchange_rates() update`.
- Keep the caller-scoped behavior from the earlier backend draft: derive native + custom priceable tokens, mark them active, fetch stale or missing prices, and return the cache snapshot.
- Remove the additive `get_my_exchange_rates` method so the public API keeps the existing endpoint name.

# Tests

Adapte tests.
