### PR TITLE
fix(frontend): tolerate partial failures in backend exchange worker

### DIFF
--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -167,10 +167,25 @@ const syncExchangeFromBackend = async ({
 		};
 	}
 
-	const [currentExchangeRate, backendPrices] = await Promise.all([
+	const [currentExchangeRateResult, backendPricesResult] = await Promise.allSettled([
 		exchangeRateUsdToCurrency(currentCurrency),
 		fetchExchangeRatesFromBackend({ identity })
 	]);
+
+	if (currentExchangeRateResult.status === 'rejected') {
+		consoleError('Error while fetching exchange rate:', currentExchangeRateResult.reason);
+	}
+
+	if (backendPricesResult.status === 'rejected') {
+		consoleError(
+			'Error while fetching exchange rate:',
+			'Failed to fetch backend exchange rates:',
+			backendPricesResult.reason
+		);
+	}
+
+	const currentExchangeRate =
+		currentExchangeRateResult.status === 'fulfilled' ? currentExchangeRateResult.value : undefined;
 
 	const {
 		currentEthPrice,
@@ -184,7 +199,21 @@ const syncExchangeFromBackend = async ({
 		currentErc20Prices,
 		currentIcrcPrices,
 		currentSplPrices
-	} = backendPrices;
+	} = backendPricesResult.status === 'fulfilled'
+		? backendPricesResult.value
+		: {
+				currentEthPrice: undefined,
+				currentBtcPrice: undefined,
+				currentIcpPrice: undefined,
+				currentSolPrice: undefined,
+				currentBnbPrice: undefined,
+				currentPolPrice: undefined,
+				currentArbitrumEthPrice: undefined,
+				currentBaseEthPrice: undefined,
+				currentErc20Prices: {},
+				currentIcrcPrices: {},
+				currentSplPrices: {}
+			};
 
 	const currentErc4626Prices = await calculateErc4626Prices({
 		erc20Prices: currentErc20Prices,

--- a/src/frontend/src/lib/workers/exchange.worker.ts
+++ b/src/frontend/src/lib/workers/exchange.worker.ts
@@ -199,21 +199,22 @@ const syncExchangeFromBackend = async ({
 		currentErc20Prices,
 		currentIcrcPrices,
 		currentSplPrices
-	} = backendPricesResult.status === 'fulfilled'
-		? backendPricesResult.value
-		: {
-				currentEthPrice: undefined,
-				currentBtcPrice: undefined,
-				currentIcpPrice: undefined,
-				currentSolPrice: undefined,
-				currentBnbPrice: undefined,
-				currentPolPrice: undefined,
-				currentArbitrumEthPrice: undefined,
-				currentBaseEthPrice: undefined,
-				currentErc20Prices: {},
-				currentIcrcPrices: {},
-				currentSplPrices: {}
-			};
+	} =
+		backendPricesResult.status === 'fulfilled'
+			? backendPricesResult.value
+			: {
+					currentEthPrice: undefined,
+					currentBtcPrice: undefined,
+					currentIcpPrice: undefined,
+					currentSolPrice: undefined,
+					currentBnbPrice: undefined,
+					currentPolPrice: undefined,
+					currentArbitrumEthPrice: undefined,
+					currentBaseEthPrice: undefined,
+					currentErc20Prices: {},
+					currentIcrcPrices: {},
+					currentSplPrices: {}
+				};
 
 	const currentErc4626Prices = await calculateErc4626Prices({
 		erc20Prices: currentErc20Prices,

--- a/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
+++ b/src/frontend/src/tests/lib/workers/exchange.worker.spec.ts
@@ -1348,9 +1348,96 @@ describe('exchange.worker', () => {
 				});
 			});
 
-			it('should post syncExchangeError when backend call fails', async () => {
+			it('should still post a sync success message when only the FX call fails', async () => {
+				vi.mocked(simplePrice).mockRejectedValueOnce(new Error('Coingecko unavailable'));
+				vi.mocked(getExchangeRates).mockResolvedValue(
+					mockMyRates([{ EvmNative: 1n } as TokenId, mockExchangeRate])
+				);
+				vi.mocked(calculateErc4626Prices).mockResolvedValue({});
+
+				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
+					...createEvent(msg),
+					data: {
+						msg,
+						data: {
+							currentCurrency: Currency.EUR,
+							erc20Addresses: [],
+							icrcCanisterIds: [],
+							splAddresses: [],
+							erc4626TokensExchangeData: []
+						}
+					}
+				};
+
+				await onExchangeMessage(mockEvent);
+
+				expect(postMessageMock).toHaveBeenCalledExactlyOnceWith({
+					msg: 'syncExchange',
+					data: expect.objectContaining({
+						currentExchangeRate: {
+							exchangeRateToUsd: null,
+							exchangeRate24hChangeMultiplier: null,
+							currency: Currency.EUR
+						},
+						currentEthPrice: {
+							ethereum: {
+								usd: 42000,
+								usd_24h_change: 1.5,
+								usd_market_cap: 800_000_000_000,
+								last_updated_at: 1000
+							}
+						}
+					})
+				});
+			});
+
+			it('should still post a sync success message when only the backend call fails', async () => {
 				vi.mocked(getExchangeRates).mockRejectedValue(new Error('Backend unavailable'));
 				vi.mocked(calculateErc4626Prices).mockResolvedValue({});
+
+				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
+					...createEvent(msg),
+					data: {
+						msg,
+						data: {
+							currentCurrency: Currency.USD,
+							erc20Addresses: [],
+							icrcCanisterIds: [],
+							splAddresses: [],
+							erc4626TokensExchangeData: []
+						}
+					}
+				};
+
+				await onExchangeMessage(mockEvent);
+
+				expect(postMessageMock).toHaveBeenCalledExactlyOnceWith({
+					msg: 'syncExchange',
+					data: {
+						currentExchangeRate: {
+							exchangeRateToUsd: 1,
+							exchangeRate24hChangeMultiplier: 1,
+							currency: Currency.USD
+						},
+						currentEthPrice: undefined,
+						currentBtcPrice: undefined,
+						currentErc20Prices: {},
+						currentIcpPrice: undefined,
+						currentIcrcPrices: {},
+						currentSolPrice: undefined,
+						currentSplPrices: {},
+						currentErc4626Prices: {},
+						currentBnbPrice: undefined,
+						currentPolPrice: undefined,
+						currentArbitrumEthPrice: undefined,
+						currentBaseEthPrice: undefined
+					}
+				});
+			});
+
+			it('should post syncExchangeError only when an unexpected error occurs', async () => {
+				vi.mocked(getExchangeRates).mockResolvedValue([]);
+				vi.mocked(calculateErc4626Prices).mockRejectedValue(new Error('Unexpected'));
 
 				const mockEvent: MessageEvent<PostMessage<PostMessageDataRequestExchangeTimer>> = {
 					...createEvent(msg),


### PR DESCRIPTION
## Motivation

Reported by Stefan on staging: token balances load, but USD values are stuck on skeleton placeholders for over a minute. The previous worker fix (#12884) addressed restart-during-sync, but a different failure mode was still present.

`syncExchangeFromBackend` ran the FX-rate CoinGecko call and the backend `get_exchange_rates` update under `Promise.all`. A single rejection — typically a transient CoinGecko blip on the FX cross-rate for non-USD currencies — threw out of the whole function, so the worker posted `syncExchangeError`, the `exchangeStore` stayed `undefined`, and `$exchangeNotInitialized` kept the skeletons visible for every token until CoinGecko recovered. The provider branch (`syncExchangeFromProviders`) already uses `Promise.allSettled` and was unaffected.

## Changes

- Use `Promise.allSettled` in `syncExchangeFromBackend`, log each rejection via `consoleError`, and fall back to `undefined` / empty maps so a usable `syncExchange` payload is always posted.

## Tests

- Replaced the (now-stale) "fail when backend errors" test with three covering the new behaviour: FX-only failure, backend-only failure, and unexpected error in downstream processing (still surfaces `syncExchangeError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
