### PR TITLE
feat(frontend): restore two-row NFT name and id in NftCard

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftCard.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { goto } from '$app/navigation';
 	import { isCollectionErc1155 } from '$eth/utils/erc1155.utils';
 	import IconAlertOctagon from '$lib/components/icons/lucide/IconAlertOctagon.svelte';
@@ -19,7 +19,7 @@
 	import { trackEvent } from '$lib/services/analytics.services';
 	import type { Nft } from '$lib/types/nft';
 	import { nftsUrl } from '$lib/utils/nav.utils';
-	import { getNftDisplayId, getNftDisplayImageUrl, getNftDisplayName } from '$lib/utils/nft.utils';
+	import { getNftDisplayId, getNftDisplayImageUrl } from '$lib/utils/nft.utils';
 
 	interface Props {
 		nft: Nft;
@@ -44,8 +44,6 @@
 		source = 'default',
 		withCollectionLabel = false
 	}: Props = $props();
-
-	const nftDisplayName = $derived(getNftDisplayName(nft));
 
 	const onClick = () => {
 		if (type === 'card-selectable' && nonNullish(onSelect) && !disabled) {
@@ -136,12 +134,13 @@
 
 	<span class="flex w-full flex-col gap-1 px-2 pb-2" class:text-disabled={disabled}>
 		<span class="truncate text-sm font-bold" class:text-primary={!disabled}>
-			{withCollectionLabel ? nft.collection.name : nftDisplayName}
+			{withCollectionLabel || isNullish(nft.name) ? nft.collection.name : nft.name}
 		</span>
-		{#if withCollectionLabel}
-			<span class="truncate text-xs" class:text-tertiary={!disabled}>
-				{nonNullish(nft.name) ? nftDisplayName : `#${getNftDisplayId(nft)}`}
-			</span>
-		{/if}
+		<span class="truncate text-xs" class:text-tertiary={!disabled}>
+			#{getNftDisplayId(nft)}
+			{#if withCollectionLabel && nonNullish(nft.name)}
+				&ndash; {nft.name}
+			{/if}
+		</span>
 	</span>
 </button>

--- a/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftCard.spec.ts
@@ -7,7 +7,6 @@ import {
 	PLAUSIBLE_EVENT_VALUES
 } from '$lib/enums/plausible';
 import { trackEvent } from '$lib/services/analytics.services';
-import { getNftDisplayName } from '$lib/utils/nft.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
 import { mockValidErc1155Nft, mockValidErc721Nft } from '$tests/mocks/nfts.mock';
 import { assertNonNullish } from '@dfinity/utils';
@@ -56,7 +55,8 @@ describe('NftCard', () => {
 
 		assertNonNullish(mockValidErc1155Nft?.name);
 
-		expect(getByText(getNftDisplayName(mockValidErc1155Nft))).toBeInTheDocument();
+		expect(getByText(mockValidErc1155Nft.name)).toBeInTheDocument();
+		expect(getByText(`#${mockValidErc1155Nft.id}`)).toBeInTheDocument();
 	});
 
 	it('should render image placeholder if no image is defined', () => {
@@ -80,7 +80,7 @@ describe('NftCard', () => {
 		assertNonNullish(mockValidErc721Nft.name);
 		assertNonNullish(mockValidErc721Nft.collection.name);
 
-		expect(getByText(getNftDisplayName(mockValidErc721Nft))).toBeInTheDocument();
+		expect(getByText(`#${mockValidErc721Nft.id}`)).toBeInTheDocument();
 	});
 
 	it('should render the correct styles for each type', async () => {
@@ -222,29 +222,15 @@ describe('NftCard', () => {
 		assertNonNullish(mockValidErc721Nft.name);
 		assertNonNullish(mockValidErc721Nft.collection.name);
 
-		// Should show the canonical NFT display name as the main label
-		expect(getByText(getNftDisplayName(mockValidErc721Nft))).toBeInTheDocument();
+		// Should show nft.name as the main label
+		expect(getByText(mockValidErc721Nft.name)).toBeInTheDocument();
 
 		// Should NOT show collection name in title
 		expect(queryByText(mockValidErc721Nft.collection.name)).toBeNull();
-	});
 
-	it('should not duplicate the NFT id when the name already includes it', () => {
-		const nft = {
-			...mockValidErc721Nft,
-			name: `${mockValidErc721Nft.name} #${mockValidErc721Nft.id}`
-		};
-
-		const { getByText, queryByText } = render(NftCard, {
-			props: {
-				nft,
-				testId,
-				type: 'card-link'
-			}
-		});
-
-		expect(getByText(nft.name)).toBeInTheDocument();
-		expect(queryByText(`${nft.name} #${nft.id}`)).not.toBeInTheDocument();
+		// Subtitle should just be the id
+		expect(getByText(`#${mockValidErc721Nft.id}`)).toBeInTheDocument();
+		expect(queryByText(`#${mockValidErc721Nft.id} – ${mockValidErc721Nft.name}`)).toBeNull();
 	});
 
 	it('should render collection name and nft name when withCollectionLabel is true', () => {
@@ -263,8 +249,8 @@ describe('NftCard', () => {
 		// Should show collection name instead of nft name as title
 		expect(getByText(mockValidErc721Nft.collection.name)).toBeInTheDocument();
 
-		// Subtitle should show the canonical NFT display name
-		expect(getByText(getNftDisplayName(mockValidErc721Nft))).toBeInTheDocument();
+		// Subtitle should show both id and nft name
+		expect(getByText(`#${mockValidErc721Nft.id} – ${mockValidErc721Nft.name}`)).toBeInTheDocument();
 	});
 
 	it('should render first the OISY NFT ID', () => {
@@ -279,8 +265,6 @@ describe('NftCard', () => {
 			}
 		});
 
-		expect(
-			getByText(getNftDisplayName({ ...mockValidErc721Nft, oisyId: mockOisyId }))
-		).toBeInTheDocument();
+		expect(getByText(`#${mockOisyId} – ${mockValidErc721Nft.name}`)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/send/SendNftsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendNftsList.spec.ts
@@ -2,7 +2,6 @@ import { POLYGON_AMOY_NETWORK } from '$env/networks/networks-evm/networks.evm.po
 import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import { i18n } from '$lib/stores/i18n.store';
 import { nftStore } from '$lib/stores/nft.store';
-import { getNftDisplayName } from '$lib/utils/nft.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
 import SendNftsListTestHost from '$tests/lib/components/send/SendNftsListTestHost.svelte';
 import { mockValidErc1155Nft } from '$tests/mocks/nfts.mock';
@@ -29,7 +28,7 @@ describe('SendNftsList.spec', () => {
 		});
 
 		for (const nft of mockNfts) {
-			expect(getByText(getNftDisplayName(nft))).toBeInTheDocument();
+			expect(getByText(`#${nft.id} – ${nft.name}`)).toBeInTheDocument();
 		}
 
 		const networkBtn = getByRole('button', { name: get(i18n).networks.chain_fusion });
@@ -49,9 +48,9 @@ describe('SendNftsList.spec', () => {
 
 		await fireEvent.input(input, { target: { value: 'ein' } });
 
-		expect(queryByText(getNftDisplayName(mockNfts[0]))).not.toBeInTheDocument();
-		expect(getByText(getNftDisplayName(mockNfts[1]))).toBeInTheDocument();
-		expect(queryByText(getNftDisplayName(mockNfts[2]))).not.toBeInTheDocument();
+		expect(queryByText('#0 – Null')).not.toBeInTheDocument();
+		expect(getByText(`#1 – Eins`)).toBeInTheDocument();
+		expect(queryByText('#2 – Zwei')).not.toBeInTheDocument();
 	});
 
 	it('shows empty-state when no matches', async () => {
@@ -100,7 +99,7 @@ describe('SendNftsList.spec', () => {
 			onSelectNetwork: vi.fn()
 		});
 
-		const nftCard = getByText(getNftDisplayName(mockNfts[1]));
+		const nftCard = getByText('#1 – Eins');
 
 		await fireEvent.click(nftCard);
 


### PR DESCRIPTION
# Motivation

PR #12919 (`fix(frontend): use NFT display names consistently`) changed the NFT collection card to show the NFT name and its `#<id>` together on a single line (via `getNftDisplayName`). On the collection page this makes the entry feel cluttered. The team prefers the previous layout, where the NFT name lives on the first row and the `#<id>` lives on its own second row below it.

This PR reverts that change for `NftCard.svelte` only, restoring the original two-row display. Other surfaces touched by #12919 (`NftLogo`, `SendNftReview`) are intentionally left alone, since the complaint is specific to the collection cards.
