### PR TITLE
fix(frontend): parse ICRC-7 NFT metadata aliases

### DIFF
--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -77,12 +77,20 @@ const ICRC7_TOKEN_THUMBNAIL_KEYS = [
 	'thumbnailUrl',
 	'thumbnail_url'
 ];
+const ICRC7_TOKEN_METADATA_URI_KEYS = [
+	'icrc7:uri',
+	'icrc7:metadata:uri',
+	'uri',
+	'metadataUri',
+	'metadata_uri'
+];
 const ICRC7_TOKEN_ATTRIBUTES_KEYS = ['icrc7:attributes', 'icrc7:metadata:attributes', 'attributes'];
 const ICRC7_TOKEN_RESERVED_ATTRIBUTE_KEYS = new Set([
 	...ICRC7_TOKEN_NAME_KEYS,
 	...ICRC7_TOKEN_DESCRIPTION_KEYS,
 	...ICRC7_TOKEN_IMAGE_KEYS,
 	...ICRC7_TOKEN_THUMBNAIL_KEYS,
+	...ICRC7_TOKEN_METADATA_URI_KEYS,
 	...ICRC7_TOKEN_ATTRIBUTES_KEYS
 ]);
 

--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -42,7 +42,14 @@ const ICRC7_SYMBOL_KEY = 'icrc7:symbol';
 const ICRC7_DESCRIPTION_KEY = 'icrc7:description';
 const ICRC7_LOGO_KEY = 'icrc7:logo';
 
