### PR TITLE
refactor(frontend): replace handleBtcValidationError switch with message map

### DIFF
--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -42,31 +42,36 @@ export type SignBtcParams = CommonBtcServiceParams & {
 // Validation errors whose handling is a uniform toast differing only by the
 // i18n key. AuthenticationRequired and the unexpected fallback are kept as
 // explicit special cases below, so they intentionally do not appear here.
-const btcValidationErrorMessages: Partial<Record<BtcSendValidationError, (i18n: I18n) => string>> =
+const btcValidationErrorMessages: Partial<Record<BtcSendValidationError, ($i18n: I18n) => string>> =
 	{
-		[BtcSendValidationError.NoNetworkId]: (i18n) => i18n.send.error.no_btc_network_id,
-		[BtcSendValidationError.InvalidDestination]: (i18n) =>
-			i18n.send.assertion.destination_address_invalid,
-		[BtcSendValidationError.InvalidAmount]: (i18n) => i18n.send.assertion.amount_invalid,
-		[BtcSendValidationError.UtxoFeeMissing]: (i18n) => i18n.send.assertion.utxos_fee_missing,
-		[BtcSendValidationError.TokenUndefined]: (i18n) => i18n.tokens.error.unexpected_undefined,
-		[BtcSendValidationError.InsufficientBalance]: (i18n) =>
-			i18n.send.assertion.btc_insufficient_balance,
-		[BtcSendValidationError.InsufficientBalanceForFee]: (i18n) =>
-			i18n.send.assertion.btc_insufficient_balance_for_fee,
-		[BtcSendValidationError.InvalidUtxoData]: (i18n) => i18n.send.assertion.btc_invalid_utxo_data,
-		[BtcSendValidationError.UtxoLocked]: (i18n) => i18n.send.assertion.btc_utxo_locked,
-		[BtcSendValidationError.InvalidFeeCalculation]: (i18n) =>
-			i18n.send.assertion.btc_invalid_fee_calculation,
-		[BtcSendValidationError.MinimumBalance]: (i18n) => i18n.send.assertion.minimum_btc_amount
+		[BtcSendValidationError.NoNetworkId]: ($i18n) => $i18n.send.error.no_btc_network_id,
+		[BtcSendValidationError.InvalidDestination]: ($i18n) =>
+			$i18n.send.assertion.destination_address_invalid,
+		[BtcSendValidationError.InvalidAmount]: ($i18n) => $i18n.send.assertion.amount_invalid,
+		[BtcSendValidationError.UtxoFeeMissing]: ($i18n) => $i18n.send.assertion.utxos_fee_missing,
+		[BtcSendValidationError.TokenUndefined]: ($i18n) => $i18n.tokens.error.unexpected_undefined,
+		[BtcSendValidationError.InsufficientBalance]: ($i18n) =>
+			$i18n.send.assertion.btc_insufficient_balance,
+		[BtcSendValidationError.InsufficientBalanceForFee]: ($i18n) =>
+			$i18n.send.assertion.btc_insufficient_balance_for_fee,
+		[BtcSendValidationError.InvalidUtxoData]: ($i18n) => $i18n.send.assertion.btc_invalid_utxo_data,
+		[BtcSendValidationError.UtxoLocked]: ($i18n) => $i18n.send.assertion.btc_utxo_locked,
+		[BtcSendValidationError.InvalidFeeCalculation]: ($i18n) =>
+			$i18n.send.assertion.btc_invalid_fee_calculation,
+		[BtcSendValidationError.MinimumBalance]: ($i18n) => $i18n.send.assertion.minimum_btc_amount
 	};
 
 /**
- * This function handles the validation errors thrown by the validateUtxosForSend function
- * It has been moved to a service so it can be shared between the BTC Send and Convert Wizard
- * @param err BtcValidationError - The validation error that was thrown
- * @param $i18n I18n - The i18n store containing translation strings
- * @returns Promise<void> - Returns void if successful, may throw errors if validation fails
+ * Shows a toast for a BTC validation error, mapping each error type to its message.
+ *
+ * Shared between the BTC Send and Convert Wizard flows. Reads the current i18n store
+ * internally, so no translation strings need to be passed in. `AuthenticationRequired`
+ * is silently ignored and any unmapped error type falls back to a generic toast.
+ *
+ * This function is synchronous and returns void.
+ *
+ * @param params - Object containing the validation error
+ * @param params.err - The {@link BtcValidationError} to surface as a toast
  */
 export const handleBtcValidationError = ({ err }: { err: BtcValidationError }) => {
 	if (err.type === BtcSendValidationError.AuthenticationRequired) {

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -39,6 +39,28 @@ export type SignBtcParams = CommonBtcServiceParams & {
 	satoshisAmount: bigint;
 };
 
+// Validation errors whose handling is a uniform toast differing only by the
+// i18n key. AuthenticationRequired and the unexpected fallback are kept as
+// explicit special cases below, so they intentionally do not appear here.
+const btcValidationErrorMessages: Partial<Record<BtcSendValidationError, (i18n: I18n) => string>> =
+	{
+		[BtcSendValidationError.NoNetworkId]: (i18n) => i18n.send.error.no_btc_network_id,
+		[BtcSendValidationError.InvalidDestination]: (i18n) =>
+			i18n.send.assertion.destination_address_invalid,
+		[BtcSendValidationError.InvalidAmount]: (i18n) => i18n.send.assertion.amount_invalid,
+		[BtcSendValidationError.UtxoFeeMissing]: (i18n) => i18n.send.assertion.utxos_fee_missing,
+		[BtcSendValidationError.TokenUndefined]: (i18n) => i18n.tokens.error.unexpected_undefined,
+		[BtcSendValidationError.InsufficientBalance]: (i18n) =>
+			i18n.send.assertion.btc_insufficient_balance,
+		[BtcSendValidationError.InsufficientBalanceForFee]: (i18n) =>
+			i18n.send.assertion.btc_insufficient_balance_for_fee,
+		[BtcSendValidationError.InvalidUtxoData]: (i18n) => i18n.send.assertion.btc_invalid_utxo_data,
+		[BtcSendValidationError.UtxoLocked]: (i18n) => i18n.send.assertion.btc_utxo_locked,
+		[BtcSendValidationError.InvalidFeeCalculation]: (i18n) =>
+			i18n.send.assertion.btc_invalid_fee_calculation,
+		[BtcSendValidationError.MinimumBalance]: (i18n) => i18n.send.assertion.minimum_btc_amount
+	};
+
 /**
  * This function handles the validation errors thrown by the validateUtxosForSend function
  * It has been moved to a service so it can be shared between the BTC Send and Convert Wizard
@@ -47,71 +69,22 @@ export type SignBtcParams = CommonBtcServiceParams & {
  * @returns Promise<void> - Returns void if successful, may throw errors if validation fails
  */
 export const handleBtcValidationError = ({ err }: { err: BtcValidationError }) => {
-	switch (err.type) {
-		case BtcSendValidationError.AuthenticationRequired:
-			return;
-		case BtcSendValidationError.NoNetworkId:
-			toastsError({
-				msg: { text: get(i18n).send.error.no_btc_network_id }
-			});
-			break;
-		case BtcSendValidationError.InvalidDestination:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.destination_address_invalid }
-			});
-			break;
-		case BtcSendValidationError.InvalidAmount:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.amount_invalid }
-			});
-			break;
-		case BtcSendValidationError.UtxoFeeMissing:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.utxos_fee_missing }
-			});
-			break;
-		case BtcSendValidationError.TokenUndefined:
-			toastsError({
-				msg: { text: get(i18n).tokens.error.unexpected_undefined }
-			});
-			break;
-		case BtcSendValidationError.InsufficientBalance:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.btc_insufficient_balance }
-			});
-			break;
-		case BtcSendValidationError.InsufficientBalanceForFee:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.btc_insufficient_balance_for_fee }
-			});
-			break;
-		case BtcSendValidationError.InvalidUtxoData:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.btc_invalid_utxo_data }
-			});
-			break;
-		case BtcSendValidationError.UtxoLocked:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.btc_utxo_locked }
-			});
-			break;
-		case BtcSendValidationError.InvalidFeeCalculation:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.btc_invalid_fee_calculation }
-			});
-			break;
-		case BtcSendValidationError.MinimumBalance:
-			toastsError({
-				msg: { text: get(i18n).send.assertion.minimum_btc_amount }
-			});
-			break;
-		default:
-			toastsError({
-				msg: { text: get(i18n).send.error.unexpected },
-				err
-			});
-			break;
+	if (err.type === BtcSendValidationError.AuthenticationRequired) {
+		return;
 	}
