### PR TITLE
fix(e2e): stabilize full-page snapshot height to stop flaky regeneration

### DIFF
--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -487,8 +487,32 @@ abstract class Homepage {
 		return currentHeight;
 	}
 
+	// Web fonts and lazily-imported images (e.g. the landing page hero) can
+	// finish loading *after* `networkidle` and reflow the page by tens of
+	// pixels. Measuring the height before they settle bakes a
+	// non-deterministic value into the screenshot viewport, which is why the
+	// full-page snapshots regenerate on every run. Block on them first.
+	private async waitForStableLayout(): Promise<void> {
+		await this.#page.evaluate(async () => {
+			await document.fonts.ready;
+
+			await Promise.all(
+				Array.from(document.querySelectorAll('img'))
+					.filter((img) => !img.complete)
+					.map(
+						(img) =>
+							new Promise<void>((resolve) => {
+								img.addEventListener('load', () => resolve(), { once: true });
+								img.addEventListener('error', () => resolve(), { once: true });
+							})
+					)
+			);
+		});
+	}
+
 	private async viewportAdjuster(): Promise<void> {
 		await this.waitForLoadState();
+		await this.waitForStableLayout();
 		const stablePageHeight = await this.getStableViewportHeight();
 
 		const currentViewport = this.#page.viewportSize();

--- a/e2e/utils/pages/homepage.page.ts
+++ b/e2e/utils/pages/homepage.page.ts
@@ -496,14 +496,28 @@ abstract class Homepage {
 		await this.#page.evaluate(async () => {
 			await document.fonts.ready;
 
+			// A `loading="lazy"` image below the fold may never start loading, so
+			// awaiting its `load` event would hang until the test timeout. Only
+			// block on images that are actually loading: eager ones, or lazy ones
+			// already within the viewport (which load immediately).
+			const inViewport = (img: HTMLImageElement): boolean => {
+				const { top, bottom } = img.getBoundingClientRect();
+				return bottom > 0 && top < window.innerHeight;
+			};
+
+			// Safety net so a single stalled download can't block the helper
+			// indefinitely.
+			const PER_IMAGE_TIMEOUT_MS = 5_000;
+
 			await Promise.all(
 				Array.from(document.querySelectorAll('img'))
-					.filter((img) => !img.complete)
+					.filter((img) => !img.complete && (img.loading !== 'lazy' || inViewport(img)))
 					.map(
 						(img) =>
 							new Promise<void>((resolve) => {
 								img.addEventListener('load', () => resolve(), { once: true });
 								img.addEventListener('error', () => resolve(), { once: true });
+								setTimeout(resolve, PER_IMAGE_TIMEOUT_MS);
 							})
 					)
 			);


### PR DESCRIPTION
# Motivation

The snapshot bot keeps regenerating `homepage` → `should-display-homepage-in-logged-out-state` with no UI change behind it (6 PRs in ~10 days). Across history the PNG width is constant but the **height fluctuates every run** (1362→1408→1442→1398). Playwright compares full images, so a different height is always a diff, which always triggers a new snapshot PR.

Root cause: `viewportAdjuster()` bakes a measured `scrollHeight` into the screenshot viewport. The landing page lazily `import()`s its hero image and uses web fonts, which settle *after* `networkidle` and reflow the page — so the height is sampled at a non-deterministic moment.

# Changes

- Add `waitForStableLayout()` (awaits `document.fonts.ready` + pending `<img>` loads) and call it before measuring the height in `viewportAdjuster()`.

# Tests

E2E is run-on-demand (`run-e2e-snapshots` label). Verified `prettier`, `eslint --max-warnings 0`, `tsc -p e2e/tsconfig.json` on the changed file. Functional check: apply the label and confirm the snapshot stops regenerating across runs.