### PR TITLE
refactor(frontend): unify send-modal network restriction under allowedNetworkIds

### DIFF
--- a/src/frontend/src/lib/components/manage/ManageTokens.svelte
+++ b/src/frontend/src/lib/components/manage/ManageTokens.svelte
@@ -102,7 +102,7 @@
 		initModalTokensListContext({
 			tokens: [],
 			filterZeroBalance: false,
-			filterNetwork: network ?? $selectedNetwork,
+			selectedFilterNetwork: network ?? $selectedNetwork,
 			// TODO: This statement is not reactive. Check if it is intentional or not.
 			// eslint-disable-next-line svelte/no-unused-svelte-ignore
 			// svelte-ignore state_referenced_locally
@@ -116,7 +116,7 @@
 		})
 	);
 
-	const { setTokens, filterNetwork } = getContext<ModalTokensListContext>(
+	const { setTokens, selectedFilterNetwork } = getContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY
 	);
 
@@ -136,8 +136,8 @@
 	});
 
 	$effect(() => {
-		if (nonNullish($filterNetwork)) {
-			network = $filterNetwork;
+		if (nonNullish($selectedFilterNetwork)) {
+			network = $selectedFilterNetwork;
 		}
 	});
 

--- a/src/frontend/src/lib/components/scanner/ScannerModal.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerModal.svelte
@@ -2,9 +2,9 @@
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
 	import { assertNever, isNullish, nonNullish } from '@dfinity/utils';
 	import { setContext, untrack } from 'svelte';
-	import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
-	import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
-	import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
+	import { BTC_MAINNET_NETWORK } from '$env/networks/networks.btc.env';
+	import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+	import { SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
 	import OpenCryptoPayWizard from '$lib/components/open-crypto-pay/OpenCryptoPayWizard.svelte';
 	import ScannerCode from '$lib/components/scanner/ScannerCode.svelte';
 	import ScannerInfo from '$lib/components/scanner/ScannerInfo.svelte';
@@ -113,7 +113,7 @@
 				id: Symbol(),
 				data: {
 					destination: code,
-					allowedNetworkIds: [SOLANA_MAINNET_NETWORK_ID]
+					allowedNetworks: [SOLANA_MAINNET_NETWORK]
 				}
 			});
 
@@ -129,7 +129,7 @@
 				id: Symbol(),
 				data: {
 					destination: code,
-					allowedNetworkIds: [BTC_MAINNET_NETWORK_ID]
+					allowedNetworks: [BTC_MAINNET_NETWORK]
 				}
 			});
 
@@ -145,7 +145,7 @@
 				id: Symbol(),
 				data: {
 					destination: code,
-					allowedNetworkIds: [ICP_NETWORK_ID]
+					allowedNetworks: [ICP_NETWORK]
 				}
 			});
 

--- a/src/frontend/src/lib/components/scanner/ScannerModal.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerModal.svelte
@@ -113,7 +113,7 @@
 				id: Symbol(),
 				data: {
 					destination: code,
-					lockedNetworkId: SOLANA_MAINNET_NETWORK_ID
+					allowedNetworkIds: [SOLANA_MAINNET_NETWORK_ID]
 				}
 			});
 
@@ -129,7 +129,7 @@
 				id: Symbol(),
 				data: {
 					destination: code,
-					lockedNetworkId: BTC_MAINNET_NETWORK_ID
+					allowedNetworkIds: [BTC_MAINNET_NETWORK_ID]
 				}
 			});
 
@@ -145,7 +145,7 @@
 				id: Symbol(),
 				data: {
 					destination: code,
-					lockedNetworkId: ICP_NETWORK_ID
+					allowedNetworkIds: [ICP_NETWORK_ID]
 				}
 			});
 

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -155,7 +155,7 @@
 			filterZeroBalance: true,
 			// eslint-disable-next-line svelte/no-unused-svelte-ignore
 			// svelte-ignore state_referenced_locally -- the modal-tokens-list context is initialized once at mount; the reactive `allowedNetwork` (a $derived) is consumed downstream by `SendTokensList`'s view-only lock.
-			filterNetwork: allowedNetwork,
+			selectedFilterNetwork: allowedNetwork,
 			filterNetworksIds:
 				nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 1
 					? allowedNetworkIds

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -156,10 +156,9 @@
 			// eslint-disable-next-line svelte/no-unused-svelte-ignore
 			// svelte-ignore state_referenced_locally -- the modal-tokens-list context is initialized once at mount; the reactive `allowedNetwork` (a $derived) is consumed downstream by `SendTokensList`'s view-only lock.
 			selectedFilterNetwork: allowedNetwork,
-			filterNetworksIds:
-				nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 1
-					? allowedNetworkIds
-					: undefined
+			// eslint-disable-next-line svelte/no-unused-svelte-ignore
+			// svelte-ignore state_referenced_locally -- same as above for the array form
+			availableFilterNetworks: allowedNetworks
 		})
 	);
 

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -50,6 +50,7 @@
 	import { SCANNED_PLAIN_ADDRESS_SEND_CONTEXT_KEY } from '$lib/stores/scanned-plain-address-send.store';
 	import { token } from '$lib/stores/token.store';
 	import type { ContactUi } from '$lib/types/contact';
+	import type { NetworkId } from '$lib/types/network';
 	import type { Nft } from '$lib/types/nft';
 	import type { QrResponse, QrStatus } from '$lib/types/qr-code';
 	import type { SendDestinationTab } from '$lib/types/send';
@@ -78,10 +79,23 @@
 	let { isTransactionsPage, isNftsPage }: Props = $props();
 
 	const initialModalData = $modalSendData;
-	const allowedNetworkIds = initialModalData?.allowedNetworkIds;
+	// Single source of truth for the set of networks the send modal is restricted to.
+	// Scanner-driven dispatches (Sol/BTC/IC, future EVM) populate it via `SendModalData`;
+	// the URL-route filter (`$selectedNetwork`, e.g. `/tokens?network=ethereum`) folds in
+	// as a single-element array fallback so downstream code only needs to read one field.
+	const allowedNetworkIds: NetworkId[] | undefined =
+		initialModalData?.allowedNetworkIds ??
+		(nonNullish($selectedNetwork) ? [$selectedNetwork.id] : undefined);
 	let allowedNetwork = $derived(
 		nonNullish(allowedNetworkIds) && allowedNetworkIds.length === 1
 			? $networks.find(({ id }) => id === allowedNetworkIds[0])
+			: undefined
+	);
+	let allowedNetworks = $derived(
+		nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 1
+			? allowedNetworkIds
+					.map((id) => $networks.find(({ id: networkId }) => networkId === id))
+					.filter((n): n is NonNullable<typeof n> => nonNullish(n))
 			: undefined
 	);
 
@@ -141,7 +155,11 @@
 			filterZeroBalance: true,
 			// eslint-disable-next-line svelte/no-unused-svelte-ignore
 			// svelte-ignore state_referenced_locally -- the modal-tokens-list context is initialized once at mount; the reactive `allowedNetwork` (a $derived) is consumed downstream by `SendTokensList`'s view-only lock.
-			filterNetwork: allowedNetwork ?? $selectedNetwork
+			filterNetwork: allowedNetwork,
+			filterNetworksIds:
+				nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 1
+					? allowedNetworkIds
+					: undefined
 		})
 	);
 
@@ -274,6 +292,7 @@
 				/>
 			{:else if currentStep?.name === WizardStepsSend.FILTER_NETWORKS}
 				<ModalNetworksFilter
+					filteredNetworks={allowedNetworks}
 					onNetworkFilter={() => goToStep(WizardStepsSend.TOKENS_LIST)}
 					showStakeBalance={false}
 				/>

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -78,9 +78,11 @@
 	let { isTransactionsPage, isNftsPage }: Props = $props();
 
 	const initialModalData = $modalSendData;
