### PR TITLE
refactor(frontend): extract shared address-derivation service factory

### DIFF
--- a/src/frontend/src/btc/services/btc-address.services.ts
+++ b/src/frontend/src/btc/services/btc-address.services.ts
@@ -1,19 +1,21 @@
 import type { BtcAddress } from '$btc/types/address';
-import { FRONTEND_DERIVATION_ENABLED } from '$env/address.env';
 import {
 	BTC_MAINNET_NETWORK_ID,
 	BTC_REGTEST_NETWORK_ID,
 	BTC_TESTNET_NETWORK_ID
 } from '$env/networks/networks.btc.env';
 import { getBtcAddress as getSignerBtcAddress } from '$lib/api/signer.api';
-import { SIGNER_MASTER_PUB_KEY } from '$lib/constants/signer.constants';
 import {
 	btcAddressMainnet,
 	btcAddressRegtest,
 	btcAddressTestnet
 } from '$lib/derived/address.derived';
 import { deriveBtcAddress } from '$lib/ic-pub-key/src/cli';
-import { loadTokenAddress, type LoadTokenAddressParams } from '$lib/services/address.services';
+import {
+	deriveTokenAddress,
+	loadTokenAddress,
+	type LoadTokenAddressParams
+} from '$lib/services/address.services';
 import {
 	btcAddressMainnetStore,
 	btcAddressRegtestStore,
@@ -28,7 +30,6 @@ import {
 	isNetworkIdBTCTestnet,
 	mapToSignerBitcoinNetwork
 } from '$lib/utils/network.utils';
-import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import type { BitcoinNetwork } from '@icp-sdk/canisters/ckbtc';
 import { get } from 'svelte/store';
 
@@ -53,25 +54,22 @@ export const getBtcAddress = async ({
 }: {
 	identity: NullishIdentity;
 	network: BitcoinNetwork;
-}): Promise<BtcAddress> => {
-	if (FRONTEND_DERIVATION_ENABLED && nonNullish(SIGNER_MASTER_PUB_KEY)) {
-		// We use the same logic of the canister method. The potential error will be handled in the consumer.
-		assertNonNullish(identity, get(i18n).auth.error.no_internet_identity);
-
-		// HACK: This is not working for Local environment for now, because the library is not aware of the `dfx_test_1` public key (used by Local deployment).
-		return deriveBtcAddress({
-			user: identity.getPrincipal().toString(),
-			network,
-			pubkey: SIGNER_MASTER_PUB_KEY.ecdsa.secp256k1.pubkey
-		});
-	}
-
-	return await getSignerBtcAddress({
+}): Promise<BtcAddress> =>
+	await deriveTokenAddress<BtcAddress>({
 		identity,
-		network: mapToSignerBitcoinNetwork({ network }),
-		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+		deriveAddress: ({ user, masterPubKey }) =>
+			deriveBtcAddress({
+				user,
+				network,
+				pubkey: masterPubKey.ecdsa.secp256k1.pubkey
+			}),
+		getSignerAddress: () =>
+			getSignerBtcAddress({
+				identity,
+				network: mapToSignerBitcoinNetwork({ network }),
+				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+			})
 	});
-};
 
 const loadBtcAddress = ({
 	networkId,

--- a/src/frontend/src/eth/services/eth-address.services.ts
+++ b/src/frontend/src/eth/services/eth-address.services.ts
@@ -1,34 +1,28 @@
-import { FRONTEND_DERIVATION_ENABLED } from '$env/address.env';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import type { EthAddress } from '$eth/types/address';
 import { getEthAddress as getSignerEthAddress } from '$lib/api/signer.api';
-import { SIGNER_MASTER_PUB_KEY } from '$lib/constants/signer.constants';
 import { deriveEthAddress } from '$lib/ic-pub-key/src/cli';
-import { loadTokenAddress } from '$lib/services/address.services';
+import { deriveTokenAddress, loadTokenAddress } from '$lib/services/address.services';
 import { ethAddressStore } from '$lib/stores/address.store';
 import { i18n } from '$lib/stores/i18n.store';
 import type { NullishIdentity } from '$lib/types/identity';
 import type { ResultSuccess } from '$lib/types/utils';
-import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
-export const getEthAddress = async (identity: NullishIdentity): Promise<EthAddress> => {
-	if (FRONTEND_DERIVATION_ENABLED && nonNullish(SIGNER_MASTER_PUB_KEY)) {
-		// We use the same logic of the canister method. The potential error will be handled in the consumer.
-		assertNonNullish(identity, get(i18n).auth.error.no_internet_identity);
-
-		// HACK: This is not working for Local environment for now, because the library is not aware of the `dfx_test_1` public key (used by Local deployment).
-		return deriveEthAddress({
-			user: identity.getPrincipal().toString(),
-			pubkey: SIGNER_MASTER_PUB_KEY.ecdsa.secp256k1.pubkey
-		});
-	}
-
-	return await getSignerEthAddress({
+export const getEthAddress = async (identity: NullishIdentity): Promise<EthAddress> =>
+	await deriveTokenAddress<EthAddress>({
 		identity,
-		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+		deriveAddress: ({ user, masterPubKey }) =>
+			deriveEthAddress({
+				user,
+				pubkey: masterPubKey.ecdsa.secp256k1.pubkey
+			}),
+		getSignerAddress: () =>
+			getSignerEthAddress({
+				identity,
+				nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+			})
 	});
-};
 
 export const loadEthAddress = (): Promise<ResultSuccess> =>
 	loadTokenAddress<EthAddress>({

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -1,3 +1,5 @@
+import { FRONTEND_DERIVATION_ENABLED } from '$env/address.env';
+import { SIGNER_MASTER_PUB_KEY } from '$lib/constants/signer.constants';
 import type { AddressStore } from '$lib/stores/address.store';
 import { authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
@@ -7,6 +9,7 @@ import type { NullishIdentity } from '$lib/types/identity';
 import type { NetworkId } from '$lib/types/network';
 import type { ResultSuccess } from '$lib/types/utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 export interface LoadTokenAddressParams<T extends Address> {
@@ -14,6 +17,40 @@ export interface LoadTokenAddressParams<T extends Address> {
 	getAddress: (identity: NullishIdentity) => Promise<T>;
 	addressStore: AddressStore<T>;
 }
+
+/**
+ * Shared frontend address-derivation flow used by the chain-specific address services.
+ *
+ * When frontend derivation is enabled and the signer master public key is known, the address is
+ * derived locally (mirroring the canister logic) instead of calling the signer API. Each chain
+ * only differs in which master public key it consumes, the derive call and the signer-API fallback,
+ * so those are injected by the caller while the guarding logic stays here.
+ */
+export const deriveTokenAddress = async <T>({
+	identity,
+	deriveAddress,
+	getSignerAddress
+}: {
+	identity: NullishIdentity;
+	deriveAddress: (params: {
+		user: string;
+		masterPubKey: NonNullable<typeof SIGNER_MASTER_PUB_KEY>;
+	}) => T | Promise<T>;
+	getSignerAddress: () => Promise<T>;
+}): Promise<T> => {
+	if (FRONTEND_DERIVATION_ENABLED && nonNullish(SIGNER_MASTER_PUB_KEY)) {
+		// We use the same logic of the canister method. The potential error will be handled in the consumer.
+		assertNonNullish(identity, get(i18n).auth.error.no_internet_identity);
+
+		// HACK: This is not working for Local environment for now, because the library is not aware of the `dfx_test_1` public key (used by Local deployment).
+		return await deriveAddress({
+			user: identity.getPrincipal().toString(),
+			masterPubKey: SIGNER_MASTER_PUB_KEY
+		});
+	}
+
+	return await getSignerAddress();
+};
 
 export const loadTokenAddress = async <T extends Address>({
 	networkId,

--- a/src/frontend/src/lib/services/address.services.ts
+++ b/src/frontend/src/lib/services/address.services.ts
@@ -22,9 +22,10 @@ export interface LoadTokenAddressParams<T extends Address> {
  * Shared frontend address-derivation flow used by the chain-specific address services.
  *
  * When frontend derivation is enabled and the signer master public key is known, the address is
- * derived locally (mirroring the canister logic) instead of calling the signer API. Each chain
- * only differs in which master public key it consumes, the derive call and the signer-API fallback,
- * so those are injected by the caller while the guarding logic stays here.
+ * derived locally (mirroring the canister logic) instead of calling the signer API. The shared
+ * global `SIGNER_MASTER_PUB_KEY` is always used; each chain only differs in which field(s) of it it
+ * reads (e.g. ECDSA `ecdsa.secp256k1` vs Schnorr `schnorr.ed25519`), the derive call and the
+ * signer-API fallback, so those are injected by the caller while the guarding logic stays here.
  */
 export const deriveTokenAddress = async <T>({
 	identity,

--- a/src/frontend/src/sol/services/sol-address.services.ts
+++ b/src/frontend/src/sol/services/sol-address.services.ts
@@ -1,4 +1,3 @@
-import { FRONTEND_DERIVATION_ENABLED } from '$env/address.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
 	SOLANA_KEY_ID,
@@ -6,15 +5,17 @@ import {
 	SOLANA_MAINNET_NETWORK_ID
 } from '$env/networks/networks.sol.env';
 import { getSchnorrPublicKey } from '$lib/api/signer.api';
-import { SIGNER_MASTER_PUB_KEY } from '$lib/constants/signer.constants';
 import { deriveSolAddress } from '$lib/ic-pub-key/src/cli';
-import { loadTokenAddress, type LoadTokenAddressParams } from '$lib/services/address.services';
+import {
+	deriveTokenAddress,
+	loadTokenAddress,
+	type LoadTokenAddressParams
+} from '$lib/services/address.services';
 import {
 	solAddressDevnetStore,
 	solAddressLocalnetStore,
 	solAddressMainnetStore
 } from '$lib/stores/address.store';
-import { i18n } from '$lib/stores/i18n.store';
 import type { CanisterApiFunctionParams } from '$lib/types/canister';
 import type { NullishIdentity } from '$lib/types/identity';
 import type { NetworkId } from '$lib/types/network';
@@ -22,36 +23,32 @@ import type { ResultSuccess } from '$lib/types/utils';
 import { SOLANA_DERIVATION_PATH_PREFIX } from '$sol/constants/sol.constants';
 import type { SolAddress } from '$sol/types/address';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
-import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { getAddressDecoder } from '@solana/kit';
-import { get } from 'svelte/store';
 
 const getSolanaPublicKey = async ({
 	derivationPath,
 	identity,
 	...rest
-}: CanisterApiFunctionParams<{ derivationPath: string[] }>): Promise<Uint8Array> => {
-	if (FRONTEND_DERIVATION_ENABLED && nonNullish(SIGNER_MASTER_PUB_KEY)) {
-		// We use the same logic of the canister method. The potential error will be handled in the consumer.
-		assertNonNullish(identity, get(i18n).auth.error.no_internet_identity);
-
-		// HACK: This is not working for Local environment for now, because the library is not aware of the `dfx_test_1` public key (used by Local deployment).
-		const publicKey = deriveSolAddress({
-			user: identity.getPrincipal().toString(),
-			derivationPath: [SOLANA_DERIVATION_PATH_PREFIX, ...derivationPath],
-			pubkey: SIGNER_MASTER_PUB_KEY.schnorr.ed25519.pubkey
-		});
-
-		return Buffer.from(publicKey, 'hex');
-	}
-
-	return await getSchnorrPublicKey({
-		...rest,
+}: CanisterApiFunctionParams<{ derivationPath: string[] }>): Promise<Uint8Array> =>
+	await deriveTokenAddress<Uint8Array>({
 		identity,
-		keyId: SOLANA_KEY_ID,
-		derivationPath: [SOLANA_DERIVATION_PATH_PREFIX, ...derivationPath]
+		deriveAddress: ({ user, masterPubKey }) => {
+			const publicKey = deriveSolAddress({
+				user,
+				derivationPath: [SOLANA_DERIVATION_PATH_PREFIX, ...derivationPath],
+				pubkey: masterPubKey.schnorr.ed25519.pubkey
+			});
+
+			return Buffer.from(publicKey, 'hex');
+		},
+		getSignerAddress: () =>
+			getSchnorrPublicKey({
+				...rest,
+				identity,
+				keyId: SOLANA_KEY_ID,
+				derivationPath: [SOLANA_DERIVATION_PATH_PREFIX, ...derivationPath]
+			})
 	});
-};
 
 const getSolAddress = async ({
 	identity,

--- a/src/frontend/src/tests/lib/services/address.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/address.services.spec.ts
@@ -34,10 +34,10 @@ describe('address.services', () => {
 	});
 
 	describe('deriveTokenAddress', () => {
-		const mockMasterPubKey = {
+		const mockMasterPubKey: NonNullable<SignerMasterPubKeys['key_1']> = {
 			ecdsa: { secp256k1: { pubkey: 'ecdsa-pubkey' } },
 			schnorr: { ed25519: { pubkey: 'schnorr-pubkey' } }
-		} as unknown as NonNullable<SignerMasterPubKeys['key_1']>;
+		};
 
 		const mockDeriveAddress = vi.fn();
 		const mockGetSignerAddress = vi.fn();

--- a/src/frontend/src/tests/lib/services/address.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/address.services.spec.ts
@@ -1,7 +1,14 @@
+import * as addressEnv from '$env/address.env';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
-import { loadTokenAddress, type LoadTokenAddressParams } from '$lib/services/address.services';
+import * as signerConstants from '$lib/constants/signer.constants';
+import {
+	deriveTokenAddress,
+	loadTokenAddress,
+	type LoadTokenAddressParams
+} from '$lib/services/address.services';
 import { authStore } from '$lib/stores/auth.store';
 import * as toastsStore from '$lib/stores/toasts.store';
+import type { SignerMasterPubKeys } from '$lib/types/signer';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import en from '$tests/mocks/i18n.mock';
 import { Ed25519KeyIdentity } from '@icp-sdk/core/identity';
@@ -24,6 +31,81 @@ describe('address.services', () => {
 		vi.clearAllMocks();
 
 		authStore.setForTesting(mockIdentity);
+	});
+
+	describe('deriveTokenAddress', () => {
+		const mockMasterPubKey = {
+			ecdsa: { secp256k1: { pubkey: 'ecdsa-pubkey' } },
+			schnorr: { ed25519: { pubkey: 'schnorr-pubkey' } }
+		} as unknown as NonNullable<SignerMasterPubKeys['key_1']>;
+
+		const mockDeriveAddress = vi.fn();
+		const mockGetSignerAddress = vi.fn();
+
+		beforeEach(() => {
+			vi.spyOn(addressEnv, 'FRONTEND_DERIVATION_ENABLED', 'get').mockReturnValue(true);
+			vi.spyOn(signerConstants, 'SIGNER_MASTER_PUB_KEY', 'get').mockReturnValue(mockMasterPubKey);
+		});
+
+		it('should derive the address on the frontend when enabled and the master key is known', async () => {
+			mockDeriveAddress.mockReturnValue('derived-address');
+
+			const result = await deriveTokenAddress<string>({
+				identity: mockIdentity,
+				deriveAddress: mockDeriveAddress,
+				getSignerAddress: mockGetSignerAddress
+			});
+
+			expect(result).toBe('derived-address');
+			expect(mockDeriveAddress).toHaveBeenCalledExactlyOnceWith({
+				user: mockIdentity.getPrincipal().toString(),
+				masterPubKey: mockMasterPubKey
+			});
+			expect(mockGetSignerAddress).not.toHaveBeenCalled();
+		});
+
+		it('should fall back to the signer API when frontend derivation is disabled', async () => {
+			vi.spyOn(addressEnv, 'FRONTEND_DERIVATION_ENABLED', 'get').mockReturnValue(false);
+			mockGetSignerAddress.mockResolvedValue('signer-address');
+
+			const result = await deriveTokenAddress<string>({
+				identity: mockIdentity,
+				deriveAddress: mockDeriveAddress,
+				getSignerAddress: mockGetSignerAddress
+			});
+
+			expect(result).toBe('signer-address');
+			expect(mockGetSignerAddress).toHaveBeenCalledOnce();
+			expect(mockDeriveAddress).not.toHaveBeenCalled();
+		});
+
+		it('should fall back to the signer API when the master key is unknown', async () => {
+			vi.spyOn(signerConstants, 'SIGNER_MASTER_PUB_KEY', 'get').mockReturnValue(undefined);
+			mockGetSignerAddress.mockResolvedValue('signer-address');
+
+			const result = await deriveTokenAddress<string>({
+				identity: mockIdentity,
+				deriveAddress: mockDeriveAddress,
+				getSignerAddress: mockGetSignerAddress
+			});
+
+			expect(result).toBe('signer-address');
+			expect(mockGetSignerAddress).toHaveBeenCalledOnce();
+			expect(mockDeriveAddress).not.toHaveBeenCalled();
+		});
+
+		it('should throw when frontend derivation is enabled but the identity is nullish', async () => {
+			await expect(
+				deriveTokenAddress<string>({
+					identity: null,
+					deriveAddress: mockDeriveAddress,
+					getSignerAddress: mockGetSignerAddress
+				})
+			).rejects.toThrow(en.auth.error.no_internet_identity);
+
+			expect(mockDeriveAddress).not.toHaveBeenCalled();
+			expect(mockGetSignerAddress).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('loadTokenAddress', () => {


### PR DESCRIPTION
# Motivation
BTC/ETH/SOL address services repeated the same derive-locally-or-fall-back-to-signer flow.

# Changes
Extracted `deriveTokenAddress<T>` into `lib/services/address.services.ts`, parameterized by the chain derive + signer-fallback callbacks. Chain specifics preserved.

# Tests
Added focused tests for the helper; existing address-service specs still pass.