### PR TITLE
perf(backend): size CoinGecko outcall response reservation to request size

### DIFF
--- a/src/backend/src/exchange/providers/coingecko/client.rs
+++ b/src/backend/src/exchange/providers/coingecko/client.rs
@@ -9,11 +9,30 @@ use crate::utils::http_outcall::get;
 const DEFAULT_BASE_URL: &str = "https://pro-api.coingecko.com/api/v3";
 const SIMPLE_PRICE_PATH: &str = "/simple/price";
 const TOKEN_PRICE_PATH: &str = "/simple/token_price";
-// Upper bound for expected CoinGecko responses (simple price / token price).
-// Typical payloads are well under this (a few KB); 50 KB provides headroom
-// while keeping http_outcall cycle costs reasonable. Avoid increasing
-// without re-evaluating observed response sizes.
+
+// `http_request` cycle cost is charged on the *reserved* `max_response_bytes`,
+// not the bytes actually returned, so a uniform cap over-charges small calls.
+// We size the reservation from the number of requested items instead.
+//
+// Each price entry (coin id / contract address plus usd, 24h change, market
+// cap and last-updated) is comfortably under ~200 bytes in observed payloads;
+// 1 KiB per item keeps a generous safety margin (an under-estimate would fail
+// the outcall, so we err high). Tune downward once real sizes are confirmed.
+const PER_ITEM_RESPONSE_BYTES: u64 = 1_024;
+// Floor so a single-item request still tolerates JSON envelope / whitespace.
+const MIN_RESPONSE_BYTES: u64 = 2_048;
+// Ceiling, unchanged from the previous fixed cap: a full `CHUNK_SIZE` (50)
+// token request reserves exactly this, so large batches keep today's headroom
+// while the always-on native batch and partial chunks reserve far less.
 const MAX_RESPONSE_BYTES: u64 = 51_200;
+
+/// Reservation for an outcall fetching `item_count` prices, clamped to
+/// `[MIN_RESPONSE_BYTES, MAX_RESPONSE_BYTES]`.
+fn response_bytes_for(item_count: usize) -> u64 {
+    (item_count as u64)
+        .saturating_mul(PER_ITEM_RESPONSE_BYTES)
+        .clamp(MIN_RESPONSE_BYTES, MAX_RESPONSE_BYTES)
+}
 
 #[derive(Deserialize)]
 struct CoinGeckoPrice {
@@ -61,8 +80,12 @@ impl CoinGeckoClient {
         }
     }
 
-    async fn fetch_prices(&self, url: &str) -> Result<HashMap<String, ExchangeData>, String> {
-        let response = get(url, vec![self.auth_header()], MAX_RESPONSE_BYTES).await?;
+    async fn fetch_prices(
+        &self,
+        url: &str,
+        max_response_bytes: u64,
+    ) -> Result<HashMap<String, ExchangeData>, String> {
+        let response = get(url, vec![self.auth_header()], max_response_bytes).await?;
 
         let prices: HashMap<String, CoinGeckoPrice> = serde_json::from_slice(&response.body)
             .map_err(|e| format!("Failed to parse CoinGecko response: {e}"))?;
@@ -89,7 +112,8 @@ impl CoinGeckoClient {
             self.base_url
         );
 
-        self.fetch_prices(&url).await
+        self.fetch_prices(&url, response_bytes_for(coin_ids.len()))
+            .await
     }
 
     /// Fetches token prices from the `CoinGecko`
@@ -106,6 +130,41 @@ impl CoinGeckoClient {
             self.base_url
         );
 
-        self.fetch_prices(&url).await
+        self.fetch_prices(&url, response_bytes_for(addresses.len()))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        response_bytes_for, MAX_RESPONSE_BYTES, MIN_RESPONSE_BYTES, PER_ITEM_RESPONSE_BYTES,
+    };
+
+    #[test]
+    fn response_bytes_zero_and_one_item_hit_floor() {
+        assert_eq!(response_bytes_for(0), MIN_RESPONSE_BYTES);
+        assert_eq!(response_bytes_for(1), MIN_RESPONSE_BYTES);
+    }
+
+    #[test]
+    fn response_bytes_scale_with_item_count() {
+        // 6 native coins: well above the floor, far below the cap.
+        assert_eq!(response_bytes_for(6), 6 * PER_ITEM_RESPONSE_BYTES);
+        assert!(response_bytes_for(6) > MIN_RESPONSE_BYTES);
+        assert!(response_bytes_for(6) < MAX_RESPONSE_BYTES);
+    }
+
+    #[test]
+    fn response_bytes_full_chunk_equals_previous_cap() {
+        // A full CHUNK_SIZE (50) token request reserves exactly the old cap,
+        // so large batches are unchanged.
+        assert_eq!(response_bytes_for(50), MAX_RESPONSE_BYTES);
+    }
+
+    #[test]
+    fn response_bytes_never_exceed_cap() {
+        assert_eq!(response_bytes_for(1_000), MAX_RESPONSE_BYTES);
+        assert_eq!(response_bytes_for(usize::MAX), MAX_RESPONSE_BYTES);
     }
 }


### PR DESCRIPTION
# Motivation

HTTP outcall cycle cost is charged on the **reserved** `max_response_bytes`, not the bytes actually returned. Every CoinGecko call reserved a flat 50 KiB regardless of payload, so the always-on native batch (~6 coins, a few hundred bytes) over-reserved by roughly 25× on the hottest, most frequent outcall.
