### PR TITLE
fix(frontend): clear failedSwapError when the swap store resets

### DIFF
--- a/src/frontend/src/lib/stores/swap.store.ts
+++ b/src/frontend/src/lib/stores/swap.store.ts
@@ -33,6 +33,7 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 	const { update, set } = data;
 	const isTokensIcrc2 = writable<IsTokensIcrc2Map | undefined>();
 	const isErc20PermitSupported = writable<IsTokensIcrc2Map | undefined>();
+	const failedSwapError = writable<SwapError | undefined>(undefined);
 
 	const sourceToken = derived(
 		[data, swappableTokens],
@@ -112,7 +113,7 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 		isSourceTokenIcrc2,
 		isSourceTokenPermitSupported,
 		receiveSupportedData,
-		failedSwapError: writable<SwapError | undefined>(undefined),
+		failedSwapError,
 		setSourceToken: (token: Token) =>
 			update((state) => ({
 				...state,
@@ -162,6 +163,7 @@ export const initSwapContext = (swapData: SwapData = {}): SwapContext => {
 				sourceToken: undefined,
 				destinationToken: undefined
 			});
+			failedSwapError.set(undefined);
 		}
 	};
 };

--- a/src/frontend/src/tests/lib/stores/swap.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap.store.spec.ts
@@ -102,6 +102,7 @@ describe('swapStore', () => {
 			destinationTokenExchangeRate,
 			destinationTokenBalance,
 			destinationToken,
+			failedSwapError,
 			reset
 		} = initSwapContext({
 			destinationToken: mockToken1,
@@ -119,6 +120,8 @@ describe('swapStore', () => {
 			data: { data: icpBalance, certified: true }
 		});
 
+		failedSwapError.set({ message: 'stale error from previous swap', variant: 'error' });
+
 		reset();
 
 		expect(get(sourceToken)).toBe(undefined);
@@ -129,6 +132,8 @@ describe('swapStore', () => {
 
 		expect(get(sourceTokenExchangeRate)).toBe(undefined);
 		expect(get(destinationTokenExchangeRate)).toBe(undefined);
+
+		expect(get(failedSwapError)).toBe(undefined);
 	});
 
 	it('should set tokens correctly', () => {


### PR DESCRIPTION
# Motivation

`SwapContext.reset()` in [`swap.store.ts`](src/frontend/src/lib/stores/swap.store.ts) only resets the inner `SwapData` writable (source/destination tokens). The `failedSwapError` writable is a separate store on the same context and was never touched by `reset()`.

`SwapModal.close()` and `GetTokenModal.close()` both call this reset on modal dismissal, so a stale error/info message from a previous failed swap survived modal close. The next time the user opened the modal and reached REVIEW, the persistent `<MessageBox>` re-rendered with the old message.

This was found while reviewing [#12971](https://github.com/dfinity/oisy-wallet/pull/12971) but is independent of that change — it would affect the existing ICP wizard's `failedSwapError` as well, so it's split out into its own PR.

# Changes

- `swap.store.ts`: hoist `failedSwapError` to a named `const` inside `initSwapContext` so `reset()` can call `failedSwapError.set(undefined)` directly alongside resetting the SwapData store.
- `swap.store.spec.ts`: extend the existing "should reset all values" test to seed `failedSwapError` with a fake error and assert it is cleared on `reset()`.

# Tests

- `npx vitest run src/frontend/src/tests/lib/stores/swap.store.spec.ts` — 28/28 passing.
- `npx prettier --check` and `npx eslint` on the touched files: clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (`claude-opus-4-7`)