### PR TITLE
perf(backend): tighten exchange refresh and activity window

### DIFF
--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -29,12 +29,12 @@ use crate::{
     },
 };
 
-/// How often exchange rates are refreshed (5 minutes).
-const PRICE_REFRESH_INTERVAL_SEC: u64 = 5 * 60;
+/// How often exchange rates are refreshed (1 minute).
+const PRICE_REFRESH_INTERVAL_SEC: u64 = 60;
 
 /// Tokens that haven't been queried within this window are considered inactive
-/// and skipped during price refreshes (1 hour).
-pub const PRICE_ACTIVITY_THRESHOLD_SEC: u64 = 60 * 60;
+/// and skipped during price refreshes (10 minutes).
+pub const PRICE_ACTIVITY_THRESHOLD_SEC: u64 = 10 * 60;
 
 /// A token's cached price is considered "fresh enough" if its
 /// [`ExchangeData::timestamp_ns`] (the provider-reported `last_updated_at`,

--- a/src/backend/src/token/activity.rs
+++ b/src/backend/src/token/activity.rs
@@ -7,8 +7,8 @@ use crate::{
     types::{StoredTokenId, VMem},
 };
 
-/// How long an inactive token's activity record is kept before housekeeping
-/// evicts it (30 minutes).
+/// How old an inactive token's activity record must be before housekeeping
+/// may evict it (30 minutes).
 ///
 /// Comfortably larger than `PRICE_ACTIVITY_THRESHOLD_SEC` (10 minutes) so any
 /// token that is still being refreshed is never accidentally removed; the

--- a/src/backend/src/token/activity.rs
+++ b/src/backend/src/token/activity.rs
@@ -8,13 +8,13 @@ use crate::{
 };
 
 /// How long an inactive token's activity record is kept before housekeeping
-/// evicts it (24 hours).
+/// evicts it (30 minutes).
 ///
-/// Generously larger than `PRICE_ACTIVITY_THRESHOLD_SEC` so any token that is
-/// still being refreshed is never accidentally removed; the goal here is just
-/// to bound the on-disk size of `token_activity` over time, not to gate
-/// refreshes.
-pub(crate) const TOKEN_ACTIVITY_RETENTION_SEC: u64 = 24 * 60 * 60;
+/// Comfortably larger than `PRICE_ACTIVITY_THRESHOLD_SEC` (10 minutes) so any
+/// token that is still being refreshed is never accidentally removed; the
+/// goal here is just to bound the on-disk size of `token_activity` over
+/// time, not to gate refreshes.
+pub(crate) const TOKEN_ACTIVITY_RETENTION_SEC: u64 = 30 * 60;
 
 fn add_to_token_activity(
     token_id: StoredTokenId,


### PR DESCRIPTION
# Motivation

Keep the backend exchange cache warm for the caller-scoped price endpoint while bounding token activity to the window requested by the backend price-loading flow.
