### PR TITLE
feat(frontend): enable only specific IC tokens for 1Sec swaps

### DIFF
--- a/src/frontend/src/lib/utils/onesec-swap.utils.ts
+++ b/src/frontend/src/lib/utils/onesec-swap.utils.ts
@@ -25,6 +25,12 @@ const buildIcpLedgerMap = (): Record<string, IcpLedgerEntry> =>
 
 export const ICP_LEDGER_TO_TOKEN = buildIcpLedgerMap();
 
+const ONESEC_ENABLED_ICP_TOKEN_SYMBOLS: ReadonlySet<Token> = new Set<Token>([
+	'USDC',
+	'USDT',
+	'cbBTC'
+]);
+
 export const computeReceiveAmount = ({
 	amount,
 	transferFeeInUnits,
@@ -61,7 +67,13 @@ const getEvmAddressForNetwork = ({
  * Returns ICP ledger canister IDs of tokens supported by OneSec on the ICP side.
  */
 export const oneSecIcpSupportedTokens = (): Promise<Set<string>> =>
-	Promise.resolve(new Set(Object.keys(ICP_LEDGER_TO_TOKEN)));
+	Promise.resolve(
+		new Set(
+			Object.entries(ICP_LEDGER_TO_TOKEN)
+				.filter(([, { token }]) => ONESEC_ENABLED_ICP_TOKEN_SYMBOLS.has(token))
+				.map(([ledger]) => ledger)
+		)
+	);
 
 /**
  * Returns ERC20 addresses (lowercased) of tokens supported by OneSec on the given EVM networks.

--- a/src/frontend/src/tests/lib/utils/onesec-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/onesec-swap.utils.spec.ts
@@ -18,6 +18,7 @@ import { mockValidToken } from '$tests/mocks/tokens.mock';
 // Real values from onesec-bridge DEFAULT_CONFIG
 const USDC_LEDGER = '53nhb-haaaa-aaaar-qbn5q-cai';
 const USDT_LEDGER = 'ij33n-oiaaa-aaaar-qbooa-cai';
+const CBBTC_LEDGER = 'io25z-dqaaa-aaaar-qbooq-cai';
 const ICP_LEDGER = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
 const USDC_ETHEREUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const USDC_ARBITRUM = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
@@ -144,12 +145,16 @@ describe('onesec-swap.utils', () => {
 	});
 
 	describe('oneSecIcpSupportedTokens', () => {
-		it('returns a Set containing all known ICP ledger canister IDs', async () => {
+		it('returns ledger canister IDs only for USDC, USDT and cbBTC', async () => {
 			const result = await oneSecIcpSupportedTokens();
 
-			expect(result).toContain(USDC_LEDGER);
-			expect(result).toContain(USDT_LEDGER);
-			expect(result).toContain(ICP_LEDGER);
+			expect(result).toEqual(new Set([USDC_LEDGER, USDT_LEDGER, CBBTC_LEDGER]));
+		});
+
+		it('excludes ICP and other tokens not in the enabled set', async () => {
+			const result = await oneSecIcpSupportedTokens();
+
+			expect(result.has(ICP_LEDGER)).toBeFalsy();
 		});
 
 		it('contains no empty strings', async () => {


### PR DESCRIPTION
# Motivation

We also want to only allow specific IC tokens for 1Sec swaps.
