### PR TITLE
revert(backend): roll back exchange-outcall parallelization (#12957, #12958)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,6 @@ dependencies = [
  "canbench-rs",
  "candid",
  "candid_parser",
- "futures",
  "getrandom 0.2.17",
  "hex",
  "ic-canister-sig-creation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,6 @@ pocket-ic = "13.0.0"
 pretty_assertions = "1.4"
 bitcoin = "0.32"
 paste = "1.0"
-# Used for `futures::future::join_all` to run independent HTTP outcalls in
-# parallel (e.g. exchange price providers). Already a transitive dep via the
-# ic-cdk stack; this declaration just makes it directly available to our crates.
-futures = "0.3"
 
 [workspace.lints.rust]
 deprecated = "allow" # Why is this allowed?

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib"]
 bitcoin = { workspace = true }
 canbench-rs = { workspace = true, optional = true }
 candid = { workspace = true }
-futures = { workspace = true }
 getrandom = { workspace = true }
 hex = { workspace = true }
 ic-canister-sig-creation = { workspace = true }

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod provider;
 mod providers;
 mod supplemental;
 
-use std::{cell::Cell, time::Duration};
+use std::time::Duration;
 
 use ic_cdk::api::time;
 use ic_cdk_timers::{set_timer, set_timer_interval};
@@ -68,35 +68,6 @@ fn native_token_ids() -> Vec<StoredTokenId> {
     ]
 }
 
-thread_local! {
-    /// Set to `true` while a `refresh_exchange_rates` future is awaiting
-    /// outcalls. Used by the timer to skip a tick when the previous refresh
-    /// hasn't finished — otherwise a slow refresh (e.g. transient provider
-    /// latency) would let subsequent ticks pile up concurrent in-flight
-    /// refreshes, multiplying outcall load instead of catching up.
-    static REFRESH_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
-}
-
-/// Wraps [`refresh_exchange_rates`] with an in-flight guard so concurrent
-/// invocations (e.g. overlapping timer ticks) become no-ops rather than
-/// starting a parallel refresh.
-async fn refresh_exchange_rates_guarded(source: &'static str) {
-    if REFRESH_IN_FLIGHT.with(Cell::get) {
-        ic_cdk::println!("Exchange rate {source} skipped: previous refresh still in flight");
-        return;
-    }
-
-    REFRESH_IN_FLIGHT.with(|f| f.set(true));
-
-    let outcome = refresh_exchange_rates().await;
-
-    REFRESH_IN_FLIGHT.with(|f| f.set(false));
-
-    if let Err(err) = outcome {
-        ic_cdk::println!("Exchange rate {source} failed: {err:?}");
-    }
-}
-
 /// Starts a recurring timer that refreshes exchange rates for active tokens
 /// every [`PRICE_REFRESH_INTERVAL_SEC`] seconds.
 ///
@@ -104,13 +75,21 @@ async fn refresh_exchange_rates_guarded(source: &'static str) {
 /// after canister init / upgrade instead of waiting for the first interval tick.
 pub(crate) fn start_exchange_rate_timer() {
     set_timer(Duration::ZERO, || {
-        ic_cdk::futures::spawn(refresh_exchange_rates_guarded("initial refresh"));
+        ic_cdk::futures::spawn(async {
+            if let Err(err) = refresh_exchange_rates().await {
+                ic_cdk::println!("Exchange rate initial refresh skipped: {err:?}");
+            }
+        });
     });
 
     let refresh_interval = Duration::from_secs(PRICE_REFRESH_INTERVAL_SEC);
 
     let _ = set_timer_interval(refresh_interval, || {
-        ic_cdk::futures::spawn(refresh_exchange_rates_guarded("refresh"));
+        ic_cdk::futures::spawn(async {
+            if let Err(err) = refresh_exchange_rates().await {
+                ic_cdk::println!("Exchange rate refresh skipped: {err:?}");
+            }
+        });
     });
 }
 

--- a/src/backend/src/exchange/providers/coingecko/mod.rs
+++ b/src/backend/src/exchange/providers/coingecko/mod.rs
@@ -3,7 +3,6 @@ mod platform;
 
 use std::collections::HashMap;
 
-use futures::future::join_all;
 use shared::types::{exchange::ExchangeData, token_id::TokenId};
 
 pub(crate) use self::platform::is_priceable_token_id;
@@ -129,80 +128,24 @@ fn classify_tokens<'a>(token_ids: &'a [StoredTokenId]) -> ClassifiedTokens<'a> {
     }
 }
 
