### PR TITLE
fix(frontend): show correct SPL token in Solana WalletConnect review

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { WalletKitTypes } from '@reown/walletkit';
 	import { onDestroy, untrack } from 'svelte';
 	import {
@@ -26,6 +26,7 @@
 	import SolWalletConnectSignReview from '$sol/components/wallet-connect/SolWalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$sol/constants/steps.constants';
 	import { SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION } from '$sol/constants/wallet-connect.constants';
+	import { enabledSplTokens } from '$sol/derived/spl.derived';
 	import {
 		sign as signService,
 		decode as decodeService
@@ -71,13 +72,22 @@
 
 	let amount = $state<bigint | undefined>();
 	let destination = $state<OptionSolAddress>();
+	let tokenAddress = $state<OptionSolAddress>();
 
 	const updateData = async () => {
-		({ amount, destination } = await decodeService({
+		({ amount, destination, tokenAddress } = await decodeService({
 			base64EncodedTransactionMessage: data,
 			networkId
 		}));
 	};
+
+	// When the transaction moves an SPL token we know, review it with that token's
+	// metadata; otherwise fall back to the network's native SOL token.
+	let reviewToken = $derived(
+		nonNullish(tokenAddress)
+			? ($enabledSplTokens.find(({ address }) => address === tokenAddress) ?? token)
+			: token
+	);
 
 	$effect(() => {
 		[data, networkId];
@@ -172,7 +182,7 @@
 				onApprove={sign}
 				onReject={reject}
 				source={address ?? ''}
-				{token}
+				token={reviewToken}
 			/>
 		{/if}
 	{/key}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -82,10 +82,13 @@
 	};
 
 	// When the transaction moves an SPL token we know, review it with that token's
-	// metadata; otherwise fall back to the network's native SOL token.
+	// metadata; otherwise fall back to the network's native SOL token. The same mint
+	// can exist on several clusters, so we match the current network too.
 	let reviewToken = $derived(
 		nonNullish(tokenAddress)
-			? ($enabledSplTokens.find(({ address }) => address === tokenAddress) ?? token)
+			? ($enabledSplTokens.find(
+					({ address, network: { id } }) => address === tokenAddress && id === networkId
+				) ?? token)
 			: token
 	);
 

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -72,6 +72,10 @@ export interface MappedSolTransaction {
 	payer?: SolAddress;
 	source?: SolAddress;
 	destination?: SolAddress;
+	// The SPL token mint moved by the transaction, when it is a token (not native SOL)
+	// transfer. Lets the review screen show the correct token metadata instead of
+	// defaulting to native SOL.
+	tokenAddress?: SplTokenAddress;
 	// `true` when the message bundles instructions that disagree on source,
 	// destination or payer. The summary keeps a single value per field, so such
 	// a transaction cannot be faithfully represented on the review screen and

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -456,14 +456,16 @@ const mapSolTokenInstruction = (instruction: SolParsedInstruction): MappedSolTra
 			data: { amount },
 			accounts: {
 				source: { address: source },
-				destination: { address: destination }
+				destination: { address: destination },
+				mint: { address: tokenAddress }
 			}
 		} = instruction;
 
 		return {
 			amount,
 			source,
-			destination
+			destination,
+			tokenAddress
 		};
 	}
 
@@ -472,14 +474,16 @@ const mapSolTokenInstruction = (instruction: SolParsedInstruction): MappedSolTra
 			data: { amount },
 			accounts: {
 				source: { address: source },
-				delegate: { address: destination }
+				delegate: { address: destination },
+				mint: { address: tokenAddress }
 			}
 		} = instruction;
 
 		return {
 			amount,
 			source,
-			destination
+			destination,
+			tokenAddress
 		};
 	}
 
@@ -528,14 +532,16 @@ const mapSolToken2022Instruction = (instruction: SolParsedInstruction): MappedSo
 			data: { amount },
 			accounts: {
 				source: { address: source },
-				destination: { address: destination }
+				destination: { address: destination },
+				mint: { address: tokenAddress }
 			}
 		} = instruction;
 
 		return {
 			amount,
 			source,
-			destination
+			destination,
+			tokenAddress
 		};
 	}
 
@@ -544,14 +550,16 @@ const mapSolToken2022Instruction = (instruction: SolParsedInstruction): MappedSo
 			data: { amount },
 			accounts: {
 				source: { address: source },
-				delegate: { address: destination }
+				delegate: { address: destination },
+				mint: { address: tokenAddress }
 			}
 		} = instruction;
 
 		return {
 			amount,
 			source,
-			destination
+			destination,
+			tokenAddress
 		};
 	}
 

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -3,7 +3,7 @@ import type { OptionSolAddress } from '$sol/types/address';
 import type { MappedSolTransaction } from '$sol/types/sol-transaction';
 import type { CompilableTransactionMessage } from '$sol/types/sol-transaction-message';
 import { mapSolInstruction } from '$sol/utils/sol-instructions.utils';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 import {
 	decompileTransactionMessageFetchingLookupTables,
 	getBase64Encoder,
@@ -54,11 +54,21 @@ export const mapSolTransactionMessage = ({
 			// disagrees on source, destination or payer would be silently dropped from the
 			// review screen. We flag it instead, leaving it to the signing flow to refuse a
 			// transaction it cannot display faithfully.
+			//
+			// The same applies to the token: the summary shows a single token's metadata and
+			// sums every amount into one figure. Bundling movements of different mints — or
+			// mixing a known SPL token with a native/unknown one — cannot be shown faithfully.
+			const mixesTokenWithNonToken =
+				(nonNullish(tokenAddress) && nonNullish(acc.amount) && isNullish(acc.tokenAddress)) ||
+				(isNullish(tokenAddress) && nonNullish(amount) && nonNullish(acc.tokenAddress));
+
 			const ambiguous =
 				(acc.ambiguous ?? false) ||
 				conflicts({ current: acc.source, next: source }) ||
 				conflicts({ current: acc.destination, next: destination }) ||
-				conflicts({ current: acc.payer, next: payer });
+				conflicts({ current: acc.payer, next: payer }) ||
+				conflicts({ current: acc.tokenAddress, next: tokenAddress }) ||
+				mixesTokenWithNonToken;
 
 			return {
 				...acc,

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -48,7 +48,7 @@ export const mapSolTransactionMessage = ({
 }: TransactionMessage): MappedSolTransaction =>
 	Array.from(instructions).reduce<MappedSolTransaction>(
 		(acc, instruction) => {
-			const { amount, source, destination, payer } = mapSolInstruction(instruction);
+			const { amount, source, destination, payer, tokenAddress } = mapSolInstruction(instruction);
 
 			// The summary holds a single value per field, so any later instruction that
 			// disagrees on source, destination or payer would be silently dropped from the
@@ -66,6 +66,7 @@ export const mapSolTransactionMessage = ({
 				...(nonNullish(source) && { source }),
 				...(nonNullish(destination) && { destination }),
 				...(nonNullish(payer) && { payer }),
+				...(nonNullish(tokenAddress) && { tokenAddress }),
 				...(ambiguous && { ambiguous })
 			};
 		},

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -32,6 +32,10 @@ import {
 	getTransferCheckedInstruction,
 	TokenInstruction
 } from '@solana-program/token';
+import {
+	getApproveCheckedInstruction as getToken2022ApproveCheckedInstruction,
+	getTransferCheckedInstruction as getToken2022TransferCheckedInstruction
+} from '@solana-program/token-2022';
 import { address, type Base58EncodedBytes, type Rpc, type SolanaRpcApi } from '@solana/kit';
 import type { MockInstance } from 'vitest';
 
@@ -985,6 +989,42 @@ describe('sol-instructions.utils', () => {
 
 		it('should forward the delegate as destination and surface the mint for an `ApproveChecked` instruction', () => {
 			const instruction = getApproveCheckedInstruction({
+				source: address(mockSolAddress),
+				mint: address(JUP_TOKEN.address),
+				delegate: address(mockSolAddress2),
+				owner: address(mockSolAddress),
+				amount: 100n,
+				decimals: 6
+			});
+
+			expect(mapSolInstruction(instruction)).toStrictEqual({
+				amount: 100n,
+				source: mockSolAddress,
+				destination: mockSolAddress2,
+				tokenAddress: JUP_TOKEN.address
+			});
+		});
+
+		it('should surface the mint as tokenAddress for a Token-2022 `TransferChecked` instruction', () => {
+			const instruction = getToken2022TransferCheckedInstruction({
+				source: address(mockSolAddress),
+				mint: address(JUP_TOKEN.address),
+				destination: address(mockSolAddress2),
+				authority: address(mockSolAddress),
+				amount: 100n,
+				decimals: 6
+			});
+
+			expect(mapSolInstruction(instruction)).toStrictEqual({
+				amount: 100n,
+				source: mockSolAddress,
+				destination: mockSolAddress2,
+				tokenAddress: JUP_TOKEN.address
+			});
+		});
+
+		it('should forward the delegate and surface the mint for a Token-2022 `ApproveChecked` instruction', () => {
+			const instruction = getToken2022ApproveCheckedInstruction({
 				source: address(mockSolAddress),
 				mint: address(JUP_TOKEN.address),
 				delegate: address(mockSolAddress2),

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -29,6 +29,7 @@ import { assertNonNullish } from '@dfinity/utils';
 import {
 	getApproveCheckedInstruction,
 	getApproveInstruction,
+	getTransferCheckedInstruction,
 	TokenInstruction
 } from '@solana-program/token';
 import { address, type Base58EncodedBytes, type Rpc, type SolanaRpcApi } from '@solana/kit';
@@ -964,7 +965,25 @@ describe('sol-instructions.utils', () => {
 			});
 		});
 
-		it('should forward the delegate as destination for an `ApproveChecked` instruction', () => {
+		it('should surface the mint as tokenAddress for a `TransferChecked` instruction', () => {
+			const instruction = getTransferCheckedInstruction({
+				source: address(mockSolAddress),
+				mint: address(JUP_TOKEN.address),
+				destination: address(mockSolAddress2),
+				authority: address(mockSolAddress),
+				amount: 100n,
+				decimals: 6
+			});
+
+			expect(mapSolInstruction(instruction)).toStrictEqual({
+				amount: 100n,
+				source: mockSolAddress,
+				destination: mockSolAddress2,
+				tokenAddress: JUP_TOKEN.address
+			});
+		});
+
+		it('should forward the delegate as destination and surface the mint for an `ApproveChecked` instruction', () => {
 			const instruction = getApproveCheckedInstruction({
 				source: address(mockSolAddress),
 				mint: address(JUP_TOKEN.address),
@@ -977,7 +996,8 @@ describe('sol-instructions.utils', () => {
 			expect(mapSolInstruction(instruction)).toStrictEqual({
 				amount: 100n,
 				source: mockSolAddress,
-				destination: mockSolAddress2
+				destination: mockSolAddress2,
+				tokenAddress: JUP_TOKEN.address
 			});
 		});
 

--- a/src/frontend/src/tests/sol/utils/sol-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transactions.utils.spec.ts
@@ -80,6 +80,27 @@ describe('sol-transactions.utils', () => {
 			expect(spyMapSolInstruction).toHaveBeenNthCalledWith(3, instruction3);
 		});
 
+		it('should propagate the tokenAddress of an SPL token instruction', () => {
+			spyMapSolInstruction.mockReturnValueOnce({
+				amount: 100n,
+				source: mockSolAddress,
+				destination: mockSolAddress2,
+				tokenAddress: mockSolAddress3
+			});
+
+			expect(
+				mapSolTransactionMessage({
+					...mockSolParsedTransactionMessage,
+					instructions: [instruction1]
+				})
+			).toStrictEqual({
+				amount: 100n,
+				source: mockSolAddress,
+				destination: mockSolAddress2,
+				tokenAddress: mockSolAddress3
+			});
+		});
+
 		it('should ignore instructions with undefined amount (no change to accumulator)', () => {
 			spyMapSolInstruction
 				.mockReturnValueOnce({ amount: undefined })

--- a/src/frontend/src/tests/sol/utils/sol-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transactions.utils.spec.ts
@@ -101,6 +101,32 @@ describe('sol-transactions.utils', () => {
 			});
 		});
 
+		it('should flag a transaction as ambiguous when it bundles different SPL mints', () => {
+			spyMapSolInstruction
+				.mockReturnValueOnce({ amount: 1n, tokenAddress: mockSolAddress2 })
+				.mockReturnValueOnce({ amount: 2n, tokenAddress: mockSolAddress3 });
+
+			expect(
+				mapSolTransactionMessage({
+					...mockSolParsedTransactionMessage,
+					instructions: [instruction1, instruction2]
+				})
+			).toStrictEqual(expect.objectContaining({ ambiguous: true }));
+		});
+
+		it('should flag a transaction as ambiguous when it mixes an SPL token with a native movement', () => {
+			spyMapSolInstruction
+				.mockReturnValueOnce({ amount: 5n, tokenAddress: mockSolAddress2 })
+				.mockReturnValueOnce({ amount: 10n });
+
+			expect(
+				mapSolTransactionMessage({
+					...mockSolParsedTransactionMessage,
+					instructions: [instruction1, instruction2]
+				})
+			).toStrictEqual(expect.objectContaining({ ambiguous: true }));
+		});
+
 		it('should ignore instructions with undefined amount (no change to accumulator)', () => {
 			spyMapSolInstruction
 				.mockReturnValueOnce({ amount: undefined })


### PR DESCRIPTION
# Motivation

The Solana WalletConnect review screen always renders the transaction with the network's **native SOL token** (`SolWalletConnectSignModal.svelte` hardcodes `SOLANA_TOKEN`). For an SPL token transfer/approval this shows the **wrong asset and decimals** — e.g. 100 USDC is displayed as "100 SOL".

This is an alternative to #13038, which addressed the same concern by **refusing to sign** any SPL transfer/approval. That blocks a flow we actively use. The mint is recoverable, so we can fix the *display* instead of removing the feature.

# Changes

- Surface the SPL mint as `tokenAddress` on `MappedSolTransaction` from the checked instruction variants (`TransferChecked` / `ApproveChecked`, both Token and Token-2022 programs) — the mint is carried in-instruction, no RPC needed.
- Propagate `tokenAddress` through `mapSolTransactionMessage`.
- In the sign modal, resolve `tokenAddress` to the user's known SPL token and review with its metadata; fall back to the native SOL token when no SPL mint is involved.
- Tests for mint surfacing and propagation.

# Tests

- `npm run format` / `npm run lint -- --max-warnings 0` / `npm run check` — clean
- `sol-instructions.utils.spec.ts`, `sol-transactions.utils.spec.ts`, `wallet-connect.services.spec.ts` — pass
