### PR TITLE
feat(frontend): show app version on signer login page

### DIFF
--- a/src/frontend/src/lib/components/settings/Settings.svelte
+++ b/src/frontend/src/lib/components/settings/Settings.svelte
@@ -178,4 +178,6 @@
 	<SettingsExperimentalFeatures />
 {/if}
 
-<SettingsVersion />
+<div class="mt-24">
+	<SettingsVersion />
+</div>

--- a/src/frontend/src/lib/components/settings/SettingsVersion.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsVersion.svelte
@@ -18,7 +18,7 @@
 	const branch = GIT_BRANCH_NAME;
 </script>
 
-<p class="mb-0 text-center text-xs text-primary">
+<p class="text-center text-xs text-primary">
 	<span class="opacity-50">{OISY_NAME}</span>
 	<ExternalLink
 		ariaLabel={replaceOisyPlaceholders($i18n.settings.alt.github_release)}
@@ -28,7 +28,7 @@
 </p>
 
 {#if TEST_FE && notEmptyString(branch) && notEmptyString(commit)}
-	<p class="mt-24 mb-0 text-center text-xs text-primary">
+	<p class="mt-24 text-center text-xs text-primary">
 		{$i18n.settings.text.git_disclaimer}<br />
 		<b>{$i18n.settings.text.git_branch_name}</b>
 		{branch}<br />

--- a/src/frontend/src/lib/components/settings/SettingsVersion.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsVersion.svelte
@@ -18,7 +18,7 @@
 	const branch = GIT_BRANCH_NAME;
 </script>
 
-<p class="text-center text-xs text-primary">
+<p class="mb-0 text-center text-xs text-primary">
 	<span class="opacity-50">{OISY_NAME}</span>
 	<ExternalLink
 		ariaLabel={replaceOisyPlaceholders($i18n.settings.alt.github_release)}
@@ -28,7 +28,7 @@
 </p>
 
 {#if TEST_FE && notEmptyString(branch) && notEmptyString(commit)}
-	<p class="mt-24 text-center text-xs text-primary">
+	<p class="mt-24 mb-0 text-center text-xs text-primary">
 		{$i18n.settings.text.git_disclaimer}<br />
 		<b>{$i18n.settings.text.git_branch_name}</b>
 		{branch}<br />

--- a/src/frontend/src/lib/components/settings/SettingsVersion.svelte
+++ b/src/frontend/src/lib/components/settings/SettingsVersion.svelte
@@ -18,7 +18,7 @@
 	const branch = GIT_BRANCH_NAME;
 </script>
 
-<p class="mt-24 text-center text-xs text-primary">
+<p class="text-center text-xs text-primary">
 	<span class="opacity-50">{OISY_NAME}</span>
 	<ExternalLink
 		ariaLabel={replaceOisyPlaceholders($i18n.settings.alt.github_release)}

--- a/src/frontend/src/lib/components/signer/SignerSignIn.svelte
+++ b/src/frontend/src/lib/components/signer/SignerSignIn.svelte
@@ -3,6 +3,7 @@
 	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
 	import ButtonAuthenticateWithHelp from '$lib/components/auth/ButtonAuthenticateWithHelp.svelte';
 	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
+	import SettingsVersion from '$lib/components/settings/SettingsVersion.svelte';
 	import SignerAnimatedAstronaut from '$lib/components/signer/SignerAnimatedAstronaut.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import { OISY_SIGNER_CONNECT_DOCS_URL } from '$lib/constants/oisy.constants';
@@ -41,6 +42,8 @@
 </p>
 
 <ButtonAuthenticateWithHelp asPopup fullWidth helpAlignment="center" needHelpLink={false} />
+
+<SettingsVersion />
 
 {#if $modalAuthHelp && nonNullish($modalAuthHelpData)}
 	<AuthHelpModal usesIdentityHelp={$modalAuthHelpData} />

--- a/src/frontend/src/lib/components/signer/SignerSignIn.svelte
+++ b/src/frontend/src/lib/components/signer/SignerSignIn.svelte
@@ -43,7 +43,9 @@
 
 <ButtonAuthenticateWithHelp asPopup fullWidth helpAlignment="center" needHelpLink={false} />
 
-<SettingsVersion />
+<div class="[&_p]:mb-0">
+	<SettingsVersion />
+</div>
 
 {#if $modalAuthHelp && nonNullish($modalAuthHelpData)}
 	<AuthHelpModal usesIdentityHelp={$modalAuthHelpData} />

--- a/src/frontend/src/routes/(sign)/sign/+page.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+page.svelte
@@ -4,7 +4,6 @@
 	import { fade, type FadeParams } from 'svelte/transition';
 	import AgreementsGuard from '$lib/components/guard/AgreementsGuard.svelte';
 	import LoaderUserProfile from '$lib/components/loaders/LoaderUserProfile.svelte';
-	import SettingsVersion from '$lib/components/settings/SettingsVersion.svelte';
 	import SignerAccounts from '$lib/components/signer/SignerAccounts.svelte';
 	import SignerCallCanister from '$lib/components/signer/SignerCallCanister.svelte';
 	import SignerConsentMessage from '$lib/components/signer/SignerConsentMessage.svelte';
@@ -80,7 +79,3 @@
 		</LoaderUserProfile>
 	{/if}
 </article>
-
-{#if $authNotSignedIn}
-	<SettingsVersion />
-{/if}

--- a/src/frontend/src/routes/(sign)/sign/+page.svelte
+++ b/src/frontend/src/routes/(sign)/sign/+page.svelte
@@ -4,6 +4,7 @@
 	import { fade, type FadeParams } from 'svelte/transition';
 	import AgreementsGuard from '$lib/components/guard/AgreementsGuard.svelte';
 	import LoaderUserProfile from '$lib/components/loaders/LoaderUserProfile.svelte';
+	import SettingsVersion from '$lib/components/settings/SettingsVersion.svelte';
 	import SignerAccounts from '$lib/components/signer/SignerAccounts.svelte';
 	import SignerCallCanister from '$lib/components/signer/SignerCallCanister.svelte';
 	import SignerConsentMessage from '$lib/components/signer/SignerConsentMessage.svelte';
@@ -79,3 +80,7 @@
 		</LoaderUserProfile>
 	{/if}
 </article>
+
+{#if $authNotSignedIn}
+	<SettingsVersion />
+{/if}


### PR DESCRIPTION
# Motivation

The Settings page already displays the running app version (and, in test/staging builds, the git branch and commit hash). The signer login page — what relying-party users see when their flow lands in the wallet — currently has no version indicator. Showing the same version line at the bottom of the signer login box makes it easy to tell which build is serving a signer session, which is useful when triaging issues reported against a specific deployment.

# Changes

- Reuse the existing `SettingsVersion` component inside `SignerSignIn`, rendered immediately after `ButtonAuthenticateWithHelp` so the version sits right below the terms-of-use text, **inside** the signer login article box.
- Externalise the previous `mt-24` top margin from `SettingsVersion` so the signer box does not grow vertically when the version is added. `Settings.svelte` now wraps `<SettingsVersion />` in a `<div class="mt-24">` to preserve the existing Settings-page spacing.
- Wrap `<SettingsVersion />` in `SignerSignIn` with `<div class="[&_p]:mb-0">` so the global `theme.scss` `p { margin: 0 0 var(--padding-2_5x) }` rule is neutralised only inside the signer box; the Settings page keeps its original bottom breathing room beneath the version line.
- No new component or i18n keys: the same version label, GitHub release link, and `TEST_FE` git-debug block already used on Settings render identically here.

Note: `SettingsVersion.svelte` still lives under `components/settings/` even though it is now reused outside of Settings. Moving it to `components/core/AppVersion.svelte` would be a cleaner home, but it touches more files and (arguably) the `settings.*` i18n keys, so I'd rather do that in a follow-up PR than mix it into this change.

# Tests

- `npx prettier --check` and `npx eslint --fix` on the touched files are clean.
- `npx svelte-check` reports the same 11 pre-existing errors as `origin/main` (all in `ic-pub-key/src/cli.ts` and `sol-instructions-token.utils.ts`); no new errors introduced.
- No automated tests existed for `SignerSignIn` or `SettingsVersion`; none added.
- Deployed to `test_fe_3` to visually confirm placement, box height, and that the Settings-page version still has its original bottom margin.

|Before|After|
|---|---|
|<img width="1340" height="730" alt="image" src="https://github.com/user-attachments/assets/c0a5bfdd-92b5-4f65-982b-231d653efe74" />|<img width="1340" height="730" alt="image" src="https://github.com/user-attachments/assets/d6f6f7d6-fb37-4e13-a6dc-79a4245da87c" />|

---
Generated by Claude Opus 4.7 (`claude-opus-4-7`).
