### PR TITLE
fix(frontend): redirect after NFT send from the detail page

### DIFF
--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -34,6 +34,7 @@
 		solAddressMainnetNotLoaded
 	} from '$lib/derived/address.derived';
 	import { modalSendData } from '$lib/derived/modal.derived';
+	import { routeNft } from '$lib/derived/nav.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { networks } from '$lib/derived/networks.derived';
 	import { pageCollectionNfts, pageNft } from '$lib/derived/page-nft.derived';
@@ -171,7 +172,15 @@
 	const close = () => {
 		// Sending the last NFT from a collection's detail page would leave the user on a URL whose
 		// NFT has been wiped from the store at the next poll, so steer them to a still-renderable page.
-		if (isNftsPage && sendProgressStep === ProgressStepsSend.DONE && nonNullish(selectedNft)) {
+		// Gate on `$routeNft` rather than the `isNftsPage` prop alone so the redirect is anchored to
+		// the actual NFT detail URL — a future caller flipping the prop on a list page wouldn't drop
+		// query params like the selected network.
+		if (
+			isNftsPage &&
+			nonNullish($routeNft) &&
+			sendProgressStep === ProgressStepsSend.DONE &&
+			nonNullish(selectedNft)
+		) {
 			// `InProgressWizard` arms a `beforeNavigate` guard via `dirtyWizardState`; the send is
 			// already done at this point, so clear it to avoid a "navigate away?" confirm popup.
 			dirtyWizardState.set(false);

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -48,6 +48,7 @@
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
+	import { dirtyWizardState } from '$lib/stores/progressWizardState.store';
 	import { SCANNED_PLAIN_ADDRESS_SEND_CONTEXT_KEY } from '$lib/stores/scanned-plain-address-send.store';
 	import { token } from '$lib/stores/token.store';
 	import type { ContactUi } from '$lib/types/contact';
@@ -171,6 +172,9 @@
 		// Sending the last NFT from a collection's detail page would leave the user on a URL whose
 		// NFT has been wiped from the store at the next poll, so steer them to a still-renderable page.
 		if (isNftsPage && sendProgressStep === ProgressStepsSend.DONE && nonNullish(selectedNft)) {
+			// `InProgressWizard` arms a `beforeNavigate` guard via `dirtyWizardState`; the send is
+			// already done at this point, so clear it to avoid a "navigate away?" confirm popup.
+			dirtyWizardState.set(false);
 			goto(getNftSendRedirectUrl({ sentNft: selectedNft, collectionNfts: $pageCollectionNfts }));
 		}
 

--- a/src/frontend/src/lib/components/send/SendModal.svelte
+++ b/src/frontend/src/lib/components/send/SendModal.svelte
@@ -3,6 +3,7 @@
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import { encodeIcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
 	import { setContext } from 'svelte';
+	import { goto } from '$app/navigation';
 	import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 	import { enabledErc4626Tokens } from '$eth/derived/erc4626.derived';
 	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
@@ -35,7 +36,7 @@
 	import { modalSendData } from '$lib/derived/modal.derived';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { networks } from '$lib/derived/networks.derived';
-	import { pageNft } from '$lib/derived/page-nft.derived';
+	import { pageCollectionNfts, pageNft } from '$lib/derived/page-nft.derived';
 	import { enabledTokens, nonFungibleTokens } from '$lib/derived/tokens.derived';
 	import { ProgressStepsSend } from '$lib/enums/progress-steps';
 	import { WizardStepsSend } from '$lib/enums/wizard-steps';
@@ -65,7 +66,7 @@
 		isNetworkIdSOLDevnet,
 		isNetworkIdSOLLocal
 	} from '$lib/utils/network.utils';
-	import { findNonFungibleToken } from '$lib/utils/nfts.utils';
+	import { findNonFungibleToken, getNftSendRedirectUrl } from '$lib/utils/nfts.utils';
 	import { decodeQrCode } from '$lib/utils/qr-code.utils';
 	import { shouldSkipDestinationStep } from '$lib/utils/send.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
@@ -166,10 +167,17 @@
 		selectedNft = undefined;
 	};
 
-	const close = () =>
+	const close = () => {
+		// Sending the last NFT from a collection's detail page would leave the user on a URL whose
+		// NFT has been wiped from the store at the next poll, so steer them to a still-renderable page.
+		if (isNftsPage && sendProgressStep === ProgressStepsSend.DONE && nonNullish(selectedNft)) {
+			goto(getNftSendRedirectUrl({ sentNft: selectedNft, collectionNfts: $pageCollectionNfts }));
+		}
+
 		closeModal(() => {
 			reset();
 		});
+	};
 
 	const isDisabled = ({ network: { id } }: Token): boolean =>
 		isNetworkIdEthereum(id) || isNetworkIdEvm(id)

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -1,5 +1,6 @@
 import type { EthAddress } from '$eth/types/address';
 import { NFT_MAX_FILESIZE_LIMIT } from '$lib/constants/app.constants';
+import { AppPath } from '$lib/constants/routes.constants';
 import { MediaStatusEnum } from '$lib/enums/media-status';
 import { MediaType } from '$lib/enums/media-type';
 import { NftCollectionSchema } from '$lib/schema/nft.schema';
@@ -9,6 +10,7 @@ import type { NftError } from '$lib/types/errors';
 import type { NetworkId, OptionNetworkId } from '$lib/types/network';
 import type { Nft, NftCollection, NftCollectionUi, NftId, NonFungibleToken } from '$lib/types/nft';
 import { areAddressesEqual } from '$lib/utils/address.utils';
+import { nftsUrl } from '$lib/utils/nav.utils';
 import { getNftIdentifier } from '$lib/utils/nft.utils';
 import { UrlSchema } from '$lib/validation/url.validation';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
@@ -307,6 +309,18 @@ export const filterSortByCollection: FilterSortByCollection = <T extends Nft | N
 	}
 
 	return result;
+};
+
+export const getNftSendRedirectUrl = ({
+	sentNft,
+	collectionNfts
+}: {
+	sentNft: Nft;
+	collectionNfts: Nft[];
+}): string => {
+	const hasRemaining = collectionNfts.some(({ id }) => id !== sentNft.id);
+
+	return hasRemaining ? nftsUrl({ collection: sentNft.collection }) : AppPath.Nfts;
 };
 
 export const findNonFungibleToken = ({

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -6,6 +6,7 @@ import {
 import { ETHEREUM_NETWORK, ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { PEPE_TOKEN } from '$env/tokens/tokens-erc20/tokens.pepe.env';
 import { NFT_MAX_FILESIZE_LIMIT } from '$lib/constants/app.constants';
+import { AppPath } from '$lib/constants/routes.constants';
 import { CustomTokenSection } from '$lib/enums/custom-token-section';
 import { MediaStatusEnum } from '$lib/enums/media-status';
 import { NetworkSchema } from '$lib/schema/network.schema';
@@ -21,6 +22,7 @@ import {
 	getMediaStatus,
 	getMediaStatusOrCache,
 	getNftCollectionUi,
+	getNftSendRedirectUrl,
 	mapTokenToCollection,
 	parseMetadataResourceUrl
 } from '$lib/utils/nfts.utils';
@@ -223,6 +225,48 @@ describe('nfts.utils', () => {
 			});
 
 			expect(nfts).toEqual([mockMainnetNft]);
+		});
+	});
+
+	describe('getNftSendRedirectUrl', () => {
+		it('returns the collection URL when other NFTs remain in the same collection', () => {
+			const result = getNftSendRedirectUrl({
+				sentNft: mockNft1,
+				collectionNfts: [mockNft1, mockNft2]
+			});
+
+			expect(result).toBe(
+				`${AppPath.Nfts}?collection=${mockNft1.collection.address}&network=${mockNft1.collection.network.id.description}`
+			);
+		});
+
+		it('returns the NFTs root URL when the sent NFT was the last in its collection', () => {
+			const result = getNftSendRedirectUrl({
+				sentNft: mockNft1,
+				collectionNfts: [mockNft1]
+			});
+
+			expect(result).toBe(AppPath.Nfts);
+		});
+
+		it('returns the NFTs root URL when the sent NFT is already absent from an empty collection list', () => {
+			const result = getNftSendRedirectUrl({
+				sentNft: mockNft1,
+				collectionNfts: []
+			});
+
+			expect(result).toBe(AppPath.Nfts);
+		});
+
+		it('returns the collection URL when the sent NFT was already removed but siblings remain', () => {
+			const result = getNftSendRedirectUrl({
+				sentNft: mockNft1,
+				collectionNfts: [mockNft2]
+			});
+
+			expect(result).toBe(
+				`${AppPath.Nfts}?collection=${mockNft1.collection.address}&network=${mockNft1.collection.network.id.description}`
+			);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

When the user sends an NFT from the NFT detail page (`/nfts/?nft=…&collection=…&network=…`), the modal closes and leaves them on the same URL. As soon as the next `LoaderNfts` poll wipes the just-sent NFT from `nftStore`, `pageNft` becomes nullish and the page falls back to the 10-second timeout in `Nft.svelte` — a noticeably broken state in between.

Note: The UI remains in this state endlessly, not just 10 sec.
<img width="1210" height="578" alt="image" src="https://github.com/user-attachments/assets/8010cf99-16a1-43b4-9f31-79e4c07be284" />

# Changes

- New `getNftSendRedirectUrl({ sentNft, collectionNfts })` helper in `nfts.utils.ts`. Returns the collection URL when other NFTs remain in the same collection (filtering out the just-sent NFT by id), or `AppPath.Nfts` when it was the last one.
- `SendModal.svelte` `close()` now detects "post-NFT-send from the detail page" and `goto()`s the computed URL before delegating to `closeModal`. Covers both IC and ETH NFT send paths since both wizards bind `sendProgressStep` and route through `onClose`.
- The detect guard combines `isNftsPage` with `nonNullish($routeNft)` so the redirect is anchored to the actual NFT detail URL — a future caller flipping the prop on a list page can't drop query params like the selected network.
- Filtering by `id !== sentNft.id` is robust to timing: at the 750 ms `close()` mark the NFT is usually still in the store (20 s poll), but it also handles the rare "store already refreshed mid-flight" case.
- Before `goto()`, clear `dirtyWizardState` so the `beforeNavigate` guard armed by `InProgressWizard` does not pop a "navigate away?" confirm. The send has already completed at that point, so the warning is no longer warranted.

# Tests

- 4 new unit tests in `nfts.utils.spec.ts` covering: siblings remain → collection URL, last NFT → NFTs root, already-empty list → NFTs root, sent NFT already removed but siblings present → collection URL.
- Existing NFT-adjacent suites stay green (234 tests passed locally: 4 new + 77 in `nfts.utils.spec.ts` + 157 in NFT components / page-nft derived / IC + ETH nft-send services).
- Verified the navigation-guard regression on `test_fe_3`; the follow-up commit suppresses the popup. Reviewer please retest the full flow there once the new deploy lands.

|Collection|After the Send|
|---|---|
|>1|<img width="1192" height="890" alt="image" src="https://github.com/user-attachments/assets/8c1d7ef7-c139-40d8-8fb0-f362b16dc8ba" />|
|1|<img width="1192" height="890" alt="image" src="https://github.com/user-attachments/assets/ed3ea3ac-ca1f-4c84-9eef-6a7c2e4f09b9" />|

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using claude-opus-4-7
