### PR TITLE
feat(frontend): match token standard in tokens and NFTs text filter

### DIFF
--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -256,9 +256,10 @@ const matchesFilter = ({
 	const lower = filter.toLowerCase();
 
 	if (isCollectionUi(item)) {
-		// search by collection name
+		// search by collection name or standard
 		const collectionName = item.collection?.name?.toLowerCase() ?? '';
-		if (collectionName.includes(lower)) {
+		const collectionStandard = item.collection?.standard?.code?.toLowerCase() ?? '';
+		if (collectionName.includes(lower) || collectionStandard.includes(lower)) {
 			return true;
 		}
 		// search by collections nfts name or id
@@ -269,12 +270,13 @@ const matchesFilter = ({
 		);
 	}
 
-	// search nfts by id, name or collection name
+	// search nfts by id, name, collection name or collection standard
 	if (isNft(item)) {
 		return (
 			(String(item.id)?.toLowerCase().includes(lower) ?? false) ||
 			(item.name?.toLowerCase().includes(lower) ?? false) ||
-			(item.collection?.name?.toLowerCase().includes(lower) ?? false)
+			(item.collection?.name?.toLowerCase().includes(lower) ?? false) ||
+			(item.collection?.standard?.code?.toLowerCase().includes(lower) ?? false)
 		);
 	}
 

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -10,7 +10,7 @@ import type { NetworkId, OptionNetworkId } from '$lib/types/network';
 import type { Nft, NftCollection, NftCollectionUi, NftId, NonFungibleToken } from '$lib/types/nft';
 import { areAddressesEqual } from '$lib/utils/address.utils';
 import { getNftIdentifier } from '$lib/utils/nft.utils';
-import { standardLabel } from '$lib/utils/tokens.utils';
+import { standardLabel } from '$lib/utils/token.utils';
 import { UrlSchema } from '$lib/validation/url.validation';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 import { SvelteMap } from 'svelte/reactivity';

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -10,6 +10,7 @@ import type { NetworkId, OptionNetworkId } from '$lib/types/network';
 import type { Nft, NftCollection, NftCollectionUi, NftId, NonFungibleToken } from '$lib/types/nft';
 import { areAddressesEqual } from '$lib/utils/address.utils';
 import { getNftIdentifier } from '$lib/utils/nft.utils';
+import { standardLabel } from '$lib/utils/tokens.utils';
 import { UrlSchema } from '$lib/validation/url.validation';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 import { SvelteMap } from 'svelte/reactivity';
@@ -254,11 +255,6 @@ const matchesFilter = ({
 	filter: string;
 }): boolean => {
 	const lower = filter.toLowerCase();
-
-	// Match against the UI-rendered `code version` label (e.g. "ext v2"), so typing
-	// the version alone, the code alone, or the combined string all work.
-	const standardLabel = (standard: NftCollection['standard'] | undefined): string =>
-		nonNullish(standard) ? `${standard.code} ${standard.version ?? ''}`.trim().toLowerCase() : '';
 
 	if (isCollectionUi(item)) {
 		// search by collection name or standard

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -255,11 +255,18 @@ const matchesFilter = ({
 }): boolean => {
 	const lower = filter.toLowerCase();
 
+	// Match against the UI-rendered `code version` label (e.g. "ext v2"), so typing
+	// the version alone, the code alone, or the combined string all work.
+	const standardLabel = (standard: NftCollection['standard'] | undefined): string =>
+		nonNullish(standard) ? `${standard.code} ${standard.version ?? ''}`.trim().toLowerCase() : '';
+
 	if (isCollectionUi(item)) {
 		// search by collection name or standard
 		const collectionName = item.collection?.name?.toLowerCase() ?? '';
-		const collectionStandard = item.collection?.standard?.code?.toLowerCase() ?? '';
-		if (collectionName.includes(lower) || collectionStandard.includes(lower)) {
+		if (
+			collectionName.includes(lower) ||
+			standardLabel(item.collection?.standard).includes(lower)
+		) {
 			return true;
 		}
 		// search by collections nfts name or id
@@ -276,7 +283,7 @@ const matchesFilter = ({
 			(String(item.id)?.toLowerCase().includes(lower) ?? false) ||
 			(item.name?.toLowerCase().includes(lower) ?? false) ||
 			(item.collection?.name?.toLowerCase().includes(lower) ?? false) ||
-			(item.collection?.standard?.code?.toLowerCase().includes(lower) ?? false)
+			standardLabel(item.collection?.standard).includes(lower)
 		);
 	}
 

--- a/src/frontend/src/lib/utils/token.utils.ts
+++ b/src/frontend/src/lib/utils/token.utils.ts
@@ -296,3 +296,11 @@ export const getTokenDisplayName = (token: Token | CardData): string =>
  */
 export const filterEnabledToken = <T extends Token>(token: T): boolean =>
 	isTokenToggleable(token) ? token.enabled : true;
+
+/** UI-rendered token-standard label, lowercased and trimmed: `<code> <version>`
+ * (e.g. "ext v2", or just "erc20" when no version). Returns an empty string
+ * for a nullish standard. Shared by token and NFT filters so the filter input
+ * matches what users see on the details page.
+ */
+export const standardLabel = (standard: TokenStandard | undefined): string =>
+	nonNullish(standard) ? `${standard.code} ${standard.version ?? ''}`.trim().toLowerCase() : '';

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -20,7 +20,7 @@ import { saveCustomTokensWithKey } from '$lib/services/manage-tokens.services';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
 import type { NullishIdentity } from '$lib/types/identity';
-import type { Token, TokenId, TokenStandard } from '$lib/types/token';
+import type { Token, TokenId } from '$lib/types/token';
 import type { TokensTotalUsdBalancePerNetwork } from '$lib/types/token-balance';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { TokenUi } from '$lib/types/token-ui';
@@ -38,7 +38,7 @@ import { isNetworkIdSOLDevnet } from '$lib/utils/network.utils';
 import { isTokenNonFungible } from '$lib/utils/nft.utils';
 import { isTokenUiGroup } from '$lib/utils/token-group.utils';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
-import { filterEnabledToken } from '$lib/utils/token.utils';
+import { filterEnabledToken, standardLabel } from '$lib/utils/token.utils';
 import { isUserNetworkEnabled } from '$lib/utils/user-networks.utils';
 import { isTokenSpl, isTokenSplCustomToken } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
@@ -441,14 +441,6 @@ export const filterEnabledTokens = <T extends Token>([$tokens]: [$tokens: T[]]):
 export const pinEnabledTokensAtTop = <T extends Token>(
 	$tokens: TokenToggleable<T>[]
 ): TokenToggleable<T>[] => $tokens.sort(({ enabled: a }, { enabled: b }) => Number(b) - Number(a));
-
-/** UI-rendered token-standard label, lowercased and trimmed: `<code> <version>`
- * (e.g. "ext v2", or just "erc20" when no version). Returns an empty string
- * for a nullish standard. Shared by token and NFT filters so the filter input
- * matches what users see on the details page.
- */
-export const standardLabel = (standard: TokenStandard | undefined): string =>
-	nonNullish(standard) ? `${standard.code} ${standard.version ?? ''}`.trim().toLowerCase() : '';
 
 /** Tells whether a single token matches a free-text filter on name, symbol,
  * the UI-rendered standard label (`<code> <version>`, e.g. "erc20" or

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -20,7 +20,7 @@ import { saveCustomTokensWithKey } from '$lib/services/manage-tokens.services';
 import { toastsError, toastsShow } from '$lib/stores/toasts.store';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
 import type { NullishIdentity } from '$lib/types/identity';
-import type { Token, TokenId } from '$lib/types/token';
+import type { Token, TokenId, TokenStandard } from '$lib/types/token';
 import type { TokensTotalUsdBalancePerNetwork } from '$lib/types/token-balance';
 import type { TokenToggleable } from '$lib/types/token-toggleable';
 import type { TokenUi } from '$lib/types/token-ui';
@@ -442,6 +442,14 @@ export const pinEnabledTokensAtTop = <T extends Token>(
 	$tokens: TokenToggleable<T>[]
 ): TokenToggleable<T>[] => $tokens.sort(({ enabled: a }, { enabled: b }) => Number(b) - Number(a));
 
+/** UI-rendered token-standard label, lowercased and trimmed: `<code> <version>`
+ * (e.g. "ext v2", or just "erc20" when no version). Returns an empty string
+ * for a nullish standard. Shared by token and NFT filters so the filter input
+ * matches what users see on the details page.
+ */
+export const standardLabel = (standard: TokenStandard | undefined): string =>
+	nonNullish(standard) ? `${standard.code} ${standard.version ?? ''}`.trim().toLowerCase() : '';
+
 /** Tells whether a single token matches a free-text filter on name, symbol,
  * the UI-rendered standard label (`<code> <version>`, e.g. "erc20" or
  * "ext v2"), or the token's contract identifier (Ethereum / Solana address,
@@ -461,14 +469,11 @@ export const doesTokenMatchFilter = ({
 }): boolean => {
 	const matchingToken = (token: Token): boolean => {
 		const { name, symbol, standard } = token;
-		// Match against the UI-rendered `code version` label (e.g. "ext v2"), so typing
-		// the version alone, the code alone, or the combined string all work.
-		const standardLabel = `${standard.code} ${standard.version ?? ''}`.trim().toLowerCase();
 
 		if (
 			name.toLowerCase().includes(filter.toLowerCase()) ||
 			symbol.toLowerCase().includes(filter.toLowerCase()) ||
-			standardLabel.includes(filter.toLowerCase())
+			standardLabel(standard).includes(filter.toLowerCase())
 		) {
 			return true;
 		}

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -442,10 +442,11 @@ export const pinEnabledTokensAtTop = <T extends Token>(
 	$tokens: TokenToggleable<T>[]
 ): TokenToggleable<T>[] => $tokens.sort(({ enabled: a }, { enabled: b }) => Number(b) - Number(a));
 
-/** Tells whether a single token matches a free-text filter on name, symbol or
- * the token's contract identifier (Ethereum / Solana address, IC ledger /
- * index / NFT canister id, ICRC custom alternative name). For IC ck-tokens
- * the underlying twin token is also considered.
+/** Tells whether a single token matches a free-text filter on name, symbol,
+ * the UI-rendered standard label (`<code> <version>`, e.g. "erc20" or
+ * "ext v2"), or the token's contract identifier (Ethereum / Solana address,
+ * IC ledger / index / NFT canister id, ICRC custom alternative name). For IC
+ * ck-tokens the underlying twin token is also considered.
  *
  * @param token - The token to test.
  * @param filter - filter keyword.

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -459,11 +459,12 @@ export const doesTokenMatchFilter = ({
 	filter: string;
 }): boolean => {
 	const matchingToken = (token: Token): boolean => {
-		const { name, symbol } = token;
+		const { name, symbol, standard } = token;
 
 		if (
 			name.toLowerCase().includes(filter.toLowerCase()) ||
-			symbol.toLowerCase().includes(filter.toLowerCase())
+			symbol.toLowerCase().includes(filter.toLowerCase()) ||
+			standard.code.toLowerCase().includes(filter.toLowerCase())
 		) {
 			return true;
 		}

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -460,11 +460,14 @@ export const doesTokenMatchFilter = ({
 }): boolean => {
 	const matchingToken = (token: Token): boolean => {
 		const { name, symbol, standard } = token;
+		// Match against the UI-rendered `code version` label (e.g. "ext v2"), so typing
+		// the version alone, the code alone, or the combined string all work.
+		const standardLabel = `${standard.code} ${standard.version ?? ''}`.trim().toLowerCase();
 
 		if (
 			name.toLowerCase().includes(filter.toLowerCase()) ||
 			symbol.toLowerCase().includes(filter.toLowerCase()) ||
-			standard.code.toLowerCase().includes(filter.toLowerCase())
+			standardLabel.includes(filter.toLowerCase())
 		) {
 			return true;
 		}

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -569,6 +569,29 @@ describe('nfts.utils', () => {
 			expect(filterSortByCollection({ items: collections, filter: 'dip721' })).toEqual([]);
 		});
 
+		it('filters NFTs by collection.standard.version and the combined `code version` label', () => {
+			const extV2Nft = {
+				...nftDeGods,
+				collection: {
+					...nftDeGods.collection,
+					standard: { code: 'ext' as const, version: 'v2' }
+				}
+			};
+
+			// version alone
+			expect(filterSortByCollection({ items: [extV2Nft, ...base], filter: 'v2' })).toEqual([
+				extV2Nft
+			]);
+			// combined `code version` UI label
+			expect(filterSortByCollection({ items: [extV2Nft, ...base], filter: 'ext v2' })).toEqual([
+				extV2Nft
+			]);
+			// case-insensitive
+			expect(filterSortByCollection({ items: [extV2Nft, ...base], filter: 'EXT V2' })).toEqual([
+				extV2Nft
+			]);
+		});
+
 		it('sorts NFTs by collection name ascending', () => {
 			const res = filterSortByCollection({
 				items: base,

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -551,6 +551,24 @@ describe('nfts.utils', () => {
 			expect(res[0].nfts).toEqual([custom]);
 		});
 
+		it('filters NFTs by collection.standard.code (case-insensitive substring)', () => {
+			// every item in base has collection.standard.code === 'erc721'
+			expect(filterSortByCollection({ items: base, filter: 'erc721' })).toEqual(base);
+			expect(filterSortByCollection({ items: base, filter: 'ERC' })).toEqual(base);
+			expect(filterSortByCollection({ items: base, filter: 'dip721' })).toEqual([]);
+		});
+
+		it('filters collection UIs by collection.standard.code (case-insensitive substring)', () => {
+			// both collections are erc721
+			const matched = filterSortByCollection({ items: collections, filter: 'erc721' });
+
+			expect(matched).toHaveLength(2);
+			expect(matched.every((c) => c.collection.standard?.code === 'erc721')).toBeTruthy();
+
+			expect(filterSortByCollection({ items: collections, filter: 'ERC' })).toHaveLength(2);
+			expect(filterSortByCollection({ items: collections, filter: 'dip721' })).toEqual([]);
+		});
+
 		it('sorts NFTs by collection name ascending', () => {
 			const res = filterSortByCollection({
 				items: base,

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -1260,6 +1260,25 @@ describe('tokens.utils', () => {
 			]);
 		});
 
+		it('should filter tokens by standard version when filter is provided', () => {
+			const extV2Token = {
+				...mockValidExtV2Token,
+				standard: { code: 'ext' as const, version: 'v2' }
+			};
+			const tokensWithVersion = [extV2Token, ...mockTokens];
+
+			// version alone
+			expect(filterTokens({ tokens: tokensWithVersion, filter: 'v2' })).toStrictEqual([extV2Token]);
+			// combined `code version` UI label
+			expect(filterTokens({ tokens: tokensWithVersion, filter: 'ext v2' })).toStrictEqual([
+				extV2Token
+			]);
+			// case-insensitive
+			expect(filterTokens({ tokens: tokensWithVersion, filter: 'EXT V2' })).toStrictEqual([
+				extV2Token
+			]);
+		});
+
 		it('should filter tokens by name correctly when filter is provided', () => {
 			expect(filterTokens({ tokens, filter: 'Bit' })).toStrictEqual([BTC_MAINNET_TOKEN]);
 			expect(filterTokens({ tokens, filter: 'Eth' })).toStrictEqual([ETHEREUM_TOKEN]);

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -1234,9 +1234,30 @@ describe('tokens.utils', () => {
 		];
 
 		it('should filter tokens by symbol correctly when filter is provided', () => {
-			expect(filterTokens({ tokens, filter: 'ICP' })).toStrictEqual([ICP_TOKEN]);
 			expect(filterTokens({ tokens, filter: 'BTC' })).toStrictEqual([BTC_MAINNET_TOKEN]);
 			expect(filterTokens({ tokens, filter: 'PEPE' })).toStrictEqual([]);
+		});
+
+		it('should filter tokens by standard correctly when filter is provided', () => {
+			expect(filterTokens({ tokens, filter: 'spl' })).toStrictEqual([mockValidSplToken]);
+			expect(filterTokens({ tokens, filter: 'dip721' })).toStrictEqual([mockValidDip721Token]);
+
+			expect(filterTokens({ tokens, filter: 'BITCOIN' })).toStrictEqual([BTC_MAINNET_TOKEN]);
+
+			// substring matches every ERC variant; mockValidIcCkToken matches via its erc20 twin
+			expect(filterTokens({ tokens, filter: 'erc' })).toStrictEqual([
+				mockValidIcCkToken,
+				mockValidErc20Token,
+				mockValidErc721Token,
+				mockValidErc1155Token
+			]);
+
+			// 'icp' is a substring of both 'icp' and 'icpunks'
+			expect(filterTokens({ tokens, filter: 'icp' })).toStrictEqual([
+				ICP_TOKEN,
+				mockValidIcCkToken,
+				mockValidIcPunksToken
+			]);
 		});
 
 		it('should filter tokens by name correctly when filter is provided', () => {


### PR DESCRIPTION
# Motivation

On the assets page, the inline text filter for tokens already matches against `name`, `symbol`, and (where applicable) `address` / `ledgerCanisterId` / `indexCanisterId` / `canisterId`. The NFT filter matches against collection name and per-NFT name / id. Neither side matched the **token standard**, so typing `erc20`, `icrc`, `dip721`, `v2`, etc. didn't narrow the list at all — even though the assets page mixes tokens and NFTs across many different standards and the NFT details page already displays the standard as `CODE version` (e.g. "EXT v2"), so users naturally try to filter by it.

# Changes

- `src/frontend/src/lib/utils/token.utils.ts` — new exported `standardLabel(standard)` helper that builds the lowercased UI label `<code> <version>` (e.g. `ext v2`, or `erc20` when no version). Lives here (not in `tokens.utils.ts`) so its import edge stays narrow — putting it in the heavier file pulled `manage-tokens.services` into the NFT module graph and re-exposed a stale `InfuraErc20Provider` mock in an unrelated test.
- `src/frontend/src/lib/utils/tokens.utils.ts` — `doesTokenMatchFilter` uses `standardLabel` to test against name, symbol, and the standard label, alongside the existing contract identifiers. Because the function is already applied through the twin-token branch, typing e.g. `erc20` also surfaces ckBTC-style IC tokens whose twin lives on Ethereum. JSDoc above `doesTokenMatchFilter` updated to match (Copilot review feedback).
- `src/frontend/src/lib/utils/nfts.utils.ts` — NFT `matchesFilter` imports `standardLabel` and applies it against `collection.standard` on both the `Nft` and `NftCollectionUi` paths. `Nft` itself doesn't carry a top-level standard in the schema, so the standard is read off the collection.

No UI/strings change — purely a filter behaviour extension.

# Tests

- `src/frontend/src/tests/lib/utils/tokens.utils.spec.ts`:
  - New `should filter tokens by standard correctly when filter is provided` case: exact code (`spl`, `dip721`), case-insensitive (`BITCOIN`), substring across all ERC variants (with `mockValidIcCkToken` picked up via its `erc20` twin), and the `icp` / `icpunks` substring overlap.
  - New `should filter tokens by standard version when filter is provided` case: version alone (`v2`), combined `code version` label (`ext v2`), and case-insensitive (`EXT V2`).
  - The existing `should filter tokens by symbol correctly` case lost its `'ICP'` line — that filter is no longer a pure symbol match, it now also picks up `icp` / `icpunks` standards, which is intentional and covered by the new test.
- `src/frontend/src/tests/lib/utils/nfts.utils.spec.ts` — three new cases: filtering NFT items and collection UIs by `collection.standard.code` (case-insensitive substring, plus a negative `dip721` case), and a third case covering the `collection.standard.version` / combined-label match.
- `npx vitest run` for the two affected spec files → 207/207 pass.
- `npm run check` → 0 errors / 0 warnings on 5661 files.
- `npx eslint --max-warnings 0` on the four changed files → clean.
- `npx prettier --check` on the four changed files → clean.

|Tokens|NFTs|
|---|---|
|<img width="612" height="712" alt="image" src="https://github.com/user-attachments/assets/da2e95b7-3ca7-4a3d-aeee-67ce8a338c84" />|<img width="612" height="712" alt="image" src="https://github.com/user-attachments/assets/5a2141a9-de63-4333-ba3b-e68b6ba625c6" />|

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.7 (claude-opus-4-7)