-	const lockedNetworkId = initialModalData?.lockedNetworkId;
-	let lockedNetwork = $derived(
-		nonNullish(lockedNetworkId) ? $networks.find(({ id }) => id === lockedNetworkId) : undefined
+	const allowedNetworkIds = initialModalData?.allowedNetworkIds;
+	let allowedNetwork = $derived(
+		nonNullish(allowedNetworkIds) && allowedNetworkIds.length === 1
+			? $networks.find(({ id }) => id === allowedNetworkIds[0])
+			: undefined
 	);
 
 	let destination = $state(initialModalData?.destination ?? '');
@@ -138,8 +140,8 @@
 			tokens: $enabledTokens,
 			filterZeroBalance: true,
 			// eslint-disable-next-line svelte/no-unused-svelte-ignore
-			// svelte-ignore state_referenced_locally -- the modal-tokens-list context is initialized once at mount; the reactive `lockedNetwork` (a $derived) is consumed downstream by `SendTokensList`'s view-only lock.
-			filterNetwork: lockedNetwork ?? $selectedNetwork
+			// svelte-ignore state_referenced_locally -- the modal-tokens-list context is initialized once at mount; the reactive `allowedNetwork` (a $derived) is consumed downstream by `SendTokensList`'s view-only lock.
+			filterNetwork: allowedNetwork ?? $selectedNetwork
 		})
 	);
 
@@ -261,7 +263,7 @@
 		{#key currentStep?.name}
 			{#if currentStep?.name === WizardStepsSend.TOKENS_LIST}
 				<SendTokensList
-					{lockedNetwork}
+					{allowedNetworkIds}
 					onSelectNetworkFilter={() => goToStep(WizardStepsSend.FILTER_NETWORKS)}
 					{onSendToken}
 				/>

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -34,7 +34,6 @@
 	} from '$lib/derived/address.derived';
 	import { modalSendData } from '$lib/derived/modal.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
-	import { networks } from '$lib/derived/networks.derived';
 	import { pageNft } from '$lib/derived/page-nft.derived';
 	import { enabledTokens, nonFungibleTokens } from '$lib/derived/tokens.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
@@ -50,7 +49,7 @@
 	import { SCANNED_PLAIN_ADDRESS_SEND_CONTEXT_KEY } from '$lib/stores/scanned-plain-address-send.store';
 	import { token } from '$lib/stores/token.store';
 	import type { ContactUi } from '$lib/types/contact';
-	import type { NetworkId } from '$lib/types/network';
+	import type { Network } from '$lib/types/network';
 	import type { Nft } from '$lib/types/nft';
 	import type { QrResponse, QrStatus } from '$lib/types/qr-code';
 	import type { SendDestinationTab } from '$lib/types/send';
@@ -83,20 +82,11 @@
 	// Scanner-driven dispatches (Sol/BTC/IC, future EVM) populate it via `SendModalData`;
 	// the URL-route filter (`$selectedNetwork`, e.g. `/tokens?network=ethereum`) folds in
 	// as a single-element array fallback so downstream code only needs to read one field.
-	const allowedNetworkIds: NetworkId[] | undefined =
-		initialModalData?.allowedNetworkIds ??
-		(nonNullish($selectedNetwork) ? [$selectedNetwork.id] : undefined);
+	const allowedNetworks: Network[] | undefined =
+		initialModalData?.allowedNetworks ??
+		(nonNullish($selectedNetwork) ? [$selectedNetwork] : undefined);
 	let allowedNetwork = $derived(
-		nonNullish(allowedNetworkIds) && allowedNetworkIds.length === 1
-			? $networks.find(({ id }) => id === allowedNetworkIds[0])
-			: undefined
-	);
-	let allowedNetworks = $derived(
-		nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 1
-			? allowedNetworkIds
-					.map((id) => $networks.find(({ id: networkId }) => networkId === id))
-					.filter((n): n is NonNullable<typeof n> => nonNullish(n))
-			: undefined
+		nonNullish(allowedNetworks) && allowedNetworks.length === 1 ? allowedNetworks[0] : undefined
 	);
 
 	let destination = $state(initialModalData?.destination ?? '');
@@ -280,7 +270,7 @@
 		{#key currentStep?.name}
 			{#if currentStep?.name === WizardStepsSend.TOKENS_LIST}
 				<SendTokensList
-					{allowedNetworkIds}
+					{allowedNetworks}
 					onSelectNetworkFilter={() => goToStep(WizardStepsSend.FILTER_NETWORKS)}
 					{onSendToken}
 				/>

--- a/src/frontend/src/lib/components/send/SendNftsList.svelte
+++ b/src/frontend/src/lib/components/send/SendNftsList.svelte
@@ -24,7 +24,9 @@
 
 	let { onSelect, onSelectNetwork }: Props = $props();
 
-	const { filterNetwork } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
+	const { selectedFilterNetwork } = getContext<ModalTokensListContext>(
+		MODAL_TOKENS_LIST_CONTEXT_KEY
+	);
 
 	let filter = $state('');
 
@@ -37,7 +39,7 @@
 		)
 	);
 	const filtered: Nft[] = $derived(
-		findNftsByNetwork({ nfts: filteredByInputAndSection, networkId: $filterNetwork?.id })
+		findNftsByNetwork({ nfts: filteredByInputAndSection, networkId: $selectedFilterNetwork?.id })
 	);
 
 	let noNftsMatch = $derived(filtered.length === 0);
@@ -56,10 +58,10 @@
 	<div class="flex items-center">
 		<button
 			class="dropdown-button h-[2.2rem] rounded-lg border border-solid border-primary"
-			aria-label={$filterNetwork?.name ?? $i18n.networks.chain_fusion}
+			aria-label={$selectedFilterNetwork?.name ?? $i18n.networks.chain_fusion}
 			onclick={onSelectNetwork}
 		>
-			<span class="font-medium">{$filterNetwork?.name ?? $i18n.networks.chain_fusion}</span>
+			<span class="font-medium">{$selectedFilterNetwork?.name ?? $i18n.networks.chain_fusion}</span>
 			<IconExpandMore size="24" />
 		</button>
 	</div>

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -6,19 +6,23 @@
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { Network } from '$lib/types/network';
+	import type { NetworkId } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
 	import { isNetworkIdBTCMainnet } from '$lib/utils/network.utils';
 
 	interface Props {
 		onSendToken: (token: Token) => void;
 		onSelectNetworkFilter: () => void;
-		lockedNetwork?: Network;
+		allowedNetworkIds?: NetworkId[];
 	}
 
-	let { onSendToken, onSelectNetworkFilter, lockedNetwork }: Props = $props();
+	let { onSendToken, onSelectNetworkFilter, allowedNetworkIds }: Props = $props();
 
-	let lockedSingleToken = $derived(isNetworkIdBTCMainnet(lockedNetwork?.id));
+	let lockedSingleToken = $derived(
+		nonNullish(allowedNetworkIds) &&
+			allowedNetworkIds.length === 1 &&
+			isNetworkIdBTCMainnet(allowedNetworkIds[0])
+	);
 
 	const onTokenButtonClick = (token: Token) => {
 		onSendToken(token);
@@ -26,7 +30,8 @@
 </script>
 
 <ModalTokensList
-	networkSelectorViewOnly={nonNullish(lockedNetwork) || nonNullish($selectedNetwork)}
+	networkSelectorViewOnly={(nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 0) ||
+		nonNullish($selectedNetwork)}
 	{onSelectNetworkFilter}
 	{onTokenButtonClick}
 >

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -4,7 +4,6 @@
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
-	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { NetworkId } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
@@ -24,17 +23,19 @@
 			isNetworkIdBTCMainnet(allowedNetworkIds[0])
 	);
 
+	// Auto-lock when exactly one network is allowed (nothing to drill into); leave the
+	// picker interactive when multiple networks are allowed so the user can narrow further,
+	// or when no restriction is set (Chain Fusion default).
+	let networkSelectorViewOnly = $derived(
+		nonNullish(allowedNetworkIds) && allowedNetworkIds.length === 1
+	);
+
 	const onTokenButtonClick = (token: Token) => {
 		onSendToken(token);
 	};
 </script>
 
-<ModalTokensList
-	networkSelectorViewOnly={(nonNullish(allowedNetworkIds) && allowedNetworkIds.length > 0) ||
-		nonNullish($selectedNetwork)}
-	{onSelectNetworkFilter}
-	{onTokenButtonClick}
->
+<ModalTokensList {networkSelectorViewOnly} {onSelectNetworkFilter} {onTokenButtonClick}>
 	{#snippet topBanner()}
 		<ScannedPlainAddressNotice singleToken={lockedSingleToken} />
 	{/snippet}

--- a/src/frontend/src/lib/components/send/SendTokensList.svelte
+++ b/src/frontend/src/lib/components/send/SendTokensList.svelte
@@ -5,29 +5,29 @@
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
-	import type { NetworkId } from '$lib/types/network';
+	import type { Network } from '$lib/types/network';
 	import type { Token } from '$lib/types/token';
 	import { isNetworkIdBTCMainnet } from '$lib/utils/network.utils';
 
 	interface Props {
 		onSendToken: (token: Token) => void;
 		onSelectNetworkFilter: () => void;
-		allowedNetworkIds?: NetworkId[];
+		allowedNetworks?: Network[];
 	}
 
-	let { onSendToken, onSelectNetworkFilter, allowedNetworkIds }: Props = $props();
+	let { onSendToken, onSelectNetworkFilter, allowedNetworks }: Props = $props();
 
 	let lockedSingleToken = $derived(
-		nonNullish(allowedNetworkIds) &&
-			allowedNetworkIds.length === 1 &&
-			isNetworkIdBTCMainnet(allowedNetworkIds[0])
+		nonNullish(allowedNetworks) &&
+			allowedNetworks.length === 1 &&
+			isNetworkIdBTCMainnet(allowedNetworks[0].id)
 	);
 
 	// Auto-lock when exactly one network is allowed (nothing to drill into); leave the
 	// picker interactive when multiple networks are allowed so the user can narrow further,
 	// or when no restriction is set (Chain Fusion default).
 	let networkSelectorViewOnly = $derived(
-		nonNullish(allowedNetworkIds) && allowedNetworkIds.length === 1
+		nonNullish(allowedNetworks) && allowedNetworks.length === 1
 	);
 
 	const onTokenButtonClick = (token: Token) => {

--- a/src/frontend/src/lib/components/swap/SwapContexts.svelte
+++ b/src/frontend/src/lib/components/swap/SwapContexts.svelte
@@ -80,7 +80,7 @@
 			$crossChainSwapNetworksMainnetsIds.includes($selectedNetwork.id)
 				? $selectedNetwork
 				: undefined,
-		filterNetworksIds: $crossChainSwapNetworksMainnetsIds
+		availableFilterNetworks: $crossChainSwapNetworksMainnets
 	});
 
 	setContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY, tokensListContext);
