### PR TITLE
chore(backend): upgrade ic-cdk to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "canbench-rs"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2669351aae7fe4fe2208838b370484dd3310cc99648500edc384cca245a3fff"
+checksum = "3d959bc8d6e4738bcfed6682d46ef105db17e5fe81d4c30e8b49b03b9badd2c8"
 dependencies = [
  "canbench-rs-macros",
  "candid",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "041885a6642bbc6096aba629814c0b15a96191e427986631d95105139702ca73"
+checksum = "3198f118892181c4f4d30cfb423511a11b9d7e8d7efb94aa58777db78da27bd8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -670,7 +670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1071,16 +1071,17 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.18.7"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efb278f5d3ef033b3eed7f01f1096eaf67701896aa5ef69f5eddf5a84833dc0"
+checksum = "818d6d5416a8f0212e1b132703b0da51e36c55f2b96677e96f2bbe7702e1bd85"
 dependencies = [
  "candid",
  "ic-cdk-executor",
  "ic-cdk-macros",
  "ic-error-types",
- "ic-management-canister-types 0.3.3",
+ "ic-management-canister-types",
  "ic0",
+ "pin-project-lite",
  "serde",
  "serde_bytes",
  "slotmap",
@@ -1089,19 +1090,20 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-executor"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f4ee8930fd2e491177e2eb7fff53ee1c407c13b9582bdc7d6920cf83109a2d"
+checksum = "33716b730ded33690b8a704bff3533fda87d229e58046823647d28816e9bcee7"
 dependencies = [
  "ic0",
  "slotmap",
+ "smallvec",
 ]
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.18.7"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb14c5d691cc9d72bb95459b4761e3a4b3444b85a63d17555d5ddd782969a1e"
+checksum = "66dad91a214945cb3605bc9ef6901b87e2ac41e3624284c2cabba49d43aa4f43"
 dependencies = [
  "candid",
  "darling",
@@ -1112,16 +1114,12 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-timers"
-version = "0.12.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb21b1f818e9989cd267c72ec5bf6390e49d5881e591117a911038f622b5d5ff"
+checksum = "6852b9c1d4a82ff50fc7318599298aee8bfb082bd7e9fe7e5c1420692b2170f7"
 dependencies = [
- "candid",
- "futures",
- "ic-cdk",
+ "ic-cdk-executor",
  "ic0",
- "serde",
- "serde_bytes",
  "slotmap",
 ]
 
@@ -1183,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "ic-ledger-types"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb52826a353b583012628af6da762b52672350686c3275234febfadeca965ea"
+checksum = "60ab0da348a638e01beb5bcc6c0b92e51efbe351950ff99c125d53fff77899d5"
 dependencies = [
  "candid",
  "crc32fast",
@@ -1194,17 +1192,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "ic-management-canister-types"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7e5b8a0f7c3b320d9450ac950547db4f24a31601b5d398f9680b64427455d2"
-dependencies = [
- "candid",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -1681,7 +1668,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1891,7 +1878,7 @@ dependencies = [
  "flate2",
  "hex",
  "ic-certification",
- "ic-management-canister-types 0.5.0",
+ "ic-management-canister-types",
  "ic-transport-types",
  "reqwest",
  "schemars",
@@ -2235,7 +2222,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2640,7 +2627,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2742,7 +2728,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3349,7 +3335,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ resolver = "2"
 
 [workspace.dependencies]
 bs58 = "0.5"
-ic-cdk = "0.18.7"
-ic-cdk-timers = "0.12.3"
-canbench-rs = { version = "0.3.0" }
+ic-cdk = "0.19.0"
+ic-cdk-timers = "1.0.0"
+canbench-rs = { version = "0.4.0" }
 ic-cycles-ledger-client = { path = "src/cycles_ledger/client" }
 ic-cycles-ledger-pic = { path = "src/cycles_ledger/pic" }
 ic-cycles-ledger-types = { path = "src/cycles_ledger/types" }
-ic-ledger-types = "0.15.0"
+ic-ledger-types = "0.16.0"
 ic-stable-structures = "0.7"
 ic-metrics-encoder = "1.1"
 ic-canister-sig-creation = "1.3"

--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -1257,7 +1257,7 @@ service : (Arg) -> {
 	// background refresh timer keeps them warm. If any cached price is
 	// missing or older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`]
 	// seconds, the endpoint kicks off a refresh for that subset **in the
-	// background** (via `ic_cdk::futures::spawn`) and returns the current cache
+	// background** (via `ic_cdk::futures::spawn_migratory`) and returns the current cache
 	// snapshot immediately. Entries that are still missing or stale at the
 	// moment of the call are returned as `None`; subsequent calls will pick up
 	// the refreshed values once the spawned fetch lands.

--- a/src/backend/src/api/exchange.rs
+++ b/src/backend/src/api/exchange.rs
@@ -24,7 +24,7 @@ use crate::{
 /// background refresh timer keeps them warm. If any cached price is
 /// missing or older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`]
 /// seconds, the endpoint kicks off a refresh for that subset **in the
-/// background** (via `ic_cdk::futures::spawn`) and returns the current cache
+/// background** (via `ic_cdk::futures::spawn_migratory`) and returns the current cache
 /// snapshot immediately. Entries that are still missing or stale at the
 /// moment of the call are returned as `None`; subsequent calls will pick up
 /// the refreshed values once the spawned fetch lands.
@@ -76,7 +76,7 @@ pub fn get_exchange_rates() -> Vec<(TokenId, Option<ExchangeRate>)> {
         // and the next call will pick up the fresh values. This deduplicates
         // outcalls under concurrent load (e.g. many users calling on a cold
         // cache).
-        ic_cdk::futures::spawn(async move {
+        ic_cdk::futures::spawn_migratory(async move {
             let outcome = fetch_and_update_prices(&stale).await;
             release_refresh_lock(lock);
             if let Err(err) = outcome {

--- a/src/backend/src/bitcoin/api.rs
+++ b/src/backend/src/bitcoin/api.rs
@@ -123,9 +123,9 @@ pub fn init_fee_percentiles_cache() {
     }
 
     // Schedule the initial cache population and timer setup to run after init completes
-    set_timer(FEE_PERCENTILES_INITIAL_DELAY, || {
+    set_timer(FEE_PERCENTILES_INITIAL_DELAY, async {
         // Set up the recurring timer to update the data
-        set_timer_interval(FEE_PERCENTILES_UPDATE_INTERVAL, || {
+        set_timer_interval(FEE_PERCENTILES_UPDATE_INTERVAL, || async {
             spawn_fee_update_if_idle();
         });
 

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -277,14 +277,15 @@ pub(crate) fn start_exchange_rate_timer() {
     // right after init / upgrade, matching the previous always-on behaviour.
     note_rate_request();
 
-    set_timer(Duration::ZERO, || {
-        ic_cdk::futures::spawn(refresh_exchange_rates_guarded("initial refresh"));
-    });
+    set_timer(
+        Duration::ZERO,
+        refresh_exchange_rates_guarded("initial refresh"),
+    );
 
     let refresh_interval = Duration::from_secs(PRICE_REFRESH_INTERVAL_SEC);
 
     let _ = set_timer_interval(refresh_interval, || {
-        ic_cdk::futures::spawn(refresh_exchange_rates_guarded("refresh"));
+        refresh_exchange_rates_guarded("refresh")
     });
 }
 

--- a/src/backend/src/utils/housekeeping.rs
+++ b/src/backend/src/utils/housekeeping.rs
@@ -58,7 +58,7 @@ fn spawn_housekeeping_if_idle() {
 
     HOUSEKEEPING_STARTED_AT.with(|cell| *cell.borrow_mut() = Some(now));
 
-    ic_cdk::futures::spawn(async {
+    ic_cdk::futures::spawn_migratory(async {
         hourly_housekeeping_tasks().await;
         HOUSEKEEPING_STARTED_AT.with(|cell| *cell.borrow_mut() = None);
     });
@@ -113,7 +113,7 @@ pub(crate) fn spawn_allow_signing_if_below_limit(stored_principal: StoredPrincip
         return;
     }
 
-    ic_cdk::futures::spawn(async move {
+    ic_cdk::futures::spawn_migratory(async move {
         if let Err(e) = signer::allow_signing().await {
             ic_cdk::println!(
                 "Error enabling signing for user {}: {:?}",
@@ -130,11 +130,11 @@ pub(crate) fn spawn_allow_signing_if_below_limit(stored_principal: StoredPrincip
 pub(crate) fn start_periodic_housekeeping_timers() {
     // Run housekeeping tasks once, immediately but asynchronously.
     let immediate = Duration::ZERO;
-    set_timer(immediate, spawn_housekeeping_if_idle);
+    set_timer(immediate, async { spawn_housekeeping_if_idle() });
 
     // Then periodically:
     let hour = Duration::from_hours(1);
-    let _ = set_timer_interval(hour, spawn_housekeeping_if_idle);
+    let _ = set_timer_interval(hour, || async { spawn_housekeeping_if_idle() });
 }
 
 /// Runs hourly housekeeping tasks:

--- a/src/backend/src/utils/http_outcall.rs
+++ b/src/backend/src/utils/http_outcall.rs
@@ -50,6 +50,7 @@ fn build_request(
         max_response_bytes: Some(max_response_bytes),
         transform: None,
         headers,
+        is_replicated: None,
     }
 }
 

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -1257,7 +1257,7 @@ service : (Arg) -> {
 	// background refresh timer keeps them warm. If any cached price is
 	// missing or older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`]
 	// seconds, the endpoint kicks off a refresh for that subset **in the
-	// background** (via `ic_cdk::futures::spawn`) and returns the current cache
+	// background** (via `ic_cdk::futures::spawn_migratory`) and returns the current cache
 	// snapshot immediately. Entries that are still missing or stale at the
 	// moment of the call are returned as `None`; subsequent calls will pick up
 	// the refreshed values once the spawned fetch lands.

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -1854,7 +1854,7 @@ export interface _SERVICE {
 	 * background refresh timer keeps them warm. If any cached price is
 	 * missing or older than [`crate::exchange::PRICE_STALENESS_THRESHOLD_SEC`]
 	 * seconds, the endpoint kicks off a refresh for that subset **in the
-	 * background** (via `ic_cdk::futures::spawn`) and returns the current cache
+	 * background** (via `ic_cdk::futures::spawn_migratory`) and returns the current cache
 	 * snapshot immediately. Entries that are still missing or stale at the
 	 * moment of the call are returned as `None`; subsequent calls will pick up
 	 * the refreshed values once the spawned fetch lands.


### PR DESCRIPTION
# Motivation

Bump `ic-cdk` 0.18.7 → 0.19.0 to gain **non-replicated HTTP outcall** support (`HttpRequestArgs.is_replicated`, via `ic-management-canister-types` 0.5.0). A stacked follow-up PR uses this to make exchange-rate outcall replication configurable.

This is the **base** of a 2-PR stack:
1. **this PR** — the dependency upgrade + mechanical migrations
2. `feat(backend): make exchange-rate HTTP outcall replication configurable` (stacked on this branch)

# Changes

- `ic-cdk` 0.18.7 → **0.19.0**
- `ic-cdk-timers` 0.12.3 → **1.0.0** — `set_timer` now takes a `Future` directly and `set_timer_interval` a closure returning a `Future` (instead of a sync closure that spawns internally). Timer call sites updated; the timer executor now drives the async task itself.
- `ic-ledger-types` 0.15.0 → **0.16.0** and `canbench-rs` 0.3.0 → **0.4.0** — required for `ic-cdk ^0.19` compatibility.
- `ic-cdk-executor` 2.0: plain `spawn` now panics if the task outlives the method. Fire-and-forget background tasks (exchange refresh, housekeeping, `allow_signing`) switch to `spawn_migratory`, the behavioural equivalent of the old `spawn`.
- `HttpRequestArgs` gains `is_replicated`; the request builder sets it to `None` (replicated — unchanged behaviour).

No interface change — `backend.did` is untouched.

# Tests

- `cargo clippy --all-features` on `wasm32-unknown-unknown` and native, for `backend` and `shared` — clean.
- `cargo test -p backend --lib` — 177 passed.
- `./scripts/format.sh` — clean.
- Timer/spawn runtime behaviour is exercised by the pocket-ic integration suite in CI.