### PR TITLE
feat(frontend): usage metrics for data downloads

### DIFF
--- a/src/frontend/src/lib/enums/plausible.ts
+++ b/src/frontend/src/lib/enums/plausible.ts
@@ -27,18 +27,20 @@ export enum PLAUSIBLE_EVENT_CONTEXTS {
 	NFT = 'nft',
 	ASSETS_TAB = 'assets_tab',
 	TOKENS = 'tokens',
+	TOKENS_BASIC = 'tokens_basic',
+	TOKENS_EXTENDED = 'tokens_extended',
 	DFX = 'dfx',
 	OPEN_CRYPTOPAY = 'open_cryptopay',
 	EARN = 'earn',
 	TRANSACTIONS = 'transactions',
+	TRANSACTIONS_BASIC = 'transactions_basic',
+	TRANSACTIONS_EXTENDED = 'transactions_extended',
 	SIGNER = 'signer',
 	NETWORKS = 'networks'
 }
 
 export enum PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS {
-	ICRC = 'icrc',
-	BASIC = 'basic',
-	EXTENDED = 'extended'
+	ICRC = 'icrc'
 }
 
 export enum PLAUSIBLE_EVENT_SUBCONTEXT_EARN {
@@ -56,9 +58,7 @@ export enum PLAUSIBLE_EVENT_SUBCONTEXT_BACKEND {
 }
 
 export enum PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS {
-	UNCERTIFIED_REMOVED = 'uncertified_removed',
-	BASIC = 'basic',
-	EXTENDED = 'extended'
+	UNCERTIFIED_REMOVED = 'uncertified_removed'
 }
 
 export enum PLAUSIBLE_EVENT_SUBCONTEXT_SIGNER {

--- a/src/frontend/src/lib/enums/plausible.ts
+++ b/src/frontend/src/lib/enums/plausible.ts
@@ -18,7 +18,8 @@ export enum PLAUSIBLE_EVENTS {
 	NETWORK_FILTER = 'network_filter',
 	NETWORK_MANAGE = 'network_manage',
 	TRANSACTION_FILTER = 'transaction_filter',
-	TOKEN_MANAGE = 'token_manage'
+	TOKEN_MANAGE = 'token_manage',
+	EXPORT_DATA = 'export_data'
 }
 
 export enum PLAUSIBLE_EVENT_CONTEXTS {
@@ -35,7 +36,9 @@ export enum PLAUSIBLE_EVENT_CONTEXTS {
 }
 
 export enum PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS {
-	ICRC = 'icrc'
+	ICRC = 'icrc',
+	BASIC = 'basic',
+	EXTENDED = 'extended'
 }
 
 export enum PLAUSIBLE_EVENT_SUBCONTEXT_EARN {
@@ -53,7 +56,9 @@ export enum PLAUSIBLE_EVENT_SUBCONTEXT_BACKEND {
 }
 
 export enum PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS {
-	UNCERTIFIED_REMOVED = 'uncertified_removed'
+	UNCERTIFIED_REMOVED = 'uncertified_removed',
+	BASIC = 'basic',
+	EXTENDED = 'extended'
 }
 
 export enum PLAUSIBLE_EVENT_SUBCONTEXT_SIGNER {
@@ -86,7 +91,8 @@ export enum PLAUSIBLE_EVENT_SOURCES {
 export enum PLAUSIBLE_EVENT_SOURCE_LOCATIONS {
 	ACTIVITY_PAGE = 'activity_page',
 	MANAGE_TOKENS = 'manage_tokens',
-	TOKEN_DETAILS = 'token_details'
+	TOKEN_DETAILS = 'token_details',
+	SETTINGS_PAGE = 'settings_page'
 }
 
 export enum PLAUSIBLE_EVENT_EVENTS_KEYS {

--- a/src/frontend/src/lib/enums/plausible.ts
+++ b/src/frontend/src/lib/enums/plausible.ts
@@ -27,14 +27,10 @@ export enum PLAUSIBLE_EVENT_CONTEXTS {
 	NFT = 'nft',
 	ASSETS_TAB = 'assets_tab',
 	TOKENS = 'tokens',
-	TOKENS_BASIC = 'tokens_basic',
-	TOKENS_EXTENDED = 'tokens_extended',
 	DFX = 'dfx',
 	OPEN_CRYPTOPAY = 'open_cryptopay',
 	EARN = 'earn',
 	TRANSACTIONS = 'transactions',
-	TRANSACTIONS_BASIC = 'transactions_basic',
-	TRANSACTIONS_EXTENDED = 'transactions_extended',
 	SIGNER = 'signer',
 	NETWORKS = 'networks'
 }
@@ -74,7 +70,11 @@ export enum PLAUSIBLE_EVENT_VALUES {
 	NFT_PAGE = 'nft-page',
 	EARN_PAGE = 'earn-page',
 	HARVEST_AUTOPILOTS_PAGE = 'harvest-autopilots-page',
-	HARVEST_AUTOPILOT_DETAIL_PAGE = 'harvest-autopilot-detail-page'
+	HARVEST_AUTOPILOT_DETAIL_PAGE = 'harvest-autopilot-detail-page',
+	TOKENS_BASIC = 'tokens_basic',
+	TOKENS_EXTENDED = 'tokens_extended',
+	TRANSACTIONS_BASIC = 'transactions_basic',
+	TRANSACTIONS_EXTENDED = 'transactions_extended'
 }
 
 export enum PLAUSIBLE_EVENT_SOURCES {
@@ -105,7 +105,8 @@ export enum PLAUSIBLE_EVENT_EVENTS_KEYS {
 	NETWORK = 'network',
 	TRANSACTION_TYPE = 'transaction_type',
 	TOKEN = 'token',
-	CONTACT = 'contact'
+	CONTACT = 'contact',
+	TYPE = 'type'
 }
 
 export enum PLAUSIBLE_EVENT_FILTER_MODIFIERS {

--- a/src/frontend/src/lib/services/export-data-analytics.services.ts
+++ b/src/frontend/src/lib/services/export-data-analytics.services.ts
@@ -1,0 +1,50 @@
+import {
+	PLAUSIBLE_EVENT_SOURCE_LOCATIONS,
+	PLAUSIBLE_EVENTS,
+	type PLAUSIBLE_EVENT_CONTEXTS,
+	type PLAUSIBLE_EVENT_RESULT_STATUSES,
+	type PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS,
+	type PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS
+} from '$lib/enums/plausible';
+import { trackEvent } from '$lib/services/analytics.services';
+import { nonNullish } from '@dfinity/utils';
+
+type ExportDataContextSelector =
+	| {
+			context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS;
+			subcontext:
+				| PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.BASIC
+				| PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.EXTENDED;
+	  }
+	| {
+			context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS;
+			subcontext:
+				| PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.BASIC
+				| PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.EXTENDED;
+	  };
+
+export type TrackExportDataParams = ExportDataContextSelector & {
+	resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
+	error?: string;
+	errorCode?: string;
+};
+
+export const trackExportData = ({
+	context,
+	subcontext,
+	resultStatus,
+	error,
+	errorCode
+}: TrackExportDataParams) => {
+	trackEvent({
+		name: PLAUSIBLE_EVENTS.EXPORT_DATA,
+		metadata: {
+			event_context: context,
+			event_subcontext: subcontext,
+			source_location: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.SETTINGS_PAGE,
+			result_status: resultStatus,
+			...(nonNullish(error) && { result_error: error }),
+			...(nonNullish(errorCode) && { result_error_code: errorCode })
+		}
+	});
+};

--- a/src/frontend/src/lib/services/export-data-analytics.services.ts
+++ b/src/frontend/src/lib/services/export-data-analytics.services.ts
@@ -2,36 +2,26 @@ import {
 	PLAUSIBLE_EVENT_SOURCE_LOCATIONS,
 	PLAUSIBLE_EVENTS,
 	type PLAUSIBLE_EVENT_CONTEXTS,
-	type PLAUSIBLE_EVENT_RESULT_STATUSES,
-	type PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS,
-	type PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS
+	type PLAUSIBLE_EVENT_RESULT_STATUSES
 } from '$lib/enums/plausible';
 import { trackEvent } from '$lib/services/analytics.services';
 import { nonNullish } from '@dfinity/utils';
 
-type ExportDataContextSelector =
-	| {
-			context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS;
-			subcontext:
-				| PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.BASIC
-				| PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.EXTENDED;
-	  }
-	| {
-			context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS;
-			subcontext:
-				| PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.BASIC
-				| PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.EXTENDED;
-	  };
+export type ExportDataContext =
+	| PLAUSIBLE_EVENT_CONTEXTS.TOKENS_BASIC
+	| PLAUSIBLE_EVENT_CONTEXTS.TOKENS_EXTENDED
+	| PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_BASIC
+	| PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_EXTENDED;
 
-export type TrackExportDataParams = ExportDataContextSelector & {
+export interface TrackExportDataParams {
+	context: ExportDataContext;
 	resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
 	error?: string;
 	errorCode?: string;
-};
+}
 
 export const trackExportData = ({
 	context,
-	subcontext,
 	resultStatus,
 	error,
 	errorCode
@@ -40,7 +30,6 @@ export const trackExportData = ({
 		name: PLAUSIBLE_EVENTS.EXPORT_DATA,
 		metadata: {
 			event_context: context,
-			event_subcontext: subcontext,
 			source_location: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.SETTINGS_PAGE,
 			result_status: resultStatus,
 			...(nonNullish(error) && { result_error: error }),

--- a/src/frontend/src/lib/services/export-data-analytics.services.ts
+++ b/src/frontend/src/lib/services/export-data-analytics.services.ts
@@ -1,27 +1,28 @@
 import {
+	PLAUSIBLE_EVENT_EVENTS_KEYS,
 	PLAUSIBLE_EVENT_SOURCE_LOCATIONS,
 	PLAUSIBLE_EVENTS,
-	type PLAUSIBLE_EVENT_CONTEXTS,
-	type PLAUSIBLE_EVENT_RESULT_STATUSES
+	type PLAUSIBLE_EVENT_RESULT_STATUSES,
+	type PLAUSIBLE_EVENT_VALUES
 } from '$lib/enums/plausible';
 import { trackEvent } from '$lib/services/analytics.services';
 import { nonNullish } from '@dfinity/utils';
 
-export type ExportDataContext =
-	| PLAUSIBLE_EVENT_CONTEXTS.TOKENS_BASIC
-	| PLAUSIBLE_EVENT_CONTEXTS.TOKENS_EXTENDED
-	| PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_BASIC
-	| PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_EXTENDED;
+export type ExportDataType =
+	| PLAUSIBLE_EVENT_VALUES.TOKENS_BASIC
+	| PLAUSIBLE_EVENT_VALUES.TOKENS_EXTENDED
+	| PLAUSIBLE_EVENT_VALUES.TRANSACTIONS_BASIC
+	| PLAUSIBLE_EVENT_VALUES.TRANSACTIONS_EXTENDED;
 
 export interface TrackExportDataParams {
-	context: ExportDataContext;
+	type: ExportDataType;
 	resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
 	error?: string;
 	errorCode?: string;
 }
 
 export const trackExportData = ({
-	context,
+	type,
 	resultStatus,
 	error,
 	errorCode
@@ -29,7 +30,8 @@ export const trackExportData = ({
 	trackEvent({
 		name: PLAUSIBLE_EVENTS.EXPORT_DATA,
 		metadata: {
-			event_context: context,
+			event_key: PLAUSIBLE_EVENT_EVENTS_KEYS.TYPE,
+			event_value: type,
 			source_location: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.SETTINGS_PAGE,
 			result_status: resultStatus,
 			...(nonNullish(error) && { result_error: error }),

--- a/src/frontend/src/lib/services/export-data.services.ts
+++ b/src/frontend/src/lib/services/export-data.services.ts
@@ -2,12 +2,7 @@ import { loadNextIcTransactionsByOldest } from '$icp/services/ic-transactions.se
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 import { Currency } from '$lib/enums/currency';
-import {
-	PLAUSIBLE_EVENT_CONTEXTS,
-	PLAUSIBLE_EVENT_RESULT_STATUSES,
-	PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS,
-	PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS
-} from '$lib/enums/plausible';
+import { PLAUSIBLE_EVENT_CONTEXTS, PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
 import { trackExportData } from '$lib/services/export-data-analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsShow } from '$lib/stores/toasts.store';
@@ -53,9 +48,9 @@ const TOKEN_CSV_FILENAME_BASE_BY_VARIANT = {
 	extended: 'oisy-tokens'
 } as const;
 
-const TOKEN_CSV_SUBCONTEXT_BY_VARIANT = {
-	basic: PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.BASIC,
-	extended: PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.EXTENDED
+const TOKEN_CSV_CONTEXT_BY_VARIANT = {
+	basic: PLAUSIBLE_EVENT_CONTEXTS.TOKENS_BASIC,
+	extended: PLAUSIBLE_EVENT_CONTEXTS.TOKENS_EXTENDED
 } as const;
 
 export const exportTokensCsv = ({
@@ -70,7 +65,7 @@ export const exportTokensCsv = ({
 	variant?: TokenCsvVariant;
 }): boolean => {
 	const $i18n = get(i18n);
-	const subcontext = TOKEN_CSV_SUBCONTEXT_BY_VARIANT[variant];
+	const context = TOKEN_CSV_CONTEXT_BY_VARIANT[variant];
 
 	if (currency !== Currency.USD && isNullish(exchangeRateToUsd)) {
 		toastsShow({
@@ -79,8 +74,7 @@ export const exportTokensCsv = ({
 			duration: 4000
 		});
 		trackExportData({
-			context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS,
-			subcontext,
+			context,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 			errorCode: 'fx_rate_unavailable'
 		});
@@ -106,8 +100,7 @@ export const exportTokensCsv = ({
 	});
 
 	trackExportData({
-		context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS,
-		subcontext,
+		context,
 		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 	});
 
@@ -190,9 +183,9 @@ const TRANSACTION_CSV_FILENAME_BASE_BY_VARIANT = {
 	extended: 'oisy-transactions'
 } as const;
 
-const TRANSACTION_CSV_SUBCONTEXT_BY_VARIANT = {
-	basic: PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.BASIC,
-	extended: PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.EXTENDED
+const TRANSACTION_CSV_CONTEXT_BY_VARIANT = {
+	basic: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_BASIC,
+	extended: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_EXTENDED
 } as const;
 
 export const exportTransactionsCsv = async ({
@@ -213,12 +206,11 @@ export const exportTransactionsCsv = async ({
 	variant?: TransactionCsvVariant;
 }): Promise<boolean> => {
 	const $i18n = get(i18n);
-	const subcontext = TRANSACTION_CSV_SUBCONTEXT_BY_VARIANT[variant];
+	const context = TRANSACTION_CSV_CONTEXT_BY_VARIANT[variant];
 
 	if (isNullish(identity)) {
 		trackExportData({
-			context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
-			subcontext,
+			context,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 			errorCode: 'no_identity'
 		});
@@ -259,8 +251,7 @@ export const exportTransactionsCsv = async ({
 		});
 
 		trackExportData({
-			context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
-			subcontext,
+			context,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 		});
 
@@ -273,8 +264,7 @@ export const exportTransactionsCsv = async ({
 			duration: 4000
 		});
 		trackExportData({
-			context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
-			subcontext,
+			context,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 			errorCode: 'build_failed',
 			error: error instanceof Error ? error.message : String(error)

--- a/src/frontend/src/lib/services/export-data.services.ts
+++ b/src/frontend/src/lib/services/export-data.services.ts
@@ -2,6 +2,13 @@ import { loadNextIcTransactionsByOldest } from '$icp/services/ic-transactions.se
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 import { Currency } from '$lib/enums/currency';
+import {
+	PLAUSIBLE_EVENT_CONTEXTS,
+	PLAUSIBLE_EVENT_RESULT_STATUSES,
+	PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS,
+	PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS
+} from '$lib/enums/plausible';
+import { trackExportData } from '$lib/services/export-data-analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsShow } from '$lib/stores/toasts.store';
 import type { ContactUi } from '$lib/types/contact';
@@ -46,6 +53,11 @@ const TOKEN_CSV_FILENAME_BASE_BY_VARIANT = {
 	extended: 'oisy-tokens'
 } as const;
 
+const TOKEN_CSV_SUBCONTEXT_BY_VARIANT = {
+	basic: PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.BASIC,
+	extended: PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.EXTENDED
+} as const;
+
 export const exportTokensCsv = ({
 	tokens,
 	currency,
@@ -58,12 +70,19 @@ export const exportTokensCsv = ({
 	variant?: TokenCsvVariant;
 }): boolean => {
 	const $i18n = get(i18n);
+	const subcontext = TOKEN_CSV_SUBCONTEXT_BY_VARIANT[variant];
 
 	if (currency !== Currency.USD && isNullish(exchangeRateToUsd)) {
 		toastsShow({
 			text: $i18n.settings.error.export_exchange_rate_unavailable,
 			level: 'error',
 			duration: 4000
+		});
+		trackExportData({
+			context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS,
+			subcontext,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+			errorCode: 'fx_rate_unavailable'
 		});
 		return false;
 	}
@@ -84,6 +103,12 @@ export const exportTokensCsv = ({
 		text: $i18n.settings.text.export_tokens_success,
 		level: 'success',
 		duration: 2000
+	});
+
+	trackExportData({
+		context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS,
+		subcontext,
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 	});
 
 	return true;
@@ -165,6 +190,11 @@ const TRANSACTION_CSV_FILENAME_BASE_BY_VARIANT = {
 	extended: 'oisy-transactions'
 } as const;
 
+const TRANSACTION_CSV_SUBCONTEXT_BY_VARIANT = {
+	basic: PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.BASIC,
+	extended: PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.EXTENDED
+} as const;
+
 export const exportTransactionsCsv = async ({
 	identity,
 	tokens,
@@ -183,8 +213,15 @@ export const exportTransactionsCsv = async ({
 	variant?: TransactionCsvVariant;
 }): Promise<boolean> => {
 	const $i18n = get(i18n);
+	const subcontext = TRANSACTION_CSV_SUBCONTEXT_BY_VARIANT[variant];
 
 	if (isNullish(identity)) {
+		trackExportData({
+			context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
+			subcontext,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+			errorCode: 'no_identity'
+		});
 		return false;
 	}
 
@@ -221,6 +258,12 @@ export const exportTransactionsCsv = async ({
 			duration: 2000
 		});
 
+		trackExportData({
+			context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
+			subcontext,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+		});
+
 		return true;
 	} catch (error: unknown) {
 		consoleError(error);
@@ -228,6 +271,13 @@ export const exportTransactionsCsv = async ({
 			text: $i18n.settings.error.export_failed,
 			level: 'error',
 			duration: 4000
+		});
+		trackExportData({
+			context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
+			subcontext,
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+			errorCode: 'build_failed',
+			error: error instanceof Error ? error.message : String(error)
 		});
 		return false;
 	}

--- a/src/frontend/src/lib/services/export-data.services.ts
+++ b/src/frontend/src/lib/services/export-data.services.ts
@@ -2,7 +2,7 @@ import { loadNextIcTransactionsByOldest } from '$icp/services/ic-transactions.se
 import { icTransactionsStore } from '$icp/stores/ic-transactions.store';
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
 import { Currency } from '$lib/enums/currency';
-import { PLAUSIBLE_EVENT_CONTEXTS, PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
+import { PLAUSIBLE_EVENT_RESULT_STATUSES, PLAUSIBLE_EVENT_VALUES } from '$lib/enums/plausible';
 import { trackExportData } from '$lib/services/export-data-analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { toastsShow } from '$lib/stores/toasts.store';
@@ -48,9 +48,9 @@ const TOKEN_CSV_FILENAME_BASE_BY_VARIANT = {
 	extended: 'oisy-tokens'
 } as const;
 
-const TOKEN_CSV_CONTEXT_BY_VARIANT = {
-	basic: PLAUSIBLE_EVENT_CONTEXTS.TOKENS_BASIC,
-	extended: PLAUSIBLE_EVENT_CONTEXTS.TOKENS_EXTENDED
+const TOKEN_CSV_TYPE_BY_VARIANT = {
+	basic: PLAUSIBLE_EVENT_VALUES.TOKENS_BASIC,
+	extended: PLAUSIBLE_EVENT_VALUES.TOKENS_EXTENDED
 } as const;
 
 export const exportTokensCsv = ({
@@ -65,7 +65,7 @@ export const exportTokensCsv = ({
 	variant?: TokenCsvVariant;
 }): boolean => {
 	const $i18n = get(i18n);
-	const context = TOKEN_CSV_CONTEXT_BY_VARIANT[variant];
+	const type = TOKEN_CSV_TYPE_BY_VARIANT[variant];
 
 	if (currency !== Currency.USD && isNullish(exchangeRateToUsd)) {
 		toastsShow({
@@ -74,7 +74,7 @@ export const exportTokensCsv = ({
 			duration: 4000
 		});
 		trackExportData({
-			context,
+			type,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 			errorCode: 'fx_rate_unavailable'
 		});
@@ -100,7 +100,7 @@ export const exportTokensCsv = ({
 	});
 
 	trackExportData({
-		context,
+		type,
 		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 	});
 
@@ -183,9 +183,9 @@ const TRANSACTION_CSV_FILENAME_BASE_BY_VARIANT = {
 	extended: 'oisy-transactions'
 } as const;
 
-const TRANSACTION_CSV_CONTEXT_BY_VARIANT = {
-	basic: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_BASIC,
-	extended: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_EXTENDED
+const TRANSACTION_CSV_TYPE_BY_VARIANT = {
+	basic: PLAUSIBLE_EVENT_VALUES.TRANSACTIONS_BASIC,
+	extended: PLAUSIBLE_EVENT_VALUES.TRANSACTIONS_EXTENDED
 } as const;
 
 export const exportTransactionsCsv = async ({
@@ -206,11 +206,11 @@ export const exportTransactionsCsv = async ({
 	variant?: TransactionCsvVariant;
 }): Promise<boolean> => {
 	const $i18n = get(i18n);
-	const context = TRANSACTION_CSV_CONTEXT_BY_VARIANT[variant];
+	const type = TRANSACTION_CSV_TYPE_BY_VARIANT[variant];
 
 	if (isNullish(identity)) {
 		trackExportData({
-			context,
+			type,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 			errorCode: 'no_identity'
 		});
@@ -251,7 +251,7 @@ export const exportTransactionsCsv = async ({
 		});
 
 		trackExportData({
-			context,
+			type,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 		});
 
@@ -264,7 +264,7 @@ export const exportTransactionsCsv = async ({
 			duration: 4000
 		});
 		trackExportData({
-			context,
+			type,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 			errorCode: 'build_failed',
 			error: error instanceof Error ? error.message : String(error)

--- a/src/frontend/src/tests/lib/services/export-data-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/export-data-analytics.services.spec.ts
@@ -1,4 +1,4 @@
-import { PLAUSIBLE_EVENT_CONTEXTS, PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
+import { PLAUSIBLE_EVENT_RESULT_STATUSES, PLAUSIBLE_EVENT_VALUES } from '$lib/enums/plausible';
 import { trackEvent } from '$lib/services/analytics.services';
 import { trackExportData } from '$lib/services/export-data-analytics.services';
 
@@ -14,14 +14,15 @@ describe('export-data-analytics.services', () => {
 	describe('trackExportData', () => {
 		it('tracks a tokens_basic success event', () => {
 			trackExportData({
-				context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS_BASIC,
+				type: PLAUSIBLE_EVENT_VALUES.TOKENS_BASIC,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 			});
 
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'export_data',
 				metadata: {
-					event_context: 'tokens_basic',
+					event_key: 'type',
+					event_value: 'tokens_basic',
 					source_location: 'settings_page',
 					result_status: 'success'
 				}
@@ -30,14 +31,15 @@ describe('export-data-analytics.services', () => {
 
 		it('tracks a transactions_extended success event', () => {
 			trackExportData({
-				context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_EXTENDED,
+				type: PLAUSIBLE_EVENT_VALUES.TRANSACTIONS_EXTENDED,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 			});
 
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'export_data',
 				metadata: {
-					event_context: 'transactions_extended',
+					event_key: 'type',
+					event_value: 'transactions_extended',
 					source_location: 'settings_page',
 					result_status: 'success'
 				}
@@ -46,7 +48,7 @@ describe('export-data-analytics.services', () => {
 
 		it('attaches result_error and result_error_code on the error path', () => {
 			trackExportData({
-				context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_BASIC,
+				type: PLAUSIBLE_EVENT_VALUES.TRANSACTIONS_BASIC,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 				error: 'row build failed',
 				errorCode: 'build_failed'
@@ -55,7 +57,8 @@ describe('export-data-analytics.services', () => {
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'export_data',
 				metadata: {
-					event_context: 'transactions_basic',
+					event_key: 'type',
+					event_value: 'transactions_basic',
 					source_location: 'settings_page',
 					result_status: 'error',
 					result_error: 'row build failed',
@@ -66,7 +69,7 @@ describe('export-data-analytics.services', () => {
 
 		it('omits result_error when only an error code is provided', () => {
 			trackExportData({
-				context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS_EXTENDED,
+				type: PLAUSIBLE_EVENT_VALUES.TOKENS_EXTENDED,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 				errorCode: 'fx_rate_unavailable'
 			});
@@ -74,7 +77,8 @@ describe('export-data-analytics.services', () => {
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'export_data',
 				metadata: {
-					event_context: 'tokens_extended',
+					event_key: 'type',
+					event_value: 'tokens_extended',
 					source_location: 'settings_page',
 					result_status: 'error',
 					result_error_code: 'fx_rate_unavailable'

--- a/src/frontend/src/tests/lib/services/export-data-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/export-data-analytics.services.spec.ts
@@ -1,9 +1,4 @@
-import {
-	PLAUSIBLE_EVENT_CONTEXTS,
-	PLAUSIBLE_EVENT_RESULT_STATUSES,
-	PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS,
-	PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS
-} from '$lib/enums/plausible';
+import { PLAUSIBLE_EVENT_CONTEXTS, PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
 import { trackEvent } from '$lib/services/analytics.services';
 import { trackExportData } from '$lib/services/export-data-analytics.services';
 
@@ -17,36 +12,32 @@ describe('export-data-analytics.services', () => {
 	});
 
 	describe('trackExportData', () => {
-		it('tracks a tokens basic success event', () => {
+		it('tracks a tokens_basic success event', () => {
 			trackExportData({
-				context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS,
-				subcontext: PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.BASIC,
+				context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS_BASIC,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 			});
 
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'export_data',
 				metadata: {
-					event_context: 'tokens',
-					event_subcontext: 'basic',
+					event_context: 'tokens_basic',
 					source_location: 'settings_page',
 					result_status: 'success'
 				}
 			});
 		});
 
-		it('tracks a transactions extended success event', () => {
+		it('tracks a transactions_extended success event', () => {
 			trackExportData({
-				context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
-				subcontext: PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.EXTENDED,
+				context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_EXTENDED,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 			});
 
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'export_data',
 				metadata: {
-					event_context: 'transactions',
-					event_subcontext: 'extended',
+					event_context: 'transactions_extended',
 					source_location: 'settings_page',
 					result_status: 'success'
 				}
@@ -55,8 +46,7 @@ describe('export-data-analytics.services', () => {
 
 		it('attaches result_error and result_error_code on the error path', () => {
 			trackExportData({
-				context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
-				subcontext: PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.BASIC,
+				context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS_BASIC,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 				error: 'row build failed',
 				errorCode: 'build_failed'
@@ -65,8 +55,7 @@ describe('export-data-analytics.services', () => {
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'export_data',
 				metadata: {
-					event_context: 'transactions',
-					event_subcontext: 'basic',
+					event_context: 'transactions_basic',
 					source_location: 'settings_page',
 					result_status: 'error',
 					result_error: 'row build failed',
@@ -77,8 +66,7 @@ describe('export-data-analytics.services', () => {
 
 		it('omits result_error when only an error code is provided', () => {
 			trackExportData({
-				context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS,
-				subcontext: PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.EXTENDED,
+				context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS_EXTENDED,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 				errorCode: 'fx_rate_unavailable'
 			});
@@ -86,8 +74,7 @@ describe('export-data-analytics.services', () => {
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'export_data',
 				metadata: {
-					event_context: 'tokens',
-					event_subcontext: 'extended',
+					event_context: 'tokens_extended',
 					source_location: 'settings_page',
 					result_status: 'error',
 					result_error_code: 'fx_rate_unavailable'

--- a/src/frontend/src/tests/lib/services/export-data-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/export-data-analytics.services.spec.ts
@@ -1,0 +1,98 @@
+import {
+	PLAUSIBLE_EVENT_CONTEXTS,
+	PLAUSIBLE_EVENT_RESULT_STATUSES,
+	PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS,
+	PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS
+} from '$lib/enums/plausible';
+import { trackEvent } from '$lib/services/analytics.services';
+import { trackExportData } from '$lib/services/export-data-analytics.services';
+
+vi.mock('$lib/services/analytics.services', () => ({
+	trackEvent: vi.fn()
+}));
+
+describe('export-data-analytics.services', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('trackExportData', () => {
+		it('tracks a tokens basic success event', () => {
+			trackExportData({
+				context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS,
+				subcontext: PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.BASIC,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+			});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: 'export_data',
+				metadata: {
+					event_context: 'tokens',
+					event_subcontext: 'basic',
+					source_location: 'settings_page',
+					result_status: 'success'
+				}
+			});
+		});
+
+		it('tracks a transactions extended success event', () => {
+			trackExportData({
+				context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
+				subcontext: PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.EXTENDED,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+			});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: 'export_data',
+				metadata: {
+					event_context: 'transactions',
+					event_subcontext: 'extended',
+					source_location: 'settings_page',
+					result_status: 'success'
+				}
+			});
+		});
+
+		it('attaches result_error and result_error_code on the error path', () => {
+			trackExportData({
+				context: PLAUSIBLE_EVENT_CONTEXTS.TRANSACTIONS,
+				subcontext: PLAUSIBLE_EVENT_SUBCONTEXT_TRANSACTIONS.BASIC,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+				error: 'row build failed',
+				errorCode: 'build_failed'
+			});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: 'export_data',
+				metadata: {
+					event_context: 'transactions',
+					event_subcontext: 'basic',
+					source_location: 'settings_page',
+					result_status: 'error',
+					result_error: 'row build failed',
+					result_error_code: 'build_failed'
+				}
+			});
+		});
+
+		it('omits result_error when only an error code is provided', () => {
+			trackExportData({
+				context: PLAUSIBLE_EVENT_CONTEXTS.TOKENS,
+				subcontext: PLAUSIBLE_EVENT_SUBCONTEXT_TOKENS.EXTENDED,
+				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+				errorCode: 'fx_rate_unavailable'
+			});
+
+			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+				name: 'export_data',
+				metadata: {
+					event_context: 'tokens',
+					event_subcontext: 'extended',
+					source_location: 'settings_page',
+					result_status: 'error',
+					result_error_code: 'fx_rate_unavailable'
+				}
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/export-data.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/export-data.services.spec.ts
@@ -162,7 +162,7 @@ describe('export-data.services', () => {
 				duration: 4000
 			});
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'tokens_extended',
+				type: 'tokens_extended',
 				resultStatus: 'error',
 				errorCode: 'fx_rate_unavailable'
 			});
@@ -187,7 +187,7 @@ describe('export-data.services', () => {
 				duration: 2000
 			});
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'tokens_basic',
+				type: 'tokens_basic',
 				resultStatus: 'success'
 			});
 		});
@@ -211,7 +211,7 @@ describe('export-data.services', () => {
 			expect(mockDownloadCsv).not.toHaveBeenCalled();
 			expect(mockToastsShow).not.toHaveBeenCalled();
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'transactions_basic',
+				type: 'transactions_basic',
 				resultStatus: 'error',
 				errorCode: 'no_identity'
 			});
@@ -254,7 +254,7 @@ describe('export-data.services', () => {
 				duration: 2000
 			});
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'transactions_basic',
+				type: 'transactions_basic',
 				resultStatus: 'success'
 			});
 		});
@@ -276,7 +276,7 @@ describe('export-data.services', () => {
 				duration: 4000
 			});
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'transactions_extended',
+				type: 'transactions_extended',
 				resultStatus: 'error',
 				errorCode: 'build_failed',
 				error: 'row build failed'

--- a/src/frontend/src/tests/lib/services/export-data.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/export-data.services.spec.ts
@@ -162,8 +162,7 @@ describe('export-data.services', () => {
 				duration: 4000
 			});
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'tokens',
-				subcontext: 'extended',
+				context: 'tokens_extended',
 				resultStatus: 'error',
 				errorCode: 'fx_rate_unavailable'
 			});
@@ -188,8 +187,7 @@ describe('export-data.services', () => {
 				duration: 2000
 			});
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'tokens',
-				subcontext: 'basic',
+				context: 'tokens_basic',
 				resultStatus: 'success'
 			});
 		});
@@ -213,8 +211,7 @@ describe('export-data.services', () => {
 			expect(mockDownloadCsv).not.toHaveBeenCalled();
 			expect(mockToastsShow).not.toHaveBeenCalled();
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'transactions',
-				subcontext: 'basic',
+				context: 'transactions_basic',
 				resultStatus: 'error',
 				errorCode: 'no_identity'
 			});
@@ -257,8 +254,7 @@ describe('export-data.services', () => {
 				duration: 2000
 			});
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'transactions',
-				subcontext: 'basic',
+				context: 'transactions_basic',
 				resultStatus: 'success'
 			});
 		});
@@ -280,8 +276,7 @@ describe('export-data.services', () => {
 				duration: 4000
 			});
 			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
-				context: 'transactions',
-				subcontext: 'extended',
+				context: 'transactions_extended',
 				resultStatus: 'error',
 				errorCode: 'build_failed',
 				error: 'row build failed'

--- a/src/frontend/src/tests/lib/services/export-data.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/export-data.services.spec.ts
@@ -194,7 +194,7 @@ describe('export-data.services', () => {
 	});
 
 	describe('exportTransactionsCsv', () => {
-		it('does nothing when the identity is missing', async () => {
+		it('tracks a no_identity error and skips the export when the identity is missing', async () => {
 			const buildTransactions = vi.fn(() => []);
 
 			const result = await exportTransactionsCsv({

--- a/src/frontend/src/tests/lib/services/export-data.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/export-data.services.spec.ts
@@ -2,6 +2,7 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { loadNextIcTransactionsByOldest } from '$icp/services/ic-transactions.services';
 import { Currency } from '$lib/enums/currency';
+import { trackExportData } from '$lib/services/export-data-analytics.services';
 import { exportTokensCsv, exportTransactionsCsv } from '$lib/services/export-data.services';
 import { toastsShow } from '$lib/stores/toasts.store';
 import { consoleError } from '$lib/utils/console.utils';
@@ -32,6 +33,10 @@ vi.mock('$lib/stores/toasts.store', () => ({
 
 vi.mock('$lib/utils/console.utils', () => ({
 	consoleError: vi.fn()
+}));
+
+vi.mock('$lib/services/export-data-analytics.services', () => ({
+	trackExportData: vi.fn()
 }));
 
 vi.mock(import('$lib/utils/csv.utils'), async (importOriginal) => {
@@ -123,6 +128,7 @@ describe('export-data.services', () => {
 	const mockDownloadCsv = vi.mocked(downloadCsv);
 	const mockToastsShow = vi.mocked(toastsShow);
 	const mockConsoleError = vi.mocked(consoleError);
+	const mockTrackExportData = vi.mocked(trackExportData);
 
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -155,6 +161,12 @@ describe('export-data.services', () => {
 				level: 'error',
 				duration: 4000
 			});
+			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
+				context: 'tokens',
+				subcontext: 'extended',
+				resultStatus: 'error',
+				errorCode: 'fx_rate_unavailable'
+			});
 		});
 
 		it('downloads the requested token CSV variant and shows a success toast', () => {
@@ -175,6 +187,11 @@ describe('export-data.services', () => {
 				level: 'success',
 				duration: 2000
 			});
+			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
+				context: 'tokens',
+				subcontext: 'basic',
+				resultStatus: 'success'
+			});
 		});
 	});
 
@@ -185,7 +202,8 @@ describe('export-data.services', () => {
 			const result = await exportTransactionsCsv({
 				...defaultTransactionParams(),
 				identity: null,
-				buildTransactions
+				buildTransactions,
+				variant: 'basic'
 			});
 
 			expect(result).toBeFalsy();
@@ -194,6 +212,12 @@ describe('export-data.services', () => {
 			expect(buildTransactions).not.toHaveBeenCalled();
 			expect(mockDownloadCsv).not.toHaveBeenCalled();
 			expect(mockToastsShow).not.toHaveBeenCalled();
+			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
+				context: 'transactions',
+				subcontext: 'basic',
+				resultStatus: 'error',
+				errorCode: 'no_identity'
+			});
 		});
 
 		it('keeps exporting after one paginated token loader fails', async () => {
@@ -232,6 +256,11 @@ describe('export-data.services', () => {
 				level: 'success',
 				duration: 2000
 			});
+			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
+				context: 'transactions',
+				subcontext: 'basic',
+				resultStatus: 'success'
+			});
 		});
 
 		it('shows an error toast when building the export throws', async () => {
@@ -249,6 +278,13 @@ describe('export-data.services', () => {
 				text: en.settings.error.export_failed,
 				level: 'error',
 				duration: 4000
+			});
+			expect(mockTrackExportData).toHaveBeenCalledExactlyOnceWith({
+				context: 'transactions',
+				subcontext: 'extended',
+				resultStatus: 'error',
+				errorCode: 'build_failed',
+				error: 'row build failed'
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

We recently added the Settings → Export data feature ([#12845](https://github.com/dfinity/oisy-wallet/pull/12845)) but never instrumented it. Adding a single `export_data` Plausible event lets us see how often the feature is used, which dataset / variant pair users reach for, and how often the download fails on the FX-rate guard or the transaction-load path.

# Changes

New `export_data` Plausible event fired from the export services on both success and error paths. Reuses existing attributes — no new ad-hoc keys.

Attributes per event:

- `event_key`: `type` (new value in `PLAUSIBLE_EVENT_EVENTS_KEYS`, alongside the existing filter keys like `transaction_type`, `token`, `contact`).
- `event_value`: one of four flat values — `tokens_basic`, `tokens_extended`, `transactions_basic`, `transactions_extended`. Added to `PLAUSIBLE_EVENT_VALUES` (the same enum that already holds the NFT / earn-page values). Carries the dataset × variant the user picked.
- `source_location`: `settings_page`. New value added to `PLAUSIBLE_EVENT_SOURCE_LOCATIONS` — pinned inside the helper so any future export entry points need to update it deliberately.
- `result_status`: `success` | `error` (existing `PLAUSIBLE_EVENT_RESULT_STATUSES`).
- `result_error`, `result_error_code`: only attached on the error path, same shape as `trackTokenManage`.

New `trackExportData` helper in `src/frontend/src/lib/services/export-data-analytics.services.ts`, modelled on `trackTokenManage`. The `type` parameter is the four-value `PLAUSIBLE_EVENT_VALUES` union so any call passing a different value fails to type-check; `event_key` is fixed inside the helper.

Wired into `export-data.services.ts`:

- `exportTokensCsv` — success path; FX-guard failure emits `errorCode: 'fx_rate_unavailable'`.
- `exportTransactionsCsv` — success path; missing-identity early return emits `errorCode: 'no_identity'`; catch path emits `errorCode: 'build_failed'` with the underlying error message in `error`.

# Tests

New spec `export-data-analytics.services.spec.ts` (4 tests) covering the success shape for both contexts, error with `error` + `errorCode`, and the code-only error path.

`export-data.services.spec.ts` extended on each existing branch to assert the matching `trackExportData` call: FX-guard failure, tokens success, missing identity, transactions success, build-failed catch path. The missing-identity test was renamed to `'tracks a no_identity error and skips the export when the identity is missing'` since the branch now emits an analytics event in addition to skipping the export work — addresses Copilot review [comment 3333736219](https://github.com/dfinity/oisy-wallet/pull/13005#discussion_r3333736219).

Quality gates pass on this branch: `npx prettier --write --cache`, `npx eslint --concurrency=1 --max-warnings 0 .`, `npx tsc --project tsconfig.spec.json --noEmit`, and `npx vitest run` over the four affected specs (70 passing). `npm run check` produces the same 11 pre-existing errors as `origin/main` (`@dfinity/ic-pub-key/ecdsa` and `sol-instructions-token.utils.ts`), none from this change.

Visual verification in a running dev server was skipped — Plausible is gated by `PLAUSIBLE_ENABLED` (off in local / staging) and the export UI itself is unchanged. The unit specs cover every call site end to end.

🤖 Claude Opus 4.7


