### PR TITLE
feat(frontend): use no-arg exchange rates endpoint

### DIFF
--- a/src/frontend/src/lib/api/backend.api.ts
+++ b/src/frontend/src/lib/api/backend.api.ts
@@ -276,15 +276,11 @@ export const getExchangeRate = async ({
 };
 
 export const getExchangeRates = async ({
-	identity,
-	...params
-}: CanisterApiFunctionParams<{
-	token_ids: TokenId[];
-	certified: boolean;
-}>): Promise<Map<string, BackendExchangeRate>> => {
+	identity
+}: CanisterApiFunctionParams): Promise<Array<[TokenId, BackendExchangeRate | undefined]>> => {
 	const { getExchangeRates } = await backendCanister({ identity });
 
-	return getExchangeRates(params);
+	return getExchangeRates();
 };
 
 export const getUserTransactions = async ({

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -48,7 +48,6 @@ import { SignupsClosedError } from '$lib/types/errors';
 import type { BackendExchangeRate } from '$lib/types/exchange';
 import { mapBackendUserAgreements } from '$lib/utils/agreements.utils';
 import { mapBackendProviderAgreements } from '$lib/utils/provider-agreements.utils';
-import { tokenIdKey } from '$lib/utils/token-id.utils';
 import { mapUserExperimentalFeatures } from '$lib/utils/user-experimental-features.utils';
 import { mapUserNetworks } from '$lib/utils/user-networks.utils';
 import {
@@ -430,24 +429,14 @@ export class BackendCanister extends Canister<BackendService> {
 		return this.mapExchangeRate(fromNullable(response));
 	};
 
-	getExchangeRates = async (
-		_params: { token_ids: TokenId[] } & QueryParams
-	): Promise<Map<string, BackendExchangeRate>> => {
+	getExchangeRates = async (): Promise<Array<[TokenId, BackendExchangeRate | undefined]>> => {
+		// `get_exchange_rates` is an update on the backend (mutates token_activity, may issue
+		// HTTP outcalls), so it always goes through the certified service.
 		const { get_exchange_rates } = this.caller({ certified: true });
 
 		const results = await get_exchange_rates();
 
-		return results.reduce<Map<string, BackendExchangeRate>>((acc, [id, rate]) => {
-			const unwrapped = this.mapExchangeRate(fromNullable(rate));
-
-			const key = tokenIdKey(id);
-
-			if (nonNullish(unwrapped) && nonNullish(key)) {
-				acc.set(key, unwrapped);
-			}
-
-			return acc;
-		}, new Map());
+		return results.map(([id, rate]) => [id, this.mapExchangeRate(fromNullable(rate))]);
 	};
 
 	getUserTransactions = async ({

--- a/src/frontend/src/lib/services/exchange.services.ts
+++ b/src/frontend/src/lib/services/exchange.services.ts
@@ -6,7 +6,6 @@ import { POLYGON_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { ICPSWAP_PROVIDER_ENABLED } from '$env/rest/icpswap.env';
 import { KONGSWAP_PROVIDER_ENABLED } from '$env/rest/kongswap.env';
-import type { Erc20ContractAddressWithNetwork } from '$icp-eth/types/icrc-erc20';
 import type { LedgerCanisterIdText } from '$icp/types/canister';
 import { getExchangeRates } from '$lib/api/backend.api';
 import { NANO_SECONDS_IN_MILLISECOND } from '$lib/constants/app.constants';
@@ -32,7 +31,6 @@ import {
 } from '$lib/utils/exchange.utils';
 import { tokenIdKey } from '$lib/utils/token-id.utils';
 import type { SplTokenAddress } from '$sol/types/spl';
-import { Principal } from '@dfinity/principal';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 
@@ -293,74 +291,22 @@ const BASE_ETH_NATIVE_ENTRY: NativeTokenEntry = {
 	tokenId: { EvmNative: BASE_NETWORK.chainId },
 	coingeckoKey: 'ethereum'
 };
-const NATIVE_TOKEN_IDS: NativeTokenEntry[] = [
-	ETH_NATIVE_ENTRY,
-	BTC_NATIVE_ENTRY,
-	ICP_NATIVE_ENTRY,
-	SOL_NATIVE_ENTRY,
-	BNB_NATIVE_ENTRY,
-	POL_NATIVE_ENTRY,
-	ARBITRUM_ETH_NATIVE_ENTRY,
-	BASE_ETH_NATIVE_ENTRY
-];
-
-const collectTokenPairs = <T>({
-	items,
-	toTokenId,
-	toIdentifier
-}: {
-	items: T[];
-	toTokenId: (item: T) => TokenId;
-	toIdentifier: (item: T) => string;
-}): { pairs: { identifier: string; key: string }[]; tokenIds: TokenId[] } =>
-	items.reduce<{ pairs: { identifier: string; key: string }[]; tokenIds: TokenId[] }>(
-		(acc, item) => {
-			const tokenId = toTokenId(item);
-			const key = tokenIdKey(tokenId);
-
-			if (isNullish(key)) {
-				return acc;
-			}
-
-			acc.tokenIds.push(tokenId);
-			acc.pairs.push({ identifier: toIdentifier(item), key });
-
-			return acc;
-		},
-		{ pairs: [], tokenIds: [] }
-	);
-
-const buildPriceMap = ({
-	pairs,
-	rates,
-	normalizeId
-}: {
-	pairs: { identifier: string; key: string }[];
-	rates: Map<string, CoingeckoSimpleTokenPrice>;
-	normalizeId?: (id: string) => string;
-}): CoingeckoSimpleTokenPriceResponse =>
-	pairs.reduce<CoingeckoSimpleTokenPriceResponse>((acc, { identifier, key }) => {
-		const rate = rates.get(key);
-
-		if (nonNullish(rate)) {
-			acc[normalizeId?.(identifier) ?? identifier] = rate;
-		}
-
-		return acc;
-	}, {});
-
-const lower = (id: string) => id.toLowerCase();
-
-export const fetchAllExchangeRatesFromBackend = async ({
-	identity,
-	erc20Addresses,
-	icrcCanisterIds,
-	splTokenAddresses
+/**
+ * Calls the per-caller `get_exchange_rates` endpoint, which derives the
+ * relevant token list server-side (native + the caller's custom tokens,
+ * filtered to priceable variants) and guarantees the response is at most
+ * ~2 minutes stale. The frontend therefore no longer has to assemble the
+ * token list itself, and no longer has to keep `erc20Addresses /
+ * icrcCanisterIds / splTokenAddresses` in sync with whatever the backend
+ * considers "the user's tokens".
+ *
+ * The returned shape is identical to the provider branch output so the worker
+ * doesn't care which source produced it.
+ */
+export const fetchExchangeRatesFromBackend = async ({
+	identity
 }: {
 	identity: Identity;
-	erc20Addresses: Erc20ContractAddressWithNetwork[];
-	icrcCanisterIds: LedgerCanisterIdText[];
-	splTokenAddresses: SplTokenAddress[];
 }): Promise<{
 	currentEthPrice: CoingeckoSimplePriceResponse | undefined;
 	currentBtcPrice: CoingeckoSimplePriceResponse | undefined;
@@ -374,40 +320,31 @@ export const fetchAllExchangeRatesFromBackend = async ({
 	currentIcrcPrices: CoingeckoSimpleTokenPriceResponse;
 	currentSplPrices: CoingeckoSimpleTokenPriceResponse;
 }> => {
-	const nativeTokenIds = NATIVE_TOKEN_IDS.map(({ tokenId }) => tokenId);
-
-	const erc20 = collectTokenPairs({
-		items: erc20Addresses,
-		toTokenId: (t) => ({ Erc20: [t.address, t.chainId] }),
-		toIdentifier: (t) => t.address
-	});
-
-	const icrc = collectTokenPairs({
-		items: icrcCanisterIds,
-		toTokenId: (id) => ({ Icrc: Principal.fromText(id) }),
-		toIdentifier: (id) => id
-	});
-
-	const spl = collectTokenPairs({
-		items: splTokenAddresses,
-		toTokenId: (addr) => ({ SplMainnet: addr }),
-		toIdentifier: (addr) => addr
-	});
-
-	const ratesByKey = await getExchangeRates({
-		token_ids: [...nativeTokenIds, ...erc20.tokenIds, ...icrc.tokenIds, ...spl.tokenIds],
-		certified: true,
-		identity
-	});
+	const rates = await getExchangeRates({ identity });
 
 	const coingeckoRates = new Map<string, CoingeckoSimpleTokenPrice>();
-	ratesByKey.forEach((rate, key) => {
-		const mapped = mapExchangeRateToCoingecko(rate);
+	const currentErc20Prices: CoingeckoSimpleTokenPriceResponse = {};
+	const currentIcrcPrices: CoingeckoSimpleTokenPriceResponse = {};
+	const currentSplPrices: CoingeckoSimpleTokenPriceResponse = {};
 
+	for (const [tokenId, rate] of rates) {
+		const mapped = mapExchangeRateToCoingecko(rate);
 		if (nonNullish(mapped)) {
-			coingeckoRates.set(key, mapped);
+			const key = tokenIdKey(tokenId);
+			if (nonNullish(key)) {
+				coingeckoRates.set(key, mapped);
+			}
+
+			if ('Erc20' in tokenId) {
+				const [address] = tokenId.Erc20;
+				currentErc20Prices[address.toLowerCase()] = mapped;
+			} else if ('Icrc' in tokenId) {
+				currentIcrcPrices[tokenId.Icrc.toText().toLowerCase()] = mapped;
+			} else if ('SplMainnet' in tokenId) {
+				currentSplPrices[tokenId.SplMainnet] = mapped;
+			}
 		}
-	});
+	}
 
 	return {
 		currentEthPrice: nativePrice({ ...ETH_NATIVE_ENTRY, coingeckoRates }),
@@ -418,17 +355,9 @@ export const fetchAllExchangeRatesFromBackend = async ({
 		currentPolPrice: nativePrice({ ...POL_NATIVE_ENTRY, coingeckoRates }),
 		currentArbitrumEthPrice: nativePrice({ ...ARBITRUM_ETH_NATIVE_ENTRY, coingeckoRates }),
 		currentBaseEthPrice: nativePrice({ ...BASE_ETH_NATIVE_ENTRY, coingeckoRates }),
-		currentErc20Prices: buildPriceMap({
-			pairs: erc20.pairs,
-			rates: coingeckoRates,
-			normalizeId: lower
-		}),
-		currentIcrcPrices: buildPriceMap({
-			pairs: icrc.pairs,
-			rates: coingeckoRates,
-			normalizeId: lower
-		}),
-		currentSplPrices: buildPriceMap({ pairs: spl.pairs, rates: coingeckoRates })
+		currentErc20Prices,
+		currentIcrcPrices,
+		currentSplPrices
 	};
 };
 

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -17,7 +17,7 @@ import {
 	exchangeRateSOLToUsd,
 	exchangeRateSPLToUsd,
 	exchangeRateUsdToCurrency,
-	fetchAllExchangeRatesFromBackend
+	fetchExchangeRatesFromBackend
 } from '$lib/services/exchange.services';
 import type { CoingeckoPlatformId, CoingeckoSimpleTokenPriceResponse } from '$lib/types/coingecko';
 import type { CoingeckoErc20PriceParams } from '$lib/types/coingecko-erc20';
@@ -138,9 +138,6 @@ const buildErc20PriceParams = (
 
 const syncExchangeFromBackend = async ({
 	currentCurrency,
-	erc20ContractAddresses,
-	icrcLedgerCanisterIds,
-	splTokenAddresses,
 	erc4626TokensExchangeData
 }: SyncExchangeParams): Promise<PostMessageDataResponseExchange> => {
 	const identity = await AuthClientProvider.getInstance().loadIdentity();
@@ -172,12 +169,7 @@ const syncExchangeFromBackend = async ({
 
 	const [currentExchangeRate, backendPrices] = await Promise.all([
 		exchangeRateUsdToCurrency(currentCurrency),
-		fetchAllExchangeRatesFromBackend({
-			identity,
-			erc20Addresses: erc20ContractAddresses,
-			icrcCanisterIds: icrcLedgerCanisterIds,
-			splTokenAddresses
-		})
+		fetchExchangeRatesFromBackend({ identity })
 	]);
 
 	const {

--- a/src/frontend/src/tests/lib/api/backend.api.spec.ts
+++ b/src/frontend/src/tests/lib/api/backend.api.spec.ts
@@ -682,10 +682,7 @@ describe('backend.api', () => {
 	});
 
 	describe('getExchangeRates', () => {
-		const tokenIds: TokenId[] = [
-			{ Icrc: Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai') },
-			{ Erc20: ['0xabc', 1n] }
-		];
+		const tokenId: TokenId = { Icrc: Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai') };
 		const mockRate: BackendExchangeRate = {
 			usd: {
 				price: 42000,
@@ -694,35 +691,21 @@ describe('backend.api', () => {
 				timestampNs: 1_000_000_000n
 			}
 		};
-
-		const mockMap = new Map([
-			['Icrc:ryjl3-tyaaa-aaaaa-aaaba-cai', mockRate],
-			['Erc20:0xabc:1', mockRate]
-		]);
+		const mockResponse: Array<[TokenId, BackendExchangeRate | undefined]> = [[tokenId, mockRate]];
 
 		beforeEach(() => {
-			backendCanisterMock.getExchangeRates.mockResolvedValue(mockMap);
+			backendCanisterMock.getExchangeRates.mockResolvedValue(mockResponse);
 		});
 
 		it('should successfully call getExchangeRates endpoint', async () => {
-			const result = await getExchangeRates({
-				...baseParams,
-				token_ids: tokenIds,
-				certified: false
-			});
+			const result = await getExchangeRates({ ...baseParams });
 
-			expect(result).toBeInstanceOf(Map);
-			expect(result.size).toBe(2);
-			expect(backendCanisterMock.getExchangeRates).toHaveBeenCalledExactlyOnceWith({
-				token_ids: tokenIds,
-				certified: false
-			});
+			expect(result).toEqual(mockResponse);
+			expect(backendCanisterMock.getExchangeRates).toHaveBeenCalledExactlyOnceWith();
 		});
 
 		it('should throw an error if identity is undefined', async () => {
-			await expect(
-				getExchangeRates({ identity: undefined, token_ids: tokenIds, certified: false })
-			).rejects.toThrow();
+			await expect(getExchangeRates({ identity: undefined })).rejects.toThrow();
 		});
 
 		it('should throw an error if getExchangeRates throws', async () => {
@@ -730,9 +713,7 @@ describe('backend.api', () => {
 				throw new Error('mock-error');
 			});
 
-			await expect(
-				getExchangeRates({ ...baseParams, token_ids: tokenIds, certified: false })
-			).rejects.toThrow();
+			await expect(getExchangeRates({ ...baseParams })).rejects.toThrow();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/backend.canister.spec.ts
@@ -1707,7 +1707,7 @@ describe('backend.canister', () => {
 			}
 		};
 
-		it('should return a Map with fully unwrapped exchange rates', async () => {
+		it('should return the response paired with unwrapped rates', async () => {
 			const rawResponse = tokenIds.map(
 				(id) => [id, [mockCandidRate]] as [typeof id, [typeof mockCandidRate]]
 			);
@@ -1715,30 +1715,29 @@ describe('backend.canister', () => {
 
 			const { getExchangeRates } = await createBackendCanister({ serviceOverride: service });
 
-			const result = await getExchangeRates({ token_ids: tokenIds, certified: false });
+			const result = await getExchangeRates();
 
-			expect(result).toBeInstanceOf(Map);
-			expect(result.size).toBe(2);
-
-			for (const rate of result.values()) {
-				expect(rate).toEqual(expectedUnwrapped);
-			}
-
+			expect(result).toEqual([
+				[tokenIds[0], expectedUnwrapped],
+				[tokenIds[1], expectedUnwrapped]
+			]);
 			expect(service.get_exchange_rates).toHaveBeenCalledExactlyOnceWith();
 		});
 
-		it('should omit entries with no rate from the Map', async () => {
-			const rawResponse = [
+		it('should map empty rates to undefined', async () => {
+			service.get_exchange_rates.mockResolvedValue([
 				[tokenIds[0], [mockCandidRate]],
 				[tokenIds[1], []]
-			] as Array<[(typeof tokenIds)[number], [] | [typeof mockCandidRate]]>;
-			service.get_exchange_rates.mockResolvedValue(rawResponse);
+			]);
 
 			const { getExchangeRates } = await createBackendCanister({ serviceOverride: service });
 
-			const result = await getExchangeRates({ token_ids: tokenIds, certified: false });
+			const result = await getExchangeRates();
 
-			expect(result.size).toBe(1);
+			expect(result).toEqual([
+				[tokenIds[0], expectedUnwrapped],
+				[tokenIds[1], undefined]
+			]);
 		});
 
 		it('should throw an error if the service throws', async () => {
@@ -1749,9 +1748,7 @@ describe('backend.canister', () => {
 
 			const { getExchangeRates } = await createBackendCanister({ serviceOverride: service });
 
-			await expect(getExchangeRates({ token_ids: tokenIds, certified: false })).rejects.toThrow(
-				mockResponseError
-			);
+			await expect(getExchangeRates()).rejects.toThrow(mockResponseError);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/exchange.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/exchange.services.spec.ts
@@ -7,7 +7,7 @@ import { fetchBatchKongSwapPrices } from '$lib/rest/kongswap.rest';
 import {
 	exchangeRateICRCToUsd,
 	exchangeRateUsdToCurrency,
-	fetchAllExchangeRatesFromBackend,
+	fetchExchangeRatesFromBackend,
 	syncExchange
 } from '$lib/services/exchange.services';
 import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
@@ -20,7 +20,6 @@ import {
 	formatIcpSwapToCoingeckoPrices,
 	formatKongSwapToCoingeckoPrices
 } from '$lib/utils/exchange.utils';
-import { tokenIdKey } from '$lib/utils/token-id.utils';
 import {
 	MOCK_CANISTER_ID_1,
 	MOCK_CANISTER_ID_2,
@@ -28,7 +27,6 @@ import {
 } from '$tests/mocks/exchanges.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { Principal } from '@dfinity/principal';
-import { nonNullish } from '@dfinity/utils';
 
 vi.mock('$lib/rest/coingecko.rest', () => ({
 	simplePrice: vi.fn(),
@@ -264,7 +262,7 @@ describe('exchange.services', () => {
 		});
 	});
 
-	describe('fetchAllExchangeRatesFromBackend', () => {
+	describe('fetchExchangeRatesFromBackend', () => {
 		const mockExchangeRate: BackendExchangeRate = {
 			usd: {
 				price: 42000,
@@ -274,77 +272,41 @@ describe('exchange.services', () => {
 			}
 		};
 
-		const mockRatesMap = (
-			...entries: [TokenId, BackendExchangeRate][]
-		): Map<string, BackendExchangeRate> =>
-			new Map(
-				entries.reduce<[string, BackendExchangeRate][]>((acc, [id, rate]) => {
-					const key = tokenIdKey(id);
-					return nonNullish(key) ? [...acc, [key, rate]] : acc;
-				}, [])
-			);
+		const expectedPrice = {
+			usd: 42000,
+			usd_24h_change: 1.5,
+			usd_market_cap: 800_000_000_000,
+			last_updated_at: 1000
+		};
 
 		beforeEach(() => {
 			vi.clearAllMocks();
 		});
 
-		it('should call getExchangeRates with native + mapped token IDs', async () => {
-			vi.mocked(getExchangeRates).mockResolvedValue(new Map());
+		it('should call getExchangeRates with no arguments other than identity', async () => {
+			vi.mocked(getExchangeRates).mockResolvedValue([]);
 
-			await fetchAllExchangeRatesFromBackend({
-				identity: mockIdentity,
-				erc20Addresses: [{ address: '0xabc', coingeckoId: 'ethereum', chainId: 1n }],
-				icrcCanisterIds: ['ryjl3-tyaaa-aaaaa-aaaba-cai'],
-				splTokenAddresses: ['SoLaddr1']
-			});
+			await fetchExchangeRatesFromBackend({ identity: mockIdentity });
 
 			expect(getExchangeRates).toHaveBeenCalledExactlyOnceWith({
-				token_ids: [
-					{ EvmNative: 1n },
-					{ BtcNativeMainnet: null },
-					{ IcpNative: null },
-					{ SolNativeMainnet: null },
-					{ EvmNative: 56n },
-					{ EvmNative: 137n },
-					{ EvmNative: 42161n },
-					{ EvmNative: 8453n },
-					{ Erc20: ['0xabc', 1n] },
-					{ Icrc: Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai') },
-					{ SplMainnet: 'SoLaddr1' }
-				],
-				certified: true,
 				identity: mockIdentity
 			});
 		});
 
-		it('should map backend response to coingecko-shaped prices', async () => {
-			const erc20TokenId: TokenId = { Erc20: ['0xabc', 1n] };
+		it('should bucket the backend response by token variant', async () => {
+			const erc20TokenId: TokenId = { Erc20: ['0xABC', 1n] };
 			const icrcTokenId: TokenId = {
 				Icrc: Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai')
 			};
 			const splTokenId: TokenId = { SplMainnet: 'SoLaddr1' };
 
-			vi.mocked(getExchangeRates).mockResolvedValue(
-				mockRatesMap(
-					[erc20TokenId, mockExchangeRate],
-					[icrcTokenId, mockExchangeRate],
-					[splTokenId, mockExchangeRate]
-				)
-			);
+			vi.mocked(getExchangeRates).mockResolvedValue([
+				[erc20TokenId, mockExchangeRate],
+				[icrcTokenId, mockExchangeRate],
+				[splTokenId, mockExchangeRate]
+			]);
 
-			const result = await fetchAllExchangeRatesFromBackend({
-				identity: mockIdentity,
-				erc20Addresses: [{ address: '0xabc', coingeckoId: 'ethereum', chainId: 1n }],
-				icrcCanisterIds: ['ryjl3-tyaaa-aaaaa-aaaba-cai'],
-				splTokenAddresses: ['SoLaddr1']
-			});
-
-			const expectedPrice = {
-				usd: 42000,
-				usd_24h_change: 1.5,
-				usd_market_cap: 800_000_000_000,
-				last_updated_at: 1000
-			};
+			const result = await fetchExchangeRatesFromBackend({ identity: mockIdentity });
 
 			expect(result.currentErc20Prices).toEqual({ '0xabc': expectedPrice });
 			expect(result.currentIcrcPrices).toEqual({
@@ -353,15 +315,10 @@ describe('exchange.services', () => {
 			expect(result.currentSplPrices).toEqual({ SoLaddr1: expectedPrice });
 		});
 
-		it('should return empty objects and undefined native prices when no rates are returned', async () => {
-			vi.mocked(getExchangeRates).mockResolvedValue(new Map());
+		it('should return undefined native prices and empty maps when the backend returns nothing', async () => {
+			vi.mocked(getExchangeRates).mockResolvedValue([]);
 
-			const result = await fetchAllExchangeRatesFromBackend({
-				identity: mockIdentity,
-				erc20Addresses: [{ address: '0xabc', coingeckoId: 'ethereum', chainId: 1n }],
-				icrcCanisterIds: ['ryjl3-tyaaa-aaaaa-aaaba-cai'],
-				splTokenAddresses: ['SoLaddr1']
-			});
+			const result = await fetchExchangeRatesFromBackend({ identity: mockIdentity });
 
 			expect(result.currentEthPrice).toBeUndefined();
 			expect(result.currentBtcPrice).toBeUndefined();
@@ -376,98 +333,19 @@ describe('exchange.services', () => {
 			expect(result.currentSplPrices).toEqual({});
 		});
 
-		it('should skip rates with no price', async () => {
-			const noPriceRate: BackendExchangeRate = {
-				usd: {
-					price: undefined,
-					price24hChangePct: 1.5,
-					marketCap: 100,
-					timestampNs: 1n
-				}
-			};
+		it('should expose native token prices when the backend provides them', async () => {
+			vi.mocked(getExchangeRates).mockResolvedValue([
+				[{ EvmNative: 1n }, mockExchangeRate],
+				[{ BtcNativeMainnet: null }, mockExchangeRate],
+				[{ IcpNative: null }, mockExchangeRate],
+				[{ SolNativeMainnet: null }, mockExchangeRate],
+				[{ EvmNative: 56n }, mockExchangeRate],
+				[{ EvmNative: 137n }, mockExchangeRate],
+				[{ EvmNative: 42161n }, mockExchangeRate],
+				[{ EvmNative: 8453n }, mockExchangeRate]
+			]);
 
-			vi.mocked(getExchangeRates).mockResolvedValue(
-				mockRatesMap([{ Erc20: ['0xabc', 1n] }, noPriceRate])
-			);
-
-			const result = await fetchAllExchangeRatesFromBackend({
-				identity: mockIdentity,
-				erc20Addresses: [{ address: '0xabc', coingeckoId: 'ethereum', chainId: 1n }],
-				icrcCanisterIds: [],
-				splTokenAddresses: []
-			});
-
-			expect(result.currentErc20Prices).toEqual({});
-		});
-
-		it('should handle empty exchange rate (not found)', async () => {
-			vi.mocked(getExchangeRates).mockResolvedValue(new Map());
-
-			const result = await fetchAllExchangeRatesFromBackend({
-				identity: mockIdentity,
-				erc20Addresses: [{ address: '0xabc', coingeckoId: 'ethereum', chainId: 1n }],
-				icrcCanisterIds: [],
-				splTokenAddresses: []
-			});
-
-			expect(result.currentErc20Prices).toEqual({});
-		});
-
-		it('should include erc20 addresses via chainId regardless of coingeckoId', async () => {
-			vi.mocked(getExchangeRates).mockResolvedValue(new Map());
-
-			await fetchAllExchangeRatesFromBackend({
-				identity: mockIdentity,
-				// @ts-expect-error Testing with non-standard coingeckoId
-				erc20Addresses: [{ address: '0xabc', coingeckoId: 'some-unknown-chain', chainId: 999n }],
-				icrcCanisterIds: [],
-				splTokenAddresses: []
-			});
-
-			expect(getExchangeRates).toHaveBeenCalledWith(
-				expect.objectContaining({
-					token_ids: [
-						{ EvmNative: 1n },
-						{ BtcNativeMainnet: null },
-						{ IcpNative: null },
-						{ SolNativeMainnet: null },
-						{ EvmNative: 56n },
-						{ EvmNative: 137n },
-						{ EvmNative: 42161n },
-						{ EvmNative: 8453n },
-						{ Erc20: ['0xabc', 999n] }
-					]
-				})
-			);
-		});
-
-		it('should return native token prices from backend', async () => {
-			vi.mocked(getExchangeRates).mockResolvedValue(
-				mockRatesMap(
-					[{ EvmNative: 1n }, mockExchangeRate],
-					[{ BtcNativeMainnet: null }, mockExchangeRate],
-					[{ IcpNative: null }, mockExchangeRate],
-					[{ SolNativeMainnet: null }, mockExchangeRate],
-					[{ EvmNative: 56n }, mockExchangeRate],
-					[{ EvmNative: 137n }, mockExchangeRate],
-					[{ EvmNative: 42161n }, mockExchangeRate],
-					[{ EvmNative: 8453n }, mockExchangeRate]
-				)
-			);
-
-			const result = await fetchAllExchangeRatesFromBackend({
-				identity: mockIdentity,
-				erc20Addresses: [],
-				icrcCanisterIds: [],
-				splTokenAddresses: []
-			});
-
-			const expectedPrice = {
-				usd: 42000,
-				usd_24h_change: 1.5,
-				usd_market_cap: 800_000_000_000,
-				last_updated_at: 1000
-			};
+			const result = await fetchExchangeRatesFromBackend({ identity: mockIdentity });
 
 			expect(result.currentEthPrice).toEqual({ ethereum: expectedPrice });
 			expect(result.currentBtcPrice).toEqual({ bitcoin: expectedPrice });
@@ -479,35 +357,24 @@ describe('exchange.services', () => {
 			expect(result.currentBaseEthPrice).toEqual({ ethereum: expectedPrice });
 		});
 
-		it('should handle missing optional fields in BackendExchangeRate', async () => {
-			const partialRate: BackendExchangeRate = {
+		it('should skip entries whose price is missing', async () => {
+			const noPriceRate: BackendExchangeRate = {
 				usd: {
-					price: 100,
-					price24hChangePct: undefined,
-					marketCap: undefined,
+					price: undefined,
+					price24hChangePct: 1.5,
+					marketCap: 100,
 					timestampNs: 1n
 				}
 			};
 
-			vi.mocked(getExchangeRates).mockResolvedValue(
-				mockRatesMap([{ Erc20: ['0xabc', 1n] }, partialRate])
-			);
+			vi.mocked(getExchangeRates).mockResolvedValue([
+				[{ Erc20: ['0xabc', 1n] }, noPriceRate],
+				[{ Erc20: ['0xdef', 1n] }, undefined]
+			]);
 
-			const result = await fetchAllExchangeRatesFromBackend({
-				identity: mockIdentity,
-				erc20Addresses: [{ address: '0xabc', coingeckoId: 'ethereum', chainId: 1n }],
-				icrcCanisterIds: [],
-				splTokenAddresses: []
-			});
+			const result = await fetchExchangeRatesFromBackend({ identity: mockIdentity });
 
-			expect(result.currentErc20Prices).toEqual({
-				'0xabc': {
-					usd: 100,
-					usd_24h_change: undefined,
-					usd_market_cap: 0,
-					last_updated_at: 0
-				}
-			});
+			expect(result.currentErc20Prices).toEqual({});
 		});
 	});
 

--- a/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
+++ b/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
@@ -18,13 +18,11 @@ import type {
 } from '$lib/types/coingecko';
 import type { BackendExchangeRate } from '$lib/types/exchange';
 import type { PostMessage, PostMessageDataRequestExchangeTimer } from '$lib/types/post-message';
-import { tokenIdKey } from '$lib/utils/token-id.utils';
 import { onExchangeMessage } from '$lib/workers/exchange.worker';
 import type { SplTokenAddress } from '$sol/types/spl';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { createMockEvent, excludeValidMessageEvents } from '$tests/mocks/workers.mock';
 import { Principal } from '@dfinity/principal';
-import { nonNullish } from '@dfinity/utils';
 
 const { backendExchangeEnabled } = vi.hoisted(() => ({
 	backendExchangeEnabled: { current: false }
@@ -1155,15 +1153,9 @@ describe('exchange.worker', () => {
 				}
 			};
 
-			const mockRatesMap = (
+			const mockMyRates = (
 				...entries: [TokenId, BackendExchangeRate][]
-			): Map<string, BackendExchangeRate> =>
-				new Map(
-					entries.reduce<[string, BackendExchangeRate][]>((acc, [id, rate]) => {
-						const key = tokenIdKey(id);
-						return nonNullish(key) ? [...acc, [key, rate]] : acc;
-					}, [])
-				);
+			): Array<[TokenId, BackendExchangeRate | undefined]> => entries;
 
 			beforeEach(() => {
 				backendExchangeEnabled.current = true;
@@ -1174,7 +1166,7 @@ describe('exchange.worker', () => {
 			});
 
 			it('should fetch prices from backend instead of CoinGecko', async () => {
-				vi.mocked(getExchangeRates).mockResolvedValue(new Map());
+				vi.mocked(getExchangeRates).mockResolvedValue([]);
 
 				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
 					...createEvent(msg),
@@ -1203,7 +1195,7 @@ describe('exchange.worker', () => {
 				};
 
 				vi.mocked(getExchangeRates).mockResolvedValue(
-					mockRatesMap([erc20TokenId, mockExchangeRate], [icrcTokenId, mockExchangeRate])
+					mockMyRates([erc20TokenId, mockExchangeRate], [icrcTokenId, mockExchangeRate])
 				);
 
 				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
@@ -1243,7 +1235,7 @@ describe('exchange.worker', () => {
 			});
 
 			it('should return native prices as undefined when backend has no data for them', async () => {
-				vi.mocked(getExchangeRates).mockResolvedValue(new Map());
+				vi.mocked(getExchangeRates).mockResolvedValue([]);
 
 				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
 					...createEvent(msg),
@@ -1273,7 +1265,7 @@ describe('exchange.worker', () => {
 
 			it('should include native token prices when backend provides them', async () => {
 				vi.mocked(getExchangeRates).mockResolvedValue(
-					mockRatesMap(
+					mockMyRates(
 						[{ EvmNative: 1n }, mockExchangeRate],
 						[{ BtcNativeMainnet: null }, mockExchangeRate],
 						[{ IcpNative: null }, mockExchangeRate],
@@ -1318,7 +1310,7 @@ describe('exchange.worker', () => {
 			});
 
 			it('should still fetch currency exchange rate from CoinGecko for non-USD currencies', async () => {
-				vi.mocked(getExchangeRates).mockResolvedValue(new Map());
+				vi.mocked(getExchangeRates).mockResolvedValue([]);
 				vi.mocked(simplePrice).mockResolvedValue({
 					bitcoin: { usd: 60000, eur: 55000, usd_24h_change: 2, eur_24h_change: 1.5 }
 				});


### PR DESCRIPTION
# Motivation

Follow up the backend endpoint replacement by switching the frontend backend-exchange path to the no-arg `get_exchange_rates` call. The worker should consume the backend's caller-scoped token list instead of assembling token IDs client-side.

# Changes

- Update `BackendCanister.getExchangeRates` and `backend.api.getExchangeRates` to call `get_exchange_rates()` with no token list.
- Switch the exchange worker backend path to `fetchExchangeRatesFromBackend`.

# Tests

Adapted tests.
