### PR TITLE
fix(frontend): show NFTs without a name in the send picker

### DIFF
--- a/src/frontend/src/lib/components/send/SendNftsList.svelte
+++ b/src/frontend/src/lib/components/send/SendNftsList.svelte
@@ -15,7 +15,7 @@
 	import { nftStore } from '$lib/stores/nft.store';
 	import type { Nft } from '$lib/types/nft';
 	import { isDesktop } from '$lib/utils/device.utils';
-	import { findNftsByNetwork } from '$lib/utils/nfts.utils';
+	import { filterSortByCollection, findNftsByNetwork } from '$lib/utils/nfts.utils';
 
 	interface Props {
 		onSelect: (nft: Nft) => void;
@@ -28,16 +28,18 @@
 
 	let filter = $state('');
 
-	const filteredByInputAndSection: Nft[] = $derived(
+	const visible: Nft[] = $derived(
 		($nftStore ?? []).filter(
 			(nft) =>
-				nft?.name?.toLowerCase().includes(filter.toLowerCase()) &&
 				nft?.collection?.section !== CustomTokenSection.SPAM &&
 				nft?.collection?.section !== CustomTokenSection.HIDDEN
 		)
 	);
 	const filtered: Nft[] = $derived(
-		findNftsByNetwork({ nfts: filteredByInputAndSection, networkId: $filterNetwork?.id })
+		filterSortByCollection({
+			items: findNftsByNetwork({ nfts: visible, networkId: $filterNetwork?.id }),
+			filter
+		})
 	);
 
 	let noNftsMatch = $derived(filtered.length === 0);

--- a/src/frontend/src/tests/lib/components/send/SendNftsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendNftsList.spec.ts
@@ -90,6 +90,27 @@ describe('SendNftsList.spec', () => {
 		expect(onSelectNetwork).toHaveBeenCalledOnce();
 	});
 
+	it('renders NFTs that have no name', () => {
+		const namelessNfts = [
+			{
+				...mockValidErc1155Nft,
+				name: undefined,
+				id: parseNftId('42'),
+				collection: { ...mockValidErc1155Nft.collection, name: 'NamelessOnes' }
+			}
+		];
+
+		nftStore.addAll(namelessNfts);
+		const { getByText } = render(SendNftsListTestHost, {
+			onSelect: vi.fn(),
+			filterNetwork: undefined,
+			onSelectNetwork: vi.fn()
+		});
+
+		expect(getByText('NamelessOnes')).toBeInTheDocument();
+		expect(getByText('#42')).toBeInTheDocument();
+	});
+
 	it('calls onSelect when an NFT card is clicked', async () => {
 		nftStore.addAll(mockNfts);
 		const onSelect = vi.fn();


### PR DESCRIPTION
# Motivation

The send-flow NFT picker silently dropped NFTs whose `name` field was undefined. The inline filter was `nft?.name?.toLowerCase().includes(filter.toLowerCase())`, which short-circuits to `undefined` (falsy) when `nft.name` is undefined — even with an empty search box.

Internet Computer NFTs are the main victim:

- `mapDip721Nft` ([src/frontend/src/icp/utils/nft.utils.ts:77](src/frontend/src/icp/utils/nft.utils.ts:77)) never sets a `name`, so **every DIP721 NFT** was dropped.
- `mapIcrc7Nft` / `mapExtNft` spread metadata as-is; any NFT whose indexer response didn't include `name` was also dropped.

EVM NFTs (Alchemy) almost always come with a name, so the bug shows up as "I only see some of my IC NFTs in the send picker", while the main NFT grid renders the same NFTs fine via `getNftDisplayName`.

# Changes

- Replace the inline name-only search filter in `SendNftsList.svelte` with `filterSortByCollection`, whose `matchesFilter` falls back to NFT id and collection name. Empty search now includes nameless NFTs (id always matches `""`); active search additionally matches collection name and token id, consistent with the main NFT page.
- SPAM / HIDDEN section exclusion is preserved as a separate predicate.

# Tests

- New spec `renders NFTs that have no name` puts an NFT with `name: undefined` into the store and asserts the picker shows `NamelessOnes` and `#42`.
- `npm run lint -- --max-warnings 0` clean.
- `npx vitest run SendNftsList.spec.ts`: 7/7 pass.


|Before|After|
|---|---|
|<img width="574" height="722" alt="image" src="https://github.com/user-attachments/assets/e62721ed-04c2-4eca-8569-198121ae3893" />|<img width="568" height="1008" alt="image" src="https://github.com/user-attachments/assets/84e3263c-a6e0-4351-a4a6-ea9f0bc2d0fc" />|

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.7 (claude-opus-4-7)