-const ICRC7_TOKEN_NAME_KEYS = ['icrc7:name', 'icrc7:metadata:name', 'name'];
+const ICRC7_TOKEN_NAME_KEYS = [
+	'icrc7:name',
+	'icrc7:title',
+	'icrc7:metadata:name',
+	'icrc7:metadata:title',
+	'name',
+	'title'
+];
 const ICRC7_TOKEN_DESCRIPTION_KEYS = [
 	'icrc7:description',
 	'icrc7:metadata:description',
@@ -50,21 +57,34 @@ const ICRC7_TOKEN_DESCRIPTION_KEYS = [
 ];
 const ICRC7_TOKEN_IMAGE_KEYS = [
 	'icrc7:image',
+	'icrc7:imageUrl',
 	'icrc7:metadata:image',
+	'icrc7:metadata:imageUrl',
 	'icrc7:image_url',
 	'icrc7:metadata:image_url',
 	'image',
+	'imageUrl',
 	'image_url'
 ];
 const ICRC7_TOKEN_THUMBNAIL_KEYS = [
 	'icrc7:thumbnail',
+	'icrc7:thumbnailUrl',
 	'icrc7:metadata:thumbnail',
+	'icrc7:metadata:thumbnailUrl',
 	'icrc7:thumbnail_url',
 	'icrc7:metadata:thumbnail_url',
 	'thumbnail',
+	'thumbnailUrl',
 	'thumbnail_url'
 ];
 const ICRC7_TOKEN_ATTRIBUTES_KEYS = ['icrc7:attributes', 'icrc7:metadata:attributes', 'attributes'];
+const ICRC7_TOKEN_SCALAR_ATTRIBUTE_KEYS = [
+	{ traitType: 'Edition', keys: ['icrc7:edition', 'icrc7:metadata:edition', 'edition'] },
+	{
+		traitType: 'Rarity Tier',
+		keys: ['icrc7:rarityTier', 'icrc7:metadata:rarityTier', 'rarityTier', 'rarity_tier']
+	}
+];
 
 const lookupText = ({
 	entries,
@@ -254,6 +274,20 @@ const lookupAttributesByKeys = ({
 	}
 };
 
+const lookupScalarAttributes = ({
+	entries
+}: {
+	entries: Array<[string, Value]>;
+}): NftMetadataWithoutId['attributes'] | undefined => {
+	const attributes = ICRC7_TOKEN_SCALAR_ATTRIBUTE_KEYS.flatMap(({ traitType, keys }) => {
+		const value = lookupStringByKeys({ entries, keys });
+
+		return nonNullish(value) ? [{ traitType, value }] : [];
+	});
+
+	return attributes.length > 0 ? attributes : undefined;
+};
+
 /**
  * Maps an ICRC-7 `icrc7_collection_metadata` response into a {@link TokenMetadata}-shaped object
  * (without `decimals`, which is not meaningful for NFT collections).
@@ -302,12 +336,17 @@ export const mapIcrc7TokenMetadata = (entries: Array<[string, Value]>): NftMetad
 		? valueToImageUrl({ value: thumbnailEntry[1] })
 		: undefined;
 	const attributes = lookupAttributesByKeys({ entries, keys: ICRC7_TOKEN_ATTRIBUTES_KEYS });
+	const scalarAttributes = lookupScalarAttributes({ entries });
+	const mergedAttributes =
+		nonNullish(attributes) || nonNullish(scalarAttributes)
+			? [...(attributes ?? []), ...(scalarAttributes ?? [])]
+			: undefined;
 
 	return {
 		...(nonNullish(name) && { name }),
 		...(nonNullish(description) && { description }),
 		...(nonNullish(imageUrl) && { imageUrl }),
 		...(nonNullish(thumbnailUrl) && { thumbnailUrl }),
-		...(nonNullish(attributes) && { attributes })
+		...(nonNullish(mergedAttributes) && { attributes: mergedAttributes })
 	};
 };

--- a/src/frontend/src/icp/utils/icrc7.utils.ts
+++ b/src/frontend/src/icp/utils/icrc7.utils.ts
@@ -78,13 +78,13 @@ const ICRC7_TOKEN_THUMBNAIL_KEYS = [
 	'thumbnail_url'
 ];
 const ICRC7_TOKEN_ATTRIBUTES_KEYS = ['icrc7:attributes', 'icrc7:metadata:attributes', 'attributes'];
-const ICRC7_TOKEN_SCALAR_ATTRIBUTE_KEYS = [
-	{ traitType: 'Edition', keys: ['icrc7:edition', 'icrc7:metadata:edition', 'edition'] },
-	{
-		traitType: 'Rarity Tier',
-		keys: ['icrc7:rarityTier', 'icrc7:metadata:rarityTier', 'rarityTier', 'rarity_tier']
-	}
-];
+const ICRC7_TOKEN_RESERVED_ATTRIBUTE_KEYS = new Set([
+	...ICRC7_TOKEN_NAME_KEYS,
+	...ICRC7_TOKEN_DESCRIPTION_KEYS,
+	...ICRC7_TOKEN_IMAGE_KEYS,
+	...ICRC7_TOKEN_THUMBNAIL_KEYS,
+	...ICRC7_TOKEN_ATTRIBUTES_KEYS
+]);
 
 const lookupText = ({
 	entries,
@@ -274,16 +274,27 @@ const lookupAttributesByKeys = ({
 	}
 };
 
-const lookupScalarAttributes = ({
+const tokenMetadataKeyToTraitType = ({ key }: { key: string }): string =>
+	key.replace(/^icrc7:metadata:/u, '').replace(/^icrc7:/u, '');
+
+const lookupAdditionalScalarAttributes = ({
 	entries
 }: {
 	entries: Array<[string, Value]>;
 }): NftMetadataWithoutId['attributes'] | undefined => {
-	const attributes = ICRC7_TOKEN_SCALAR_ATTRIBUTE_KEYS.flatMap(({ traitType, keys }) => {
-		const value = lookupStringByKeys({ entries, keys });
+	const attributes = mapNftAttributes(
+		entries.flatMap(([key, value]) => {
+			if (ICRC7_TOKEN_RESERVED_ATTRIBUTE_KEYS.has(key)) {
+				return [];
+			}
 
-		return nonNullish(value) ? [{ traitType, value }] : [];
-	});
+			const attributeValue = valueToAttributeValue({ value });
+
+			return nonNullish(attributeValue)
+				? [{ trait_type: tokenMetadataKeyToTraitType({ key }), value: attributeValue }]
+				: [];
+		})
+	);
 
 	return attributes.length > 0 ? attributes : undefined;
 };
@@ -336,7 +347,7 @@ export const mapIcrc7TokenMetadata = (entries: Array<[string, Value]>): NftMetad
 		? valueToImageUrl({ value: thumbnailEntry[1] })
 		: undefined;
 	const attributes = lookupAttributesByKeys({ entries, keys: ICRC7_TOKEN_ATTRIBUTES_KEYS });
-	const scalarAttributes = lookupScalarAttributes({ entries });
+	const scalarAttributes = lookupAdditionalScalarAttributes({ entries });
 	const mergedAttributes =
 		nonNullish(attributes) || nonNullish(scalarAttributes)
 			? [...(attributes ?? []), ...(scalarAttributes ?? [])]

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -179,10 +179,7 @@ describe('icrc7.utils', () => {
 					['title', { Text: 'The CEO' }],
 					['tokenId', { Nat: 1n }],
 					['edition', { Text: '#001' }],
-					[
-						'owner',
-						{ Text: '32vht-6nko3-fxqgs-z7rrt-b2vs3-hdpnp-3nb5a-rnxjm-citus-uuvqc-zae' }
-					],
+					['owner', { Text: '32vht-6nko3-fxqgs-z7rrt-b2vs3-hdpnp-3nb5a-rnxjm-citus-uuvqc-zae' }],
 					['rarityTier', { Text: 'TIER1' }],
 					['description', { Text: '' }],
 					[

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -173,7 +173,7 @@ describe('icrc7.utils', () => {
 			});
 		});
 
-		it('should map Caffeine-style token metadata keys', () => {
+		it('should map Caffeine-style token metadata keys and extra scalar fields', () => {
 			expect(
 				mapIcrc7TokenMetadata([
 					['title', { Text: 'The CEO' }],
@@ -181,6 +181,7 @@ describe('icrc7.utils', () => {
 					['edition', { Text: '#001' }],
 					['owner', { Text: '32vht-6nko3-fxqgs-z7rrt-b2vs3-hdpnp-3nb5a-rnxjm-citus-uuvqc-zae' }],
 					['rarityTier', { Text: 'TIER1' }],
+					['icrc7:metadata:powerLevel', { Int: 9001n }],
 					['description', { Text: '' }],
 					[
 						'imageUrl',
@@ -195,8 +196,14 @@ describe('icrc7.utils', () => {
 				imageUrl:
 					'https://blob.caffeine.ai/v1/blob/?blob_hash=sha256%3A6fc6a25f4d52e13a80b007aeac3641106587d1f331447ce506a9bb1afd399eeb&owner_id=sey3i-jyaaa-aaaap-quo3q-cai&project_id=019de6f2-675c-775e-9eda-2adf4341566c',
 				attributes: [
-					{ traitType: 'Edition', value: '#001' },
-					{ traitType: 'Rarity Tier', value: 'TIER1' }
+					{ traitType: 'tokenId', value: '1' },
+					{ traitType: 'edition', value: '#001' },
+					{
+						traitType: 'owner',
+						value: '32vht-6nko3-fxqgs-z7rrt-b2vs3-hdpnp-3nb5a-rnxjm-citus-uuvqc-zae'
+					},
+					{ traitType: 'rarityTier', value: 'TIER1' },
+					{ traitType: 'powerLevel', value: '9001' }
 				]
 			});
 		});

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -173,6 +173,37 @@ describe('icrc7.utils', () => {
 			});
 		});
 
+		it('should map Caffeine-style token metadata keys', () => {
+			expect(
+				mapIcrc7TokenMetadata([
+					['title', { Text: 'The CEO' }],
+					['tokenId', { Nat: 1n }],
+					['edition', { Text: '#001' }],
+					[
+						'owner',
+						{ Text: '32vht-6nko3-fxqgs-z7rrt-b2vs3-hdpnp-3nb5a-rnxjm-citus-uuvqc-zae' }
+					],
+					['rarityTier', { Text: 'TIER1' }],
+					['description', { Text: '' }],
+					[
+						'imageUrl',
+						{
+							Text: 'https://blob.caffeine.ai/v1/blob/?blob_hash=sha256%3A6fc6a25f4d52e13a80b007aeac3641106587d1f331447ce506a9bb1afd399eeb&owner_id=sey3i-jyaaa-aaaap-quo3q-cai&project_id=019de6f2-675c-775e-9eda-2adf4341566c'
+						}
+					]
+				])
+			).toEqual({
+				name: 'The CEO',
+				description: '',
+				imageUrl:
+					'https://blob.caffeine.ai/v1/blob/?blob_hash=sha256%3A6fc6a25f4d52e13a80b007aeac3641106587d1f331447ce506a9bb1afd399eeb&owner_id=sey3i-jyaaa-aaaap-quo3q-cai&project_id=019de6f2-675c-775e-9eda-2adf4341566c',
+				attributes: [
+					{ traitType: 'Edition', value: '#001' },
+					{ traitType: 'Rarity Tier', value: 'TIER1' }
+				]
+			});
+		});
+
 		it('should map image blobs into data URLs', () => {
 			expect(
 				mapIcrc7TokenMetadata([

--- a/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/icrc7.utils.spec.ts
@@ -162,6 +162,7 @@ describe('icrc7.utils', () => {
 				mapIcrc7TokenMetadata([
 					['icrc7:metadata:name', { Text: 'Namespaced token' }],
 					['icrc7:metadata:description', { Text: 'Namespaced description' }],
+					['icrc7:metadata:uri', { Text: 'https://example.com/token.json' }],
 					['icrc7:metadata:image_url', { Text: 'https://example.com/token.png' }],
 					['icrc7:metadata:thumbnail_url', { Text: 'https://example.com/token-thumb.png' }]
 				])


### PR DESCRIPTION
# Motivation

ICRC-7 NFT metadata from the Caffeine collection can expose user-facing fields such as `title`, `imageUrl`, and arbitrary flat scalar metadata entries. The frontend metadata mapper only recognized `name`, snake_case image keys, and explicit `attributes`, so those NFTs could lose their display name, media URL, and trait-like metadata.

# Changes

- Recognize `title` as an ICRC-7 NFT display name alias.
- Recognize camelCase `imageUrl` / `thumbnailUrl` metadata aliases.
- Continue mapping structured `icrc7:attributes` / `attributes` metadata via the shared NFT attribute mapper.
- Map arbitrary non-core scalar ICRC-7 token metadata entries into NFT attributes instead of hard-coding specific trait names.

# Tests

Added tests.
