### PR TITLE
refactor(frontend): extract shared openOnWalletReady helper for receive components

### DIFF
--- a/src/frontend/src/btc/components/receive/BtcReceive.svelte
+++ b/src/frontend/src/btc/components/receive/BtcReceive.svelte
@@ -10,7 +10,7 @@
 	import { modalBtcReceive } from '$lib/derived/modal.derived';
 	import { networkAddressStore } from '$lib/derived/network-address.derived';
 	import { networkId } from '$lib/derived/network.derived';
-	import { waitWalletReady } from '$lib/services/actions.services';
+	import { openOnWalletReady } from '$lib/services/actions.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { isNetworkIdBTCRegtest, isNetworkIdBTCTestnet } from '$lib/utils/network.utils';
@@ -27,17 +27,8 @@
 
 	const isDisabled = (): boolean => isNullish(addressData) || !addressData.certified;
 
-	const openReceive = async (modalId: symbol) => {
-		if (isDisabled()) {
-			const status = await waitWalletReady(isDisabled);
-
-			if (status === 'timeout') {
-				return;
-			}
-		}
-
-		modalStore.openBtcReceive(modalId);
-	};
+	const openReceive = (modalId: symbol) =>
+		openOnWalletReady({ isDisabled, open: () => modalStore.openBtcReceive(modalId) });
 </script>
 
 <ReceiveButtonWithModal isOpen={$modalBtcReceive} open={openReceive}>

--- a/src/frontend/src/eth/components/receive/EthReceive.svelte
+++ b/src/frontend/src/eth/components/receive/EthReceive.svelte
@@ -6,7 +6,7 @@
 	import { modalEthReceive } from '$lib/derived/modal.derived';
 	import { networkAddress } from '$lib/derived/network-address.derived';
 	import { networkEthereum } from '$lib/derived/network.derived';
-	import { waitWalletReady } from '$lib/services/actions.services';
+	import { openOnWalletReady } from '$lib/services/actions.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Token } from '$lib/types/token';
@@ -19,17 +19,8 @@
 
 	const isDisabled = (): boolean => $metamaskNotInitialized;
 
-	const openReceive = async (modalId: symbol) => {
-		if (isDisabled()) {
-			const status = await waitWalletReady(isDisabled);
-
-			if (status === 'timeout') {
-				return;
-			}
-		}
-
-		modalStore.openEthReceive(modalId);
-	};
+	const openReceive = (modalId: symbol) =>
+		openOnWalletReady({ isDisabled, open: () => modalStore.openEthReceive(modalId) });
 </script>
 
 <ReceiveButtonWithModal isOpen={$modalEthReceive} open={openReceive}>

--- a/src/frontend/src/lib/services/actions.services.ts
+++ b/src/frontend/src/lib/services/actions.services.ts
@@ -29,3 +29,21 @@ export const waitWalletReady = async (isDisabled: () => boolean): Promise<'ready
 
 	return result;
 };
+
+export const openOnWalletReady = async ({
+	isDisabled,
+	open
+}: {
+	isDisabled: () => boolean;
+	open: () => void;
+}): Promise<void> => {
+	if (isDisabled()) {
+		const status = await waitWalletReady(isDisabled);
+
+		if (status === 'timeout') {
+			return;
+		}
+	}
+
+	open();
+};

