### PR TITLE
feat(backend)!: add set_exchange_rate_enabled to toggle exchange rates without touching API keys

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1350,6 +1350,15 @@ service : (Arg) -> {
 	set_api_keys : (ApiKeys) -> ();
 	// Add or update custom token for the user.
 	set_custom_token : (CustomToken) -> ();
+	// Enables or disables periodic exchange-rate refresh without touching the stored API keys.
+	//
+	// Sets `exchange_rate_enabled` to `Some(enabled)`, leaving the configured `CoinGecko` (and other)
+	// keys intact. Disabling stops the refresh outcalls even while a key is configured; enabling lets
+	// them resume (still gated on a `CoinGecko` key being set, see
+	// [`is_exchange_rate_refresh_enabled`]).
+	//
+	// Restricted to canister controllers only.
+	set_exchange_rate_enabled : (bool) -> ();
 	set_many_custom_tokens : (vec CustomToken) -> ();
 	// Toggles whether sign-ups of new users are allowed. Restricted to canister controllers.
 	//

--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -7,10 +7,10 @@ use crate::{
         priceable_tokens_for_caller, release_refresh_lock, stale_or_missing_tokens,
         try_acquire_refresh_lock,
     },
-    state::read_state,
+    state::{mutate_api_keys, read_state},
     token,
     types::{StoredPrincipal, StoredTokenId},
-    utils::guards::caller_is_not_anonymous,
+    utils::guards::{caller_is_controller, caller_is_not_anonymous},
 };
 
 /// Returns the latest USD prices for the caller's priceable tokens.
@@ -101,4 +101,17 @@ pub fn get_exchange_rate(token_id: TokenId) -> Option<ExchangeRate> {
 #[must_use]
 pub fn exchange_rate_enabled() -> bool {
     is_exchange_rate_refresh_enabled()
+}
+
+/// Enables or disables periodic exchange-rate refresh without touching the stored API keys.
+///
+/// Sets `exchange_rate_enabled` to `Some(enabled)`, leaving the configured `CoinGecko` (and other)
+/// keys intact. Disabling stops the refresh outcalls even while a key is configured; enabling lets
+/// them resume (still gated on a `CoinGecko` key being set, see
+/// [`is_exchange_rate_refresh_enabled`]).
+///
+/// Restricted to canister controllers only.
+#[update(guard = "caller_is_controller")]
+pub fn set_exchange_rate_enabled(enabled: bool) {
+    mutate_api_keys(|keys| keys.exchange_rate_enabled = Some(enabled));
 }

--- a/src/backend/src/state/mod.rs
+++ b/src/backend/src/state/mod.rs
@@ -164,3 +164,13 @@ pub(crate) fn write_api_keys(api_keys: ApiKeys) {
         state.api_keys.set(Some(Candid(api_keys)));
     });
 }
+
+/// Mutates the stored API keys in place, preserving any field the closure leaves untouched.
+///
+/// Use this instead of [`write_api_keys`] when a single field needs to change without
+/// overwriting the others (e.g. toggling `exchange_rate_enabled` without re-supplying keys).
+pub(crate) fn mutate_api_keys(f: impl FnOnce(&mut ApiKeys)) {
+    let mut api_keys = with_api_keys(Clone::clone);
+    f(&mut api_keys);
+    write_api_keys(api_keys);
+}

--- a/src/backend/tests/it/exchange.rs
+++ b/src/backend/tests/it/exchange.rs
@@ -1,0 +1,73 @@
+use candid::Principal;
+use pretty_assertions::assert_eq;
+use shared::types::api_keys::ApiKeys;
+
+use crate::utils::pocketic::{controller, setup, PicCanisterTrait};
+
+fn api_keys_with_coingecko() -> ApiKeys {
+    ApiKeys {
+        coingecko_api_key: Some("test-key".to_string()),
+        ..ApiKeys::default()
+    }
+}
+
+#[test]
+fn set_exchange_rate_enabled_toggles_without_touching_keys() {
+    let pic_setup = setup();
+
+    // Configure a CoinGecko key so refresh is enabled by default.
+    assert_eq!(
+        pic_setup.update::<()>(controller(), "set_api_keys", api_keys_with_coingecko()),
+        Ok(())
+    );
+    assert_eq!(
+        pic_setup.query::<bool>(controller(), "exchange_rate_enabled", ()),
+        Ok(true),
+        "Refresh should be enabled once a CoinGecko key is set."
+    );
+
+    // Disable refresh without re-supplying the keys.
+    assert_eq!(
+        pic_setup.update::<()>(controller(), "set_exchange_rate_enabled", false),
+        Ok(())
+    );
+    assert_eq!(
+        pic_setup.query::<bool>(controller(), "exchange_rate_enabled", ()),
+        Ok(false),
+        "Refresh should be disabled after toggling it off."
+    );
+
+    // The stored keys must be preserved across the toggle.
+    let stored = pic_setup
+        .query::<ApiKeys>(controller(), "get_api_keys", ())
+        .expect("controller can read API keys");
+    assert_eq!(
+        stored.coingecko_api_key,
+        Some("test-key".to_string()),
+        "Toggling refresh must not clear the configured keys."
+    );
+    assert_eq!(stored.exchange_rate_enabled, Some(false));
+
+    // Re-enable refresh.
+    assert_eq!(
+        pic_setup.update::<()>(controller(), "set_exchange_rate_enabled", true),
+        Ok(())
+    );
+    assert_eq!(
+        pic_setup.query::<bool>(controller(), "exchange_rate_enabled", ()),
+        Ok(true),
+        "Refresh should be enabled again after toggling it back on."
+    );
+}
+
+#[test]
+fn set_exchange_rate_enabled_is_controller_only() {
+    let pic_setup = setup();
+
+    assert!(
+        pic_setup
+            .update::<()>(Principal::anonymous(), "set_exchange_rate_enabled", false)
+            .is_err(),
+        "Anonymous caller must not be able to toggle exchange-rate refresh."
+    );
+}

