### PR TITLE
feat(frontend): start EVM send flow from scanned QR address

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendForm.svelte
+++ b/src/frontend/src/eth/components/send/EthSendForm.svelte
@@ -6,6 +6,7 @@
 	import EthSendAmount from '$eth/components/send/EthSendAmount.svelte';
 	import { ETH_FEE_CONTEXT_KEY, type EthFeeContext } from '$eth/stores/eth-fee.store';
 	import { isEthAddress } from '$eth/utils/account.utils';
+	import ScannedPlainAddressNotice from '$lib/components/send/ScannedPlainAddressNotice.svelte';
 	import SendFeeInfo from '$lib/components/send/SendFeeInfo.svelte';
 	import SendForm from '$lib/components/send/SendForm.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -55,6 +56,10 @@
 	{onNext}
 	{selectedContact}
 >
+	{#snippet topBanner()}
+		<ScannedPlainAddressNotice styleClass="mb-6!" />
+	{/snippet}
+
 	{#snippet sendAmount()}
 		<EthSendAmount {nativeEthereumToken} {onTokensList} bind:amount bind:insufficientFunds />
 	{/snippet}

--- a/src/frontend/src/eth/components/send/EthSendReview.svelte
+++ b/src/frontend/src/eth/components/send/EthSendReview.svelte
@@ -6,6 +6,7 @@
 	import { ETH_FEE_CONTEXT_KEY, type EthFeeContext } from '$eth/stores/eth-fee.store';
 	import { isEthAddress } from '$eth/utils/account.utils';
 	import ReviewNetwork from '$lib/components/send/ReviewNetwork.svelte';
+	import ScannedPlainAddressNotice from '$lib/components/send/ScannedPlainAddressNotice.svelte';
 	import SendReview from '$lib/components/send/SendReview.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
@@ -38,6 +39,10 @@
 </script>
 
 <SendReview {amount} {destination} disabled={invalid} {nft} {onBack} {onSend} {selectedContact}>
+	{#snippet topBanner()}
+		<ScannedPlainAddressNotice styleClass="mb-6!" />
+	{/snippet}
+
 	{#snippet fee()}
 		<EthFeeDisplay>
 			{#snippet label()}

--- a/src/frontend/src/lib/components/scanner/ScannerCode.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerCode.svelte
@@ -9,6 +9,7 @@
 	import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 	import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 	import { OCP_PAY_WITH_BTC_ENABLED } from '$env/open-crypto-pay.env';
+	import { isEthAddress } from '$eth/utils/account.utils';
 	import IconChain from '$lib/components/icons/IconChain.svelte';
 	import QrCodeScanner from '$lib/components/qr/QrCodeScanner.svelte';
 	import ScannerCodeInfoButton from '$lib/components/scanner/ScannerCodeInfoButton.svelte';
@@ -113,6 +114,11 @@
 
 		if (isIcPrincipal(trimmed)) {
 			onNext({ results: ScannerResults.IC_SEND, code: trimmed });
+			return;
+		}
+
+		if (isEthAddress(trimmed)) {
+			onNext({ results: ScannerResults.EVM_SEND, code: trimmed });
 			return;
 		}
 

--- a/src/frontend/src/lib/components/scanner/ScannerModal.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerModal.svelte
@@ -2,7 +2,9 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { assertNever, isNullish, nonNullish } from '@dfinity/utils';
 	import { setContext, untrack } from 'svelte';
+	import { SUPPORTED_EVM_MAINNET_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.env';
 	import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
+	import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 	import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 	import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 	import OpenCryptoPayWizard from '$lib/components/open-crypto-pay/OpenCryptoPayWizard.svelte';
@@ -146,6 +148,22 @@
 				data: {
 					destination: code,
 					lockedNetworkIds: [ICP_NETWORK_ID]
+				}
+			});
+
+			return;
+		}
+
+		if (results === ScannerResults.EVM_SEND) {
+			if (isNullish(code)) {
+				return;
+			}
+
+			modalStore.openSend({
+				id: Symbol(),
+				data: {
+					destination: code,
+					lockedNetworkIds: [ETHEREUM_NETWORK_ID, ...SUPPORTED_EVM_MAINNET_NETWORK_IDS]
 				}
 			});
 

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -134,6 +134,8 @@
 	let modal = $state<WizardModal<WizardStepsSend>>();
 	let selectedNft = $derived($pageNft);
 
+	const isLockedToMultipleNetworks = nonNullish(lockedNetworkIds) && lockedNetworkIds.length > 1;
+
 	setContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		initModalTokensListContext({
@@ -141,7 +143,9 @@
 			filterZeroBalance: true,
 			// eslint-disable-next-line svelte/no-unused-svelte-ignore
 			// svelte-ignore state_referenced_locally -- the modal-tokens-list context is initialized once at mount; the reactive `lockedNetwork` (a $derived) is consumed downstream by `SendTokensList`'s view-only lock.
-			filterNetwork: lockedNetwork ?? $selectedNetwork
+			filterNetwork: isLockedToMultipleNetworks ? undefined : (lockedNetwork ?? $selectedNetwork),
+			filterNetworksIds: isLockedToMultipleNetworks ? lockedNetworkIds : undefined,
+			filterNetworksLabel: isLockedToMultipleNetworks ? $i18n.networks.evm_networks : undefined
 		})
 	);
 

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -84,6 +84,13 @@
 			? $networks.find(({ id }) => id === lockedNetworkIds[0])
 			: undefined
 	);
+	let lockedNetworks = $derived(
+		nonNullish(lockedNetworkIds) && lockedNetworkIds.length > 1
+			? lockedNetworkIds
+					.map((id) => $networks.find((n) => n.id === id))
+					.filter((n): n is NonNullable<typeof n> => nonNullish(n))
+			: undefined
+	);
 
 	let destination = $state(initialModalData?.destination ?? '');
 	let activeSendDestinationTab = $state<SendDestinationTab>('recentlyUsed');
@@ -278,6 +285,8 @@
 				/>
 			{:else if currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
 				<ModalNetworksFilter
+					allNetworksLabel={isLockedToMultipleNetworks ? $i18n.networks.evm_networks : undefined}
+					filteredNetworks={lockedNetworks}
 					onNetworkFilter={() => goToStep(WizardStepsSend.TOKENS_LIST)}
 					showStakeBalance={false}
 				/>

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -30,17 +30,26 @@
 		return isNetworkIdBTCMainnet(lockedNetworkIds[0]) ? 'single-token' : 'multi-token';
 	});
 
+	// Multi-network locks (EVM mainnets) leave the filter button interactive so the user
+	// can drill into a specific chain; the popup then restricts the choices to the locked
+	// subset. Single-network locks and URL-route filters keep the historical view-only
+	// behaviour — there's no meaningful drill-down for a single network.
+	let networkSelectorViewOnly = $derived.by(() => {
+		if (nonNullish(lockedNetworkIds) && lockedNetworkIds.length > 1) {
+			return false;
+		}
+		return (
+			(nonNullish(lockedNetworkIds) && lockedNetworkIds.length === 1) ||
+			nonNullish($selectedNetwork)
+		);
+	});
+
 	const onTokenButtonClick = (token: Token) => {
 		onSendToken(token);
 	};
 </script>
 
-<ModalTokensList
-	networkSelectorViewOnly={(nonNullish(lockedNetworkIds) && lockedNetworkIds.length > 0) ||
-		nonNullish($selectedNetwork)}
-	{onSelectNetworkFilter}
-	{onTokenButtonClick}
->
+<ModalTokensList {networkSelectorViewOnly} {onSelectNetworkFilter} {onTokenButtonClick}>
 	{#snippet topBanner()}
 		<ScannedPlainAddressNotice variant={noticeVariant} />
 	{/snippet}

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import ScannedPlainAddressNotice from '$lib/components/send/ScannedPlainAddressNotice.svelte';
+	import ScannedPlainAddressNotice, {
+		type ScannedPlainAddressNoticeVariant
+	} from '$lib/components/send/ScannedPlainAddressNotice.svelte';
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
@@ -18,11 +20,15 @@
 
 	let { onSendToken, onSelectNetworkFilter, lockedNetworkIds }: Props = $props();
 
-	let lockedSingleToken = $derived(
-		nonNullish(lockedNetworkIds) &&
-			lockedNetworkIds.length === 1 &&
-			isNetworkIdBTCMainnet(lockedNetworkIds[0])
-	);
+	let noticeVariant: ScannedPlainAddressNoticeVariant = $derived.by(() => {
+		if (!nonNullish(lockedNetworkIds) || lockedNetworkIds.length === 0) {
+			return 'multi-token';
+		}
+		if (lockedNetworkIds.length > 1) {
+			return 'multi-network';
+		}
+		return isNetworkIdBTCMainnet(lockedNetworkIds[0]) ? 'single-token' : 'multi-token';
+	});
 
 	const onTokenButtonClick = (token: Token) => {
 		onSendToken(token);
@@ -36,7 +42,7 @@
 	{onTokenButtonClick}
 >
 	{#snippet topBanner()}
-		<ScannedPlainAddressNotice variant={lockedSingleToken ? 'single-token' : 'multi-token'} />
+		<ScannedPlainAddressNotice variant={noticeVariant} />
 	{/snippet}
 	{#snippet tokenListItem(token, onClick)}
 		<ModalTokensListItem {onClick} {token} />

--- a/src/frontend/src/lib/types/scanner.ts
+++ b/src/frontend/src/lib/types/scanner.ts
@@ -3,7 +3,8 @@ export enum ScannerResults {
 	WALLET_CONNECT = 'wallet_connect',
 	SOL_SEND = 'sol_send',
 	BTC_SEND = 'btc_send',
-	IC_SEND = 'ic_send'
+	IC_SEND = 'ic_send',
+	EVM_SEND = 'evm_send'
 }
 
 export interface UniversalScannerData {

--- a/src/frontend/src/lib/utils/send.utils.ts
+++ b/src/frontend/src/lib/utils/send.utils.ts
@@ -1,4 +1,5 @@
 import { invalidBtcAddress } from '$btc/utils/btc-address.utils';
+import { isEthAddress } from '$eth/utils/account.utils';
 import type { NetworkId } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import { isNullishOrEmpty } from '$lib/utils/input.utils';
@@ -6,6 +7,8 @@ import {
 	isNetworkIdBitcoin,
 	isNetworkIdBTCRegtest,
 	isNetworkIdBTCTestnet,
+	isNetworkIdEthereum,
+	isNetworkIdEvm,
 	isNetworkIdICP,
 	isNetworkIdSolana
 } from '$lib/utils/network.utils';
@@ -67,6 +70,10 @@ export const shouldSkipDestinationStep = ({
 
 	if (isNetworkIdICP(network.id)) {
 		return isValidPrincipalText(destination);
+	}
+
+	if (isNetworkIdEthereum(network.id) || isNetworkIdEvm(network.id)) {
+		return isEthAddress(destination);
 	}
 
 	return false;

--- a/src/frontend/src/tests/lib/components/scanner/ScannerCode.spec.ts
+++ b/src/frontend/src/tests/lib/components/scanner/ScannerCode.spec.ts
@@ -16,6 +16,7 @@ import * as deviceUtils from '$lib/utils/device.utils';
 import * as openCryptoPayUtils from '$lib/utils/open-crypto-pay.utils';
 import * as timeoutUtils from '$lib/utils/timeout.utils';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
+import { mockEthAddress, mockEthAddress3 } from '$tests/mocks/eth.mock';
 import { mockPrincipal, mockPrincipalText } from '$tests/mocks/identity.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { encodeIcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
@@ -643,6 +644,149 @@ describe('ScannerCode.svelte', () => {
 
 		expect(mockOnNext).not.toHaveBeenCalledWith(
 			expect.objectContaining({ results: ScannerResults.IC_SEND })
+		);
+	});
+
+	it('should call onNext with EVM_SEND result for a checksummed 0x-prefixed address', async () => {
+		renderWithContext();
+
+		await openManualEntry();
+
+		const input = await screen.findByPlaceholderText(en.scanner.text.enter_or_paste_code);
+		await fireEvent.input(input, { target: { value: mockEthAddress3 } });
+
+		const button = screen.getByRole('button', { name: en.core.text.continue });
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({
+				results: ScannerResults.EVM_SEND,
+				code: mockEthAddress3
+			});
+		});
+
+		expect(openCryptoPayServices.processOpenCryptoPayCode).not.toHaveBeenCalled();
+	});
+
+	it('should call onNext with EVM_SEND result for a lowercase 0x-prefixed address', async () => {
+		renderWithContext();
+
+		await openManualEntry();
+
+		const lowercase = mockEthAddress3.toLowerCase();
+		const input = await screen.findByPlaceholderText(en.scanner.text.enter_or_paste_code);
+		await fireEvent.input(input, { target: { value: lowercase } });
+
+		const button = screen.getByRole('button', { name: en.core.text.continue });
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({
+				results: ScannerResults.EVM_SEND,
+				code: lowercase
+			});
+		});
+
+		expect(openCryptoPayServices.processOpenCryptoPayCode).not.toHaveBeenCalled();
+	});
+
+	it('should trim surrounding whitespace when forwarding an EVM address', async () => {
+		renderWithContext();
+
+		await openManualEntry();
+
+		const input = await screen.findByPlaceholderText(en.scanner.text.enter_or_paste_code);
+		await fireEvent.input(input, { target: { value: `  ${mockEthAddress3}  ` } });
+
+		const button = screen.getByRole('button', { name: en.core.text.continue });
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(mockOnNext).toHaveBeenCalledExactlyOnceWith({
+				results: ScannerResults.EVM_SEND,
+				code: mockEthAddress3
+			});
+		});
+	});
+
+	it('should not dispatch EVM_SEND for an ethereum: URI (falls through to OpenCryptoPay)', async () => {
+		vi.mocked(openCryptoPayServices.processOpenCryptoPayCode).mockRejectedValue(new Error());
+
+		renderWithContext();
+
+		await openManualEntry();
+
+		// EIP-681 / chain-prefixed URIs are explicitly out of scope — the bare-only
+		// detection rule means anything with a scheme prefix falls through to
+		// OpenCryptoPay rather than dispatching EVM_SEND.
+		const ethereumUri = `ethereum:${mockEthAddress3}`;
+		const input = await screen.findByPlaceholderText(en.scanner.text.enter_or_paste_code);
+		await fireEvent.input(input, { target: { value: ethereumUri } });
+
+		const button = screen.getByRole('button', { name: en.core.text.continue });
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(openCryptoPayServices.processOpenCryptoPayCode).toHaveBeenCalledExactlyOnceWith(
+				ethereumUri
+			);
+		});
+
+		expect(mockOnNext).not.toHaveBeenCalledWith(
+			expect.objectContaining({ results: ScannerResults.EVM_SEND })
+		);
+	});
+
+	it('should not dispatch EVM_SEND for an EVM address with query parameters (falls through to OpenCryptoPay)', async () => {
+		vi.mocked(openCryptoPayServices.processOpenCryptoPayCode).mockRejectedValue(new Error());
+
+		renderWithContext();
+
+		await openManualEntry();
+
+		const codeWithQuery = `${mockEthAddress3}?amount=1`;
+		const input = await screen.findByPlaceholderText(en.scanner.text.enter_or_paste_code);
+		await fireEvent.input(input, { target: { value: codeWithQuery } });
+
+		const button = screen.getByRole('button', { name: en.core.text.continue });
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(openCryptoPayServices.processOpenCryptoPayCode).toHaveBeenCalledExactlyOnceWith(
+				codeWithQuery
+			);
+		});
+
+		expect(mockOnNext).not.toHaveBeenCalledWith(
+			expect.objectContaining({ results: ScannerResults.EVM_SEND })
+		);
+	});
+
+	it('should not dispatch EVM_SEND for a wrong-length 0x hex string (falls through to OpenCryptoPay)', async () => {
+		vi.mocked(openCryptoPayServices.processOpenCryptoPayCode).mockRejectedValue(new Error());
+
+		renderWithContext();
+
+		await openManualEntry();
+
+		// `mockEthAddress` is a 64-hex-char string with a 0x prefix — i.e. the size
+		// of a transaction hash or storage slot, not a 20-byte address. ethers'
+		// isAddress rejects it on length, so the scanner must fall through to
+		// OpenCryptoPay rather than mis-classifying it as a send destination.
+		const input = await screen.findByPlaceholderText(en.scanner.text.enter_or_paste_code);
+		await fireEvent.input(input, { target: { value: mockEthAddress } });
+
+		const button = screen.getByRole('button', { name: en.core.text.continue });
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(openCryptoPayServices.processOpenCryptoPayCode).toHaveBeenCalledExactlyOnceWith(
+				mockEthAddress
+			);
+		});
+
+		expect(mockOnNext).not.toHaveBeenCalledWith(
+			expect.objectContaining({ results: ScannerResults.EVM_SEND })
 		);
 	});
 

