### PR TITLE
feat(frontend): track token standard, name and symbol in manage events

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"7f1d6eca-f677-4347-94d4-346a87ed4bd3","pid":83961,"procStart":"Tue May 26 12:14:17 2026","acquiredAt":1779807260670}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"7f1d6eca-f677-4347-94d4-346a87ed4bd3","pid":83961,"procStart":"Tue May 26 12:14:17 2026","acquiredAt":1779807260670}

--- a/src/frontend/src/eth/components/tokens/EthHideTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/EthHideTokenModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { assertNonNullish } from '@dfinity/utils';
+	import { assertNonNullish, nonNullish } from '@dfinity/utils';
 	import type { Identity } from '@icp-sdk/core/agent';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { onMount } from 'svelte';
@@ -49,8 +49,10 @@
 			metadata: {
 				tokenId: `${selectedToken.id.description}`,
 				tokenSymbol: selectedToken.symbol,
-				tokenName: selectedToken.name,
-				tokenStandard: selectedToken.standard.code,
+				...(nonNullish(selectedToken.name) && { tokenName: selectedToken.name }),
+				...(nonNullish(selectedToken.standard) && {
+					tokenStandard: selectedToken.standard.code
+				}),
 				address: selectedToken.address,
 				networkId: `${selectedToken.network.id.description}`,
 				source: HIDE_TOKEN_MODAL_ROUTE

--- a/src/frontend/src/eth/components/tokens/EthHideTokenModal.svelte
+++ b/src/frontend/src/eth/components/tokens/EthHideTokenModal.svelte
@@ -49,6 +49,8 @@
 			metadata: {
 				tokenId: `${selectedToken.id.description}`,
 				tokenSymbol: selectedToken.symbol,
+				tokenName: selectedToken.name,
+				tokenStandard: selectedToken.standard.code,
 				address: selectedToken.address,
 				networkId: `${selectedToken.network.id.description}`,
 				source: HIDE_TOKEN_MODAL_ROUTE

--- a/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
+++ b/src/frontend/src/icp/components/tokens/IcHideTokenModal.svelte
@@ -54,6 +54,11 @@
 			metadata: {
 				ledgerCanisterId,
 				indexCanisterId: `${indexCanisterId}`,
+				...(nonNullish(selectedToken?.symbol) && { tokenSymbol: selectedToken.symbol }),
+				...(nonNullish(selectedToken?.name) && { tokenName: selectedToken.name }),
+				...(nonNullish(selectedToken?.standard) && {
+					tokenStandard: selectedToken.standard.code
+				}),
 				networkId: 'ICP',
 				source: HIDE_TOKEN_MODAL_ROUTE
 			}

--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -146,6 +146,7 @@ const mapTokenManageToken = <T extends SaveTokensToken>({
 	return {
 		network: tokenNetwork,
 		address,
+		...('standard' in token && nonNullish(token.standard) && { standard: token.standard.code }),
 		...('symbol' in token && nonNullish(token.symbol) && { symbol: token.symbol }),
 		...('name' in token && nonNullish(token.name) && { name: token.name })
 	};
@@ -252,6 +253,9 @@ export const saveTokens = async <
 			const indexCanisterId = 'indexCanisterId' in token ? token.indexCanisterId : undefined;
 			const tokenId = 'id' in token ? token.id : undefined;
 			const tokenSymbol = 'symbol' in token ? token.symbol : undefined;
+			const tokenName = 'name' in token ? token.name : undefined;
+			const tokenStandard =
+				'standard' in token && nonNullish(token.standard) ? token.standard.code : undefined;
 			const network = 'network' in token ? token.network : undefined;
 
 			trackEvent({
@@ -264,6 +268,8 @@ export const saveTokens = async <
 					...(nonNullish(indexCanisterId) && { indexCanisterId }),
 					...(nonNullish(tokenId) && { tokenId: `${tokenId.description}` }),
 					...(nonNullish(tokenSymbol) && { tokenSymbol }),
+					...(nonNullish(tokenName) && { tokenName }),
+					...(nonNullish(tokenStandard) && { tokenStandard }),
 					...(nonNullish(network) && { networkId: `${network.id.description}` }),
 					...{ source: MANAGE_TOKENS_MODAL_ROUTE }
 				}

--- a/src/frontend/src/lib/services/token-manage-analytics.services.ts
+++ b/src/frontend/src/lib/services/token-manage-analytics.services.ts
@@ -17,6 +17,7 @@ export type TokenManageSourceLocation =
 export interface TokenManageEventToken {
 	network: string;
 	address: string;
+	standard?: string;
 	symbol?: string;
 	name?: string;
 }
@@ -50,6 +51,7 @@ export const trackTokenManage = ({
 			...(nonNullish(value) && { event_value: value }),
 			token_network: token.network,
 			token_address: token.address,
+			...(nonNullish(token.standard) && { token_standard: token.standard }),
 			...(nonNullish(token.symbol) && { token_symbol: token.symbol }),
 			...(nonNullish(token.name) && { token_name: token.name }),
 			source_location: sourceLocation,

--- a/src/frontend/src/sol/components/tokens/SolHideTokenModal.svelte
+++ b/src/frontend/src/sol/components/tokens/SolHideTokenModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { assertNonNullish } from '@dfinity/utils';
+	import { assertNonNullish, nonNullish } from '@dfinity/utils';
 	import type { Identity } from '@icp-sdk/core/agent';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { onMount } from 'svelte';
@@ -49,8 +49,10 @@
 			metadata: {
 				tokenId: `${selectedToken.id.description}`,
 				tokenSymbol: selectedToken.symbol,
-				tokenName: selectedToken.name,
-				tokenStandard: selectedToken.standard.code,
+				...(nonNullish(selectedToken.name) && { tokenName: selectedToken.name }),
+				...(nonNullish(selectedToken.standard) && {
+					tokenStandard: selectedToken.standard.code
+				}),
 				address: selectedToken.address,
 				networkId: `${selectedToken.network.id.description}`,
 				source: HIDE_TOKEN_MODAL_ROUTE

--- a/src/frontend/src/sol/components/tokens/SolHideTokenModal.svelte
+++ b/src/frontend/src/sol/components/tokens/SolHideTokenModal.svelte
@@ -49,6 +49,8 @@
 			metadata: {
 				tokenId: `${selectedToken.id.description}`,
 				tokenSymbol: selectedToken.symbol,
+				tokenName: selectedToken.name,
+				tokenStandard: selectedToken.standard.code,
 				address: selectedToken.address,
 				networkId: `${selectedToken.network.id.description}`,
 				source: HIDE_TOKEN_MODAL_ROUTE

--- a/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/manage-tokens.services.spec.ts
@@ -114,6 +114,8 @@ describe('manage-tokens.services', () => {
 						indexCanisterId: 'indexCanisterId' in token ? token.indexCanisterId : undefined,
 						tokenId: token.id?.description,
 						tokenSymbol: token.symbol,
+						tokenName: token.name,
+						tokenStandard: token.standard.code,
 						networkId: token.network?.id.description,
 						source: MANAGE_TOKENS_MODAL_ROUTE
 					}
@@ -129,6 +131,7 @@ describe('manage-tokens.services', () => {
 								: 'ledgerCanisterId' in token
 									? token.ledgerCanisterId
 									: token.id.description,
+						standard: token.standard.code,
 						symbol: token.symbol,
 						name: token.name
 					},
@@ -235,6 +238,7 @@ describe('manage-tokens.services', () => {
 								: 'ledgerCanisterId' in token
 									? token.ledgerCanisterId
 									: token.id.description,
+						standard: token.standard.code,
 						symbol: token.symbol,
 						name: token.name
 					},
@@ -277,6 +281,7 @@ describe('manage-tokens.services', () => {
 								: 'ledgerCanisterId' in token
 									? token.ledgerCanisterId
 									: token.id.description,
+						standard: token.standard.code,
 						symbol: token.symbol,
 						name: token.name
 					},

--- a/src/frontend/src/tests/lib/services/token-manage-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/token-manage-analytics.services.spec.ts
@@ -23,6 +23,7 @@ describe('token-manage-analytics.services', () => {
 				token: {
 					network: 'ICP',
 					address: 'sey3i-jyaaa-aaaap-quo3q-cai',
+					standard: 'icrc7',
 					symbol: 'CCC',
 					name: 'CCC NFT Platform'
 				}
@@ -34,6 +35,7 @@ describe('token-manage-analytics.services', () => {
 					event_modifier: 'import',
 					token_network: 'ICP',
 					token_address: 'sey3i-jyaaa-aaaap-quo3q-cai',
+					token_standard: 'icrc7',
 					token_symbol: 'CCC',
 					token_name: 'CCC NFT Platform',
 					source_location: 'manage_tokens',


### PR DESCRIPTION
# Motivation

The token manage analytics events (enable / disable / import / hide) currently don't carry the token's `standard`, and miss `name` (and in one path `symbol`). This makes the data hard to read — particularly for NFTs, where the collection name and standard (`erc721`, `erc1155`, `icrc7`, …) are the primary identifiers.

# Changes

- `token-manage-analytics.services.ts`: added optional `standard` to `TokenManageEventToken` and emit `token_standard` in the Plausible `token_manage` event.
- `manage-tokens.services.ts`:
  - `mapTokenManageToken` now picks `standard.code` alongside `symbol` / `name`.
  - Legacy `manage_tokens_enable_success` / `manage_tokens_disable_success` trackEvent now includes `tokenName` and `tokenStandard`.
- `EthHideTokenModal.svelte`, `SolHideTokenModal.svelte`: add `tokenName` and `tokenStandard` to disable trackEvent metadata.
- `IcHideTokenModal.svelte`: add `tokenSymbol` (previously missing), `tokenName` and `tokenStandard`.

# Tests

Updated `manage-tokens.services.spec.ts` and `token-manage-analytics.services.spec.ts` to assert the new fields.