--- a/src/backend/tests/it/main.rs
+++ b/src/backend/tests/it/main.rs
@@ -4,6 +4,7 @@ mod bitcoin;
 mod config;
 mod contacts;
 mod custom_token;
+mod exchange;
 mod settings;
 mod signer;
 mod stats;

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -1350,6 +1350,15 @@ service : (Arg) -> {
 	set_api_keys : (ApiKeys) -> ();
 	// Add or update custom token for the user.
 	set_custom_token : (CustomToken) -> ();
+	// Enables or disables periodic exchange-rate refresh without touching the stored API keys.
+	//
+	// Sets `exchange_rate_enabled` to `Some(enabled)`, leaving the configured `CoinGecko` (and other)
+	// keys intact. Disabling stops the refresh outcalls even while a key is configured; enabling lets
+	// them resume (still gated on a `CoinGecko` key being set, see
+	// [`is_exchange_rate_refresh_enabled`]).
+	//
+	// Restricted to canister controllers only.
+	set_exchange_rate_enabled : (bool) -> ();
 	set_many_custom_tokens : (vec CustomToken) -> ();
 	// Toggles whether sign-ups of new users are allowed. Restricted to canister controllers.
 	//

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -1968,6 +1968,17 @@ export interface _SERVICE {
 	 * Add or update custom token for the user.
 	 */
 	set_custom_token: ActorMethod<[CustomToken], undefined>;
+	/**
+	 * Enables or disables periodic exchange-rate refresh without touching the stored API keys.
+	 *
+	 * Sets `exchange_rate_enabled` to `Some(enabled)`, leaving the configured `CoinGecko` (and other)
+	 * keys intact. Disabling stops the refresh outcalls even while a key is configured; enabling lets
+	 * them resume (still gated on a `CoinGecko` key being set, see
+	 * [`is_exchange_rate_refresh_enabled`]).
+	 *
+	 * Restricted to canister controllers only.
+	 */
+	set_exchange_rate_enabled: ActorMethod<[boolean], undefined>;
 	set_many_custom_tokens: ActorMethod<[Array<CustomToken>], undefined>;
 	/**
 	 * Toggles whether sign-ups of new users are allowed. Restricted to canister controllers.

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -778,6 +778,7 @@ export const idlFactory = ({ IDL }) => {
 		),
 		set_api_keys: IDL.Func([ApiKeys], [], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),
+		set_exchange_rate_enabled: IDL.Func([IDL.Bool], [], []),
 		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),
 		set_new_user_signups_allowed: IDL.Func([IDL.Bool], [], []),
 		set_user_show_testnets: IDL.Func([SetShowTestnetsRequest], [SetUserShowTestnetsResult], []),

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -787,6 +787,7 @@ export const idlFactory = ({ IDL }) => {
 		),
 		set_api_keys: IDL.Func([ApiKeys], [], []),
 		set_custom_token: IDL.Func([CustomToken], [], []),
+		set_exchange_rate_enabled: IDL.Func([IDL.Bool], [], []),
 		set_many_custom_tokens: IDL.Func([IDL.Vec(CustomToken)], [], []),
 		set_new_user_signups_allowed: IDL.Func([IDL.Bool], [], []),
 		set_user_show_testnets: IDL.Func([SetShowTestnetsRequest], [SetUserShowTestnetsResult], []),


### PR DESCRIPTION
# Motivation

Toggling the periodic exchange-rate refresh currently requires calling `set_api_keys`, which **overwrites the entire `ApiKeys` record**. To pause or resume rate fetching without dropping the configured CoinGecko (and other) keys, an operator has to re-supply every key on each toggle — error-prone and easy to leak/clobber a key.

This adds a dedicated controller-only method that flips only the existing `exchange_rate_enabled` flag, leaving the stored keys untouched.

BREAKING CHANGE: new method set_exchange_rate_enabled.

# Changes

- `set_exchange_rate_enabled(enabled: bool)` — new controller-guarded `update` endpoint in `api/exchange.rs`. Sets `ApiKeys::exchange_rate_enabled` to `Some(enabled)` without modifying any other field. The public `exchange_rate_enabled` query and the refresh timer keep using the existing `is_exchange_rate_refresh_enabled` predicate (still gated on a CoinGecko key being set), so behaviour stays consistent.
- `state::mutate_api_keys` — small read-modify-write helper that mutates the stored `ApiKeys` in place, preserving fields the closure leaves untouched. Reused by the new endpoint instead of round-tripping the whole record.
- Regenerated `backend.did` and the `src/declarations/backend/` bindings (non-breaking: additive method).

# Tests

- `set_exchange_rate_enabled_toggles_without_touching_keys` — sets a CoinGecko key, toggles refresh off then on, and asserts `exchange_rate_enabled` flips accordingly **and** the stored key is preserved across the toggle.
- `set_exchange_rate_enabled_is_controller_only` — asserts an anonymous caller is rejected.