### PR TITLE
feat(frontend): filter main token list by token contract id / address

### DIFF
--- a/src/frontend/src/lib/utils/token-list.utils.ts
+++ b/src/frontend/src/lib/utils/token-list.utils.ts
@@ -3,12 +3,12 @@ import type { TokenUi } from '$lib/types/token-ui';
 import type { TokenUiOrGroupUi } from '$lib/types/token-ui-group';
 import { isTokenUiGroup } from '$lib/utils/token-group.utils';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
+import { doesTokenMatchFilter } from '$lib/utils/tokens.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { SvelteMap } from 'svelte/reactivity';
 
 const getFilterCondition = ({ filter, token }: { filter: string; token: TokenUi }): boolean =>
-	token.name.toLowerCase().indexOf(filter.toLowerCase()) >= 0 ||
-	token.symbol.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
+	doesTokenMatchFilter({ token, filter });
 
 export const getFilteredTokenList = ({
 	filter,

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -442,19 +442,22 @@ export const pinEnabledTokensAtTop = <T extends Token>(
 	$tokens: TokenToggleable<T>[]
 ): TokenToggleable<T>[] => $tokens.sort(({ enabled: a }, { enabled: b }) => Number(b) - Number(a));
 
-/** Filters provided tokens list according to a filter keyword
+/** Tells whether a single token matches a free-text filter on name, symbol or
+ * the token's contract identifier (Ethereum / Solana address, IC ledger /
+ * index / NFT canister id, ICRC custom alternative name). For IC ck-tokens
+ * the underlying twin token is also considered.
  *
- * @param tokens - The list of tokens.
+ * @param token - The token to test.
  * @param filter - filter keyword.
- * @returns Filtered list of tokens.
- * */
-export const filterTokens = <T extends Token>({
-	tokens,
+ * @returns Whether the token matches the filter.
+ */
+export const doesTokenMatchFilter = ({
+	token,
 	filter
 }: {
-	tokens: T[];
+	token: Token;
 	filter: string;
-}): T[] => {
+}): boolean => {
 	const matchingToken = (token: Token): boolean => {
 		const { name, symbol } = token;
 
@@ -500,13 +503,26 @@ export const filterTokens = <T extends Token>({
 		return false;
 	};
 
-	return isNullishOrEmpty(filter)
-		? tokens
-		: tokens.filter((token) => {
-				const twinToken = isIcCkToken(token) ? token.twinToken : undefined;
-				return matchingToken(token) || (nonNullish(twinToken) && matchingToken(twinToken));
-			});
+	const twinToken = isIcCkToken(token) ? token.twinToken : undefined;
+	return matchingToken(token) || (nonNullish(twinToken) && matchingToken(twinToken));
 };
+
+/** Filters provided tokens list according to a filter keyword
+ *
+ * @param tokens - The list of tokens.
+ * @param filter - filter keyword.
+ * @returns Filtered list of tokens.
+ * */
+export const filterTokens = <T extends Token>({
+	tokens,
+	filter
+}: {
+	tokens: T[];
+	filter: string;
+}): T[] =>
+	isNullishOrEmpty(filter)
+		? tokens
+		: tokens.filter((token) => doesTokenMatchFilter({ token, filter }));
 
 /** Finds the token with the given symbol
  *

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -477,18 +477,22 @@ export const doesTokenMatchFilter = ({
 		}
 
 		if (isTokenErc20(token) || isTokenErc721(token) || isTokenErc1155(token) || isTokenSpl(token)) {
-			return areAddressesPartiallyEqual({
-				address1: token.address,
-				address2: filter,
-				networkId: token.network.id
-			});
+			return (
+				nonNullish(token.address) &&
+				areAddressesPartiallyEqual({
+					address1: token.address,
+					address2: filter,
+					networkId: token.network.id
+				})
+			);
 		}
 
 		if (isTokenIc(token)) {
 			const { ledgerCanisterId, indexCanisterId } = token;
 
 			return (
-				ledgerCanisterId.toLowerCase().includes(filter.toLowerCase()) ||
+				(nonNullish(ledgerCanisterId) &&
+					ledgerCanisterId.toLowerCase().includes(filter.toLowerCase())) ||
 				(nonNullish(indexCanisterId) &&
 					indexCanisterId.toLowerCase().includes(filter.toLowerCase()))
 			);
@@ -497,7 +501,7 @@ export const doesTokenMatchFilter = ({
 		if (isTokenIcNft(token)) {
 			const { canisterId } = token;
 
-			return canisterId.toLowerCase().includes(filter.toLowerCase());
+			return nonNullish(canisterId) && canisterId.toLowerCase().includes(filter.toLowerCase());
 		}
 
 		return false;

--- a/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-list.utils.spec.ts
@@ -17,6 +17,9 @@ import {
 	getFilteredTokenList
 } from '$lib/utils/token-list.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockValidIcrcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { SvelteMap } from 'svelte/reactivity';
 
 // Mock data for tokens
@@ -73,6 +76,61 @@ describe('token-list.utils', () => {
 
 			expect(result).toHaveLength(0);
 		});
+
+		it('should filter the list based on ERC20 contract address', () => {
+			const erc20TokenUi: TokenUi = mockValidErc20Token;
+			const list: TokenUiOrGroupUi[] = [tokenUi, { token: erc20TokenUi }];
+			const result = getFilteredTokenList({ filter: mockValidErc20Token.address, list });
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ token: erc20TokenUi });
+		});
+
+		it('should filter the list based on a partial, case-insensitive ERC20 contract address', () => {
+			const erc20TokenUi: TokenUi = mockValidErc20Token;
+			const list: TokenUiOrGroupUi[] = [tokenUi, { token: erc20TokenUi }];
+			const result = getFilteredTokenList({
+				filter: mockValidErc20Token.address.slice(0, 6).toLowerCase(),
+				list
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ token: erc20TokenUi });
+		});
+
+		it('should filter the list based on SPL contract address', () => {
+			const splTokenUi: TokenUi = mockValidSplToken;
+			const list: TokenUiOrGroupUi[] = [tokenUi, { token: splTokenUi }];
+			const result = getFilteredTokenList({ filter: mockValidSplToken.address, list });
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ token: splTokenUi });
+		});
+
+		it('should filter the list based on ICRC ledger canister id', () => {
+			const icrcTokenUi: TokenUi = mockValidIcrcToken;
+			const list: TokenUiOrGroupUi[] = [tokenUi, { token: icrcTokenUi }];
+			const result = getFilteredTokenList({
+				filter: mockValidIcrcToken.ledgerCanisterId,
+				list
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ token: icrcTokenUi });
+		});
+
+		it('should filter a token group when one of its tokens matches by address', () => {
+			const erc20TokenUi: TokenUi = mockValidErc20Token;
+			const groupWithErc20: TokenUiGroup = {
+				...tokenGroup,
+				tokens: [...tokenGroup.tokens, erc20TokenUi]
+			};
+			const list: TokenUiOrGroupUi[] = [tokenUi, { group: groupWithErc20 }];
+			const result = getFilteredTokenList({ filter: mockValidErc20Token.address, list });
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ group: groupWithErc20 });
+		});
 	});
 
 	describe('getFilteredTokenGroup', () => {
@@ -96,12 +154,25 @@ describe('token-list.utils', () => {
 
 			expect(result).toHaveLength(0);
 		});
+
+		it('should return tokens matching the filter by ERC20 contract address', () => {
+			const erc20TokenUi: TokenUi = mockValidErc20Token;
+			const list: TokenUi[] = [token1, token2, erc20TokenUi];
+			const result = getFilteredTokenGroup({ filter: mockValidErc20Token.address, list });
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual(erc20TokenUi);
+		});
 	});
 
 	describe('getDisabledOrModifiedTokens', () => {
-		vi.mock('$lib/utils/network.utils.ts', () => ({
-			showTokenFilteredBySelectedNetwork: vi.fn()
-		}));
+		vi.mock(import('$lib/utils/network.utils'), async (importOriginal) => {
+			const actual = await importOriginal();
+			return {
+				...actual,
+				showTokenFilteredBySelectedNetwork: vi.fn()
+			};
+		});
 
 		const dummyNetwork: Network = ICP_NETWORK;
 


### PR DESCRIPTION
# Motivation

The free-text filter on the main token list currently only matches by token name or symbol. The Manage Tokens modal already supports matching by contract id / address (ERC20/721/1155 and SPL address, ICRC ledger and index canister id, IC NFT canister id, ICRC custom `alternativeName`, ck twin token), which is much more convenient when looking up a token whose name or symbol is ambiguous or unknown. This PR aligns the two so the main list filter accepts the same inputs as the modal.

# Changes

- Extracted the per-token matching predicate from `filterTokens` in `src/frontend/src/lib/utils/tokens.utils.ts` into a shared `doesTokenMatchFilter` helper. No behavior change for the modal.
- Replaced the `name` / `symbol`-only check in `src/frontend/src/lib/utils/token-list.utils.ts` with a call to `doesTokenMatchFilter`, so the main token list now also matches on contract id / address.

# Tests

- Existing `filterTokens` suite (including all per-token-type address-matching cases) continues to pass — it now exercises the extracted helper.
- Added unit tests in `src/frontend/src/tests/lib/utils/token-list.utils.spec.ts` covering main-list filtering by ERC20 address (full, partial, case-insensitive), SPL address, ICRC ledger canister id, and the token-group case where one token in a group matches by address.
- Adjusted the pre-existing `$lib/utils/network.utils` mock in the same spec from a full replacement to a partial mock so the address-matching code path (which depends on `isNetworkIdICP`) still resolves real exports.

|Active|Inactive|
|---|---|
|<img width="643" height="657" alt="image" src="https://github.com/user-attachments/assets/4e62aa77-5a5e-4016-b5c4-0826081125e8" />|<img width="643" height="657" alt="image" src="https://github.com/user-attachments/assets/7d95f676-c4b6-4083-8617-ff1c127fd2a5" />|


---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (claude-opus-4-7)