+
+	const $i18n = get(i18n);
+
+	const message = btcValidationErrorMessages[err.type];
+	if (nonNullish(message)) {
+		toastsError({ msg: { text: message($i18n) } });
+		return;
+	}
+
+	toastsError({
+		msg: { text: $i18n.send.error.unexpected },
+		err
+	});
 };
 
 /**

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -1,5 +1,10 @@
 import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
-import { sendBtc, validateBtcSend, type SendBtcParams } from '$btc/services/btc-send.services';
+import {
+	handleBtcValidationError,
+	sendBtc,
+	validateBtcSend,
+	type SendBtcParams
+} from '$btc/services/btc-send.services';
 import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { BtcSendValidationError, BtcValidationError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
@@ -8,11 +13,15 @@ import * as btcUtils from '$icp/utils/btc.utils';
 import * as backendAPI from '$lib/api/backend.api';
 import * as signerAPI from '$lib/api/signer.api';
 import { ZERO } from '$lib/constants/app.constants';
+import { i18n } from '$lib/stores/i18n.store';
+import * as toastsStore from '$lib/stores/toasts.store';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
 import { mockUtxosFee } from '$tests/mocks/btc.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
 import type { CkBtcMinterDid } from '@icp-sdk/canisters/ckbtc';
+import { get } from 'svelte/store';
+import type { MockInstance } from 'vitest';
 
 // Mock environment variables (same as btc-utxos.service.spec.ts)
 vi.mock('$env/networks/networks.icrc.env', () => ({
@@ -36,6 +45,81 @@ describe('btc-send.services', () => {
 	const error = new Error('test error');
 
 	beforeEach(() => {});
+
+	describe('handleBtcValidationError', () => {
+		let spyToastsError: MockInstance;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			spyToastsError = vi.spyOn(toastsStore, 'toastsError').mockReturnValue(Symbol('toast'));
+		});
+
+		it('should not toast for AuthenticationRequired', () => {
+			handleBtcValidationError({
+				err: new BtcValidationError(BtcSendValidationError.AuthenticationRequired)
+			});
+
+			expect(spyToastsError).not.toHaveBeenCalled();
+		});
+
+		it.each([
+			{ type: BtcSendValidationError.NoNetworkId, text: get(i18n).send.error.no_btc_network_id },
+			{
+				type: BtcSendValidationError.InvalidDestination,
+				text: get(i18n).send.assertion.destination_address_invalid
+			},
+			{ type: BtcSendValidationError.InvalidAmount, text: get(i18n).send.assertion.amount_invalid },
+			{
+				type: BtcSendValidationError.UtxoFeeMissing,
+				text: get(i18n).send.assertion.utxos_fee_missing
+			},
+			{
+				type: BtcSendValidationError.TokenUndefined,
+				text: get(i18n).tokens.error.unexpected_undefined
+			},
+			{
+				type: BtcSendValidationError.InsufficientBalance,
+				text: get(i18n).send.assertion.btc_insufficient_balance
+			},
+			{
+				type: BtcSendValidationError.InsufficientBalanceForFee,
+				text: get(i18n).send.assertion.btc_insufficient_balance_for_fee
+			},
+			{
+				type: BtcSendValidationError.InvalidUtxoData,
+				text: get(i18n).send.assertion.btc_invalid_utxo_data
+			},
+			{ type: BtcSendValidationError.UtxoLocked, text: get(i18n).send.assertion.btc_utxo_locked },
+			{
+				type: BtcSendValidationError.InvalidFeeCalculation,
+				text: get(i18n).send.assertion.btc_invalid_fee_calculation
+			},
+			{
+				type: BtcSendValidationError.MinimumBalance,
+				text: get(i18n).send.assertion.minimum_btc_amount
+			}
+		])('should toast the mapped message for $type', ({ type, text }) => {
+			handleBtcValidationError({ err: new BtcValidationError(type) });
+
+			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
+				msg: { text }
+			});
+		});
+
+		it.each([
+			BtcSendValidationError.PendingTransactionsNotAvailable,
+			'unknown_error_type' as BtcSendValidationError
+		])('should toast the unexpected error with err for %s', (type) => {
+			const err = new BtcValidationError(type);
+
+			handleBtcValidationError({ err });
+
+			expect(spyToastsError).toHaveBeenCalledExactlyOnceWith({
+				msg: { text: get(i18n).send.error.unexpected },
+				err
+			});
+		});
+	});
 
 	describe('sendBtc', () => {
 		it('should call all required functions', async () => {


### PR DESCRIPTION
# Motivation
`handleBtcValidationError` was a ~66-line switch whose 11 arms were identical except for the i18n key.

# Changes
Replaced those arms with a `btcValidationErrorMessages` map; kept `AuthenticationRequired` (early return) and the unexpected fallback (forwards `err`) explicit. Behavior unchanged.

# Tests
Added coverage for the handler (previously none): every mapped error, the no-toast case, and the unexpected-with-`err` path.