--- a/src/frontend/src/lib/services/actions.services.ts
+++ b/src/frontend/src/lib/services/actions.services.ts
@@ -35,7 +35,7 @@ export const openOnWalletReady = async ({
 	open
 }: {
 	isDisabled: () => boolean;
-	open: () => void;
+	open: () => void | Promise<void>;
 }): Promise<void> => {
 	if (isDisabled()) {
 		const status = await waitWalletReady(isDisabled);
@@ -45,5 +45,5 @@ export const openOnWalletReady = async ({
 		}
 	}
 
-	open();
+	await open();
 };

--- a/src/frontend/src/sol/components/receive/SolReceive.svelte
+++ b/src/frontend/src/sol/components/receive/SolReceive.svelte
@@ -4,7 +4,7 @@
 	import ReceiveModal from '$lib/components/receive/ReceiveModal.svelte';
 	import { modalSolReceive } from '$lib/derived/modal.derived';
 	import { networkAddressStore } from '$lib/derived/network-address.derived';
-	import { waitWalletReady } from '$lib/services/actions.services';
+	import { openOnWalletReady } from '$lib/services/actions.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Token } from '$lib/types/token';
@@ -22,17 +22,8 @@
 	// TODO: PRODSEC: provide the ATA address too in the receive modal for SPL tokens
 	let address = $derived(addressData?.data);
 
-	const openReceive = async (modalId: symbol) => {
-		if (isDisabled()) {
-			const status = await waitWalletReady(isDisabled);
-
-			if (status === 'timeout') {
-				return;
-			}
-		}
-
-		modalStore.openSolReceive(modalId);
-	};
+	const openReceive = (modalId: symbol) =>
+		openOnWalletReady({ isDisabled, open: () => modalStore.openSolReceive(modalId) });
 </script>
 
 <ReceiveButtonWithModal isOpen={$modalSolReceive} open={openReceive}>

--- a/src/frontend/src/tests/lib/services/actions.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/actions.services.spec.ts
@@ -1,0 +1,53 @@
+import { openOnWalletReady } from '$lib/services/actions.services';
+import { busy } from '$lib/stores/busy.store';
+import * as toastsStore from '$lib/stores/toasts.store';
+
+
+describe('actions.services', () => {
+	describe('openOnWalletReady', () => {
+		beforeEach(() => {
+			vi.clearAllMocks();
+			vi.useRealTimers();
+			busy.stop();
+		});
+
+		it('calls open immediately when not disabled', async () => {
+			const open = vi.fn();
+
+			await openOnWalletReady({ isDisabled: () => false, open });
+
+			expect(open).toHaveBeenCalledOnce();
+		});
+
+		it('waits for the wallet to be ready, then calls open', async () => {
+			vi.useFakeTimers();
+
+			const open = vi.fn();
+
+			// Disabled on the first check (triggering the wait), then ready.
+			const isDisabled = vi.fn().mockReturnValueOnce(true).mockReturnValue(false);
+
+			const promise = openOnWalletReady({ isDisabled, open });
+
+			await vi.runAllTimersAsync();
+			await promise;
+
+			expect(open).toHaveBeenCalledOnce();
+		});
+
+		it('does not call open when the wallet stays disabled until timeout', async () => {
+			vi.useFakeTimers();
+
+			const open = vi.fn();
+			const toastsSpy = vi.spyOn(toastsStore, 'toastsShow');
+
+			const promise = openOnWalletReady({ isDisabled: () => true, open });
+
+			await vi.runAllTimersAsync();
+			await promise;
+
+			expect(open).not.toHaveBeenCalled();
+			expect(toastsSpy).toHaveBeenCalledOnce();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/actions.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/actions.services.spec.ts
@@ -2,7 +2,6 @@ import { openOnWalletReady } from '$lib/services/actions.services';
 import { busy } from '$lib/stores/busy.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 
-
 describe('actions.services', () => {
 	describe('openOnWalletReady', () => {
 		beforeEach(() => {

--- a/src/frontend/src/tests/lib/services/actions.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/actions.services.spec.ts
@@ -10,6 +10,11 @@ describe('actions.services', () => {
 			busy.stop();
 		});
 
+		afterEach(() => {
+			vi.useRealTimers();
+			vi.restoreAllMocks();
+		});
+
 		it('calls open immediately when not disabled', async () => {
 			const open = vi.fn();
 
@@ -18,17 +23,29 @@ describe('actions.services', () => {
 			expect(open).toHaveBeenCalledOnce();
 		});
 
-		it('waits for the wallet to be ready, then calls open', async () => {
+		it('waits at least one retry interval before calling open once the wallet is ready', async () => {
 			vi.useFakeTimers();
 
 			const open = vi.fn();
 
-			// Disabled on the first check (triggering the wait), then ready.
-			const isDisabled = vi.fn().mockReturnValueOnce(true).mockReturnValue(false);
+			// Disabled on the outer guard check and the first `waitReady` check (so a
+			// retry interval must elapse), then ready on the subsequent check.
+			const isDisabled = vi
+				.fn()
+				.mockReturnValueOnce(true)
+				.mockReturnValueOnce(true)
+				.mockReturnValue(false);
 
 			const promise = openOnWalletReady({ isDisabled, open });
 
-			await vi.runAllTimersAsync();
+			// Let microtasks settle without advancing the retry timer: `open` must not
+			// have been called yet because the wallet is still disabled.
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(open).not.toHaveBeenCalled();
+
+			// Advance past one 500ms retry interval so the next readiness check runs.
+			await vi.advanceTimersByTimeAsync(500);
 			await promise;
 
 			expect(open).toHaveBeenCalledOnce();


### PR DESCRIPTION
# Motivation
BTC/ETH/SOL receive components each duplicated the same 'wait for wallet ready, then open modal' flow.

# Changes
Extracted `openOnWalletReady({ isDisabled, open })` alongside `waitWalletReady`; the three components now delegate to it. Behavior unchanged.

# Tests
Added a spec for the helper (opens when ready, bails on timeout, opens immediately when not disabled).