-/// Input to one parallel fan-out branch: the native-coin batch carries the
-/// list of coin IDs to fetch; the per-chunk branch carries the platform name
-/// and an address slice.
-enum FetchInput<'a> {
-    Native(Vec<&'a str>),
-    Chunk {
-        platform: &'a str,
-        addresses: &'a [String],
-    },
-}
-
-/// Lightweight tag returned alongside each outcome so the post-`join_all`
-/// loop knows how to interpret the result. `Chunk` re-borrows the platform
-/// name (the original lives in `contract_platforms`, which outlives the
-/// futures) so we don't need to clone strings.
-enum FetchTag<'a> {
-    Native,
-    Chunk(&'a str),
-}
-
 impl ExchangePriceProvider for CoinGeckoProvider {
     async fn fetch_prices(
         &self,
         token_ids: &[StoredTokenId],
     ) -> Result<Vec<(StoredTokenId, ExchangeData)>, String> {
+        let mut result = Vec::new();
+
         let ClassifiedTokens {
             native_coins,
             contract_platforms,
             address_to_token_id,
         } = classify_tokens(token_ids);
 
-        // Issue all independent HTTP outcalls concurrently. On the IC each
-        // outcall goes through consensus independently, so the prior
-        // sequential loop added up to multi-second wall-time penalties for
-        // users with tokens spread across several chains. `join_all` polls
-        // each future together, so the total wait is the slowest single
-        // outcall instead of the sum of all of them.
-        let mut inputs: Vec<FetchInput<'_>> = Vec::new();
-
         if !native_coins.is_empty() {
-            inputs.push(FetchInput::Native(native_coins.keys().copied().collect()));
-        }
+            let coin_ids: Vec<&str> = native_coins.keys().copied().collect();
 
-        for (platform, addresses) in &contract_platforms {
-            for chunk in addresses.chunks(CHUNK_SIZE) {
-                inputs.push(FetchInput::Chunk {
-                    platform: platform.as_str(),
-                    addresses: chunk,
-                });
-            }
-        }
-
-        let outcomes = join_all(inputs.into_iter().map(|input| async move {
-            match input {
-                FetchInput::Native(coin_ids) => {
-                    let outcome = self.client.fetch_coin_prices(&coin_ids).await;
-                    (FetchTag::Native, outcome)
-                }
-                FetchInput::Chunk {
-                    platform,
-                    addresses,
-                } => {
-                    let outcome = self.client.fetch_token_prices(platform, addresses).await;
-                    (FetchTag::Chunk(platform), outcome)
-                }
-            }
-        }))
-        .await;
-
-        let mut result = Vec::new();
-
-        for (tag, outcome) in outcomes {
-            match (tag, outcome) {
-                (FetchTag::Native, Ok(prices)) => {
+            match self.client.fetch_coin_prices(&coin_ids).await {
+                Ok(prices) => {
                     for (coin_id, exchange_data) in &prices {
                         if let Some(token_ids) = native_coins.get(coin_id.as_str()) {
                             for token_id in token_ids {
@@ -211,20 +154,27 @@ impl ExchangePriceProvider for CoinGeckoProvider {
                         }
                     }
                 }
-                (FetchTag::Native, Err(err)) => {
+                Err(err) => {
                     ic_cdk::println!("Failed to fetch native coin prices: {err}");
                 }
-                (FetchTag::Chunk(platform), Ok(prices)) => {
-                    for (address, exchange_data) in prices {
-                        if let Some(token_id) =
-                            address_to_token_id.get(&(platform.to_string(), address.to_lowercase()))
-                        {
-                            result.push((token_id.clone(), exchange_data));
+            }
+        }
+
+        for (platform, addresses) in &contract_platforms {
+            for chunk in addresses.chunks(CHUNK_SIZE) {
+                match self.client.fetch_token_prices(platform, chunk).await {
+                    Ok(prices) => {
+                        for (address, exchange_data) in prices {
+                            if let Some(token_id) =
+                                address_to_token_id.get(&(platform.clone(), address.to_lowercase()))
+                            {
+                                result.push((token_id.clone(), exchange_data));
+                            }
                         }
                     }
-                }
-                (FetchTag::Chunk(platform), Err(err)) => {
-                    ic_cdk::println!("Failed to fetch prices for {platform}: {err}");
+                    Err(err) => {
+                        ic_cdk::println!("Failed to fetch prices for {platform}: {err}");
+                    }
                 }
             }
         }

--- a/src/backend/src/exchange/providers/icpswap/mod.rs
+++ b/src/backend/src/exchange/providers/icpswap/mod.rs
@@ -1,4 +1,3 @@
-use futures::future::join_all;
 use ic_cdk::{api::time, management_canister::HttpHeader};
 use serde::Deserialize;
 use serde_json::from_slice;
@@ -118,28 +117,17 @@ impl SupplementalPriceProvider for IcpSwapProvider {
 
     fn supplement<'a>(&'a self, missing: &'a [StoredTokenId]) -> SupplementalPricesFuture<'a> {
         Box::pin(async move {
-            // ICPSwap exposes one URL per token — there is no batch endpoint.
-            // Issuing the per-token outcalls in parallel turns N sequential
-            // round trips into a single fan-out.
-            let outcomes = join_all(missing.iter().filter_map(|stored| {
+            let mut out = Vec::new();
+
+            for stored in missing {
                 let StoredTokenId(TokenId::Icrc(ledger_id)) = stored else {
-                    return None;
+                    continue;
                 };
 
                 let ledger_text = ledger_id.to_text();
 
-                Some(async move {
-                    let outcome = self.fetch_icrc_token_usd(&ledger_text).await;
-                    (stored.clone(), ledger_text, outcome)
-                })
-            }))
-            .await;
-
-            let mut out = Vec::new();
-
-            for (stored, ledger_text, outcome) in outcomes {
-                match outcome {
-                    Ok(Some(data)) => out.push((stored, data)),
+                match self.fetch_icrc_token_usd(&ledger_text).await {
+                    Ok(Some(data)) => out.push((stored.clone(), data)),
                     Ok(None) => {}
                     Err(err) => {
                         ic_cdk::println!("ICPSwap price fetch for {ledger_text} failed: {err}");


### PR DESCRIPTION
# Motivation

Staging canister `d3nvo-aaaaa-aaaar-qagzq-cai` is trapping on `get_user_profile` (and likely other queries) with:

> Canister called \`ic0.trap\` with message: 'Panicked at 'assertion failed: psize >= size + min_overhead', /rust/deps/dlmalloc-0.2.11/src/dlmalloc.rs:1201:9'

That's the dlmalloc free-path coalescing invariant failing — i.e. **heap corruption**, not OOM (memory is 120 MB / 3 GB). The corruption is showing up wherever the next allocator call lands; the trapping endpoint is a query that doesn't touch the exchange path, but it lives on the same heap.

`Memory Size: 120_051_382 Bytes` rules out memory limits. The deployed wasm has #12957 + #12958. The likely culprit is the new fan-out: parallel HTTP outcalls allocate many response buffers simultaneously, and something in that allocation pattern (likely interacting with `futures::future::join_all` and the management-canister outcall response buffer handling) is corrupting the heap.

Rolling both back to restore service. Investigation continues separately before re-attempting the perf work.

# Changes

- `git revert` of #12958 (`perf(backend): guard against overlapping exchange refresh ticks`).
- `git revert` of #12957 (`perf(backend): parallelize exchange-rate HTTP outcalls`).

The sequential outcall behaviour from main pre-#12957 is restored. Cold-cache latency goes back to "minutes" (the original problem), but the canister stays up.

# Tests

- `cargo check -p backend --target wasm32-unknown-unknown` clean.
- `./scripts/lint.rust.sh` clean.
- `cargo test -p backend --lib exchange::` — 22 pass.
- [ ] Once deployed: `dfx canister status d3nvo-...` should show a new module hash; `get_user_profile` calls should return without trapping.

# Follow-up

- #12959 is also affected (depends on the same lock helpers from #12958). Will rebase / close as appropriate after this lands.
- Root cause investigation: suspect `futures::future::join_all` + IC HTTP outcall response buffer interaction. Will reproduce in pocket-ic before re-attempting.