### PR TITLE
test(frontend): expose InfuraErc20Provider in eth provider spec mocks

### DIFF
--- a/src/frontend/src/tests/eth/services/eth-open-crypto-pay.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-open-crypto-pay.services.spec.ts
@@ -32,6 +32,7 @@ vi.mock('$eth/providers/infura-erc20-icp.providers', () => ({
 }));
 
 vi.mock('$eth/providers/infura-erc20.providers', () => ({
+	InfuraErc20Provider: vi.fn(class {}),
 	infuraErc20Providers: vi.fn(() => ({ getFeeData: vi.fn() }))
 }));
 

--- a/src/frontend/src/tests/eth/services/send.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/send.services.spec.ts
@@ -35,6 +35,7 @@ vi.mock('$eth/providers/infura-cketh.providers', () => ({
 }));
 
 vi.mock('$eth/providers/infura-erc20.providers', () => ({
+	InfuraErc20Provider: vi.fn(class {}),
 	infuraErc20Providers: vi.fn(() => ({
 		populateTransaction: vi.fn().mockResolvedValue({ data: '0xerc20data' })
 	}))


### PR DESCRIPTION
# Motivation

Two specs mock `$eth/providers/infura-erc20.providers` with a factory that only stubs the `infuraErc20Providers` function but omits the `InfuraErc20Provider` class. Today the tests pass because nothing in their transitive import graph reaches `infura-erc4626.providers.ts`, which re-exports the class via `export class InfuraErc4626Provider extends InfuraErc20Provider`. The moment a new import edge does, Vitest blows up with `No "InfuraErc20Provider" export is defined on the "$eth/providers/infura-erc20.providers" mock`.

Exposed by PR #13001 during an unrelated refactor — fixing it pre-emptively so the next import-graph shift doesn't break CI. `src/frontend/src/tests/eth/services/erc20.services.spec.ts` already includes the class in its mock; this PR brings the other two specs in line with that pattern.

# Changes

- `src/frontend/src/tests/eth/services/eth-open-crypto-pay.services.spec.ts`: add `InfuraErc20Provider: vi.fn(class {})` to the `$eth/providers/infura-erc20.providers` mock factory.
- `src/frontend/src/tests/eth/services/send.services.spec.ts`: same fix.

Mirrors the existing pattern in `erc20.services.spec.ts` (line 34). A no-op `class {}` is sufficient because no methods on the class are invoked through these specs' paths — the class only needs to exist as an export for any transitive `extends InfuraErc20Provider` consumer.

# Tests

- `npx vitest run src/frontend/src/tests/eth/services/{eth-open-crypto-pay,send,erc20}.services.spec.ts` → 33/33 pass.
- `npx eslint --max-warnings 0` on both edited files → clean.
- `npx prettier --check` on both edited files → no formatting changes needed.
- `npm run check` shows 11 pre-existing errors in `ic-pub-key/src/cli.ts` and `sol/utils/sol-instructions-token.utils.ts` — both present on `origin/main` and unrelated to this change.

🤖 Claude Sonnet 4.6