### PR TITLE
perf(backend): parallelize exchange-rate HTTP outcalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "canbench-rs",
  "candid",
  "candid_parser",
+ "futures",
  "getrandom 0.2.17",
  "hex",
  "ic-canister-sig-creation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ pocket-ic = "13.0.0"
 pretty_assertions = "1.4"
 bitcoin = "0.32"
 paste = "1.0"
+# Used for `futures::future::join_all` to run independent HTTP outcalls in
+# parallel (e.g. exchange price providers). Already a transitive dep via the
+# ic-cdk stack; this declaration just makes it directly available to our crates.
+futures = "0.3"
 
 [workspace.lints.rust]
 deprecated = "allow" # Why is this allowed?

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 bitcoin = { workspace = true }
 canbench-rs = { workspace = true, optional = true }
 candid = { workspace = true }
+futures = { workspace = true }
 getrandom = { workspace = true }
 hex = { workspace = true }
 ic-canister-sig-creation = { workspace = true }

--- a/src/backend/src/exchange/providers/coingecko/mod.rs
+++ b/src/backend/src/exchange/providers/coingecko/mod.rs
@@ -129,20 +129,24 @@ fn classify_tokens<'a>(token_ids: &'a [StoredTokenId]) -> ClassifiedTokens<'a> {
     }
 }
 
