### PR TITLE
chore(frontend): extend sprinkles s1e6

### DIFF
--- a/src/frontend/src/env/reward-campaigns.json
+++ b/src/frontend/src/env/reward-campaigns.json
@@ -141,7 +141,7 @@
 		"campaignHref": "rewards.campaigns.sprinkles_s1e6.campaign_href",
 		"learnMoreHref": "https://docs.oisy.com/rewards/oisy-sprinkles",
 		"startDate": "2026-04-08T12:00:00.000Z",
-		"endDate": "2026-05-31T12:00:00.000Z",
+		"endDate": "2026-06-30T12:00:00.000Z",
 		"welcome": {
 			"title": "rewards.campaigns.sprinkles_s1e6.welcome.title",
 			"subtitle": "rewards.campaigns.sprinkles_s1e6.welcome.subtitle",

--- a/src/frontend/src/env/reward-campaigns.json
+++ b/src/frontend/src/env/reward-campaigns.json
@@ -141,7 +141,7 @@
 		"campaignHref": "rewards.campaigns.sprinkles_s1e6.campaign_href",
 		"learnMoreHref": "https://docs.oisy.com/rewards/oisy-sprinkles",
 		"startDate": "2026-04-08T12:00:00.000Z",
-		"endDate": "2026-06-30T12:00:00.000Z",
+		"endDate": "2026-07-31T12:00:00.000Z",
 		"welcome": {
 			"title": "rewards.campaigns.sprinkles_s1e6.welcome.title",
 			"subtitle": "rewards.campaigns.sprinkles_s1e6.welcome.subtitle",


### PR DESCRIPTION
# Motivation

Sprinkles s1e6 ended on May 31.

# Changes

- ~Extend till June 30~
- Extend till July 31

# Tests

<img height="400" alt="image" src="https://github.com/user-attachments/assets/cdde5b39-4020-49eb-ba78-0faa9d3e0540" />
