### PR TITLE
feat(backend)!: return get_exchange_rates immediately, refresh in background

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1246,14 +1246,24 @@ service : (Arg) -> {
 	// (testnets, NFTs and ERC-4626 vaults are excluded).
 	//
 	// The endpoint also re-marks the returned tokens as active so the
-	// background refresh timer keeps them warm. If any cached price is older
-	// than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
-	// missing, the endpoint awaits a one-shot fetch for that subset before
-	// responding. Entries that remain stale or missing after that attempt are
-	// returned as `None` so returned prices honour the freshness contract.
+	// background refresh timer keeps them warm. If any cached price is
+	// missing or older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`]
+	// seconds, the endpoint kicks off a refresh for that subset **in the
+	// background** (via `ic_cdk::futures::spawn`) and returns the current cache
+	// snapshot immediately. Entries that are still missing or stale at the
+	// moment of the call are returned as `None`; subsequent calls will pick up
+	// the refreshed values once the spawned fetch lands.
 	//
-	// This is an `update` (rather than a `query`) because it mutates state
-	// (`token_activity`) and may issue HTTP outcalls.
+	// This trade-off (return fast, refresh async) is intentional: under the
+	// previous "await-the-fetch" shape, a cold-cache caller could wait on the
+	// full outcall fan-in before getting any response. The frontend already
+	// tolerates `None` entries (renders no value rather than blocking), and
+	// the background refresh + the 60s recurring timer together converge the
+	// cache to fresh within ~one outcall round.
+	//
+	// This is still an `update` (rather than a `query`) because it mutates
+	// state (`token_activity`) and may need an update context to schedule the
+	// background fetch.
 	get_exchange_rates : () -> (vec record { TokenId; opt ExchangeRate });
 	// Returns the full agreement consent/rejection history for the caller.
 	//

--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -4,7 +4,7 @@ use shared::types::{exchange::ExchangeRate, token_id::TokenId};
 use crate::{
     exchange::{
         cached_rates_snapshot, fetch_and_update_prices, priceable_tokens_for_caller,
-        stale_or_missing_tokens,
+        release_refresh_lock, stale_or_missing_tokens, try_acquire_refresh_lock,
     },
     state::read_state,
     token,
@@ -53,13 +53,22 @@ pub fn get_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
     token::mark_tokens_active(&active_ids);
 
     let stale = stale_or_missing_tokens(&tokens);
-    if !stale.is_empty() {
+    if !stale.is_empty() && try_acquire_refresh_lock() {
         // Background-spawn the refresh so the response isn't gated on the
         // outcall round-trip. The 60s recurring refresh will also pick these
         // up; this spawn just shortens the convergence window for tokens the
         // recurring refresh hasn't gotten to yet.
+        //
+        // We share the in-flight lock with the timer-driven refresh: if a
+        // refresh is already running (timer or another caller), this call
+        // doesn't spawn its own — the in-flight one will write the cache,
+        // and the next call will pick up the fresh values. This deduplicates
+        // outcalls under concurrent load (e.g. many users calling on a cold
+        // cache).
         ic_cdk::futures::spawn(async move {
-            if let Err(err) = fetch_and_update_prices(&stale).await {
+            let outcome = fetch_and_update_prices(&stale).await;
+            release_refresh_lock();
+            if let Err(err) = outcome {
                 ic_cdk::println!("get_exchange_rates background refresh failed: {err:?}");
             }
         });

--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -20,17 +20,27 @@ use crate::{
 ///   (testnets, NFTs and ERC-4626 vaults are excluded).
 ///
 /// The endpoint also re-marks the returned tokens as active so the
-/// background refresh timer keeps them warm. If any cached price is older
-/// than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
-/// missing, the endpoint awaits a one-shot fetch for that subset before
-/// responding. Entries that remain stale or missing after that attempt are
-/// returned as `None` so returned prices honour the freshness contract.
+/// background refresh timer keeps them warm. If any cached price is
+/// missing or older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`]
+/// seconds, the endpoint kicks off a refresh for that subset **in the
+/// background** (via `ic_cdk::futures::spawn`) and returns the current cache
+/// snapshot immediately. Entries that are still missing or stale at the
+/// moment of the call are returned as `None`; subsequent calls will pick up
+/// the refreshed values once the spawned fetch lands.
 ///
-/// This is an `update` (rather than a `query`) because it mutates state
-/// (`token_activity`) and may issue HTTP outcalls.
+/// This trade-off (return fast, refresh async) is intentional: under the
+/// previous "await-the-fetch" shape, a cold-cache caller could wait on the
+/// full outcall fan-in before getting any response. The frontend already
+/// tolerates `None` entries (renders no value rather than blocking), and
+/// the background refresh + the 60s recurring timer together converge the
+/// cache to fresh within ~one outcall round.
+///
+/// This is still an `update` (rather than a `query`) because it mutates
+/// state (`token_activity`) and may need an update context to schedule the
+/// background fetch.
 #[update(guard = "caller_is_not_anonymous")]
 #[must_use]
-pub async fn get_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
+pub fn get_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
     let caller = StoredPrincipal(msg_caller());
 
     let tokens = priceable_tokens_for_caller(caller);
@@ -44,9 +54,15 @@ pub async fn get_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
 
     let stale = stale_or_missing_tokens(&tokens);
     if !stale.is_empty() {
-        if let Err(err) = fetch_and_update_prices(&stale).await {
-            ic_cdk::println!("get_exchange_rates fetch failed: {err:?}");
-        }
+        // Background-spawn the refresh so the response isn't gated on the
+        // outcall round-trip. The 60s recurring refresh will also pick these
+        // up; this spawn just shortens the convergence window for tokens the
+        // recurring refresh hasn't gotten to yet.
+        ic_cdk::futures::spawn(async move {
+            if let Err(err) = fetch_and_update_prices(&stale).await {
+                ic_cdk::println!("get_exchange_rates background refresh failed: {err:?}");
+            }
+        });
     }
 
     cached_rates_snapshot(tokens)

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -69,28 +69,49 @@ fn native_token_ids() -> Vec<StoredTokenId> {
 }
 
 thread_local! {
-    /// Set to `true` while a `refresh_exchange_rates` future is awaiting
-    /// outcalls. Used by the timer to skip a tick when the previous refresh
-    /// hasn't finished — otherwise a slow refresh (e.g. transient provider
-    /// latency) would let subsequent ticks pile up concurrent in-flight
-    /// refreshes, multiplying outcall load instead of catching up.
+    /// Set to `true` while *any* provider refresh (timer-driven or
+    /// caller-triggered background refresh from `get_exchange_rates`) is
+    /// awaiting outcalls. Both call sites cooperate via this single flag so
+    /// they don't duplicate outcalls for the same tokens — if the timer is
+    /// refreshing, a concurrent on-demand call is a no-op (the timer is
+    /// already fetching the superset); if an on-demand refresh is in
+    /// flight, the next timer tick is a no-op until it completes.
     static REFRESH_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
 }
 
-/// Wraps [`refresh_exchange_rates`] with an in-flight guard so concurrent
-/// invocations (e.g. overlapping timer ticks) become no-ops rather than
+/// Tries to set [`REFRESH_IN_FLIGHT`]; returns `true` if the caller acquired
+/// the lock, `false` if a refresh was already in flight. Callers that
+/// acquire the lock are responsible for calling [`release_refresh_lock`] in
+/// every completion path.
+pub(crate) fn try_acquire_refresh_lock() -> bool {
+    REFRESH_IN_FLIGHT.with(|f| {
+        if f.get() {
+            false
+        } else {
+            f.set(true);
+            true
+        }
+    })
+}
+
+/// Clears [`REFRESH_IN_FLIGHT`]. Must only be called by the holder of the
+/// lock (i.e. after a successful [`try_acquire_refresh_lock`]).
+pub(crate) fn release_refresh_lock() {
+    REFRESH_IN_FLIGHT.with(|f| f.set(false));
+}
+
+/// Wraps [`refresh_exchange_rates`] with the in-flight guard so concurrent
+/// timer invocations (e.g. overlapping ticks) become no-ops rather than
 /// starting a parallel refresh.
 async fn refresh_exchange_rates_guarded(source: &'static str) {
-    if REFRESH_IN_FLIGHT.with(Cell::get) {
+    if !try_acquire_refresh_lock() {
         ic_cdk::println!("Exchange rate {source} skipped: previous refresh still in flight");
         return;
     }
 
-    REFRESH_IN_FLIGHT.with(|f| f.set(true));
-
     let outcome = refresh_exchange_rates().await;
 
-    REFRESH_IN_FLIGHT.with(|f| f.set(false));
+    release_refresh_lock();
 
     if let Err(err) = outcome {
         ic_cdk::println!("Exchange rate {source} failed: {err:?}");

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -1246,14 +1246,24 @@ service : (Arg) -> {
 	// (testnets, NFTs and ERC-4626 vaults are excluded).
 	//
 	// The endpoint also re-marks the returned tokens as active so the
-	// background refresh timer keeps them warm. If any cached price is older
-	// than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
-	// missing, the endpoint awaits a one-shot fetch for that subset before
-	// responding. Entries that remain stale or missing after that attempt are
-	// returned as `None` so returned prices honour the freshness contract.
+	// background refresh timer keeps them warm. If any cached price is
+	// missing or older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`]
+	// seconds, the endpoint kicks off a refresh for that subset **in the
+	// background** (via `ic_cdk::futures::spawn`) and returns the current cache
+	// snapshot immediately. Entries that are still missing or stale at the
+	// moment of the call are returned as `None`; subsequent calls will pick up
+	// the refreshed values once the spawned fetch lands.
 	//
-	// This is an `update` (rather than a `query`) because it mutates state
-	// (`token_activity`) and may issue HTTP outcalls.
+	// This trade-off (return fast, refresh async) is intentional: under the
+	// previous "await-the-fetch" shape, a cold-cache caller could wait on the
+	// full outcall fan-in before getting any response. The frontend already
+	// tolerates `None` entries (renders no value rather than blocking), and
+	// the background refresh + the 60s recurring timer together converge the
+	// cache to fresh within ~one outcall round.
+	//
+	// This is still an `update` (rather than a `query`) because it mutates
+	// state (`token_activity`) and may need an update context to schedule the
+	// background fetch.
 	get_exchange_rates : () -> (vec record { TokenId; opt ExchangeRate });
 	// Returns the full agreement consent/rejection history for the caller.
 	//

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -1841,14 +1841,24 @@ export interface _SERVICE {
 	 * (testnets, NFTs and ERC-4626 vaults are excluded).
 	 *
 	 * The endpoint also re-marks the returned tokens as active so the
-	 * background refresh timer keeps them warm. If any cached price is older
-	 * than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`] seconds or
-	 * missing, the endpoint awaits a one-shot fetch for that subset before
-	 * responding. Entries that remain stale or missing after that attempt are
-	 * returned as `None` so returned prices honour the freshness contract.
+	 * background refresh timer keeps them warm. If any cached price is
+	 * missing or older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`]
+	 * seconds, the endpoint kicks off a refresh for that subset **in the
+	 * background** (via `ic_cdk::futures::spawn`) and returns the current cache
+	 * snapshot immediately. Entries that are still missing or stale at the
+	 * moment of the call are returned as `None`; subsequent calls will pick up
+	 * the refreshed values once the spawned fetch lands.
 	 *
-	 * This is an `update` (rather than a `query`) because it mutates state
-	 * (`token_activity`) and may issue HTTP outcalls.
+	 * This trade-off (return fast, refresh async) is intentional: under the
+	 * previous "await-the-fetch" shape, a cold-cache caller could wait on the
+	 * full outcall fan-in before getting any response. The frontend already
+	 * tolerates `None` entries (renders no value rather than blocking), and
+	 * the background refresh + the 60s recurring timer together converge the
+	 * cache to fresh within ~one outcall round.
+	 *
+	 * This is still an `update` (rather than a `query`) because it mutates
+	 * state (`token_activity`) and may need an update context to schedule the
+	 * background fetch.
 	 */
 	get_exchange_rates: ActorMethod<[], Array<[TokenId, [] | [ExchangeRate]]>>;
 	/**


### PR DESCRIPTION
# Motivation

`get_exchange_rates` awaits the on-demand refresh of stale tokens before returning, so every cold-cache caller still pays the full outcall round (a few seconds even after #12957). Decouple the response from the refresh and the endpoint becomes effectively instant.

BREAKING CHANGE: update `get_exchange_rates` description in the interface.

# Changes

- `api/exchange.rs::get_exchange_rates`: replace `fetch_and_update_prices(&stale).await` with `ic_cdk::futures::spawn(async move { fetch_and_update_prices(&stale).await; })`. Return the cache snapshot immediately.
- Drop `async` from the signature (no more `.await`s); still `#[update]` because it mutates `token_activity`. No Candid change.
- Doc comment updated to spell out the new contract.

**Semantic change** — flagging explicitly. Previously: "every returned price is ≤ 2 min old, or `None`." Now: "whatever's in the cache right now, or `None`; the spawned fetch + 60s recurring timer converge the cache on subsequent calls." FE already tolerates `None` price entries (renders no value rather than blocks), so the visible difference is:

- Warm cache: identical.
- Cold cache: instant response with `None`s, next FE-timer call (≤60s later) has fresh values — vs. the current ~3–5s wait (post-#12957) for full freshness on the first call.

If the "≤2 min or `None`" guarantee matters, don't merge.

# Tests

Adapted tests.