-/// One unit of work for the parallel fan-out: either the single batched
-/// native-coin call, or a per-platform chunk of token contract addresses.
-///
-/// We materialise this as an enum (rather than two separate `join_all`
-/// passes) so all outcalls run as one wave: the native-coin call has no
-/// reason to block the per-platform calls and vice-versa.
-enum FetchUnit<'a> {
-    Native {
-        coin_ids: Vec<&'a str>,
-    },
+/// Input to one parallel fan-out branch: the native-coin batch carries the
+/// list of coin IDs to fetch; the per-chunk branch carries the platform name
+/// and an address slice.
+enum FetchInput<'a> {
+    Native(Vec<&'a str>),
     Chunk {
         platform: &'a str,
         addresses: &'a [String],
     },
+}
+
+/// Lightweight tag returned alongside each outcome so the post-`join_all`
+/// loop knows how to interpret the result. `Chunk` re-borrows the platform
+/// name (the original lives in `contract_platforms`, which outlives the
+/// futures) so we don't need to clone strings.
+enum FetchTag<'a> {
+    Native,
+    Chunk(&'a str),
 }
 
 impl ExchangePriceProvider for CoinGeckoProvider {
@@ -156,58 +160,49 @@ impl ExchangePriceProvider for CoinGeckoProvider {
             address_to_token_id,
         } = classify_tokens(token_ids);
 
-        // Collect all the independent HTTP outcalls into a single set of
-        // futures so they can be issued concurrently.
-        //
-        // On the IC each outcall goes through consensus independently, so
-        // sequentialising the loop (the prior shape) added up to multi-second
-        // wall-time penalties for users with tokens spread across several
-        // chains. `join_all` polls each future together, so the total wait is
-        // the slowest single outcall instead of the sum of all of them.
-        let mut units: Vec<FetchUnit<'_>> = Vec::new();
+        // Issue all independent HTTP outcalls concurrently. On the IC each
+        // outcall goes through consensus independently, so the prior
+        // sequential loop added up to multi-second wall-time penalties for
+        // users with tokens spread across several chains. `join_all` polls
+        // each future together, so the total wait is the slowest single
+        // outcall instead of the sum of all of them.
+        let mut inputs: Vec<FetchInput<'_>> = Vec::new();
 
         if !native_coins.is_empty() {
-            units.push(FetchUnit::Native {
-                coin_ids: native_coins.keys().copied().collect(),
-            });
+            inputs.push(FetchInput::Native(native_coins.keys().copied().collect()));
         }
 
         for (platform, addresses) in &contract_platforms {
             for chunk in addresses.chunks(CHUNK_SIZE) {
-                units.push(FetchUnit::Chunk {
+                inputs.push(FetchInput::Chunk {
                     platform: platform.as_str(),
                     addresses: chunk,
                 });
             }
         }
 
-        let outcomes = join_all(units.into_iter().map(|unit| async move {
-            match unit {
-                FetchUnit::Native { coin_ids } => (
-                    FetchUnit::Native {
-                        coin_ids: coin_ids.clone(),
-                    },
-                    self.client.fetch_coin_prices(&coin_ids).await,
-                ),
-                FetchUnit::Chunk {
+        let outcomes = join_all(inputs.into_iter().map(|input| async move {
+            match input {
+                FetchInput::Native(coin_ids) => {
+                    let outcome = self.client.fetch_coin_prices(&coin_ids).await;
+                    (FetchTag::Native, outcome)
+                }
+                FetchInput::Chunk {
                     platform,
                     addresses,
-                } => (
-                    FetchUnit::Chunk {
-                        platform,
-                        addresses,
-                    },
-                    self.client.fetch_token_prices(platform, addresses).await,
-                ),
+                } => {
+                    let outcome = self.client.fetch_token_prices(platform, addresses).await;
+                    (FetchTag::Chunk(platform), outcome)
+                }
             }
         }))
         .await;
 
         let mut result = Vec::new();
 
-        for (unit, outcome) in outcomes {
-            match (unit, outcome) {
-                (FetchUnit::Native { .. }, Ok(prices)) => {
+        for (tag, outcome) in outcomes {
+            match (tag, outcome) {
+                (FetchTag::Native, Ok(prices)) => {
                     for (coin_id, exchange_data) in &prices {
                         if let Some(token_ids) = native_coins.get(coin_id.as_str()) {
                             for token_id in token_ids {
@@ -216,10 +211,10 @@ impl ExchangePriceProvider for CoinGeckoProvider {
                         }
                     }
                 }
-                (FetchUnit::Native { .. }, Err(err)) => {
+                (FetchTag::Native, Err(err)) => {
                     ic_cdk::println!("Failed to fetch native coin prices: {err}");
                 }
-                (FetchUnit::Chunk { platform, .. }, Ok(prices)) => {
+                (FetchTag::Chunk(platform), Ok(prices)) => {
                     for (address, exchange_data) in prices {
                         if let Some(token_id) =
                             address_to_token_id.get(&(platform.to_string(), address.to_lowercase()))
@@ -228,7 +223,7 @@ impl ExchangePriceProvider for CoinGeckoProvider {
                         }
                     }
                 }
-                (FetchUnit::Chunk { platform, .. }, Err(err)) => {
+                (FetchTag::Chunk(platform), Err(err)) => {
                     ic_cdk::println!("Failed to fetch prices for {platform}: {err}");
                 }
             }

--- a/src/backend/src/exchange/providers/coingecko/mod.rs
+++ b/src/backend/src/exchange/providers/coingecko/mod.rs
@@ -3,6 +3,7 @@ mod platform;
 
 use std::collections::HashMap;
 
+use futures::future::join_all;
 use shared::types::{exchange::ExchangeData, token_id::TokenId};
 
 pub(crate) use self::platform::is_priceable_token_id;
@@ -128,24 +129,85 @@ fn classify_tokens<'a>(token_ids: &'a [StoredTokenId]) -> ClassifiedTokens<'a> {
     }
 }
 
+/// One unit of work for the parallel fan-out: either the single batched
+/// native-coin call, or a per-platform chunk of token contract addresses.
+///
+/// We materialise this as an enum (rather than two separate `join_all`
+/// passes) so all outcalls run as one wave: the native-coin call has no
+/// reason to block the per-platform calls and vice-versa.
+enum FetchUnit<'a> {
+    Native {
+        coin_ids: Vec<&'a str>,
+    },
+    Chunk {
+        platform: &'a str,
+        addresses: &'a [String],
+    },
+}
+
 impl ExchangePriceProvider for CoinGeckoProvider {
     async fn fetch_prices(
         &self,
         token_ids: &[StoredTokenId],
     ) -> Result<Vec<(StoredTokenId, ExchangeData)>, String> {
-        let mut result = Vec::new();
-
         let ClassifiedTokens {
             native_coins,
             contract_platforms,
             address_to_token_id,
         } = classify_tokens(token_ids);
 
-        if !native_coins.is_empty() {
-            let coin_ids: Vec<&str> = native_coins.keys().copied().collect();
+        // Collect all the independent HTTP outcalls into a single set of
+        // futures so they can be issued concurrently.
+        //
+        // On the IC each outcall goes through consensus independently, so
+        // sequentialising the loop (the prior shape) added up to multi-second
+        // wall-time penalties for users with tokens spread across several
+        // chains. `join_all` polls each future together, so the total wait is
+        // the slowest single outcall instead of the sum of all of them.
+        let mut units: Vec<FetchUnit<'_>> = Vec::new();
 
-            match self.client.fetch_coin_prices(&coin_ids).await {
-                Ok(prices) => {
+        if !native_coins.is_empty() {
+            units.push(FetchUnit::Native {
+                coin_ids: native_coins.keys().copied().collect(),
+            });
+        }
+
+        for (platform, addresses) in &contract_platforms {
+            for chunk in addresses.chunks(CHUNK_SIZE) {
+                units.push(FetchUnit::Chunk {
+                    platform: platform.as_str(),
+                    addresses: chunk,
+                });
+            }
+        }
+
+        let outcomes = join_all(units.into_iter().map(|unit| async move {
+            match unit {
+                FetchUnit::Native { coin_ids } => (
+                    FetchUnit::Native {
+                        coin_ids: coin_ids.clone(),
+                    },
+                    self.client.fetch_coin_prices(&coin_ids).await,
+                ),
+                FetchUnit::Chunk {
+                    platform,
+                    addresses,
+                } => (
+                    FetchUnit::Chunk {
+                        platform,
+                        addresses,
+                    },
+                    self.client.fetch_token_prices(platform, addresses).await,
+                ),
+            }
+        }))
+        .await;
+
+        let mut result = Vec::new();
+
+        for (unit, outcome) in outcomes {
+            match (unit, outcome) {
+                (FetchUnit::Native { .. }, Ok(prices)) => {
                     for (coin_id, exchange_data) in &prices {
                         if let Some(token_ids) = native_coins.get(coin_id.as_str()) {
                             for token_id in token_ids {
@@ -154,27 +216,20 @@ impl ExchangePriceProvider for CoinGeckoProvider {
                         }
                     }
                 }
-                Err(err) => {
+                (FetchUnit::Native { .. }, Err(err)) => {
                     ic_cdk::println!("Failed to fetch native coin prices: {err}");
                 }
-            }
-        }
-
-        for (platform, addresses) in &contract_platforms {
-            for chunk in addresses.chunks(CHUNK_SIZE) {
-                match self.client.fetch_token_prices(platform, chunk).await {
-                    Ok(prices) => {
-                        for (address, exchange_data) in prices {
-                            if let Some(token_id) =
-                                address_to_token_id.get(&(platform.clone(), address.to_lowercase()))
-                            {
-                                result.push((token_id.clone(), exchange_data));
-                            }
+                (FetchUnit::Chunk { platform, .. }, Ok(prices)) => {
+                    for (address, exchange_data) in prices {
+                        if let Some(token_id) =
+                            address_to_token_id.get(&(platform.to_string(), address.to_lowercase()))
+                        {
+                            result.push((token_id.clone(), exchange_data));
                         }
                     }
-                    Err(err) => {
-                        ic_cdk::println!("Failed to fetch prices for {platform}: {err}");
-                    }
+                }
+                (FetchUnit::Chunk { platform, .. }, Err(err)) => {
+                    ic_cdk::println!("Failed to fetch prices for {platform}: {err}");
                 }
             }
         }

--- a/src/backend/src/exchange/providers/icpswap/mod.rs
+++ b/src/backend/src/exchange/providers/icpswap/mod.rs
@@ -1,3 +1,4 @@
+use futures::future::join_all;
 use ic_cdk::{api::time, management_canister::HttpHeader};
 use serde::Deserialize;
 use serde_json::from_slice;
@@ -117,17 +118,28 @@ impl SupplementalPriceProvider for IcpSwapProvider {
 
     fn supplement<'a>(&'a self, missing: &'a [StoredTokenId]) -> SupplementalPricesFuture<'a> {
         Box::pin(async move {
-            let mut out = Vec::new();
-
-            for stored in missing {
+            // ICPSwap exposes one URL per token — there is no batch endpoint.
+            // Issuing the per-token outcalls in parallel turns N sequential
+            // round trips into a single fan-out.
+            let outcomes = join_all(missing.iter().filter_map(|stored| {
                 let StoredTokenId(TokenId::Icrc(ledger_id)) = stored else {
-                    continue;
+                    return None;
                 };
 
                 let ledger_text = ledger_id.to_text();
 
-                match self.fetch_icrc_token_usd(&ledger_text).await {
-                    Ok(Some(data)) => out.push((stored.clone(), data)),
+                Some(async move {
+                    let outcome = self.fetch_icrc_token_usd(&ledger_text).await;
+                    (stored.clone(), ledger_text, outcome)
+                })
+            }))
+            .await;
+
+            let mut out = Vec::new();
+
+            for (stored, ledger_text, outcome) in outcomes {
+                match outcome {
+                    Ok(Some(data)) => out.push((stored, data)),
                     Ok(None) => {}
                     Err(err) => {
                         ic_cdk::println!("ICPSwap price fetch for {ledger_text} failed: {err}");


### PR DESCRIPTION
# Motivation

On staging, cold-cache `get_exchange_rates` can take **minutes** on first login because each exchange-provider call is an IC HTTP outcall (~few s through consensus) and both providers await them one at a time:

- **CoinGecko**: native-coin call + one outcall per `(platform, chunk)`, awaited in series.
- **ICPSwap**: one outcall **per ICRC token** (no batch endpoint), awaited in series — dominant cost for users with many ICRCs not priced by CoinGecko.

The browser sits on a 5-min agent poll, so every second of skeleton = a second of canister wall-time.

# Changes

- `coingecko/mod.rs`: collect the native + per-platform-chunk calls into one `Vec<FetchUnit>` and fan out with `futures::future::join_all`.
- `icpswap/mod.rs`: fan the per-ICRC-token outcalls out with `join_all`.
- Add `futures = "0.3"` to workspace + backend `Cargo.toml`. Already a transitive dep; matches `oisy-rewards-canister`, `chain-fusion-signer`, `oisy-test`.

Same number of outcalls, same cycle cost — only the wall-clock collapses to the slowest single outcall.

# Tests

Adapted tests.
