### PR TITLE
docs(ai): document spec-assets folder convention for spec-driven development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,6 @@ Claude-specific runtime layer. Anything not contradicted here defers to
 >
 > - Frontend → [`docs/ai/frontend/README.md`](./docs/ai/frontend/README.md)
 > - Backend → [`docs/ai/backend/README.md`](./docs/ai/backend/README.md)
-> - Implementing a spec → [`docs/ai/spec-driven-development/workflow.md`](./docs/ai/spec-driven-development/workflow.md)
 
 ---
 
@@ -25,6 +24,25 @@ Claude-specific runtime layer. Anything not contradicted here defers to
   - Adding a new dependency (npm or Cargo).
   - Adding a new top-level folder.
   - Touching `backend.did`, generated `declarations/`, or stable state.
+
+---
+
+## Workflows
+
+### Spec-driven development
+
+oisy has a spec-driven development workflow for new features,
+improvements, and bugfixes — see
+[`docs/ai/spec-driven-development/workflow.md`](./docs/ai/spec-driven-development/workflow.md).
+A spec is authored in Cowork first, then implemented in Claude Code on
+a branch / PR.
+
+**Always ask before using it.** When the user describes a feature,
+improvement, or bugfix without naming the workflow, acknowledge that the
+workflow exists and ask whether to use it. Only follow the workflow
+after the user agrees. If they decline (or the change is clearly too
+small to warrant a spec, e.g. a one-line typo), implement directly —
+still following the rest of CLAUDE.md and AGENTS.md.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Claude-specific runtime layer. Anything not contradicted here defers to
 >
 > - Frontend → [`docs/ai/frontend/README.md`](./docs/ai/frontend/README.md)
 > - Backend → [`docs/ai/backend/README.md`](./docs/ai/backend/README.md)
+> - Implementing a spec → [`docs/ai/spec-driven-development/workflow.md`](./docs/ai/spec-driven-development/workflow.md)
 
 ---
 

--- a/docs/ai/spec-driven-development/workflow.md
+++ b/docs/ai/spec-driven-development/workflow.md
@@ -94,9 +94,11 @@ If the implementation reveals gaps or the spec needs updating, the spec is the s
 After the PR merges:
 
 1. **Update `docs/ai/PRODUCT.md`** to reflect the new behavior. This keeps the product spec accurate for all future builds.
-2. **Remove the spec's asset folder** (`specs/<name>/` — wireframes, designs, etc.). The spec `.md` stays; the assets were planning artifacts that don't track later UI changes and become silent traps once the implementation diverges. Git history retains them if they're ever needed again.
+2. **Remove the spec's `wireframes/` folder** (`specs/<name>/wireframes/`). Wireframes are rough planning mocks that don't track later UI changes and become silent traps once the implementation diverges. Git history retains them if needed. Other asset subfolders — `designs/` in particular — typically stay: higher-fidelity outputs are useful as cross-feature reference and age better than throwaway HTML mocks. If `specs/<name>/` ends up empty after the cleanup, remove the empty parent folder too.
 
-Both updates can land in a single small cleanup PR. A project can deviate from step 2 (e.g. if assets are linked from external docs and must remain browseable), but the decision should be explicit in the project's `CLAUDE.md` so the convention isn't skipped silently.
+Before deleting wireframes, scan for any pattern worth promoting to a curated reference (e.g. `docs/ai/frontend/patterns/` or a Storybook entry) — a pattern that first appeared in a wireframe and proves useful across features deserves a home outside the per-spec folder.
+
+Both updates can land in a single small cleanup PR. A project can deviate (e.g. keep wireframes for external linking, or also delete designs), but the deviation should be explicit in the project's `CLAUDE.md` so the convention isn't skipped silently.
 
 ---
 

--- a/docs/ai/spec-driven-development/workflow.md
+++ b/docs/ai/spec-driven-development/workflow.md
@@ -10,8 +10,7 @@ This workflow uses **Cowork** for specification and **Claude Code** for implemen
 
 ```
 dfinity/oisy-wallet/
-├── .claude/
-│   └── CLAUDE.md                                       # Instructions for Claude Code (references PRODUCT.md and specs/)
+├── CLAUDE.md                                           # Instructions for Claude Code (references PRODUCT.md and specs/)
 └── docs/
     └── ai/
         ├── PRODUCT.md                                  # Living description of all current product behaviors

--- a/docs/ai/spec-driven-development/workflow.md
+++ b/docs/ai/spec-driven-development/workflow.md
@@ -11,15 +11,19 @@ This workflow uses **Cowork** for specification and **Claude Code** for implemen
 ```
 dfinity/oisy-wallet/
 ├── .claude/
