### PR TITLE
docs(ai): require spec header pointing to the workflow doc

### DIFF
--- a/docs/ai/spec-driven-development/workflow.md
+++ b/docs/ai/spec-driven-development/workflow.md
@@ -46,6 +46,10 @@ We work through open questions together: scope, edge cases, constraints, accepta
 
 Cowork produces a spec file. You copy it into `docs/ai/spec-driven-development/specs/` in your local repo. The spec is intentionally written for Claude Code — it references real file paths, component names, and existing patterns where possible.
 
+**Spec header:** Every spec must begin with the following line so Claude Code knows it is part of this workflow:
+
+> This spec follows the workflow defined in `docs/ai/spec-driven-development/workflow.md`.
+
 **Spec filename convention:** `YYYY-MM-DD-<type>-<short-description>.md`
 
 The date prefix keeps specs sorted chronologically in the directory. The type prefix signals the nature of the work at a glance:

--- a/docs/ai/spec-driven-development/workflow.md
+++ b/docs/ai/spec-driven-development/workflow.md
@@ -46,7 +46,7 @@ We work through open questions together: scope, edge cases, constraints, accepta
 
 Cowork produces a spec file. You copy it into `docs/ai/spec-driven-development/specs/` in your local repo. The spec is intentionally written for Claude Code — it references real file paths, component names, and existing patterns where possible.
 
-**Spec header:** Every spec must begin with the following line so Claude Code knows it is part of this workflow:
+**Spec header:** Every new spec must begin with the following line so Claude Code knows it is part of this workflow:
 
 > This spec follows the workflow defined in `docs/ai/spec-driven-development/workflow.md`.
 


### PR DESCRIPTION
# Motivation

The spec-driven workflow ([`docs/ai/spec-driven-development/workflow.md`](docs/ai/spec-driven-development/workflow.md)) describes where specs live and how they are named, but nothing inside a spec itself signals that the file is part of this workflow. When Claude Code opens a spec it has to infer that from the directory path alone. Adding a one-line "this spec follows the workflow at ..." header at the top of every spec makes the link explicit and self-contained: any tool, agent, or human reading the spec immediately sees which workflow it belongs to and can pull the workflow doc into context.

# Changes

- Add a **Spec header** rule to Step 3 (_Spec (Cowork → You)_) of [`docs/ai/spec-driven-development/workflow.md`](docs/ai/spec-driven-development/workflow.md). Every new spec must begin with the line (exact copy/paste, backticks included):

  ```markdown
  This spec follows the workflow defined in `docs/ai/spec-driven-development/workflow.md`.
  ```

No other content in the workflow doc changes. Existing specs in `docs/ai/spec-driven-development/specs/` are not retro-fitted in this PR — the rule is scoped to new specs going forward, which is why the doc uses "Every new spec".

# Tests

Docs-only change; no code paths touched. Verified locally that the file still renders correctly and the new section sits between the Step 3 intro and the **Spec filename convention** block.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: claude-opus-4-7
