### PR TITLE
docs(ai): update PRODUCT.md in the same PR, not post-merge

### DIFF
--- a/docs/ai/spec-driven-development/workflow.md
+++ b/docs/ai/spec-driven-development/workflow.md
@@ -85,6 +85,8 @@ Open Claude Code in the oisy-wallet repo and say:
 
 Claude Code reads the spec, reads `docs/ai/PRODUCT.md` for system context, and begins building. It has the GitHub MCP configured and can open PRs, create branches, and interact with issues directly.
 
+**Update `docs/ai/PRODUCT.md` in the same PR** as the behaviour change, not afterwards. Claude Code is best placed to write the description because by the time the PR is ready, it has the implementation context (what _actually_ shipped, including any [Step 5 — Adjust](#step-5--adjust-claude-code--spec) deviations from the spec). Landing PRODUCT.md alongside the code also keeps `main` from briefly disagreeing with itself between merge and the cleanup PR. Cowork can still review the draft if a product re-think emerges.
+
 ### Step 5 — Adjust (Claude Code ↔ Spec)
 
 If the implementation reveals gaps or the spec needs updating, the spec is the source of truth — keep it in sync with reality.
@@ -93,14 +95,15 @@ If the implementation reveals gaps or the spec needs updating, the spec is the s
 
 **Come back to Cowork** if the gap reveals a deeper ambiguity — something that requires rethinking scope, resolving a product question, or deciding between approaches. Cowork is better for that dialogue, and the updated spec should reflect the decision before Code continues.
 
-### Step 6 — Merge & Update (Claude Code)
+### Step 6 — Post-merge cleanup (Claude Code)
 
 After the PR merges:
 
-1. **Update `docs/ai/PRODUCT.md`** to reflect the new behavior. This keeps the product spec accurate for all future builds.
-2. **Remove the spec's asset folder** (`specs/<name>/` — wireframes, designs, etc.). The spec `.md` stays; the assets were planning artifacts. Once the feature ships, the shipped app is the source of truth — the code itself, plus `PRODUCT.md` for behaviour and the design-system / component library for visual conventions. Holding on to spec assets after merge just creates silent traps once the implementation evolves. Git history retains them if they're ever genuinely needed again.
+1. **Remove the spec's asset folder** (`specs/<name>/` — wireframes, designs, etc.). The spec `.md` stays; the assets were planning artifacts. Once the feature ships, the shipped app is the source of truth — the code itself, plus `PRODUCT.md` for behaviour and the design-system / component library for visual conventions. Holding on to spec assets after merge just creates silent traps once the implementation evolves. Git history retains them if they're ever genuinely needed again.
 
-Both updates can land in a single small cleanup PR. A project can deviate from step 2 (e.g. if assets are linked from external docs and must remain browseable), but the decision should be explicit in the project's `CLAUDE.md` so the convention isn't skipped silently.
+This can land as a small follow-up PR. A project can deviate (e.g. if assets are linked from external docs and must remain browseable), but the decision should be explicit in the project's `CLAUDE.md` so the convention isn't skipped silently.
+
+(`PRODUCT.md` is updated in the **same** PR as the behaviour change — see [Step 4](#step-4--build-claude-code) — not here.)
 
 ---
 
@@ -116,7 +119,7 @@ Before closing a PR, Claude Code diffs the final implementation against the spec
 
 ### PRODUCT.md stays current
 
-`PRODUCT.md` is updated as part of every merge, not as an afterthought. Claude Code should be instructed in `CLAUDE.md` to patch `PRODUCT.md` as part of its standard post-implementation step.
+`PRODUCT.md` is updated in the **same PR** as the behaviour change, not as a post-merge afterthought. This keeps `main` from briefly carrying code whose product description does not yet match, and means the description is written by Claude Code with the implementation context fresh.
 
 ### CLAUDE.md wires everything together
 
@@ -124,7 +127,7 @@ Before closing a PR, Claude Code diffs the final implementation against the spec
 
 - Always read `docs/ai/PRODUCT.md` at session start
 - Look for specs in `docs/ai/spec-driven-development/specs/`
-- Update `PRODUCT.md` after merging
+- Update `PRODUCT.md` in the same PR as the behaviour change (not post-merge)
 
 ---
 


### PR DESCRIPTION
# Motivation

Step 6 of [`docs/ai/spec-driven-development/workflow.md`](docs/ai/spec-driven-development/workflow.md) currently parks the `PRODUCT.md` update as a post-merge cleanup. That creates a window where `main` carries shipped code whose product description does not yet match, with no upside — Claude Code is already the right author for the description (it has the implementation context, including any Step 5 "Adjust" deviations from the spec), and it is already on the branch. Surfaced while implementing [#13044](https://github.com/dfinity/oisy-wallet/pull/13044), where I noted "PRODUCT.md not updated" as a divergence; we agreed it should land alongside the behaviour change instead.

# Changes

- **Step 4 (Build):** adds an explicit "Update `PRODUCT.md` in the same PR" requirement, with a short rationale (implementation context, no staleness window) and a note that Cowork can still review the draft.
- **Step 6 (Merge & Update → Post-merge cleanup):** renamed and trimmed. Only the asset-folder removal remains as a post-merge action. Adds a back-reference to Step 4 so the reader knows where `PRODUCT.md` lives now.
- **"PRODUCT.md stays current" subsection** (under _Improvements Over a Basic Workflow_): rewritten to reflect the same-PR convention.
- **"CLAUDE.md wires everything together"** bullet: `Update PRODUCT.md after merging` → `Update PRODUCT.md in the same PR as the behaviour change (not post-merge)`.

No code changes; docs only.

# Tests

Docs-only change; no code paths touched. `npx prettier --check docs/ai/spec-driven-development/workflow.md` passes. Verified locally that the back-references in the new Step 4 / Step 6 phrasing point to the correct anchor IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.7 (\`claude-opus-4-7\`)