### PR TITLE
fix(frontend): sort NFT traits with numeric-aware ordering

### DIFF
--- a/src/frontend/src/lib/components/nfts/NftMetadataList.svelte
+++ b/src/frontend/src/lib/components/nfts/NftMetadataList.svelte
@@ -21,6 +21,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { getContractExplorerUrl } from '$lib/utils/networks.utils';
 	import { mapTokenToCollection } from '$lib/utils/nfts.utils';
+	import { compareNatural } from '$lib/utils/string.utils';
 
 	interface Props {
 		nft?: Nft;
@@ -39,7 +40,7 @@
 	const sortedAttributes = $derived(
 		nonNullish(nft?.attributes)
 			? // eslint-disable-next-line local-rules/prefer-object-params -- This is a sorting function, so the parameters will be provided not as an object but as separate arguments.
-				nft.attributes.toSorted((a, b) => a.traitType.localeCompare(b.traitType))
+				nft.attributes.toSorted((a, b) => compareNatural(a.traitType, b.traitType))
 			: []
 	);
 

--- a/src/frontend/src/lib/utils/string.utils.ts
+++ b/src/frontend/src/lib/utils/string.utils.ts
@@ -1,0 +1,5 @@
+// A single reused `Intl.Collator` is faster/more consistent than constructing one per comparison.
+const naturalCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+// eslint-disable-next-line local-rules/prefer-object-params -- This is a sort function, so the parameters will be provided not as an object but as separate arguments.
+export const compareNatural = (a: string, b: string): number => naturalCollator.compare(a, b);

--- a/src/frontend/src/tests/lib/utils/string.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/string.utils.spec.ts
@@ -1,0 +1,50 @@
+import { compareNatural } from '$lib/utils/string.utils';
+
+describe('string.utils', () => {
+	describe('compareNatural', () => {
+		it('should sort embedded numbers numerically, not lexicographically', () => {
+			const input = ['10 Address', '1 Name', '2 Age'];
+
+			expect(input.toSorted(compareNatural)).toEqual(['1 Name', '2 Age', '10 Address']);
+		});
+
+		it('should keep pure alphabetical ordering for plain strings', () => {
+			const input = ['banana', 'apple', 'cherry'];
+
+			expect(input.toSorted(compareNatural)).toEqual(['apple', 'banana', 'cherry']);
+		});
+
+		it('should be case-insensitive (sensitivity: base)', () => {
+			expect(compareNatural('apple', 'Apple')).toBe(0);
+			expect(compareNatural('Banana', 'apple')).toBeGreaterThan(0);
+		});
+
+		it('should sort numbers anywhere in the string numerically', () => {
+			const input = ['item 10', 'item 2', 'item 1'];
+
+			expect(input.toSorted(compareNatural)).toEqual(['item 1', 'item 2', 'item 10']);
+		});
+
+		it('should sort multi-digit numeric prefixes correctly', () => {
+			const input = ['100 Z', '20 Y', '3 X'];
+
+			expect(input.toSorted(compareNatural)).toEqual(['3 X', '20 Y', '100 Z']);
+		});
+
+		it('should return 0 for equal strings', () => {
+			expect(compareNatural('1 Name', '1 Name')).toBe(0);
+		});
+
+		it('should handle empty strings', () => {
+			expect(compareNatural('', '')).toBe(0);
+			expect(compareNatural('', 'a')).toBeLessThan(0);
+			expect(compareNatural('a', '')).toBeGreaterThan(0);
+		});
+
+		it('should fall back to alphabetical when numeric prefixes are equal', () => {
+			const input = ['1 Banana', '1 Apple', '1 Cherry'];
+
+			expect(input.toSorted(compareNatural)).toEqual(['1 Apple', '1 Banana', '1 Cherry']);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

The NFT details page sorts its **Item traits** by `traitType` using `String.prototype.localeCompare()`. That comparator is purely lexicographic, so trait names that share a numeric prefix (e.g. `"1 Name"`, `"2 Age"`, `"10 Address"`) come out as `1, 10, 2` instead of the expected `1, 2, 10`. NFTs whose metadata happens to use numbers as a prefix to order traits therefore display them in the wrong order.

# Changes

- `src/frontend/src/lib/utils/string.utils.ts` *(new)* — adds `compareNatural(a, b)`, a small string comparator backed by a single reused `Intl.Collator` with `{ numeric: true, sensitivity: 'base' }`. The `numeric: true` option is the platform's standard way to make embedded digit runs compare as numbers; `sensitivity: 'base'` matches the case-insensitive behavior used by the comparator in `tokens.utils.ts`.
- `src/frontend/src/lib/components/nfts/NftMetadataList.svelte` — replaces the inline `a.traitType.localeCompare(b.traitType)` in the `sortedAttributes` derived with `compareNatural(a.traitType, b.traitType)`. This is the only behavioral change in the UI.

The helper lives in a new `string.utils.ts` rather than being inlined so other future call sites can reuse it. It does not touch the existing `Intl.Collator` in `tokens.utils.ts` (still local to that module's sort pipeline) — consolidating that one is out of scope here.

# Tests

- `src/frontend/src/tests/lib/utils/string.utils.spec.ts` *(new)* — 8 cases covering: numeric prefixes (`"10 Address" / "1 Name" / "2 Age"` → `1, 2, 10`), purely alphabetical strings, multi-digit prefixes (`3, 20, 100`), numbers embedded mid-string (`item 1 / 2 / 10`), case-insensitivity, equal-string `0` return, empty strings, and alphabetical tie-breaking when numeric prefixes are equal (`"1 Apple" < "1 Banana"`).
- Existing `NftMetadataList.spec.ts` continues to pass — the component still renders all attributes; only their order changes for inputs that contain embedded numbers (mock attributes in that spec don't).
- Quality gates run from the worktree:
  - `npx prettier --write` on the three touched files — clean.
  - `npx eslint --max-warnings=0` on the three touched files — clean.
  - `npm run check` (svelte-kit sync + svelte-check) — `0 ERRORS 0 WARNINGS` across 5654 files.
  - `npx vitest run src/frontend/src/tests/lib/utils/string.utils.spec.ts` — 8/8 passing.
  - `npx vitest run src/frontend/src/tests/lib/components/nfts/NftMetadataList.spec.ts` — 8/8 passing.

|Before|After|
|---|---|
|<img width="590" height="611" alt="image" src="https://github.com/user-attachments/assets/591de5e5-0a77-411c-b26e-8c191b57c5cc" />|<img width="590" height="611" alt="image" src="https://github.com/user-attachments/assets/c0cad878-fa19-471e-a5b6-268b62d7faff" />|

---

🤖 Claude Opus 4.7