### PR TITLE
fix(backend): accept ICPSwap success code 200 and tighten response cap

### DIFF
--- a/src/backend/src/exchange/providers/icpswap/mod.rs
+++ b/src/backend/src/exchange/providers/icpswap/mod.rs
@@ -11,8 +11,13 @@ use crate::{
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.icpswap.com";
-/// `ICPSwap` token info responses are small JSON objects; keep the cap tight for cycle costs.
-const MAX_RESPONSE_BYTES: u64 = 8_192;
+/// `ICPSwap` token-info responses measure ~1.1 KiB on the wire (~0.7 KiB body + ~0.4 KiB headers).
+/// `max_response_bytes` is charged on headers + body, so 2 KiB keeps a safe margin over the
+/// observed size while minimising cycle cost.
+const MAX_RESPONSE_BYTES: u64 = 2_048;
+/// `api.icpswap.com` carries an HTTP-style status in the JSON envelope's `code` field; `200` marks
+/// success while errors use other codes (e.g. `404` for an unknown token).
+const ICPSWAP_SUCCESS_CODE: i64 = 200;
 /// Pools with TVL at or below this threshold are considered stale and their prices are discarded.
 const MIN_TVL_USD: f64 = 500.0;
 
@@ -38,7 +43,7 @@ fn exchange_data_from_icpswap_envelope(
     parsed: IcpSwapEnvelope,
     timestamp_ns: u64,
 ) -> Option<ExchangeData> {
-    if parsed.code != 0 {
+    if parsed.code != ICPSWAP_SUCCESS_CODE {
         return None;
     }
     let token = parsed.data?;
@@ -158,7 +163,7 @@ mod tests {
 
     #[test]
     fn parse_icpswap_body_success() {
-        let json = br#"{"code":0,"message":null,"data":{"tokenLedgerId":"ryjl3-tyaaa-aaaaa-aaaba-cai","tokenName":"x","tokenSymbol":"X","price":"1.25","priceChange24H":"-2.5","tvlUSD":"50000","tvlUSDChange24H":"0","txCount24H":"0","volumeUSD24H":"0","volumeUSD7D":"0","totalVolumeUSD":"0","priceLow24H":"0","priceHigh24H":"0","priceLow7D":"0","priceHigh7D":"0","priceLow30D":"0","priceHigh30D":"0"}}"#;
+        let json = br#"{"code":200,"message":null,"data":{"tokenLedgerId":"ryjl3-tyaaa-aaaaa-aaaba-cai","tokenName":"x","tokenSymbol":"X","price":"1.25","priceChange24H":"-2.5","tvlUSD":"50000","tvlUSDChange24H":"0","txCount24H":"0","volumeUSD24H":"0","volumeUSD7D":"0","totalVolumeUSD":"0","priceLow24H":"0","priceHigh24H":"0","priceLow7D":"0","priceHigh7D":"0","priceLow30D":"0","priceHigh30D":"0"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         let d = exchange_data_from_icpswap_envelope(parsed, 99).unwrap();
         assert_eq!(d.timestamp_ns, 99);
@@ -167,8 +172,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_icpswap_body_rejects_nonzero_code() {
+    fn parse_icpswap_body_rejects_error_code() {
         let json = br#"{"code":404,"message":"not found","data":null}"#;
+        let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
+        assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
+    }
+
+    #[test]
+    fn parse_icpswap_body_rejects_legacy_zero_code() {
+        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"50000"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
     }
@@ -176,7 +188,7 @@ mod tests {
     #[test]
     fn parse_icpswap_body_filters_non_finite_price_change() {
         let json =
-            br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.0","priceChange24H":"NaN","tvlUSD":"1000"}}"#;
+            br#"{"code":200,"data":{"tokenLedgerId":"x","price":"1.0","priceChange24H":"NaN","tvlUSD":"1000"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         let d = exchange_data_from_icpswap_envelope(parsed, 0).unwrap();
         assert_eq!(d.price, Some(1.0));
@@ -185,35 +197,35 @@ mod tests {
 
     #[test]
     fn parse_icpswap_body_rejects_bad_price() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"0","priceChange24H":"0","tvlUSD":"100"}}"#;
+        let json = br#"{"code":200,"data":{"tokenLedgerId":"x","price":"0","priceChange24H":"0","tvlUSD":"100"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
     }
 
     #[test]
     fn parse_icpswap_body_rejects_tvl_below_threshold() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"100"}}"#;
+        let json = br#"{"code":200,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"100"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
     }
 
     #[test]
     fn parse_icpswap_body_rejects_zero_tvl() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"0"}}"#;
+        let json = br#"{"code":200,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"0"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
     }
 
     #[test]
     fn parse_icpswap_body_rejects_tvl_at_threshold() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"500"}}"#;
