### PR TITLE
chore(backend): disable ICPSwap exchange-rate provider

### DIFF
--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -306,7 +306,7 @@ fn update_price(token_id: &StoredTokenId, exchange_data: &ExchangeData) {
 /// orthogonal runtime `exchange_rate_enabled` gate ([`is_exchange_rate_refresh_enabled`]) still
 /// wins: when refresh is off, neither provider runs regardless of these flags.
 const COINGECKO_PROVIDER_ENABLED: bool = true;
-const ICPSWAP_PROVIDER_ENABLED: bool = true;
+const ICPSWAP_PROVIDER_ENABLED: bool = false;
 
 /// Ordered supplemental sources that run after `CoinGecko` for tokens still missing a valid USD
 /// price.


### PR DESCRIPTION
# Motivation

ICPSwap should no longer supplement backend exchange rates; CoinGecko stays the sole backend provider. The per-provider `const` kill-switches (#13066) exist precisely for this one-line code-level flip.

# Changes

Flip `ICPSWAP_PROVIDER_ENABLED` to `false` in `src/backend/src/exchange/mod.rs`; `supplemental_price_providers` now returns an empty list. No candid/`backend.did` changes.

# Tests

No tests reference the flag wiring (composite tests inject mock providers), so none needed adjusting. `format.sh`, `lint.rust.sh`, `lint.did.sh` pass; full backend suite running locally and in CI.