### PR TITLE
fix(frontend): use NFT display names consistently

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import { goto } from '$app/navigation';
 	import { isCollectionErc1155 } from '$eth/utils/erc1155.utils';
 	import IconAlertOctagon from '$lib/components/icons/lucide/IconAlertOctagon.svelte';
@@ -19,7 +19,7 @@
 	import { trackEvent } from '$lib/services/analytics.services';
 	import type { Nft } from '$lib/types/nft';
 	import { nftsUrl } from '$lib/utils/nav.utils';
-	import { getNftDisplayId, getNftDisplayImageUrl } from '$lib/utils/nft.utils';
+	import { getNftDisplayId, getNftDisplayImageUrl, getNftDisplayName } from '$lib/utils/nft.utils';
 
 	interface Props {
 		nft: Nft;
@@ -44,6 +44,8 @@
 		source = 'default',
 		withCollectionLabel = false
 	}: Props = $props();
+
+	const nftDisplayName = $derived(getNftDisplayName(nft));
 
 	const onClick = () => {
 		if (type === 'card-selectable' && nonNullish(onSelect) && !disabled) {
@@ -134,13 +136,12 @@
 
 	<span class="flex w-full flex-col gap-1 px-2 pb-2" class:text-disabled={disabled}>
 		<span class="truncate text-sm font-bold" class:text-primary={!disabled}>
-			{withCollectionLabel || isNullish(nft.name) ? nft.collection.name : nft.name}
+			{withCollectionLabel ? nft.collection.name : nftDisplayName}
 		</span>
-		<span class="truncate text-xs" class:text-tertiary={!disabled}>
-			#{getNftDisplayId(nft)}
-			{#if withCollectionLabel && nonNullish(nft.name)}
-				&ndash; {nft.name}
-			{/if}
-		</span>
+		{#if withCollectionLabel}
+			<span class="truncate text-xs" class:text-tertiary={!disabled}>
+				{nonNullish(nft.name) ? nftDisplayName : `#${getNftDisplayId(nft)}`}
+			</span>
+		{/if}
 	</span>
 </button>

--- a/src/frontend/src/lib/components/nfts/NftLogo.svelte
+++ b/src/frontend/src/lib/components/nfts/NftLogo.svelte
@@ -11,7 +11,7 @@
 	import type { LogoSize } from '$lib/types/components';
 	import type { Nft } from '$lib/types/nft';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { getNftDisplayImageUrl } from '$lib/utils/nft.utils';
+	import { getNftDisplayImageUrl, getNftDisplayName } from '$lib/utils/nft.utils';
 
 	interface Props {
 		nft: Nft;
@@ -33,8 +33,9 @@
 		badgeTestId
 	}: Props = $props();
 
+	const nftDisplayName = $derived(getNftDisplayName(nft));
+
 	const {
-		name,
 		collection: { network }
 	} = $derived(nft);
 </script>
@@ -43,7 +44,7 @@
 	<div style={`width: ${logoSizes[logoSize]}; height: ${logoSizes[logoSize]};`}>
 		<NftDisplayGuard {nft} type="nft-logo">
 			<Logo
-				alt={replacePlaceholders($i18n.core.alt.logo, { $name: name ?? '' })}
+				alt={replacePlaceholders($i18n.core.alt.logo, { $name: nftDisplayName })}
 				circle={false}
 				{color}
 				{ring}

--- a/src/frontend/src/lib/components/tokens/SendNftReview.svelte
+++ b/src/frontend/src/lib/components/tokens/SendNftReview.svelte
@@ -2,12 +2,15 @@
 	import NftLogo from '$lib/components/nfts/NftLogo.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Nft } from '$lib/types/nft';
+	import { getNftDisplayName } from '$lib/utils/nft.utils';
 
 	interface Props {
 		nft: Nft;
 	}
 
 	let { nft }: Props = $props();
+
+	const nftDisplayName = $derived(getNftDisplayName(nft));
 </script>
 
 <div class="mb-5 flex rounded-lg border-1 border-brand-subtle-20 bg-brand-subtle-10 p-3">
@@ -16,7 +19,7 @@
 			<NftLogo badge={{ type: 'network' }} {nft} />
 		</span>
 		<div class="ml-4 flex flex-col">
-			<span class="flex font-bold">{$i18n.send.text.send}: {nft?.name} #{nft?.id}</span>
+			<span class="flex font-bold">{$i18n.send.text.send}: {nftDisplayName}</span>
 			<span class="flex text-tertiary">{nft.collection.network.name}</span>
 		</div>
 	</div>

--- a/src/frontend/src/tests/lib/components/nfts/Nft.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/Nft.spec.ts
@@ -1,5 +1,6 @@
 import Nft from '$lib/components/nfts/Nft.svelte';
 import { nftStore } from '$lib/stores/nft.store';
+import { getNftDisplayName } from '$lib/utils/nft.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
 import { mockValidErc1155Nft } from '$tests/mocks/nfts.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
@@ -18,7 +19,7 @@ describe('Nft', () => {
 	it('should render the nft', () => {
 		const { container, getByText } = render(Nft);
 
-		const name: HTMLElement | null = getByText(`${mockNft.name} #${mockNft.id}`);
+		const name: HTMLElement | null = getByText(getNftDisplayName(mockNft));
 
 		expect(name).toBeInTheDocument();
 

--- a/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
@@ -7,8 +7,8 @@ import {
 	PLAUSIBLE_EVENT_VALUES
 } from '$lib/enums/plausible';
 import { trackEvent } from '$lib/services/analytics.services';
-import { parseNftId } from '$lib/validation/nft.validation';
 import { getNftDisplayName } from '$lib/utils/nft.utils';
+import { parseNftId } from '$lib/validation/nft.validation';
 import { mockValidErc1155Nft, mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
@@ -229,6 +229,24 @@ describe('NftCard', () => {
 		expect(queryByText(mockValidErc721Nft.collection.name)).toBeNull();
 	});
 
+	it('should not duplicate the NFT id when the name already includes it', () => {
+		const nft = {
+			...mockValidErc721Nft,
+			name: `${mockValidErc721Nft.name} #${mockValidErc721Nft.id}`
+		};
+
+		const { getByText, queryByText } = render(NftCard, {
+			props: {
+				nft,
+				testId,
+				type: 'card-link'
+			}
+		});
+
+		expect(getByText(nft.name)).toBeInTheDocument();
+		expect(queryByText(`${nft.name} #${nft.id}`)).not.toBeInTheDocument();
+	});
+
 	it('should render collection name and nft name when withCollectionLabel is true', () => {
 		const { getByText } = render(NftCard, {
 			props: {
@@ -261,6 +279,8 @@ describe('NftCard', () => {
 			}
 		});
 
-		expect(getByText(getNftDisplayName({ ...mockValidErc721Nft, oisyId: mockOisyId }))).toBeInTheDocument();
+		expect(
+			getByText(getNftDisplayName({ ...mockValidErc721Nft, oisyId: mockOisyId }))
+		).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '$lib/enums/plausible';
 import { trackEvent } from '$lib/services/analytics.services';
 import { parseNftId } from '$lib/validation/nft.validation';
+import { getNftDisplayName } from '$lib/utils/nft.utils';
 import { mockValidErc1155Nft, mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
@@ -55,8 +56,7 @@ describe('NftCard', () => {
 
 		assertNonNullish(mockValidErc1155Nft?.name);
 
-		expect(getByText(mockValidErc1155Nft.name)).toBeInTheDocument();
-		expect(getByText(`#${mockValidErc1155Nft.id}`)).toBeInTheDocument();
+		expect(getByText(getNftDisplayName(mockValidErc1155Nft))).toBeInTheDocument();
 	});
 
 	it('should render image placeholder if no image is defined', () => {
@@ -80,7 +80,7 @@ describe('NftCard', () => {
 		assertNonNullish(mockValidErc721Nft.name);
 		assertNonNullish(mockValidErc721Nft.collection.name);
 
-		expect(getByText(`#${mockValidErc721Nft.id}`)).toBeInTheDocument();
+		expect(getByText(getNftDisplayName(mockValidErc721Nft))).toBeInTheDocument();
 	});
 
 	it('should render the correct styles for each type', async () => {
@@ -222,15 +222,11 @@ describe('NftCard', () => {
 		assertNonNullish(mockValidErc721Nft.name);
 		assertNonNullish(mockValidErc721Nft.collection.name);
 
-		// Should show nft.name as the main label
-		expect(getByText(mockValidErc721Nft.name)).toBeInTheDocument();
+		// Should show the canonical NFT display name as the main label
+		expect(getByText(getNftDisplayName(mockValidErc721Nft))).toBeInTheDocument();
 
 		// Should NOT show collection name in title
 		expect(queryByText(mockValidErc721Nft.collection.name)).toBeNull();
-
-		// Subtitle should just be the id
-		expect(getByText(`#${mockValidErc721Nft.id}`)).toBeInTheDocument();
-		expect(queryByText(`#${mockValidErc721Nft.id} – ${mockValidErc721Nft.name}`)).toBeNull();
 	});
 
 	it('should render collection name and nft name when withCollectionLabel is true', () => {
@@ -249,8 +245,8 @@ describe('NftCard', () => {
 		// Should show collection name instead of nft name as title
 		expect(getByText(mockValidErc721Nft.collection.name)).toBeInTheDocument();
 
-		// Subtitle should show both id and nft name
-		expect(getByText(`#${mockValidErc721Nft.id} – ${mockValidErc721Nft.name}`)).toBeInTheDocument();
+		// Subtitle should show the canonical NFT display name
+		expect(getByText(getNftDisplayName(mockValidErc721Nft))).toBeInTheDocument();
 	});
 
 	it('should render first the OISY NFT ID', () => {
@@ -265,6 +261,6 @@ describe('NftCard', () => {
 			}
 		});
 
-		expect(getByText(`#${mockOisyId} – ${mockValidErc721Nft.name}`)).toBeInTheDocument();
+		expect(getByText(getNftDisplayName({ ...mockValidErc721Nft, oisyId: mockOisyId }))).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/nfts/NftLogo.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftLogo.spec.ts
@@ -1,5 +1,6 @@
 import IconSend from '$lib/components/icons/IconSend.svelte';
 import NftLogo from '$lib/components/nfts/NftLogo.svelte';
+import { getNftDisplayName } from '$lib/utils/nft.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidErc721Nft } from '$tests/mocks/nfts.mock';
@@ -17,7 +18,7 @@ describe('NftLogo', () => {
 		expect(getByTestId('nft-logo')).toBeInTheDocument();
 
 		const expected = replacePlaceholders(en.core.alt.logo, {
-			$name: mockValidErc721Nft.name ?? ''
+			$name: getNftDisplayName(mockValidErc721Nft)
 		});
 
 		expect(getByAltText(expected)).toBeInTheDocument();

--- a/src/frontend/src/tests/lib/components/nfts/NftLogo.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftLogo.spec.ts
@@ -1,7 +1,7 @@
 import IconSend from '$lib/components/icons/IconSend.svelte';
 import NftLogo from '$lib/components/nfts/NftLogo.svelte';
-import { getNftDisplayName } from '$lib/utils/nft.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { getNftDisplayName } from '$lib/utils/nft.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 import { render } from '@testing-library/svelte';
@@ -19,6 +19,22 @@ describe('NftLogo', () => {
 
 		const expected = replacePlaceholders(en.core.alt.logo, {
 			$name: getNftDisplayName(mockValidErc721Nft)
+		});
+
+		expect(getByAltText(expected)).toBeInTheDocument();
+	});
+
+	it('should use the collection fallback in the logo alt text when the NFT name is missing', () => {
+		const nft = { ...mockValidErc721Nft, name: undefined };
+
+		const { getByAltText } = render(NftLogo, {
+			props: {
+				nft
+			}
+		});
+
+		const expected = replacePlaceholders(en.core.alt.logo, {
+			$name: getNftDisplayName(nft)
 		});
 
 		expect(getByAltText(expected)).toBeInTheDocument();

--- a/src/frontend/src/tests/lib/components/send/SendNftsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendNftsList.spec.ts
@@ -2,6 +2,7 @@ import { POLYGON_AMOY_NETWORK } from '$env/networks/networks-evm/networks.evm.po
 import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import { i18n } from '$lib/stores/i18n.store';
 import { nftStore } from '$lib/stores/nft.store';
+import { getNftDisplayName } from '$lib/utils/nft.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
 import SendNftsListTestHost from '$tests/lib/components/send/SendNftsListTestHost.svelte';
 import { mockValidErc1155Nft } from '$tests/mocks/nfts.mock';
@@ -28,7 +29,7 @@ describe('SendNftsList.spec', () => {
 		});
 
 		for (const nft of mockNfts) {
-			expect(getByText(`#${nft.id} – ${nft.name}`)).toBeInTheDocument();
+			expect(getByText(getNftDisplayName(nft))).toBeInTheDocument();
 		}
 
 		const networkBtn = getByRole('button', { name: get(i18n).networks.chain_fusion });
@@ -48,9 +49,9 @@ describe('SendNftsList.spec', () => {
 
 		await fireEvent.input(input, { target: { value: 'ein' } });
 
-		expect(queryByText('#0 – Null')).not.toBeInTheDocument();
-		expect(getByText(`#1 – Eins`)).toBeInTheDocument();
-		expect(queryByText('#2 – Zwei')).not.toBeInTheDocument();
+		expect(queryByText(getNftDisplayName(mockNfts[0]))).not.toBeInTheDocument();
+		expect(getByText(getNftDisplayName(mockNfts[1]))).toBeInTheDocument();
+		expect(queryByText(getNftDisplayName(mockNfts[2]))).not.toBeInTheDocument();
 	});
 
 	it('shows empty-state when no matches', async () => {
@@ -99,7 +100,7 @@ describe('SendNftsList.spec', () => {
 			onSelectNetwork: vi.fn()
 		});
 
-		const nftCard = getByText('#1 – Eins');
+		const nftCard = getByText(getNftDisplayName(mockNfts[1]));
 
 		await fireEvent.click(nftCard);
 

--- a/src/frontend/src/tests/lib/components/tokens/SendNftReview.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/SendNftReview.spec.ts
@@ -18,4 +18,17 @@ describe('SendNftReview', () => {
 		// Network name
 		expect(getByText(nft.collection.network.name)).toBeInTheDocument();
 	});
+
+	it('does not duplicate the NFT id when the name already includes it', () => {
+		const nft = {
+			...mockValidErc721Nft,
+			name: `${mockValidErc721Nft.name} #${mockValidErc721Nft.id}`
+		};
+		const sendLabel = get(i18n).send.text.send;
+
+		const { getByText, queryByText } = render(SendNftReview, { props: { nft } });
+
+		expect(getByText(`${sendLabel}: ${nft.name}`)).toBeInTheDocument();
+		expect(queryByText(`${sendLabel}: ${nft.name} #${nft.id}`)).not.toBeInTheDocument();
+	});
 });

--- a/src/frontend/src/tests/lib/components/tokens/SendNftReview.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/SendNftReview.spec.ts
@@ -1,5 +1,6 @@
 import SendNftReview from '$lib/components/tokens/SendNftReview.svelte';
 import { i18n } from '$lib/stores/i18n.store';
+import { getNftDisplayName } from '$lib/utils/nft.utils';
 import { mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
@@ -11,8 +12,8 @@ describe('SendNftReview', () => {
 
 		const { getByText } = render(SendNftReview, { props: { nft } });
 
-		// "Send: {name} #{id}"
-		expect(getByText(`${sendLabel}: ${nft.name} #${nft.id}`)).toBeInTheDocument();
+		// "Send: {displayName}"
+		expect(getByText(`${sendLabel}: ${getNftDisplayName(nft)}`)).toBeInTheDocument();
 
 		// Network name
 		expect(getByText(nft.collection.network.name)).toBeInTheDocument();

--- a/src/frontend/src/tests/lib/utils/transaction.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transaction.utils.spec.ts
@@ -20,6 +20,12 @@ import { createMockIcTransactionsUi } from '$tests/mocks/ic-transactions.mock';
 import { createTransactionsUiWithCmp } from '$tests/mocks/transactions.mock';
 import { get } from 'svelte/store';
 
+vi.mock('$lib/utils/format.utils', () => ({
+	formatSecondsToNormalizedDate: vi
+		.fn()
+		.mockImplementation(({ seconds }: { seconds: number }): string => `date-${seconds}`)
+}));
+
 describe('transaction.utils', () => {
 	describe('mapIcon', () => {
 		const allNonPendingStatus = TransactionStatusSchema.options.filter(
@@ -91,21 +97,15 @@ describe('transaction.utils', () => {
 
 		beforeEach(() => {
 			vi.clearAllMocks();
-
-			vi.mock('$lib/utils/format.utils', () => ({
-				formatSecondsToNormalizedDate: vi
-					.fn()
-					.mockImplementation(({ seconds, currentDate: _ }): string => seconds.toString())
-			}));
 		});
 
 		it('should group transactions by formatted date when they are unique', () => {
 			expect(groupTransactionsByDate(mockTransactions)).toEqual({
-				'1': [mockTransactions[0]],
-				'2': [mockTransactions[1]],
-				'3': [mockTransactions[2]],
-				'4': [mockTransactions[3]],
-				'5': [mockTransactions[4]]
+				'date-1': [mockTransactions[0]],
+				'date-2': [mockTransactions[1]],
+				'date-3': [mockTransactions[2]],
+				'date-4': [mockTransactions[3]],
+				'date-5': [mockTransactions[4]]
 			});
 		});
 
@@ -134,8 +134,8 @@ describe('transaction.utils', () => {
 			] as AnyTransactionUiWithCmp[];
 
 			expect(groupTransactionsByDate(transactions)).toEqual({
-				'1': transactions.slice(0, 3),
-				'2': transactions.slice(3)
+				'date-1': transactions.slice(0, 3),
+				'date-2': transactions.slice(3)
 			});
 		});
 
@@ -150,7 +150,7 @@ describe('transaction.utils', () => {
 			] as AnyTransactionUiWithCmp[];
 
 			expect(groupTransactionsByDate(transactions)).toEqual({
-				'1': [transactions[0]],
+				'date-1': [transactions[0]],
 				[undefinedKey]: [transactions[1]]
 			});
 		});
@@ -169,8 +169,8 @@ describe('transaction.utils', () => {
 			] as AnyTransactionUiWithCmp[];
 
 			expect(groupTransactionsByDate(transactions)).toEqual({
-				[1]: [transactions[0]],
-				[nowInSeconds.toString()]: [transactions[1]]
+				'date-1': [transactions[0]],
+				[`date-${nowInSeconds}`]: [transactions[1]]
 			});
 		});
 
@@ -184,8 +184,8 @@ describe('transaction.utils', () => {
 			] as AnyTransactionUiWithCmp[];
 
 			expect(groupTransactionsByDate(transactions)).toEqual({
-				'1': [transactions[0]],
-				[nowInSeconds.toString()]: [transactions[1]]
+				'date-1': [transactions[0]],
+				[`date-${nowInSeconds}`]: [transactions[1]]
 			});
 		});
 


### PR DESCRIPTION
# Motivation

NFT display names should consistently use the shared `getNftDisplayName` helper so token IDs are not duplicated and collection-name fallbacks work the same across NFT UI surfaces.

# Changes

- Use `getNftDisplayName` in NFT cards, NFT send review, and NFT logo alt text.
- Preserve collection labels where cards already show collection context separately.

# Tests

Adapted tests.