+        let json = br#"{"code":200,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"500"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
     }
 
     #[test]
     fn parse_icpswap_body_accepts_tvl_above_threshold() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"500.01"}}"#;
+        let json = br#"{"code":200,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"500.01"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         let d = exchange_data_from_icpswap_envelope(parsed, 0).unwrap();
         assert_eq!(d.price, Some(1.25));
@@ -221,14 +233,14 @@ mod tests {
 
     #[test]
     fn parse_icpswap_body_rejects_nan_tvl() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"NaN"}}"#;
+        let json = br#"{"code":200,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"NaN"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
     }
 
     #[test]
     fn parse_icpswap_body_rejects_negative_tvl() {
-        let json = br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"-500"}}"#;
+        let json = br#"{"code":200,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5","tvlUSD":"-500"}}"#;
         let parsed: IcpSwapEnvelope = serde_json::from_slice(json).unwrap();
         assert!(exchange_data_from_icpswap_envelope(parsed, 0).is_none());
     }
@@ -236,7 +248,7 @@ mod tests {
     #[test]
     fn parse_icpswap_body_rejects_missing_tvl() {
         let json =
-            br#"{"code":0,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5"}}"#;
+            br#"{"code":200,"data":{"tokenLedgerId":"x","price":"1.25","priceChange24H":"-2.5"}}"#;
         let parsed: Result<IcpSwapEnvelope, _> = serde_json::from_slice(json);
         assert!(parsed
             .ok()


### PR DESCRIPTION
## Motivation

While reviewing the exchange-rate flow we found that the **ICPSwap supplemental price provider silently discards every successful response** in production.

The parser rejected any envelope whose JSON `code` field was not `0` ([`mod.rs`](../blob/main/src/backend/src/exchange/providers/icpswap/mod.rs)):

```rust
if parsed.code != 0 { return None; }
```

But the live `https://api.icpswap.com/info/token/{ledger_id}` returns `code: 200` on success — errors use HTTP-style codes (e.g. `404` "Token not found"). Verified against 13 real ledgers, all returning `code: 200`:

| Ledger | `code` |
|---|---|
| ckBTC `mxzaz-…` | 200 |
| ckUSDC `xevnm-…` | 200 |
| ICP `ryjl3-…` | 200 |
| … (all 13) | 200 |

Net effect: ICRC tokens that fall back to ICPSwap (those CoinGecko can't price) **never received a supplemental USD price**, while the outcall still burned cycles. The provider is registered and active (`supplemental_price_providers()` → `IcpSwapProvider::default()`).

The unit tests baked in the wrong assumption — the *error*-path fixture already used the real `404`, but the *success* fixtures used `0`, which was never matched against a live success response.

## Changes

- Accept `200` as the success code (named `ICPSWAP_SUCCESS_CODE`) and document the API's HTTP-style `code` contract.
- Update success-path test fixtures `0` → `200`; rename the rejection test and add a regression test asserting the legacy `0` is now rejected.
- **Tighten `MAX_RESPONSE_BYTES` 8 KiB → 2 KiB.** Measured token-info responses are ~1.1 KiB on the wire (~0.7 KiB body + ~0.4 KiB headers). `max_response_bytes` is [charged on headers + body](https://internetcomputer.org/docs/current/developer-docs/security/security-best-practices/https-outcalls), so 2 KiB keeps ~1.8× headroom over the observed size while cutting the reserved-bytes cycle cost ~4× per outcall.

## Testing

- `cargo test -p backend exchange::providers::icpswap` — 12 passed
- `./scripts/format.sh`, `./scripts/lint.rust.sh` — clean

No `.did` / interface change.