### PR TITLE
fix(frontend): don't restart exchange worker on token-list changes in backend mode

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeWorker.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeWorker.svelte
@@ -48,16 +48,22 @@
 	const debounceSyncTimer = debounce(syncTimer, 1000);
 
 	$effect(() => {
-		[
-			worker,
-			backendExchangeEnabled,
-			$authIdentity,
-			$currentCurrency,
-			$enabledMergedErc20TokensAddresses,
-			$enabledIcrcLedgerCanisterIdsNoCk,
-			$enabledSplTokenAddresses,
-			$erc4626TokensExchangeData
-		];
+		// Inputs that matter to both data sources (and the source toggle itself).
+		[worker, backendExchangeEnabled, $authIdentity, $currentCurrency, $erc4626TokensExchangeData];
+
+		// The token-list inputs only matter to the public-provider branch: in
+		// backend mode the canister derives the caller's token set server-side
+		// (see `fetchExchangeRatesFromBackend`), so a change here would restart
+		// the worker and fire a redundant `get_exchange_rates` update for an
+		// identical result. Reading them only in provider mode keeps them out of
+		// this effect's dependency set when the backend cache is the source.
+		if (!backendExchangeEnabled) {
+			[
+				$enabledMergedErc20TokensAddresses,
+				$enabledIcrcLedgerCanisterIdsNoCk,
+				$enabledSplTokenAddresses
+			];
+		}
 
 		debounceSyncTimer();
 	});

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeWorker.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeWorker.spec.ts
@@ -127,4 +127,29 @@ describe('ExchangeWorker', () => {
 		expect(stopExchangeTimer).toHaveBeenCalledOnce();
 		expect(startExchangeTimer).toHaveBeenCalledOnce();
 	});
+
+	it('runs in backend mode and still restarts on always-relevant input change', async () => {
+		vi.spyOn(backendExchangeEnabledServices, 'loadBackendExchangeEnabled').mockResolvedValue(true);
+
+		render(ExchangeWorker);
+
+		await waitTimer();
+
+		// Started against the backend cache once the runtime flag resolves.
+		expect(startExchangeTimer).toHaveBeenLastCalledWith(
+			expect.objectContaining({ backendExchangeEnabled: true })
+		);
+
+		const callsBeforeCurrencyChange = startExchangeTimer.mock.calls.length;
+
+		// Currency is relevant to the backend branch too, so it must still restart.
+		currencyStore.switchCurrency(Currency.CHF);
+
+		await waitTimer();
+
+		expect(startExchangeTimer.mock.calls).toHaveLength(callsBeforeCurrencyChange + 1);
+		expect(startExchangeTimer).toHaveBeenLastCalledWith(
+			expect.objectContaining({ currentCurrency: Currency.CHF, backendExchangeEnabled: true })
+		);
+	});
 });

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeWorker.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeWorker.spec.ts
@@ -4,7 +4,23 @@ import * as backendExchangeEnabledServices from '$lib/services/backend-exchange-
 import { ExchangeWorker as ExchangeWorkerObj } from '$lib/services/worker.exchange.services';
 import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 import { currencyStore } from '$lib/stores/currency.store';
+import type * as SplDerived from '$sol/derived/spl.derived';
+import type { SplTokenAddress } from '$sol/types/spl';
 import { render } from '@testing-library/svelte';
+import type { Writable } from 'svelte/store';
+
+// Drive one provider-only token-list store directly so we can assert the
+// backend-mode effect does NOT depend on it (while provider mode still does).
+const mockStores = vi.hoisted(() => ({
+	enabledSplTokenAddresses: null as Writable<SplTokenAddress[]> | null
+}));
+
+vi.mock('$sol/derived/spl.derived', async (importOriginal) => {
+	const actual = await importOriginal<typeof SplDerived>();
+	const { writable } = await import('svelte/store');
+	mockStores.enabledSplTokenAddresses = writable<SplTokenAddress[]>([]);
+	return { ...actual, enabledSplTokenAddresses: mockStores.enabledSplTokenAddresses };
+});
 
 describe('ExchangeWorker', () => {
 	const stopExchangeTimer = vi.fn();
@@ -25,6 +41,8 @@ describe('ExchangeWorker', () => {
 
 		vi.spyOn(ExchangeWorkerObj, 'init').mockResolvedValue(mockWorker);
 		vi.spyOn(backendExchangeEnabledServices, 'loadBackendExchangeEnabled').mockResolvedValue(false);
+
+		mockStores.enabledSplTokenAddresses?.set([]);
 	});
 
 	afterEach(() => {
@@ -151,5 +169,39 @@ describe('ExchangeWorker', () => {
 		expect(startExchangeTimer).toHaveBeenLastCalledWith(
 			expect.objectContaining({ currentCurrency: Currency.CHF, backendExchangeEnabled: true })
 		);
+	});
+
+	// Control: in provider mode a token-list change must still restart, which also
+	// proves the store-driving mechanism below actually propagates to the worker.
+	it('restarts in provider mode when a token-list store changes', async () => {
+		render(ExchangeWorker);
+
+		await waitTimer();
+
+		const callsBefore = startExchangeTimer.mock.calls.length;
+
+		mockStores.enabledSplTokenAddresses?.set(['EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v']);
+
+		await waitTimer();
+
+		expect(startExchangeTimer.mock.calls.length).toBeGreaterThan(callsBefore);
+	});
+
+	it('does NOT restart in backend mode when a token-list store changes', async () => {
+		vi.spyOn(backendExchangeEnabledServices, 'loadBackendExchangeEnabled').mockResolvedValue(true);
+
+		render(ExchangeWorker);
+
+		await waitTimer();
+
+		const callsBefore = startExchangeTimer.mock.calls.length;
+
+		// The backend derives the token set server-side, so this input is not a
+		// dependency of the backend-mode sync and must not trigger a restart.
+		mockStores.enabledSplTokenAddresses?.set(['EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v']);
+
+		await waitTimer();
+
+		expect(startExchangeTimer.mock.calls).toHaveLength(callsBefore);
 	});
 });


### PR DESCRIPTION
# Motivation

The exchange worker restarts whenever any tracked input changes; and a restart fires an **immediate** `get_exchange_rates` update call.

In **backend mode**, the worker's backend branch (`syncExchangeFromBackend`) uses only `currentCurrency` and `erc4626TokensExchangeData`; the canister derives the caller's token set server-side. Yet the `$effect` also tracked `erc20Addresses` / `icrcCanisterIds` / `splAddresses`, so every time those derived lists settle during wallet load, the worker restarted and re-issued a redundant update call for an identical result.