-│   └── CLAUDE.md              # Instructions for Claude Code (references PRODUCT.md and specs/)
+│   └── CLAUDE.md                                       # Instructions for Claude Code (references PRODUCT.md and specs/)
 └── docs/
     └── ai/
-        ├── PRODUCT.md         # Living description of all current product behaviors
+        ├── PRODUCT.md                                  # Living description of all current product behaviors
         └── spec-driven-development/
-            ├── workflow.md    # This document
+            ├── workflow.md                             # This document
             └── specs/
                 ├── 2026-05-10-feat-add-token-swapping.md
                 ├── 2026-05-24-fix-wallet-sync-race.md
+                ├── 2026-06-04-feat-limit-orders.md     # the spec
+                ├── 2026-06-04-feat-limit-orders/       # optional assets for this spec
+                │   ├── wireframes/                     # HTML mocks (e.g. from Cowork)
+                │   └── designs/                        # design outputs (e.g. from Claude Design)
                 └── ...
 ```
 
@@ -57,6 +61,18 @@ The date prefix keeps specs sorted chronologically in the directory. The type pr
 Example: `2026-06-02-impr-track-learn-more-clicks.md`
 
 **Cowork session naming:** Name the session to match the spec — same type prefix and short description, without the date. E.g. `impr: Track Learn More clicks in Plausible`. This keeps the sidebar readable and makes it easy to link a session back to its spec.
+
+**Spec asset folder:** A spec may bring along supporting assets — HTML wireframes from Cowork, design outputs from Claude Design, diagrams, screenshots, etc. Place them in a sibling folder that matches the spec filename without the `.md` extension, and group them inside by source type:
+
+```
+specs/
+├── 2026-06-04-feat-limit-orders.md          # the spec
+└── 2026-06-04-feat-limit-orders/            # assets for the spec
+    ├── wireframes/                          # HTML mocks (e.g. from Cowork)
+    └── designs/                             # design outputs (e.g. from Claude Design)
+```
+
+This keeps the `specs/` listing readable (one `.md` per spec) while letting each spec carry its own assets. The folder is optional — many specs will not need one. References from the spec to an asset use a relative path, e.g. `[rounding demo](./2026-06-04-feat-limit-orders/wireframes/rounding-demo.html)`.
 
 ### Step 4 — Build (Claude Code)
 

--- a/docs/ai/spec-driven-development/workflow.md
+++ b/docs/ai/spec-driven-development/workflow.md
@@ -91,7 +91,12 @@ If the implementation reveals gaps or the spec needs updating, the spec is the s
 
 ### Step 6 — Merge & Update (Claude Code)
 
-After the PR merges, update `docs/ai/PRODUCT.md` to reflect the new behavior. This keeps the product spec accurate for all future builds.
+After the PR merges:
+
+1. **Update `docs/ai/PRODUCT.md`** to reflect the new behavior. This keeps the product spec accurate for all future builds.
+2. **Remove the spec's asset folder** (`specs/<name>/` — wireframes, designs, etc.). The spec `.md` stays; the assets were planning artifacts that don't track later UI changes and become silent traps once the implementation diverges. Git history retains them if they're ever needed again.
+
+Both updates can land in a single small cleanup PR. A project can deviate from step 2 (e.g. if assets are linked from external docs and must remain browseable), but the decision should be explicit in the project's `CLAUDE.md` so the convention isn't skipped silently.
 
 ---
 

--- a/docs/ai/spec-driven-development/workflow.md
+++ b/docs/ai/spec-driven-development/workflow.md
@@ -94,11 +94,9 @@ If the implementation reveals gaps or the spec needs updating, the spec is the s
 After the PR merges:
 
 1. **Update `docs/ai/PRODUCT.md`** to reflect the new behavior. This keeps the product spec accurate for all future builds.
-2. **Remove the spec's `wireframes/` folder** (`specs/<name>/wireframes/`). Wireframes are rough planning mocks that don't track later UI changes and become silent traps once the implementation diverges. Git history retains them if needed. Other asset subfolders — `designs/` in particular — typically stay: higher-fidelity outputs are useful as cross-feature reference and age better than throwaway HTML mocks. If `specs/<name>/` ends up empty after the cleanup, remove the empty parent folder too.
+2. **Remove the spec's asset folder** (`specs/<name>/` — wireframes, designs, etc.). The spec `.md` stays; the assets were planning artifacts. Once the feature ships, the shipped app is the source of truth — the code itself, plus `PRODUCT.md` for behaviour and the design-system / component library for visual conventions. Holding on to spec assets after merge just creates silent traps once the implementation evolves. Git history retains them if they're ever genuinely needed again.
 
-Before deleting wireframes, scan for any pattern worth promoting to a curated reference (e.g. `docs/ai/frontend/patterns/` or a Storybook entry) — a pattern that first appeared in a wireframe and proves useful across features deserves a home outside the per-spec folder.
-
-Both updates can land in a single small cleanup PR. A project can deviate (e.g. keep wireframes for external linking, or also delete designs), but the deviation should be explicit in the project's `CLAUDE.md` so the convention isn't skipped silently.
+Both updates can land in a single small cleanup PR. A project can deviate from step 2 (e.g. if assets are linked from external docs and must remain browseable), but the decision should be explicit in the project's `CLAUDE.md` so the convention isn't skipped silently.
 
 ---
 


### PR DESCRIPTION
# Motivation

The [spec-driven development workflow](https://github.com/dfinity/oisy-wallet/blob/main/docs/ai/spec-driven-development/workflow.md) (added in #13013 / #13015) lets specs live in the repo but doesn't say where _spec assets_ should go — HTML wireframes from Cowork, design outputs from Claude Design, diagrams, screenshots, etc. The first real use of the workflow (the limit-orders feature in #13034) needed somewhere to put five wireframe HTMLs and the question of where they should land had to be invented on the fly.

This small PR cherry-picks the convention chosen there into `main` so future specs — for any project — can follow it from the start without rebasing on or duplicating that larger work.

# Changes

- `docs/ai/spec-driven-development/workflow.md`:
  - Extends the **Repository Structure** tree to show the sibling-folder pattern: `specs/<name>.md` + an optional `specs/<name>/` folder, grouped inside by source type (`wireframes/`, `designs/`, …).
  - Adds a short **Spec asset folder** subsection under the existing _Spec filename convention_ explaining the pattern and giving an example relative-path link from a spec to one of its assets.

The convention itself: place supporting assets in a sibling folder whose name matches the spec filename without the `.md` extension, with one subfolder per source type. Keeps `specs/` readable (one `.md` per spec) while letting each spec carry its own assets. The folder is optional — many specs will not need one.


- `CLAUDE.md`: add a new `## Workflows` section with a `### Spec-driven development` subsection — names the workflow, links to `workflow.md`, and adds an explicit **"Always ask before using it"** directive so Claude surfaces the workflow and waits for user agreement when the user describes a feature / improvement / bugfix, rather than silently following it or silently skipping it. The decline path and the small-change carve-out (e.g. one-line typo) are both spelled out so the ask-rule doesn't loop on trivia. Replaces an earlier, passive "Implementing a spec → workflow.md" bullet in the Mandatory first step callout that only triggered on phrasing users rarely use first.


- `workflow.md`: extend **Step 6 — Merge & Update** with a second sub-step — remove the spec's asset folder (`specs/<name>/` — wireframes, designs, etc.) post-merge. The spec `.md` stays as a record of the design conversation, but the shipped app is the source of truth for everything else: the code, `PRODUCT.md` for behaviour, and the design-system / component library for visual conventions. Holding on to spec assets post-merge just creates silent traps once the implementation evolves. A project can deviate (e.g. if assets are linked from external docs) but must say so in its `CLAUDE.md`.

# Tests

N/A — docs-only change to a single Markdown file. Local quality gates (`npm run format`, `npm run lint`, `npm run check`, `npm run test`) all pass on the worktree.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7)

---

# Review follow-ups

- `discussion_r3371098539` — corrected the Repository Structure tree to show `CLAUDE.md` at the repo root instead of under a non-existent `.claude/` directory (commit `02d70d903`).






