### PR TITLE
perf(backend): idle-gate the always-on native exchange-rate refresh

### DIFF
--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -4,8 +4,8 @@ use shared::types::{exchange::ExchangeRate, token_id::TokenId};
 use crate::{
     exchange::{
         cached_rates_snapshot, fetch_and_update_prices, is_exchange_rate_refresh_enabled,
-        priceable_tokens_for_caller, release_refresh_lock, stale_or_missing_tokens,
-        try_acquire_refresh_lock,
+        note_rate_request, priceable_tokens_for_caller, release_refresh_lock,
+        stale_or_missing_tokens, try_acquire_refresh_lock,
     },
     state::read_state,
     token,
@@ -43,6 +43,10 @@ use crate::{
 #[must_use]
 pub fn get_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
     let caller = StoredPrincipal(msg_caller());
+
+    // Signal that a caller wants rates, so the recurring timer keeps the
+    // always-on native tokens warm (see `should_refresh_natives`).
+    note_rate_request();
 
     let tokens = priceable_tokens_for_caller(caller);
 

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -89,6 +89,36 @@ thread_local! {
     /// flight, the next timer tick is a no-op until it completes.
     static REFRESH_IN_FLIGHT: Cell<Option<RefreshLock>> = const { Cell::new(None) };
     static REFRESH_LOCK_GENERATION: Cell<u64> = const { Cell::new(0) };
+
+    /// IC timestamp of the most recent caller-driven rate request (or canister
+    /// start). The recurring timer keeps the always-on native tokens warm only
+    /// while this is recent: with no caller within
+    /// [`PRICE_ACTIVITY_THRESHOLD_SEC`], there is no point spending outcall
+    /// cycles refreshing native prices for nobody. Ephemeral by design — it is
+    /// re-armed on every init / upgrade (see [`start_exchange_rate_timer`]) and
+    /// by every `get_exchange_rates` call.
+    static LAST_RATE_REQUEST_AT: Cell<Option<u64>> = const { Cell::new(None) };
+}
+
+/// Records that a caller requested exchange rates at `now_ns`, re-arming the
+/// native-token refresh performed by [`refresh_exchange_rates`].
+pub(crate) fn note_rate_request_at(now_ns: u64) {
+    LAST_RATE_REQUEST_AT.with(|c| c.set(Some(now_ns)));
+}
+
+/// [`note_rate_request_at`] using the current IC time.
+pub(crate) fn note_rate_request() {
+    note_rate_request_at(time());
+}
+
+/// Whether the always-on native tokens should be refreshed this tick: only if
+/// a caller has requested rates within [`PRICE_ACTIVITY_THRESHOLD_SEC`]. When
+/// nobody has, the timer skips natives (and, with no active custom tokens
+/// either, issues zero outcalls).
+fn should_refresh_natives(now_ns: u64, last_request_ns: Option<u64>) -> bool {
+    last_request_ns.is_some_and(|last| {
+        now_ns.saturating_sub(last) <= PRICE_ACTIVITY_THRESHOLD_SEC * 1_000_000_000
+    })
 }
 
 fn next_refresh_lock(now_ns: u64) -> RefreshLock {
@@ -169,6 +199,10 @@ async fn refresh_exchange_rates_guarded(source: &'static str) {
 /// An immediate one-shot refresh runs first so that rates are available right
 /// after canister init / upgrade instead of waiting for the first interval tick.
 pub(crate) fn start_exchange_rate_timer() {
+    // Arm the native refresh so prices are warmed for the first activity window
+    // right after init / upgrade, matching the previous always-on behaviour.
+    note_rate_request();
+
     set_timer(Duration::ZERO, || {
         ic_cdk::futures::spawn(refresh_exchange_rates_guarded("initial refresh"));
     });
@@ -336,7 +370,12 @@ pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
     let now = time();
     let threshold = now.saturating_sub(PRICE_ACTIVITY_THRESHOLD_SEC * 1_000_000_000);
 
-    let mut tokens_to_fetch: Vec<StoredTokenId> = native_token_ids();
+    let mut tokens_to_fetch: Vec<StoredTokenId> =
+        if should_refresh_natives(now, LAST_RATE_REQUEST_AT.with(Cell::get)) {
+            native_token_ids()
+        } else {
+            Vec::new()
+        };
 
     let active_custom_tokens: Vec<StoredTokenId> = read_state(|s| {
         s.token_activity
@@ -365,9 +404,37 @@ pub(crate) async fn refresh_exchange_rates() -> Result<(), ExchangeError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        release_refresh_lock, try_acquire_refresh_lock_at, REFRESH_IN_FLIGHT,
-        REFRESH_LOCK_GENERATION, REFRESH_LOCK_TIMEOUT_NS,
+        release_refresh_lock, should_refresh_natives, try_acquire_refresh_lock_at,
+        PRICE_ACTIVITY_THRESHOLD_SEC, REFRESH_IN_FLIGHT, REFRESH_LOCK_GENERATION,
+        REFRESH_LOCK_TIMEOUT_NS,
     };
+
+    const ACTIVITY_THRESHOLD_NS: u64 = PRICE_ACTIVITY_THRESHOLD_SEC * 1_000_000_000;
+
+    #[test]
+    fn natives_refresh_when_request_within_threshold() {
+        let now = 10 * ACTIVITY_THRESHOLD_NS;
+        assert!(should_refresh_natives(now, Some(now)));
+        // Exactly at the threshold boundary still refreshes (<=).
+        assert!(should_refresh_natives(
+            now,
+            Some(now - ACTIVITY_THRESHOLD_NS)
+        ));
+    }
+
+    #[test]
+    fn natives_skip_when_request_older_than_threshold() {
+        let now = 10 * ACTIVITY_THRESHOLD_NS;
+        assert!(!should_refresh_natives(
+            now,
+            Some(now - ACTIVITY_THRESHOLD_NS - 1)
+        ));
+    }
+
+    #[test]
+    fn natives_skip_when_never_requested() {
+        assert!(!should_refresh_natives(10 * ACTIVITY_THRESHOLD_NS, None));
+    }
 
     fn reset_refresh_lock() {
         REFRESH_IN_FLIGHT.with(|cell| cell.set(None));


### PR DESCRIPTION
# Motivation

The recurring 60s refresh timer fetched the 8 always-on native tokens **unconditionally**: one CoinGecko outcall every minute, ~1,440/day, *forever*, even when no user has been connected for hours. Outcalls are the dominant cycle cost, so every idle minute is wasted cycles.

# Changes

- Track `LAST_RATE_REQUEST_AT` (ephemeral thread-local) — the last caller-driven `get_exchange_rates` time.
- `refresh_exchange_rates` now includes the native tokens only when a caller has requested rates within `PRICE_ACTIVITY_THRESHOLD_SEC` (10 min) — the same window already used to gate custom tokens. When fully idle, the tick fetches nothing and issues **zero outcalls**.
- Re-arm on init / upgrade (`start_exchange_rate_timer`) so prices are warmed for the first activity window, preserving today's "fresh right after deploy" behaviour.
- The on-demand path is unchanged: the first caller after an idle period finds natives stale/missing and triggers the existing background refresh, so users never see a cold cache.

# Tests

Added tests.