@@ -96,7 +96,7 @@
 	});
 
 	$effect(() => {
-		tokensListContext.setFilterNetworksIds($crossChainSwapNetworksMainnetsIds);
+		tokensListContext.setAvailableFilterNetworks($crossChainSwapNetworksMainnets);
 	});
 
 	setContext<IcTokenFeeContext>(IC_TOKEN_FEE_CONTEXT_KEY, {

--- a/src/frontend/src/lib/components/swap/SwapContexts.svelte
+++ b/src/frontend/src/lib/components/swap/SwapContexts.svelte
@@ -75,7 +75,7 @@
 
 	const tokensListContext = initModalTokensListContext({
 		tokens: [],
-		filterNetwork:
+		selectedFilterNetwork:
 			nonNullish($selectedNetwork) &&
 			$crossChainSwapNetworksMainnetsIds.includes($selectedNetwork.id)
 				? $selectedNetwork

--- a/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
@@ -72,7 +72,7 @@
 		receiveSupportedData
 	} = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
-	const { setFilterNetwork, setFilterQuery } = getContext<ModalTokensListContext>(
+	const { setSelectedFilterNetwork, setFilterQuery } = getContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY
 	);
 
@@ -166,7 +166,7 @@
 		if (side === 'source') {
 			setNetworksMode({ enabled: true });
 
-			setFilterNetwork(getPreferredNetworkForSide({ side }));
+			setSelectedFilterNetwork(getPreferredNetworkForSide({ side }));
 
 			return;
 		}
@@ -176,7 +176,7 @@
 			// no source yet: no constraints
 			setNetworksMode({ enabled: false });
 
-			setFilterNetwork(getPreferredNetworkForSide({ side }));
+			setSelectedFilterNetwork(getPreferredNetworkForSide({ side }));
 
 			return;
 		}
@@ -187,7 +187,7 @@
 
 		setNetworksMode({ enabled: false, allowedIds });
 
-		setFilterNetwork(getPreferredNetworkForSide({ side, allowedIds }));
+		setSelectedFilterNetwork(getPreferredNetworkForSide({ side, allowedIds }));
 	};
 
 	const enterTokenList = (side: TokenSide) => {
@@ -218,11 +218,11 @@
 		if (selectTokenType === 'source') {
 			setSourceToken(token);
 
-			setFilterNetwork(token.network);
+			setSelectedFilterNetwork(token.network);
 		} else if (selectTokenType === 'destination') {
 			setDestinationToken(token);
 
-			setFilterNetwork(token.network);
+			setSelectedFilterNetwork(token.network);
 		}
 
 		closeTokenList();

--- a/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalNetworksFilter.svelte
@@ -26,7 +26,7 @@
 		onNetworkFilter
 	}: Props = $props();
 
-	const { setFilterNetwork, filterNetwork } = getContext<ModalTokensListContext>(
+	const { setSelectedFilterNetwork, selectedFilterNetwork } = getContext<ModalTokensListContext>(
 		MODAL_TOKENS_LIST_CONTEXT_KEY
 	);
 
@@ -35,7 +35,7 @@
 	const onNetworkSelect = (networkId: OptionNetworkId) => {
 		const network = $networks.find(({ id }) => id === networkId);
 
-		setFilterNetwork(network);
+		setSelectedFilterNetwork(network);
 
 		back();
 	};
@@ -46,7 +46,7 @@
 		{allNetworksEnabled}
 		labelsSize="lg"
 		onSelected={onNetworkSelect}
-		selectedNetworkId={$filterNetwork?.id}
+		selectedNetworkId={$selectedFilterNetwork?.id}
 		{showStakeBalance}
 		showTestnets={false}
 		supportedNetworks={filteredNetworks}

--- a/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
@@ -43,7 +43,7 @@
 
 	const {
 		filteredTokens,
-		filterNetwork,
+		selectedFilterNetwork,
 		filterQuery,
 		setFilterQuery,
 		filterCategoryTag,
@@ -93,11 +93,11 @@
 
 	<div class="flex items-center gap-2">
 		<ModalFilterButton
-			ariaLabel={$filterNetwork?.name ?? $i18n.networks.chain_fusion}
+			ariaLabel={$selectedFilterNetwork?.name ?? $i18n.networks.chain_fusion}
 			disabled={networkSelectorViewOnly}
 			onclick={() => !networkSelectorViewOnly && onSelectNetworkFilter()}
 		>
-			{$filterNetwork?.name ?? $i18n.networks.chain_fusion}
+			{$selectedFilterNetwork?.name ?? $i18n.networks.chain_fusion}
 		</ModalFilterButton>
 
 		{#if $showTokenCategoryFilter}

--- a/src/frontend/src/lib/stores/modal-tokens-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-tokens-list.store.ts
@@ -20,7 +20,7 @@ import { derived, writable, type Readable } from 'svelte/store';
 export interface ModalTokensListData {
 	tokens: Token[];
 	filterQuery?: string;
-	filterNetwork?: Network;
+	selectedFilterNetwork?: Network;
 	filterZeroBalance?: boolean;
 	sortByBalance?: boolean;
 	filterNetworksIds?: NetworkId[];
@@ -36,7 +36,10 @@ export const initModalTokensListContext = (
 
 	const tokens = derived([data], ([{ tokens }]) => tokens);
 	const filterQuery = derived([data], ([{ filterQuery }]) => filterQuery);
-	const filterNetwork = derived([data], ([{ filterNetwork }]) => filterNetwork);
+	const selectedFilterNetwork = derived(
+		[data],
+		([{ selectedFilterNetwork }]) => selectedFilterNetwork
+	);
 	const filterZeroBalance = derived([data], ([{ filterZeroBalance }]) => filterZeroBalance);
 	const sortByBalance = derived([data], ([{ sortByBalance }]) => sortByBalance ?? true);
 	const filterNetworksIds = derived([data], ([{ filterNetworksIds }]) => filterNetworksIds);
@@ -47,7 +50,7 @@ export const initModalTokensListContext = (
 		[
 			tokens,
 			filterQuery,
-			filterNetwork,
+			selectedFilterNetwork,
 			filterZeroBalance,
 			sortByBalance,
 			exchanges,
@@ -61,7 +64,7 @@ export const initModalTokensListContext = (
 		([
 			$tokens,
 			$filterQuery,
-			$filterNetwork,
+			$selectedFilterNetwork,
 			$filterZeroBalance,
 			$sortByBalance,
 			$exchanges,
@@ -85,8 +88,8 @@ export const initModalTokensListContext = (
 
 			const filteredByNetwork = filterTokensForSelectedNetwork([
 				filteredByNetworkIds,
-				$filterNetwork,
-				isNullish($filterNetwork)
+				$selectedFilterNetwork,
+				isNullish($selectedFilterNetwork)
 			]);
 
 			const filteredByNft = filterTokensByNft({
@@ -121,7 +124,7 @@ export const initModalTokensListContext = (
 
 	return {
 		filterQuery,
-		filterNetwork,
+		selectedFilterNetwork,
 		filterCategoryTag,
 		filteredTokens,
 		setTokens: (tokens: Token[]) =>
@@ -134,10 +137,10 @@ export const initModalTokensListContext = (
 				...state,
 				filterQuery: query
 			})),
-		setFilterNetwork: (network: Network | undefined) =>
+		setSelectedFilterNetwork: (network: Network | undefined) =>
 			update((state) => ({
 				...state,
-				filterNetwork: network
+				selectedFilterNetwork: network
 			})),
 		setFilterNetworksIds: (networksIds: NetworkId[] | undefined) =>
 			update((state) => ({
@@ -153,7 +156,7 @@ export const initModalTokensListContext = (
 			update((state) => ({
 				...state,
 				filterQuery: undefined,
-				filterNetwork: undefined,
+				selectedFilterNetwork: undefined,
 				filterZeroBalance: undefined,
 				sortByBalance: undefined,
 				filterNetworksIds: undefined,
@@ -166,12 +169,12 @@ export const initModalTokensListContext = (
 
 export interface ModalTokensListContext {
 	filterQuery: Readable<string | undefined>;
-	filterNetwork: Readable<Network | undefined>;
+	selectedFilterNetwork: Readable<Network | undefined>;
 	filterCategoryTag: Readable<TokenCategoryTagValue | undefined>;
 	filteredTokens: Readable<TokenUi[]>;
 	setTokens: (tokens: Token[]) => void;
 	setFilterQuery: (query: string) => void;
-	setFilterNetwork: (network: Network | undefined) => void;
+	setSelectedFilterNetwork: (network: Network | undefined) => void;
 	setFilterNetworksIds: (networksIds: NetworkId[] | undefined) => void;
 	setFilterCategoryTag: (categoryTag: TokenCategoryTagValue | undefined) => void;
 	resetFilters: () => void;

--- a/src/frontend/src/lib/stores/modal-tokens-list.store.ts
+++ b/src/frontend/src/lib/stores/modal-tokens-list.store.ts
@@ -5,7 +5,7 @@ import { stakeBalances } from '$lib/derived/stake.derived';
 import { tokensToPin } from '$lib/derived/tokens.derived';
 import type { TokenCategoryTagValue } from '$lib/enums/token-tag';
 import { balancesStore } from '$lib/stores/balances.store';
-import type { Network, NetworkId } from '$lib/types/network';
+import type { Network } from '$lib/types/network';
 import type { Token } from '$lib/types/token';
 import type { TokenUi } from '$lib/types/token-ui';
 import {
@@ -23,7 +23,7 @@ export interface ModalTokensListData {
 	selectedFilterNetwork?: Network;
 	filterZeroBalance?: boolean;
 	sortByBalance?: boolean;
-	filterNetworksIds?: NetworkId[];
+	availableFilterNetworks?: Network[];
 	filterNfts?: boolean;
 	filterCategoryTag?: TokenCategoryTagValue;
 }
@@ -42,7 +42,10 @@ export const initModalTokensListContext = (
 	);
 	const filterZeroBalance = derived([data], ([{ filterZeroBalance }]) => filterZeroBalance);
 	const sortByBalance = derived([data], ([{ sortByBalance }]) => sortByBalance ?? true);
-	const filterNetworksIds = derived([data], ([{ filterNetworksIds }]) => filterNetworksIds);
+	const availableFilterNetworks = derived(
+		[data],
+		([{ availableFilterNetworks }]) => availableFilterNetworks
+	);
 	const filterNfts = derived([data], ([{ filterNfts }]) => filterNfts);
 	const filterCategoryTag = derived([data], ([{ filterCategoryTag }]) => filterCategoryTag);
 
@@ -58,7 +61,7 @@ export const initModalTokensListContext = (
 			stakeBalances,
 			tokensToPin,
 			networks,
-			filterNetworksIds,
+			availableFilterNetworks,
 			filterNfts
 		],
 		([
@@ -72,17 +75,17 @@ export const initModalTokensListContext = (
 			$stakeBalances,
 			$tokensToPin,
 			$networksToPin,
-			$filterNetworksIds,
+			$availableFilterNetworks,
 			$filterNfts
 		]) => {
 			const filteredByQuery = filterTokens({ tokens: $tokens, filter: $filterQuery ?? '' });
 
 			const filteredByNetworkIds =
-				nonNullish($filterNetworksIds) && $filterNetworksIds.length > 0
+				nonNullish($availableFilterNetworks) && $availableFilterNetworks.length > 0
 					? filterTokensForSelectedNetworks([
 							filteredByQuery,
-							$filterNetworksIds,
-							isNullish($filterNetworksIds)
+							$availableFilterNetworks.map(({ id }) => id),
+							isNullish($availableFilterNetworks)
 						])
 					: filteredByQuery;
 
@@ -142,10 +145,10 @@ export const initModalTokensListContext = (
 				...state,
 				selectedFilterNetwork: network
 			})),
-		setFilterNetworksIds: (networksIds: NetworkId[] | undefined) =>
+		setAvailableFilterNetworks: (availableNetworks: Network[] | undefined) =>
 			update((state) => ({
 				...state,
-				filterNetworksIds: networksIds
+				availableFilterNetworks: availableNetworks
 			})),
 		setFilterCategoryTag: (categoryTag: TokenCategoryTagValue | undefined) =>
 			update((state) => ({
@@ -159,7 +162,7 @@ export const initModalTokensListContext = (
 				selectedFilterNetwork: undefined,
 				filterZeroBalance: undefined,
 				sortByBalance: undefined,
-				filterNetworksIds: undefined,
+				availableFilterNetworks: undefined,
 				filterNfts: undefined,
 				filterCategoryTag: undefined
 			}));
@@ -175,7 +178,7 @@ export interface ModalTokensListContext {
 	setTokens: (tokens: Token[]) => void;
 	setFilterQuery: (query: string) => void;
 	setSelectedFilterNetwork: (network: Network | undefined) => void;
-	setFilterNetworksIds: (networksIds: NetworkId[] | undefined) => void;
+	setAvailableFilterNetworks: (availableNetworks: Network[] | undefined) => void;
 	setFilterCategoryTag: (categoryTag: TokenCategoryTagValue | undefined) => void;
 	resetFilters: () => void;
 }

--- a/src/frontend/src/lib/types/send.ts
+++ b/src/frontend/src/lib/types/send.ts
@@ -28,5 +28,5 @@ export type SendDestinationTab = 'recentlyUsed' | 'contacts';
 
 export interface SendModalData {
 	destination: string;
-	lockedNetworkId: NetworkId;
+	allowedNetworkIds: NetworkId[];
 }

--- a/src/frontend/src/lib/types/send.ts
+++ b/src/frontend/src/lib/types/send.ts
@@ -1,6 +1,6 @@
 import type { ProgressStepsSend, ProgressStepsSendIc } from '$lib/enums/progress-steps';
 import type { NullishIdentity } from '$lib/types/identity';
-import type { NetworkId } from '$lib/types/network';
+import type { Network } from '$lib/types/network';
 import type { NftId, NonFungibleToken } from '$lib/types/nft';
 
 export interface TransferParams {
@@ -28,5 +28,5 @@ export type SendDestinationTab = 'recentlyUsed' | 'contacts';
 
 export interface SendModalData {
 	destination: string;
-	allowedNetworkIds: NetworkId[];
+	allowedNetworks: Network[];
 }

--- a/src/frontend/src/tests/lib/components/send/SendNftsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendNftsList.spec.ts
@@ -23,7 +23,7 @@ describe('SendNftsList.spec', () => {
 		nftStore.addAll(mockNfts);
 		const { getByText, getByRole } = render(SendNftsListTestHost, {
 			onSelect: vi.fn(),
-			filterNetwork: undefined,
+			selectedFilterNetwork: undefined,
 			onSelectNetwork: vi.fn()
 		});
 
@@ -40,7 +40,7 @@ describe('SendNftsList.spec', () => {
 		nftStore.addAll(mockNfts);
 		const { getByText, queryByText, getByPlaceholderText } = render(SendNftsListTestHost, {
 			onSelect: vi.fn(),
-			filterNetwork: undefined,
+			selectedFilterNetwork: undefined,
 			onSelectNetwork: vi.fn()
 		});
 
@@ -57,7 +57,7 @@ describe('SendNftsList.spec', () => {
 		nftStore.addAll(mockNfts);
 		const { getByPlaceholderText, getByText, queryByText } = render(SendNftsListTestHost, {
 			onSelect: vi.fn(),
-			filterNetwork: undefined,
+			selectedFilterNetwork: undefined,
 			onSelectNetwork: vi.fn()
 		});
 
@@ -77,7 +77,7 @@ describe('SendNftsList.spec', () => {
 		const { getByRole } = render(SendNftsListTestHost, {
 			onSelect: vi.fn(),
 			onSelectNetwork,
-			filterNetwork: POLYGON_AMOY_NETWORK
+			selectedFilterNetwork: POLYGON_AMOY_NETWORK
 		});
 
 		const btn = getByRole('button', { name: POLYGON_AMOY_NETWORK.name });
@@ -95,7 +95,7 @@ describe('SendNftsList.spec', () => {
 		const onSelect = vi.fn();
 		const { getByText } = render(SendNftsListTestHost, {
 			onSelect,
-			filterNetwork: undefined,
+			selectedFilterNetwork: undefined,
 			onSelectNetwork: vi.fn()
 		});
 
@@ -131,7 +131,7 @@ describe('SendNftsList.spec', () => {
 		nftStore.addAll(sectionMockNfts);
 		const { getByPlaceholderText, getByText, queryByText } = render(SendNftsListTestHost, {
 			onSelect: vi.fn(),
-			filterNetwork: undefined,
+			selectedFilterNetwork: undefined,
 			onSelectNetwork: vi.fn()
 		});
 

--- a/src/frontend/src/tests/lib/components/send/SendNftsListTestHost.svelte
+++ b/src/frontend/src/tests/lib/components/send/SendNftsListTestHost.svelte
@@ -12,16 +12,16 @@
 	interface Props {
 		onSelect: (nft: Nft) => void;
 		onSelectNetwork: () => void;
-		filterNetwork?: Network;
+		selectedFilterNetwork?: Network;
 	}
 
-	const { onSelect, filterNetwork, onSelectNetwork }: Props = $props();
+	const { onSelect, selectedFilterNetwork, onSelectNetwork }: Props = $props();
 
 	setContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY, {
 		// TODO: This statement is not reactive. Check if it is intentional or not.
 		// eslint-disable-next-line svelte/no-unused-svelte-ignore
 		// svelte-ignore state_referenced_locally
-		filterNetwork: readable(filterNetwork)
+		selectedFilterNetwork: readable(selectedFilterNetwork)
 	} as unknown as ModalTokensListContext);
 </script>
 

--- a/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
@@ -36,7 +36,7 @@ const renderSendTokensList = ({
 				initModalTokensListContext({
 					tokens: [BTC_MAINNET_TOKEN],
 					filterZeroBalance: false,
-					filterNetwork: undefined,
+					selectedFilterNetwork: undefined,
 					filterQuery: ''
 				})
 			],

--- a/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
@@ -1,8 +1,8 @@
-import { ARBITRUM_MAINNET_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
-import { BASE_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.base.env';
-import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
-import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
+import { BTC_MAINNET_NETWORK } from '$env/networks/networks.btc.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import SendTokensList from '$lib/components/send/SendTokensList.svelte';
 import { SEND_SCANNED_PLAIN_ADDRESS_NOTICE } from '$lib/constants/test-ids.constants';
@@ -12,23 +12,23 @@ import {
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
 import { SCANNED_PLAIN_ADDRESS_SEND_CONTEXT_KEY } from '$lib/stores/scanned-plain-address-send.store';
-import type { NetworkId } from '$lib/types/network';
+import type { Network } from '$lib/types/network';
 import { fireEvent, render } from '@testing-library/svelte';
 
 const renderSendTokensList = ({
 	scannerDriven = false,
-	allowedNetworkIds,
+	allowedNetworks,
 	onSelectNetworkFilter = vi.fn()
 }: {
 	scannerDriven?: boolean;
-	allowedNetworkIds?: NetworkId[];
+	allowedNetworks?: Network[];
 	onSelectNetworkFilter?: () => void;
 } = {}) =>
 	render(SendTokensList, {
 		props: {
 			onSendToken: vi.fn(),
 			onSelectNetworkFilter,
-			allowedNetworkIds
+			allowedNetworks
 		},
 		context: new Map<symbol, unknown>([
 			[
@@ -63,7 +63,7 @@ describe('SendTokensList', () => {
 		it('disables the filter button when locked to a single network (BTC mainnet)', async () => {
 			const onSelectNetworkFilter = vi.fn();
 			const { getByRole } = renderSendTokensList({
-				allowedNetworkIds: [BTC_MAINNET_NETWORK_ID],
+				allowedNetworks: [BTC_MAINNET_NETWORK],
 				onSelectNetworkFilter
 			});
 
@@ -78,7 +78,7 @@ describe('SendTokensList', () => {
 
 		it('disables the filter button when locked to a single network (Ethereum, URL-route case)', () => {
 			const { getByRole } = renderSendTokensList({
-				allowedNetworkIds: [ETHEREUM_NETWORK_ID]
+				allowedNetworks: [ETHEREUM_NETWORK]
 			});
 
 			expect(getByRole('button', { name: en.networks.chain_fusion })).toBeDisabled();
@@ -87,7 +87,7 @@ describe('SendTokensList', () => {
 		it('keeps the filter button interactive when multiple networks are allowed', async () => {
 			const onSelectNetworkFilter = vi.fn();
 			const { getByRole } = renderSendTokensList({
-				allowedNetworkIds: [ETHEREUM_NETWORK_ID, BASE_NETWORK_ID, ARBITRUM_MAINNET_NETWORK_ID],
+				allowedNetworks: [ETHEREUM_NETWORK, BASE_NETWORK, ARBITRUM_MAINNET_NETWORK],
 				onSelectNetworkFilter
 			});
 
@@ -118,7 +118,7 @@ describe('SendTokensList', () => {
 		it('renders the single-token copy when locked to BTC mainnet', () => {
 			const { getByText, queryByText } = renderSendTokensList({
 				scannerDriven: true,
-				allowedNetworkIds: [BTC_MAINNET_NETWORK_ID]
+				allowedNetworks: [BTC_MAINNET_NETWORK]
 			});
 
 			expect(
@@ -130,7 +130,7 @@ describe('SendTokensList', () => {
 		it('renders the default multi-token copy when locked to a non-BTC network', () => {
 			const { getByText, queryByText } = renderSendTokensList({
 				scannerDriven: true,
-				allowedNetworkIds: [ICP_NETWORK_ID]
+				allowedNetworks: [ICP_NETWORK]
 			});
 
 			expect(getByText(en.send.info.scanned_address_only_destination)).toBeInTheDocument();

--- a/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendTokensList.spec.ts
@@ -1,3 +1,8 @@
+import { ARBITRUM_MAINNET_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.base.env';
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import SendTokensList from '$lib/components/send/SendTokensList.svelte';
 import { SEND_SCANNED_PLAIN_ADDRESS_NOTICE } from '$lib/constants/test-ids.constants';
@@ -7,13 +12,23 @@ import {
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
 import { SCANNED_PLAIN_ADDRESS_SEND_CONTEXT_KEY } from '$lib/stores/scanned-plain-address-send.store';
-import { render } from '@testing-library/svelte';
+import type { NetworkId } from '$lib/types/network';
+import { fireEvent, render } from '@testing-library/svelte';
 
-const renderSendTokensList = ({ scannerDriven = false }: { scannerDriven?: boolean } = {}) =>
+const renderSendTokensList = ({
+	scannerDriven = false,
+	allowedNetworkIds,
+	onSelectNetworkFilter = vi.fn()
+}: {
+	scannerDriven?: boolean;
+	allowedNetworkIds?: NetworkId[];
+	onSelectNetworkFilter?: () => void;
+} = {}) =>
 	render(SendTokensList, {
 		props: {
 			onSendToken: vi.fn(),
-			onSelectNetworkFilter: vi.fn()
+			onSelectNetworkFilter,
+			allowedNetworkIds
 		},
 		context: new Map<symbol, unknown>([
 			[
@@ -42,5 +57,86 @@ describe('SendTokensList', () => {
 
 		expect(getByTestId(SEND_SCANNED_PLAIN_ADDRESS_NOTICE)).toBeInTheDocument();
 		expect(getByText(en.send.info.scanned_address_only_destination)).toBeInTheDocument();
+	});
+
+	describe('network filter button auto-lock', () => {
+		it('disables the filter button when locked to a single network (BTC mainnet)', async () => {
+			const onSelectNetworkFilter = vi.fn();
+			const { getByRole } = renderSendTokensList({
+				allowedNetworkIds: [BTC_MAINNET_NETWORK_ID],
+				onSelectNetworkFilter
+			});
+
+			const button = getByRole('button', { name: en.networks.chain_fusion });
+
+			expect(button).toBeDisabled();
+
+			await fireEvent.click(button);
+
+			expect(onSelectNetworkFilter).not.toHaveBeenCalled();
+		});
+
+		it('disables the filter button when locked to a single network (Ethereum, URL-route case)', () => {
+			const { getByRole } = renderSendTokensList({
+				allowedNetworkIds: [ETHEREUM_NETWORK_ID]
+			});
+
+			expect(getByRole('button', { name: en.networks.chain_fusion })).toBeDisabled();
+		});
+
+		it('keeps the filter button interactive when multiple networks are allowed', async () => {
+			const onSelectNetworkFilter = vi.fn();
+			const { getByRole } = renderSendTokensList({
+				allowedNetworkIds: [ETHEREUM_NETWORK_ID, BASE_NETWORK_ID, ARBITRUM_MAINNET_NETWORK_ID],
+				onSelectNetworkFilter
+			});
+
+			const button = getByRole('button', { name: en.networks.chain_fusion });
+
+			expect(button).toBeEnabled();
+
+			await fireEvent.click(button);
+
+			expect(onSelectNetworkFilter).toHaveBeenCalledOnce();
+		});
+
+		it('keeps the filter button interactive when no restriction is set', async () => {
+			const onSelectNetworkFilter = vi.fn();
+			const { getByRole } = renderSendTokensList({ onSelectNetworkFilter });
+
+			const button = getByRole('button', { name: en.networks.chain_fusion });
+
+			expect(button).toBeEnabled();
+
+			await fireEvent.click(button);
+
+			expect(onSelectNetworkFilter).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('BTC single-token notice variant', () => {
+		it('renders the single-token copy when locked to BTC mainnet', () => {
+			const { getByText, queryByText } = renderSendTokensList({
+				scannerDriven: true,
+				allowedNetworkIds: [BTC_MAINNET_NETWORK_ID]
+			});
+
+			expect(
+				getByText(en.send.info.scanned_address_only_destination_single_token)
+			).toBeInTheDocument();
+			expect(queryByText(en.send.info.scanned_address_only_destination)).not.toBeInTheDocument();
+		});
+
+		it('renders the default multi-token copy when locked to a non-BTC network', () => {
+			const { getByText, queryByText } = renderSendTokensList({
+				scannerDriven: true,
+				allowedNetworkIds: [ICP_NETWORK_ID]
+			});
+
+			expect(getByText(en.send.info.scanned_address_only_destination)).toBeInTheDocument();
+			expect(
+				queryByText(en.send.info.scanned_address_only_destination_single_token)
+			).not.toBeInTheDocument();
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/swap/SwapContexts.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapContexts.spec.ts
@@ -82,7 +82,7 @@ describe('SwapContexts', () => {
 					setTokens: expect.any(Function),
 					setFilterQuery: expect.any(Function),
 					setSelectedFilterNetwork: expect.any(Function),
-					setFilterNetworksIds: expect.any(Function),
+					setAvailableFilterNetworks: expect.any(Function),
 					resetFilters: expect.any(Function)
 				})
 			);

--- a/src/frontend/src/tests/lib/components/swap/SwapContexts.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapContexts.spec.ts
@@ -77,11 +77,11 @@ describe('SwapContexts', () => {
 				MODAL_TOKENS_LIST_CONTEXT_KEY,
 				expect.objectContaining({
 					filterQuery: expect.any(Object),
-					filterNetwork: expect.any(Object),
+					selectedFilterNetwork: expect.any(Object),
 					filteredTokens: expect.any(Object),
 					setTokens: expect.any(Function),
 					setFilterQuery: expect.any(Function),
-					setFilterNetwork: expect.any(Function),
+					setSelectedFilterNetwork: expect.any(Function),
 					setFilterNetworksIds: expect.any(Function),
 					resetFilters: expect.any(Function)
 				})

--- a/src/frontend/src/tests/lib/components/tokens/ModalTokensListTestHost.svelte
+++ b/src/frontend/src/tests/lib/components/tokens/ModalTokensListTestHost.svelte
@@ -37,7 +37,7 @@
 			// svelte-ignore state_referenced_locally
 			tokens,
 			filterZeroBalance: false,
-			filterNetwork: undefined,
+			selectedFilterNetwork: undefined,
 			filterQuery: '',
 			// TODO: This statement is not reactive. Check if it is intentional or not.
 			// eslint-disable-next-line svelte/no-unused-svelte-ignore

--- a/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
@@ -78,7 +78,7 @@ describe('modalTokensListStore', () => {
 	it('should ensure derived stores update at most once when the store changes', async () => {
 		await testDerivedUpdates(() =>
 			initModalTokensListContext({
-				filterNetwork: ICP_NETWORK,
+				selectedFilterNetwork: ICP_NETWORK,
 				filterQuery: 'test',
 				filterZeroBalance: true,
 				tokens: [mockToken1, mockToken2]
@@ -87,21 +87,21 @@ describe('modalTokensListStore', () => {
 	});
 
 	it('should have all expected values', () => {
-		const { filterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
-			filterNetwork: ICP_NETWORK,
+		const { selectedFilterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
+			selectedFilterNetwork: ICP_NETWORK,
 			filterZeroBalance: true,
 			tokens: [mockToken1, mockToken2]
 		});
 
-		expect(get(filterNetwork)).toBe(ICP_NETWORK);
+		expect(get(selectedFilterNetwork)).toBe(ICP_NETWORK);
 		expect(get(filterQuery)).toBe(undefined);
 		expect(get(filteredTokens)).toStrictEqual([mockTokenUi2, mockTokenUi1]);
 	});
 
 	it('should reset all filters', () => {
-		const { filterNetwork, filteredTokens, filterQuery, filterCategoryTag, resetFilters } =
+		const { selectedFilterNetwork, filteredTokens, filterQuery, filterCategoryTag, resetFilters } =
 			initModalTokensListContext({
-				filterNetwork: ICP_NETWORK,
+				selectedFilterNetwork: ICP_NETWORK,
 				filterQuery: 'test',
 				filterCategoryTag: TokenCategoryTagValue.STABLECOIN,
 				tokens: [mockToken1, mockToken2]
@@ -109,7 +109,7 @@ describe('modalTokensListStore', () => {
 
 		resetFilters();
 
-		expect(get(filterNetwork)).toBe(undefined);
+		expect(get(selectedFilterNetwork)).toBe(undefined);
 		expect(get(filterQuery)).toBe(undefined);
 		expect(get(filterCategoryTag)).toBe(undefined);
 		expect(get(filteredTokens)).toStrictEqual([mockTokenUi2, mockTokenUi1]);
@@ -127,52 +127,53 @@ describe('modalTokensListStore', () => {
 		expect(get(filteredTokens)).toHaveLength(1);
 	});
 
-	it('should update filter network via setFilterNetwork', () => {
-		const { filterNetwork, filteredTokens, setFilterNetwork } = initModalTokensListContext({
-			filterZeroBalance: true,
-			tokens: [mockToken1, mockToken2]
-		});
+	it('should update filter network via setSelectedFilterNetwork', () => {
+		const { selectedFilterNetwork, filteredTokens, setSelectedFilterNetwork } =
+			initModalTokensListContext({
+				filterZeroBalance: true,
+				tokens: [mockToken1, mockToken2]
+			});
 
-		expect(get(filterNetwork)).toBeUndefined();
+		expect(get(selectedFilterNetwork)).toBeUndefined();
 
-		setFilterNetwork(ICP_NETWORK);
+		setSelectedFilterNetwork(ICP_NETWORK);
 
-		expect(get(filterNetwork)).toBe(ICP_NETWORK);
+		expect(get(selectedFilterNetwork)).toBe(ICP_NETWORK);
 		expect(get(filteredTokens)).toStrictEqual([mockTokenUi2, mockTokenUi1]);
 
-		setFilterNetwork(undefined);
+		setSelectedFilterNetwork(undefined);
 
-		expect(get(filterNetwork)).toBeUndefined();
+		expect(get(selectedFilterNetwork)).toBeUndefined();
 	});
 
 	it('should filter tokens by network', () => {
-		const { filterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
-			filterNetwork: ETHEREUM_NETWORK,
+		const { selectedFilterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
+			selectedFilterNetwork: ETHEREUM_NETWORK,
 			filterZeroBalance: true,
 			tokens: [mockToken1, mockToken2]
 		});
 
-		expect(get(filterNetwork)).toBe(ETHEREUM_NETWORK);
+		expect(get(selectedFilterNetwork)).toBe(ETHEREUM_NETWORK);
 		expect(get(filterQuery)).toBe(undefined);
 		expect(get(filteredTokens)).toStrictEqual([]);
 	});
 
 	it('should filter tokens by query', () => {
-		const { filterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
-			filterNetwork: ICP_NETWORK,
+		const { selectedFilterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
+			selectedFilterNetwork: ICP_NETWORK,
 			filterQuery: 'ckBTC',
 			filterZeroBalance: true,
 			tokens: [mockToken1, mockToken2]
 		});
 
-		expect(get(filterNetwork)).toBe(ICP_NETWORK);
+		expect(get(selectedFilterNetwork)).toBe(ICP_NETWORK);
 		expect(get(filterQuery)).toBe('ckBTC');
 		expect(get(filteredTokens)).toStrictEqual([mockTokenUi1]);
 	});
 
 	it('should filter zero-balance tokens', () => {
-		const { filterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
-			filterNetwork: ICP_NETWORK,
+		const { selectedFilterNetwork, filteredTokens, filterQuery } = initModalTokensListContext({
+			selectedFilterNetwork: ICP_NETWORK,
 			filterZeroBalance: true,
 			tokens: [mockToken1, mockToken2]
 		});
@@ -182,7 +183,7 @@ describe('modalTokensListStore', () => {
 			data: { data: ZERO, certified: true }
 		});
 
-		expect(get(filterNetwork)).toBe(ICP_NETWORK);
+		expect(get(selectedFilterNetwork)).toBe(ICP_NETWORK);
 		expect(get(filterQuery)).toBe(undefined);
 		expect(get(filteredTokens)).toStrictEqual([mockTokenUi1]);
 	});
@@ -319,11 +320,11 @@ describe('modalTokensListStore', () => {
 			expect(result).toEqual([mockTokenUi3, mockTokenUi4]);
 		});
 
-		it('should combine filterNetworksIds with filterNetwork', () => {
+		it('should combine filterNetworksIds with selectedFilterNetwork', () => {
 			const { filteredTokens } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
 				filterNetworksIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id],
-				filterNetwork: ETHEREUM_NETWORK,
+				selectedFilterNetwork: ETHEREUM_NETWORK,
 				filterZeroBalance: false
 			});
 

--- a/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/modal-tokens-list.store.spec.ts
@@ -232,7 +232,7 @@ describe('modalTokensListStore', () => {
 		});
 	});
 
-	describe('modalTokensListStore - filterNetworksIds', () => {
+	describe('modalTokensListStore - availableFilterNetworks', () => {
 		const ethExchangeValue = 3;
 		const ethBalance = bn1Bi;
 
@@ -284,17 +284,17 @@ describe('modalTokensListStore', () => {
 			);
 		});
 
-		it('should filter tokens by filterNetworksIds when provided', () => {
+		it('should filter tokens by availableFilterNetworks when provided', () => {
 			const { filteredTokens } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
-				filterNetworksIds: [ETHEREUM_NETWORK.id],
+				availableFilterNetworks: [ETHEREUM_NETWORK],
 				filterZeroBalance: false
 			});
 
 			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
 		});
 
-		it('should not filter when filterNetworksIds is undefined', () => {
+		it('should not filter when availableFilterNetworks is undefined', () => {
 			const { filteredTokens } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
 				filterZeroBalance: false
@@ -307,10 +307,10 @@ describe('modalTokensListStore', () => {
 			expect(result).toEqual([mockTokenUi3, mockTokenUi4]);
 		});
 
-		it('should filter tokens by multiple network IDs', () => {
+		it('should filter tokens by multiple networks', () => {
 			const { filteredTokens } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
-				filterNetworksIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id],
+				availableFilterNetworks: [ETHEREUM_NETWORK, ARBITRUM_MAINNET_NETWORK],
 				filterZeroBalance: false
 			});
 
@@ -320,10 +320,10 @@ describe('modalTokensListStore', () => {
 			expect(result).toEqual([mockTokenUi3, mockTokenUi4]);
 		});
 
-		it('should combine filterNetworksIds with selectedFilterNetwork', () => {
+		it('should combine availableFilterNetworks with selectedFilterNetwork', () => {
 			const { filteredTokens } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
-				filterNetworksIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id],
+				availableFilterNetworks: [ETHEREUM_NETWORK, ARBITRUM_MAINNET_NETWORK],
 				selectedFilterNetwork: ETHEREUM_NETWORK,
 				filterZeroBalance: false
 			});
@@ -331,10 +331,10 @@ describe('modalTokensListStore', () => {
 			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
 		});
 
-		it('should combine filterNetworksIds with filterQuery', () => {
+		it('should combine availableFilterNetworks with filterQuery', () => {
 			const { filteredTokens } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
-				filterNetworksIds: [ETHEREUM_NETWORK.id, ARBITRUM_MAINNET_NETWORK.id],
+				availableFilterNetworks: [ETHEREUM_NETWORK, ARBITRUM_MAINNET_NETWORK],
 				filterQuery: 'Ethereum',
 				filterZeroBalance: false
 			});
@@ -342,55 +342,55 @@ describe('modalTokensListStore', () => {
 			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
 		});
 
-		it('should update filterNetworksIds using setFilterNetworksIds', () => {
-			const { filteredTokens, setFilterNetworksIds } = initModalTokensListContext({
+		it('should update availableFilterNetworks using setAvailableFilterNetworks', () => {
+			const { filteredTokens, setAvailableFilterNetworks } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
-				filterNetworksIds: [ETHEREUM_NETWORK.id],
+				availableFilterNetworks: [ETHEREUM_NETWORK],
 				filterZeroBalance: false
 			});
 
 			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
 
-			setFilterNetworksIds([ARBITRUM_MAINNET_NETWORK.id]);
+			setAvailableFilterNetworks([ARBITRUM_MAINNET_NETWORK]);
 
 			expect(get(filteredTokens)).toEqual([mockTokenUi4]);
 		});
 
-		it('should clear filterNetworksIds when setFilterNetworksIds is called with undefined', () => {
-			const { filteredTokens, setFilterNetworksIds } = initModalTokensListContext({
+		it('should clear availableFilterNetworks when setAvailableFilterNetworks is called with undefined', () => {
+			const { filteredTokens, setAvailableFilterNetworks } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
-				filterNetworksIds: [ETHEREUM_NETWORK.id],
+				availableFilterNetworks: [ETHEREUM_NETWORK],
 				filterZeroBalance: false
 			});
 
 			expect(get(filteredTokens)).toEqual([mockTokenUi3]);
 
-			setFilterNetworksIds(undefined);
+			setAvailableFilterNetworks(undefined);
 
 			const result = get(filteredTokens);
 
 			expect(result).toHaveLength(2);
 		});
 
-		it('should clear filterNetworksIds when setFilterNetworksIds is called with empty array', () => {
+		it('should clear availableFilterNetworks when setAvailableFilterNetworks is called with empty array', () => {
 			const { filteredTokens } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
-				filterNetworksIds: [],
+				availableFilterNetworks: [],
 				filterZeroBalance: false
 			});
 
 			expect(get(filteredTokens)).toEqual([mockTokenUi3, mockTokenUi4]);
 		});
 
-		it('should clear filterNetworksIds when changed setFilterNetworksIds to empty array', () => {
-			const { filteredTokens, setFilterNetworksIds } = initModalTokensListContext({
+		it('should clear availableFilterNetworks when changed setAvailableFilterNetworks to empty array', () => {
+			const { filteredTokens, setAvailableFilterNetworks } = initModalTokensListContext({
 				tokens: [mockToken3, mockToken4],
 				filterZeroBalance: false
 			});
 
 			expect(get(filteredTokens)).toEqual([mockTokenUi3, mockTokenUi4]);
 
-			setFilterNetworksIds([]);
+			setAvailableFilterNetworks([]);
 
 			const result = get(filteredTokens);
 


### PR DESCRIPTION
# Motivation

The send modal's network picker had two disable triggers handling two distinct concerns:

1. **Scanner-driven restriction** — a destination that's only valid on a fixed network set (today: Sol / BTC / IC scanner dispatches, each on one network). Carried in `SendModalData.lockedNetworkId: NetworkId`.
2. **URL-route filter** — the user is on a network-specific view (`/tokens?network=ethereum`, the tokens-grouped-by-network expanded card, etc.) and hits the global Send button. Carried via `$selectedNetwork`.

Both end up showing the same UI — picker disabled, token list filtered — but via separate code paths reading separate stores, and the name `lockedNetworkId` doesn't read sensibly once the field needs to express more than one network (forthcoming work needs that for the EVM scanner case, where a bare hex address is valid on every EVM mainnet).

This refactor renames the fields, reshapes the restriction to an array, folds both concerns into a single source of truth, and harmonizes the naming on `ModalTokensListContext` so the user's pick (`selectedFilterNetwork`) and the set they can pick from (`availableFilterNetworks`) read as a deliberate, symmetric pair. No observable behaviour change on `main`: every existing path keeps its current disabled/enabled state and the same token-list filter. The `length > 1` interactive branch is forward-looking — no caller dispatches it yet.

# Changes

- `SendModalData.lockedNetworkId: NetworkId` → `allowedNetworks: Network[]`. The name matches the underlying intent (the set of networks the destination can be sent on) and scales to multiple entries. The three existing scanner dispatches in `ScannerModal` (Sol/BTC/IC) switch from the `*_NETWORK_ID` constants to the corresponding `*_NETWORK` objects.
- `SendModal` derives an effective `allowedNetworks` from both the scanner data and the URL-route filter: `initialModalData?.allowedNetworks ?? (nonNullish($selectedNetwork) ? [$selectedNetwork] : undefined)`. Scanner intent takes precedence (it's the more specific signal); the URL fallback only kicks in when no scanner restriction is set. Downstream consumers (`SendTokensList`, the modal-tokens-list context, `ModalNetworksFilter`) read only this unified field.
- `SendTokensList.networkSelectorViewOnly` collapses to `allowedNetworks?.length === 1` — the auto-lock rule. The two existing single-network paths (BTC/Sol/IC scanner and URL-route) both land in this branch and stay disabled exactly as before; a future multi-network case (the EVM scanner) lands in the `length > 1` branch and is interactive.
- `SendTokensList` no longer reads `$selectedNetwork` directly. The single source of truth is `allowedNetworks`.
- `ModalNetworksFilter` receives `filteredNetworks={allowedNetworks}` so any future picker interaction respects the restriction. For the existing single-network cases the picker is disabled anyway so the prop is moot; for the no-restriction default the prop is undefined and the popup lists every enabled network exactly as today.
- `ModalTokensListContext.filterNetwork: Network` → `selectedFilterNetwork: Network` (rename only — same type, same semantics). The name now says what the field is: the user's currently-selected network from the popup, as opposed to a static restriction.
- `ModalTokensListContext.filterNetworksIds: NetworkId[]` → `availableFilterNetworks: Network[]` (rename + type change). The two fields now read as a symmetric pair (same noun, singular vs plural, both hold `Network` objects) and the name says what the field holds: the set of networks the user can pick from. `setFilterNetworksIds` becomes `setAvailableFilterNetworks` taking `Network[]`. The store's filter derive converts to IDs internally (`.map(({ id }) => id)`) so the existing `filterTokensForSelectedNetworks` helper stays untouched.
- `SwapContexts.svelte` switches from `$crossChainSwapNetworksMainnetsIds` to the existing `$crossChainSwapNetworksMainnets` derived (which already exposes `Network[]` from the same source data) to populate `availableFilterNetworks`.

# Tests

- `SendTokensList.spec.ts` extends its render helper to accept an `allowedNetworks: Network[]` prop and pins two truth tables end to end.
- Network filter button auto-lock: locked to `[BTC_MAINNET_NETWORK]` (scanner-driven single) → disabled, click is a no-op; locked to `[ETHEREUM_NETWORK]` (URL-route single, after `SendModal` folds `$selectedNetwork` into the same field) → disabled; locked to `[ETHEREUM_NETWORK, BASE_NETWORK, ARBITRUM_MAINNET_NETWORK]` → enabled, click forwards to `onSelectNetworkFilter` (the future drill-down hand-off); no restriction → enabled, same hand-off.
- BTC single-token notice variant: `[BTC_MAINNET_NETWORK]` renders `scanned_address_only_destination_single_token` and not the default copy; `[ICP_NETWORK]` renders the default copy and not the single-token variant.
- `modal-tokens-list.store.spec.ts` `filterNetworksIds` describe block renames to `availableFilterNetworks`; fixtures pass `Network` objects instead of IDs; setter calls use `setAvailableFilterNetworks`. The truth-table shape (single-network filter, multi-network filter, combination with `selectedFilterNetwork`, combination with `filterQuery`, setter, undefined/empty clearing) is unchanged.
- `SwapContexts.spec.ts` updates the `setContext` shape assertion to expect `setAvailableFilterNetworks` instead of `setFilterNetworksIds`.
- Local quality gates: `prettier --check` clean on touched files; `eslint --max-warnings 0` clean across the touched tree; `svelte-check` reports `0 errors, 0 warnings` across 5661 files; `vitest run` of the scanner, send, util, store, and swap specs passes (328 tests across 48 files), including the unchanged `SendModal.spec.ts` reactivity suite.

🤖 Claude Opus 4.7
