### PR TITLE
perf(backend): guard against overlapping exchange refresh ticks

### DIFF
--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -93,7 +93,7 @@ async fn refresh_exchange_rates_guarded(source: &'static str) {
     REFRESH_IN_FLIGHT.with(|f| f.set(false));
 
     if let Err(err) = outcome {
-        ic_cdk::println!("Exchange rate {source} skipped: {err:?}");
+        ic_cdk::println!("Exchange rate {source} failed: {err:?}");
     }
 }
 

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod provider;
 mod providers;
 mod supplemental;
 
-use std::time::Duration;
+use std::{cell::Cell, time::Duration};
 
 use ic_cdk::api::time;
 use ic_cdk_timers::{set_timer, set_timer_interval};
@@ -68,6 +68,35 @@ fn native_token_ids() -> Vec<StoredTokenId> {
     ]
 }
 
+thread_local! {
+    /// Set to `true` while a `refresh_exchange_rates` future is awaiting
+    /// outcalls. Used by the timer to skip a tick when the previous refresh
+    /// hasn't finished — otherwise a slow refresh (e.g. transient provider
+    /// latency) would let subsequent ticks pile up concurrent in-flight
+    /// refreshes, multiplying outcall load instead of catching up.
+    static REFRESH_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Wraps [`refresh_exchange_rates`] with an in-flight guard so concurrent
+/// invocations (e.g. overlapping timer ticks) become no-ops rather than
+/// starting a parallel refresh.
+async fn refresh_exchange_rates_guarded(source: &'static str) {
+    if REFRESH_IN_FLIGHT.with(Cell::get) {
+        ic_cdk::println!("Exchange rate {source} skipped: previous refresh still in flight");
+        return;
+    }
+
+    REFRESH_IN_FLIGHT.with(|f| f.set(true));
+
+    let outcome = refresh_exchange_rates().await;
+
+    REFRESH_IN_FLIGHT.with(|f| f.set(false));
+
+    if let Err(err) = outcome {
+        ic_cdk::println!("Exchange rate {source} skipped: {err:?}");
+    }
+}
+
 /// Starts a recurring timer that refreshes exchange rates for active tokens
 /// every [`PRICE_REFRESH_INTERVAL_SEC`] seconds.
 ///
@@ -75,21 +104,13 @@ fn native_token_ids() -> Vec<StoredTokenId> {
 /// after canister init / upgrade instead of waiting for the first interval tick.
 pub(crate) fn start_exchange_rate_timer() {
     set_timer(Duration::ZERO, || {
-        ic_cdk::futures::spawn(async {
-            if let Err(err) = refresh_exchange_rates().await {
-                ic_cdk::println!("Exchange rate initial refresh skipped: {err:?}");
-            }
-        });
+        ic_cdk::futures::spawn(refresh_exchange_rates_guarded("initial refresh"));
     });
 
     let refresh_interval = Duration::from_secs(PRICE_REFRESH_INTERVAL_SEC);
 
     let _ = set_timer_interval(refresh_interval, || {
-        ic_cdk::futures::spawn(async {
-            if let Err(err) = refresh_exchange_rates().await {
-                ic_cdk::println!("Exchange rate refresh skipped: {err:?}");
-            }
-        });
+        ic_cdk::futures::spawn(refresh_exchange_rates_guarded("refresh"));
     });
 }
 


### PR DESCRIPTION
# Motivation

`set_timer_interval(60s) + ic_cdk::futures::spawn` fires a refresh future every minute regardless of whether the previous one is still awaiting outcalls. With today's sequential loops, a single refresh can exceed 60s on cold cache and ticks pile up concurrent refreshes for no gain.

#12957 makes a single refresh sub-second so this scenario is mostly retired, but a slow upstream (>60s on one outcall) would re-introduce it. Removes the latent footgun.

# Changes

- Add thread-local `REFRESH_IN_FLIGHT: Cell<bool>` in `exchange/mod.rs`.
- New `refresh_exchange_rates_guarded(source)` sets the flag, awaits the refresh, clears the flag. If a previous refresh is in flight it logs and returns immediately.
- Both timer callbacks (one-shot + interval) route through it.

Cooperative single-threaded canister execution means no atomics needed — the flag can only change across an `.await`, which is exactly the contention case.

# Tests

Adapted tests.