--- a/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
@@ -12,16 +12,21 @@ import {
 } from '$lib/stores/modal-tokens-list.store';
 import { SCANNED_PLAIN_ADDRESS_SEND_CONTEXT_KEY } from '$lib/stores/scanned-plain-address-send.store';
 import type { NetworkId } from '$lib/types/network';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 
 const renderSendTokensList = ({
 	scannerDriven = false,
-	lockedNetworkIds
-}: { scannerDriven?: boolean; lockedNetworkIds?: NetworkId[] } = {}) =>
+	lockedNetworkIds,
+	onSelectNetworkFilter = vi.fn()
+}: {
+	scannerDriven?: boolean;
+	lockedNetworkIds?: NetworkId[];
+	onSelectNetworkFilter?: () => void;
+} = {}) =>
 	render(SendTokensList, {
 		props: {
 			onSendToken: vi.fn(),
-			onSelectNetworkFilter: vi.fn(),
+			onSelectNetworkFilter,
 			lockedNetworkIds
 		},
 		context: new Map<symbol, unknown>([
@@ -93,5 +98,54 @@ describe('SendTokensList', () => {
 		expect(
 			queryByText(en.send.info.scanned_address_only_destination_single_token)
 		).not.toBeInTheDocument();
+	});
+
+	describe('network filter button interactivity', () => {
+		it('disables the filter button when locked to a single network', async () => {
+			const onSelectNetworkFilter = vi.fn();
+			const { getByRole } = renderSendTokensList({
+				scannerDriven: true,
+				lockedNetworkIds: [BTC_MAINNET_NETWORK_ID],
+				onSelectNetworkFilter
+			});
+
+			const button = getByRole('button', { name: en.networks.chain_fusion });
+
+			expect(button).toBeDisabled();
+
+			await fireEvent.click(button);
+
+			expect(onSelectNetworkFilter).not.toHaveBeenCalled();
+		});
+
+		it('keeps the filter button interactive when locked to multiple networks so the user can drill down', async () => {
+			const onSelectNetworkFilter = vi.fn();
+			const { getByRole } = renderSendTokensList({
+				scannerDriven: true,
+				lockedNetworkIds: [ETHEREUM_NETWORK_ID, ...SUPPORTED_EVM_MAINNET_NETWORK_IDS],
+				onSelectNetworkFilter
+			});
+
+			const button = getByRole('button', { name: en.networks.chain_fusion });
+
+			expect(button).toBeEnabled();
+
+			await fireEvent.click(button);
+
+			expect(onSelectNetworkFilter).toHaveBeenCalledOnce();
+		});
+
+		it('keeps the filter button interactive when no lock is set', async () => {
+			const onSelectNetworkFilter = vi.fn();
+			const { getByRole } = renderSendTokensList({ onSelectNetworkFilter });
+
+			const button = getByRole('button', { name: en.networks.chain_fusion });
+
+			expect(button).toBeEnabled();
+
+			await fireEvent.click(button);
+
+			expect(onSelectNetworkFilter).toHaveBeenCalledOnce();
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
@@ -1,3 +1,7 @@
+import { SUPPORTED_EVM_MAINNET_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.env';
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import SendTokensList from '$lib/components/send/SendTokensList.svelte';
 import { SEND_SCANNED_PLAIN_ADDRESS_NOTICE } from '$lib/constants/test-ids.constants';
@@ -7,13 +11,18 @@ import {
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
 import { SCANNED_PLAIN_ADDRESS_SEND_CONTEXT_KEY } from '$lib/stores/scanned-plain-address-send.store';
+import type { NetworkId } from '$lib/types/network';
 import { render } from '@testing-library/svelte';
 
-const renderSendTokensList = ({ scannerDriven = false }: { scannerDriven?: boolean } = {}) =>
+const renderSendTokensList = ({
+	scannerDriven = false,
+	lockedNetworkIds
+}: { scannerDriven?: boolean; lockedNetworkIds?: NetworkId[] } = {}) =>
 	render(SendTokensList, {
 		props: {
 			onSendToken: vi.fn(),
-			onSelectNetworkFilter: vi.fn()
+			onSelectNetworkFilter: vi.fn(),
+			lockedNetworkIds
 		},
 		context: new Map<symbol, unknown>([
 			[
@@ -42,5 +51,47 @@ describe('SendTokensList', () => {
 
 		expect(getByTestId(SEND_SCANNED_PLAIN_ADDRESS_NOTICE)).toBeInTheDocument();
 		expect(getByText(en.send.info.scanned_address_only_destination)).toBeInTheDocument();
+	});
+
+	it('renders the single-token variant when locked to BTC mainnet only', () => {
+		const { getByText, queryByText } = renderSendTokensList({
+			scannerDriven: true,
+			lockedNetworkIds: [BTC_MAINNET_NETWORK_ID]
+		});
+
+		expect(
+			getByText(en.send.info.scanned_address_only_destination_single_token)
+		).toBeInTheDocument();
+		expect(queryByText(en.send.info.scanned_address_only_destination)).not.toBeInTheDocument();
+	});
+
+	it('renders the multi-token variant when locked to a single non-BTC network', () => {
+		const { getByText, queryByText } = renderSendTokensList({
+			scannerDriven: true,
+			lockedNetworkIds: [ICP_NETWORK_ID]
+		});
+
+		expect(getByText(en.send.info.scanned_address_only_destination)).toBeInTheDocument();
+		expect(
+			queryByText(en.send.info.scanned_address_only_destination_single_token)
+		).not.toBeInTheDocument();
+		expect(
+			queryByText(en.send.info.scanned_address_only_destination_multi_network)
+		).not.toBeInTheDocument();
+	});
+
+	it('renders the multi-network variant when locked to multiple EVM mainnets', () => {
+		const { getByText, queryByText } = renderSendTokensList({
+			scannerDriven: true,
+			lockedNetworkIds: [ETHEREUM_NETWORK_ID, ...SUPPORTED_EVM_MAINNET_NETWORK_IDS]
+		});
+
+		expect(
+			getByText(en.send.info.scanned_address_only_destination_multi_network)
+		).toBeInTheDocument();
+		expect(queryByText(en.send.info.scanned_address_only_destination)).not.toBeInTheDocument();
+		expect(
+			queryByText(en.send.info.scanned_address_only_destination_single_token)
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/utils/send.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/send.utils.spec.ts
@@ -3,13 +3,14 @@ import {
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.btc.env';
+import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { isInvalidDestinationBtc, shouldSkipDestinationStep } from '$lib/utils/send.utils';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
-import { mockEthAddress } from '$tests/mocks/eth.mock';
+import { mockEthAddress, mockEthAddress3 } from '$tests/mocks/eth.mock';
 import { mockPrincipalText } from '$tests/mocks/identity.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 
@@ -111,9 +112,60 @@ describe('send.utils', () => {
 			).toBeFalsy();
 		});
 
-		it('returns false when the chosen token is on Ethereum (unsupported by skip)', () => {
+		it('returns true when destination is a valid EVM address and the token is on Ethereum', () => {
+			expect(
+				shouldSkipDestinationStep({ destination: mockEthAddress3, token: ETHEREUM_TOKEN })
+			).toBeTruthy();
+		});
+
+		it('returns true when destination is a valid EVM address and the token is on a non-Ethereum EVM mainnet', () => {
+			// `mockEthAddress3` is a 0x-prefixed 40-hex address with a valid mixed-case
+			// checksum, so it satisfies `isEthAddress` regardless of which EVM chain the
+			// token lives on. Base is exercised here as a representative non-Ethereum
+			// EVM mainnet; the underlying predicate is `isNetworkIdEvm`, which captures
+			// every entry in `SUPPORTED_EVM_NETWORK_IDS` (Base / BSC / Polygon / Arbitrum).
+			expect(
+				shouldSkipDestinationStep({ destination: mockEthAddress3, token: BASE_ETH_TOKEN })
+			).toBeTruthy();
+		});
+
+		it('returns false when destination is the wrong length to be an EVM address', () => {
+			// `mockEthAddress` is 64 hex chars (transaction-hash sized) rather than the
+			// 40 hex chars of a 20-byte EVM address, so ethers' `isAddress` rejects it.
 			expect(
 				shouldSkipDestinationStep({ destination: mockEthAddress, token: ETHEREUM_TOKEN })
+			).toBeFalsy();
+
+			expect(
+				shouldSkipDestinationStep({ destination: mockEthAddress, token: BASE_ETH_TOKEN })
+			).toBeFalsy();
+		});
+
+		it('returns false when destination is a non-EVM address but the token is on an EVM network', () => {
+			expect(
+				shouldSkipDestinationStep({ destination: mockBtcAddress, token: ETHEREUM_TOKEN })
+			).toBeFalsy();
+
+			expect(
+				shouldSkipDestinationStep({ destination: mockSolAddress, token: ETHEREUM_TOKEN })
+			).toBeFalsy();
+
+			expect(
+				shouldSkipDestinationStep({ destination: mockPrincipalText, token: BASE_ETH_TOKEN })
+			).toBeFalsy();
+		});
+
+		it('returns false when destination is a valid EVM address but the token is not on an EVM network', () => {
+			expect(
+				shouldSkipDestinationStep({ destination: mockEthAddress3, token: BTC_MAINNET_TOKEN })
+			).toBeFalsy();
+
+			expect(
+				shouldSkipDestinationStep({ destination: mockEthAddress3, token: ICP_TOKEN })
+			).toBeFalsy();
+
+			expect(
+				shouldSkipDestinationStep({ destination: mockEthAddress3, token: SOLANA_TOKEN })
 			).toBeFalsy();
 		});
 	});


### PR DESCRIPTION
# Motivation

> Stacked on [#12978](https://github.com/dfinity/oisy-wallet/pull/12978) (multi-network send-modal lock infrastructure). Once that merges, GitHub will retarget this PR onto `main`.

Adds the actual EVM scanner → send behaviour on top of the infrastructure prepared in #12978. Same UX as the BTC/IC path from [#12970](https://github.com/dfinity/oisy-wallet/pull/12970) and the Solana path from [#12943](https://github.com/dfinity/oisy-wallet/pull/12943): scan a bare destination from the main page → send modal opens with the destination pre-filled and the token selector locked → on token selection, jump straight to amount entry if the address is valid for that token's network → on amount + review, show the `ScannedPlainAddressNotice` warning.

The new twist: a bare EVM hex address is valid on every enabled EVM mainnet (Ethereum, Base, BSC, Polygon, Arbitrum, …), so the lock spans the whole set. The token selector filters to all enabled EVM mainnets and the user picks both the network and the token in one step — or, if they prefer, opens the filter popup (restricted to the same EVM-mainnet subset, labelled "EVM Networks") and drills into a single chain first. Sepolia and any other EVM testnet are explicitly excluded. EIP-3770 chain-prefixed addresses (`eth:0x…`), ENS names, and any URI-shaped input fall through to OpenCryptoPay, mirroring the deliberately narrow detection from the Sol/BTC/IC paths.

# Changes

- `SendTokensList` derives the `ScannedPlainAddressNotice` variant directly from `lockedNetworkIds`: 0 / undefined → `multi-token` (default); 1 + BTC mainnet → `single-token`; > 1 → `multi-network`; anything else single → `multi-token`. `SendModal`, when the lock spans multiple networks, switches the modal-tokens-list context from `filterNetwork: lockedNetwork ?? $selectedNetwork` to `filterNetworksIds: lockedNetworkIds` plus the new `filterNetworksLabel: $i18n.networks.evm_networks`, so the token list filters to the EVM subset and the filter button reads "EVM Networks".
- `shouldSkipDestinationStep` gains an EVM branch: token on an Ethereum or EVM network (`isNetworkIdEthereum || isNetworkIdEvm`) + `isEthAddress(destination)` → skip. Same fall-through guarantee as the Sol/BTC/IC paths.
- `EthSendForm` and `EthSendReview` add the `topBanner` snippet wiring `<ScannedPlainAddressNotice styleClass="mb-6!" />` (default `multi-token` variant — the network has been decided by the time the user is on Form / Review, so the generic reminder is the right one). The notice reads `SCANNED_PLAIN_ADDRESS_SEND_CONTEXT_KEY` from context so it stays invisible on existing button-driven send flows. The same wizard components serve every EVM chain, so one wiring covers all of them.
- `ScannerResults` gains `EVM_SEND`. `ScannerCode.processCode` dispatches it when `isEthAddress(trimmed)` matches — i.e. a 0x-prefixed 40-hex-char address (lowercase or mixed-case checksum), which is what ethers' `isAddress` accepts. `ScannerModal.onNext` handles `EVM_SEND` by opening the send modal with `lockedNetworkIds: [ETHEREUM_NETWORK_ID, ...SUPPORTED_EVM_MAINNET_NETWORK_IDS]`.
- `SendTokensList.networkSelectorViewOnly` is lifted into an explicit `$derived.by` with three cases: multi-lock → enabled (drill-down); single-lock → disabled (nothing to drill); URL-route filter without lock → disabled (URL is the source of truth). `SendModal` resolves `lockedNetworks: Network[]` from the locked ids (when length > 1) and passes them to `ModalNetworksFilter` as `filteredNetworks`, together with `allNetworksLabel = networks.evm_networks` so the popup's all-networks entry reads "EVM Networks" rather than the misleading default "All networks".

# Tests

- `ScannerCode.spec.ts` gains six cases pinning the `EVM_SEND` contract: bare 0x-prefixed checksummed address → `EVM_SEND` and does NOT hit OpenCryptoPay; bare lowercase 0x address → `EVM_SEND`; surrounding whitespace → trimmed; `ethereum:0x…` URI → fall through; `0x…?amount=1` → fall through; 64-hex-char input (transaction-hash sized) → fall through (`isAddress` rejects the length).
- `send.utils.spec.ts` extends the `shouldSkipDestinationStep` truth table for the EVM branch: valid 0x address + ETH token → true; valid 0x address + a non-Ethereum EVM mainnet (Base, exercising `isNetworkIdEvm`) → true; wrong-length address + ETH/EVM token → false; non-EVM destination + EVM token → false; valid EVM address + non-EVM token → false. The pre-existing "unsupported by skip" case is rewritten in terms of address length so the assertion still holds with the new EVM branch in place.
- `SendTokensList.spec.ts` extends its fixture to accept `lockedNetworkIds` and pins two truth tables end to end. Variant selection: `[BTC_MAINNET_NETWORK_ID]` → single-token; `[ICP_NETWORK_ID]` → multi-token; `[ETHEREUM_NETWORK_ID, ...SUPPORTED_EVM_MAINNET_NETWORK_IDS]` → multi-network. Filter-button interactivity: single-network lock → disabled, click is a no-op; multi-network lock → enabled, click forwards to `onSelectNetworkFilter` (the drill-down hand-off); no lock → enabled.
- The matching `ScannedPlainAddressNotice` `variant='multi-network'` case and the `ModalNetworksFilter` `allNetworksLabel` cases live in [#12978](https://github.com/dfinity/oisy-wallet/pull/12978).
- Local quality gates: `prettier --check` clean on touched files (a pre-existing warning on `static/manifest.webmanifest` is unrelated and present on `main`); `eslint --max-warnings 0` clean across the touched tree; `svelte-check` reports `0 errors, 0 warnings` across 5661 files; `vitest run` of the scanner, send, util, and network-filter specs passes (208 tests across 30 files), including the unchanged `SendModal.spec.ts` reactivity suite.

Browser-side verification (camera-based QR scan end-to-end) needs the deployed app with auth + canisters and is not exercised here — relying on the unit-test contracts above plus the unchanged Sol/BTC/IC paths as the visual reference. Currently deployed to `test_fe_3` (https://fe3.oisy.com) for manual verification.

🤖 Claude Opus 4.7
