### PR TITLE
fix(frontend): avoid Icrc7 import modal for known NFT collections

### DIFF
--- a/src/frontend/src/icp/components/tokens/IcIcrc7DeepLinkHandler.svelte
+++ b/src/frontend/src/icp/components/tokens/IcIcrc7DeepLinkHandler.svelte
@@ -3,9 +3,12 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { page } from '$app/state';
 	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
-	import { icrc7CustomTokensNotInitialized, icrc7Tokens } from '$icp/derived/icrc7.derived';
+	import { extCustomTokensNotInitialized } from '$icp/derived/ext.derived';
+	import { icPunksCustomTokensNotInitialized } from '$icp/derived/icpunks.derived';
+	import { icrc7CustomTokensNotInitialized } from '$icp/derived/icrc7.derived';
 	import { resolveIcrc7CollectionDeepLinkAction } from '$icp/services/icrc7-deep-link.services';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import { nonFungibleTokens } from '$lib/derived/tokens.derived';
 	import { WizardStepsManageTokens } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -14,13 +17,18 @@
 	const handledIcrc7DeepLinkCanisterIds = new SvelteSet<string>();
 
 	const icrc7DeepLinkAction = $derived.by(() => {
-		if (isNullish($authIdentity) || $icrc7CustomTokensNotInitialized) {
+		if (
+			isNullish($authIdentity) ||
+			$extCustomTokensNotInitialized ||
+			$icPunksCustomTokensNotInitialized ||
+			$icrc7CustomTokensNotInitialized
+		) {
 			return undefined;
 		}
 
 		return resolveIcrc7CollectionDeepLinkAction({
 			url: page.url,
-			tokens: $icrc7Tokens
+			tokens: $nonFungibleTokens
 		});
 	});
 

--- a/src/frontend/src/icp/services/icrc7-deep-link.services.ts
+++ b/src/frontend/src/icp/services/icrc7-deep-link.services.ts
@@ -1,8 +1,11 @@
 import { ICP_NETWORK_ID, ICP_NETWORK_SYMBOL } from '$env/networks/networks.icp.env';
 import type { Icrc7CustomToken } from '$icp/types/icrc7-custom-token';
-import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
+import { isTokenIcrc7CustomToken } from '$icp/utils/icrc7.utils';
+import { COLLECTION_PARAM, NETWORK_PARAM, NFT_PARAM } from '$lib/constants/routes.constants';
 import { CanisterIdTextSchema, type CanisterIdText } from '$lib/types/canister';
+import type { CustomToken } from '$lib/types/custom-token';
 import type { NetworkId } from '$lib/types/network';
+import type { NonFungibleToken } from '$lib/types/nft';
 import { isNullish } from '@dfinity/utils';
 
 export interface Icrc7CollectionDeepLink {
@@ -23,7 +26,7 @@ export const parseIcrc7CollectionDeepLink = ({
 	const collection = url.searchParams.get(COLLECTION_PARAM);
 	const network = url.searchParams.get(NETWORK_PARAM);
 
-	if (network !== ICP_NETWORK_SYMBOL) {
+	if (network !== ICP_NETWORK_SYMBOL || url.searchParams.has(NFT_PARAM)) {
 		return;
 	}
 
@@ -44,7 +47,7 @@ export const resolveIcrc7CollectionDeepLinkAction = ({
 	tokens
 }: {
 	url: URL;
-	tokens: Icrc7CustomToken[];
+	tokens: CustomToken<NonFungibleToken>[];
 }): Icrc7CollectionDeepLinkAction | undefined => {
 	const deepLink = parseIcrc7CollectionDeepLink({ url });
 
@@ -52,10 +55,16 @@ export const resolveIcrc7CollectionDeepLinkAction = ({
 		return;
 	}
 
-	const token = tokens.find(({ canisterId }) => canisterId === deepLink.canisterId);
+	const token = tokens.find(
+		(token) => 'canisterId' in token && token.canisterId === deepLink.canisterId
+	);
 
 	if (isNullish(token)) {
 		return { type: 'import', ...deepLink };
+	}
+
+	if (!isTokenIcrc7CustomToken(token)) {
+		return;
 	}
 
 	return { type: token.enabled ? 'ready' : 'enable', token, ...deepLink };

--- a/src/frontend/src/tests/icp/services/icrc7-deep-link.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/icrc7-deep-link.services.spec.ts
@@ -3,17 +3,21 @@ import {
 	parseIcrc7CollectionDeepLink,
 	resolveIcrc7CollectionDeepLinkAction
 } from '$icp/services/icrc7-deep-link.services';
-import { COLLECTION_PARAM, NETWORK_PARAM } from '$lib/constants/routes.constants';
+import { COLLECTION_PARAM, NETWORK_PARAM, NFT_PARAM } from '$lib/constants/routes.constants';
+import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
+import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
 import { mockIcrc7CanisterId, mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 import { nonNullish } from '@dfinity/utils';
 
 describe('icrc7-deep-link.services', () => {
 	const urlWithParams = ({
 		collection,
-		network
+		network,
+		nft
 	}: {
 		collection?: string;
 		network?: string;
+		nft?: string;
 	}): URL => {
 		const url = new URL('https://oisy.com/nfts/');
 
@@ -23,6 +27,10 @@ describe('icrc7-deep-link.services', () => {
 
 		if (nonNullish(network)) {
 			url.searchParams.set(NETWORK_PARAM, network);
+		}
+
+		if (nonNullish(nft)) {
+			url.searchParams.set(NFT_PARAM, nft);
 		}
 
 		return url;
@@ -66,6 +74,18 @@ describe('icrc7-deep-link.services', () => {
 			expect(
 				parseIcrc7CollectionDeepLink({
 					url: urlWithParams({ collection: mockIcrc7CanisterId, network: 'ETH' })
+				})
+			).toBeUndefined();
+		});
+
+		it('should return undefined when an NFT is selected', () => {
+			expect(
+				parseIcrc7CollectionDeepLink({
+					url: urlWithParams({
+						collection: mockIcrc7CanisterId,
+						network: 'ICP',
+						nft: '1'
+					})
 				})
 			).toBeUndefined();
 		});
@@ -114,6 +134,18 @@ describe('icrc7-deep-link.services', () => {
 				canisterId: mockIcrc7CanisterId,
 				networkId: ICP_NETWORK_ID
 			});
+		});
+
+		it.each([
+			{ name: 'EXT', token: { ...mockValidExtV2Token, enabled: true } },
+			{ name: 'IC Punks', token: { ...mockValidIcPunksToken, enabled: true } }
+		])('should return undefined for a known $name collection', ({ token }) => {
+			expect(
+				resolveIcrc7CollectionDeepLinkAction({
+					url: urlWithParams({ collection: token.canisterId, network: 'ICP' }),
+					tokens: [token]
+				})
+			).toBeUndefined();
 		});
 
 		it('should return undefined for invalid deep links', () => {


### PR DESCRIPTION
# Motivation

Clicking regular ICP NFT collections or NFT detail links can reuse the same `collection` and `network=ICP` query params as the ICRC-7 deep-link import flow. That caused the manage-token import modal to open for existing non-ICRC-7 collections.
