### PR TITLE
refactor(frontend): introduce stake wizard registry

### DIFF
--- a/src/frontend/src/lib/components/stake/StakeWizard.svelte
+++ b/src/frontend/src/lib/components/stake/StakeWizard.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import type { WizardStep } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import HarvestStakeWizard from '$eth/components/stake/harvest-autopilot/HarvestStakeWizard.svelte';
-	import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import { getStakeWizardComponent } from '$lib/config/stake.config';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { Vault } from '$lib/types/vaults';
@@ -27,10 +26,14 @@
 		onNext,
 		onBack
 	}: Props = $props();
+
+	let WizardComponent = $derived(
+		nonNullish(vault) ? getStakeWizardComponent(vault.token) : undefined
+	);
 </script>
 
-{#if nonNullish(vault) && isTokenHarvestAutopilot(vault.token)}
-	<HarvestStakeWizard
+{#if nonNullish(WizardComponent) && nonNullish(vault)}
+	<WizardComponent
 		{currentStep}
 		{onBack}
 		{onClose}

--- a/src/frontend/src/lib/components/stake/UnstakeWizard.svelte
+++ b/src/frontend/src/lib/components/stake/UnstakeWizard.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import type { WizardStep } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
-	import HarvestUnstakeWizard from '$eth/components/stake/harvest-autopilot/HarvestUnstakeWizard.svelte';
-	import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import { getUnstakeWizardComponent } from '$lib/config/stake.config';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { Vault } from '$lib/types/vaults';
@@ -27,10 +26,14 @@
 		onNext,
 		onBack
 	}: Props = $props();
+
+	let WizardComponent = $derived(
+		nonNullish(vault) ? getUnstakeWizardComponent(vault.token) : undefined
+	);
 </script>
 
-{#if nonNullish(vault) && isTokenHarvestAutopilot(vault.token)}
-	<HarvestUnstakeWizard
+{#if nonNullish(WizardComponent) && nonNullish(vault)}
+	<WizardComponent
 		{currentStep}
 		{onBack}
 		{onClose}

--- a/src/frontend/src/lib/config/stake.config.ts
+++ b/src/frontend/src/lib/config/stake.config.ts
@@ -1,13 +1,17 @@
 import { goto } from '$app/navigation';
+import HarvestStakeWizard from '$eth/components/stake/harvest-autopilot/HarvestStakeWizard.svelte';
+import HarvestUnstakeWizard from '$eth/components/stake/harvest-autopilot/HarvestUnstakeWizard.svelte';
 import { HARVEST_AUTOPILOT_URL } from '$eth/constants/harvest-autopilots.constants';
+import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 import { AppPath } from '$lib/constants/routes.constants';
 import {
 	WizardStepsClaimStakingReward,
 	WizardStepsStake,
 	WizardStepsUnstake
 } from '$lib/enums/wizard-steps';
-import { StakeProvider, type StakeProviderConfig } from '$lib/types/stake';
+import { StakeProvider, type StakeProviderConfig, type StakeWizardEntry } from '$lib/types/stake';
 import type { WizardStepsParams } from '$lib/types/steps';
+import type { Token } from '$lib/types/token';
 import type { WizardSteps } from '@dfinity/gix-components';
 
 export const stakeWizardSteps = ({ i18n }: WizardStepsParams): WizardSteps<WizardStepsStake> => [
@@ -67,3 +71,21 @@ export const stakeProvidersConfig: Record<StakeProvider, StakeProviderConfig> = 
 		}
 	}
 };
+
+const stakeWizardRegistry: StakeWizardEntry[] = [
+	{
+		matches: isTokenHarvestAutopilot,
+		stakeComponent: HarvestStakeWizard,
+		unstakeComponent: HarvestUnstakeWizard
+	}
+];
+
+export const getStakeWizardComponent = (
+	token: Token
+): StakeWizardEntry['stakeComponent'] | undefined =>
+	stakeWizardRegistry.find(({ matches }) => matches(token))?.stakeComponent;
+
+export const getUnstakeWizardComponent = (
+	token: Token
+): StakeWizardEntry['unstakeComponent'] | undefined =>
+	stakeWizardRegistry.find(({ matches }) => matches(token))?.unstakeComponent;

--- a/src/frontend/src/lib/types/stake.ts
+++ b/src/frontend/src/lib/types/stake.ts
@@ -1,6 +1,9 @@
 import type { EarningCardData } from '$lib/types/earning';
-import type { Amount } from '$lib/types/send';
+import type { Amount, OptionAmount } from '$lib/types/send';
 import type { Token } from '$lib/types/token';
+import type { Vault } from '$lib/types/vaults';
+import type { WizardStep } from '@dfinity/gix-components';
+import type { Component } from 'svelte';
 
 export enum StakeProvider {
 	HARVEST_AUTOPILOTS = 'harvest_autopilots'
@@ -17,4 +20,27 @@ export interface StakeProviderConfig {
 	logo: string;
 	url: string;
 	card: EarningCardData;
+}
+
+interface StakeWizardBaseProps {
+	amount: OptionAmount;
+	vault: Vault;
+	currentStep?: WizardStep;
+	onClose: () => void;
+	onNext: () => void;
+	onBack: () => void;
+}
+
+export interface StakeWizardComponentProps extends StakeWizardBaseProps {
+	stakeProgressStep: string;
+}
+
+export interface UnstakeWizardComponentProps extends StakeWizardBaseProps {
+	unstakeProgressStep: string;
+}
+
+export interface StakeWizardEntry {
+	matches: (token: Token) => boolean;
+	stakeComponent: Component<StakeWizardComponentProps>;
+	unstakeComponent: Component<UnstakeWizardComponentProps>;
 }


### PR DESCRIPTION
# Motivation

`StakeWizard.svelte` and `UnstakeWizard.svelte` hard-code the `isTokenHarvestAutopilot(...)` check, so every new stake provider has to be wired into both components by hand. The check belongs in config, not in the wizard shells.

# Changes

- Add `StakeWizardEntry`, `StakeWizardComponentProps` and `UnstakeWizardComponentProps` to `lib/types/stake.ts`.
- Add `stakeWizardRegistry`, `getStakeWizardComponent` and `getUnstakeWizardComponent` to `lib/config/stake.config.ts`.
- Replace the inline branch in `StakeWizard.svelte` and `UnstakeWizard.svelte` with the registry lookup.

# Tests

Existing tests suffice.
