### PR TITLE
fix(frontend): treat all IC NFT collections as zero-fee in getTokenFee

### DIFF
--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -38,7 +38,7 @@
 
 <SendReview {amount} {destination} disabled={invalid} {nft} {onBack} {onSend} {selectedContact}>
 	{#snippet fee()}
-		{#if !$isIcMintingAccount}
+		{#if !$isIcMintingAccount && isNullish(nft)}
 			<IcTokenFee />
 		{/if}
 	{/snippet}

--- a/src/frontend/src/icp/components/send/IcSendReview.svelte
+++ b/src/frontend/src/icp/components/send/IcSendReview.svelte
@@ -38,7 +38,7 @@
 
 <SendReview {amount} {destination} disabled={invalid} {nft} {onBack} {onSend} {selectedContact}>
 	{#snippet fee()}
-		{#if !$isIcMintingAccount && isNullish(nft)}
+		{#if !$isIcMintingAccount}
 			<IcTokenFee />
 		{/if}
 	{/snippet}

--- a/src/frontend/src/icp/utils/token.utils.ts
+++ b/src/frontend/src/icp/utils/token.utils.ts
@@ -1,8 +1,8 @@
-import { isTokenExt } from '$icp/utils/ext.utils';
+import { isTokenIcNft } from '$icp/utils/ic-nft.utils';
 import { isTokenIc } from '$icp/utils/icrc.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import type { Token } from '$lib/types/token';
 
-// Tokens EXT have zero fee
+// IC NFT collections (EXT, DIP-721, IcPunks, ICRC-7) have zero transfer fee.
 export const getTokenFee = <T extends Token>(token: Partial<T>): bigint | undefined =>
-	isTokenExt(token) ? ZERO : isTokenIc(token) ? token.fee : undefined;
+	isTokenIcNft(token) ? ZERO : isTokenIc(token) ? token.fee : undefined;

--- a/src/frontend/src/tests/icp/components/send/IcSendReview.spec.ts
+++ b/src/frontend/src/tests/icp/components/send/IcSendReview.spec.ts
@@ -3,6 +3,7 @@ import IcSendReview from '$icp/components/send/IcSendReview.svelte';
 import { isIcMintingAccount } from '$icp/stores/ic-minting-account.store';
 import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
 import en from '$tests/mocks/i18n.mock';
+import { mockValidDip721Nft } from '$tests/mocks/nfts.mock';
 import { render } from '@testing-library/svelte';
 
 describe('IcSendReview', () => {
@@ -51,6 +52,15 @@ describe('IcSendReview', () => {
 
 		const { queryByText } = render(IcSendReview, {
 			props,
+			context: mockContext
+		});
+
+		expect(queryByText(en.fee.text.fee)).toBeNull();
+	});
+
+	it('should not render the fee row when sending an NFT', () => {
+		const { queryByText } = render(IcSendReview, {
+			props: { ...props, nft: mockValidDip721Nft },
 			context: mockContext
 		});
 

--- a/src/frontend/src/tests/icp/components/send/IcSendReview.spec.ts
+++ b/src/frontend/src/tests/icp/components/send/IcSendReview.spec.ts
@@ -2,6 +2,7 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import IcSendReview from '$icp/components/send/IcSendReview.svelte';
 import { isIcMintingAccount } from '$icp/stores/ic-minting-account.store';
 import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
+import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidDip721Nft } from '$tests/mocks/nfts.mock';
 import { render } from '@testing-library/svelte';
@@ -58,12 +59,22 @@ describe('IcSendReview', () => {
 		expect(queryByText(en.fee.text.fee)).toBeNull();
 	});
 
-	it('should not render the fee row when sending an NFT', () => {
-		const { queryByText } = render(IcSendReview, {
+	it('should render the fee row as zero when sending an NFT (collections have no transfer fee)', () => {
+		const nftContext = new Map([]);
+		nftContext.set(
+			SEND_CONTEXT_KEY,
+			initSendContext({
+				token: mockValidDip721Token
+			})
+		);
+
+		const { container, getByText } = render(IcSendReview, {
 			props: { ...props, nft: mockValidDip721Nft },
-			context: mockContext
+			context: nftContext
 		});
 
-		expect(queryByText(en.fee.text.fee)).toBeNull();
+		expect(getByText(en.fee.text.fee)).toBeInTheDocument();
+
+		expect(container).toHaveTextContent(`0 ${mockValidDip721Token.symbol}`);
 	});
 });

--- a/src/frontend/src/tests/icp/utils/token.utils.spec.ts
+++ b/src/frontend/src/tests/icp/utils/token.utils.spec.ts
@@ -6,8 +6,11 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { getTokenFee } from '$icp/utils/token.utils';
 import { ZERO } from '$lib/constants/app.constants';
+import { mockValidDip721Token } from '$tests/mocks/dip721-tokens.mock';
 import { mockValidExtV2Token } from '$tests/mocks/ext-tokens.mock';
 import { mockValidDip20Token, mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidIcPunksToken } from '$tests/mocks/icpunks-tokens.mock';
+import { mockValidIcrc7Token } from '$tests/mocks/icrc7-tokens.mock';
 
 describe('token.utils', () => {
 	describe('getTokenFee', () => {
@@ -23,8 +26,13 @@ describe('token.utils', () => {
 			expect(getTokenFee(mockValidDip20Token)).toBe(mockValidDip20Token.fee);
 		});
 
-		it('should return zero for EXT tokens', () => {
-			expect(getTokenFee(mockValidExtV2Token)).toBe(ZERO);
+		it.each([
+			{ label: 'EXT', token: mockValidExtV2Token },
+			{ label: 'DIP-721', token: mockValidDip721Token },
+			{ label: 'IcPunks', token: mockValidIcPunksToken },
+			{ label: 'ICRC-7', token: mockValidIcrc7Token }
+		])('should return zero for IC NFT collections ($label)', ({ token }) => {
+			expect(getTokenFee(token)).toBe(ZERO);
 		});
 
 		it('should return undefined for other token standards', () => {


### PR DESCRIPTION
# Motivation

When reviewing an NFT transfer on the Internet Computer (e.g. IC SPICY, an ICP NFT collection), the `Fee` row in the review modal showed a flickering skeleton loader for `Dip721` / `IcPunks` / `Icrc7` collections, and a layout-shifting "jump back" for `Ext` collections that already rendered `0 SYMBOL`.

Root cause is in the existing `getTokenFee` util:

```7:8:src/frontend/src/icp/utils/token.utils.ts
export const getTokenFee = <T extends Token>(token: Partial<T>): bigint | undefined =>
	isTokenIcNft(token) ? ZERO : isTokenIc(token) ? token.fee : undefined;
```

Previously the function only special-cased `isTokenExt`, which is just one of the four IC NFT standards. For `Dip721`, `IcPunks`, and `Icrc7`, neither `isTokenExt` nor `isTokenIc` matched, so the function returned `undefined`. `FeeDisplay` → `ConvertAmountDisplay` then rendered `SkeletonText` while waiting for a value that never arrived (the flicker), and `ConvertAmountExchange` toggled between a small skeleton and an empty cell as `amount` resolved (the "jump back" still visible on `Ext`).

OISY's `sendNft` service does not pass any `fee` argument to the underlying `transferDip721` / `transferIcPunks` / `transferIcrc7` / `transferExtV2` calls — IC NFT collection transfers are deterministically zero-fee. Hence the right model is "zero fee", not "unknown fee".

There is already an aggregate util `isTokenIcNft` in `src/frontend/src/icp/utils/ic-nft.utils.ts` that covers `Ext + Dip721 + IcPunks + Icrc7`. Reusing it is enough — no new abstractions, no new flags, no new prop on `IcSendReview`.
