### PR TITLE
docs(ai): add spec for Liquidium lend & borrow integration

### DIFF
--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow.md
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow.md
@@ -8,7 +8,7 @@ Let users **supply (lend)** and **borrow** native assets through the [Liquidium]
 
 The integration uses Liquidium's official TypeScript SDK, [`@liquidium/client`](https://www.npmjs.com/package/@liquidium/client), via its **account-based profile path** (`client.accounts`, `client.lending`, `client.positions`, `client.market`, `client.quote`). This is the path Liquidium documents for apps that "own a full lending dashboard" — supply, borrow, repay, withdraw, and monitor positions across sessions.
 
-This feature follows the **Earn pattern**, not Trade. (The limit-orders spec, [`2026-06-04-feat-limit-orders.md`](./2026-06-04-feat-limit-orders.md), already states: *"Lend & Borrow (coming later) follows the Earn pattern, not Trade."*) Liquidium appears as a new provider on the existing **Earn** surface and opens a dedicated management page, mirroring how Harvest Autopilot works today.
+This feature follows the **Earn pattern**, not Trade. (The limit-orders spec, [`2026-06-04-feat-limit-orders.md`](./2026-06-04-feat-limit-orders.md), already states: _"Lend & Borrow (coming later) follows the Earn pattern, not Trade."_) Liquidium appears as a new provider on the existing **Earn** surface and opens a dedicated management page, mirroring how Harvest Autopilot works today.
 
 ---
 
@@ -34,9 +34,9 @@ This feature follows the **Earn pattern**, not Trade. (The limit-orders spec, [`
 
 The "optimal" integration was chosen against three constraints: reuse oisy's existing patterns, keep protocol logic on Liquidium's side, and ship safely behind a flag.
 
-1. **Account-based SDK path, not Instant Loans.** The user requirement is to *deposit BTC/USDC/USDT and borrow against that deposit as collateral*, and to manage positions over time. That is exactly Liquidium's "account-based profile flow." Instant Loans is an accountless, single-shot borrow flow with no persistent supply/collateral dashboard, so it does not satisfy the requirement. We use `client.lending` + `client.positions` + `client.accounts`.
+1. **Account-based SDK path, not Instant Loans.** The user requirement is to _deposit BTC/USDC/USDT and borrow against that deposit as collateral_, and to manage positions over time. That is exactly Liquidium's "account-based profile flow." Instant Loans is an accountless, single-shot borrow flow with no persistent supply/collateral dashboard, so it does not satisfy the requirement. We use `client.lending` + `client.positions` + `client.accounts`.
 
-2. **Provider-card pattern, two intent-based entries.** oisy already has a config-driven provider-card system (`EarningProvider` in `src/frontend/src/lib/types/earning-provider.ts`, assembled in `src/frontend/src/lib/providers/earning.providers.ts`, cards configured in `$env/earning-providers.json`), where a card's action navigates to a dedicated provider page — exactly like Harvest Autopilot (`HARVEST_AUTOPILOT_PROVIDER_ID`). Liquidium reuses this on **two** surfaces: the existing **Earn** page (lend framing) and a **new top-level Borrow** page (borrow framing), both pointing to one shared provider page. Earn and Borrow are kept distinct because they serve different users — *Earn is the simple, mainstream "get yield" entry; Borrow is the advanced "take on debt for liquidity" entry* — and Earn deliberately stays even if a DeFi umbrella is added later (see Navigation context → Future direction).
+2. **Provider-card pattern, two intent-based entries.** oisy already has a config-driven provider-card system (`EarningProvider` in `src/frontend/src/lib/types/earning-provider.ts`, assembled in `src/frontend/src/lib/providers/earning.providers.ts`, cards configured in `$env/earning-providers.json`), where a card's action navigates to a dedicated provider page — exactly like Harvest Autopilot (`HARVEST_AUTOPILOT_PROVIDER_ID`). Liquidium reuses this on **two** surfaces: the existing **Earn** page (lend framing) and a **new top-level Borrow** page (borrow framing), both pointing to one shared provider page. Earn and Borrow are kept distinct because they serve different users — _Earn is the simple, mainstream "get yield" entry; Borrow is the advanced "take on debt for liquidity" entry_ — and Earn deliberately stays even if a DeFi umbrella is added later (see Navigation context → Future direction).
 
 3. **Reuse the swap wizard.** Supply / Borrow / Repay / Withdraw are each a `Form → Review → Progress` modal wizard, reusing the structure and components under `src/frontend/src/lib/components/swap/` (`SwapModal.svelte`, `SwapForm.svelte`, `SwapReview.svelte`, `SwapProgress.svelte`, `SwapModalWizardSteps.svelte`) and the Harvest Autopilot stake wizard as the closest existing precedent.
 
@@ -48,13 +48,13 @@ The "optimal" integration was chosen against three constraints: reuse oisy's exi
 
 ### SDK
 
-|              |                                                                            |
-| ------------ | -------------------------------------------------------------------------- |
-| Package      | `@liquidium/client`                                                        |
-| Client       | `LiquidiumClient` (bundles Liquidium mainnet canister IDs by default)      |
-| Docs         | https://liquidium-inc.github.io/liquidium-sdk/                             |
-| Source       | https://github.com/Liquidium-Inc/liquidium-sdk                             |
-| Runtime      | Browser `fetch`, `BigInt`, ESM; viem public client for EVM (ETH) reads     |
+|         |                                                                        |
+| ------- | ---------------------------------------------------------------------- |
+| Package | `@liquidium/client`                                                    |
+| Client  | `LiquidiumClient` (bundles Liquidium mainnet canister IDs by default)  |
+| Docs    | https://liquidium-inc.github.io/liquidium-sdk/                         |
+| Source  | https://github.com/Liquidium-Inc/liquidium-sdk                         |
+| Runtime | Browser `fetch`, `BigInt`, ESM; viem public client for EVM (ETH) reads |
 
 Client construction (in a new `src/frontend/src/lib/api/liquidium.api.ts`):
 
@@ -62,9 +62,9 @@ Client construction (in a new `src/frontend/src/lib/api/liquidium.api.ts`):
 import { LiquidiumClient } from '@liquidium/client';
 
 const client = new LiquidiumClient({
-  identity,                         // oisy's signed-in IC identity (for client.lending canister calls)
-  evmRpcUrl: VITE_EVM_RPC_URL,      // only needed for ETH/USDT(ERC) reads & external withdrawals
-  headers: { 'x-client-name': 'oisy' }
+	identity, // oisy's signed-in IC identity (for client.lending canister calls)
+	evmRpcUrl: VITE_EVM_RPC_URL, // only needed for ETH/USDT(ERC) reads & external withdrawals
+	headers: { 'x-client-name': 'oisy' }
 });
 ```
 
@@ -72,14 +72,14 @@ const client = new LiquidiumClient({
 
 ### Core dependency — the `WalletAdapter` (oisy signer bridge)
 
-**This is the single most load-bearing piece of the integration.** Every Liquidium *write* flow — profile creation, supply, borrow, repay, withdraw — authorizes through a SDK `WalletAdapter` that oisy must implement, backed by oisy's existing signer(s). It is **one multi-chain adapter** (not one per chain); the SDK calls only the capability methods a given flow needs (all optional):
+**This is the single most load-bearing piece of the integration.** Every Liquidium _write_ flow — profile creation, supply, borrow, repay, withdraw — authorizes through a SDK `WalletAdapter` that oisy must implement, backed by oisy's existing signer(s). It is **one multi-chain adapter** (not one per chain); the SDK calls only the capability methods a given flow needs (all optional):
 
-| `WalletAdapter` method | Used for | oisy backing |
-| ---------------------- | -------- | ------------ |
-| `signMessage(req)`        | profile creation, borrow, withdraw (authorization) | sign with the relevant chain address's key |
-| `sendEthTransaction(req)` | ERC stablecoin / contract-interaction supply, ETH native sends | oisy ETH signer |
-| `sendBtcTransaction(req)` | native-BTC transfer-path supply | oisy BTC signer (signer canister / threshold-ECDSA) |
-| `signPsbt(req)`           | PSBT-based BTC actions (when exposed) | oisy BTC PSBT signing |
+| `WalletAdapter` method    | Used for                                                       | oisy backing                                        |
+| ------------------------- | -------------------------------------------------------------- | --------------------------------------------------- |
+| `signMessage(req)`        | profile creation, borrow, withdraw (authorization)             | sign with the relevant chain address's key          |
+| `sendEthTransaction(req)` | ERC stablecoin / contract-interaction supply, ETH native sends | oisy ETH signer                                     |
+| `sendBtcTransaction(req)` | native-BTC transfer-path supply                                | oisy BTC signer (signer canister / threshold-ECDSA) |
+| `signPsbt(req)`           | PSBT-based BTC actions (when exposed)                          | oisy BTC PSBT signing                               |
 
 Notes:
 
@@ -89,14 +89,14 @@ Notes:
 
 ### SDK modules used
 
-| Module             | Used for                                                                              |
-| ------------------ | ------------------------------------------------------------------------------------- |
-| `client.accounts`  | Create/reuse the Liquidium profile for the signed-in identity; linked-wallet lookup   |
-| `client.market`    | `pools`, `prices`, pool rate lookups — drives the asset list, APYs, caps, availability |
-| `client.lending`   | `supply(...)`, `borrow(...)`, `withdraw(...)`, repay, inflow reporting                 |
-| `client.positions` | Per-pool positions, health factor, aggregate stats — drives the dashboard + hero total |
-| `client.quote`     | `calculateLtv(...)`, `getMinimumBorrowAmount(asset)` — pre-submit validation           |
-| `client.activities`/`client.history` | Optional: feed position/transaction history into oisy's Activity view (stretch) |
+| Module                               | Used for                                                                               |
+| ------------------------------------ | -------------------------------------------------------------------------------------- |
+| `client.accounts`                    | Create/reuse the Liquidium profile for the signed-in identity; linked-wallet lookup    |
+| `client.market`                      | `pools`, `prices`, pool rate lookups — drives the asset list, APYs, caps, availability |
+| `client.lending`                     | `supply(...)`, `borrow(...)`, `withdraw(...)`, repay, inflow reporting                 |
+| `client.positions`                   | Per-pool positions, health factor, aggregate stats — drives the dashboard + hero total |
+| `client.quote`                       | `calculateLtv(...)`, `getMinimumBorrowAmount(asset)` — pre-submit validation           |
+| `client.activities`/`client.history` | Optional: feed position/transaction history into oisy's Activity view (stretch)        |
 
 > **Repay method:** Liquidium's product surface lists Repay as a first-class action and the `client.lending` module is documented as "Supply, borrow, withdraw, and inflow reporting." The exact repay entry point (`client.lending.repay(...)` vs. a borrow-position settlement call) must be confirmed against the generated API reference before implementation. See Open questions.
 
@@ -106,7 +106,7 @@ Notes:
 
 **Supply is collateral.** When a user supplies an asset, it automatically counts toward collateral. Borrowing is over-collateralised: total collateral value must exceed borrow value with a safety buffer.
 
-**Max LTV vs. liquidation threshold.** *Max LTV* caps how much can be borrowed when opening/increasing a position. *Liquidation threshold* (higher than max LTV) is where the position becomes liquidatable. The gap is the safety buffer. Both are per-pool; a portfolio with multiple collaterals uses a weighted-average liquidation threshold.
+**Max LTV vs. liquidation threshold.** _Max LTV_ caps how much can be borrowed when opening/increasing a position. _Liquidation threshold_ (higher than max LTV) is where the position becomes liquidatable. The gap is the safety buffer. Both are per-pool; a portfolio with multiple collaterals uses a weighted-average liquidation threshold.
 
 **Health factor.** Portfolio health is surfaced as a percentage: `100%` = no debt; `>0%..99%` = safe (higher is safer); near `0%` = at risk; `0%` = partially liquidatable. oisy displays the percentage form (Liquidium's default).
 
@@ -122,12 +122,12 @@ Before any borrow (and before a withdraw that reduces collateral), validate with
 
 ```ts
 const ltv = client.quote.calculateLtv(
-  { collateralPoolId, borrowPoolId, collateralAmount, borrowAmount },
-  pools,
-  prices
+	{ collateralPoolId, borrowPoolId, collateralAmount, borrowAmount },
+	pools,
+	prices
 );
 if (ltv.validationErrors.length > 0) {
-  // surface ltv.validationErrors[].message inline; disable Review/Confirm
+	// surface ltv.validationErrors[].message inline; disable Review/Confirm
 }
 ```
 
@@ -152,14 +152,14 @@ Liquidium is reached from **two** top-level surfaces, framed by user intent, bot
 
 Both cards' actions navigate to the same shared provider page (`/providers/liquidium/`), which contains the full supply + borrow + repay + withdraw experience. Keeping `Earn` and `Borrow` as separate verbs is deliberate: **Earn is the low-knowledge, mainstream "get yield" entry; Borrow is the more advanced "take on debt for liquidity" entry.** They are not merged so the simple use case stays simple.
 
-| Surface                                          | Type            | Purpose                                                                      |
-| ------------------------------------------------ | --------------- | ---------------------------------------------------------------------------- |
-| **Liquidium card on Earn** (`/earn/`)            | Entry point     | Lend framing — supply APY, your supplied value                               |
-| **Liquidium card on Borrow** (`/borrow/`)        | Entry point     | Borrow framing — borrow rate, your borrowing power / debt                    |
-| **Liquidium provider page** (`/providers/liquidium/`) | Management view | Per-provider full picture — positions, health, supply/borrow/repay/withdraw |
-| **Assets page tabs** (Earning + new Liabilities) | Holdings view   | "Where are all my assets/debts?" — positions grouped **by type**, across all providers |
+| Surface                                               | Type            | Purpose                                                                                |
+| ----------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------- |
+| **Liquidium card on Earn** (`/earn/`)                 | Entry point     | Lend framing — supply APY, your supplied value                                         |
+| **Liquidium card on Borrow** (`/borrow/`)             | Entry point     | Borrow framing — borrow rate, your borrowing power / debt                              |
+| **Liquidium provider page** (`/providers/liquidium/`) | Management view | Per-provider full picture — positions, health, supply/borrow/repay/withdraw            |
+| **Assets page tabs** (Earning + new Liabilities)      | Holdings view   | "Where are all my assets/debts?" — positions grouped **by type**, across all providers |
 
-**Grouping principle (Assets page).** On the Assets page, positions are grouped by *type* (asset vs. liability), **not** by provider. There is no "Liquidium section." A Liquidium supply appears in the **Earning** tab next to Harvest Autopilot stakes; a Liquidium borrow appears in the new **Liabilities** tab. Each card names its provider. Rationale: on Assets the user cares about *what kind* of holding it is; on the provider page they care about *that provider*.
+**Grouping principle (Assets page).** On the Assets page, positions are grouped by _type_ (asset vs. liability), **not** by provider. There is no "Liquidium section." A Liquidium supply appears in the **Earning** tab next to Harvest Autopilot stakes; a Liquidium borrow appears in the new **Liabilities** tab. Each card names its provider. Rationale: on Assets the user cares about _what kind_ of holding it is; on the provider page they care about _that provider_.
 
 New routes/constants in `src/frontend/src/lib/constants/routes.constants.ts`:
 
@@ -233,7 +233,7 @@ Assets page
 
 - **On the Assets → Liabilities tab (compact):** a single colour-coded **health tag next to the provider group title** — e.g. "Healthy at 68%" (green), "At risk at 16%" (amber), "Critical at 7%" (red). One small element; it deliberately does not take a full banner here, to keep the Assets page dense. This risk colour is a **separate axis** from the red "owed" amount styling, so "this is debt" and "this is dangerous" never blur together.
 - **On the provider page (`/providers/liquidium/`, large):** the full health display — big percentage, coloured track, "Liquidation at 0%", and an alert with direct **Repay** / **Add collateral** actions when in the amber/red band.
-- **On the Liabilities tab label itself (status dot):** a small indicator circle in the top-right of the **Liabilities** tab label, so the user sees a problem even when that tab is not selected. **Amber** when any borrow provider is *at risk*, **red** when any is *critical*, hidden when all are healthy. With multiple providers it shows the **worst** state. Implemented in `Assets.svelte`'s `Tabs` config (the tab gets a status badge derived from the per-provider health stores).
+- **On the Liabilities tab label itself (status dot):** a small indicator circle in the top-right of the **Liabilities** tab label, so the user sees a problem even when that tab is not selected. **Amber** when any borrow provider is _at risk_, **red** when any is _critical_, hidden when all are healthy. With multiple providers it shows the **worst** state. Implemented in `Assets.svelte`'s `Tabs` config (the tab gets a status badge derived from the per-provider health stores).
 
 (Active push/notification alerting when health approaches the threshold is a candidate fast-follow; v1 guarantees the always-visible in-app status described here. Exact amber/red band thresholds to match Liquidium's own UI — see Open questions.)
 
@@ -255,15 +255,15 @@ Gated by `LIQUIDIUM_ENABLED`. Three regions:
 
 **Three states:**
 
-- *New user (no profile / no positions):* My positions shows an empty state with a prominent **Supply** CTA; the Markets list is the focus. Borrow actions are disabled until the user has collateral.
-- *Has supply, no borrow:* position rows with Supply/Withdraw; Borrow becomes enabled; health factor shows `100%` (no debt).
-- *Has supply and borrow:* full rows with all four actions; live health factor with colour coding.
+- _New user (no profile / no positions):_ My positions shows an empty state with a prominent **Supply** CTA; the Markets list is the focus. Borrow actions are disabled until the user has collateral.
+- _Has supply, no borrow:_ position rows with Supply/Withdraw; Borrow becomes enabled; health factor shows `100%` (no debt).
+- _Has supply and borrow:_ full rows with all four actions; live health factor with colour coding.
 
 ### Hero net-worth total
 
 Liquidium **net value** (Σ supplied − Σ borrowed, in fiat) is added to the hero net-worth total, consistent with how the limit-orders spec rolls DEX balances into the hero. Supplied collateral adds to the total; outstanding debt subtracts from it. The hero shows only the total figure — no breakdown label.
 
-**Where positions are visible:** Liquidium supplied/borrowed balances do **not** appear in the **Tokens** tab — that tab is strictly spot wallet balances. Supplies appear in the **Earning** tab, borrows appear in the **Liabilities** tab, and both are summarised on `/providers/liquidium/`. Note that funds the user *received* from a borrow (e.g. borrowed USDC now sitting in their wallet) are real spot balances and **do** show in Tokens as normal — that is distinct from the protocol-side debt shown under Liabilities.
+**Where positions are visible:** Liquidium supplied/borrowed balances do **not** appear in the **Tokens** tab — that tab is strictly spot wallet balances. Supplies appear in the **Earning** tab, borrows appear in the **Liabilities** tab, and both are summarised on `/providers/liquidium/`. Note that funds the user _received_ from a borrow (e.g. borrowed USDC now sitting in their wallet) are real spot balances and **do** show in Tokens as normal — that is distinct from the protocol-side debt shown under Liabilities.
 
 ---
 
@@ -286,6 +286,7 @@ Entry points: the Markets list "Supply" CTA, and a position row "Supply" action.
 Entry points: a position row "Borrow" action; or "Borrow" from a market the user already supplies to. Disabled entirely until the user has collateral.
 
 **Form** —
+
 - **Collateral context:** read-only summary of current collateral and available borrowing power (from `client.positions` + `calculateLtv`).
 - **Borrow asset selector** + amount, with fiat equivalent.
 - **Minimum borrow** shown from `getMinimumBorrowAmount(asset)`; submit blocked below it.
@@ -331,7 +332,7 @@ Liquidium actions don't all settle synchronously — native-BTC legs need multip
 
 **The existing mechanism (OneSec is the reference implementation):**
 
-- Backend (user-profile canister) stores an `ActiveUserTransaction` per user: `id` (FE-generated UUIDv4), `status` (`Pending → Executing → Succeeded | Failed`, transitions enforced by the backend), `external_refs` (learned-mid-flow `{ key, value }` pointers — e.g. a tx hash — that say *where to read status*), `progress_step` (FE-written step label), `data` (a per-integration variant), `updated_at_ns`, and `error`. API: `create`/`get`/`update`/`delete` in `src/frontend/src/lib/api/backend.api.ts`.
+- Backend (user-profile canister) stores an `ActiveUserTransaction` per user: `id` (FE-generated UUIDv4), `status` (`Pending → Executing → Succeeded | Failed`, transitions enforced by the backend), `external_refs` (learned-mid-flow `{ key, value }` pointers — e.g. a tx hash — that say _where to read status_), `progress_step` (FE-written step label), `data` (a per-integration variant), `updated_at_ns`, and `error`. API: `create`/`get`/`update`/`delete` in `src/frontend/src/lib/api/backend.api.ts`.
 - Frontend: `activeUserTransactionsStore` (`src/frontend/src/lib/stores/active-user-transactions.store.ts`, persisted per principal); services `createActiveUserTransaction` / `updateActiveUserTransaction` / `loadActiveUserTransactions` / `applyActiveUserTransactionPollUpdate` (`active-user-transactions.services.ts`); `LoaderActiveUserTransactions.svelte` runs a global poll timer over `activeUserTransactionsPending`; and the active-transactions UI (`ActiveUserTransactionsButton`/`List`/`Item`) surfaces them with an unseen badge. Terminal transactions trigger a wallet/balance refresh once (guarded by `terminalSideEffectsApplied`).
 
 **What Liquidium adds:**
@@ -456,7 +457,7 @@ The facts are understood; these need a product/architecture call.
 1. **Profile ownership** — SDK contract is confirmed (`getProfileId(walletAddress)`, `createProfile({ account, chain, walletAdapter })`, `prepareCreateProfile({ account })`; a profile is owned by a wallet `account` on a `chain`, creation signature-gated via `walletAdapter.signMessage(...)`; silent bootstrap specified in "Profile bootstrapping"). **Decide:** which oisy-controlled address (BTC vs. ETH) owns the Liquidium profile, and whether one profile across the user's assets is right vs. multiple linked wallets (`listLinkedWallets`). Distinct from the rail question above (this is about account ownership, not the funds rail).
 2. **EVM RPC config** — ETH/USDT(ERC) reads need an EVM RPC (`evmRpcUrl`/viem). **Decide:** reuse an existing oisy RPC config or add a `VITE_EVM_RPC_URL`. If absent, ETH-side pools degrade to "temporarily unavailable."
 3. **Withdraw destinations** — v1 keeps borrows/withdrawals to oisy-controlled addresses. **Decide:** whether external-address withdrawal (CEX/Ledger) is a v1 inclusion or a fast follow.
-4. **Active liquidation alerting** — v1 always shows the in-app health status (Liabilities tab + provider page) — decided. **Decide:** whether to add *active* alerting (push/email/in-wallet notification) as a fast-follow when health approaches the threshold.
+4. **Active liquidation alerting** — v1 always shows the in-app health status (Liabilities tab + provider page) — decided. **Decide:** whether to add _active_ alerting (push/email/in-wallet notification) as a fast-follow when health approaches the threshold.
 5. **Backend `ActiveUserTransactionData` variant** — the active-transactions mechanism requires the backend canister to add Liquidium variant(s) to the `ActiveUserTransactionData` Candid type (currently OneSec-only); this is a known prerequisite (Rust + `.did`) that must land before the FE wiring. **Decide:** the variant shape (per-action `LiquidiumSupply`/`Borrow`/`Repay`/`Withdraw` vs. one `Liquidium` variant with an action field). See "Asynchronous settlement & active transactions".
 6. **[PARKED — revisit] Risk on the hero/overview** — since debt grows on its own, **decide** whether to surface a small health indicator near the net-worth total (visible whenever the user holds debt), so a user who never opens the Liabilities tab is still warned. Deferred by request.
 

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow.md
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow.md
@@ -63,12 +63,14 @@ import { LiquidiumClient } from '@liquidium/client';
 
 const client = new LiquidiumClient({
 	identity, // oisy's signed-in IC identity (for client.lending canister calls)
-	evmRpcUrl: VITE_EVM_RPC_URL, // only needed for ETH/USDT(ERC) reads & external withdrawals
+	evmPublicClient, // reuse oisy's existing Alchemy-backed viem client (ETH/USDT ERC reads) — see Pending decisions
 	headers: { 'x-client-name': 'oisy' }
 });
 ```
 
 `environment` defaults to mainnet; `icHost`/`canisterIds` only need overriding for local/staging. The IC identity that oisy already manages for canister calls is passed as `identity` so Liquidium canister calls are signed as the same principal.
+
+> **Note:** the `WalletAdapter` is **not** a constructor option — it is passed **per write call** (`createProfile`, `supply`, `borrow`, `withdraw`). Only `identity` (and optional EVM read config) live on the client. See Open questions → "Identity / signing model".
 
 ### Core dependency — the `WalletAdapter` (oisy signer bridge)
 
@@ -89,16 +91,16 @@ Notes:
 
 ### SDK modules used
 
-| Module                               | Used for                                                                               |
-| ------------------------------------ | -------------------------------------------------------------------------------------- |
-| `client.accounts`                    | Create/reuse the Liquidium profile for the signed-in identity; linked-wallet lookup    |
-| `client.market`                      | `pools`, `prices`, pool rate lookups — drives the asset list, APYs, caps, availability |
-| `client.lending`                     | `supply(...)`, `borrow(...)`, `withdraw(...)`, repay, inflow reporting                 |
-| `client.positions`                   | Per-pool positions, health factor, aggregate stats — drives the dashboard + hero total |
-| `client.quote`                       | `calculateLtv(...)`, `getMinimumBorrowAmount(asset)` — pre-submit validation           |
-| `client.activities`/`client.history` | Optional: feed position/transaction history into oisy's Activity view (stretch)        |
+| Module                               | Used for                                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `client.accounts`                    | Create/reuse the Liquidium profile for the signed-in identity; linked-wallet lookup         |
+| `client.market`                      | `pools`, `prices`, pool rate lookups — drives the asset list, APYs, caps, availability      |
+| `client.lending`                     | `supply(...)` (deposit **and** repayment), `borrow(...)`, `withdraw(...)`, inflow reporting |
+| `client.positions`                   | Per-pool positions, health factor, aggregate stats — drives the dashboard + hero total      |
+| `client.quote`                       | `calculateLtv(...)`, `getMinimumBorrowAmount(asset)` — pre-submit validation                |
+| `client.activities`/`client.history` | Optional: feed position/transaction history into oisy's Activity view (stretch)             |
 
-> **Repay method:** Liquidium's product surface lists Repay as a first-class action and the `client.lending` module is documented as "Supply, borrow, withdraw, and inflow reporting." The exact repay entry point (`client.lending.repay(...)` vs. a borrow-position settlement call) must be confirmed against the generated API reference before implementation. See Open questions.
+> **Repay method (confirmed):** There is **no `client.lending.repay(...)`**. Repaying an account-based position is an inflow on the supply path — `client.lending.supply({ ..., action: 'repayment' })` (`SupplyAction.repayment`). The full-debt amount for the "Max (full debt)" shortcut comes from `client.positions.getMaxRepayAmount(profileId, poolId, bufferBps?)` (principal + accrued interest + small buffer, default 10 bps).
 
 ### Key concepts (from Liquidium docs)
 
@@ -302,11 +304,11 @@ Entry points: a position row "Borrow" action; or "Borrow" from a market the user
 
 Entry point: position row "Repay" (only when that asset has debt).
 
-**Form** — asset pre-filled. Amount input with a "Max (full debt)" shortcut that fills the outstanding amount (principal + accrued interest, from `client.positions`). Shows current debt and the **projected health factor after repay** (improves). Wallet balance shown; if insufficient, surface the shortfall clearly. Transaction fee row.
+**Form** — asset pre-filled. Amount input with a "Max (full debt)" shortcut that fills the outstanding amount from `client.positions.getMaxRepayAmount(profileId, poolId)` (principal + accrued interest + small buffer). Shows current debt and the **projected health factor after repay** (improves). Wallet balance shown; if insufficient, surface the shortfall clearly. Transaction fee row.
 
 **Review** — title "Review repay". Hero: repay amount + fiat. Rows: remaining debt after repay, projected health factor. Back + "Repay".
 
-**Progress** — submits the repay call (see Repay-method open question). On success the debt decreases (or clears) and health factor improves.
+**Progress** — submits via `client.lending.supply({ ..., action: 'repayment' })`. On success the debt decreases (or clears) and health factor improves.
 
 ### Withdraw
 
@@ -436,17 +438,15 @@ Aspects this spec has not detailed yet — captured here as a reminder; each nee
 
 ## Open questions (facts to confirm)
 
-Things we still need to find out or verify — answers are not yet known.
+Verified against the installed SDK (`@liquidium/client` v0.3.0, `node_modules/@liquidium/client/dist/index.d.ts`) and the oisy codebase. Six of seven are resolved; #7 is the only one the SDK cannot answer.
 
-1. **Liquidium mainnet readiness per asset** — confirm which pools (BTC/ETH/USDC/USDT) are live on Liquidium mainnet now vs. "coming soon," so the Markets list reflects reality. Drive from `client.market`, but confirm the gating field.
-2. **Repay method** — confirm the exact SDK entry point for repaying an account-based borrow position (`client.lending.repay(...)` vs. a position-settlement call) against the generated API reference (`api-reference/generated/`).
-3. **Identity / signing model** — Liquidium write actions authorize via the `WalletAdapter` (`signMessage` + chain sends), keyed to wallet addresses — not the SDK `identity` config alone. Confirm whether the SDK `identity` (for canister calls) **and** the `WalletAdapter` (for address-scoped signatures) are both needed, and how oisy's signer satisfies each.
-4. **Token/price coverage** — verify oisy's token registry covers logos and USD price feeds for every Liquidium-listed asset (ckBTC/ckUSDC/ckUSDT are present; confirm ckETH/native ETH and the exact USDC/USDT ledgers Liquidium uses).
-5. **Asset & network representation (native vs ICP ck-assets) — and the rail per leg.** Liquidium markets its lending networks as **Bitcoin** and **Ethereum** (Solana "coming soon"); the Internet Computer is the execution layer and assets are held internally as chain-key tokens (ckBTC/ckETH/ckUSDT). The SDK returns a **transfer target** per deposit/repayment that is either an `icrcAccount` or a `nativeAddress` (see Transfer Targets). The unconfirmed fact that gates several downstream decisions:
-   - **Does the BTC pool's supply target expose an `icrcAccount` (ckBTC) or only a `nativeAddress`?** If `icrcAccount`, oisy can fund it with a near-instant ckBTC ICRC-1/2 transfer (it already holds ckBTC), bypassing Bitcoin confirmations; if `nativeAddress`, supply requires a native BTC send (multi-confirmation). Confirm for the BTC pool (and likewise ckETH/ckUSDT vs native ETH/USDT). Not confirmed whether the BTC pool accepts direct ckBTC deposits vs. expecting native BTC (possibly via the ckBTC minter).
-   - Dependent decisions once the above is known: how to label the **Networks** field per leg (economic asset vs. transport rail), and whether to let the user supply from ckBTC (instant) or native BTC (confirmation-bound). Note: ckBTC is the same BTC market via the ICRC rail, **not** a separate "ckBTC market" — present it as BTC.
-6. **`client.activities` contract** — confirm the exact `client.activities.list(...)` request/response shape (and `client.history`) against the generated API reference — specifically that returned activity records key cleanly to the `external_refs` oisy stores (loan ref / activity id / tx_hash) so the poller can correlate SDK activity → `ActiveUserTransaction`. See "Sources of truth & reconciliation".
-7. **Health-factor band thresholds** — confirm Liquidium's exact amber/red "at risk" / "critical" cut-offs so oisy's health colours match the protocol's own notion of risk.
+1. **Liquidium mainnet readiness per asset** — **Resolved (mechanism).** The `Pool` type exposes no "coming soon" field. Availability is derived at runtime: `client.market.listPools()` returns only pools that exist, each carrying `frozen: boolean` and optional `supplyCap`/`borrowCap`. **Gating rule:** a pool absent from `listPools()`, or with `frozen === true`, or at cap → render "Coming soon"/disabled; never hard-code the asset list. The live mainnet set is whatever `listPools()` returns at load time. (`Pool`, `MarketModule.listPools`, `getPoolRate`.)
+2. **Repay method** — **Resolved (corrects an earlier assumption).** There is **no `client.lending.repay(...)`**. For an account-based position, repayment is `client.lending.supply({ ..., action: 'repayment' })` (`SupplyAction.repayment`). `client.positions.getMaxRepayAmount(profileId, poolId, bufferBps?)` returns the full-debt figure (principal + accrued interest + small buffer, default 10 bps) backing the "Max (full debt)" shortcut. (`LendingModule.supply`, `SupplyAction`, `PositionsModule.getMaxRepayAmount`.)
+3. **Identity / signing model** — **Resolved.** Both are required and operate at different layers. `identity` is passed once at `new LiquidiumClient({ identity })` for signed IC canister calls. The `WalletAdapter` is passed **per write call** (not at construction) for address-scoped signatures: `createProfile({ account, chain, walletAdapter })`, `borrow`/`withdraw` take `{ signerChain, signerWalletAdapter }`, and `supply` takes `Pick<WalletAdapter, 'sendBtcTransaction' | 'sendEthTransaction'>`. All `WalletAdapter` methods are optional; the SDK invokes only the capability a given flow needs. (`LiquidiumClientConfig`, `WalletAdapter`, `WalletExecutionParams`.)
+4. **Token/price coverage** — **Resolved.** Every Liquidium asset is already in oisy's registry with matching contract addresses and USD price feeds: ckBTC, ckETH, ckUSDC (`xevnm-gaaaa-aaaar-qafnq-cai`), ckUSDT (`cngnf-vqaaa-aaaar-qag4q-cai`), native ETH, ERC-20 USDC (`0xA0b8…48`) and USDT (`0xdAC1…ec7`) — the last two exactly matching the SDK's `USDC_CONTRACT_ADDRESS`/`USDT_CONTRACT_ADDRESS`. Prices come from oisy's existing exchange services (CoinGecko, with IcpSwap/KongSwap fallbacks). **No registry additions needed.**
+5. **Asset & network representation / rail per leg** — **Resolved (mechanism).** The SDK returns the rail per leg as a discriminated `SupplyTarget = NativeAddressSupplyTarget | IcrcAccountSupplyTarget` (`type: 'nativeAddress' | 'icrcAccount'`) on the `SupplyFlow` from `client.lending.supply(...)`. oisy **does not hard-code the rail** — it inspects `flow.target.type` and routes: `icrcAccount` → oisy ICRC-1/2 ledger transfer (near-instant; e.g. ckBTC) then `flow.submit(...)`/`submitInflow`; `nativeAddress` → native send via the adapter (`sendBtcTransaction`/`sendEthTransaction`, confirmation-bound). The **Networks** field labels the economic asset (BTC/ETH); the rail is an execution detail, surfaced not chosen. The exact target a given pool returns is a runtime fact the SDK reports per call, so oisy handles both branches. ckBTC is the same BTC market via the ICRC rail, **not** a separate "ckBTC market" — present it as BTC. (`SupplyTarget`, `SupplyFlow`, `SupplyAction`.)
+6. **`client.activities` contract** — **Resolved.** `client.activities.list({ profileId | shortRef, filter })` returns `Activity[]` (`InflowActivity` {deposit|repayment} ∪ `OutflowActivity` {borrow|withdraw}); each record carries `id`, `poolId`, `asset`, `chain`, `amount`, `txid`, `txids[]`, `confirmations`, `requiredConfirmations`, `status`. `client.activities.getStatus({ … })` polls a single activity/receipt. These key cleanly to oisy's `external_refs` (activity `id` / `txid`), and `confirmations`/`requiredConfirmations` drive the native-BTC progress UI. `client.history.getUserTransactionHistory(user, …)` provides settled history (`type: supply|borrow|repay|withdraw`). (`ActivitiesModule`, `Activity`, `HistoryModule`.)
+7. **Health-factor band thresholds** — **Resolved (no protocol bands exist).** Liquidium publishes no discrete amber/red cut-offs; its docs describe health as a continuous gradient (100% = no debt, >0–99% = safe/"higher is safer", near 0% = at risk, 0% = partially liquidatable), and the SDK exposes only the raw value (`HealthFactor.healthFactor`, scaled by `RATE_SCALE`/`RATE_DECIMALS`) with no band constants. oisy therefore **chooses its own display bands**, anchored to those semantics: 🟢 Healthy ≥ 50%, 🟠 At risk 15–50%, 🔴 Critical < 15%. Defined once in a constant and reused by the Liabilities tag, the status dot, and the provider-page health display.
 
 ---
 
@@ -454,11 +454,11 @@ Things we still need to find out or verify — answers are not yet known.
 
 The facts are understood; these need a product/architecture call.
 
-1. **Profile ownership** — SDK contract is confirmed (`getProfileId(walletAddress)`, `createProfile({ account, chain, walletAdapter })`, `prepareCreateProfile({ account })`; a profile is owned by a wallet `account` on a `chain`, creation signature-gated via `walletAdapter.signMessage(...)`; silent bootstrap specified in "Profile bootstrapping"). **Decide:** which oisy-controlled address (BTC vs. ETH) owns the Liquidium profile, and whether one profile across the user's assets is right vs. multiple linked wallets (`listLinkedWallets`). Distinct from the rail question above (this is about account ownership, not the funds rail).
-2. **EVM RPC config** — ETH/USDT(ERC) reads need an EVM RPC (`evmRpcUrl`/viem). **Decide:** reuse an existing oisy RPC config or add a `VITE_EVM_RPC_URL`. If absent, ETH-side pools degrade to "temporarily unavailable."
-3. **Withdraw destinations** — v1 keeps borrows/withdrawals to oisy-controlled addresses. **Decide:** whether external-address withdrawal (CEX/Ledger) is a v1 inclusion or a fast follow.
-4. **Active liquidation alerting** — v1 always shows the in-app health status (Liabilities tab + provider page) — decided. **Decide:** whether to add _active_ alerting (push/email/in-wallet notification) as a fast-follow when health approaches the threshold.
-5. **Backend `ActiveUserTransactionData` variant** — the active-transactions mechanism requires the backend canister to add Liquidium variant(s) to the `ActiveUserTransactionData` Candid type (currently OneSec-only); this is a known prerequisite (Rust + `.did`) that must land before the FE wiring. **Decide:** the variant shape (per-action `LiquidiumSupply`/`Borrow`/`Repay`/`Withdraw` vs. one `Liquidium` variant with an action field). See "Asynchronous settlement & active transactions".
+1. **Profile ownership** — **Decided: ETH-owned, single profile.** oisy can `signMessage` only on the ETH key today (`eth_personal_sign`/EIP-191; the BTC signer signs transactions, not arbitrary messages — no BIP-322), and profile creation/borrow/withdraw are signature-gated via `walletAdapter.signMessage`. So the profile is owned by the user's **ETH address** (`createProfile({ account: <eth>, chain: 'ETH', walletAdapter })`; `borrow`/`withdraw` use `signerChain: 'ETH'`). A **single** profile is used (one cross-collateral pool, one health factor); other addresses can be associated later via `listLinkedWallets`. Profile ownership is independent of the funds rail — BTC/ckBTC collateral still enters via the transfer rail (`sendBtcTransaction`/ICRC + `submitInflow`), which needs no message signing. (A BTC-owned profile is a future option gated on adding BIP-322 signing to oisy.)
+2. **EVM RPC config** — **Decided: reuse oisy's existing Alchemy viem client; no new env var.** The SDK's `LiquidiumClientConfig` accepts `evmPublicClient?: EvmReadClient` (a viem public client), and oisy already builds one against Alchemy (`alchemy.providers.ts`, keyed by `VITE_ALCHEMY_API_KEY`). Pass that client as `evmPublicClient` rather than adding a `VITE_EVM_RPC_URL`/raw URL — no new secret, reuses oisy's provider config. If the Alchemy key is unset or Ethereum is disabled, ETH-side pools degrade to "temporarily unavailable" (see Error handling / Disabled networks).
+3. **Withdraw destinations** — **Decided: fast-follow, not v1.** v1 delivers all borrows/withdrawals to the user's own oisy-controlled address only. The SDK supports external receivers (`receiverAddress` on `borrow`/`withdraw`; `ExternalOutflowReceiver`), but external-address withdrawal (CEX/Ledger) adds per-chain address validation and wrong-address-loss safeguards that the core wizards don't otherwise need — deferred to a fast-follow once the core lend/borrow loop is proven. (Already reflected in Scope → "Not in v1".)
+4. **Active liquidation alerting** — **Decided: fast-follow.** v1 ships the always-visible in-app health status only (Liabilities tag, status dot, provider-page display). _Active_ alerting (push/email/in-wallet notification as health nears the threshold) is deferred — it requires a background health-watch trigger and a delivery channel beyond what the core wizards need. Revisit as a fast-follow once the in-app surfacing is validated.
+5. **Backend `ActiveUserTransactionData` variant** — **Decided: a single `Liquidium` variant with an action field.** Add one `Liquidium : LiquidiumData` variant to `ActiveUserTransactionData` (Rust + `.did`), where `LiquidiumData = { action: LiquidiumAction (Supply|Borrow|Repay|Withdraw), pool_id: text, token: TokenId, amount: nat }`. The four actions share this shape; dynamic/learned-mid-flow values (loan ref, activity id, tx_hash, receiver) ride in the existing `external_refs` — the type's intended escape hatch — rather than bespoke per-action fields. This keeps one Candid type and one validation arm, and a future action becomes a new enum value, not a new variant. (Contrast OneSec's per-direction variants, which exist because their payloads genuinely differ.) Prerequisite: lands before the FE wiring. See "Asynchronous settlement & active transactions".
 6. **[PARKED — revisit] Risk on the hero/overview** — since debt grows on its own, **decide** whether to surface a small health indicator near the net-worth total (visible whenever the user holds debt), so a user who never opens the Liabilities tab is still warned. Deferred by request.
 
 ---

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow.md
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow.md
@@ -1,0 +1,472 @@
+# Spec: Lend & Borrow via Liquidium
+
+This spec follows the workflow defined in `docs/ai/spec-driven-development/workflow.md`.
+
+## What we're building
+
+Let users **supply (lend)** and **borrow** native assets through the [Liquidium](https://liquidium.fi) cross-chain lending protocol, directly from oisy. This is an integration — the lending logic (pools, interest accrual, collateral accounting, liquidations) runs inside Liquidium's canisters on the Internet Computer. Oisy provides the UX and signs the canister calls with the user's existing identity.
+
+The integration uses Liquidium's official TypeScript SDK, [`@liquidium/client`](https://www.npmjs.com/package/@liquidium/client), via its **account-based profile path** (`client.accounts`, `client.lending`, `client.positions`, `client.market`, `client.quote`). This is the path Liquidium documents for apps that "own a full lending dashboard" — supply, borrow, repay, withdraw, and monitor positions across sessions.
+
+This feature follows the **Earn pattern**, not Trade. (The limit-orders spec, [`2026-06-04-feat-limit-orders.md`](./2026-06-04-feat-limit-orders.md), already states: *"Lend & Borrow (coming later) follows the Earn pattern, not Trade."*) Liquidium appears as a new provider on the existing **Earn** surface and opens a dedicated management page, mirroring how Harvest Autopilot works today.
+
+---
+
+## Scope (v1)
+
+- Connect / create a Liquidium profile for the signed-in oisy identity (transparent, no separate account UX where avoidable).
+- **Supply** a supported asset to a Liquidium pool to earn yield (this also becomes collateral).
+- **Borrow** a supported asset against supplied collateral, subject to max-LTV.
+- **Repay** an open borrow position (full or partial).
+- **Withdraw** supplied assets (up to the amount that keeps the position healthy).
+- A shared **Liquidium provider page** (`/providers/liquidium/`) showing per-asset positions, supply/borrow APY, portfolio health factor, net value, and net APY.
+- Two intent-based entry points: the existing **Earn** page (lend framing) and a **new top-level Borrow page** (borrow framing); both lead to the shared provider page. **Settings moves to the user menu** to keep the nav budget.
+- Surface positions on the **Assets page**: supplies in the existing **Earning** tab (alongside other providers), borrows in a new **Liabilities** tab — grouped by type, each card labelled with its provider.
+- Liquidium **net value** (supplied − borrowed) is included in the hero net-worth total.
+
+**Supported assets (v1):** BTC (ckBTC), ETH (ckETH), USDC, and USDT — matching Liquidium's advertised markets. Pools that are not yet live on Liquidium mainnet are shown as "Coming soon" and are not selectable (driven by `client.market` pool availability, never hard-coded). See Open questions.
+
+**Not in v1:** accountless Instant Loans, the "Liquidium Loop" leveraged flow, custom vaults, liquidation-dashboard participation, same-asset borrowing UI specialisation (the protocol may allow it per-pool; v1 just respects whatever `client.market` reports), and withdrawing borrowed funds to an external CEX/Ledger address (v1 borrows to the user's own oisy-controlled address only).
+
+---
+
+## Why this approach (integration rationale)
+
+The "optimal" integration was chosen against three constraints: reuse oisy's existing patterns, keep protocol logic on Liquidium's side, and ship safely behind a flag.
+
+1. **Account-based SDK path, not Instant Loans.** The user requirement is to *deposit BTC/USDC/USDT and borrow against that deposit as collateral*, and to manage positions over time. That is exactly Liquidium's "account-based profile flow." Instant Loans is an accountless, single-shot borrow flow with no persistent supply/collateral dashboard, so it does not satisfy the requirement. We use `client.lending` + `client.positions` + `client.accounts`.
+
+2. **Provider-card pattern, two intent-based entries.** oisy already has a config-driven provider-card system (`EarningProvider` in `src/frontend/src/lib/types/earning-provider.ts`, assembled in `src/frontend/src/lib/providers/earning.providers.ts`, cards configured in `$env/earning-providers.json`), where a card's action navigates to a dedicated provider page — exactly like Harvest Autopilot (`HARVEST_AUTOPILOT_PROVIDER_ID`). Liquidium reuses this on **two** surfaces: the existing **Earn** page (lend framing) and a **new top-level Borrow** page (borrow framing), both pointing to one shared provider page. Earn and Borrow are kept distinct because they serve different users — *Earn is the simple, mainstream "get yield" entry; Borrow is the advanced "take on debt for liquidity" entry* — and Earn deliberately stays even if a DeFi umbrella is added later (see Navigation context → Future direction).
+
+3. **Reuse the swap wizard.** Supply / Borrow / Repay / Withdraw are each a `Form → Review → Progress` modal wizard, reusing the structure and components under `src/frontend/src/lib/components/swap/` (`SwapModal.svelte`, `SwapForm.svelte`, `SwapReview.svelte`, `SwapProgress.svelte`, `SwapModalWizardSteps.svelte`) and the Harvest Autopilot stake wizard as the closest existing precedent.
+
+4. **Feature-flagged.** Gated by a new `LIQUIDIUM_ENABLED` flag following the existing convention (`parseBoolEnvVar(import.meta.env.VITE_LIQUIDIUM_ENABLED)` in a new `src/frontend/src/env/liquidium.ts`, mirroring `EARNING_ENABLED` in `env/earning.ts`). Disabled in production until ready.
+
+---
+
+## Liquidium integration
+
+### SDK
+
+|              |                                                                            |
+| ------------ | -------------------------------------------------------------------------- |
+| Package      | `@liquidium/client`                                                        |
+| Client       | `LiquidiumClient` (bundles Liquidium mainnet canister IDs by default)      |
+| Docs         | https://liquidium-inc.github.io/liquidium-sdk/                             |
+| Source       | https://github.com/Liquidium-Inc/liquidium-sdk                             |
+| Runtime      | Browser `fetch`, `BigInt`, ESM; viem public client for EVM (ETH) reads     |
+
+Client construction (in a new `src/frontend/src/lib/api/liquidium.api.ts`):
+
+```ts
+import { LiquidiumClient } from '@liquidium/client';
+
+const client = new LiquidiumClient({
+  identity,                         // oisy's signed-in IC identity (for client.lending canister calls)
+  evmRpcUrl: VITE_EVM_RPC_URL,      // only needed for ETH/USDT(ERC) reads & external withdrawals
+  headers: { 'x-client-name': 'oisy' }
+});
+```
+
+`environment` defaults to mainnet; `icHost`/`canisterIds` only need overriding for local/staging. The IC identity that oisy already manages for canister calls is passed as `identity` so Liquidium canister calls are signed as the same principal.
+
+### Core dependency — the `WalletAdapter` (oisy signer bridge)
+
+**This is the single most load-bearing piece of the integration.** Every Liquidium *write* flow — profile creation, supply, borrow, repay, withdraw — authorizes through a SDK `WalletAdapter` that oisy must implement, backed by oisy's existing signer(s). It is **one multi-chain adapter** (not one per chain); the SDK calls only the capability methods a given flow needs (all optional):
+
+| `WalletAdapter` method | Used for | oisy backing |
+| ---------------------- | -------- | ------------ |
+| `signMessage(req)`        | profile creation, borrow, withdraw (authorization) | sign with the relevant chain address's key |
+| `sendEthTransaction(req)` | ERC stablecoin / contract-interaction supply, ETH native sends | oisy ETH signer |
+| `sendBtcTransaction(req)` | native-BTC transfer-path supply | oisy BTC signer (signer canister / threshold-ECDSA) |
+| `signPsbt(req)`           | PSBT-based BTC actions (when exposed) | oisy BTC PSBT signing |
+
+Notes:
+
+- The adapter holds both BTC and ETH capabilities on one object; oisy routes each method to the correct internal signer. It may be composed from per-chain signer helpers, but the SDK consumes a single adapter.
+- **Which capabilities are required depends on the rail (see Open questions → "Asset & network representation / rail per leg").** `signMessage` is always needed. `sendEthTransaction` is needed for the ERC stablecoin path. `sendBtcTransaction`/`signPsbt` are needed **only for the native-BTC rail** — if oisy supplies the BTC pool as **ckBTC** (`icrcAccount` target), that leg uses oisy's own ICRC-1/2 ledger transfer + inflow reporting and does **not** touch the adapter's BTC methods.
+- Profiles are owned by a wallet **address** + signed message (see Pending decisions → "Profile ownership"), so the adapter's `signMessage`/address wiring also determines profile ownership.
+
+### SDK modules used
+
+| Module             | Used for                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| `client.accounts`  | Create/reuse the Liquidium profile for the signed-in identity; linked-wallet lookup   |
+| `client.market`    | `pools`, `prices`, pool rate lookups — drives the asset list, APYs, caps, availability |
+| `client.lending`   | `supply(...)`, `borrow(...)`, `withdraw(...)`, repay, inflow reporting                 |
+| `client.positions` | Per-pool positions, health factor, aggregate stats — drives the dashboard + hero total |
+| `client.quote`     | `calculateLtv(...)`, `getMinimumBorrowAmount(asset)` — pre-submit validation           |
+| `client.activities`/`client.history` | Optional: feed position/transaction history into oisy's Activity view (stretch) |
+
+> **Repay method:** Liquidium's product surface lists Repay as a first-class action and the `client.lending` module is documented as "Supply, borrow, withdraw, and inflow reporting." The exact repay entry point (`client.lending.repay(...)` vs. a borrow-position settlement call) must be confirmed against the generated API reference before implementation. See Open questions.
+
+### Key concepts (from Liquidium docs)
+
+**Pools and share-based accounting.** Each asset (BTC, ETH, USDC, USDT) has its own pool with independent, dynamically-adjusting (Aave-style kink) interest rates. Suppliers earn the **supply APY**; borrowers pay the **borrow APY**. Interest accrues continuously via share-based accounting (no per-user cron).
+
+**Supply is collateral.** When a user supplies an asset, it automatically counts toward collateral. Borrowing is over-collateralised: total collateral value must exceed borrow value with a safety buffer.
+
+**Max LTV vs. liquidation threshold.** *Max LTV* caps how much can be borrowed when opening/increasing a position. *Liquidation threshold* (higher than max LTV) is where the position becomes liquidatable. The gap is the safety buffer. Both are per-pool; a portfolio with multiple collaterals uses a weighted-average liquidation threshold.
+
+**Health factor.** Portfolio health is surfaced as a percentage: `100%` = no debt; `>0%..99%` = safe (higher is safer); near `0%` = at risk; `0%` = partially liquidatable. oisy displays the percentage form (Liquidium's default).
+
+**Amounts in smallest units.** All SDK amounts are in each asset's base unit — BTC in **satoshis**, USDC/USDT in token base units per pool decimals. oisy converts to/from human units at the UI edge only.
+
+**Minimum borrow amounts.** BTC borrows ≥ `5_100n` sats; USDC/USDT borrows ≥ `1_000_000n` base units. Display the minimum via `getMinimumBorrowAmount(asset)` before submit; block submit below it.
+
+**Native / cross-chain.** Assets enter and leave native (no user-facing wrapped tokens). Under the hood Liquidium uses chain-key assets (ckBTC, ckETH, ckUSDT) and IC Chain Fusion. Supplying BTC pulls from the user's BTC balance; borrowing USDT can target an Ethereum address. v1 keeps funds within oisy-controlled addresses.
+
+### LTV / pre-submit validation
+
+Before any borrow (and before a withdraw that reduces collateral), validate with the SDK so the protocol never receives an invalid request:
+
+```ts
+const ltv = client.quote.calculateLtv(
+  { collateralPoolId, borrowPoolId, collateralAmount, borrowAmount },
+  pools,
+  prices
+);
+if (ltv.validationErrors.length > 0) {
+  // surface ltv.validationErrors[].message inline; disable Review/Confirm
+}
+```
+
+The same `pools` and `prices` come from `client.market`. `calculateLtv` is a pure helper — safe to call live as the user types (debounced).
+
+---
+
+## Navigation context
+
+This feature **adds one new top-level entry, `Borrow`**, and moves **Settings into the user menu** to stay within the ~5-item nav budget. The top-level nav (`src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte`) becomes:
+
+**Assets · Activity · Earn · Borrow · Explore** (Settings → user menu).
+
+(Note: on `main` today, Settings is still a top-level item and there is no Borrow entry; both change here. The limit-orders spec also assumed Settings moves to the user menu.)
+
+### Two intent-based entry points, one provider page
+
+Liquidium is reached from **two** top-level surfaces, framed by user intent, both leading to the **same** Liquidium provider page:
+
+- **Earn** (`/earn/`) — for mainstream users who just want yield. The Liquidium card here is framed around **lending / supply APY**.
+- **Borrow** (`/borrow/`) — a new page that mirrors the Earn page's structure but lists **borrow-capable** providers, framed around **borrow cost** (rate/APR). The Liquidium card here is framed around borrowing.
+
+Both cards' actions navigate to the same shared provider page (`/providers/liquidium/`), which contains the full supply + borrow + repay + withdraw experience. Keeping `Earn` and `Borrow` as separate verbs is deliberate: **Earn is the low-knowledge, mainstream "get yield" entry; Borrow is the more advanced "take on debt for liquidity" entry.** They are not merged so the simple use case stays simple.
+
+| Surface                                          | Type            | Purpose                                                                      |
+| ------------------------------------------------ | --------------- | ---------------------------------------------------------------------------- |
+| **Liquidium card on Earn** (`/earn/`)            | Entry point     | Lend framing — supply APY, your supplied value                               |
+| **Liquidium card on Borrow** (`/borrow/`)        | Entry point     | Borrow framing — borrow rate, your borrowing power / debt                    |
+| **Liquidium provider page** (`/providers/liquidium/`) | Management view | Per-provider full picture — positions, health, supply/borrow/repay/withdraw |
+| **Assets page tabs** (Earning + new Liabilities) | Holdings view   | "Where are all my assets/debts?" — positions grouped **by type**, across all providers |
+
+**Grouping principle (Assets page).** On the Assets page, positions are grouped by *type* (asset vs. liability), **not** by provider. There is no "Liquidium section." A Liquidium supply appears in the **Earning** tab next to Harvest Autopilot stakes; a Liquidium borrow appears in the new **Liabilities** tab. Each card names its provider. Rationale: on Assets the user cares about *what kind* of holding it is; on the provider page they care about *that provider*.
+
+New routes/constants in `src/frontend/src/lib/constants/routes.constants.ts`:
+
+- `AppPath.Borrow = '/borrow/'` — the new top-level Borrow page. `src/frontend/src/routes/(app)/borrow/+page.svelte` renders a borrow-framed provider list (mirrors the Earn page's `Earning.svelte` structure).
+- `AppPath.ProvidersLiquidium = '/providers/liquidium/'` — the shared Liquidium provider page, reached from both the Earn and Borrow cards. A neutral `/providers/` namespace (rather than `/earn/liquidium/`) is used precisely because it is reached from both entry points. `src/frontend/src/routes/(app)/providers/liquidium/+page.svelte` renders it, mirroring how `earn/autopilot/+page.svelte` renders `HarvestAutopilot`. (The breadcrumb reflects the entry point — "Earn › Liquidium" or "Borrow › Liquidium".)
+- `AppPath.Liabilities = '/liabilities/'` — the new Assets-page tab. `src/frontend/src/routes/(app)/liabilities/+page.svelte` renders `<Assets tab={TokenTypes.LIABILITIES} />`, mirroring how `earning/+page.svelte` renders `<Assets tab={TokenTypes.EARNING} />`.
+
+### Future direction (north star — not v1)
+
+Later, a single DeFi **umbrella** entry (option 2) may group all providers **technically** — Staking, Lend, Borrow, Trade (limit orders) — as sub-tabs, giving advanced/"degen" users one place for everything. **`Earn` is kept as a top-level entry even then**: it remains the simple, curated, low-knowledge "get yield" surface for mainstream users, while the umbrella serves power users. This also resolves the eventual asymmetry with the in-flight limit-orders/Trade work (currently a Trading tab under Assets). v1 does **not** build the umbrella; it only adds `Borrow` alongside `Earn`, with the shared `/providers/` route chosen so it slots cleanly under an umbrella later.
+
+---
+
+## Where it lives
+
+### Provider cards (Earn page + Borrow page)
+
+Liquidium appears as a provider card on **two** pages. Both reuse oisy's existing `EarningOpportunityCard` / `DefaultEarningOpportunityCard` components, configured via `$env/earning-providers.json` (validated by `env-earning-providers.schema.ts`). To support lending semantics, extend `EarningType` in `src/frontend/src/lib/types/earning-provider.ts` from `'stake' | 'reward'` to `'stake' | 'reward' | 'lending'`, and add the provider data store to `earningDataStores` in `src/frontend/src/lib/providers/earning.providers.ts` (e.g. `LIQUIDIUM_PROVIDER_ID` → `liquidiumEarningData` in a new `src/frontend/src/lib/derived/liquidium-earning.derived.ts`).
+
+**Earn-page card (lend framing).** Mirrors the live Harvest Autopilot card field set for parity: the `APY` badge ("Max. APY", best supply APY across live pools, green), then `NETWORKS`, `ASSETS` (BTC, ETH, USDC, USDT as overlapping logos), `CURRENT_EARNING` (the user's net interest, green, "+ $X/year"), and `EARNING_POTENTIAL` (blue, "+ $X/year"). Structure is constant regardless of position — only values change. `actionText`: "Lend & Borrow". See wireframe [`earn-card.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/earn-card.html).
+
+**Borrow-page card (borrow framing).** Same component, borrow-oriented fields: a badge showing the **borrow rate** (e.g. "Borrow APR from 0.94%", styled as cost not green yield), `NETWORKS`, `ASSETS`, and — when the user has collateral/debt — their **borrowing power** and **current debt + borrow rate**. `actionText`: "Borrow". The Borrow page (`/borrow/`) is structured like the Earn page (`Earning.svelte`) but lists only borrow-capable providers.
+
+**Both cards' actions navigate to the same page:** `goto(AppPath.ProvidersLiquidium)` (`/providers/liquidium/`). The destination is identical; only the card framing and the entry point differ.
+
+### Borrow page (`/borrow/`)
+
+Mirrors the Earn page skeleton (`Earning.svelte`): a header section plus a "Borrowing options" provider list. The header's two summary boxes are the borrow equivalents of Earn's "Earning potential" / "Active earning":
+
+- **Borrowing power** (≈ Earn's "potential") — how much the user could borrow now, based on their best/available provider and current collateral (blue). Shows `$0` / disabled-feel when the user has no collateral.
+- **Active loans** (≈ Earn's "active earning") — total currently borrowed, plus **interest per year** (shown as a cost, red, e.g. "− $2,590/year"), plus a **worst-health chip** across the user's borrow accounts (green/amber/red — "Healthy/At risk/Critical · N%"). The worst-health surfacing here is deliberate: this is the most decision-relevant signal on the Borrow page.
+
+Below, the **Borrowing options** list contains the borrow-framed **Liquidium card** only (other borrow providers → "coming soon" placeholder). The card shows a borrow-rate badge ("Borrow APR from X%"), Networks, borrow Assets, and — when the user has debt — "Currently borrowing" and "Interest / year". Its action opens `/providers/liquidium/`. See wireframe [`borrow-page.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page.html).
+
+### Dapps carousel slide (promo entry point)
+
+The dapps carousel (`src/frontend/src/lib/components/dapps/DappsCarousel.svelte`) shows promo slides. A slide either opens the **dapp-details modal** (default, explorer-style) or navigates **internally** when given a `pagePath` (handled in `DappsCarouselSlide.svelte`'s `open()` — `nonNullish(pagePath)` → `goto(...)`).
+
+There are **two distinct Liquidium presences here, with separate IDs:**
+
+- **Existing** — the `"liquidium"` entry in `$env/dapp-descriptions.json` already has a `carousel` block. It has **no `pagePath`**, so its slide opens the **dapp-details (explorer) modal**. **Leave it as-is** — it's the dapp-directory listing.
+- **New (this spec)** — a **code-synthesized slide with a new id**, opening the Liquidium page, exactly mirroring the `harvestAutopilotSlide` pattern in `DappsCarousel.svelte`:
+  - Add a derived `liquidiumSlide` (gated by `LIQUIDIUM_ENABLED`) shaped as `CarouselSlideOisyDappDescription`: a **new unique `id`** (e.g. `LIQUIDIUM_PROVIDER_ID` — distinct from `"liquidium"` so it doesn't collide with the dapp-descriptions entry), `carousel.text` + `carousel.callToAction` (new i18n keys), `logo`, `name`. Prepend it to `dappsCarouselSlides` alongside `harvestAutopilotSlide`.
+  - Generalise the `pagePath` prop passed to `DappsCarouselSlide` so each synthesized slide maps to its route: the Harvest slide → `AppPath.Earn` (existing), the new Liquidium slide → `AppPath.ProvidersLiquidium`. So clicking it `goto`s `/providers/liquidium/` instead of opening the dapp modal.
+
+Net: the explorer/dapp-details card stays (id `"liquidium"`); the new carousel card (new id) is a direct promo into the Liquidium provider page, just like Harvest Autopilot's slide deep-links into `/earn/`. See wireframe [`carousel-slide.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/carousel-slide.html).
+
+### Assets page — Earning tab and new Liabilities tab
+
+The Assets page (`src/frontend/src/lib/components/tokens/Assets.svelte`) has a tab bar: today **Tokens · NFTs · Earning** (Earning gated by `EARNING_ENABLED`). This feature adds a fourth tab, **Liabilities**, after Earning.
+
+**Tab model:**
+
+```
+Assets page
+├── Tokens          spot wallet balances (unchanged)
+├── NFTs            (unchanged)
+├── Earning         "My assets" — all yield-bearing positions, ALL providers
+│                     (Harvest Autopilot stakes + Liquidium supplies)
+└── Liabilities     "My liabilities" — all debt positions, ALL providers   ← NEW
+                      (Liquidium borrows) — negative decoration
+```
+
+**Earning tab (generalised).** Today `EarningsList.svelte` only maps Harvest Autopilot vaults. It is generalised to also list **Liquidium supply positions** as cards. Cards are grouped by type, not provider; each card shows a **provider label** (e.g. "Harvest Autopilot", "Liquidium") so the user can tell sources apart. A Liquidium supply card shows the asset, supplied amount + supply APY, and fiat value.
+
+**Liabilities tab (new).** A new `TokenTypes.LIABILITIES` enum value and a `LiabilitiesList.svelte` that lists **borrow positions**, **grouped by provider** (v1: a single "Liquidium" group). Within a group, each card shows the asset, borrowed amount, and a **"negative" decoration** — minus sign on the amount, red/owed styling — to make clear this is debt, not a holding. The interest figure is labelled **"Borrow rate"** (the cost you pay), **not "APY"** — APY/earnings framing is reserved for the asset side, and it is styled as a cost (amber/neutral), never as green yield. The provider is named by the **group header** (so it need not repeat on each card). Empty state when the user has no debt.
+
+> Note: the Liabilities tab is grouped **by provider** (unlike the Earning tab, which is a flat list grouped by type with a per-card provider label). The driver is the health factor below — it is a **per-provider** measure, so it belongs at the provider group level, not per asset.
+
+**Liquidation-risk status (must always be visible).** Debt accrues interest continuously, so a position drifts toward its liquidation threshold over time even with no user action; collateral value can also fall. If the **health factor** reaches the threshold, the provider liquidates collateral. Health factor is computed **per provider** (each provider has its own shared collateral pool and weighted-average liquidation threshold), so it is shown **once per provider group**, not per card.
+
+- **On the Assets → Liabilities tab (compact):** a single colour-coded **health tag next to the provider group title** — e.g. "Healthy at 68%" (green), "At risk at 16%" (amber), "Critical at 7%" (red). One small element; it deliberately does not take a full banner here, to keep the Assets page dense. This risk colour is a **separate axis** from the red "owed" amount styling, so "this is debt" and "this is dangerous" never blur together.
+- **On the provider page (`/providers/liquidium/`, large):** the full health display — big percentage, coloured track, "Liquidation at 0%", and an alert with direct **Repay** / **Add collateral** actions when in the amber/red band.
+- **On the Liabilities tab label itself (status dot):** a small indicator circle in the top-right of the **Liabilities** tab label, so the user sees a problem even when that tab is not selected. **Amber** when any borrow provider is *at risk*, **red** when any is *critical*, hidden when all are healthy. With multiple providers it shows the **worst** state. Implemented in `Assets.svelte`'s `Tabs` config (the tab gets a status badge derived from the per-provider health stores).
+
+(Active push/notification alerting when health approaches the threshold is a candidate fast-follow; v1 guarantees the always-visible in-app status described here. Exact amber/red band thresholds to match Liquidium's own UI — see Open questions.)
+
+**Nav selection.** `NavigationMenuMainItems.svelte` keeps the **Assets** top-level item highlighted on the Liabilities route: extend `assetsSelected` (currently `isRouteTokens || isRouteNfts || isRouteEarning || isRouteTransactions`) and the `assetsPath` logic to include `TokenTypes.LIABILITIES` / `AppPath.Liabilities`, and add an `isRouteLiabilities` helper in `src/frontend/src/lib/utils/nav.utils.ts`.
+
+**Gating.** The Liabilities tab is gated on the borrow feature flag (`LIQUIDIUM_ENABLED`) so it does not render an empty tab before any borrow provider ships. The Earning tab stays on `EARNING_ENABLED`; Liquidium supply cards within it are additionally gated by `LIQUIDIUM_ENABLED`.
+
+> A Liquidium position set therefore appears across **two** Assets tabs — supplies under Earning, borrows under Liabilities — plus the consolidated per-provider view on `/providers/liquidium/`. This is intended: Assets is organised by type; the provider page is organised by provider.
+
+### Liquidium provider page (`/providers/liquidium/`)
+
+Gated by `LIQUIDIUM_ENABLED`. Three regions:
+
+**Header** — one-line description, "Learn more" link (to Liquidium docs), and a portfolio summary: **Health factor** (percentage with colour: green high → amber → red near 0%), **Net value**, and **Net APY** (can be negative; show sign and colour). Sourced from `client.positions` aggregate stats.
+
+**My positions** — one row per asset the user has supplied and/or borrowed. Each row shows: asset, **Supplied** amount + supply APY, **Borrowed** amount + borrow APY, and fiat equivalents. Row actions: **Supply**, **Borrow**, **Repay**, **Withdraw** (Repay shown only when there's debt in that asset; Withdraw only when there's a supplied balance). Refreshed by polling while the page is visible (same approach as the limit-orders Active Orders polling).
+
+**Markets** — pools the user has not entered yet, each showing supply APY, borrow APY, and a **Supply** CTA. Pools not live on mainnet render disabled with a "Coming soon" pill. Driven entirely by `client.market.pools` availability.
+
+**Three states:**
+
+- *New user (no profile / no positions):* My positions shows an empty state with a prominent **Supply** CTA; the Markets list is the focus. Borrow actions are disabled until the user has collateral.
+- *Has supply, no borrow:* position rows with Supply/Withdraw; Borrow becomes enabled; health factor shows `100%` (no debt).
+- *Has supply and borrow:* full rows with all four actions; live health factor with colour coding.
+
+### Hero net-worth total
+
+Liquidium **net value** (Σ supplied − Σ borrowed, in fiat) is added to the hero net-worth total, consistent with how the limit-orders spec rolls DEX balances into the hero. Supplied collateral adds to the total; outstanding debt subtracts from it. The hero shows only the total figure — no breakdown label.
+
+**Where positions are visible:** Liquidium supplied/borrowed balances do **not** appear in the **Tokens** tab — that tab is strictly spot wallet balances. Supplies appear in the **Earning** tab, borrows appear in the **Liabilities** tab, and both are summarised on `/providers/liquidium/`. Note that funds the user *received* from a borrow (e.g. borrowed USDC now sitting in their wallet) are real spot balances and **do** show in Tokens as normal — that is distinct from the protocol-side debt shown under Liabilities.
+
+---
+
+## Action flows
+
+All four actions are modal wizards: **Form → Review → Progress**, reusing `SwapModalWizardSteps.svelte` and the swap form/review/progress components as the structural template. Amount-on-the-left, token/asset context on the right — matching oisy's existing form layout. Fiat equivalents shown throughout in the user's selected currency, using oisy's existing price store.
+
+### Supply (lend)
+
+Entry points: the Markets list "Supply" CTA, and a position row "Supply" action.
+
+**Form** — asset selector (only Liquidium-supported assets the user holds; if a position row launched it, the asset is pre-filled and locked). Amount input with **wallet balance** shown and a "Max" shortcut, plus fiat equivalent. Shows the pool's current **supply APY** and an info line that supplied assets also serve as collateral. A transaction-fee row (collapsible, same pattern as `SwapFee.svelte`). Agreement checkbox: "I understand my assets will be supplied to the Liquidium protocol and are subject to on-chain smart-contract risk." Review disabled until checked. Button: "Review".
+
+**Review** — title "Review supply". Hero: amount + fiat. "To: Liquidium" row. Resulting supply APY. Transaction fee. Back + "Supply".
+
+**Progress** — submits via `client.lending.supply(...)`. On success the modal closes and the asset appears (or updates) in My positions. Health factor and net value refresh.
+
+### Borrow
+
+Entry points: a position row "Borrow" action; or "Borrow" from a market the user already supplies to. Disabled entirely until the user has collateral.
+
+**Form** —
+- **Collateral context:** read-only summary of current collateral and available borrowing power (from `client.positions` + `calculateLtv`).
+- **Borrow asset selector** + amount, with fiat equivalent.
+- **Minimum borrow** shown from `getMinimumBorrowAmount(asset)`; submit blocked below it.
+- **LTV / health preview:** live, debounced `client.quote.calculateLtv(...)`. Show resulting **LTV** and the **projected health factor** with colour. If `validationErrors` is non-empty, show the messages inline and disable Review.
+- **Borrow APY** for the selected pool.
+- A clear risk line: "Borrowing reduces your health factor. If it falls too far your collateral can be liquidated."
+
+**Review** — title "Review borrow". Hero: borrow amount + fiat. Rows: borrow APY, resulting LTV, **projected health factor** (with the same colour scale as the dashboard). If projected health crosses into the amber/red band, show a warning box; if it crosses a high-risk threshold, require a confirmation checkbox before "Borrow" is enabled (mirrors the limit-orders below-market −5% checkbox pattern). Back + "Borrow".
+
+**Progress** — submits via `client.lending.borrow(...)`. On success, the borrowed asset is delivered to the user's oisy address; the position row updates and health factor refreshes.
+
+### Repay
+
+Entry point: position row "Repay" (only when that asset has debt).
+
+**Form** — asset pre-filled. Amount input with a "Max (full debt)" shortcut that fills the outstanding amount (principal + accrued interest, from `client.positions`). Shows current debt and the **projected health factor after repay** (improves). Wallet balance shown; if insufficient, surface the shortfall clearly. Transaction fee row.
+
+**Review** — title "Review repay". Hero: repay amount + fiat. Rows: remaining debt after repay, projected health factor. Back + "Repay".
+
+**Progress** — submits the repay call (see Repay-method open question). On success the debt decreases (or clears) and health factor improves.
+
+### Withdraw
+
+Entry point: position row "Withdraw" (only when that asset has a supplied balance).
+
+**Form** — asset pre-filled. Amount input. The **maximum withdrawable** amount is the larger-of-zero portion of supply that keeps the position healthy (free collateral); show it as a clickable "Max" shortcut and as the cap — the user cannot exceed it. If the user has debt, show the **projected health factor after withdraw** (decreases) live via `calculateLtv`, with warning/confirm if it crosses risk bands (same pattern as Borrow). Reserved-by-debt context line. Transaction fee row.
+
+**Review** — title "Review withdraw". Hero: amount + fiat. "From: Liquidium" row. "You receive" = amount − transfer fee (fee deducted from the withdrawal, unlike supply). Projected health factor. Back + "Withdraw".
+
+**Progress** — submits via `client.lending.withdraw(...)`. On success the supplied balance decreases and net value / health refresh.
+
+---
+
+## Profile bootstrapping
+
+Liquidium account-based flows require a profile. On first entry to the Liquidium dashboard (or first action), oisy calls `client.accounts` to look up an existing profile for the signed-in identity and creates one if absent. This is transparent: the user sees a brief "Setting up Liquidium…" step rather than a separate account-creation screen. If profile creation requires a signature, fold it into the first action's Progress step. See Open questions for the exact `createProfile` signature requirements.
+
+---
+
+## Asynchronous settlement & active transactions
+
+Liquidium actions don't all settle synchronously — native-BTC legs need multiple Bitcoin confirmations (~30–60 min), and even ICRC/canister legs are async. **No Liquidium action blocks its modal until settlement.** Instead, every Liquidium action reuses oisy's existing **active-user-transactions** mechanism (recently added for the OneSec / 1sec integration), which lets the execution modal close immediately while a backend-persisted record tracks the transaction to completion.
+
+**The existing mechanism (OneSec is the reference implementation):**
+
+- Backend (user-profile canister) stores an `ActiveUserTransaction` per user: `id` (FE-generated UUIDv4), `status` (`Pending → Executing → Succeeded | Failed`, transitions enforced by the backend), `external_refs` (learned-mid-flow `{ key, value }` pointers — e.g. a tx hash — that say *where to read status*), `progress_step` (FE-written step label), `data` (a per-integration variant), `updated_at_ns`, and `error`. API: `create`/`get`/`update`/`delete` in `src/frontend/src/lib/api/backend.api.ts`.
+- Frontend: `activeUserTransactionsStore` (`src/frontend/src/lib/stores/active-user-transactions.store.ts`, persisted per principal); services `createActiveUserTransaction` / `updateActiveUserTransaction` / `loadActiveUserTransactions` / `applyActiveUserTransactionPollUpdate` (`active-user-transactions.services.ts`); `LoaderActiveUserTransactions.svelte` runs a global poll timer over `activeUserTransactionsPending`; and the active-transactions UI (`ActiveUserTransactionsButton`/`List`/`Item`) surfaces them with an unseen badge. Terminal transactions trigger a wallet/balance refresh once (guarded by `terminalSideEffectsApplied`).
+
+**What Liquidium adds:**
+
+1. **Backend dependency (required).** The `ActiveUserTransactionData` Candid variant is currently OneSec-only (`OneSecEvmToIcp` / `OneSecIcpToEvm`). The backend canister must add Liquidium variant(s) — e.g. `LiquidiumSupply` / `LiquidiumBorrow` / `LiquidiumRepay` / `LiquidiumWithdraw` (or one `Liquidium` variant carrying action + pool + amount). This is a Rust + `.did` change and is a prerequisite for the FE work. See Open questions.
+2. **Register on submit.** Each action's **Progress** step calls `createActiveUserTransaction({ identity, id, data, progressStep, externalRefs })`, then the **modal can close before settlement**. The position/loan immediately shows a **pending** state on the provider page and the Earning/Liabilities tabs.
+3. **External refs = where to read status.** Store the Liquidium identifiers as `external_refs` (e.g. the loan `ref`, a deposit/activity id, and for native BTC the `tx_hash`). Some are known at submit; others are added via `updateActiveUserTransaction` as they're learned mid-flow.
+4. **Poller.** Add `pollLiquidiumActiveUserTransactions` (mirroring `pollOneSecActiveUserTransactions`) and an `isLiquidiumActiveUserTransaction` filter, wired into `LoaderActiveUserTransactions`. It reads status from the Liquidium SDK via the refs (`client.activities` for confirmation-level detail, `client.instantLoans.get` / `client.positions` as applicable) and calls `applyActiveUserTransactionPollUpdate` to advance `status`/`progress_step`.
+5. **Terminal side-effects.** On `Succeeded`, refresh Liquidium positions/health and wallet balances once (reuse the existing terminal-refresh path).
+
+This applies to **all four flows** (Supply, Borrow, Repay, Withdraw). The fast ckBTC/ICRC legs simply resolve quickly; the slow native-BTC legs surface as pending with confirmation progress and resolve in the background — the user can navigate away or close oisy and the state is re-derived from the backend on return.
+
+See wireframe [`active-transactions.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/active-transactions.html) for how a Liquidium **deposit (Supply)** and **loan (Borrow)** render in the Active-transactions panel, alongside a OneSec swap for parity (status circle, "Liquidium · step" subtitle, confirmation progress, dismiss-on-terminal).
+
+### Sources of truth & reconciliation
+
+The SDK also exposes the user's open/in-flight transactions (`client.activities.list(...)` — receipt/confirmation status; `client.history` — settled history; `client.positions` and `client.instantLoans.get(...)` — current state). So there are two records of an in-flight action: oisy's `ActiveUserTransaction` and Liquidium's own activity view. These are **not co-equal sources of truth** — they have different roles, and defining that prevents disagreement:
+
+- **Liquidium (SDK / protocol) is the source of truth for _state_.** It is authoritative on confirmations, settlement, fills, real debt and health, and it is _complete_ — it includes Liquidium activity the user performed **outside** oisy (e.g. on Liquidium's own app), which oisy's store will never have.
+- **oisy's `ActiveUserTransaction` store is a tracking/index projection**, not a state authority. It records "the user started this from oisy + where to read its status" (`external_refs`) and drives the close-early / pending-badge / terminal-side-effects UX. Its `status` is **derived from the SDK, never asserted independently.**
+
+**Reconciliation rules:**
+
+1. **SDK wins on state.** The active-transactions poller maps SDK activity/loan status → `ActiveUserTransaction.status`; never the reverse. The store mirrors the protocol; it does not override it.
+2. **The store only covers the gap the SDK can't.** Between "user sent funds" and "protocol detected them" (the `awaiting_deposit`/pre-detection window), the SDK may not yet show the item — that is exactly when the locally-created record bridges. Once the SDK reports terminal, the local record is retired.
+3. **Positions and net worth come only from `client.positions`** — never from the active-transactions store. A pending supply shows as "pending" in the Active-transactions panel but is **not** counted in net worth / Earning / Liabilities until `positions` reflects it. This avoids double-counting.
+4. **Never write `Succeeded` optimistically.** The backend treats terminal states (`Succeeded`/`Failed`) as final and irreversible, so the poller only transitions to terminal once the SDK confirms — an early `Succeeded` could not be walked back if the protocol later fails the action.
+5. **Correlate via `external_refs`** (loan ref / activity id / tx_hash) for idempotent matching. SDK-reported activity that oisy did not initiate has no local record and simply surfaces via `positions` / `history` / the Activity view — which is fine.
+
+Net: **one source of truth for state (the protocol, via the SDK); the `ActiveUserTransaction` store is a derived, oisy-scoped tracking projection over it.**
+
+---
+
+## Data, polling, and stores
+
+- A `liquidium.services.ts` (in `src/frontend/src/lib/services/`) wraps the SDK calls and maps results to oisy types/units.
+- A derived store (`liquidium-earning.derived.ts`) exposes the user's aggregate position for the Earn card and hero total, and feeds both Assets tabs: the supply side into `EarningsList` and the borrow side into the new `LiabilitiesList`.
+- Markets (`client.market.pools` + `prices`) and positions (`client.positions`) are loaded on dashboard open and polled while visible; the hero total subscribes to the positions-derived net value.
+- All fiat conversion uses oisy's existing price store and currency setting. ckBTC, ckUSDC, ckUSDT and the ETH/USDT tokens already exist in oisy's token registry (`$env/tokens/...`), so logos and USD price feeds should largely be covered — confirm coverage (Open questions).
+
+---
+
+## Error handling
+
+- SDK/canister errors surface as inline messages on the relevant wizard step; the Progress step shows a clear failure state with a retry where safe.
+- `calculateLtv` `validationErrors` are shown inline and block Review/Confirm.
+- Below-minimum borrow amounts block submit with the minimum shown.
+- Network/identity errors (e.g. EVM RPC unavailable for ETH reads) degrade gracefully: affected pools show "Temporarily unavailable" rather than breaking the whole dashboard.
+
+---
+
+## Acceptance criteria
+
+- [ ] A new top-level **Borrow** entry exists; **Settings moves to the user menu**; nav is Assets · Activity · Earn · Borrow · Explore (gated by `LIQUIDIUM_ENABLED`).
+- [ ] Liquidium card appears on **both** the Earn page (lend framing: supply APY) and the Borrow page (borrow framing: borrow rate), hidden in production until ready.
+- [ ] Both cards' actions navigate to the same shared provider page `/providers/liquidium/`.
+- [ ] A new code-synthesized dapps-carousel slide (new id, gated by `LIQUIDIUM_ENABLED`) opens `/providers/liquidium/` via `pagePath`/`goto` — mirroring Harvest Autopilot; the existing `"liquidium"` dapp-descriptions slide is unchanged and still opens the dapp-details modal.
+- [ ] Borrow page header shows **Borrowing power** and **Active loans** (total + interest/year + worst-health chip across accounts).
+- [ ] Earn card shows best live supply APY, assets, and (when present) the user's supplied value / net interest; Borrow card shows borrow rate and (when present) borrowing power / debt.
+- [ ] Provider page header shows health factor (%), net value, and net APY with correct colour coding.
+- [ ] Markets list is driven by `client.market` availability; non-live pools show "Coming soon" and are not selectable.
+- [ ] Supply flow (Form → Review → Progress) completes via `client.lending.supply` and the position appears in My positions.
+- [ ] Assets page shows a fourth tab, **Liabilities**, after Earning (gated by `LIQUIDIUM_ENABLED`); the **Assets** top-level nav item stays highlighted on the Liabilities route.
+- [ ] Earning tab lists Liquidium **supply** positions alongside Harvest Autopilot stakes; each card shows a provider label.
+- [ ] Liabilities tab lists **borrow** positions **grouped by provider**; cards use a negative decoration (minus amount, red/owed styling); empty state when no debt.
+- [ ] On the Liabilities tab the interest figure is labelled "Borrow rate" (a cost), never "APY"; it is not styled as green yield.
+- [ ] Each provider group shows a single compact, colour-coded health tag next to its title ("Healthy/At risk/Critical at N%"); health is per-provider (one tag per group, not per card).
+- [ ] The full/large health display (percentage, track, Repay / Add collateral actions) lives on the provider page `/providers/liquidium/`, not on the Assets tab.
+- [ ] The **Liabilities** tab label shows a status dot (top-right) — amber if any provider is at risk, red if any is critical, hidden when all healthy, worst-of when multiple — visible regardless of which Assets tab is active.
+- [ ] Risk colour is on a separate axis from the red "owed" amount styling.
+- [ ] Positions are grouped by type, not provider — no "Liquidium section"; supplies under Earning, borrows under Liabilities.
+- [ ] Supplied/borrowed balances are not shown in the Tokens tab; hero net-worth adds supplied collateral and subtracts outstanding debt (net value).
+- [ ] Borrow is disabled until the user has collateral.
+- [ ] Borrow form shows minimum borrow (`getMinimumBorrowAmount`) and blocks submit below it.
+- [ ] Borrow form runs live, debounced `calculateLtv`; surfaces `validationErrors` and disables Review on error.
+- [ ] Borrow review shows resulting LTV and projected health factor; high-risk borrow requires a confirmation checkbox.
+- [ ] Borrow delivers funds to the user's oisy address and updates the position + health factor.
+- [ ] Repay flow supports partial and "Max (full debt)"; debt decreases/clears and health factor improves.
+- [ ] Withdraw flow caps the amount at free (non-collateralising) supply and cannot exceed it.
+- [ ] Withdraw with outstanding debt shows projected health factor and warns/confirms on risk-band crossings.
+- [ ] Withdraw "You receive" reflects amount − transfer fee.
+- [ ] A single multi-chain `WalletAdapter` backed by oisy's signer(s) satisfies every write flow's signing (`signMessage` always; `sendEthTransaction`/`sendBtcTransaction`/`signPsbt` per the rail decision).
+- [ ] Liquidium profile is created/reused transparently on first interaction: `getProfileId(walletAddress)` → if null, `createProfile({ account, chain, walletAdapter })` (signature-gated), folded into the first action's Progress step.
+- [ ] All amounts sent to the SDK are in base units (sats / token base units); UI shows human units and fiat.
+- [ ] Positions and health update via polling without a page reload.
+- [ ] Every Liquidium action (Supply/Borrow/Repay/Withdraw) registers an `ActiveUserTransaction` and the modal can close before settlement; the position/loan shows a pending state and resolves via the global active-transactions poller, surviving refresh and navigation.
+- [ ] Native-BTC legs show confirmation progress while pending; ckBTC/ICRC legs resolve quickly; terminal success refreshes positions/health/balances once.
+- [ ] All four wizards reuse the Form → Review → Progress structure and oisy form layout.
+
+---
+
+## Not yet specified (to flesh out)
+
+Aspects this spec has not detailed yet — captured here as a reminder; each needs its own pass before or during the build.
+
+- **Analytics / track events.** Ensure the whole borrow/lend surface emits proper analytics, consistent with oisy's existing `trackEvent` + `PLAUSIBLE_EVENTS` usage. Cover: page opens (Earn, Borrow, provider page), each action's lifecycle (started → reviewed → submitted → succeeded/failed) for supply/borrow/repay/withdraw, card and carousel-slide opens, and health-risk events. Define the event names and metadata.
+- **Disabled networks.** Make the feature work and look right for users who have **Ethereum or Bitcoin disabled** (in their network settings / `userNetworks`) — possibly both. Pools on a disabled network should degrade gracefully (hidden, or clearly disabled with a hint); Markets, cards, and asset selectors must not offer unusable options; and net-worth / positions math must stay correct. Define the behaviour for each disabled-network combination (ETH off, BTC off, both off).
+- **Feature and provider flags (runtime kill-switch).** Beyond the build-time `LIQUIDIUM_ENABLED` flag, keep a **runtime provider-level flag in production** so a provider can be temporarily disabled without a full code-change cycle — e.g. if a Liquidium SDK issue is detected, flip a flag (config + redeploy, or remote config) and the app hides/disables the provider and blocks new actions gracefully while everything else keeps working. Define where the flag lives (env/config vs. remote-fetched) and the disabled-state UX (are existing positions still viewable? are in-flight active transactions still tracked? new actions blocked with a notice?).
+
+---
+
+## Open questions (facts to confirm)
+
+Things we still need to find out or verify — answers are not yet known.
+
+1. **Liquidium mainnet readiness per asset** — confirm which pools (BTC/ETH/USDC/USDT) are live on Liquidium mainnet now vs. "coming soon," so the Markets list reflects reality. Drive from `client.market`, but confirm the gating field.
+2. **Repay method** — confirm the exact SDK entry point for repaying an account-based borrow position (`client.lending.repay(...)` vs. a position-settlement call) against the generated API reference (`api-reference/generated/`).
+3. **Identity / signing model** — Liquidium write actions authorize via the `WalletAdapter` (`signMessage` + chain sends), keyed to wallet addresses — not the SDK `identity` config alone. Confirm whether the SDK `identity` (for canister calls) **and** the `WalletAdapter` (for address-scoped signatures) are both needed, and how oisy's signer satisfies each.
+4. **Token/price coverage** — verify oisy's token registry covers logos and USD price feeds for every Liquidium-listed asset (ckBTC/ckUSDC/ckUSDT are present; confirm ckETH/native ETH and the exact USDC/USDT ledgers Liquidium uses).
+5. **Asset & network representation (native vs ICP ck-assets) — and the rail per leg.** Liquidium markets its lending networks as **Bitcoin** and **Ethereum** (Solana "coming soon"); the Internet Computer is the execution layer and assets are held internally as chain-key tokens (ckBTC/ckETH/ckUSDT). The SDK returns a **transfer target** per deposit/repayment that is either an `icrcAccount` or a `nativeAddress` (see Transfer Targets). The unconfirmed fact that gates several downstream decisions:
+   - **Does the BTC pool's supply target expose an `icrcAccount` (ckBTC) or only a `nativeAddress`?** If `icrcAccount`, oisy can fund it with a near-instant ckBTC ICRC-1/2 transfer (it already holds ckBTC), bypassing Bitcoin confirmations; if `nativeAddress`, supply requires a native BTC send (multi-confirmation). Confirm for the BTC pool (and likewise ckETH/ckUSDT vs native ETH/USDT). Not confirmed whether the BTC pool accepts direct ckBTC deposits vs. expecting native BTC (possibly via the ckBTC minter).
+   - Dependent decisions once the above is known: how to label the **Networks** field per leg (economic asset vs. transport rail), and whether to let the user supply from ckBTC (instant) or native BTC (confirmation-bound). Note: ckBTC is the same BTC market via the ICRC rail, **not** a separate "ckBTC market" — present it as BTC.
+6. **`client.activities` contract** — confirm the exact `client.activities.list(...)` request/response shape (and `client.history`) against the generated API reference — specifically that returned activity records key cleanly to the `external_refs` oisy stores (loan ref / activity id / tx_hash) so the poller can correlate SDK activity → `ActiveUserTransaction`. See "Sources of truth & reconciliation".
+7. **Health-factor band thresholds** — confirm Liquidium's exact amber/red "at risk" / "critical" cut-offs so oisy's health colours match the protocol's own notion of risk.
+
+---
+
+## Pending decisions (facts are clear — we just need to decide)
+
+The facts are understood; these need a product/architecture call.
+
+1. **Profile ownership** — SDK contract is confirmed (`getProfileId(walletAddress)`, `createProfile({ account, chain, walletAdapter })`, `prepareCreateProfile({ account })`; a profile is owned by a wallet `account` on a `chain`, creation signature-gated via `walletAdapter.signMessage(...)`; silent bootstrap specified in "Profile bootstrapping"). **Decide:** which oisy-controlled address (BTC vs. ETH) owns the Liquidium profile, and whether one profile across the user's assets is right vs. multiple linked wallets (`listLinkedWallets`). Distinct from the rail question above (this is about account ownership, not the funds rail).
+2. **EVM RPC config** — ETH/USDT(ERC) reads need an EVM RPC (`evmRpcUrl`/viem). **Decide:** reuse an existing oisy RPC config or add a `VITE_EVM_RPC_URL`. If absent, ETH-side pools degrade to "temporarily unavailable."
+3. **Withdraw destinations** — v1 keeps borrows/withdrawals to oisy-controlled addresses. **Decide:** whether external-address withdrawal (CEX/Ledger) is a v1 inclusion or a fast follow.
+4. **Active liquidation alerting** — v1 always shows the in-app health status (Liabilities tab + provider page) — decided. **Decide:** whether to add *active* alerting (push/email/in-wallet notification) as a fast-follow when health approaches the threshold.
+5. **Backend `ActiveUserTransactionData` variant** — the active-transactions mechanism requires the backend canister to add Liquidium variant(s) to the `ActiveUserTransactionData` Candid type (currently OneSec-only); this is a known prerequisite (Rust + `.did`) that must land before the FE wiring. **Decide:** the variant shape (per-action `LiquidiumSupply`/`Borrow`/`Repay`/`Withdraw` vs. one `Liquidium` variant with an action field). See "Asynchronous settlement & active transactions".
+6. **[PARKED — revisit] Risk on the hero/overview** — since debt grows on its own, **decide** whether to surface a small health indicator near the net-worth total (visible whenever the user holds debt), so a user who never opens the Liabilities tab is still warned. Deferred by request.
+
+---
+
+## References
+
+- Spec-driven workflow: [`docs/ai/spec-driven-development/workflow.md`](../workflow.md)
+- Template / sibling spec: [`2026-06-04-feat-limit-orders.md`](./2026-06-04-feat-limit-orders.md)
+- Wireframes: [`./2026-06-07-feat-liquidium-lend-borrow/wireframes/`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/) — Earn-page card ([`earn-card.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/earn-card.html)); Borrow page ([`borrow-page.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page.html), full-page incl. nav: [`borrow-page-full.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page-full.html)); Liquidium provider page ([`dashboard.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/dashboard.html)); flows ([`supply.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/supply.html), [`borrow.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow.html), [`repay.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/repay.html), [`withdraw.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/withdraw.html)); Assets-page tabs ([`earning-tab.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/earning-tab.html), [`liabilities-tab.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/liabilities-tab.html)); active transactions ([`active-transactions.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/active-transactions.html)); carousel slide ([`carousel-slide.html`](./2026-06-07-feat-liquidium-lend-borrow/wireframes/carousel-slide.html))
+- Liquidium SDK docs: https://liquidium-inc.github.io/liquidium-sdk/
+- Liquidium SDK (npm): https://www.npmjs.com/package/@liquidium/client
+- Liquidium core concepts: https://liquidium.fi/docs/quick-start/core-concepts

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/active-transactions.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/active-transactions.html
@@ -1,105 +1,394 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Active transactions — Liquidium (wireframe)</title>
-<style>
-:root{--bg:#e9eefb;--card:#ffffff;--line:#e5e9f2;--txt:#16203a;--muted:#737e91;--blue:#2f6df6;--blue-sub:#dce6fd;--green:#15a35b;--green-sub:#e6f7ee;--red:#df4a3c;--red-sub:#fce8e6}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif;min-height:100vh}
-svg{display:block}
-.wfbar{max-width:430px;margin:16px auto 0;background:#fff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#8a94a8;border:1px solid #c9d2e6;border-radius:5px;padding:1px 6px;margin-bottom:7px}
-.wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
-.wfbar .ctrls button{background:#f4f6fb;border:1px solid var(--line);color:var(--txt);border-radius:8px;padding:5px 10px;font-size:12px;cursor:pointer}
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Active transactions — Liquidium (wireframe)</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--card: #ffffff;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #737e91;
+				--blue: #2f6df6;
+				--blue-sub: #dce6fd;
+				--green: #15a35b;
+				--green-sub: #e6f7ee;
+				--red: #df4a3c;
+				--red-sub: #fce8e6;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+				min-height: 100vh;
+			}
+			svg {
+				display: block;
+			}
+			.wfbar {
+				max-width: 430px;
+				margin: 16px auto 0;
+				background: #fff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.wfbar .tag {
+				display: inline-block;
+				font-size: 10px;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+				color: #8a94a8;
+				border: 1px solid #c9d2e6;
+				border-radius: 5px;
+				padding: 1px 6px;
+				margin-bottom: 7px;
+			}
+			.wfbar .ctrls {
+				display: flex;
+				gap: 6px;
+				align-items: center;
+				margin-top: 10px;
+				flex-wrap: wrap;
+				padding-top: 9px;
+				border-top: 1px solid #eef1f7;
+			}
+			.wfbar .ctrls button {
+				background: #f4f6fb;
+				border: 1px solid var(--line);
+				color: var(--txt);
+				border-radius: 8px;
+				padding: 5px 10px;
+				font-size: 12px;
+				cursor: pointer;
+			}
 
-/* popover panel (opened from the Active-transactions button) */
-.panel{max-width:430px;margin:14px auto;background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:0 8px 30px rgba(20,30,60,.12);overflow:hidden}
-.phead{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}
-.phead .t{font-weight:700}
-.phead .bell{position:relative;width:34px;height:34px;border-radius:10px;border:1px solid var(--line);display:grid;place-items:center}
-.phead .bell svg{width:18px;height:18px;stroke:#16203a;fill:none;stroke-width:1.8}
-.phead .bell .b{position:absolute;top:-4px;right:-4px;min-width:16px;height:16px;border-radius:9px;background:var(--blue);color:#fff;font-size:10px;font-weight:700;display:grid;place-items:center;padding:0 4px}
-.body{padding:12px 14px}
-.sec{margin-bottom:16px}.sec:last-child{margin-bottom:0}
-.sec .h{font-size:13px;font-weight:700;margin-bottom:8px}
-ul{list-style:none;margin:0;padding:0}
-.item{display:flex;align-items:center;gap:12px;padding:9px 6px;border-radius:10px}
-.item:hover{background:#f7f9fc}
-.circle{position:relative;flex:0 0 40px;width:40px;height:40px;border-radius:50%;display:grid;place-items:center}
-.circle svg{width:20px;height:20px;fill:none;stroke-width:1.9;stroke-linecap:round;stroke-linejoin:round}
-.c-pending{background:var(--blue-sub);color:var(--blue)}.c-pending svg{stroke:var(--blue)}
-.c-ok{background:var(--green-sub);color:var(--green)}.c-ok svg{stroke:var(--green)}
-.c-fail{background:var(--red-sub);color:var(--red)}.c-fail svg{stroke:var(--red)}
-.unseen{position:absolute;top:0;left:0;width:9px;height:9px;border-radius:50%;background:var(--blue);box-shadow:0 0 0 2px #fff}
-.mid{flex:1;min-width:0}
-.title{font-size:14px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.sub{font-size:12px;color:var(--muted);display:flex;align-items:center;gap:6px}
-.dot{width:3px;height:3px;border-radius:50%;background:#c2cad8}
-.end{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:12px}
-.x{width:24px;height:24px;border-radius:7px;border:0;background:transparent;color:#9aa4b5;display:grid;place-items:center;cursor:pointer}
-.x:hover{background:#eef1f7}.x svg{width:15px;height:15px;stroke:currentColor;fill:none;stroke-width:2}
-.empty{text-align:center;opacity:.6;padding:18px 0}
-</style></head>
-<body>
-<div class="wfbar">
-  <span class="tag">Wireframe — controls below are not part of the UI</span>
-  <div>The <b>Active transactions</b> panel (opened from the header button), reusing the OneSec <code>ActiveUserTransactionItem</code> layout. Liquidium renders a <b>deposit (Supply)</b> and a <b>loan (Borrow)</b> as items here — status circle, title, "Liquidium · step" subtitle, relative time, dismiss when terminal. A OneSec swap is shown in "Previous" for parity. Native-BTC supply shows confirmation progress.</div>
-  <div class="ctrls"><span>Demo:</span><button id="advance">Advance BTC supply confirmations</button></div>
-</div>
+			/* popover panel (opened from the Active-transactions button) */
+			.panel {
+				max-width: 430px;
+				margin: 14px auto;
+				background: var(--card);
+				border: 1px solid var(--line);
+				border-radius: 16px;
+				box-shadow: 0 8px 30px rgba(20, 30, 60, 0.12);
+				overflow: hidden;
+			}
+			.phead {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 14px 16px;
+				border-bottom: 1px solid var(--line);
+			}
+			.phead .t {
+				font-weight: 700;
+			}
+			.phead .bell {
+				position: relative;
+				width: 34px;
+				height: 34px;
+				border-radius: 10px;
+				border: 1px solid var(--line);
+				display: grid;
+				place-items: center;
+			}
+			.phead .bell svg {
+				width: 18px;
+				height: 18px;
+				stroke: #16203a;
+				fill: none;
+				stroke-width: 1.8;
+			}
+			.phead .bell .b {
+				position: absolute;
+				top: -4px;
+				right: -4px;
+				min-width: 16px;
+				height: 16px;
+				border-radius: 9px;
+				background: var(--blue);
+				color: #fff;
+				font-size: 10px;
+				font-weight: 700;
+				display: grid;
+				place-items: center;
+				padding: 0 4px;
+			}
+			.body {
+				padding: 12px 14px;
+			}
+			.sec {
+				margin-bottom: 16px;
+			}
+			.sec:last-child {
+				margin-bottom: 0;
+			}
+			.sec .h {
+				font-size: 13px;
+				font-weight: 700;
+				margin-bottom: 8px;
+			}
+			ul {
+				list-style: none;
+				margin: 0;
+				padding: 0;
+			}
+			.item {
+				display: flex;
+				align-items: center;
+				gap: 12px;
+				padding: 9px 6px;
+				border-radius: 10px;
+			}
+			.item:hover {
+				background: #f7f9fc;
+			}
+			.circle {
+				position: relative;
+				flex: 0 0 40px;
+				width: 40px;
+				height: 40px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+			}
+			.circle svg {
+				width: 20px;
+				height: 20px;
+				fill: none;
+				stroke-width: 1.9;
+				stroke-linecap: round;
+				stroke-linejoin: round;
+			}
+			.c-pending {
+				background: var(--blue-sub);
+				color: var(--blue);
+			}
+			.c-pending svg {
+				stroke: var(--blue);
+			}
+			.c-ok {
+				background: var(--green-sub);
+				color: var(--green);
+			}
+			.c-ok svg {
+				stroke: var(--green);
+			}
+			.c-fail {
+				background: var(--red-sub);
+				color: var(--red);
+			}
+			.c-fail svg {
+				stroke: var(--red);
+			}
+			.unseen {
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 9px;
+				height: 9px;
+				border-radius: 50%;
+				background: var(--blue);
+				box-shadow: 0 0 0 2px #fff;
+			}
+			.mid {
+				flex: 1;
+				min-width: 0;
+			}
+			.title {
+				font-size: 14px;
+				font-weight: 600;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+			.sub {
+				font-size: 12px;
+				color: var(--muted);
+				display: flex;
+				align-items: center;
+				gap: 6px;
+			}
+			.dot {
+				width: 3px;
+				height: 3px;
+				border-radius: 50%;
+				background: #c2cad8;
+			}
+			.end {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.x {
+				width: 24px;
+				height: 24px;
+				border-radius: 7px;
+				border: 0;
+				background: transparent;
+				color: #9aa4b5;
+				display: grid;
+				place-items: center;
+				cursor: pointer;
+			}
+			.x:hover {
+				background: #eef1f7;
+			}
+			.x svg {
+				width: 15px;
+				height: 15px;
+				stroke: currentColor;
+				fill: none;
+				stroke-width: 2;
+			}
+			.empty {
+				text-align: center;
+				opacity: 0.6;
+				padding: 18px 0;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wfbar">
+			<span class="tag">Wireframe — controls below are not part of the UI</span>
+			<div>
+				The <b>Active transactions</b> panel (opened from the header button), reusing the OneSec
+				<code>ActiveUserTransactionItem</code> layout. Liquidium renders a
+				<b>deposit (Supply)</b> and a <b>loan (Borrow)</b> as items here — status circle, title,
+				"Liquidium · step" subtitle, relative time, dismiss when terminal. A OneSec swap is shown in
+				"Previous" for parity. Native-BTC supply shows confirmation progress.
+			</div>
+			<div class="ctrls">
+				<span>Demo:</span><button id="advance">Advance BTC supply confirmations</button>
+			</div>
+		</div>
 
-<div class="panel">
-  <div class="phead">
-    <span class="t">Active transactions</span>
-    <span class="bell"><svg viewBox="0 0 24 24"><path d="M6 9a6 6 0 0 1 12 0c0 4.5 2 5.5 2 5.5H4S6 13.5 6 9z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg><span class="b" id="badge">2</span></span>
-  </div>
-  <div class="body" id="body"></div>
-</div>
+		<div class="panel">
+			<div class="phead">
+				<span class="t">Active transactions</span>
+				<span class="bell"
+					><svg viewBox="0 0 24 24">
+						<path d="M6 9a6 6 0 0 1 12 0c0 4.5 2 5.5 2 5.5H4S6 13.5 6 9z" />
+						<path d="M10 19a2 2 0 0 0 4 0" /></svg
+					><span class="b" id="badge">2</span></span
+				>
+			</div>
+			<div class="body" id="body"></div>
+		</div>
 
-<script>
-  const convertIcon = '<svg viewBox="0 0 24 24"><path d="M4 9a8 8 0 0 1 13-3l3 3"/><path d="M20 5v4h-4"/><path d="M20 15a8 8 0 0 1-13 3l-3-3"/><path d="M4 19v-4h4"/></svg>';
-  const alertIcon = '<svg viewBox="0 0 24 24"><path d="M12 3l9 16H3z"/><path d="M12 10v4"/><path d="M12 17h.01"/></svg>';
-  const xIcon = '<svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18"/></svg>';
+		<script>
+			const convertIcon =
+				'<svg viewBox="0 0 24 24"><path d="M4 9a8 8 0 0 1 13-3l3 3"/><path d="M20 5v4h-4"/><path d="M20 15a8 8 0 0 1-13 3l-3-3"/><path d="M4 19v-4h4"/></svg>';
+			const alertIcon =
+				'<svg viewBox="0 0 24 24"><path d="M12 3l9 16H3z"/><path d="M12 10v4"/><path d="M12 17h.01"/></svg>';
+			const xIcon = '<svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18"/></svg>';
 
-  let txs = [
-    {id:'a', title:'Supply 0.25 BTC', provider:'Liquidium', step:'2 of 6 confirmations', status:'pending', time:'1m', unseen:true, conf:{n:2,t:6}},
-    {id:'b', title:'Borrow 20,000 USDC', provider:'Liquidium', step:'Processing', status:'pending', time:'30s', unseen:true},
-    {id:'c', title:'Supply 12,000 USDC', provider:'Liquidium', step:'Supplied', status:'ok', time:'2h', unseen:false},
-    {id:'d', title:'Swap 0.5 ETH → ckETH', provider:'OneSec', step:'Ethereum → Internet Computer', status:'ok', time:'1d', unseen:false, swap:true}
-  ];
+			let txs = [
+				{
+					id: 'a',
+					title: 'Supply 0.25 BTC',
+					provider: 'Liquidium',
+					step: '2 of 6 confirmations',
+					status: 'pending',
+					time: '1m',
+					unseen: true,
+					conf: { n: 2, t: 6 }
+				},
+				{
+					id: 'b',
+					title: 'Borrow 20,000 USDC',
+					provider: 'Liquidium',
+					step: 'Processing',
+					status: 'pending',
+					time: '30s',
+					unseen: true
+				},
+				{
+					id: 'c',
+					title: 'Supply 12,000 USDC',
+					provider: 'Liquidium',
+					step: 'Supplied',
+					status: 'ok',
+					time: '2h',
+					unseen: false
+				},
+				{
+					id: 'd',
+					title: 'Swap 0.5 ETH → ckETH',
+					provider: 'OneSec',
+					step: 'Ethereum → Internet Computer',
+					status: 'ok',
+					time: '1d',
+					unseen: false,
+					swap: true
+				}
+			];
 
-  function itemHtml(tx){
-    const cls = tx.status==='ok'?'c-ok':tx.status==='fail'?'c-fail':'c-pending';
-    const icon = tx.status==='fail'?alertIcon:convertIcon;
-    const terminal = tx.status==='ok'||tx.status==='fail';
-    // OneSec swap keeps "network → network · provider"; Liquidium uses "provider · step"
-    const sub = tx.swap
-      ? `<span>${tx.step}</span><span class="dot"></span><span>${tx.provider}</span>`
-      : `<span>${tx.provider}</span><span class="dot"></span><span>${tx.step}</span>`;
-    return `<li class="item">
-      <div class="circle ${cls}">${icon}${tx.unseen?'<span class="unseen"></span>':''}</div>
+			function itemHtml(tx) {
+				const cls = tx.status === 'ok' ? 'c-ok' : tx.status === 'fail' ? 'c-fail' : 'c-pending';
+				const icon = tx.status === 'fail' ? alertIcon : convertIcon;
+				const terminal = tx.status === 'ok' || tx.status === 'fail';
+				// OneSec swap keeps "network → network · provider"; Liquidium uses "provider · step"
+				const sub = tx.swap
+					? `<span>${tx.step}</span><span class="dot"></span><span>${tx.provider}</span>`
+					: `<span>${tx.provider}</span><span class="dot"></span><span>${tx.step}</span>`;
+				return `<li class="item">
+      <div class="circle ${cls}">${icon}${tx.unseen ? '<span class="unseen"></span>' : ''}</div>
       <div class="mid"><div class="title">${tx.title}</div><div class="sub">${sub}</div></div>
-      <div class="end"><span>${tx.time}</span>${terminal?`<button class="x" title="Dismiss">${xIcon}</button>`:''}</div>
+      <div class="end"><span>${tx.time}</span>${terminal ? `<button class="x" title="Dismiss">${xIcon}</button>` : ''}</div>
     </li>`;
-  }
-  function render(){
-    const groups = [
-      {h:'In progress', list:txs.filter(t=>t.status==='pending')},
-      {h:'Failed', list:txs.filter(t=>t.status==='fail')},
-      {h:'Previous', list:txs.filter(t=>t.status==='ok')}
-    ];
-    const body = document.getElementById('body');
-    if(txs.length===0){body.innerHTML='<p class="empty">You have no active transactions.</p>';return;}
-    body.innerHTML = groups.filter(g=>g.list.length).map(g=>
-      `<div class="sec"><div class="h">${g.h}</div><ul>${g.list.map(itemHtml).join('')}</ul></div>`).join('');
-    document.getElementById('badge').textContent = txs.filter(t=>t.unseen).length;
-    body.querySelectorAll('.x').forEach((b,i)=>{});
-  }
-  document.getElementById('advance').addEventListener('click',()=>{
-    const tx = txs.find(t=>t.id==='a'); if(!tx) return;
-    if(tx.status!=='pending') return;
-    tx.conf.n = Math.min(tx.conf.t, tx.conf.n+2);
-    if(tx.conf.n>=tx.conf.t){ tx.status='ok'; tx.step='Supplied'; tx.unseen=true; }
-    else { tx.step = `${tx.conf.n} of ${tx.conf.t} confirmations`; }
-    render();
-  });
-  render();
-</script>
-</body></html>
+			}
+			function render() {
+				const groups = [
+					{ h: 'In progress', list: txs.filter((t) => t.status === 'pending') },
+					{ h: 'Failed', list: txs.filter((t) => t.status === 'fail') },
+					{ h: 'Previous', list: txs.filter((t) => t.status === 'ok') }
+				];
+				const body = document.getElementById('body');
+				if (txs.length === 0) {
+					body.innerHTML = '<p class="empty">You have no active transactions.</p>';
+					return;
+				}
+				body.innerHTML = groups
+					.filter((g) => g.list.length)
+					.map(
+						(g) =>
+							`<div class="sec"><div class="h">${g.h}</div><ul>${g.list.map(itemHtml).join('')}</ul></div>`
+					)
+					.join('');
+				document.getElementById('badge').textContent = txs.filter((t) => t.unseen).length;
+				body.querySelectorAll('.x').forEach((b, i) => {});
+			}
+			document.getElementById('advance').addEventListener('click', () => {
+				const tx = txs.find((t) => t.id === 'a');
+				if (!tx) return;
+				if (tx.status !== 'pending') return;
+				tx.conf.n = Math.min(tx.conf.t, tx.conf.n + 2);
+				if (tx.conf.n >= tx.conf.t) {
+					tx.status = 'ok';
+					tx.step = 'Supplied';
+					tx.unseen = true;
+				} else {
+					tx.step = `${tx.conf.n} of ${tx.conf.t} confirmations`;
+				}
+				render();
+			});
+			render();
+		</script>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/active-transactions.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/active-transactions.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Active transactions — Liquidium (wireframe)</title>
+<style>
+:root{--bg:#e9eefb;--card:#ffffff;--line:#e5e9f2;--txt:#16203a;--muted:#737e91;--blue:#2f6df6;--blue-sub:#dce6fd;--green:#15a35b;--green-sub:#e6f7ee;--red:#df4a3c;--red-sub:#fce8e6}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif;min-height:100vh}
+svg{display:block}
+.wfbar{max-width:430px;margin:16px auto 0;background:#fff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#8a94a8;border:1px solid #c9d2e6;border-radius:5px;padding:1px 6px;margin-bottom:7px}
+.wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
+.wfbar .ctrls button{background:#f4f6fb;border:1px solid var(--line);color:var(--txt);border-radius:8px;padding:5px 10px;font-size:12px;cursor:pointer}
+
+/* popover panel (opened from the Active-transactions button) */
+.panel{max-width:430px;margin:14px auto;background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:0 8px 30px rgba(20,30,60,.12);overflow:hidden}
+.phead{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}
+.phead .t{font-weight:700}
+.phead .bell{position:relative;width:34px;height:34px;border-radius:10px;border:1px solid var(--line);display:grid;place-items:center}
+.phead .bell svg{width:18px;height:18px;stroke:#16203a;fill:none;stroke-width:1.8}
+.phead .bell .b{position:absolute;top:-4px;right:-4px;min-width:16px;height:16px;border-radius:9px;background:var(--blue);color:#fff;font-size:10px;font-weight:700;display:grid;place-items:center;padding:0 4px}
+.body{padding:12px 14px}
+.sec{margin-bottom:16px}.sec:last-child{margin-bottom:0}
+.sec .h{font-size:13px;font-weight:700;margin-bottom:8px}
+ul{list-style:none;margin:0;padding:0}
+.item{display:flex;align-items:center;gap:12px;padding:9px 6px;border-radius:10px}
+.item:hover{background:#f7f9fc}
+.circle{position:relative;flex:0 0 40px;width:40px;height:40px;border-radius:50%;display:grid;place-items:center}
+.circle svg{width:20px;height:20px;fill:none;stroke-width:1.9;stroke-linecap:round;stroke-linejoin:round}
+.c-pending{background:var(--blue-sub);color:var(--blue)}.c-pending svg{stroke:var(--blue)}
+.c-ok{background:var(--green-sub);color:var(--green)}.c-ok svg{stroke:var(--green)}
+.c-fail{background:var(--red-sub);color:var(--red)}.c-fail svg{stroke:var(--red)}
+.unseen{position:absolute;top:0;left:0;width:9px;height:9px;border-radius:50%;background:var(--blue);box-shadow:0 0 0 2px #fff}
+.mid{flex:1;min-width:0}
+.title{font-size:14px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.sub{font-size:12px;color:var(--muted);display:flex;align-items:center;gap:6px}
+.dot{width:3px;height:3px;border-radius:50%;background:#c2cad8}
+.end{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:12px}
+.x{width:24px;height:24px;border-radius:7px;border:0;background:transparent;color:#9aa4b5;display:grid;place-items:center;cursor:pointer}
+.x:hover{background:#eef1f7}.x svg{width:15px;height:15px;stroke:currentColor;fill:none;stroke-width:2}
+.empty{text-align:center;opacity:.6;padding:18px 0}
+</style></head>
+<body>
+<div class="wfbar">
+  <span class="tag">Wireframe — controls below are not part of the UI</span>
+  <div>The <b>Active transactions</b> panel (opened from the header button), reusing the OneSec <code>ActiveUserTransactionItem</code> layout. Liquidium renders a <b>deposit (Supply)</b> and a <b>loan (Borrow)</b> as items here — status circle, title, "Liquidium · step" subtitle, relative time, dismiss when terminal. A OneSec swap is shown in "Previous" for parity. Native-BTC supply shows confirmation progress.</div>
+  <div class="ctrls"><span>Demo:</span><button id="advance">Advance BTC supply confirmations</button></div>
+</div>
+
+<div class="panel">
+  <div class="phead">
+    <span class="t">Active transactions</span>
+    <span class="bell"><svg viewBox="0 0 24 24"><path d="M6 9a6 6 0 0 1 12 0c0 4.5 2 5.5 2 5.5H4S6 13.5 6 9z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg><span class="b" id="badge">2</span></span>
+  </div>
+  <div class="body" id="body"></div>
+</div>
+
+<script>
+  const convertIcon = '<svg viewBox="0 0 24 24"><path d="M4 9a8 8 0 0 1 13-3l3 3"/><path d="M20 5v4h-4"/><path d="M20 15a8 8 0 0 1-13 3l-3-3"/><path d="M4 19v-4h4"/></svg>';
+  const alertIcon = '<svg viewBox="0 0 24 24"><path d="M12 3l9 16H3z"/><path d="M12 10v4"/><path d="M12 17h.01"/></svg>';
+  const xIcon = '<svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18"/></svg>';
+
+  let txs = [
+    {id:'a', title:'Supply 0.25 BTC', provider:'Liquidium', step:'2 of 6 confirmations', status:'pending', time:'1m', unseen:true, conf:{n:2,t:6}},
+    {id:'b', title:'Borrow 20,000 USDC', provider:'Liquidium', step:'Processing', status:'pending', time:'30s', unseen:true},
+    {id:'c', title:'Supply 12,000 USDC', provider:'Liquidium', step:'Supplied', status:'ok', time:'2h', unseen:false},
+    {id:'d', title:'Swap 0.5 ETH → ckETH', provider:'OneSec', step:'Ethereum → Internet Computer', status:'ok', time:'1d', unseen:false, swap:true}
+  ];
+
+  function itemHtml(tx){
+    const cls = tx.status==='ok'?'c-ok':tx.status==='fail'?'c-fail':'c-pending';
+    const icon = tx.status==='fail'?alertIcon:convertIcon;
+    const terminal = tx.status==='ok'||tx.status==='fail';
+    // OneSec swap keeps "network → network · provider"; Liquidium uses "provider · step"
+    const sub = tx.swap
+      ? `<span>${tx.step}</span><span class="dot"></span><span>${tx.provider}</span>`
+      : `<span>${tx.provider}</span><span class="dot"></span><span>${tx.step}</span>`;
+    return `<li class="item">
+      <div class="circle ${cls}">${icon}${tx.unseen?'<span class="unseen"></span>':''}</div>
+      <div class="mid"><div class="title">${tx.title}</div><div class="sub">${sub}</div></div>
+      <div class="end"><span>${tx.time}</span>${terminal?`<button class="x" title="Dismiss">${xIcon}</button>`:''}</div>
+    </li>`;
+  }
+  function render(){
+    const groups = [
+      {h:'In progress', list:txs.filter(t=>t.status==='pending')},
+      {h:'Failed', list:txs.filter(t=>t.status==='fail')},
+      {h:'Previous', list:txs.filter(t=>t.status==='ok')}
+    ];
+    const body = document.getElementById('body');
+    if(txs.length===0){body.innerHTML='<p class="empty">You have no active transactions.</p>';return;}
+    body.innerHTML = groups.filter(g=>g.list.length).map(g=>
+      `<div class="sec"><div class="h">${g.h}</div><ul>${g.list.map(itemHtml).join('')}</ul></div>`).join('');
+    document.getElementById('badge').textContent = txs.filter(t=>t.unseen).length;
+    body.querySelectorAll('.x').forEach((b,i)=>{});
+  }
+  document.getElementById('advance').addEventListener('click',()=>{
+    const tx = txs.find(t=>t.id==='a'); if(!tx) return;
+    if(tx.status!=='pending') return;
+    tx.conf.n = Math.min(tx.conf.t, tx.conf.n+2);
+    if(tx.conf.n>=tx.conf.t){ tx.status='ok'; tx.step='Supplied'; tx.unseen=true; }
+    else { tx.step = `${tx.conf.n} of ${tx.conf.t} confirmations`; }
+    render();
+  });
+  render();
+</script>
+</body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page-full.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page-full.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>OISY — Borrow page (full)</title>
+<style>
+:root{--bg:#e7edfb;--card:#ffffff;--box:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#737e91;--blue:#2f6df6;--blue-soft:#dbe6fd;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
+*{box-sizing:border-box}html,body{margin:0}
+body{background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif;min-height:100vh}
+svg{display:block}
+.app{display:flex;min-height:100vh}
+
+/* sidebar */
+.side{width:266px;flex:0 0 266px;padding:22px 16px;display:flex;flex-direction:column}
+.brand{display:flex;align-items:center;gap:10px;padding:0 10px;margin-bottom:26px}
+.brand .mark{width:38px;height:38px;border-radius:50%;background:var(--blue);display:grid;place-items:center}
+.brand .mark svg{width:22px;height:22px;stroke:#fff;fill:none;stroke-width:2}
+.brand .name{font-weight:800;letter-spacing:.02em;line-height:1}
+.brand .name small{display:block;font-size:11px;font-weight:800;color:#16203a}
+.nav{display:flex;flex-direction:column;gap:4px}
+.nav a{display:flex;align-items:center;gap:13px;padding:11px 12px;border-radius:12px;color:#54607a;text-decoration:none;font-weight:600;font-size:15px}
+.nav a svg{width:21px;height:21px;stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+.nav a.on{background:var(--blue-soft);color:var(--blue)}
+.nav a:hover:not(.on){background:#eef2fb}
+.badge-new{margin-left:6px;background:#e5484d;color:#fff;font-size:10px;font-weight:800;letter-spacing:.04em;border-radius:6px;padding:2px 6px}
+.side .spacer{flex:1}
+.side .social{display:flex;gap:10px;padding:0 12px}
+.side .social a{width:30px;height:30px;border-radius:50%;background:#fff;display:grid;place-items:center;color:#16203a}
+.side .social svg{width:15px;height:15px;fill:currentColor}
+
+/* main */
+.main{flex:1;position:relative;padding:20px 26px 70px}
+.topbar{display:flex;justify-content:flex-end;align-items:center;gap:10px;margin-bottom:6px}
+.netpill{display:flex;align-items:center;gap:8px;background:#fff;border:1px solid var(--line);border-radius:12px;padding:9px 14px;font-weight:600;font-size:14px;box-shadow:0 1px 2px rgba(20,30,60,.05)}
+.netpill svg{width:16px;height:16px;stroke:#16203a;fill:none;stroke-width:1.8}
+.iconbtn{width:42px;height:42px;border-radius:12px;background:#fff;border:1px solid var(--line);display:grid;place-items:center;box-shadow:0 1px 2px rgba(20,30,60,.05);cursor:pointer}
+.iconbtn svg{width:19px;height:19px;stroke:#16203a;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+
+.content{max-width:600px;margin:6px auto 0}
+.section{background:var(--card);border-radius:18px;padding:22px;margin-bottom:18px;box-shadow:0 1px 3px rgba(20,30,60,.05)}
+.welcome{text-align:center}
+.welcome h2{margin:0 0 6px;font-size:21px}
+.welcome p{margin:0 auto 18px;color:var(--muted);font-size:14px;max-width:430px}
+.link{color:var(--blue);text-decoration:none;font-weight:600}
+.boxes{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.box{background:var(--box);border-radius:14px;padding:16px;text-align:center}
+.box .h{font-size:13px;font-weight:700;display:flex;gap:5px;justify-content:center;align-items:center}
+.box .h .q{width:15px;height:15px;border-radius:50%;border:1px solid var(--muted);color:var(--muted);font-size:10px;display:inline-grid;place-items:center}
+.box .big{font-size:23px;font-weight:800;margin-top:10px}
+.box .big.blue{color:var(--blue)}.box .big.cost{color:var(--red)}
+.box .sub{font-size:13px;color:#5d6678;margin-top:3px}
+.chip{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;font-weight:700;border-radius:999px;padding:3px 10px;margin-top:9px}
+.chip .d{width:7px;height:7px;border-radius:50%}
+.chip.ok{color:var(--green);background:#e6f7ee;border:1px solid #a8e0c2}.chip.ok .d{background:var(--green)}
+h4{margin:0 0 14px;font-size:16px}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.pcard{border:1px solid var(--line);border-radius:16px;padding:16px;display:flex;flex-direction:column;background:#fff}
+.top{display:flex;align-items:flex-start;margin-bottom:12px}
+.logo{width:44px;height:44px;border-radius:50%;display:grid;place-items:center;font-weight:700;background:#9b6cff;color:#fff;font-size:18px}
+.bdg{margin-left:auto;border:1px solid var(--line);border-radius:999px;padding:5px 11px;font-size:11.5px;white-space:nowrap}
+.bdg b{color:var(--amber);margin-left:3px}
+h3{margin:0 0 6px;font-size:19px}
+.desc{color:var(--muted);font-size:13px;margin:0 0 14px}
+.list{display:flex;flex-direction:column;gap:11px;font-size:13px;margin-bottom:16px}
+.li{display:flex;justify-content:space-between;align-items:center;border-top:1px solid var(--line);padding-top:11px}
+.li:first-child{border-top:0;padding-top:0}
+.li .k{color:var(--muted)}
+.li .v{font-weight:700}
+.li .v.cost{color:var(--red)}
+.icons{display:flex}
+.icons span{width:21px;height:21px;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:700;margin-left:-6px;border:2px solid #fff;color:#fff}
+.icons span:first-child{margin-left:0}
+.btc{background:#f7931a}.eth{background:#7b88a8}.usdc{background:#2775ca}.usdt{background:#26a17b}.net-eth{background:#3c3c4d}
+.cta{margin-top:auto;width:100%;background:var(--green);color:#fff;border:0;border-radius:12px;padding:13px;font-weight:700;font-size:15px;cursor:pointer}
+.ghost{border:1px dashed #c9d2e6;border-radius:16px;display:grid;place-items:center;color:var(--muted);font-size:13px;text-align:center;padding:20px}
+
+.footer{position:fixed;left:0;right:0;bottom:0;display:flex;justify-content:space-between;align-items:center;padding:14px 26px;font-size:12.5px;color:#5d6678}
+.footer .l{display:flex;gap:10px}
+.footer .l a{width:28px;height:28px;border-radius:50%;background:#fff;display:grid;place-items:center;color:#16203a}
+.footer .l svg{width:14px;height:14px;fill:currentColor}
+.footer .r{display:flex;align-items:center;gap:6px}
+.footer .r .inf{color:#2f6df6;font-weight:800}
+.footer .r .heart{color:#e5484d}
+.footer .r a{color:#2f6df6;text-decoration:none;font-weight:600}
+@media(max-width:900px){.side{display:none}}
+</style></head>
+<body>
+<div class="app">
+
+  <!-- SIDEBAR -->
+  <aside class="side">
+    <div class="brand">
+      <span class="mark"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7"/><path d="M9 12a3 3 0 0 1 6 0"/></svg></span>
+      <span class="name">OISY<small>WALLET</small></span>
+    </div>
+    <nav class="nav">
+      <a href="#"><svg viewBox="0 0 24 24"><rect x="3" y="6" width="18" height="13" rx="2.5"/><path d="M3 10h18"/><circle cx="16.5" cy="14" r="1.2"/></svg> Assets</a>
+      <a href="#"><svg viewBox="0 0 24 24"><path d="M3.5 12a8.5 8.5 0 1 0 2.8-6.3"/><path d="M3 4.5V8h3.5"/><path d="M12 8v4.2l3 1.8"/></svg> Activity</a>
+      <a href="#"><svg viewBox="0 0 24 24"><path d="M12 21v-8"/><path d="M12 13c0-3.3 2.2-5.5 5.5-5.5C17.5 10.8 15.3 13 12 13z"/><path d="M12 13c0-3.3-2.2-5.5-5.5-5.5C6.5 10.8 8.7 13 12 13z"/></svg> Earn</a>
+      <a class="on" href="#"><svg viewBox="0 0 24 24"><path d="M12 3v9"/><path d="M8 9l4 4 4-4"/><path d="M4 15v2.5A2.5 2.5 0 0 0 6.5 20h11a2.5 2.5 0 0 0 2.5-2.5V15"/></svg> Borrow <span class="badge-new">NEW</span></a>
+      <a href="#"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8.5"/><path d="M15.5 8.5l-2 5.5-5.5 2 2-5.5z"/></svg> Explore</a>
+    </nav>
+    <div class="spacer"></div>
+    <div class="social">
+      <a href="#" title="X"><svg viewBox="0 0 24 24"><path d="M3 3l7.5 9.8L3.4 21H6l5.6-6.4L16.3 21H21l-7.9-10.3L20.6 3H18l-5.2 5.9L8.4 3z"/></svg></a>
+      <a href="#" title="GitHub"><svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.300-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.6 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.3.2 2.3.1 2.6.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z"/></svg></a>
+    </div>
+  </aside>
+
+  <!-- MAIN -->
+  <main class="main">
+    <div class="topbar">
+      <span class="netpill"><svg viewBox="0 0 24 24"><path d="M7 7l-3 3 3 3M17 7l3 3-3 3M14 5l-4 14"/></svg> All networks <svg viewBox="0 0 24 24" style="width:14px;height:14px;margin-left:2px"><path d="M6 9l6 6 6-6"/></svg></span>
+      <button class="iconbtn" title="Notifications"><svg viewBox="0 0 24 24"><path d="M6 9a6 6 0 0 1 12 0c0 4.5 2 5.5 2 5.5H4S6 13.5 6 9z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg></button>
+      <button class="iconbtn" title="Scan"><svg viewBox="0 0 24 24"><path d="M4 8V6.5A2.5 2.5 0 0 1 6.5 4H8M16 4h1.5A2.5 2.5 0 0 1 20 6.5V8M20 16v1.5a2.5 2.5 0 0 1-2.5 2.5H16M8 20H6.5A2.5 2.5 0 0 1 4 17.5V16"/></svg></button>
+      <button class="iconbtn" title="Profile &amp; Settings"><svg viewBox="0 0 24 24"><circle cx="12" cy="8.5" r="3.8"/><path d="M4.5 20c0-4 3.7-6 7.5-6s7.5 2 7.5 6"/></svg></button>
+    </div>
+
+    <div class="content">
+
+      <div class="section welcome">
+        <h2>Welcome to Borrow!</h2>
+        <p>Access liquidity without selling — borrow stablecoins or BTC against your crypto. <a class="link" href="#">Learn more ↗</a></p>
+        <div class="boxes">
+          <div class="box">
+            <div class="h">Borrowing power <span class="q">?</span></div>
+            <div class="big blue">$12,019</div>
+            <div class="sub">remaining · best provider</div>
+          </div>
+          <div class="box">
+            <div class="h">Active loans</div>
+            <div class="big cost">− $2,590/year</div>
+            <div class="sub">$35,000 borrowed</div>
+            <div class="chip ok"><span class="d"></span>Healthy · 68%</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="section">
+        <h4>Borrowing options</h4>
+        <div class="grid">
+          <div class="pcard">
+            <div class="top">
+              <span class="logo">L</span>
+              <span class="bdg">Borrow APR from<b>0.94%</b></span>
+            </div>
+            <h3>Liquidium</h3>
+            <p class="desc">Borrow USDC, USDT or BTC against your supplied collateral.</p>
+            <div class="list">
+              <div class="li"><span class="k">Networks</span><span class="v"><span class="icons"><span class="btc">₿</span><span class="net-eth">◆</span></span></span></div>
+              <div class="li"><span class="k">Borrow assets</span><span class="v"><span class="icons"><span class="btc">B</span><span class="eth">E</span><span class="usdc">U</span><span class="usdt">T</span></span></span></div>
+              <div class="li"><span class="k">Currently borrowing</span><span class="v cost">− $35,000</span></div>
+              <div class="li"><span class="k">Interest / year</span><span class="v cost">− $2,590</span></div>
+            </div>
+            <button class="cta">Borrow</button>
+          </div>
+          <div class="ghost">More borrow providers<br/>coming soon</div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+</div>
+
+<div class="footer">
+  <div class="l">
+    <a href="#" title="X"><svg viewBox="0 0 24 24"><path d="M3 3l7.5 9.8L3.4 21H6l5.6-6.4L16.3 21H21l-7.9-10.3L20.6 3H18l-5.2 5.9L8.4 3z"/></svg></a>
+    <a href="#" title="GitHub"><svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.6 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.3.2 2.3.1 2.6.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z"/></svg></a>
+  </div>
+  <div class="r"><span class="inf">∞</span> Incubated with <span class="heart">♥</span> by <a href="#">DFINITY Foundation</a> © 2026</div>
+</div>
+</body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page-full.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page-full.html
@@ -1,170 +1,681 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>OISY — Borrow page (full)</title>
-<style>
-:root{--bg:#e7edfb;--card:#ffffff;--box:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#737e91;--blue:#2f6df6;--blue-soft:#dbe6fd;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
-*{box-sizing:border-box}html,body{margin:0}
-body{background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif;min-height:100vh}
-svg{display:block}
-.app{display:flex;min-height:100vh}
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>OISY — Borrow page (full)</title>
+		<style>
+			:root {
+				--bg: #e7edfb;
+				--card: #ffffff;
+				--box: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #737e91;
+				--blue: #2f6df6;
+				--blue-soft: #dbe6fd;
+				--green: #15a35b;
+				--amber: #d8890a;
+				--red: #df4a3c;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			html,
+			body {
+				margin: 0;
+			}
+			body {
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+				min-height: 100vh;
+			}
+			svg {
+				display: block;
+			}
+			.app {
+				display: flex;
+				min-height: 100vh;
+			}
 
-/* sidebar */
-.side{width:266px;flex:0 0 266px;padding:22px 16px;display:flex;flex-direction:column}
-.brand{display:flex;align-items:center;gap:10px;padding:0 10px;margin-bottom:26px}
-.brand .mark{width:38px;height:38px;border-radius:50%;background:var(--blue);display:grid;place-items:center}
-.brand .mark svg{width:22px;height:22px;stroke:#fff;fill:none;stroke-width:2}
-.brand .name{font-weight:800;letter-spacing:.02em;line-height:1}
-.brand .name small{display:block;font-size:11px;font-weight:800;color:#16203a}
-.nav{display:flex;flex-direction:column;gap:4px}
-.nav a{display:flex;align-items:center;gap:13px;padding:11px 12px;border-radius:12px;color:#54607a;text-decoration:none;font-weight:600;font-size:15px}
-.nav a svg{width:21px;height:21px;stroke:currentColor;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
-.nav a.on{background:var(--blue-soft);color:var(--blue)}
-.nav a:hover:not(.on){background:#eef2fb}
-.badge-new{margin-left:6px;background:#e5484d;color:#fff;font-size:10px;font-weight:800;letter-spacing:.04em;border-radius:6px;padding:2px 6px}
-.side .spacer{flex:1}
-.side .social{display:flex;gap:10px;padding:0 12px}
-.side .social a{width:30px;height:30px;border-radius:50%;background:#fff;display:grid;place-items:center;color:#16203a}
-.side .social svg{width:15px;height:15px;fill:currentColor}
+			/* sidebar */
+			.side {
+				width: 266px;
+				flex: 0 0 266px;
+				padding: 22px 16px;
+				display: flex;
+				flex-direction: column;
+			}
+			.brand {
+				display: flex;
+				align-items: center;
+				gap: 10px;
+				padding: 0 10px;
+				margin-bottom: 26px;
+			}
+			.brand .mark {
+				width: 38px;
+				height: 38px;
+				border-radius: 50%;
+				background: var(--blue);
+				display: grid;
+				place-items: center;
+			}
+			.brand .mark svg {
+				width: 22px;
+				height: 22px;
+				stroke: #fff;
+				fill: none;
+				stroke-width: 2;
+			}
+			.brand .name {
+				font-weight: 800;
+				letter-spacing: 0.02em;
+				line-height: 1;
+			}
+			.brand .name small {
+				display: block;
+				font-size: 11px;
+				font-weight: 800;
+				color: #16203a;
+			}
+			.nav {
+				display: flex;
+				flex-direction: column;
+				gap: 4px;
+			}
+			.nav a {
+				display: flex;
+				align-items: center;
+				gap: 13px;
+				padding: 11px 12px;
+				border-radius: 12px;
+				color: #54607a;
+				text-decoration: none;
+				font-weight: 600;
+				font-size: 15px;
+			}
+			.nav a svg {
+				width: 21px;
+				height: 21px;
+				stroke: currentColor;
+				fill: none;
+				stroke-width: 1.8;
+				stroke-linecap: round;
+				stroke-linejoin: round;
+			}
+			.nav a.on {
+				background: var(--blue-soft);
+				color: var(--blue);
+			}
+			.nav a:hover:not(.on) {
+				background: #eef2fb;
+			}
+			.badge-new {
+				margin-left: 6px;
+				background: #e5484d;
+				color: #fff;
+				font-size: 10px;
+				font-weight: 800;
+				letter-spacing: 0.04em;
+				border-radius: 6px;
+				padding: 2px 6px;
+			}
+			.side .spacer {
+				flex: 1;
+			}
+			.side .social {
+				display: flex;
+				gap: 10px;
+				padding: 0 12px;
+			}
+			.side .social a {
+				width: 30px;
+				height: 30px;
+				border-radius: 50%;
+				background: #fff;
+				display: grid;
+				place-items: center;
+				color: #16203a;
+			}
+			.side .social svg {
+				width: 15px;
+				height: 15px;
+				fill: currentColor;
+			}
 
-/* main */
-.main{flex:1;position:relative;padding:20px 26px 70px}
-.topbar{display:flex;justify-content:flex-end;align-items:center;gap:10px;margin-bottom:6px}
-.netpill{display:flex;align-items:center;gap:8px;background:#fff;border:1px solid var(--line);border-radius:12px;padding:9px 14px;font-weight:600;font-size:14px;box-shadow:0 1px 2px rgba(20,30,60,.05)}
-.netpill svg{width:16px;height:16px;stroke:#16203a;fill:none;stroke-width:1.8}
-.iconbtn{width:42px;height:42px;border-radius:12px;background:#fff;border:1px solid var(--line);display:grid;place-items:center;box-shadow:0 1px 2px rgba(20,30,60,.05);cursor:pointer}
-.iconbtn svg{width:19px;height:19px;stroke:#16203a;fill:none;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+			/* main */
+			.main {
+				flex: 1;
+				position: relative;
+				padding: 20px 26px 70px;
+			}
+			.topbar {
+				display: flex;
+				justify-content: flex-end;
+				align-items: center;
+				gap: 10px;
+				margin-bottom: 6px;
+			}
+			.netpill {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				background: #fff;
+				border: 1px solid var(--line);
+				border-radius: 12px;
+				padding: 9px 14px;
+				font-weight: 600;
+				font-size: 14px;
+				box-shadow: 0 1px 2px rgba(20, 30, 60, 0.05);
+			}
+			.netpill svg {
+				width: 16px;
+				height: 16px;
+				stroke: #16203a;
+				fill: none;
+				stroke-width: 1.8;
+			}
+			.iconbtn {
+				width: 42px;
+				height: 42px;
+				border-radius: 12px;
+				background: #fff;
+				border: 1px solid var(--line);
+				display: grid;
+				place-items: center;
+				box-shadow: 0 1px 2px rgba(20, 30, 60, 0.05);
+				cursor: pointer;
+			}
+			.iconbtn svg {
+				width: 19px;
+				height: 19px;
+				stroke: #16203a;
+				fill: none;
+				stroke-width: 1.8;
+				stroke-linecap: round;
+				stroke-linejoin: round;
+			}
 
-.content{max-width:600px;margin:6px auto 0}
-.section{background:var(--card);border-radius:18px;padding:22px;margin-bottom:18px;box-shadow:0 1px 3px rgba(20,30,60,.05)}
-.welcome{text-align:center}
-.welcome h2{margin:0 0 6px;font-size:21px}
-.welcome p{margin:0 auto 18px;color:var(--muted);font-size:14px;max-width:430px}
-.link{color:var(--blue);text-decoration:none;font-weight:600}
-.boxes{display:grid;grid-template-columns:1fr 1fr;gap:14px}
-.box{background:var(--box);border-radius:14px;padding:16px;text-align:center}
-.box .h{font-size:13px;font-weight:700;display:flex;gap:5px;justify-content:center;align-items:center}
-.box .h .q{width:15px;height:15px;border-radius:50%;border:1px solid var(--muted);color:var(--muted);font-size:10px;display:inline-grid;place-items:center}
-.box .big{font-size:23px;font-weight:800;margin-top:10px}
-.box .big.blue{color:var(--blue)}.box .big.cost{color:var(--red)}
-.box .sub{font-size:13px;color:#5d6678;margin-top:3px}
-.chip{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;font-weight:700;border-radius:999px;padding:3px 10px;margin-top:9px}
-.chip .d{width:7px;height:7px;border-radius:50%}
-.chip.ok{color:var(--green);background:#e6f7ee;border:1px solid #a8e0c2}.chip.ok .d{background:var(--green)}
-h4{margin:0 0 14px;font-size:16px}
-.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-.pcard{border:1px solid var(--line);border-radius:16px;padding:16px;display:flex;flex-direction:column;background:#fff}
-.top{display:flex;align-items:flex-start;margin-bottom:12px}
-.logo{width:44px;height:44px;border-radius:50%;display:grid;place-items:center;font-weight:700;background:#9b6cff;color:#fff;font-size:18px}
-.bdg{margin-left:auto;border:1px solid var(--line);border-radius:999px;padding:5px 11px;font-size:11.5px;white-space:nowrap}
-.bdg b{color:var(--amber);margin-left:3px}
-h3{margin:0 0 6px;font-size:19px}
-.desc{color:var(--muted);font-size:13px;margin:0 0 14px}
-.list{display:flex;flex-direction:column;gap:11px;font-size:13px;margin-bottom:16px}
-.li{display:flex;justify-content:space-between;align-items:center;border-top:1px solid var(--line);padding-top:11px}
-.li:first-child{border-top:0;padding-top:0}
-.li .k{color:var(--muted)}
-.li .v{font-weight:700}
-.li .v.cost{color:var(--red)}
-.icons{display:flex}
-.icons span{width:21px;height:21px;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:700;margin-left:-6px;border:2px solid #fff;color:#fff}
-.icons span:first-child{margin-left:0}
-.btc{background:#f7931a}.eth{background:#7b88a8}.usdc{background:#2775ca}.usdt{background:#26a17b}.net-eth{background:#3c3c4d}
-.cta{margin-top:auto;width:100%;background:var(--green);color:#fff;border:0;border-radius:12px;padding:13px;font-weight:700;font-size:15px;cursor:pointer}
-.ghost{border:1px dashed #c9d2e6;border-radius:16px;display:grid;place-items:center;color:var(--muted);font-size:13px;text-align:center;padding:20px}
+			.content {
+				max-width: 600px;
+				margin: 6px auto 0;
+			}
+			.section {
+				background: var(--card);
+				border-radius: 18px;
+				padding: 22px;
+				margin-bottom: 18px;
+				box-shadow: 0 1px 3px rgba(20, 30, 60, 0.05);
+			}
+			.welcome {
+				text-align: center;
+			}
+			.welcome h2 {
+				margin: 0 0 6px;
+				font-size: 21px;
+			}
+			.welcome p {
+				margin: 0 auto 18px;
+				color: var(--muted);
+				font-size: 14px;
+				max-width: 430px;
+			}
+			.link {
+				color: var(--blue);
+				text-decoration: none;
+				font-weight: 600;
+			}
+			.boxes {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				gap: 14px;
+			}
+			.box {
+				background: var(--box);
+				border-radius: 14px;
+				padding: 16px;
+				text-align: center;
+			}
+			.box .h {
+				font-size: 13px;
+				font-weight: 700;
+				display: flex;
+				gap: 5px;
+				justify-content: center;
+				align-items: center;
+			}
+			.box .h .q {
+				width: 15px;
+				height: 15px;
+				border-radius: 50%;
+				border: 1px solid var(--muted);
+				color: var(--muted);
+				font-size: 10px;
+				display: inline-grid;
+				place-items: center;
+			}
+			.box .big {
+				font-size: 23px;
+				font-weight: 800;
+				margin-top: 10px;
+			}
+			.box .big.blue {
+				color: var(--blue);
+			}
+			.box .big.cost {
+				color: var(--red);
+			}
+			.box .sub {
+				font-size: 13px;
+				color: #5d6678;
+				margin-top: 3px;
+			}
+			.chip {
+				display: inline-flex;
+				align-items: center;
+				gap: 6px;
+				font-size: 11.5px;
+				font-weight: 700;
+				border-radius: 999px;
+				padding: 3px 10px;
+				margin-top: 9px;
+			}
+			.chip .d {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+			}
+			.chip.ok {
+				color: var(--green);
+				background: #e6f7ee;
+				border: 1px solid #a8e0c2;
+			}
+			.chip.ok .d {
+				background: var(--green);
+			}
+			h4 {
+				margin: 0 0 14px;
+				font-size: 16px;
+			}
+			.grid {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				gap: 16px;
+			}
+			.pcard {
+				border: 1px solid var(--line);
+				border-radius: 16px;
+				padding: 16px;
+				display: flex;
+				flex-direction: column;
+				background: #fff;
+			}
+			.top {
+				display: flex;
+				align-items: flex-start;
+				margin-bottom: 12px;
+			}
+			.logo {
+				width: 44px;
+				height: 44px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				background: #9b6cff;
+				color: #fff;
+				font-size: 18px;
+			}
+			.bdg {
+				margin-left: auto;
+				border: 1px solid var(--line);
+				border-radius: 999px;
+				padding: 5px 11px;
+				font-size: 11.5px;
+				white-space: nowrap;
+			}
+			.bdg b {
+				color: var(--amber);
+				margin-left: 3px;
+			}
+			h3 {
+				margin: 0 0 6px;
+				font-size: 19px;
+			}
+			.desc {
+				color: var(--muted);
+				font-size: 13px;
+				margin: 0 0 14px;
+			}
+			.list {
+				display: flex;
+				flex-direction: column;
+				gap: 11px;
+				font-size: 13px;
+				margin-bottom: 16px;
+			}
+			.li {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				border-top: 1px solid var(--line);
+				padding-top: 11px;
+			}
+			.li:first-child {
+				border-top: 0;
+				padding-top: 0;
+			}
+			.li .k {
+				color: var(--muted);
+			}
+			.li .v {
+				font-weight: 700;
+			}
+			.li .v.cost {
+				color: var(--red);
+			}
+			.icons {
+				display: flex;
+			}
+			.icons span {
+				width: 21px;
+				height: 21px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-size: 10px;
+				font-weight: 700;
+				margin-left: -6px;
+				border: 2px solid #fff;
+				color: #fff;
+			}
+			.icons span:first-child {
+				margin-left: 0;
+			}
+			.btc {
+				background: #f7931a;
+			}
+			.eth {
+				background: #7b88a8;
+			}
+			.usdc {
+				background: #2775ca;
+			}
+			.usdt {
+				background: #26a17b;
+			}
+			.net-eth {
+				background: #3c3c4d;
+			}
+			.cta {
+				margin-top: auto;
+				width: 100%;
+				background: var(--green);
+				color: #fff;
+				border: 0;
+				border-radius: 12px;
+				padding: 13px;
+				font-weight: 700;
+				font-size: 15px;
+				cursor: pointer;
+			}
+			.ghost {
+				border: 1px dashed #c9d2e6;
+				border-radius: 16px;
+				display: grid;
+				place-items: center;
+				color: var(--muted);
+				font-size: 13px;
+				text-align: center;
+				padding: 20px;
+			}
 
-.footer{position:fixed;left:0;right:0;bottom:0;display:flex;justify-content:space-between;align-items:center;padding:14px 26px;font-size:12.5px;color:#5d6678}
-.footer .l{display:flex;gap:10px}
-.footer .l a{width:28px;height:28px;border-radius:50%;background:#fff;display:grid;place-items:center;color:#16203a}
-.footer .l svg{width:14px;height:14px;fill:currentColor}
-.footer .r{display:flex;align-items:center;gap:6px}
-.footer .r .inf{color:#2f6df6;font-weight:800}
-.footer .r .heart{color:#e5484d}
-.footer .r a{color:#2f6df6;text-decoration:none;font-weight:600}
-@media(max-width:900px){.side{display:none}}
-</style></head>
-<body>
-<div class="app">
+			.footer {
+				position: fixed;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				padding: 14px 26px;
+				font-size: 12.5px;
+				color: #5d6678;
+			}
+			.footer .l {
+				display: flex;
+				gap: 10px;
+			}
+			.footer .l a {
+				width: 28px;
+				height: 28px;
+				border-radius: 50%;
+				background: #fff;
+				display: grid;
+				place-items: center;
+				color: #16203a;
+			}
+			.footer .l svg {
+				width: 14px;
+				height: 14px;
+				fill: currentColor;
+			}
+			.footer .r {
+				display: flex;
+				align-items: center;
+				gap: 6px;
+			}
+			.footer .r .inf {
+				color: #2f6df6;
+				font-weight: 800;
+			}
+			.footer .r .heart {
+				color: #e5484d;
+			}
+			.footer .r a {
+				color: #2f6df6;
+				text-decoration: none;
+				font-weight: 600;
+			}
+			@media (max-width: 900px) {
+				.side {
+					display: none;
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div class="app">
+			<!-- SIDEBAR -->
+			<aside class="side">
+				<div class="brand">
+					<span class="mark"
+						><svg viewBox="0 0 24 24">
+							<circle cx="12" cy="12" r="7" />
+							<path d="M9 12a3 3 0 0 1 6 0" /></svg
+					></span>
+					<span class="name">OISY<small>WALLET</small></span>
+				</div>
+				<nav class="nav">
+					<a href="#"
+						><svg viewBox="0 0 24 24">
+							<rect x="3" y="6" width="18" height="13" rx="2.5" />
+							<path d="M3 10h18" />
+							<circle cx="16.5" cy="14" r="1.2" />
+						</svg>
+						Assets</a
+					>
+					<a href="#"
+						><svg viewBox="0 0 24 24">
+							<path d="M3.5 12a8.5 8.5 0 1 0 2.8-6.3" />
+							<path d="M3 4.5V8h3.5" />
+							<path d="M12 8v4.2l3 1.8" />
+						</svg>
+						Activity</a
+					>
+					<a href="#"
+						><svg viewBox="0 0 24 24">
+							<path d="M12 21v-8" />
+							<path d="M12 13c0-3.3 2.2-5.5 5.5-5.5C17.5 10.8 15.3 13 12 13z" />
+							<path d="M12 13c0-3.3-2.2-5.5-5.5-5.5C6.5 10.8 8.7 13 12 13z" />
+						</svg>
+						Earn</a
+					>
+					<a class="on" href="#"
+						><svg viewBox="0 0 24 24">
+							<path d="M12 3v9" />
+							<path d="M8 9l4 4 4-4" />
+							<path d="M4 15v2.5A2.5 2.5 0 0 0 6.5 20h11a2.5 2.5 0 0 0 2.5-2.5V15" />
+						</svg>
+						Borrow <span class="badge-new">NEW</span></a
+					>
+					<a href="#"
+						><svg viewBox="0 0 24 24">
+							<circle cx="12" cy="12" r="8.5" />
+							<path d="M15.5 8.5l-2 5.5-5.5 2 2-5.5z" />
+						</svg>
+						Explore</a
+					>
+				</nav>
+				<div class="spacer"></div>
+				<div class="social">
+					<a href="#" title="X"
+						><svg viewBox="0 0 24 24">
+							<path
+								d="M3 3l7.5 9.8L3.4 21H6l5.6-6.4L16.3 21H21l-7.9-10.3L20.6 3H18l-5.2 5.9L8.4 3z"
+							/></svg
+					></a>
+					<a href="#" title="GitHub"
+						><svg viewBox="0 0 24 24">
+							<path
+								d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.300-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.6 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.3.2 2.3.1 2.6.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z"
+							/></svg
+					></a>
+				</div>
+			</aside>
 
-  <!-- SIDEBAR -->
-  <aside class="side">
-    <div class="brand">
-      <span class="mark"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7"/><path d="M9 12a3 3 0 0 1 6 0"/></svg></span>
-      <span class="name">OISY<small>WALLET</small></span>
-    </div>
-    <nav class="nav">
-      <a href="#"><svg viewBox="0 0 24 24"><rect x="3" y="6" width="18" height="13" rx="2.5"/><path d="M3 10h18"/><circle cx="16.5" cy="14" r="1.2"/></svg> Assets</a>
-      <a href="#"><svg viewBox="0 0 24 24"><path d="M3.5 12a8.5 8.5 0 1 0 2.8-6.3"/><path d="M3 4.5V8h3.5"/><path d="M12 8v4.2l3 1.8"/></svg> Activity</a>
-      <a href="#"><svg viewBox="0 0 24 24"><path d="M12 21v-8"/><path d="M12 13c0-3.3 2.2-5.5 5.5-5.5C17.5 10.8 15.3 13 12 13z"/><path d="M12 13c0-3.3-2.2-5.5-5.5-5.5C6.5 10.8 8.7 13 12 13z"/></svg> Earn</a>
-      <a class="on" href="#"><svg viewBox="0 0 24 24"><path d="M12 3v9"/><path d="M8 9l4 4 4-4"/><path d="M4 15v2.5A2.5 2.5 0 0 0 6.5 20h11a2.5 2.5 0 0 0 2.5-2.5V15"/></svg> Borrow <span class="badge-new">NEW</span></a>
-      <a href="#"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8.5"/><path d="M15.5 8.5l-2 5.5-5.5 2 2-5.5z"/></svg> Explore</a>
-    </nav>
-    <div class="spacer"></div>
-    <div class="social">
-      <a href="#" title="X"><svg viewBox="0 0 24 24"><path d="M3 3l7.5 9.8L3.4 21H6l5.6-6.4L16.3 21H21l-7.9-10.3L20.6 3H18l-5.2 5.9L8.4 3z"/></svg></a>
-      <a href="#" title="GitHub"><svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.300-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.6 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.3.2 2.3.1 2.6.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z"/></svg></a>
-    </div>
-  </aside>
+			<!-- MAIN -->
+			<main class="main">
+				<div class="topbar">
+					<span class="netpill"
+						><svg viewBox="0 0 24 24"><path d="M7 7l-3 3 3 3M17 7l3 3-3 3M14 5l-4 14" /></svg> All
+						networks
+						<svg viewBox="0 0 24 24" style="width: 14px; height: 14px; margin-left: 2px">
+							<path d="M6 9l6 6 6-6" /></svg
+					></span>
+					<button class="iconbtn" title="Notifications">
+						<svg viewBox="0 0 24 24">
+							<path d="M6 9a6 6 0 0 1 12 0c0 4.5 2 5.5 2 5.5H4S6 13.5 6 9z" />
+							<path d="M10 19a2 2 0 0 0 4 0" />
+						</svg>
+					</button>
+					<button class="iconbtn" title="Scan">
+						<svg viewBox="0 0 24 24">
+							<path
+								d="M4 8V6.5A2.5 2.5 0 0 1 6.5 4H8M16 4h1.5A2.5 2.5 0 0 1 20 6.5V8M20 16v1.5a2.5 2.5 0 0 1-2.5 2.5H16M8 20H6.5A2.5 2.5 0 0 1 4 17.5V16"
+							/>
+						</svg>
+					</button>
+					<button class="iconbtn" title="Profile &amp; Settings">
+						<svg viewBox="0 0 24 24">
+							<circle cx="12" cy="8.5" r="3.8" />
+							<path d="M4.5 20c0-4 3.7-6 7.5-6s7.5 2 7.5 6" />
+						</svg>
+					</button>
+				</div>
 
-  <!-- MAIN -->
-  <main class="main">
-    <div class="topbar">
-      <span class="netpill"><svg viewBox="0 0 24 24"><path d="M7 7l-3 3 3 3M17 7l3 3-3 3M14 5l-4 14"/></svg> All networks <svg viewBox="0 0 24 24" style="width:14px;height:14px;margin-left:2px"><path d="M6 9l6 6 6-6"/></svg></span>
-      <button class="iconbtn" title="Notifications"><svg viewBox="0 0 24 24"><path d="M6 9a6 6 0 0 1 12 0c0 4.5 2 5.5 2 5.5H4S6 13.5 6 9z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg></button>
-      <button class="iconbtn" title="Scan"><svg viewBox="0 0 24 24"><path d="M4 8V6.5A2.5 2.5 0 0 1 6.5 4H8M16 4h1.5A2.5 2.5 0 0 1 20 6.5V8M20 16v1.5a2.5 2.5 0 0 1-2.5 2.5H16M8 20H6.5A2.5 2.5 0 0 1 4 17.5V16"/></svg></button>
-      <button class="iconbtn" title="Profile &amp; Settings"><svg viewBox="0 0 24 24"><circle cx="12" cy="8.5" r="3.8"/><path d="M4.5 20c0-4 3.7-6 7.5-6s7.5 2 7.5 6"/></svg></button>
-    </div>
+				<div class="content">
+					<div class="section welcome">
+						<h2>Welcome to Borrow!</h2>
+						<p>
+							Access liquidity without selling — borrow stablecoins or BTC against your crypto.
+							<a class="link" href="#">Learn more ↗</a>
+						</p>
+						<div class="boxes">
+							<div class="box">
+								<div class="h">Borrowing power <span class="q">?</span></div>
+								<div class="big blue">$12,019</div>
+								<div class="sub">remaining · best provider</div>
+							</div>
+							<div class="box">
+								<div class="h">Active loans</div>
+								<div class="big cost">− $2,590/year</div>
+								<div class="sub">$35,000 borrowed</div>
+								<div class="chip ok"><span class="d"></span>Healthy · 68%</div>
+							</div>
+						</div>
+					</div>
 
-    <div class="content">
+					<div class="section">
+						<h4>Borrowing options</h4>
+						<div class="grid">
+							<div class="pcard">
+								<div class="top">
+									<span class="logo">L</span>
+									<span class="bdg">Borrow APR from<b>0.94%</b></span>
+								</div>
+								<h3>Liquidium</h3>
+								<p class="desc">Borrow USDC, USDT or BTC against your supplied collateral.</p>
+								<div class="list">
+									<div class="li">
+										<span class="k">Networks</span
+										><span class="v"
+											><span class="icons"
+												><span class="btc">₿</span><span class="net-eth">◆</span></span
+											></span
+										>
+									</div>
+									<div class="li">
+										<span class="k">Borrow assets</span
+										><span class="v"
+											><span class="icons"
+												><span class="btc">B</span><span class="eth">E</span
+												><span class="usdc">U</span><span class="usdt">T</span></span
+											></span
+										>
+									</div>
+									<div class="li">
+										<span class="k">Currently borrowing</span><span class="v cost">− $35,000</span>
+									</div>
+									<div class="li">
+										<span class="k">Interest / year</span><span class="v cost">− $2,590</span>
+									</div>
+								</div>
+								<button class="cta">Borrow</button>
+							</div>
+							<div class="ghost">More borrow providers<br />coming soon</div>
+						</div>
+					</div>
+				</div>
+			</main>
+		</div>
 
-      <div class="section welcome">
-        <h2>Welcome to Borrow!</h2>
-        <p>Access liquidity without selling — borrow stablecoins or BTC against your crypto. <a class="link" href="#">Learn more ↗</a></p>
-        <div class="boxes">
-          <div class="box">
-            <div class="h">Borrowing power <span class="q">?</span></div>
-            <div class="big blue">$12,019</div>
-            <div class="sub">remaining · best provider</div>
-          </div>
-          <div class="box">
-            <div class="h">Active loans</div>
-            <div class="big cost">− $2,590/year</div>
-            <div class="sub">$35,000 borrowed</div>
-            <div class="chip ok"><span class="d"></span>Healthy · 68%</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="section">
-        <h4>Borrowing options</h4>
-        <div class="grid">
-          <div class="pcard">
-            <div class="top">
-              <span class="logo">L</span>
-              <span class="bdg">Borrow APR from<b>0.94%</b></span>
-            </div>
-            <h3>Liquidium</h3>
-            <p class="desc">Borrow USDC, USDT or BTC against your supplied collateral.</p>
-            <div class="list">
-              <div class="li"><span class="k">Networks</span><span class="v"><span class="icons"><span class="btc">₿</span><span class="net-eth">◆</span></span></span></div>
-              <div class="li"><span class="k">Borrow assets</span><span class="v"><span class="icons"><span class="btc">B</span><span class="eth">E</span><span class="usdc">U</span><span class="usdt">T</span></span></span></div>
-              <div class="li"><span class="k">Currently borrowing</span><span class="v cost">− $35,000</span></div>
-              <div class="li"><span class="k">Interest / year</span><span class="v cost">− $2,590</span></div>
-            </div>
-            <button class="cta">Borrow</button>
-          </div>
-          <div class="ghost">More borrow providers<br/>coming soon</div>
-        </div>
-      </div>
-
-    </div>
-  </main>
-</div>
-
-<div class="footer">
-  <div class="l">
-    <a href="#" title="X"><svg viewBox="0 0 24 24"><path d="M3 3l7.5 9.8L3.4 21H6l5.6-6.4L16.3 21H21l-7.9-10.3L20.6 3H18l-5.2 5.9L8.4 3z"/></svg></a>
-    <a href="#" title="GitHub"><svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.6 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.3.2 2.3.1 2.6.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z"/></svg></a>
-  </div>
-  <div class="r"><span class="inf">∞</span> Incubated with <span class="heart">♥</span> by <a href="#">DFINITY Foundation</a> © 2026</div>
-</div>
-</body></html>
+		<div class="footer">
+			<div class="l">
+				<a href="#" title="X"
+					><svg viewBox="0 0 24 24">
+						<path
+							d="M3 3l7.5 9.8L3.4 21H6l5.6-6.4L16.3 21H21l-7.9-10.3L20.6 3H18l-5.2 5.9L8.4 3z"
+						/></svg
+				></a>
+				<a href="#" title="GitHub"
+					><svg viewBox="0 0 24 24">
+						<path
+							d="M12 2a10 10 0 0 0-3.2 19.5c.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.3-3.4-1.3-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.6 0 0 .8-.3 2.7 1a9.4 9.4 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.3.2 2.3.1 2.6.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5A10 10 0 0 0 12 2z"
+						/></svg
+				></a>
+			</div>
+			<div class="r">
+				<span class="inf">∞</span> Incubated with <span class="heart">♥</span> by
+				<a href="#">DFINITY Foundation</a> © 2026
+			</div>
+		</div>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page.html
@@ -1,139 +1,476 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Borrow page — wireframe</title>
-<style>
-:root{--bg:#e9eefb;--card:#ffffff;--box:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--blue:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
-.wfbar{max-width:640px;margin:14px auto 0;background:#fff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#8a94a8;border:1px solid #c9d2e6;border-radius:5px;padding:1px 6px;margin-bottom:7px}
-.wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
-.wfbar .ctrls button{background:#f4f6fb;border:1px solid var(--line);color:var(--muted);border-radius:8px;padding:4px 10px;font-size:12px;cursor:pointer}
-.wfbar .ctrls button.on{color:var(--txt);border-color:var(--blue)}
-.wrap{max-width:640px;margin:0 auto;padding:16px}
-.section{background:var(--card);border-radius:16px;padding:20px;margin-bottom:16px;box-shadow:0 1px 2px rgba(20,30,60,.04)}
-.welcome{text-align:center}
-.welcome h2{margin:0 0 6px;font-size:20px}
-.welcome p{margin:0 auto 16px;color:var(--muted);font-size:13.5px;max-width:440px}
-.link{color:var(--blue);text-decoration:none}
-.boxes{display:grid;grid-template-columns:1fr 1fr;gap:12px}
-.box{background:var(--box);border-radius:12px;padding:14px;text-align:center}
-.box .h{font-size:13px;font-weight:600;display:flex;gap:5px;justify-content:center;align-items:center}
-.box .h .q{width:14px;height:14px;border-radius:50%;border:1px solid var(--muted);color:var(--muted);font-size:10px;display:inline-grid;place-items:center}
-.box .big{font-size:22px;font-weight:700;margin-top:8px}
-.box .big.blue{color:var(--blue)}.box .big.cost{color:var(--red)}
-.box .sub{font-size:13px;color:var(--muted);margin-top:2px}
-.chip{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;font-weight:600;border-radius:999px;padding:2px 9px;margin-top:8px}
-.chip .d{width:7px;height:7px;border-radius:50%}
-.chip.ok{color:var(--green);background:#e6f7ee}.chip.ok .d{background:var(--green)}
-.chip.amber{color:var(--amber);background:#fbf1de}.chip.amber .d{background:var(--amber)}
-.chip.red{color:var(--red);background:#fce8e6}.chip.red .d{background:var(--red)}
-h4{margin:0 0 14px;font-size:16px}
-.grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
-@media(max-width:520px){.boxes,.grid{grid-template-columns:1fr}}
-.pcard{border:1px solid var(--line);border-radius:14px;padding:15px;display:flex;flex-direction:column;background:#fff}
-.top{display:flex;align-items:flex-start;margin-bottom:12px}
-.logo{width:42px;height:42px;border-radius:50%;display:grid;place-items:center;font-weight:700;background:#9b6cff;color:#fff}
-.badge{margin-left:auto;border:1px solid var(--line);border-radius:999px;padding:4px 11px;font-size:11.5px;white-space:nowrap}
-.badge b{color:var(--amber);margin-left:3px}
-h3{margin:0 0 6px;font-size:19px}
-.desc{color:var(--muted);font-size:13px;margin:0 0 14px}
-.list{display:flex;flex-direction:column;gap:10px;font-size:13px;margin-bottom:16px}
-.li{display:flex;justify-content:space-between;align-items:center;border-top:1px solid var(--line);padding-top:10px}
-.li:first-child{border-top:0;padding-top:0}
-.li .k{color:var(--muted)}
-.li .v{font-weight:700}
-.li .v.cost{color:var(--red)}
-.icons{display:flex}
-.icons span{width:20px;height:20px;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:700;margin-left:-6px;border:2px solid #fff}
-.icons span:first-child{margin-left:0}
-.btc{background:#f7931a;color:#fff}.eth{background:#8a93b2;color:#fff}.usdc{background:#2775ca;color:#fff}.usdt{background:#26a17b;color:#fff}
-.net-btc{background:#f7931a;color:#fff}.net-eth{background:#3c3c4d;color:#fff}
-.cta{margin-top:auto;width:100%;background:var(--green);color:#fff;border:0;border-radius:10px;padding:12px;font-weight:700;font-size:14px;cursor:pointer}
-.ghost{border:1px dashed #c9d2e6;border-radius:14px;display:grid;place-items:center;color:var(--muted);font-size:13px;text-align:center;padding:20px}
-.hide{display:none}
-</style></head><body>
-<div class="wfbar">
-  <span class="tag">Wireframe — controls below are not part of the UI</span>
-  <div>The new top-level <b>Borrow</b> page (<code>/borrow/</code>), mirroring the Earn page skeleton. Header boxes: <b>Borrowing power</b> (potential, best provider) and <b>Active loans</b> (total + interest/year + <b>worst health</b> across accounts). Below: the borrow-framed <b>Liquidium card</b> (borrow tokens + rates) → opens <code>/providers/liquidium/</code>.</div>
-  <div class="ctrls"><span>Demo · your state:</span>
-    <button data-s="none" class="on">No loans</button>
-    <button data-s="healthy">Active · healthy</button>
-    <button data-s="atrisk">Active · at risk</button>
-  </div>
-</div>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Borrow page — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--card: #ffffff;
+				--box: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--blue: #2f6df6;
+				--green: #15a35b;
+				--amber: #d8890a;
+				--red: #df4a3c;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+			}
+			.wfbar {
+				max-width: 640px;
+				margin: 14px auto 0;
+				background: #fff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.wfbar .tag {
+				display: inline-block;
+				font-size: 10px;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+				color: #8a94a8;
+				border: 1px solid #c9d2e6;
+				border-radius: 5px;
+				padding: 1px 6px;
+				margin-bottom: 7px;
+			}
+			.wfbar .ctrls {
+				display: flex;
+				gap: 6px;
+				align-items: center;
+				margin-top: 10px;
+				flex-wrap: wrap;
+				padding-top: 9px;
+				border-top: 1px solid #eef1f7;
+			}
+			.wfbar .ctrls button {
+				background: #f4f6fb;
+				border: 1px solid var(--line);
+				color: var(--muted);
+				border-radius: 8px;
+				padding: 4px 10px;
+				font-size: 12px;
+				cursor: pointer;
+			}
+			.wfbar .ctrls button.on {
+				color: var(--txt);
+				border-color: var(--blue);
+			}
+			.wrap {
+				max-width: 640px;
+				margin: 0 auto;
+				padding: 16px;
+			}
+			.section {
+				background: var(--card);
+				border-radius: 16px;
+				padding: 20px;
+				margin-bottom: 16px;
+				box-shadow: 0 1px 2px rgba(20, 30, 60, 0.04);
+			}
+			.welcome {
+				text-align: center;
+			}
+			.welcome h2 {
+				margin: 0 0 6px;
+				font-size: 20px;
+			}
+			.welcome p {
+				margin: 0 auto 16px;
+				color: var(--muted);
+				font-size: 13.5px;
+				max-width: 440px;
+			}
+			.link {
+				color: var(--blue);
+				text-decoration: none;
+			}
+			.boxes {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				gap: 12px;
+			}
+			.box {
+				background: var(--box);
+				border-radius: 12px;
+				padding: 14px;
+				text-align: center;
+			}
+			.box .h {
+				font-size: 13px;
+				font-weight: 600;
+				display: flex;
+				gap: 5px;
+				justify-content: center;
+				align-items: center;
+			}
+			.box .h .q {
+				width: 14px;
+				height: 14px;
+				border-radius: 50%;
+				border: 1px solid var(--muted);
+				color: var(--muted);
+				font-size: 10px;
+				display: inline-grid;
+				place-items: center;
+			}
+			.box .big {
+				font-size: 22px;
+				font-weight: 700;
+				margin-top: 8px;
+			}
+			.box .big.blue {
+				color: var(--blue);
+			}
+			.box .big.cost {
+				color: var(--red);
+			}
+			.box .sub {
+				font-size: 13px;
+				color: var(--muted);
+				margin-top: 2px;
+			}
+			.chip {
+				display: inline-flex;
+				align-items: center;
+				gap: 6px;
+				font-size: 11.5px;
+				font-weight: 600;
+				border-radius: 999px;
+				padding: 2px 9px;
+				margin-top: 8px;
+			}
+			.chip .d {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+			}
+			.chip.ok {
+				color: var(--green);
+				background: #e6f7ee;
+			}
+			.chip.ok .d {
+				background: var(--green);
+			}
+			.chip.amber {
+				color: var(--amber);
+				background: #fbf1de;
+			}
+			.chip.amber .d {
+				background: var(--amber);
+			}
+			.chip.red {
+				color: var(--red);
+				background: #fce8e6;
+			}
+			.chip.red .d {
+				background: var(--red);
+			}
+			h4 {
+				margin: 0 0 14px;
+				font-size: 16px;
+			}
+			.grid {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				gap: 14px;
+			}
+			@media (max-width: 520px) {
+				.boxes,
+				.grid {
+					grid-template-columns: 1fr;
+				}
+			}
+			.pcard {
+				border: 1px solid var(--line);
+				border-radius: 14px;
+				padding: 15px;
+				display: flex;
+				flex-direction: column;
+				background: #fff;
+			}
+			.top {
+				display: flex;
+				align-items: flex-start;
+				margin-bottom: 12px;
+			}
+			.logo {
+				width: 42px;
+				height: 42px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				background: #9b6cff;
+				color: #fff;
+			}
+			.badge {
+				margin-left: auto;
+				border: 1px solid var(--line);
+				border-radius: 999px;
+				padding: 4px 11px;
+				font-size: 11.5px;
+				white-space: nowrap;
+			}
+			.badge b {
+				color: var(--amber);
+				margin-left: 3px;
+			}
+			h3 {
+				margin: 0 0 6px;
+				font-size: 19px;
+			}
+			.desc {
+				color: var(--muted);
+				font-size: 13px;
+				margin: 0 0 14px;
+			}
+			.list {
+				display: flex;
+				flex-direction: column;
+				gap: 10px;
+				font-size: 13px;
+				margin-bottom: 16px;
+			}
+			.li {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				border-top: 1px solid var(--line);
+				padding-top: 10px;
+			}
+			.li:first-child {
+				border-top: 0;
+				padding-top: 0;
+			}
+			.li .k {
+				color: var(--muted);
+			}
+			.li .v {
+				font-weight: 700;
+			}
+			.li .v.cost {
+				color: var(--red);
+			}
+			.icons {
+				display: flex;
+			}
+			.icons span {
+				width: 20px;
+				height: 20px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-size: 10px;
+				font-weight: 700;
+				margin-left: -6px;
+				border: 2px solid #fff;
+			}
+			.icons span:first-child {
+				margin-left: 0;
+			}
+			.btc {
+				background: #f7931a;
+				color: #fff;
+			}
+			.eth {
+				background: #8a93b2;
+				color: #fff;
+			}
+			.usdc {
+				background: #2775ca;
+				color: #fff;
+			}
+			.usdt {
+				background: #26a17b;
+				color: #fff;
+			}
+			.net-btc {
+				background: #f7931a;
+				color: #fff;
+			}
+			.net-eth {
+				background: #3c3c4d;
+				color: #fff;
+			}
+			.cta {
+				margin-top: auto;
+				width: 100%;
+				background: var(--green);
+				color: #fff;
+				border: 0;
+				border-radius: 10px;
+				padding: 12px;
+				font-weight: 700;
+				font-size: 14px;
+				cursor: pointer;
+			}
+			.ghost {
+				border: 1px dashed #c9d2e6;
+				border-radius: 14px;
+				display: grid;
+				place-items: center;
+				color: var(--muted);
+				font-size: 13px;
+				text-align: center;
+				padding: 20px;
+			}
+			.hide {
+				display: none;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wfbar">
+			<span class="tag">Wireframe — controls below are not part of the UI</span>
+			<div>
+				The new top-level <b>Borrow</b> page (<code>/borrow/</code>), mirroring the Earn page
+				skeleton. Header boxes: <b>Borrowing power</b> (potential, best provider) and
+				<b>Active loans</b> (total + interest/year + <b>worst health</b> across accounts). Below:
+				the borrow-framed <b>Liquidium card</b> (borrow tokens + rates) → opens
+				<code>/providers/liquidium/</code>.
+			</div>
+			<div class="ctrls">
+				<span>Demo · your state:</span>
+				<button data-s="none" class="on">No loans</button>
+				<button data-s="healthy">Active · healthy</button>
+				<button data-s="atrisk">Active · at risk</button>
+			</div>
+		</div>
 
-<div class="wrap">
+		<div class="wrap">
+			<!-- Header section -->
+			<div class="section welcome">
+				<h2>Welcome to Borrow!</h2>
+				<p>
+					Access liquidity without selling — borrow stablecoins or BTC against your crypto.
+					<a class="link" href="#">Learn more ↗</a>
+				</p>
+				<div class="boxes">
+					<div class="box">
+						<div class="h">Borrowing power <span class="q">?</span></div>
+						<div class="big blue" id="power">$47,019</div>
+						<div class="sub" id="powerSub">available · best provider</div>
+					</div>
+					<div class="box">
+						<div class="h">Active loans</div>
+						<div class="big cost" id="loanYr">$0.00</div>
+						<div class="sub" id="loanTot">no active loans</div>
+						<div class="chip ok hide" id="health">
+							<span class="d"></span><span id="healthText">Healthy · 68%</span>
+						</div>
+					</div>
+				</div>
+			</div>
 
-  <!-- Header section -->
-  <div class="section welcome">
-    <h2>Welcome to Borrow!</h2>
-    <p>Access liquidity without selling — borrow stablecoins or BTC against your crypto. <a class="link" href="#">Learn more ↗</a></p>
-    <div class="boxes">
-      <div class="box">
-        <div class="h">Borrowing power <span class="q">?</span></div>
-        <div class="big blue" id="power">$47,019</div>
-        <div class="sub" id="powerSub">available · best provider</div>
-      </div>
-      <div class="box">
-        <div class="h">Active loans</div>
-        <div class="big cost" id="loanYr">$0.00</div>
-        <div class="sub" id="loanTot">no active loans</div>
-        <div class="chip ok hide" id="health"><span class="d"></span><span id="healthText">Healthy · 68%</span></div>
-      </div>
-    </div>
-  </div>
+			<!-- Opportunities section -->
+			<div class="section">
+				<h4>Borrowing options</h4>
+				<div class="grid">
+					<div class="pcard">
+						<div class="top">
+							<span class="logo">L</span>
+							<span class="badge">Borrow APR from<b>0.94%</b></span>
+						</div>
+						<h3>Liquidium</h3>
+						<p class="desc">Borrow USDC, USDT or BTC against your supplied collateral.</p>
+						<div class="list" id="cardList">
+							<div class="li">
+								<span class="k">Networks</span
+								><span class="v"
+									><span class="icons"
+										><span class="net-btc">₿</span><span class="net-eth">◆</span></span
+									></span
+								>
+							</div>
+							<div class="li">
+								<span class="k">Borrow assets</span
+								><span class="v"
+									><span class="icons"
+										><span class="btc">B</span><span class="eth">E</span><span class="usdc">U</span
+										><span class="usdt">T</span></span
+									></span
+								>
+							</div>
+							<!-- position rows injected -->
+						</div>
+						<button class="cta">Borrow</button>
+					</div>
 
-  <!-- Opportunities section -->
-  <div class="section">
-    <h4>Borrowing options</h4>
-    <div class="grid">
+					<div class="ghost">More borrow providers<br />coming soon</div>
+				</div>
+			</div>
+		</div>
 
-      <div class="pcard">
-        <div class="top">
-          <span class="logo">L</span>
-          <span class="badge">Borrow APR from<b>0.94%</b></span>
-        </div>
-        <h3>Liquidium</h3>
-        <p class="desc">Borrow USDC, USDT or BTC against your supplied collateral.</p>
-        <div class="list" id="cardList">
-          <div class="li"><span class="k">Networks</span><span class="v"><span class="icons"><span class="net-btc">₿</span><span class="net-eth">◆</span></span></span></div>
-          <div class="li"><span class="k">Borrow assets</span><span class="v"><span class="icons"><span class="btc">B</span><span class="eth">E</span><span class="usdc">U</span><span class="usdt">T</span></span></span></div>
-          <!-- position rows injected -->
-        </div>
-        <button class="cta">Borrow</button>
-      </div>
-
-      <div class="ghost">More borrow providers<br/>coming soon</div>
-
-    </div>
-  </div>
-
-</div>
-
-<script>
-  const data = {
-    none:    {power:'$47,019', powerSub:'available · best provider', loanYr:'$0.00', loanTot:'no active loans', health:null, rows:''},
-    healthy: {power:'$12,019', powerSub:'remaining · best provider', loanYr:'− $2,590/year', loanTot:'$35,000 borrowed', health:{b:'ok',t:'Healthy · 68%'},
-              rows:`<div class="li"><span class="k">Currently borrowing</span><span class="v cost">− $35,000</span></div><div class="li"><span class="k">Interest / year</span><span class="v cost">− $2,590</span></div>`},
-    atrisk:  {power:'$1,140', powerSub:'remaining · best provider', loanYr:'− $2,590/year', loanTot:'$35,000 borrowed', health:{b:'amber',t:'At risk · 16%'},
-              rows:`<div class="li"><span class="k">Currently borrowing</span><span class="v cost">− $35,000</span></div><div class="li"><span class="k">Interest / year</span><span class="v cost">− $2,590</span></div>`}
-  };
-  const baseRows = document.getElementById('cardList').innerHTML;
-  function render(s){
-    const d = data[s];
-    document.getElementById('power').textContent = d.power;
-    document.getElementById('powerSub').textContent = d.powerSub;
-    document.getElementById('loanYr').textContent = d.loanYr;
-    document.getElementById('loanTot').textContent = d.loanTot;
-    const h = document.getElementById('health');
-    if(d.health){ h.className='chip '+d.health.b; document.getElementById('healthText').textContent=d.health.t; }
-    else { h.className='chip ok hide'; }
-    document.getElementById('cardList').innerHTML = baseRows + d.rows;
-  }
-  document.querySelectorAll('.ctrls button').forEach(b=>b.addEventListener('click',()=>{
-    document.querySelectorAll('.ctrls button').forEach(x=>x.classList.remove('on'));
-    b.classList.add('on'); render(b.dataset.s);
-  }));
-  render('none');
-</script>
-</body></html>
+		<script>
+			const data = {
+				none: {
+					power: '$47,019',
+					powerSub: 'available · best provider',
+					loanYr: '$0.00',
+					loanTot: 'no active loans',
+					health: null,
+					rows: ''
+				},
+				healthy: {
+					power: '$12,019',
+					powerSub: 'remaining · best provider',
+					loanYr: '− $2,590/year',
+					loanTot: '$35,000 borrowed',
+					health: { b: 'ok', t: 'Healthy · 68%' },
+					rows: `<div class="li"><span class="k">Currently borrowing</span><span class="v cost">− $35,000</span></div><div class="li"><span class="k">Interest / year</span><span class="v cost">− $2,590</span></div>`
+				},
+				atrisk: {
+					power: '$1,140',
+					powerSub: 'remaining · best provider',
+					loanYr: '− $2,590/year',
+					loanTot: '$35,000 borrowed',
+					health: { b: 'amber', t: 'At risk · 16%' },
+					rows: `<div class="li"><span class="k">Currently borrowing</span><span class="v cost">− $35,000</span></div><div class="li"><span class="k">Interest / year</span><span class="v cost">− $2,590</span></div>`
+				}
+			};
+			const baseRows = document.getElementById('cardList').innerHTML;
+			function render(s) {
+				const d = data[s];
+				document.getElementById('power').textContent = d.power;
+				document.getElementById('powerSub').textContent = d.powerSub;
+				document.getElementById('loanYr').textContent = d.loanYr;
+				document.getElementById('loanTot').textContent = d.loanTot;
+				const h = document.getElementById('health');
+				if (d.health) {
+					h.className = 'chip ' + d.health.b;
+					document.getElementById('healthText').textContent = d.health.t;
+				} else {
+					h.className = 'chip ok hide';
+				}
+				document.getElementById('cardList').innerHTML = baseRows + d.rows;
+			}
+			document.querySelectorAll('.ctrls button').forEach((b) =>
+				b.addEventListener('click', () => {
+					document.querySelectorAll('.ctrls button').forEach((x) => x.classList.remove('on'));
+					b.classList.add('on');
+					render(b.dataset.s);
+				})
+			);
+			render('none');
+		</script>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow-page.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Borrow page — wireframe</title>
+<style>
+:root{--bg:#e9eefb;--card:#ffffff;--box:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--blue:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
+.wfbar{max-width:640px;margin:14px auto 0;background:#fff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#8a94a8;border:1px solid #c9d2e6;border-radius:5px;padding:1px 6px;margin-bottom:7px}
+.wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
+.wfbar .ctrls button{background:#f4f6fb;border:1px solid var(--line);color:var(--muted);border-radius:8px;padding:4px 10px;font-size:12px;cursor:pointer}
+.wfbar .ctrls button.on{color:var(--txt);border-color:var(--blue)}
+.wrap{max-width:640px;margin:0 auto;padding:16px}
+.section{background:var(--card);border-radius:16px;padding:20px;margin-bottom:16px;box-shadow:0 1px 2px rgba(20,30,60,.04)}
+.welcome{text-align:center}
+.welcome h2{margin:0 0 6px;font-size:20px}
+.welcome p{margin:0 auto 16px;color:var(--muted);font-size:13.5px;max-width:440px}
+.link{color:var(--blue);text-decoration:none}
+.boxes{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+.box{background:var(--box);border-radius:12px;padding:14px;text-align:center}
+.box .h{font-size:13px;font-weight:600;display:flex;gap:5px;justify-content:center;align-items:center}
+.box .h .q{width:14px;height:14px;border-radius:50%;border:1px solid var(--muted);color:var(--muted);font-size:10px;display:inline-grid;place-items:center}
+.box .big{font-size:22px;font-weight:700;margin-top:8px}
+.box .big.blue{color:var(--blue)}.box .big.cost{color:var(--red)}
+.box .sub{font-size:13px;color:var(--muted);margin-top:2px}
+.chip{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;font-weight:600;border-radius:999px;padding:2px 9px;margin-top:8px}
+.chip .d{width:7px;height:7px;border-radius:50%}
+.chip.ok{color:var(--green);background:#e6f7ee}.chip.ok .d{background:var(--green)}
+.chip.amber{color:var(--amber);background:#fbf1de}.chip.amber .d{background:var(--amber)}
+.chip.red{color:var(--red);background:#fce8e6}.chip.red .d{background:var(--red)}
+h4{margin:0 0 14px;font-size:16px}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+@media(max-width:520px){.boxes,.grid{grid-template-columns:1fr}}
+.pcard{border:1px solid var(--line);border-radius:14px;padding:15px;display:flex;flex-direction:column;background:#fff}
+.top{display:flex;align-items:flex-start;margin-bottom:12px}
+.logo{width:42px;height:42px;border-radius:50%;display:grid;place-items:center;font-weight:700;background:#9b6cff;color:#fff}
+.badge{margin-left:auto;border:1px solid var(--line);border-radius:999px;padding:4px 11px;font-size:11.5px;white-space:nowrap}
+.badge b{color:var(--amber);margin-left:3px}
+h3{margin:0 0 6px;font-size:19px}
+.desc{color:var(--muted);font-size:13px;margin:0 0 14px}
+.list{display:flex;flex-direction:column;gap:10px;font-size:13px;margin-bottom:16px}
+.li{display:flex;justify-content:space-between;align-items:center;border-top:1px solid var(--line);padding-top:10px}
+.li:first-child{border-top:0;padding-top:0}
+.li .k{color:var(--muted)}
+.li .v{font-weight:700}
+.li .v.cost{color:var(--red)}
+.icons{display:flex}
+.icons span{width:20px;height:20px;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:700;margin-left:-6px;border:2px solid #fff}
+.icons span:first-child{margin-left:0}
+.btc{background:#f7931a;color:#fff}.eth{background:#8a93b2;color:#fff}.usdc{background:#2775ca;color:#fff}.usdt{background:#26a17b;color:#fff}
+.net-btc{background:#f7931a;color:#fff}.net-eth{background:#3c3c4d;color:#fff}
+.cta{margin-top:auto;width:100%;background:var(--green);color:#fff;border:0;border-radius:10px;padding:12px;font-weight:700;font-size:14px;cursor:pointer}
+.ghost{border:1px dashed #c9d2e6;border-radius:14px;display:grid;place-items:center;color:var(--muted);font-size:13px;text-align:center;padding:20px}
+.hide{display:none}
+</style></head><body>
+<div class="wfbar">
+  <span class="tag">Wireframe — controls below are not part of the UI</span>
+  <div>The new top-level <b>Borrow</b> page (<code>/borrow/</code>), mirroring the Earn page skeleton. Header boxes: <b>Borrowing power</b> (potential, best provider) and <b>Active loans</b> (total + interest/year + <b>worst health</b> across accounts). Below: the borrow-framed <b>Liquidium card</b> (borrow tokens + rates) → opens <code>/providers/liquidium/</code>.</div>
+  <div class="ctrls"><span>Demo · your state:</span>
+    <button data-s="none" class="on">No loans</button>
+    <button data-s="healthy">Active · healthy</button>
+    <button data-s="atrisk">Active · at risk</button>
+  </div>
+</div>
+
+<div class="wrap">
+
+  <!-- Header section -->
+  <div class="section welcome">
+    <h2>Welcome to Borrow!</h2>
+    <p>Access liquidity without selling — borrow stablecoins or BTC against your crypto. <a class="link" href="#">Learn more ↗</a></p>
+    <div class="boxes">
+      <div class="box">
+        <div class="h">Borrowing power <span class="q">?</span></div>
+        <div class="big blue" id="power">$47,019</div>
+        <div class="sub" id="powerSub">available · best provider</div>
+      </div>
+      <div class="box">
+        <div class="h">Active loans</div>
+        <div class="big cost" id="loanYr">$0.00</div>
+        <div class="sub" id="loanTot">no active loans</div>
+        <div class="chip ok hide" id="health"><span class="d"></span><span id="healthText">Healthy · 68%</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Opportunities section -->
+  <div class="section">
+    <h4>Borrowing options</h4>
+    <div class="grid">
+
+      <div class="pcard">
+        <div class="top">
+          <span class="logo">L</span>
+          <span class="badge">Borrow APR from<b>0.94%</b></span>
+        </div>
+        <h3>Liquidium</h3>
+        <p class="desc">Borrow USDC, USDT or BTC against your supplied collateral.</p>
+        <div class="list" id="cardList">
+          <div class="li"><span class="k">Networks</span><span class="v"><span class="icons"><span class="net-btc">₿</span><span class="net-eth">◆</span></span></span></div>
+          <div class="li"><span class="k">Borrow assets</span><span class="v"><span class="icons"><span class="btc">B</span><span class="eth">E</span><span class="usdc">U</span><span class="usdt">T</span></span></span></div>
+          <!-- position rows injected -->
+        </div>
+        <button class="cta">Borrow</button>
+      </div>
+
+      <div class="ghost">More borrow providers<br/>coming soon</div>
+
+    </div>
+  </div>
+
+</div>
+
+<script>
+  const data = {
+    none:    {power:'$47,019', powerSub:'available · best provider', loanYr:'$0.00', loanTot:'no active loans', health:null, rows:''},
+    healthy: {power:'$12,019', powerSub:'remaining · best provider', loanYr:'− $2,590/year', loanTot:'$35,000 borrowed', health:{b:'ok',t:'Healthy · 68%'},
+              rows:`<div class="li"><span class="k">Currently borrowing</span><span class="v cost">− $35,000</span></div><div class="li"><span class="k">Interest / year</span><span class="v cost">− $2,590</span></div>`},
+    atrisk:  {power:'$1,140', powerSub:'remaining · best provider', loanYr:'− $2,590/year', loanTot:'$35,000 borrowed', health:{b:'amber',t:'At risk · 16%'},
+              rows:`<div class="li"><span class="k">Currently borrowing</span><span class="v cost">− $35,000</span></div><div class="li"><span class="k">Interest / year</span><span class="v cost">− $2,590</span></div>`}
+  };
+  const baseRows = document.getElementById('cardList').innerHTML;
+  function render(s){
+    const d = data[s];
+    document.getElementById('power').textContent = d.power;
+    document.getElementById('powerSub').textContent = d.powerSub;
+    document.getElementById('loanYr').textContent = d.loanYr;
+    document.getElementById('loanTot').textContent = d.loanTot;
+    const h = document.getElementById('health');
+    if(d.health){ h.className='chip '+d.health.b; document.getElementById('healthText').textContent=d.health.t; }
+    else { h.className='chip ok hide'; }
+    document.getElementById('cardList').innerHTML = baseRows + d.rows;
+  }
+  document.querySelectorAll('.ctrls button').forEach(b=>b.addEventListener('click',()=>{
+    document.querySelectorAll('.ctrls button').forEach(x=>x.classList.remove('on'));
+    b.classList.add('on'); render(b.dataset.s);
+  }));
+  render('none');
+</script>
+</body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Borrow flow — wireframe</title>
+<style>
+  :root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+  .wfbar{max-width:460px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+  .wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#6b7787;border:1px solid #b9c4dd;border-radius:5px;padding:1px 6px;margin-bottom:7px}
+  .wfbar .ctrls{display:flex;gap:10px;align-items:center;margin-top:10px;padding-top:9px;border-top:1px solid #eef1f7}
+  .wfbar .ctrls span{white-space:nowrap}
+  .modal{max-width:460px;margin:14px auto;background:var(--panel);border:1px solid var(--line);border-radius:16px;overflow:hidden}
+  .head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}
+  .head h2{font-size:16px;margin:0}
+  .steps{display:flex;gap:6px}
+  .dot{width:7px;height:7px;border-radius:50%;background:var(--line)}
+  .dot.on{background:var(--accent)}
+  .body{padding:16px}
+  .field{background:var(--panel2);border:1px solid var(--line);border-radius:12px;padding:12px;margin-bottom:12px}
+  .field .top{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}
+  .field .mid{display:flex;align-items:center;justify-content:space-between;margin-top:6px}
+  input{background:transparent;border:0;color:var(--txt);font-size:24px;width:60%;outline:none}
+  .selpill{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-weight:600}
+  .coin{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:11px}
+  .usdc{background:#2775ca;color:#fff}.btc{background:#f7931a;color:#0e1218}
+  .infoline{display:flex;justify-content:space-between;font-size:12.5px;color:var(--muted);padding:6px 2px}
+  .infoline b{color:var(--txt);font-weight:600}
+  .hfbar{height:8px;border-radius:6px;background:linear-gradient(90deg,var(--red),var(--amber) 45%,var(--green));position:relative;margin:8px 0 4px}
+  .hfbar .mark{position:absolute;top:-3px;width:3px;height:14px;background:#fff;border-radius:2px;transition:left .15s}
+  .warn{border-radius:10px;padding:10px 12px;font-size:12.5px;margin:10px 0;display:none}
+  .warn.amber{background:#fbf1de;border:1px solid #ecd29a;color:#8a5d05;display:block}
+  .warn.red{background:#fce8e6;border:1px solid #f3b6ad;color:#b5392c;display:block}
+  .warn label{display:flex;gap:8px;align-items:flex-start;margin-top:8px;cursor:pointer}
+  .err{color:var(--red);font-size:12px;margin:6px 2px;display:none}
+  button{font:inherit;cursor:pointer}
+  .btn{width:100%;background:var(--accent);color:#fff;border:0;border-radius:11px;padding:13px;font-weight:600;font-size:15px}
+  .btn:disabled{opacity:.4;cursor:not-allowed}
+  .foot{padding:0 16px 16px;display:flex;gap:10px}
+  .btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
+  .hero{text-align:center;padding:8px 0 14px}
+  .hero .big{font-size:30px;font-weight:700}
+  .hide{display:none}
+  .rr{display:flex;justify-content:space-between;padding:9px 0;border-top:1px solid var(--line);font-size:13.5px}
+  .rr:first-child{border-top:0}
+  .spin{width:34px;height:34px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;margin:18px auto;animation:s 1s linear infinite}
+  @keyframes s{to{transform:rotate(360deg)}}
+</style>
+</head>
+<body>
+<div class="wfbar">
+  <span class="tag">Wireframe — controls below are not part of the UI</span>
+  <div>Borrow flow (Form → Review → Progress). Collateral: 1 BTC ($67,170). LTV, projected health factor, and the warning/confirmation thresholds update live (same logic as <code>client.quote.calculateLtv</code>). You can also type in the "You borrow" field.</div>
+  <div class="ctrls"><span>Demo · borrow amount:</span>
+    <input id="slider" type="range" min="0" max="50000" step="500" value="20000" style="flex:1"/>
+  </div>
+</div>
+
+<div class="modal">
+  <div class="head">
+    <h2 id="title">Borrow</h2>
+    <div class="steps"><span class="dot on" id="d0"></span><span class="dot" id="d1"></span><span class="dot" id="d2"></span></div>
+  </div>
+
+  <!-- FORM -->
+  <div id="form">
+    <div class="body">
+      <div class="infoline"><span>Collateral</span><b>1 BTC · $67,170</b></div>
+      <div class="infoline"><span>Borrowing power (max LTV 70%)</span><b>$47,019</b></div>
+
+      <div class="field">
+        <div class="top"><span>You borrow</span><span>min 1.00 USDC</span></div>
+        <div class="mid">
+          <input id="amt" type="number" value="20000" min="0"/>
+          <span class="selpill"><span class="coin usdc">U</span>USDC</span>
+        </div>
+        <div class="infoline" style="padding-top:8px"><span id="fiat">$20,000.00</span><span>Borrow APY <b style="color:var(--amber)">7.40%</b></span></div>
+      </div>
+
+      <div class="infoline"><span>Resulting LTV</span><b id="ltv">29.8%</b></div>
+      <div class="infoline"><span>Projected health factor</span><b id="hfval" style="color:var(--green)">76%</b></div>
+      <div class="hfbar"><div class="mark" id="mark" style="left:76%"></div></div>
+
+      <div class="err" id="err">Borrow exceeds max LTV for this collateral.</div>
+      <div class="warn" id="warn">
+        <span id="warntext"></span>
+        <label id="confirmWrap" class="hide"><input type="checkbox" id="confirm"/> I understand this borrow puts my position at high liquidation risk.</label>
+      </div>
+      <div class="infoline" style="color:var(--muted)"><span>Borrowing reduces your health factor. If it falls too far your collateral can be liquidated.</span></div>
+    </div>
+    <div class="foot"><button class="btn" id="toReview">Review</button></div>
+  </div>
+
+  <!-- REVIEW -->
+  <div id="review" class="hide">
+    <div class="body">
+      <div class="hero"><div class="muted">You borrow</div><div class="big" id="rAmt">20,000 USDC</div><div class="muted" id="rFiat">$20,000.00</div></div>
+      <div class="rr"><span class="muted">Borrow APY</span><b style="color:var(--amber)">7.40%</b></div>
+      <div class="rr"><span class="muted">Resulting LTV</span><b id="rLtv">29.8%</b></div>
+      <div class="rr"><span class="muted">Projected health factor</span><b id="rHf" style="color:var(--green)">76%</b></div>
+      <div class="rr"><span class="muted">Provider</span><b>Liquidium</b></div>
+      <div class="rr"><span class="muted">Funds delivered to</span><b>Your oisy address</b></div>
+      <div class="warn" id="rWarn"><span id="rWarnText"></span></div>
+    </div>
+    <div class="foot"><button class="btn ghost" id="back">Back</button><button class="btn" id="place">Borrow</button></div>
+  </div>
+
+  <!-- PROGRESS -->
+  <div id="progress" class="hide">
+    <div class="body" style="text-align:center">
+      <div class="spin"></div>
+      <div id="progText">Submitting borrow to Liquidium…</div>
+      <div class="muted small" style="margin-top:6px">client.lending.borrow(...)</div>
+    </div>
+  </div>
+</div>
+
+<script>
+  const COLLAT=67170, MAXLTV=0.70, LIQ=0.80; // liquidation threshold
+  const amt=document.getElementById('amt'), slider=document.getElementById('slider');
+  function calc(v){
+    const ltv=v/COLLAT;                 // borrow / collateral
+    // health factor % shown by Liquidium: 100% = no debt, ->0% as ltv -> liquidation threshold
+    const hf=Math.max(0, Math.round((1 - ltv/LIQ)*100));
+    return {ltv,hf};
+  }
+  function band(hf){ if(hf<20) return 'red'; if(hf<45) return 'amber'; return 'ok'; }
+  function color(hf){ return hf<20?'var(--red)':hf<45?'var(--amber)':'var(--green)'; }
+  function update(v){
+    const {ltv,hf}=calc(v);
+    document.getElementById('fiat').textContent='$'+v.toLocaleString('en-US',{minimumFractionDigits:2});
+    document.getElementById('ltv').textContent=(ltv*100).toFixed(1)+'%';
+    const hfval=document.getElementById('hfval'); hfval.textContent=hf+'%'; hfval.style.color=color(hf);
+    document.getElementById('mark').style.left=hf+'%';
+    const over = ltv>MAXLTV;
+    document.getElementById('err').style.display=over?'block':'none';
+    const w=document.getElementById('warn'), wt=document.getElementById('warntext'), cw=document.getElementById('confirmWrap'), cb=document.getElementById('confirm');
+    const b=band(hf);
+    w.className='warn'+(over?'':(b==='red'?' red':b==='amber'?' amber':''));
+    if(!over && b==='red'){wt.textContent='This borrow puts your position close to liquidation. ';cw.classList.remove('hide');}
+    else if(!over && b==='amber'){wt.textContent='This borrow noticeably lowers your health factor.';cw.classList.add('hide');cb.checked=false;}
+    else {cw.classList.add('hide');cb.checked=false;}
+    document.getElementById('toReview').disabled = over || v<=0 || (b==='red' && !cb.checked);
+  }
+  amt.addEventListener('input',()=>{slider.value=Math.min(50000,amt.value||0);update(+amt.value||0);});
+  slider.addEventListener('input',()=>{amt.value=slider.value;update(+slider.value);});
+  document.getElementById('confirm').addEventListener('change',()=>update(+amt.value||0));
+
+  function show(id){['form','review','progress'].forEach((s,i)=>{document.getElementById(s).classList.toggle('hide',s!==id);document.getElementById('d'+i).classList.toggle('on', ['form','review','progress'].indexOf(id)>=i);});}
+  document.getElementById('toReview').addEventListener('click',()=>{
+    const v=+amt.value||0,{ltv,hf}=calc(v);
+    document.getElementById('rAmt').textContent=v.toLocaleString('en-US')+' USDC';
+    document.getElementById('rFiat').textContent='$'+v.toLocaleString('en-US',{minimumFractionDigits:2});
+    document.getElementById('rLtv').textContent=(ltv*100).toFixed(1)+'%';
+    const rhf=document.getElementById('rHf');rhf.textContent=hf+'%';rhf.style.color=color(hf);
+    const rw=document.getElementById('rWarn');const b=band(hf);
+    rw.className='warn'+(b==='red'?' red':b==='amber'?' amber':'');
+    document.getElementById('rWarnText').textContent = b==='red'?'High liquidation risk — monitor your position closely.':b==='amber'?'This borrow lowers your health factor.':'';
+    document.getElementById('title').textContent='Review borrow';
+    show('review');
+  });
+  document.getElementById('back').addEventListener('click',()=>{document.getElementById('title').textContent='Borrow';show('form');});
+  document.getElementById('place').addEventListener('click',()=>{
+    document.getElementById('title').textContent='Borrowing';show('progress');
+    setTimeout(()=>{document.getElementById('progText').textContent='Done — funds delivered. Position updated.';document.querySelector('.spin').style.display='none';},1600);
+  });
+  update(20000);
+</script>
+</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/borrow.html
@@ -1,172 +1,498 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Borrow flow — wireframe</title>
-<style>
-  :root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
-  *{box-sizing:border-box}
-  body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-  .wfbar{max-width:460px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-  .wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#6b7787;border:1px solid #b9c4dd;border-radius:5px;padding:1px 6px;margin-bottom:7px}
-  .wfbar .ctrls{display:flex;gap:10px;align-items:center;margin-top:10px;padding-top:9px;border-top:1px solid #eef1f7}
-  .wfbar .ctrls span{white-space:nowrap}
-  .modal{max-width:460px;margin:14px auto;background:var(--panel);border:1px solid var(--line);border-radius:16px;overflow:hidden}
-  .head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}
-  .head h2{font-size:16px;margin:0}
-  .steps{display:flex;gap:6px}
-  .dot{width:7px;height:7px;border-radius:50%;background:var(--line)}
-  .dot.on{background:var(--accent)}
-  .body{padding:16px}
-  .field{background:var(--panel2);border:1px solid var(--line);border-radius:12px;padding:12px;margin-bottom:12px}
-  .field .top{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}
-  .field .mid{display:flex;align-items:center;justify-content:space-between;margin-top:6px}
-  input{background:transparent;border:0;color:var(--txt);font-size:24px;width:60%;outline:none}
-  .selpill{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-weight:600}
-  .coin{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:11px}
-  .usdc{background:#2775ca;color:#fff}.btc{background:#f7931a;color:#0e1218}
-  .infoline{display:flex;justify-content:space-between;font-size:12.5px;color:var(--muted);padding:6px 2px}
-  .infoline b{color:var(--txt);font-weight:600}
-  .hfbar{height:8px;border-radius:6px;background:linear-gradient(90deg,var(--red),var(--amber) 45%,var(--green));position:relative;margin:8px 0 4px}
-  .hfbar .mark{position:absolute;top:-3px;width:3px;height:14px;background:#fff;border-radius:2px;transition:left .15s}
-  .warn{border-radius:10px;padding:10px 12px;font-size:12.5px;margin:10px 0;display:none}
-  .warn.amber{background:#fbf1de;border:1px solid #ecd29a;color:#8a5d05;display:block}
-  .warn.red{background:#fce8e6;border:1px solid #f3b6ad;color:#b5392c;display:block}
-  .warn label{display:flex;gap:8px;align-items:flex-start;margin-top:8px;cursor:pointer}
-  .err{color:var(--red);font-size:12px;margin:6px 2px;display:none}
-  button{font:inherit;cursor:pointer}
-  .btn{width:100%;background:var(--accent);color:#fff;border:0;border-radius:11px;padding:13px;font-weight:600;font-size:15px}
-  .btn:disabled{opacity:.4;cursor:not-allowed}
-  .foot{padding:0 16px 16px;display:flex;gap:10px}
-  .btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
-  .hero{text-align:center;padding:8px 0 14px}
-  .hero .big{font-size:30px;font-weight:700}
-  .hide{display:none}
-  .rr{display:flex;justify-content:space-between;padding:9px 0;border-top:1px solid var(--line);font-size:13.5px}
-  .rr:first-child{border-top:0}
-  .spin{width:34px;height:34px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;margin:18px auto;animation:s 1s linear infinite}
-  @keyframes s{to{transform:rotate(360deg)}}
-</style>
-</head>
-<body>
-<div class="wfbar">
-  <span class="tag">Wireframe — controls below are not part of the UI</span>
-  <div>Borrow flow (Form → Review → Progress). Collateral: 1 BTC ($67,170). LTV, projected health factor, and the warning/confirmation thresholds update live (same logic as <code>client.quote.calculateLtv</code>). You can also type in the "You borrow" field.</div>
-  <div class="ctrls"><span>Demo · borrow amount:</span>
-    <input id="slider" type="range" min="0" max="50000" step="500" value="20000" style="flex:1"/>
-  </div>
-</div>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Borrow flow — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--panel: #ffffff;
+				--panel2: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--accent: #2f6df6;
+				--green: #15a35b;
+				--amber: #d8890a;
+				--red: #df4a3c;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Helvetica,
+					Arial,
+					sans-serif;
+			}
+			.wfbar {
+				max-width: 460px;
+				margin: 14px auto 0;
+				background: #ffffff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.wfbar .tag {
+				display: inline-block;
+				font-size: 10px;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+				color: #6b7787;
+				border: 1px solid #b9c4dd;
+				border-radius: 5px;
+				padding: 1px 6px;
+				margin-bottom: 7px;
+			}
+			.wfbar .ctrls {
+				display: flex;
+				gap: 10px;
+				align-items: center;
+				margin-top: 10px;
+				padding-top: 9px;
+				border-top: 1px solid #eef1f7;
+			}
+			.wfbar .ctrls span {
+				white-space: nowrap;
+			}
+			.modal {
+				max-width: 460px;
+				margin: 14px auto;
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 16px;
+				overflow: hidden;
+			}
+			.head {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 14px 16px;
+				border-bottom: 1px solid var(--line);
+			}
+			.head h2 {
+				font-size: 16px;
+				margin: 0;
+			}
+			.steps {
+				display: flex;
+				gap: 6px;
+			}
+			.dot {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+				background: var(--line);
+			}
+			.dot.on {
+				background: var(--accent);
+			}
+			.body {
+				padding: 16px;
+			}
+			.field {
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				border-radius: 12px;
+				padding: 12px;
+				margin-bottom: 12px;
+			}
+			.field .top {
+				display: flex;
+				justify-content: space-between;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.field .mid {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				margin-top: 6px;
+			}
+			input {
+				background: transparent;
+				border: 0;
+				color: var(--txt);
+				font-size: 24px;
+				width: 60%;
+				outline: none;
+			}
+			.selpill {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 999px;
+				padding: 6px 12px;
+				font-weight: 600;
+			}
+			.coin {
+				width: 24px;
+				height: 24px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				font-size: 11px;
+			}
+			.usdc {
+				background: #2775ca;
+				color: #fff;
+			}
+			.btc {
+				background: #f7931a;
+				color: #0e1218;
+			}
+			.infoline {
+				display: flex;
+				justify-content: space-between;
+				font-size: 12.5px;
+				color: var(--muted);
+				padding: 6px 2px;
+			}
+			.infoline b {
+				color: var(--txt);
+				font-weight: 600;
+			}
+			.hfbar {
+				height: 8px;
+				border-radius: 6px;
+				background: linear-gradient(90deg, var(--red), var(--amber) 45%, var(--green));
+				position: relative;
+				margin: 8px 0 4px;
+			}
+			.hfbar .mark {
+				position: absolute;
+				top: -3px;
+				width: 3px;
+				height: 14px;
+				background: #fff;
+				border-radius: 2px;
+				transition: left 0.15s;
+			}
+			.warn {
+				border-radius: 10px;
+				padding: 10px 12px;
+				font-size: 12.5px;
+				margin: 10px 0;
+				display: none;
+			}
+			.warn.amber {
+				background: #fbf1de;
+				border: 1px solid #ecd29a;
+				color: #8a5d05;
+				display: block;
+			}
+			.warn.red {
+				background: #fce8e6;
+				border: 1px solid #f3b6ad;
+				color: #b5392c;
+				display: block;
+			}
+			.warn label {
+				display: flex;
+				gap: 8px;
+				align-items: flex-start;
+				margin-top: 8px;
+				cursor: pointer;
+			}
+			.err {
+				color: var(--red);
+				font-size: 12px;
+				margin: 6px 2px;
+				display: none;
+			}
+			button {
+				font: inherit;
+				cursor: pointer;
+			}
+			.btn {
+				width: 100%;
+				background: var(--accent);
+				color: #fff;
+				border: 0;
+				border-radius: 11px;
+				padding: 13px;
+				font-weight: 600;
+				font-size: 15px;
+			}
+			.btn:disabled {
+				opacity: 0.4;
+				cursor: not-allowed;
+			}
+			.foot {
+				padding: 0 16px 16px;
+				display: flex;
+				gap: 10px;
+			}
+			.btn.ghost {
+				background: transparent;
+				border: 1px solid var(--line);
+				color: var(--txt);
+			}
+			.hero {
+				text-align: center;
+				padding: 8px 0 14px;
+			}
+			.hero .big {
+				font-size: 30px;
+				font-weight: 700;
+			}
+			.hide {
+				display: none;
+			}
+			.rr {
+				display: flex;
+				justify-content: space-between;
+				padding: 9px 0;
+				border-top: 1px solid var(--line);
+				font-size: 13.5px;
+			}
+			.rr:first-child {
+				border-top: 0;
+			}
+			.spin {
+				width: 34px;
+				height: 34px;
+				border: 3px solid var(--line);
+				border-top-color: var(--accent);
+				border-radius: 50%;
+				margin: 18px auto;
+				animation: s 1s linear infinite;
+			}
+			@keyframes s {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wfbar">
+			<span class="tag">Wireframe — controls below are not part of the UI</span>
+			<div>
+				Borrow flow (Form → Review → Progress). Collateral: 1 BTC ($67,170). LTV, projected health
+				factor, and the warning/confirmation thresholds update live (same logic as
+				<code>client.quote.calculateLtv</code>). You can also type in the "You borrow" field.
+			</div>
+			<div class="ctrls">
+				<span>Demo · borrow amount:</span>
+				<input
+					id="slider"
+					type="range"
+					min="0"
+					max="50000"
+					step="500"
+					value="20000"
+					style="flex: 1"
+				/>
+			</div>
+		</div>
 
-<div class="modal">
-  <div class="head">
-    <h2 id="title">Borrow</h2>
-    <div class="steps"><span class="dot on" id="d0"></span><span class="dot" id="d1"></span><span class="dot" id="d2"></span></div>
-  </div>
+		<div class="modal">
+			<div class="head">
+				<h2 id="title">Borrow</h2>
+				<div class="steps">
+					<span class="dot on" id="d0"></span><span class="dot" id="d1"></span
+					><span class="dot" id="d2"></span>
+				</div>
+			</div>
 
-  <!-- FORM -->
-  <div id="form">
-    <div class="body">
-      <div class="infoline"><span>Collateral</span><b>1 BTC · $67,170</b></div>
-      <div class="infoline"><span>Borrowing power (max LTV 70%)</span><b>$47,019</b></div>
+			<!-- FORM -->
+			<div id="form">
+				<div class="body">
+					<div class="infoline"><span>Collateral</span><b>1 BTC · $67,170</b></div>
+					<div class="infoline"><span>Borrowing power (max LTV 70%)</span><b>$47,019</b></div>
 
-      <div class="field">
-        <div class="top"><span>You borrow</span><span>min 1.00 USDC</span></div>
-        <div class="mid">
-          <input id="amt" type="number" value="20000" min="0"/>
-          <span class="selpill"><span class="coin usdc">U</span>USDC</span>
-        </div>
-        <div class="infoline" style="padding-top:8px"><span id="fiat">$20,000.00</span><span>Borrow APY <b style="color:var(--amber)">7.40%</b></span></div>
-      </div>
+					<div class="field">
+						<div class="top"><span>You borrow</span><span>min 1.00 USDC</span></div>
+						<div class="mid">
+							<input id="amt" type="number" value="20000" min="0" />
+							<span class="selpill"><span class="coin usdc">U</span>USDC</span>
+						</div>
+						<div class="infoline" style="padding-top: 8px">
+							<span id="fiat">$20,000.00</span
+							><span>Borrow APY <b style="color: var(--amber)">7.40%</b></span>
+						</div>
+					</div>
 
-      <div class="infoline"><span>Resulting LTV</span><b id="ltv">29.8%</b></div>
-      <div class="infoline"><span>Projected health factor</span><b id="hfval" style="color:var(--green)">76%</b></div>
-      <div class="hfbar"><div class="mark" id="mark" style="left:76%"></div></div>
+					<div class="infoline"><span>Resulting LTV</span><b id="ltv">29.8%</b></div>
+					<div class="infoline">
+						<span>Projected health factor</span><b id="hfval" style="color: var(--green)">76%</b>
+					</div>
+					<div class="hfbar"><div class="mark" id="mark" style="left: 76%"></div></div>
 
-      <div class="err" id="err">Borrow exceeds max LTV for this collateral.</div>
-      <div class="warn" id="warn">
-        <span id="warntext"></span>
-        <label id="confirmWrap" class="hide"><input type="checkbox" id="confirm"/> I understand this borrow puts my position at high liquidation risk.</label>
-      </div>
-      <div class="infoline" style="color:var(--muted)"><span>Borrowing reduces your health factor. If it falls too far your collateral can be liquidated.</span></div>
-    </div>
-    <div class="foot"><button class="btn" id="toReview">Review</button></div>
-  </div>
+					<div class="err" id="err">Borrow exceeds max LTV for this collateral.</div>
+					<div class="warn" id="warn">
+						<span id="warntext"></span>
+						<label id="confirmWrap" class="hide"
+							><input type="checkbox" id="confirm" /> I understand this borrow puts my position at
+							high liquidation risk.</label
+						>
+					</div>
+					<div class="infoline" style="color: var(--muted)">
+						<span
+							>Borrowing reduces your health factor. If it falls too far your collateral can be
+							liquidated.</span
+						>
+					</div>
+				</div>
+				<div class="foot"><button class="btn" id="toReview">Review</button></div>
+			</div>
 
-  <!-- REVIEW -->
-  <div id="review" class="hide">
-    <div class="body">
-      <div class="hero"><div class="muted">You borrow</div><div class="big" id="rAmt">20,000 USDC</div><div class="muted" id="rFiat">$20,000.00</div></div>
-      <div class="rr"><span class="muted">Borrow APY</span><b style="color:var(--amber)">7.40%</b></div>
-      <div class="rr"><span class="muted">Resulting LTV</span><b id="rLtv">29.8%</b></div>
-      <div class="rr"><span class="muted">Projected health factor</span><b id="rHf" style="color:var(--green)">76%</b></div>
-      <div class="rr"><span class="muted">Provider</span><b>Liquidium</b></div>
-      <div class="rr"><span class="muted">Funds delivered to</span><b>Your oisy address</b></div>
-      <div class="warn" id="rWarn"><span id="rWarnText"></span></div>
-    </div>
-    <div class="foot"><button class="btn ghost" id="back">Back</button><button class="btn" id="place">Borrow</button></div>
-  </div>
+			<!-- REVIEW -->
+			<div id="review" class="hide">
+				<div class="body">
+					<div class="hero">
+						<div class="muted">You borrow</div>
+						<div class="big" id="rAmt">20,000 USDC</div>
+						<div class="muted" id="rFiat">$20,000.00</div>
+					</div>
+					<div class="rr">
+						<span class="muted">Borrow APY</span><b style="color: var(--amber)">7.40%</b>
+					</div>
+					<div class="rr"><span class="muted">Resulting LTV</span><b id="rLtv">29.8%</b></div>
+					<div class="rr">
+						<span class="muted">Projected health factor</span
+						><b id="rHf" style="color: var(--green)">76%</b>
+					</div>
+					<div class="rr"><span class="muted">Provider</span><b>Liquidium</b></div>
+					<div class="rr">
+						<span class="muted">Funds delivered to</span><b>Your oisy address</b>
+					</div>
+					<div class="warn" id="rWarn"><span id="rWarnText"></span></div>
+				</div>
+				<div class="foot">
+					<button class="btn ghost" id="back">Back</button
+					><button class="btn" id="place">Borrow</button>
+				</div>
+			</div>
 
-  <!-- PROGRESS -->
-  <div id="progress" class="hide">
-    <div class="body" style="text-align:center">
-      <div class="spin"></div>
-      <div id="progText">Submitting borrow to Liquidium…</div>
-      <div class="muted small" style="margin-top:6px">client.lending.borrow(...)</div>
-    </div>
-  </div>
-</div>
+			<!-- PROGRESS -->
+			<div id="progress" class="hide">
+				<div class="body" style="text-align: center">
+					<div class="spin"></div>
+					<div id="progText">Submitting borrow to Liquidium…</div>
+					<div class="muted small" style="margin-top: 6px">client.lending.borrow(...)</div>
+				</div>
+			</div>
+		</div>
 
-<script>
-  const COLLAT=67170, MAXLTV=0.70, LIQ=0.80; // liquidation threshold
-  const amt=document.getElementById('amt'), slider=document.getElementById('slider');
-  function calc(v){
-    const ltv=v/COLLAT;                 // borrow / collateral
-    // health factor % shown by Liquidium: 100% = no debt, ->0% as ltv -> liquidation threshold
-    const hf=Math.max(0, Math.round((1 - ltv/LIQ)*100));
-    return {ltv,hf};
-  }
-  function band(hf){ if(hf<20) return 'red'; if(hf<45) return 'amber'; return 'ok'; }
-  function color(hf){ return hf<20?'var(--red)':hf<45?'var(--amber)':'var(--green)'; }
-  function update(v){
-    const {ltv,hf}=calc(v);
-    document.getElementById('fiat').textContent='$'+v.toLocaleString('en-US',{minimumFractionDigits:2});
-    document.getElementById('ltv').textContent=(ltv*100).toFixed(1)+'%';
-    const hfval=document.getElementById('hfval'); hfval.textContent=hf+'%'; hfval.style.color=color(hf);
-    document.getElementById('mark').style.left=hf+'%';
-    const over = ltv>MAXLTV;
-    document.getElementById('err').style.display=over?'block':'none';
-    const w=document.getElementById('warn'), wt=document.getElementById('warntext'), cw=document.getElementById('confirmWrap'), cb=document.getElementById('confirm');
-    const b=band(hf);
-    w.className='warn'+(over?'':(b==='red'?' red':b==='amber'?' amber':''));
-    if(!over && b==='red'){wt.textContent='This borrow puts your position close to liquidation. ';cw.classList.remove('hide');}
-    else if(!over && b==='amber'){wt.textContent='This borrow noticeably lowers your health factor.';cw.classList.add('hide');cb.checked=false;}
-    else {cw.classList.add('hide');cb.checked=false;}
-    document.getElementById('toReview').disabled = over || v<=0 || (b==='red' && !cb.checked);
-  }
-  amt.addEventListener('input',()=>{slider.value=Math.min(50000,amt.value||0);update(+amt.value||0);});
-  slider.addEventListener('input',()=>{amt.value=slider.value;update(+slider.value);});
-  document.getElementById('confirm').addEventListener('change',()=>update(+amt.value||0));
+		<script>
+			const COLLAT = 67170,
+				MAXLTV = 0.7,
+				LIQ = 0.8; // liquidation threshold
+			const amt = document.getElementById('amt'),
+				slider = document.getElementById('slider');
+			function calc(v) {
+				const ltv = v / COLLAT; // borrow / collateral
+				// health factor % shown by Liquidium: 100% = no debt, ->0% as ltv -> liquidation threshold
+				const hf = Math.max(0, Math.round((1 - ltv / LIQ) * 100));
+				return { ltv, hf };
+			}
+			function band(hf) {
+				if (hf < 20) return 'red';
+				if (hf < 45) return 'amber';
+				return 'ok';
+			}
+			function color(hf) {
+				return hf < 20 ? 'var(--red)' : hf < 45 ? 'var(--amber)' : 'var(--green)';
+			}
+			function update(v) {
+				const { ltv, hf } = calc(v);
+				document.getElementById('fiat').textContent =
+					'$' + v.toLocaleString('en-US', { minimumFractionDigits: 2 });
+				document.getElementById('ltv').textContent = (ltv * 100).toFixed(1) + '%';
+				const hfval = document.getElementById('hfval');
+				hfval.textContent = hf + '%';
+				hfval.style.color = color(hf);
+				document.getElementById('mark').style.left = hf + '%';
+				const over = ltv > MAXLTV;
+				document.getElementById('err').style.display = over ? 'block' : 'none';
+				const w = document.getElementById('warn'),
+					wt = document.getElementById('warntext'),
+					cw = document.getElementById('confirmWrap'),
+					cb = document.getElementById('confirm');
+				const b = band(hf);
+				w.className = 'warn' + (over ? '' : b === 'red' ? ' red' : b === 'amber' ? ' amber' : '');
+				if (!over && b === 'red') {
+					wt.textContent = 'This borrow puts your position close to liquidation. ';
+					cw.classList.remove('hide');
+				} else if (!over && b === 'amber') {
+					wt.textContent = 'This borrow noticeably lowers your health factor.';
+					cw.classList.add('hide');
+					cb.checked = false;
+				} else {
+					cw.classList.add('hide');
+					cb.checked = false;
+				}
+				document.getElementById('toReview').disabled =
+					over || v <= 0 || (b === 'red' && !cb.checked);
+			}
+			amt.addEventListener('input', () => {
+				slider.value = Math.min(50000, amt.value || 0);
+				update(+amt.value || 0);
+			});
+			slider.addEventListener('input', () => {
+				amt.value = slider.value;
+				update(+slider.value);
+			});
+			document.getElementById('confirm').addEventListener('change', () => update(+amt.value || 0));
 
-  function show(id){['form','review','progress'].forEach((s,i)=>{document.getElementById(s).classList.toggle('hide',s!==id);document.getElementById('d'+i).classList.toggle('on', ['form','review','progress'].indexOf(id)>=i);});}
-  document.getElementById('toReview').addEventListener('click',()=>{
-    const v=+amt.value||0,{ltv,hf}=calc(v);
-    document.getElementById('rAmt').textContent=v.toLocaleString('en-US')+' USDC';
-    document.getElementById('rFiat').textContent='$'+v.toLocaleString('en-US',{minimumFractionDigits:2});
-    document.getElementById('rLtv').textContent=(ltv*100).toFixed(1)+'%';
-    const rhf=document.getElementById('rHf');rhf.textContent=hf+'%';rhf.style.color=color(hf);
-    const rw=document.getElementById('rWarn');const b=band(hf);
-    rw.className='warn'+(b==='red'?' red':b==='amber'?' amber':'');
-    document.getElementById('rWarnText').textContent = b==='red'?'High liquidation risk — monitor your position closely.':b==='amber'?'This borrow lowers your health factor.':'';
-    document.getElementById('title').textContent='Review borrow';
-    show('review');
-  });
-  document.getElementById('back').addEventListener('click',()=>{document.getElementById('title').textContent='Borrow';show('form');});
-  document.getElementById('place').addEventListener('click',()=>{
-    document.getElementById('title').textContent='Borrowing';show('progress');
-    setTimeout(()=>{document.getElementById('progText').textContent='Done — funds delivered. Position updated.';document.querySelector('.spin').style.display='none';},1600);
-  });
-  update(20000);
-</script>
-</body>
+			function show(id) {
+				['form', 'review', 'progress'].forEach((s, i) => {
+					document.getElementById(s).classList.toggle('hide', s !== id);
+					document
+						.getElementById('d' + i)
+						.classList.toggle('on', ['form', 'review', 'progress'].indexOf(id) >= i);
+				});
+			}
+			document.getElementById('toReview').addEventListener('click', () => {
+				const v = +amt.value || 0,
+					{ ltv, hf } = calc(v);
+				document.getElementById('rAmt').textContent = v.toLocaleString('en-US') + ' USDC';
+				document.getElementById('rFiat').textContent =
+					'$' + v.toLocaleString('en-US', { minimumFractionDigits: 2 });
+				document.getElementById('rLtv').textContent = (ltv * 100).toFixed(1) + '%';
+				const rhf = document.getElementById('rHf');
+				rhf.textContent = hf + '%';
+				rhf.style.color = color(hf);
+				const rw = document.getElementById('rWarn');
+				const b = band(hf);
+				rw.className = 'warn' + (b === 'red' ? ' red' : b === 'amber' ? ' amber' : '');
+				document.getElementById('rWarnText').textContent =
+					b === 'red'
+						? 'High liquidation risk — monitor your position closely.'
+						: b === 'amber'
+							? 'This borrow lowers your health factor.'
+							: '';
+				document.getElementById('title').textContent = 'Review borrow';
+				show('review');
+			});
+			document.getElementById('back').addEventListener('click', () => {
+				document.getElementById('title').textContent = 'Borrow';
+				show('form');
+			});
+			document.getElementById('place').addEventListener('click', () => {
+				document.getElementById('title').textContent = 'Borrowing';
+				show('progress');
+				setTimeout(() => {
+					document.getElementById('progText').textContent =
+						'Done — funds delivered. Position updated.';
+					document.querySelector('.spin').style.display = 'none';
+				}, 1600);
+			});
+			update(20000);
+		</script>
+	</body>
 </html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/carousel-slide.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/carousel-slide.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Dapps carousel — Liquidium slide (wireframe)</title>
+<style>
+:root{--bg:#e9eefb;--card:#ffffff;--line:#e5e9f2;--txt:#16203a;--muted:#737e91;--brand:#2f6df6}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif;min-height:100vh}
+svg{display:block}
+.wfbar{max-width:520px;margin:16px auto 0;background:#fff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#8a94a8;border:1px solid #c9d2e6;border-radius:5px;padding:1px 6px;margin-bottom:7px}
+.wrap{max-width:520px;margin:16px auto;padding:0 16px}
+.card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:16px 18px;box-shadow:0 1px 3px rgba(20,30,60,.05)}
+.slide{display:flex;align-items:center;justify-content:space-between;gap:8px;min-height:72px}
+.logo{width:64px;height:64px;border-radius:50%;display:grid;place-items:center;font-weight:800;font-size:22px;margin-right:16px;flex:0 0 64px}
+.lq{background:#9b6cff;color:#fff}.ha{background:#1f6f4a;color:#fff}.air{background:#f4b942;color:#3a2a00}
+.mid{flex:1;min-width:0}
+.mid .text{margin-bottom:4px}
+.cta{background:none;border:0;padding:0;color:var(--brand);font-weight:700;font-size:14px;cursor:pointer}
+.close{border:0;background:none;color:#9aa4b5;cursor:pointer;align-self:flex-start;padding:2px}
+.close svg{width:20px;height:20px;stroke:currentColor;fill:none;stroke-width:2}
+.controls{display:flex;align-items:center;justify-content:center;gap:14px;margin-top:14px}
+.arrow{width:30px;height:30px;border-radius:50%;border:1px solid var(--line);background:#fff;display:grid;place-items:center;cursor:pointer}
+.arrow svg{width:15px;height:15px;stroke:#16203a;fill:none;stroke-width:2}
+.dots{display:flex;gap:7px}
+.dot{width:7px;height:7px;border-radius:50%;background:#cdd6e6;cursor:pointer}
+.dot.on{background:var(--brand)}
+.tag-new{font-size:10px;font-weight:700;color:#2f6df6;border:1px solid #cdddfb;background:#eef4ff;border-radius:6px;padding:1px 6px;margin-left:8px;vertical-align:middle}
+.toast{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);background:#1f2a44;color:#fff;padding:9px 14px;border-radius:9px;font-size:13px;opacity:0;transition:.25s}
+.toast.show{opacity:1}
+</style></head>
+<body>
+<div class="wfbar">
+  <span class="tag">Wireframe — this is real UI (arrows, dots, CTA, close are the actual controls)</span>
+  <div>The dapps carousel with the <b>new Liquidium "Lend &amp; Borrow" slide</b> (synthesized in code, new id) — its CTA navigates internally to <code>/providers/liquidium/</code>, exactly like the Harvest Autopilot slide deep-links to <code>/earn/</code>. (The separate existing <code>"liquidium"</code> dapp-descriptions slide, which opens the explorer/dapp-details modal, is not shown here — it's unchanged.) Use the arrows/dots to move between slides; CTAs show where they'd navigate.</div>
+</div>
+
+<div class="wrap">
+  <div class="card">
+    <div class="slide">
+      <div class="logo" id="logo"></div>
+      <div class="mid">
+        <div class="text" id="text"></div>
+        <button class="cta" id="cta"></button>
+      </div>
+      <button class="close" id="close" title="Dismiss"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18"/></svg></button>
+    </div>
+    <div class="controls">
+      <button class="arrow" id="prev"><svg viewBox="0 0 24 24"><path d="M15 6l-6 6 6 6"/></svg></button>
+      <div class="dots" id="dots"></div>
+      <button class="arrow" id="next"><svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"/></svg></button>
+    </div>
+  </div>
+</div>
+<div class="toast" id="toast"></div>
+
+<script>
+  const slides = [
+    {logo:'L', cls:'lq', text:'Lend &amp; borrow native BTC against stablecoins.', cta:'Open Liquidium', target:'/providers/liquidium/', isNew:true},
+    {logo:'🚜', cls:'ha', text:'Maximize yield with 1-click autopilot vaults.', cta:'Go to Autopilot', target:'/earn/'},
+    {logo:'★', cls:'air', text:'Use OISY and EARN! Ep. 6 is live.', cta:'Check status', target:'rewards modal'}
+  ];
+  let i = 0;
+  function toast(m){const t=document.getElementById('toast');t.textContent=m;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),1700);}
+  function render(){
+    const s = slides[i];
+    const logo = document.getElementById('logo');
+    logo.className = 'logo '+s.cls; logo.textContent = s.logo;
+    document.getElementById('text').innerHTML = s.text + (s.isNew?'<span class="tag-new">NEW</span>':'');
+    document.getElementById('cta').textContent = s.cta + ' →';
+    document.getElementById('dots').innerHTML = slides.map((_,j)=>`<span class="dot ${j===i?'on':''}" data-j="${j}"></span>`).join('');
+    document.querySelectorAll('.dot').forEach(d=>d.onclick=()=>{i=+d.dataset.j;render();});
+  }
+  document.getElementById('prev').onclick=()=>{i=(i-1+slides.length)%slides.length;render();};
+  document.getElementById('next').onclick=()=>{i=(i+1)%slides.length;render();};
+  document.getElementById('cta').onclick=()=>{const s=slides[i];toast(s.target.startsWith('/')?('→ navigates to '+s.target):('→ opens '+s.target));};
+  document.getElementById('close').onclick=()=>toast('Slide dismissed (hidden for this user)');
+  render();
+</script>
+</body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/carousel-slide.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/carousel-slide.html
@@ -1,78 +1,303 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Dapps carousel — Liquidium slide (wireframe)</title>
-<style>
-:root{--bg:#e9eefb;--card:#ffffff;--line:#e5e9f2;--txt:#16203a;--muted:#737e91;--brand:#2f6df6}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif;min-height:100vh}
-svg{display:block}
-.wfbar{max-width:520px;margin:16px auto 0;background:#fff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#8a94a8;border:1px solid #c9d2e6;border-radius:5px;padding:1px 6px;margin-bottom:7px}
-.wrap{max-width:520px;margin:16px auto;padding:0 16px}
-.card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:16px 18px;box-shadow:0 1px 3px rgba(20,30,60,.05)}
-.slide{display:flex;align-items:center;justify-content:space-between;gap:8px;min-height:72px}
-.logo{width:64px;height:64px;border-radius:50%;display:grid;place-items:center;font-weight:800;font-size:22px;margin-right:16px;flex:0 0 64px}
-.lq{background:#9b6cff;color:#fff}.ha{background:#1f6f4a;color:#fff}.air{background:#f4b942;color:#3a2a00}
-.mid{flex:1;min-width:0}
-.mid .text{margin-bottom:4px}
-.cta{background:none;border:0;padding:0;color:var(--brand);font-weight:700;font-size:14px;cursor:pointer}
-.close{border:0;background:none;color:#9aa4b5;cursor:pointer;align-self:flex-start;padding:2px}
-.close svg{width:20px;height:20px;stroke:currentColor;fill:none;stroke-width:2}
-.controls{display:flex;align-items:center;justify-content:center;gap:14px;margin-top:14px}
-.arrow{width:30px;height:30px;border-radius:50%;border:1px solid var(--line);background:#fff;display:grid;place-items:center;cursor:pointer}
-.arrow svg{width:15px;height:15px;stroke:#16203a;fill:none;stroke-width:2}
-.dots{display:flex;gap:7px}
-.dot{width:7px;height:7px;border-radius:50%;background:#cdd6e6;cursor:pointer}
-.dot.on{background:var(--brand)}
-.tag-new{font-size:10px;font-weight:700;color:#2f6df6;border:1px solid #cdddfb;background:#eef4ff;border-radius:6px;padding:1px 6px;margin-left:8px;vertical-align:middle}
-.toast{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);background:#1f2a44;color:#fff;padding:9px 14px;border-radius:9px;font-size:13px;opacity:0;transition:.25s}
-.toast.show{opacity:1}
-</style></head>
-<body>
-<div class="wfbar">
-  <span class="tag">Wireframe — this is real UI (arrows, dots, CTA, close are the actual controls)</span>
-  <div>The dapps carousel with the <b>new Liquidium "Lend &amp; Borrow" slide</b> (synthesized in code, new id) — its CTA navigates internally to <code>/providers/liquidium/</code>, exactly like the Harvest Autopilot slide deep-links to <code>/earn/</code>. (The separate existing <code>"liquidium"</code> dapp-descriptions slide, which opens the explorer/dapp-details modal, is not shown here — it's unchanged.) Use the arrows/dots to move between slides; CTAs show where they'd navigate.</div>
-</div>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Dapps carousel — Liquidium slide (wireframe)</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--card: #ffffff;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #737e91;
+				--brand: #2f6df6;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+				min-height: 100vh;
+			}
+			svg {
+				display: block;
+			}
+			.wfbar {
+				max-width: 520px;
+				margin: 16px auto 0;
+				background: #fff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.wfbar .tag {
+				display: inline-block;
+				font-size: 10px;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+				color: #8a94a8;
+				border: 1px solid #c9d2e6;
+				border-radius: 5px;
+				padding: 1px 6px;
+				margin-bottom: 7px;
+			}
+			.wrap {
+				max-width: 520px;
+				margin: 16px auto;
+				padding: 0 16px;
+			}
+			.card {
+				background: var(--card);
+				border: 1px solid var(--line);
+				border-radius: 16px;
+				padding: 16px 18px;
+				box-shadow: 0 1px 3px rgba(20, 30, 60, 0.05);
+			}
+			.slide {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 8px;
+				min-height: 72px;
+			}
+			.logo {
+				width: 64px;
+				height: 64px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 800;
+				font-size: 22px;
+				margin-right: 16px;
+				flex: 0 0 64px;
+			}
+			.lq {
+				background: #9b6cff;
+				color: #fff;
+			}
+			.ha {
+				background: #1f6f4a;
+				color: #fff;
+			}
+			.air {
+				background: #f4b942;
+				color: #3a2a00;
+			}
+			.mid {
+				flex: 1;
+				min-width: 0;
+			}
+			.mid .text {
+				margin-bottom: 4px;
+			}
+			.cta {
+				background: none;
+				border: 0;
+				padding: 0;
+				color: var(--brand);
+				font-weight: 700;
+				font-size: 14px;
+				cursor: pointer;
+			}
+			.close {
+				border: 0;
+				background: none;
+				color: #9aa4b5;
+				cursor: pointer;
+				align-self: flex-start;
+				padding: 2px;
+			}
+			.close svg {
+				width: 20px;
+				height: 20px;
+				stroke: currentColor;
+				fill: none;
+				stroke-width: 2;
+			}
+			.controls {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				gap: 14px;
+				margin-top: 14px;
+			}
+			.arrow {
+				width: 30px;
+				height: 30px;
+				border-radius: 50%;
+				border: 1px solid var(--line);
+				background: #fff;
+				display: grid;
+				place-items: center;
+				cursor: pointer;
+			}
+			.arrow svg {
+				width: 15px;
+				height: 15px;
+				stroke: #16203a;
+				fill: none;
+				stroke-width: 2;
+			}
+			.dots {
+				display: flex;
+				gap: 7px;
+			}
+			.dot {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+				background: #cdd6e6;
+				cursor: pointer;
+			}
+			.dot.on {
+				background: var(--brand);
+			}
+			.tag-new {
+				font-size: 10px;
+				font-weight: 700;
+				color: #2f6df6;
+				border: 1px solid #cdddfb;
+				background: #eef4ff;
+				border-radius: 6px;
+				padding: 1px 6px;
+				margin-left: 8px;
+				vertical-align: middle;
+			}
+			.toast {
+				position: fixed;
+				left: 50%;
+				bottom: 18px;
+				transform: translateX(-50%);
+				background: #1f2a44;
+				color: #fff;
+				padding: 9px 14px;
+				border-radius: 9px;
+				font-size: 13px;
+				opacity: 0;
+				transition: 0.25s;
+			}
+			.toast.show {
+				opacity: 1;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wfbar">
+			<span class="tag"
+				>Wireframe — this is real UI (arrows, dots, CTA, close are the actual controls)</span
+			>
+			<div>
+				The dapps carousel with the <b>new Liquidium "Lend &amp; Borrow" slide</b> (synthesized in
+				code, new id) — its CTA navigates internally to <code>/providers/liquidium/</code>, exactly
+				like the Harvest Autopilot slide deep-links to <code>/earn/</code>. (The separate existing
+				<code>"liquidium"</code> dapp-descriptions slide, which opens the explorer/dapp-details
+				modal, is not shown here — it's unchanged.) Use the arrows/dots to move between slides; CTAs
+				show where they'd navigate.
+			</div>
+		</div>
 
-<div class="wrap">
-  <div class="card">
-    <div class="slide">
-      <div class="logo" id="logo"></div>
-      <div class="mid">
-        <div class="text" id="text"></div>
-        <button class="cta" id="cta"></button>
-      </div>
-      <button class="close" id="close" title="Dismiss"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18"/></svg></button>
-    </div>
-    <div class="controls">
-      <button class="arrow" id="prev"><svg viewBox="0 0 24 24"><path d="M15 6l-6 6 6 6"/></svg></button>
-      <div class="dots" id="dots"></div>
-      <button class="arrow" id="next"><svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6"/></svg></button>
-    </div>
-  </div>
-</div>
-<div class="toast" id="toast"></div>
+		<div class="wrap">
+			<div class="card">
+				<div class="slide">
+					<div class="logo" id="logo"></div>
+					<div class="mid">
+						<div class="text" id="text"></div>
+						<button class="cta" id="cta"></button>
+					</div>
+					<button class="close" id="close" title="Dismiss">
+						<svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18" /></svg>
+					</button>
+				</div>
+				<div class="controls">
+					<button class="arrow" id="prev">
+						<svg viewBox="0 0 24 24"><path d="M15 6l-6 6 6 6" /></svg>
+					</button>
+					<div class="dots" id="dots"></div>
+					<button class="arrow" id="next">
+						<svg viewBox="0 0 24 24"><path d="M9 6l6 6-6 6" /></svg>
+					</button>
+				</div>
+			</div>
+		</div>
+		<div class="toast" id="toast"></div>
 
-<script>
-  const slides = [
-    {logo:'L', cls:'lq', text:'Lend &amp; borrow native BTC against stablecoins.', cta:'Open Liquidium', target:'/providers/liquidium/', isNew:true},
-    {logo:'🚜', cls:'ha', text:'Maximize yield with 1-click autopilot vaults.', cta:'Go to Autopilot', target:'/earn/'},
-    {logo:'★', cls:'air', text:'Use OISY and EARN! Ep. 6 is live.', cta:'Check status', target:'rewards modal'}
-  ];
-  let i = 0;
-  function toast(m){const t=document.getElementById('toast');t.textContent=m;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),1700);}
-  function render(){
-    const s = slides[i];
-    const logo = document.getElementById('logo');
-    logo.className = 'logo '+s.cls; logo.textContent = s.logo;
-    document.getElementById('text').innerHTML = s.text + (s.isNew?'<span class="tag-new">NEW</span>':'');
-    document.getElementById('cta').textContent = s.cta + ' →';
-    document.getElementById('dots').innerHTML = slides.map((_,j)=>`<span class="dot ${j===i?'on':''}" data-j="${j}"></span>`).join('');
-    document.querySelectorAll('.dot').forEach(d=>d.onclick=()=>{i=+d.dataset.j;render();});
-  }
-  document.getElementById('prev').onclick=()=>{i=(i-1+slides.length)%slides.length;render();};
-  document.getElementById('next').onclick=()=>{i=(i+1)%slides.length;render();};
-  document.getElementById('cta').onclick=()=>{const s=slides[i];toast(s.target.startsWith('/')?('→ navigates to '+s.target):('→ opens '+s.target));};
-  document.getElementById('close').onclick=()=>toast('Slide dismissed (hidden for this user)');
-  render();
-</script>
-</body></html>
+		<script>
+			const slides = [
+				{
+					logo: 'L',
+					cls: 'lq',
+					text: 'Lend &amp; borrow native BTC against stablecoins.',
+					cta: 'Open Liquidium',
+					target: '/providers/liquidium/',
+					isNew: true
+				},
+				{
+					logo: '🚜',
+					cls: 'ha',
+					text: 'Maximize yield with 1-click autopilot vaults.',
+					cta: 'Go to Autopilot',
+					target: '/earn/'
+				},
+				{
+					logo: '★',
+					cls: 'air',
+					text: 'Use OISY and EARN! Ep. 6 is live.',
+					cta: 'Check status',
+					target: 'rewards modal'
+				}
+			];
+			let i = 0;
+			function toast(m) {
+				const t = document.getElementById('toast');
+				t.textContent = m;
+				t.classList.add('show');
+				setTimeout(() => t.classList.remove('show'), 1700);
+			}
+			function render() {
+				const s = slides[i];
+				const logo = document.getElementById('logo');
+				logo.className = 'logo ' + s.cls;
+				logo.textContent = s.logo;
+				document.getElementById('text').innerHTML =
+					s.text + (s.isNew ? '<span class="tag-new">NEW</span>' : '');
+				document.getElementById('cta').textContent = s.cta + ' →';
+				document.getElementById('dots').innerHTML = slides
+					.map((_, j) => `<span class="dot ${j === i ? 'on' : ''}" data-j="${j}"></span>`)
+					.join('');
+				document.querySelectorAll('.dot').forEach(
+					(d) =>
+						(d.onclick = () => {
+							i = +d.dataset.j;
+							render();
+						})
+				);
+			}
+			document.getElementById('prev').onclick = () => {
+				i = (i - 1 + slides.length) % slides.length;
+				render();
+			};
+			document.getElementById('next').onclick = () => {
+				i = (i + 1) % slides.length;
+				render();
+			};
+			document.getElementById('cta').onclick = () => {
+				const s = slides[i];
+				toast(s.target.startsWith('/') ? '→ navigates to ' + s.target : '→ opens ' + s.target);
+			};
+			document.getElementById('close').onclick = () =>
+				toast('Slide dismissed (hidden for this user)');
+			render();
+		</script>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/dashboard.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/dashboard.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Liquidium dashboard — wireframe</title>
+<style>
+  :root{
+    --bg:#e9eefb; --panel:#ffffff; --panel2:#f4f6fb; --line:#e5e9f2;
+    --txt:#16203a; --muted:#6b7787; --accent:#2f6df6; --accent2:#9b6cff;
+    --green:#15a35b; --amber:#d8890a; --red:#df4a3c;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+  .wrap{max-width:520px;margin:0 auto;padding:18px}
+  .wfbar{max-width:520px;margin:14px auto 8px;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+  .wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#6b7787;border:1px solid #b9c4dd;border-radius:5px;padding:1px 6px;margin-bottom:7px}
+  .wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
+  .wfbar .ctrls button{background:var(--panel2);border:1px solid var(--line);color:var(--muted);border-radius:8px;padding:5px 10px;font-size:12px;cursor:pointer}
+  .wfbar .ctrls button.on{color:var(--txt);border-color:var(--accent)}
+  h1{font-size:18px;margin:0}
+  .crumbs{color:var(--muted);font-size:12px;margin-bottom:12px}
+  .crumbs a{color:var(--accent);text-decoration:none}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:16px;margin-bottom:14px}
+  .row{display:flex;align-items:center;justify-content:space-between;gap:10px}
+  .muted{color:var(--muted)}
+  .small{font-size:12px}
+  .summary{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:12px}
+  .summary .box{background:var(--panel2);border:1px solid var(--line);border-radius:10px;padding:10px}
+  .summary .lbl{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em}
+  .summary .val{font-size:18px;font-weight:600;margin-top:2px}
+  .hf .val{color:var(--green)}
+  .sec-title{font-weight:600;margin:18px 0 8px;display:flex;justify-content:space-between;align-items:center}
+  .asset{display:flex;align-items:center;gap:10px}
+  .coin{width:30px;height:30px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:12px;color:#0e1218}
+  .btc{background:#f7931a}.eth{background:#8a93b2}.usdc{background:#2775ca;color:#fff}.usdt{background:#26a17b;color:#fff}
+  .posrow{padding:12px 0;border-top:1px solid var(--line)}
+  .posrow:first-of-type{border-top:0}
+  .legs{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:8px 0}
+  .leg{background:var(--panel2);border-radius:8px;padding:8px 10px}
+  .leg .k{font-size:11px;color:var(--muted)}
+  .leg .v{font-weight:600}
+  .apy{color:var(--green);font-size:12px}
+  .apy.borrow{color:var(--amber)}
+  .acts{display:flex;gap:8px;flex-wrap:wrap}
+  button{font:inherit;cursor:pointer}
+  .btn{background:var(--accent);color:#fff;border:0;border-radius:9px;padding:8px 14px;font-weight:600}
+  .btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
+  .btn.sm{padding:6px 11px;font-size:12.5px}
+  .btn:disabled{opacity:.4;cursor:not-allowed}
+  .pill{font-size:11px;padding:2px 8px;border-radius:999px;background:var(--panel2);border:1px solid var(--line);color:var(--muted)}
+  .pill.soon{color:var(--amber);border-color:#ecd29a}
+  .mkrow{display:flex;align-items:center;justify-content:space-between;padding:11px 0;border-top:1px solid var(--line)}
+  .mkrow:first-of-type{border-top:0}
+  .hide{display:none}
+  .learn{color:var(--accent);text-decoration:none;font-size:12px}
+  .toast{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);background:#1f2a44;border:1px solid #1f2a44;color:#fff;padding:9px 14px;border-radius:9px;font-size:13px;opacity:0;transition:.25s}
+  .toast.show{opacity:1}
+</style>
+</head>
+<body>
+<div class="wfbar">
+  <span class="tag">Wireframe — controls below are not part of the UI</span>
+  <div>Interactive mock of the Liquidium dashboard (the <code>/earn/liquidium/</code> provider page). Action buttons show toasts only — each opens its own flow wireframe.</div>
+  <div class="ctrls"><span>Demo · user state:</span>
+    <button data-state="new" class="on">New user</button>
+    <button data-state="supply">Supply, no borrow</button>
+    <button data-state="full">Supply + borrow</button>
+  </div>
+</div>
+<div class="wrap">
+  <div class="crumbs"><a href="#">Earn</a> › Liquidium</div>
+
+  <div class="card">
+    <div class="row">
+      <h1>Liquidium</h1>
+      <a class="learn" href="#">Learn more ↗</a>
+    </div>
+    <div class="muted small" style="margin-top:4px">Lend &amp; borrow native BTC, ETH, USDC and USDT. Lending logic runs on Liquidium's canisters; oisy provides the UX.</div>
+    <div class="summary">
+      <div class="box hf"><div class="lbl">Health factor</div><div class="val" id="hf">100%</div></div>
+      <div class="box"><div class="lbl">Net value</div><div class="val" id="nv">$0.00</div></div>
+      <div class="box"><div class="lbl">Net APY</div><div class="val" id="napy">—</div></div>
+    </div>
+  </div>
+
+  <div class="sec-title">My positions</div>
+  <div class="card" id="positions"><!-- filled by JS --></div>
+
+  <div class="sec-title">Markets</div>
+  <div class="card" id="markets"></div>
+</div>
+<div class="toast" id="toast"></div>
+
+<script>
+  const pools = [
+    {sym:'BTC', cls:'btc', supply:'1.94%', borrow:'3.10%', live:true},
+    {sym:'USDC',cls:'usdc',supply:'5.20%', borrow:'7.40%', live:true},
+    {sym:'USDT',cls:'usdt',supply:'5.05%', borrow:'7.25%', live:true},
+    {sym:'ETH', cls:'eth', supply:'—',     borrow:'—',     live:false}
+  ];
+  const states = {
+    new:  {hf:'100%', hfcol:'var(--green)', nv:'$0.00', napy:'—', positions:[]},
+    supply:{hf:'100%', hfcol:'var(--green)', nv:'$67,170', napy:'+1.94%', positions:[
+       {sym:'BTC',cls:'btc',supplied:'1 BTC',suppliedF:'$67,170',sApy:'1.94%',borrowed:null}
+    ]},
+    full: {hf:'68%', hfcol:'var(--green)', nv:'$32,170', napy:'-0.62%', positions:[
+       {sym:'BTC',cls:'btc',supplied:'1 BTC',suppliedF:'$67,170',sApy:'1.94%',borrowed:null},
+       {sym:'USDC',cls:'usdc',supplied:null,borrowed:'35,000 USDC',borrowedF:'$35,000',bApy:'7.40%'}
+    ]}
+  };
+  function toast(m){const t=document.getElementById('toast');t.textContent=m;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),1600);}
+
+  function render(stateKey){
+    const s = states[stateKey];
+    document.getElementById('hf').textContent = s.hf;
+    document.getElementById('hf').style.color = s.hfcol;
+    document.getElementById('nv').textContent = s.nv;
+    const napy = document.getElementById('napy'); napy.textContent = s.napy;
+    napy.style.color = s.napy.startsWith('-') ? 'var(--red)' : (s.napy==='—'?'var(--muted)':'var(--green)');
+
+    const pos = document.getElementById('positions');
+    if(!s.positions.length){
+      pos.innerHTML = `<div class="muted" style="text-align:center;padding:14px 0">No positions yet. Supply an asset to start earning — it also becomes collateral you can borrow against.</div>
+      <div style="text-align:center"><button class="btn" onclick="toast('→ opens supply.html')">Supply an asset</button></div>`;
+    } else {
+      pos.innerHTML = s.positions.map(p=>{
+        const hasBorrow = !!p.borrowed, hasSupply = !!p.supplied;
+        return `<div class="posrow">
+          <div class="row"><div class="asset"><div class="coin ${p.cls}">${p.sym[0]}</div><div><div style="font-weight:600">${p.sym}</div></div></div></div>
+          <div class="legs">
+            <div class="leg"><div class="k">Supplied</div><div class="v">${hasSupply?p.supplied:'—'}</div>${hasSupply?`<div class="small muted">${p.suppliedF} · <span class="apy">${p.sApy} APY</span></div>`:''}</div>
+            <div class="leg"><div class="k">Borrowed</div><div class="v">${hasBorrow?p.borrowed:'—'}</div>${hasBorrow?`<div class="small muted">${p.borrowedF} · <span class="apy borrow">${p.bApy} APY</span></div>`:''}</div>
+          </div>
+          <div class="acts">
+            <button class="btn sm" onclick="toast('→ opens supply.html')">Supply</button>
+            <button class="btn sm ghost" ${stateKey==='new'?'disabled':''} onclick="toast('→ opens borrow.html')">Borrow</button>
+            ${hasBorrow?`<button class="btn sm ghost" onclick="toast('→ opens repay.html')">Repay</button>`:''}
+            ${hasSupply?`<button class="btn sm ghost" onclick="toast('→ opens withdraw.html')">Withdraw</button>`:''}
+          </div>
+        </div>`;
+      }).join('');
+    }
+
+    document.getElementById('markets').innerHTML = pools.map(p=>`
+      <div class="mkrow">
+        <div class="asset"><div class="coin ${p.cls}">${p.sym[0]}</div>
+          <div><div style="font-weight:600">${p.sym} ${p.live?'':'<span class="pill soon">Coming soon</span>'}</div>
+          <div class="small muted">Supply <span class="apy">${p.supply}</span> · Borrow <span class="apy borrow">${p.borrow}</span></div></div></div>
+        <button class="btn sm ${p.live?'':'ghost'}" ${p.live?'':'disabled'} onclick="toast('→ opens supply.html')">Supply</button>
+      </div>`).join('');
+  }
+  document.querySelectorAll('.ctrls button').forEach(b=>b.addEventListener('click',()=>{
+    document.querySelectorAll('.ctrls button').forEach(x=>x.classList.remove('on'));
+    b.classList.add('on'); render(b.dataset.state);
+  }));
+  render('new');
+</script>
+</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/dashboard.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/dashboard.html
@@ -1,160 +1,457 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Liquidium dashboard — wireframe</title>
-<style>
-  :root{
-    --bg:#e9eefb; --panel:#ffffff; --panel2:#f4f6fb; --line:#e5e9f2;
-    --txt:#16203a; --muted:#6b7787; --accent:#2f6df6; --accent2:#9b6cff;
-    --green:#15a35b; --amber:#d8890a; --red:#df4a3c;
-  }
-  *{box-sizing:border-box}
-  body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-  .wrap{max-width:520px;margin:0 auto;padding:18px}
-  .wfbar{max-width:520px;margin:14px auto 8px;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-  .wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#6b7787;border:1px solid #b9c4dd;border-radius:5px;padding:1px 6px;margin-bottom:7px}
-  .wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
-  .wfbar .ctrls button{background:var(--panel2);border:1px solid var(--line);color:var(--muted);border-radius:8px;padding:5px 10px;font-size:12px;cursor:pointer}
-  .wfbar .ctrls button.on{color:var(--txt);border-color:var(--accent)}
-  h1{font-size:18px;margin:0}
-  .crumbs{color:var(--muted);font-size:12px;margin-bottom:12px}
-  .crumbs a{color:var(--accent);text-decoration:none}
-  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:16px;margin-bottom:14px}
-  .row{display:flex;align-items:center;justify-content:space-between;gap:10px}
-  .muted{color:var(--muted)}
-  .small{font-size:12px}
-  .summary{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:12px}
-  .summary .box{background:var(--panel2);border:1px solid var(--line);border-radius:10px;padding:10px}
-  .summary .lbl{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em}
-  .summary .val{font-size:18px;font-weight:600;margin-top:2px}
-  .hf .val{color:var(--green)}
-  .sec-title{font-weight:600;margin:18px 0 8px;display:flex;justify-content:space-between;align-items:center}
-  .asset{display:flex;align-items:center;gap:10px}
-  .coin{width:30px;height:30px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:12px;color:#0e1218}
-  .btc{background:#f7931a}.eth{background:#8a93b2}.usdc{background:#2775ca;color:#fff}.usdt{background:#26a17b;color:#fff}
-  .posrow{padding:12px 0;border-top:1px solid var(--line)}
-  .posrow:first-of-type{border-top:0}
-  .legs{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:8px 0}
-  .leg{background:var(--panel2);border-radius:8px;padding:8px 10px}
-  .leg .k{font-size:11px;color:var(--muted)}
-  .leg .v{font-weight:600}
-  .apy{color:var(--green);font-size:12px}
-  .apy.borrow{color:var(--amber)}
-  .acts{display:flex;gap:8px;flex-wrap:wrap}
-  button{font:inherit;cursor:pointer}
-  .btn{background:var(--accent);color:#fff;border:0;border-radius:9px;padding:8px 14px;font-weight:600}
-  .btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
-  .btn.sm{padding:6px 11px;font-size:12.5px}
-  .btn:disabled{opacity:.4;cursor:not-allowed}
-  .pill{font-size:11px;padding:2px 8px;border-radius:999px;background:var(--panel2);border:1px solid var(--line);color:var(--muted)}
-  .pill.soon{color:var(--amber);border-color:#ecd29a}
-  .mkrow{display:flex;align-items:center;justify-content:space-between;padding:11px 0;border-top:1px solid var(--line)}
-  .mkrow:first-of-type{border-top:0}
-  .hide{display:none}
-  .learn{color:var(--accent);text-decoration:none;font-size:12px}
-  .toast{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);background:#1f2a44;border:1px solid #1f2a44;color:#fff;padding:9px 14px;border-radius:9px;font-size:13px;opacity:0;transition:.25s}
-  .toast.show{opacity:1}
-</style>
-</head>
-<body>
-<div class="wfbar">
-  <span class="tag">Wireframe — controls below are not part of the UI</span>
-  <div>Interactive mock of the Liquidium dashboard (the <code>/earn/liquidium/</code> provider page). Action buttons show toasts only — each opens its own flow wireframe.</div>
-  <div class="ctrls"><span>Demo · user state:</span>
-    <button data-state="new" class="on">New user</button>
-    <button data-state="supply">Supply, no borrow</button>
-    <button data-state="full">Supply + borrow</button>
-  </div>
-</div>
-<div class="wrap">
-  <div class="crumbs"><a href="#">Earn</a> › Liquidium</div>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Liquidium dashboard — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--panel: #ffffff;
+				--panel2: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--accent: #2f6df6;
+				--accent2: #9b6cff;
+				--green: #15a35b;
+				--amber: #d8890a;
+				--red: #df4a3c;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Helvetica,
+					Arial,
+					sans-serif;
+			}
+			.wrap {
+				max-width: 520px;
+				margin: 0 auto;
+				padding: 18px;
+			}
+			.wfbar {
+				max-width: 520px;
+				margin: 14px auto 8px;
+				background: #ffffff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.wfbar .tag {
+				display: inline-block;
+				font-size: 10px;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+				color: #6b7787;
+				border: 1px solid #b9c4dd;
+				border-radius: 5px;
+				padding: 1px 6px;
+				margin-bottom: 7px;
+			}
+			.wfbar .ctrls {
+				display: flex;
+				gap: 6px;
+				align-items: center;
+				margin-top: 10px;
+				flex-wrap: wrap;
+				padding-top: 9px;
+				border-top: 1px solid #eef1f7;
+			}
+			.wfbar .ctrls button {
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				color: var(--muted);
+				border-radius: 8px;
+				padding: 5px 10px;
+				font-size: 12px;
+				cursor: pointer;
+			}
+			.wfbar .ctrls button.on {
+				color: var(--txt);
+				border-color: var(--accent);
+			}
+			h1 {
+				font-size: 18px;
+				margin: 0;
+			}
+			.crumbs {
+				color: var(--muted);
+				font-size: 12px;
+				margin-bottom: 12px;
+			}
+			.crumbs a {
+				color: var(--accent);
+				text-decoration: none;
+			}
+			.card {
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 14px;
+				padding: 16px;
+				margin-bottom: 14px;
+			}
+			.row {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 10px;
+			}
+			.muted {
+				color: var(--muted);
+			}
+			.small {
+				font-size: 12px;
+			}
+			.summary {
+				display: grid;
+				grid-template-columns: repeat(3, 1fr);
+				gap: 10px;
+				margin-top: 12px;
+			}
+			.summary .box {
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				border-radius: 10px;
+				padding: 10px;
+			}
+			.summary .lbl {
+				font-size: 11px;
+				color: var(--muted);
+				text-transform: uppercase;
+				letter-spacing: 0.04em;
+			}
+			.summary .val {
+				font-size: 18px;
+				font-weight: 600;
+				margin-top: 2px;
+			}
+			.hf .val {
+				color: var(--green);
+			}
+			.sec-title {
+				font-weight: 600;
+				margin: 18px 0 8px;
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+			}
+			.asset {
+				display: flex;
+				align-items: center;
+				gap: 10px;
+			}
+			.coin {
+				width: 30px;
+				height: 30px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				font-size: 12px;
+				color: #0e1218;
+			}
+			.btc {
+				background: #f7931a;
+			}
+			.eth {
+				background: #8a93b2;
+			}
+			.usdc {
+				background: #2775ca;
+				color: #fff;
+			}
+			.usdt {
+				background: #26a17b;
+				color: #fff;
+			}
+			.posrow {
+				padding: 12px 0;
+				border-top: 1px solid var(--line);
+			}
+			.posrow:first-of-type {
+				border-top: 0;
+			}
+			.legs {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				gap: 8px;
+				margin: 8px 0;
+			}
+			.leg {
+				background: var(--panel2);
+				border-radius: 8px;
+				padding: 8px 10px;
+			}
+			.leg .k {
+				font-size: 11px;
+				color: var(--muted);
+			}
+			.leg .v {
+				font-weight: 600;
+			}
+			.apy {
+				color: var(--green);
+				font-size: 12px;
+			}
+			.apy.borrow {
+				color: var(--amber);
+			}
+			.acts {
+				display: flex;
+				gap: 8px;
+				flex-wrap: wrap;
+			}
+			button {
+				font: inherit;
+				cursor: pointer;
+			}
+			.btn {
+				background: var(--accent);
+				color: #fff;
+				border: 0;
+				border-radius: 9px;
+				padding: 8px 14px;
+				font-weight: 600;
+			}
+			.btn.ghost {
+				background: transparent;
+				border: 1px solid var(--line);
+				color: var(--txt);
+			}
+			.btn.sm {
+				padding: 6px 11px;
+				font-size: 12.5px;
+			}
+			.btn:disabled {
+				opacity: 0.4;
+				cursor: not-allowed;
+			}
+			.pill {
+				font-size: 11px;
+				padding: 2px 8px;
+				border-radius: 999px;
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				color: var(--muted);
+			}
+			.pill.soon {
+				color: var(--amber);
+				border-color: #ecd29a;
+			}
+			.mkrow {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 11px 0;
+				border-top: 1px solid var(--line);
+			}
+			.mkrow:first-of-type {
+				border-top: 0;
+			}
+			.hide {
+				display: none;
+			}
+			.learn {
+				color: var(--accent);
+				text-decoration: none;
+				font-size: 12px;
+			}
+			.toast {
+				position: fixed;
+				left: 50%;
+				bottom: 18px;
+				transform: translateX(-50%);
+				background: #1f2a44;
+				border: 1px solid #1f2a44;
+				color: #fff;
+				padding: 9px 14px;
+				border-radius: 9px;
+				font-size: 13px;
+				opacity: 0;
+				transition: 0.25s;
+			}
+			.toast.show {
+				opacity: 1;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wfbar">
+			<span class="tag">Wireframe — controls below are not part of the UI</span>
+			<div>
+				Interactive mock of the Liquidium dashboard (the <code>/earn/liquidium/</code> provider
+				page). Action buttons show toasts only — each opens its own flow wireframe.
+			</div>
+			<div class="ctrls">
+				<span>Demo · user state:</span>
+				<button data-state="new" class="on">New user</button>
+				<button data-state="supply">Supply, no borrow</button>
+				<button data-state="full">Supply + borrow</button>
+			</div>
+		</div>
+		<div class="wrap">
+			<div class="crumbs"><a href="#">Earn</a> › Liquidium</div>
 
-  <div class="card">
-    <div class="row">
-      <h1>Liquidium</h1>
-      <a class="learn" href="#">Learn more ↗</a>
-    </div>
-    <div class="muted small" style="margin-top:4px">Lend &amp; borrow native BTC, ETH, USDC and USDT. Lending logic runs on Liquidium's canisters; oisy provides the UX.</div>
-    <div class="summary">
-      <div class="box hf"><div class="lbl">Health factor</div><div class="val" id="hf">100%</div></div>
-      <div class="box"><div class="lbl">Net value</div><div class="val" id="nv">$0.00</div></div>
-      <div class="box"><div class="lbl">Net APY</div><div class="val" id="napy">—</div></div>
-    </div>
-  </div>
+			<div class="card">
+				<div class="row">
+					<h1>Liquidium</h1>
+					<a class="learn" href="#">Learn more ↗</a>
+				</div>
+				<div class="muted small" style="margin-top: 4px">
+					Lend &amp; borrow native BTC, ETH, USDC and USDT. Lending logic runs on Liquidium's
+					canisters; oisy provides the UX.
+				</div>
+				<div class="summary">
+					<div class="box hf">
+						<div class="lbl">Health factor</div>
+						<div class="val" id="hf">100%</div>
+					</div>
+					<div class="box">
+						<div class="lbl">Net value</div>
+						<div class="val" id="nv">$0.00</div>
+					</div>
+					<div class="box">
+						<div class="lbl">Net APY</div>
+						<div class="val" id="napy">—</div>
+					</div>
+				</div>
+			</div>
 
-  <div class="sec-title">My positions</div>
-  <div class="card" id="positions"><!-- filled by JS --></div>
+			<div class="sec-title">My positions</div>
+			<div class="card" id="positions"><!-- filled by JS --></div>
 
-  <div class="sec-title">Markets</div>
-  <div class="card" id="markets"></div>
-</div>
-<div class="toast" id="toast"></div>
+			<div class="sec-title">Markets</div>
+			<div class="card" id="markets"></div>
+		</div>
+		<div class="toast" id="toast"></div>
 
-<script>
-  const pools = [
-    {sym:'BTC', cls:'btc', supply:'1.94%', borrow:'3.10%', live:true},
-    {sym:'USDC',cls:'usdc',supply:'5.20%', borrow:'7.40%', live:true},
-    {sym:'USDT',cls:'usdt',supply:'5.05%', borrow:'7.25%', live:true},
-    {sym:'ETH', cls:'eth', supply:'—',     borrow:'—',     live:false}
-  ];
-  const states = {
-    new:  {hf:'100%', hfcol:'var(--green)', nv:'$0.00', napy:'—', positions:[]},
-    supply:{hf:'100%', hfcol:'var(--green)', nv:'$67,170', napy:'+1.94%', positions:[
-       {sym:'BTC',cls:'btc',supplied:'1 BTC',suppliedF:'$67,170',sApy:'1.94%',borrowed:null}
-    ]},
-    full: {hf:'68%', hfcol:'var(--green)', nv:'$32,170', napy:'-0.62%', positions:[
-       {sym:'BTC',cls:'btc',supplied:'1 BTC',suppliedF:'$67,170',sApy:'1.94%',borrowed:null},
-       {sym:'USDC',cls:'usdc',supplied:null,borrowed:'35,000 USDC',borrowedF:'$35,000',bApy:'7.40%'}
-    ]}
-  };
-  function toast(m){const t=document.getElementById('toast');t.textContent=m;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),1600);}
+		<script>
+			const pools = [
+				{ sym: 'BTC', cls: 'btc', supply: '1.94%', borrow: '3.10%', live: true },
+				{ sym: 'USDC', cls: 'usdc', supply: '5.20%', borrow: '7.40%', live: true },
+				{ sym: 'USDT', cls: 'usdt', supply: '5.05%', borrow: '7.25%', live: true },
+				{ sym: 'ETH', cls: 'eth', supply: '—', borrow: '—', live: false }
+			];
+			const states = {
+				new: { hf: '100%', hfcol: 'var(--green)', nv: '$0.00', napy: '—', positions: [] },
+				supply: {
+					hf: '100%',
+					hfcol: 'var(--green)',
+					nv: '$67,170',
+					napy: '+1.94%',
+					positions: [
+						{
+							sym: 'BTC',
+							cls: 'btc',
+							supplied: '1 BTC',
+							suppliedF: '$67,170',
+							sApy: '1.94%',
+							borrowed: null
+						}
+					]
+				},
+				full: {
+					hf: '68%',
+					hfcol: 'var(--green)',
+					nv: '$32,170',
+					napy: '-0.62%',
+					positions: [
+						{
+							sym: 'BTC',
+							cls: 'btc',
+							supplied: '1 BTC',
+							suppliedF: '$67,170',
+							sApy: '1.94%',
+							borrowed: null
+						},
+						{
+							sym: 'USDC',
+							cls: 'usdc',
+							supplied: null,
+							borrowed: '35,000 USDC',
+							borrowedF: '$35,000',
+							bApy: '7.40%'
+						}
+					]
+				}
+			};
+			function toast(m) {
+				const t = document.getElementById('toast');
+				t.textContent = m;
+				t.classList.add('show');
+				setTimeout(() => t.classList.remove('show'), 1600);
+			}
 
-  function render(stateKey){
-    const s = states[stateKey];
-    document.getElementById('hf').textContent = s.hf;
-    document.getElementById('hf').style.color = s.hfcol;
-    document.getElementById('nv').textContent = s.nv;
-    const napy = document.getElementById('napy'); napy.textContent = s.napy;
-    napy.style.color = s.napy.startsWith('-') ? 'var(--red)' : (s.napy==='—'?'var(--muted)':'var(--green)');
+			function render(stateKey) {
+				const s = states[stateKey];
+				document.getElementById('hf').textContent = s.hf;
+				document.getElementById('hf').style.color = s.hfcol;
+				document.getElementById('nv').textContent = s.nv;
+				const napy = document.getElementById('napy');
+				napy.textContent = s.napy;
+				napy.style.color = s.napy.startsWith('-')
+					? 'var(--red)'
+					: s.napy === '—'
+						? 'var(--muted)'
+						: 'var(--green)';
 
-    const pos = document.getElementById('positions');
-    if(!s.positions.length){
-      pos.innerHTML = `<div class="muted" style="text-align:center;padding:14px 0">No positions yet. Supply an asset to start earning — it also becomes collateral you can borrow against.</div>
+				const pos = document.getElementById('positions');
+				if (!s.positions.length) {
+					pos.innerHTML = `<div class="muted" style="text-align:center;padding:14px 0">No positions yet. Supply an asset to start earning — it also becomes collateral you can borrow against.</div>
       <div style="text-align:center"><button class="btn" onclick="toast('→ opens supply.html')">Supply an asset</button></div>`;
-    } else {
-      pos.innerHTML = s.positions.map(p=>{
-        const hasBorrow = !!p.borrowed, hasSupply = !!p.supplied;
-        return `<div class="posrow">
+				} else {
+					pos.innerHTML = s.positions
+						.map((p) => {
+							const hasBorrow = !!p.borrowed,
+								hasSupply = !!p.supplied;
+							return `<div class="posrow">
           <div class="row"><div class="asset"><div class="coin ${p.cls}">${p.sym[0]}</div><div><div style="font-weight:600">${p.sym}</div></div></div></div>
           <div class="legs">
-            <div class="leg"><div class="k">Supplied</div><div class="v">${hasSupply?p.supplied:'—'}</div>${hasSupply?`<div class="small muted">${p.suppliedF} · <span class="apy">${p.sApy} APY</span></div>`:''}</div>
-            <div class="leg"><div class="k">Borrowed</div><div class="v">${hasBorrow?p.borrowed:'—'}</div>${hasBorrow?`<div class="small muted">${p.borrowedF} · <span class="apy borrow">${p.bApy} APY</span></div>`:''}</div>
+            <div class="leg"><div class="k">Supplied</div><div class="v">${hasSupply ? p.supplied : '—'}</div>${hasSupply ? `<div class="small muted">${p.suppliedF} · <span class="apy">${p.sApy} APY</span></div>` : ''}</div>
+            <div class="leg"><div class="k">Borrowed</div><div class="v">${hasBorrow ? p.borrowed : '—'}</div>${hasBorrow ? `<div class="small muted">${p.borrowedF} · <span class="apy borrow">${p.bApy} APY</span></div>` : ''}</div>
           </div>
           <div class="acts">
             <button class="btn sm" onclick="toast('→ opens supply.html')">Supply</button>
-            <button class="btn sm ghost" ${stateKey==='new'?'disabled':''} onclick="toast('→ opens borrow.html')">Borrow</button>
-            ${hasBorrow?`<button class="btn sm ghost" onclick="toast('→ opens repay.html')">Repay</button>`:''}
-            ${hasSupply?`<button class="btn sm ghost" onclick="toast('→ opens withdraw.html')">Withdraw</button>`:''}
+            <button class="btn sm ghost" ${stateKey === 'new' ? 'disabled' : ''} onclick="toast('→ opens borrow.html')">Borrow</button>
+            ${hasBorrow ? `<button class="btn sm ghost" onclick="toast('→ opens repay.html')">Repay</button>` : ''}
+            ${hasSupply ? `<button class="btn sm ghost" onclick="toast('→ opens withdraw.html')">Withdraw</button>` : ''}
           </div>
         </div>`;
-      }).join('');
-    }
+						})
+						.join('');
+				}
 
-    document.getElementById('markets').innerHTML = pools.map(p=>`
+				document.getElementById('markets').innerHTML = pools
+					.map(
+						(p) => `
       <div class="mkrow">
         <div class="asset"><div class="coin ${p.cls}">${p.sym[0]}</div>
-          <div><div style="font-weight:600">${p.sym} ${p.live?'':'<span class="pill soon">Coming soon</span>'}</div>
+          <div><div style="font-weight:600">${p.sym} ${p.live ? '' : '<span class="pill soon">Coming soon</span>'}</div>
           <div class="small muted">Supply <span class="apy">${p.supply}</span> · Borrow <span class="apy borrow">${p.borrow}</span></div></div></div>
-        <button class="btn sm ${p.live?'':'ghost'}" ${p.live?'':'disabled'} onclick="toast('→ opens supply.html')">Supply</button>
-      </div>`).join('');
-  }
-  document.querySelectorAll('.ctrls button').forEach(b=>b.addEventListener('click',()=>{
-    document.querySelectorAll('.ctrls button').forEach(x=>x.classList.remove('on'));
-    b.classList.add('on'); render(b.dataset.state);
-  }));
-  render('new');
-</script>
-</body>
+        <button class="btn sm ${p.live ? '' : 'ghost'}" ${p.live ? '' : 'disabled'} onclick="toast('→ opens supply.html')">Supply</button>
+      </div>`
+					)
+					.join('');
+			}
+			document.querySelectorAll('.ctrls button').forEach((b) =>
+				b.addEventListener('click', () => {
+					document.querySelectorAll('.ctrls button').forEach((x) => x.classList.remove('on'));
+					b.classList.add('on');
+					render(b.dataset.state);
+				})
+			);
+			render('new');
+		</script>
+	</body>
 </html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/earn-card.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/earn-card.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Earn page · Liquidium card — wireframe</title>
+<style>
+:root{--bg:#e9eefb;--panel:#ffffff;--disabled:#ffffff;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--tertiary:#6b7787;--accent:#2f6df6;--green:#15a35b;--blue:#2f6df6}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
+.wfbar{max-width:760px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#6b7787;border:1px solid #b9c4dd;border-radius:5px;padding:1px 6px;margin-bottom:7px}
+.wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
+.wfbar .ctrls button{background:var(--panel);border:1px solid var(--line);color:var(--muted);border-radius:8px;padding:4px 10px;font-size:12px;cursor:pointer}
+.wfbar .ctrls button.on{color:var(--txt);border-color:var(--accent)}
+.wrap{max-width:760px;margin:0 auto;padding:18px}
+.crumbs{color:var(--muted);font-size:12px;margin-bottom:14px}
+h4{margin:0 0 14px;font-size:15px}
+.grid{display:grid;grid-template-columns:repeat(2,1fr);gap:14px}
+@media(max-width:560px){.grid{grid-template-columns:1fr}}
+/* card mirrors EarningOpportunityCard: rounded, bordered, disabled bg */
+.card{display:flex;flex-direction:column;border:1px solid var(--line);background:var(--disabled);border-radius:12px;padding:14px 13px}
+.top{display:flex;align-items:flex-start;margin-bottom:12px}
+.logo{width:40px;height:40px;border-radius:50%;display:grid;place-items:center;font-weight:700}
+.lq{background:#9b6cff;color:#fff}.ha{background:#1f6f4a;color:#fff}
+.badge{margin-left:auto;border:1px solid var(--line);background:var(--panel);border-radius:999px;padding:4px 11px;font-size:11.5px;white-space:nowrap}
+.badge b{color:var(--green);margin-left:3px}
+h3{margin:0 0 6px;font-size:18px}
+.desc{color:var(--muted);font-size:12.5px;margin:0 0 14px}
+.list{display:flex;flex-direction:column;gap:9px;font-size:12.5px;margin-bottom:16px}
+.li{display:flex;justify-content:space-between;align-items:center}
+.li .k{color:var(--tertiary)}
+.li .v{font-weight:700}
+.li .v.earn{color:var(--green)}
+.li .v.pot{color:var(--blue)}
+.icons{display:flex}
+.icons span{width:20px;height:20px;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:700;margin-left:-6px;border:2px solid var(--disabled)}
+.icons span:first-child{margin-left:0}
+.btc{background:#f7931a;color:#0e1218}.eth{background:#8a93b2;color:#0e1218}.usdc{background:#2775ca;color:#fff}.usdt{background:#26a17b;color:#fff}.icp{background:#e3318f;color:#fff}
+.net-btc{background:#f7931a;color:#0e1218}.net-eth{background:#3c3c4d;color:#fff}.net-icp{background:#1c1c28;color:#fff}
+button.cta{margin-top:auto;width:100%;background:var(--green);color:#ffffff;border:0;border-radius:9px;padding:11px;font-weight:700;font-size:14px;cursor:pointer}
+.ctx{opacity:.55}
+</style></head><body>
+<div class="wfbar">
+  <span class="tag">Wireframe — controls below are not part of the UI</span>
+  <div>The <b>Liquidium card</b> in the "Earning opportunities" list on the Earn page (<code>/earn/</code>), using oisy's <code>EarningOpportunityCard</code> field structure — <b>Networks</b>, <b>Assets</b>, <b>Currently earning</b> (green, /year), <b>Earning potential</b> (blue, /year) — matching the live Harvest card (faded, right) for parity.</div>
+  <div class="ctrls"><span>Demo · your Liquidium state:</span>
+    <button data-state="none" class="on">No position</button>
+    <button data-state="active">Has position</button>
+  </div>
+</div>
+
+<div class="wrap">
+  <div class="crumbs">Earn</div>
+  <h4>Earning opportunities</h4>
+  <div class="grid">
+
+    <!-- Liquidium card -->
+    <div class="card">
+      <div class="top">
+        <span class="logo lq">L</span>
+        <span class="badge">Max. APY<b>5.95%</b></span>
+      </div>
+      <h3>Liquidium</h3>
+      <p class="desc">Lend native assets to earn yield, or borrow against them — BTC, ETH, USDC, USDT.</p>
+      <div class="list">
+        <div class="li"><span class="k">Networks</span>
+          <span class="v"><span class="icons"><span class="net-btc">₿</span><span class="net-eth">◆</span></span></span></div>
+        <div class="li"><span class="k">Assets</span>
+          <span class="v"><span class="icons"><span class="btc">B</span><span class="eth">E</span><span class="usdc">U</span><span class="usdt">T</span></span></span></div>
+        <div class="li"><span class="k">Currently earning</span><span class="v earn" id="cur">+ $0.00/year</span></div>
+        <div class="li"><span class="k">Earning potential</span><span class="v pot" id="pot">+ $24.80/year</span></div>
+      </div>
+      <button class="cta">Lend &amp; Borrow</button>
+    </div>
+
+    <!-- context: existing Harvest Autopilot card (matches the live screenshot) -->
+    <div class="card ctx">
+      <div class="top">
+        <span class="logo ha">🚜</span>
+        <span class="badge">Max. APY<b>5.95%</b></span>
+      </div>
+      <h3>Harvest - Autopilot</h3>
+      <p class="desc">Maximized yield efficiency with 1-click autopilot vaults.</p>
+      <div class="list">
+        <div class="li"><span class="k">Networks</span>
+          <span class="v"><span class="icons"><span class="net-icp">∞</span><span class="net-eth">◆</span><span class="net-btc">₿</span></span></span></div>
+        <div class="li"><span class="k">Assets</span>
+          <span class="v"><span class="icons"><span class="usdc">$</span><span class="eth">w</span><span class="btc">B</span><span class="usdt">T</span></span></span></div>
+        <div class="li"><span class="k">Currently earning</span><span class="v earn">+ $0.07/year</span></div>
+        <div class="li"><span class="k">Earning potential</span><span class="v pot">+ $18.39/year</span></div>
+      </div>
+      <button class="cta">Go to Autopilot</button>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  // Same field structure regardless of state; only the values change.
+  const states = {
+    none:   {cur:'+ $0.00/year',  pot:'+ $24.80/year'},
+    active: {cur:'+ $612.00/year', pot:'+ $9.40/year'}
+  };
+  function render(s){
+    document.getElementById('cur').textContent = states[s].cur;
+    document.getElementById('pot').textContent = states[s].pot;
+  }
+  document.querySelectorAll('.ctrls button').forEach(b=>b.addEventListener('click',()=>{
+    document.querySelectorAll('.ctrls button').forEach(x=>x.classList.remove('on'));
+    b.classList.add('on'); render(b.dataset.state);
+  }));
+  render('none');
+</script>
+</body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/earn-card.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/earn-card.html
@@ -1,111 +1,363 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Earn page · Liquidium card — wireframe</title>
-<style>
-:root{--bg:#e9eefb;--panel:#ffffff;--disabled:#ffffff;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--tertiary:#6b7787;--accent:#2f6df6;--green:#15a35b;--blue:#2f6df6}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
-.wfbar{max-width:760px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#6b7787;border:1px solid #b9c4dd;border-radius:5px;padding:1px 6px;margin-bottom:7px}
-.wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
-.wfbar .ctrls button{background:var(--panel);border:1px solid var(--line);color:var(--muted);border-radius:8px;padding:4px 10px;font-size:12px;cursor:pointer}
-.wfbar .ctrls button.on{color:var(--txt);border-color:var(--accent)}
-.wrap{max-width:760px;margin:0 auto;padding:18px}
-.crumbs{color:var(--muted);font-size:12px;margin-bottom:14px}
-h4{margin:0 0 14px;font-size:15px}
-.grid{display:grid;grid-template-columns:repeat(2,1fr);gap:14px}
-@media(max-width:560px){.grid{grid-template-columns:1fr}}
-/* card mirrors EarningOpportunityCard: rounded, bordered, disabled bg */
-.card{display:flex;flex-direction:column;border:1px solid var(--line);background:var(--disabled);border-radius:12px;padding:14px 13px}
-.top{display:flex;align-items:flex-start;margin-bottom:12px}
-.logo{width:40px;height:40px;border-radius:50%;display:grid;place-items:center;font-weight:700}
-.lq{background:#9b6cff;color:#fff}.ha{background:#1f6f4a;color:#fff}
-.badge{margin-left:auto;border:1px solid var(--line);background:var(--panel);border-radius:999px;padding:4px 11px;font-size:11.5px;white-space:nowrap}
-.badge b{color:var(--green);margin-left:3px}
-h3{margin:0 0 6px;font-size:18px}
-.desc{color:var(--muted);font-size:12.5px;margin:0 0 14px}
-.list{display:flex;flex-direction:column;gap:9px;font-size:12.5px;margin-bottom:16px}
-.li{display:flex;justify-content:space-between;align-items:center}
-.li .k{color:var(--tertiary)}
-.li .v{font-weight:700}
-.li .v.earn{color:var(--green)}
-.li .v.pot{color:var(--blue)}
-.icons{display:flex}
-.icons span{width:20px;height:20px;border-radius:50%;display:grid;place-items:center;font-size:10px;font-weight:700;margin-left:-6px;border:2px solid var(--disabled)}
-.icons span:first-child{margin-left:0}
-.btc{background:#f7931a;color:#0e1218}.eth{background:#8a93b2;color:#0e1218}.usdc{background:#2775ca;color:#fff}.usdt{background:#26a17b;color:#fff}.icp{background:#e3318f;color:#fff}
-.net-btc{background:#f7931a;color:#0e1218}.net-eth{background:#3c3c4d;color:#fff}.net-icp{background:#1c1c28;color:#fff}
-button.cta{margin-top:auto;width:100%;background:var(--green);color:#ffffff;border:0;border-radius:9px;padding:11px;font-weight:700;font-size:14px;cursor:pointer}
-.ctx{opacity:.55}
-</style></head><body>
-<div class="wfbar">
-  <span class="tag">Wireframe — controls below are not part of the UI</span>
-  <div>The <b>Liquidium card</b> in the "Earning opportunities" list on the Earn page (<code>/earn/</code>), using oisy's <code>EarningOpportunityCard</code> field structure — <b>Networks</b>, <b>Assets</b>, <b>Currently earning</b> (green, /year), <b>Earning potential</b> (blue, /year) — matching the live Harvest card (faded, right) for parity.</div>
-  <div class="ctrls"><span>Demo · your Liquidium state:</span>
-    <button data-state="none" class="on">No position</button>
-    <button data-state="active">Has position</button>
-  </div>
-</div>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Earn page · Liquidium card — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--panel: #ffffff;
+				--disabled: #ffffff;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--tertiary: #6b7787;
+				--accent: #2f6df6;
+				--green: #15a35b;
+				--blue: #2f6df6;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+			}
+			.wfbar {
+				max-width: 760px;
+				margin: 14px auto 0;
+				background: #ffffff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.wfbar .tag {
+				display: inline-block;
+				font-size: 10px;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+				color: #6b7787;
+				border: 1px solid #b9c4dd;
+				border-radius: 5px;
+				padding: 1px 6px;
+				margin-bottom: 7px;
+			}
+			.wfbar .ctrls {
+				display: flex;
+				gap: 6px;
+				align-items: center;
+				margin-top: 10px;
+				flex-wrap: wrap;
+				padding-top: 9px;
+				border-top: 1px solid #eef1f7;
+			}
+			.wfbar .ctrls button {
+				background: var(--panel);
+				border: 1px solid var(--line);
+				color: var(--muted);
+				border-radius: 8px;
+				padding: 4px 10px;
+				font-size: 12px;
+				cursor: pointer;
+			}
+			.wfbar .ctrls button.on {
+				color: var(--txt);
+				border-color: var(--accent);
+			}
+			.wrap {
+				max-width: 760px;
+				margin: 0 auto;
+				padding: 18px;
+			}
+			.crumbs {
+				color: var(--muted);
+				font-size: 12px;
+				margin-bottom: 14px;
+			}
+			h4 {
+				margin: 0 0 14px;
+				font-size: 15px;
+			}
+			.grid {
+				display: grid;
+				grid-template-columns: repeat(2, 1fr);
+				gap: 14px;
+			}
+			@media (max-width: 560px) {
+				.grid {
+					grid-template-columns: 1fr;
+				}
+			}
+			/* card mirrors EarningOpportunityCard: rounded, bordered, disabled bg */
+			.card {
+				display: flex;
+				flex-direction: column;
+				border: 1px solid var(--line);
+				background: var(--disabled);
+				border-radius: 12px;
+				padding: 14px 13px;
+			}
+			.top {
+				display: flex;
+				align-items: flex-start;
+				margin-bottom: 12px;
+			}
+			.logo {
+				width: 40px;
+				height: 40px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+			}
+			.lq {
+				background: #9b6cff;
+				color: #fff;
+			}
+			.ha {
+				background: #1f6f4a;
+				color: #fff;
+			}
+			.badge {
+				margin-left: auto;
+				border: 1px solid var(--line);
+				background: var(--panel);
+				border-radius: 999px;
+				padding: 4px 11px;
+				font-size: 11.5px;
+				white-space: nowrap;
+			}
+			.badge b {
+				color: var(--green);
+				margin-left: 3px;
+			}
+			h3 {
+				margin: 0 0 6px;
+				font-size: 18px;
+			}
+			.desc {
+				color: var(--muted);
+				font-size: 12.5px;
+				margin: 0 0 14px;
+			}
+			.list {
+				display: flex;
+				flex-direction: column;
+				gap: 9px;
+				font-size: 12.5px;
+				margin-bottom: 16px;
+			}
+			.li {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+			}
+			.li .k {
+				color: var(--tertiary);
+			}
+			.li .v {
+				font-weight: 700;
+			}
+			.li .v.earn {
+				color: var(--green);
+			}
+			.li .v.pot {
+				color: var(--blue);
+			}
+			.icons {
+				display: flex;
+			}
+			.icons span {
+				width: 20px;
+				height: 20px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-size: 10px;
+				font-weight: 700;
+				margin-left: -6px;
+				border: 2px solid var(--disabled);
+			}
+			.icons span:first-child {
+				margin-left: 0;
+			}
+			.btc {
+				background: #f7931a;
+				color: #0e1218;
+			}
+			.eth {
+				background: #8a93b2;
+				color: #0e1218;
+			}
+			.usdc {
+				background: #2775ca;
+				color: #fff;
+			}
+			.usdt {
+				background: #26a17b;
+				color: #fff;
+			}
+			.icp {
+				background: #e3318f;
+				color: #fff;
+			}
+			.net-btc {
+				background: #f7931a;
+				color: #0e1218;
+			}
+			.net-eth {
+				background: #3c3c4d;
+				color: #fff;
+			}
+			.net-icp {
+				background: #1c1c28;
+				color: #fff;
+			}
+			button.cta {
+				margin-top: auto;
+				width: 100%;
+				background: var(--green);
+				color: #ffffff;
+				border: 0;
+				border-radius: 9px;
+				padding: 11px;
+				font-weight: 700;
+				font-size: 14px;
+				cursor: pointer;
+			}
+			.ctx {
+				opacity: 0.55;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wfbar">
+			<span class="tag">Wireframe — controls below are not part of the UI</span>
+			<div>
+				The <b>Liquidium card</b> in the "Earning opportunities" list on the Earn page
+				(<code>/earn/</code>), using oisy's <code>EarningOpportunityCard</code> field structure —
+				<b>Networks</b>, <b>Assets</b>, <b>Currently earning</b> (green, /year),
+				<b>Earning potential</b> (blue, /year) — matching the live Harvest card (faded, right) for
+				parity.
+			</div>
+			<div class="ctrls">
+				<span>Demo · your Liquidium state:</span>
+				<button data-state="none" class="on">No position</button>
+				<button data-state="active">Has position</button>
+			</div>
+		</div>
 
-<div class="wrap">
-  <div class="crumbs">Earn</div>
-  <h4>Earning opportunities</h4>
-  <div class="grid">
+		<div class="wrap">
+			<div class="crumbs">Earn</div>
+			<h4>Earning opportunities</h4>
+			<div class="grid">
+				<!-- Liquidium card -->
+				<div class="card">
+					<div class="top">
+						<span class="logo lq">L</span>
+						<span class="badge">Max. APY<b>5.95%</b></span>
+					</div>
+					<h3>Liquidium</h3>
+					<p class="desc">
+						Lend native assets to earn yield, or borrow against them — BTC, ETH, USDC, USDT.
+					</p>
+					<div class="list">
+						<div class="li">
+							<span class="k">Networks</span>
+							<span class="v"
+								><span class="icons"
+									><span class="net-btc">₿</span><span class="net-eth">◆</span></span
+								></span
+							>
+						</div>
+						<div class="li">
+							<span class="k">Assets</span>
+							<span class="v"
+								><span class="icons"
+									><span class="btc">B</span><span class="eth">E</span><span class="usdc">U</span
+									><span class="usdt">T</span></span
+								></span
+							>
+						</div>
+						<div class="li">
+							<span class="k">Currently earning</span
+							><span class="v earn" id="cur">+ $0.00/year</span>
+						</div>
+						<div class="li">
+							<span class="k">Earning potential</span
+							><span class="v pot" id="pot">+ $24.80/year</span>
+						</div>
+					</div>
+					<button class="cta">Lend &amp; Borrow</button>
+				</div>
 
-    <!-- Liquidium card -->
-    <div class="card">
-      <div class="top">
-        <span class="logo lq">L</span>
-        <span class="badge">Max. APY<b>5.95%</b></span>
-      </div>
-      <h3>Liquidium</h3>
-      <p class="desc">Lend native assets to earn yield, or borrow against them — BTC, ETH, USDC, USDT.</p>
-      <div class="list">
-        <div class="li"><span class="k">Networks</span>
-          <span class="v"><span class="icons"><span class="net-btc">₿</span><span class="net-eth">◆</span></span></span></div>
-        <div class="li"><span class="k">Assets</span>
-          <span class="v"><span class="icons"><span class="btc">B</span><span class="eth">E</span><span class="usdc">U</span><span class="usdt">T</span></span></span></div>
-        <div class="li"><span class="k">Currently earning</span><span class="v earn" id="cur">+ $0.00/year</span></div>
-        <div class="li"><span class="k">Earning potential</span><span class="v pot" id="pot">+ $24.80/year</span></div>
-      </div>
-      <button class="cta">Lend &amp; Borrow</button>
-    </div>
+				<!-- context: existing Harvest Autopilot card (matches the live screenshot) -->
+				<div class="card ctx">
+					<div class="top">
+						<span class="logo ha">🚜</span>
+						<span class="badge">Max. APY<b>5.95%</b></span>
+					</div>
+					<h3>Harvest - Autopilot</h3>
+					<p class="desc">Maximized yield efficiency with 1-click autopilot vaults.</p>
+					<div class="list">
+						<div class="li">
+							<span class="k">Networks</span>
+							<span class="v"
+								><span class="icons"
+									><span class="net-icp">∞</span><span class="net-eth">◆</span
+									><span class="net-btc">₿</span></span
+								></span
+							>
+						</div>
+						<div class="li">
+							<span class="k">Assets</span>
+							<span class="v"
+								><span class="icons"
+									><span class="usdc">$</span><span class="eth">w</span><span class="btc">B</span
+									><span class="usdt">T</span></span
+								></span
+							>
+						</div>
+						<div class="li">
+							<span class="k">Currently earning</span><span class="v earn">+ $0.07/year</span>
+						</div>
+						<div class="li">
+							<span class="k">Earning potential</span><span class="v pot">+ $18.39/year</span>
+						</div>
+					</div>
+					<button class="cta">Go to Autopilot</button>
+				</div>
+			</div>
+		</div>
 
-    <!-- context: existing Harvest Autopilot card (matches the live screenshot) -->
-    <div class="card ctx">
-      <div class="top">
-        <span class="logo ha">🚜</span>
-        <span class="badge">Max. APY<b>5.95%</b></span>
-      </div>
-      <h3>Harvest - Autopilot</h3>
-      <p class="desc">Maximized yield efficiency with 1-click autopilot vaults.</p>
-      <div class="list">
-        <div class="li"><span class="k">Networks</span>
-          <span class="v"><span class="icons"><span class="net-icp">∞</span><span class="net-eth">◆</span><span class="net-btc">₿</span></span></span></div>
-        <div class="li"><span class="k">Assets</span>
-          <span class="v"><span class="icons"><span class="usdc">$</span><span class="eth">w</span><span class="btc">B</span><span class="usdt">T</span></span></span></div>
-        <div class="li"><span class="k">Currently earning</span><span class="v earn">+ $0.07/year</span></div>
-        <div class="li"><span class="k">Earning potential</span><span class="v pot">+ $18.39/year</span></div>
-      </div>
-      <button class="cta">Go to Autopilot</button>
-    </div>
-
-  </div>
-</div>
-
-<script>
-  // Same field structure regardless of state; only the values change.
-  const states = {
-    none:   {cur:'+ $0.00/year',  pot:'+ $24.80/year'},
-    active: {cur:'+ $612.00/year', pot:'+ $9.40/year'}
-  };
-  function render(s){
-    document.getElementById('cur').textContent = states[s].cur;
-    document.getElementById('pot').textContent = states[s].pot;
-  }
-  document.querySelectorAll('.ctrls button').forEach(b=>b.addEventListener('click',()=>{
-    document.querySelectorAll('.ctrls button').forEach(x=>x.classList.remove('on'));
-    b.classList.add('on'); render(b.dataset.state);
-  }));
-  render('none');
-</script>
-</body></html>
+		<script>
+			// Same field structure regardless of state; only the values change.
+			const states = {
+				none: { cur: '+ $0.00/year', pot: '+ $24.80/year' },
+				active: { cur: '+ $612.00/year', pot: '+ $9.40/year' }
+			};
+			function render(s) {
+				document.getElementById('cur').textContent = states[s].cur;
+				document.getElementById('pot').textContent = states[s].pot;
+			}
+			document.querySelectorAll('.ctrls button').forEach((b) =>
+				b.addEventListener('click', () => {
+					document.querySelectorAll('.ctrls button').forEach((x) => x.classList.remove('on'));
+					b.classList.add('on');
+					render(b.dataset.state);
+				})
+			);
+			render('none');
+		</script>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/earning-tab.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/earning-tab.html
@@ -1,65 +1,270 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Assets · Earning tab — wireframe</title>
-<style>
-:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
-.note{max-width:520px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.wrap{max-width:520px;margin:0 auto;padding:14px 18px 28px}
-.hero{padding:6px 2px 14px}.hero .lbl{color:var(--muted);font-size:12px}.hero .tot{font-size:30px;font-weight:700}
-.tabs{display:flex;gap:18px;border-bottom:1px solid var(--line);margin:6px 0 16px}
-.tabs a{position:relative;color:var(--muted);text-decoration:none;padding:9px 0;font-weight:600;border-bottom:2px solid transparent;font-size:14px;cursor:pointer}
-.tabs a.on{color:var(--txt);border-bottom-color:var(--accent)}
-.tabdot{position:absolute;top:4px;right:-9px;width:8px;height:8px;border-radius:50%;box-shadow:0 0 0 2px var(--bg)}
-.tabdot.amber{background:var(--amber)}
-.tabdot.red{background:var(--red)}
-.sec{font-weight:600;margin:4px 0 10px;color:var(--muted);font-size:13px;text-transform:uppercase;letter-spacing:.04em}
-.card{background:var(--panel);border:1px solid var(--line);border-radius:13px;padding:13px 14px;margin-bottom:10px;display:flex;align-items:center;justify-content:space-between;cursor:pointer}
-.card:hover{border-color:var(--accent)}
-.left{display:flex;align-items:center;gap:12px}
-.coin{width:34px;height:34px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:13px}
-.btc{background:#f7931a;color:#0e1218}.eth{background:#8a93b2;color:#0e1218}.usdc{background:#2775ca;color:#fff}.icp{background:#e3318f;color:#fff}
-.name{font-weight:600}
-.prov{font-size:11.5px;color:var(--muted);display:inline-flex;align-items:center;gap:5px;margin-top:2px}
-.dot{width:6px;height:6px;border-radius:50%}
-.dot.l{background:#9b6cff}.dot.h{background:#3ecf8e}
-.right{text-align:right}
-.amt{font-weight:600}
-.apy{font-size:12px;color:var(--green);margin-top:2px}
-.fiat{font-size:12px;color:var(--muted)}
-</style></head><body>
-<div class="note">Wireframe — Assets page, <b>Earning</b> tab ("My assets"). Generalised from autopilot-only to all yield-bearing positions across providers. Cards are grouped by type, each labelled with its provider. Liquidium supplies sit next to Harvest Autopilot stakes. Click "Liabilities" to see the sibling tab. Note the status dot on the <b>Liabilities</b> tab — shown here as an example (amber) to demonstrate that the risk indicator is visible even when that tab is not selected.</div>
-<div class="wrap">
-  <div class="hero"><div class="lbl">Net worth</div><div class="tot">$112,438.20</div></div>
-  <div class="tabs">
-    <a>Tokens</a><a>NFTs</a><a class="on">Earning</a>
-    <a onclick="location.href='liabilities-tab.html'">Liabilities<span class="tabdot amber" title="A borrow provider is at risk"></span></a>
-  </div>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Assets · Earning tab — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--panel: #ffffff;
+				--panel2: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--accent: #2f6df6;
+				--green: #15a35b;
+				--amber: #d8890a;
+				--red: #df4a3c;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+			}
+			.note {
+				max-width: 520px;
+				margin: 14px auto 0;
+				background: #ffffff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.wrap {
+				max-width: 520px;
+				margin: 0 auto;
+				padding: 14px 18px 28px;
+			}
+			.hero {
+				padding: 6px 2px 14px;
+			}
+			.hero .lbl {
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.hero .tot {
+				font-size: 30px;
+				font-weight: 700;
+			}
+			.tabs {
+				display: flex;
+				gap: 18px;
+				border-bottom: 1px solid var(--line);
+				margin: 6px 0 16px;
+			}
+			.tabs a {
+				position: relative;
+				color: var(--muted);
+				text-decoration: none;
+				padding: 9px 0;
+				font-weight: 600;
+				border-bottom: 2px solid transparent;
+				font-size: 14px;
+				cursor: pointer;
+			}
+			.tabs a.on {
+				color: var(--txt);
+				border-bottom-color: var(--accent);
+			}
+			.tabdot {
+				position: absolute;
+				top: 4px;
+				right: -9px;
+				width: 8px;
+				height: 8px;
+				border-radius: 50%;
+				box-shadow: 0 0 0 2px var(--bg);
+			}
+			.tabdot.amber {
+				background: var(--amber);
+			}
+			.tabdot.red {
+				background: var(--red);
+			}
+			.sec {
+				font-weight: 600;
+				margin: 4px 0 10px;
+				color: var(--muted);
+				font-size: 13px;
+				text-transform: uppercase;
+				letter-spacing: 0.04em;
+			}
+			.card {
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 13px;
+				padding: 13px 14px;
+				margin-bottom: 10px;
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				cursor: pointer;
+			}
+			.card:hover {
+				border-color: var(--accent);
+			}
+			.left {
+				display: flex;
+				align-items: center;
+				gap: 12px;
+			}
+			.coin {
+				width: 34px;
+				height: 34px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				font-size: 13px;
+			}
+			.btc {
+				background: #f7931a;
+				color: #0e1218;
+			}
+			.eth {
+				background: #8a93b2;
+				color: #0e1218;
+			}
+			.usdc {
+				background: #2775ca;
+				color: #fff;
+			}
+			.icp {
+				background: #e3318f;
+				color: #fff;
+			}
+			.name {
+				font-weight: 600;
+			}
+			.prov {
+				font-size: 11.5px;
+				color: var(--muted);
+				display: inline-flex;
+				align-items: center;
+				gap: 5px;
+				margin-top: 2px;
+			}
+			.dot {
+				width: 6px;
+				height: 6px;
+				border-radius: 50%;
+			}
+			.dot.l {
+				background: #9b6cff;
+			}
+			.dot.h {
+				background: #3ecf8e;
+			}
+			.right {
+				text-align: right;
+			}
+			.amt {
+				font-weight: 600;
+			}
+			.apy {
+				font-size: 12px;
+				color: var(--green);
+				margin-top: 2px;
+			}
+			.fiat {
+				font-size: 12px;
+				color: var(--muted);
+			}
+		</style>
+	</head>
+	<body>
+		<div class="note">
+			Wireframe — Assets page, <b>Earning</b> tab ("My assets"). Generalised from autopilot-only to
+			all yield-bearing positions across providers. Cards are grouped by type, each labelled with
+			its provider. Liquidium supplies sit next to Harvest Autopilot stakes. Click "Liabilities" to
+			see the sibling tab. Note the status dot on the <b>Liabilities</b> tab — shown here as an
+			example (amber) to demonstrate that the risk indicator is visible even when that tab is not
+			selected.
+		</div>
+		<div class="wrap">
+			<div class="hero">
+				<div class="lbl">Net worth</div>
+				<div class="tot">$112,438.20</div>
+			</div>
+			<div class="tabs">
+				<a>Tokens</a><a>NFTs</a><a class="on">Earning</a>
+				<a onclick="location.href = 'liabilities-tab.html'"
+					>Liabilities<span class="tabdot amber" title="A borrow provider is at risk"></span
+				></a>
+			</div>
 
-  <div class="sec">My assets</div>
+			<div class="sec">My assets</div>
 
-  <div class="card">
-    <div class="left"><div class="coin btc">B</div>
-      <div><div class="name">BTC</div><div class="prov"><span class="dot l"></span>Liquidium · Supplied</div></div></div>
-    <div class="right"><div class="amt">1.00 BTC</div><div class="apy">1.94% APY</div><div class="fiat">$67,170.00</div></div>
-  </div>
+			<div class="card">
+				<div class="left">
+					<div class="coin btc">B</div>
+					<div>
+						<div class="name">BTC</div>
+						<div class="prov"><span class="dot l"></span>Liquidium · Supplied</div>
+					</div>
+				</div>
+				<div class="right">
+					<div class="amt">1.00 BTC</div>
+					<div class="apy">1.94% APY</div>
+					<div class="fiat">$67,170.00</div>
+				</div>
+			</div>
 
-  <div class="card">
-    <div class="left"><div class="coin usdc">U</div>
-      <div><div class="name">USDC</div><div class="prov"><span class="dot l"></span>Liquidium · Supplied</div></div></div>
-    <div class="right"><div class="amt">12,000 USDC</div><div class="apy">5.20% APY</div><div class="fiat">$12,000.00</div></div>
-  </div>
+			<div class="card">
+				<div class="left">
+					<div class="coin usdc">U</div>
+					<div>
+						<div class="name">USDC</div>
+						<div class="prov"><span class="dot l"></span>Liquidium · Supplied</div>
+					</div>
+				</div>
+				<div class="right">
+					<div class="amt">12,000 USDC</div>
+					<div class="apy">5.20% APY</div>
+					<div class="fiat">$12,000.00</div>
+				</div>
+			</div>
 
-  <div class="card">
-    <div class="left"><div class="coin icp">I</div>
-      <div><div class="name">ICP</div><div class="prov"><span class="dot h"></span>Harvest Autopilot · Staked</div></div></div>
-    <div class="right"><div class="amt">2,400 ICP</div><div class="apy">8.10% APY</div><div class="fiat">$28,800.00</div></div>
-  </div>
+			<div class="card">
+				<div class="left">
+					<div class="coin icp">I</div>
+					<div>
+						<div class="name">ICP</div>
+						<div class="prov"><span class="dot h"></span>Harvest Autopilot · Staked</div>
+					</div>
+				</div>
+				<div class="right">
+					<div class="amt">2,400 ICP</div>
+					<div class="apy">8.10% APY</div>
+					<div class="fiat">$28,800.00</div>
+				</div>
+			</div>
 
-  <div class="card">
-    <div class="left"><div class="coin eth">E</div>
-      <div><div class="name">ETH</div><div class="prov"><span class="dot h"></span>Harvest Autopilot · Staked</div></div></div>
-    <div class="right"><div class="amt">1.2 ETH</div><div class="apy">3.40% APY</div><div class="fiat">$4,468.20</div></div>
-  </div>
-</div>
-</body></html>
+			<div class="card">
+				<div class="left">
+					<div class="coin eth">E</div>
+					<div>
+						<div class="name">ETH</div>
+						<div class="prov"><span class="dot h"></span>Harvest Autopilot · Staked</div>
+					</div>
+				</div>
+				<div class="right">
+					<div class="amt">1.2 ETH</div>
+					<div class="apy">3.40% APY</div>
+					<div class="fiat">$4,468.20</div>
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/earning-tab.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/earning-tab.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Assets · Earning tab — wireframe</title>
+<style>
+:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
+.note{max-width:520px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.wrap{max-width:520px;margin:0 auto;padding:14px 18px 28px}
+.hero{padding:6px 2px 14px}.hero .lbl{color:var(--muted);font-size:12px}.hero .tot{font-size:30px;font-weight:700}
+.tabs{display:flex;gap:18px;border-bottom:1px solid var(--line);margin:6px 0 16px}
+.tabs a{position:relative;color:var(--muted);text-decoration:none;padding:9px 0;font-weight:600;border-bottom:2px solid transparent;font-size:14px;cursor:pointer}
+.tabs a.on{color:var(--txt);border-bottom-color:var(--accent)}
+.tabdot{position:absolute;top:4px;right:-9px;width:8px;height:8px;border-radius:50%;box-shadow:0 0 0 2px var(--bg)}
+.tabdot.amber{background:var(--amber)}
+.tabdot.red{background:var(--red)}
+.sec{font-weight:600;margin:4px 0 10px;color:var(--muted);font-size:13px;text-transform:uppercase;letter-spacing:.04em}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:13px;padding:13px 14px;margin-bottom:10px;display:flex;align-items:center;justify-content:space-between;cursor:pointer}
+.card:hover{border-color:var(--accent)}
+.left{display:flex;align-items:center;gap:12px}
+.coin{width:34px;height:34px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:13px}
+.btc{background:#f7931a;color:#0e1218}.eth{background:#8a93b2;color:#0e1218}.usdc{background:#2775ca;color:#fff}.icp{background:#e3318f;color:#fff}
+.name{font-weight:600}
+.prov{font-size:11.5px;color:var(--muted);display:inline-flex;align-items:center;gap:5px;margin-top:2px}
+.dot{width:6px;height:6px;border-radius:50%}
+.dot.l{background:#9b6cff}.dot.h{background:#3ecf8e}
+.right{text-align:right}
+.amt{font-weight:600}
+.apy{font-size:12px;color:var(--green);margin-top:2px}
+.fiat{font-size:12px;color:var(--muted)}
+</style></head><body>
+<div class="note">Wireframe — Assets page, <b>Earning</b> tab ("My assets"). Generalised from autopilot-only to all yield-bearing positions across providers. Cards are grouped by type, each labelled with its provider. Liquidium supplies sit next to Harvest Autopilot stakes. Click "Liabilities" to see the sibling tab. Note the status dot on the <b>Liabilities</b> tab — shown here as an example (amber) to demonstrate that the risk indicator is visible even when that tab is not selected.</div>
+<div class="wrap">
+  <div class="hero"><div class="lbl">Net worth</div><div class="tot">$112,438.20</div></div>
+  <div class="tabs">
+    <a>Tokens</a><a>NFTs</a><a class="on">Earning</a>
+    <a onclick="location.href='liabilities-tab.html'">Liabilities<span class="tabdot amber" title="A borrow provider is at risk"></span></a>
+  </div>
+
+  <div class="sec">My assets</div>
+
+  <div class="card">
+    <div class="left"><div class="coin btc">B</div>
+      <div><div class="name">BTC</div><div class="prov"><span class="dot l"></span>Liquidium · Supplied</div></div></div>
+    <div class="right"><div class="amt">1.00 BTC</div><div class="apy">1.94% APY</div><div class="fiat">$67,170.00</div></div>
+  </div>
+
+  <div class="card">
+    <div class="left"><div class="coin usdc">U</div>
+      <div><div class="name">USDC</div><div class="prov"><span class="dot l"></span>Liquidium · Supplied</div></div></div>
+    <div class="right"><div class="amt">12,000 USDC</div><div class="apy">5.20% APY</div><div class="fiat">$12,000.00</div></div>
+  </div>
+
+  <div class="card">
+    <div class="left"><div class="coin icp">I</div>
+      <div><div class="name">ICP</div><div class="prov"><span class="dot h"></span>Harvest Autopilot · Staked</div></div></div>
+    <div class="right"><div class="amt">2,400 ICP</div><div class="apy">8.10% APY</div><div class="fiat">$28,800.00</div></div>
+  </div>
+
+  <div class="card">
+    <div class="left"><div class="coin eth">E</div>
+      <div><div class="name">ETH</div><div class="prov"><span class="dot h"></span>Harvest Autopilot · Staked</div></div></div>
+    <div class="right"><div class="amt">1.2 ETH</div><div class="apy">3.40% APY</div><div class="fiat">$4,468.20</div></div>
+  </div>
+</div>
+</body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/liabilities-tab.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/liabilities-tab.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Assets · Liabilities tab — wireframe</title>
+<style>
+:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
+.wfbar{max-width:520px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#6b7787;border:1px solid #b9c4dd;border-radius:5px;padding:1px 6px;margin-bottom:7px}
+.wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
+.wrap{max-width:520px;margin:0 auto;padding:14px 18px 28px}
+.hero{padding:6px 2px 12px}.hero .lbl{color:var(--muted);font-size:12px}.hero .tot{font-size:30px;font-weight:700}
+.tabs{display:flex;gap:18px;border-bottom:1px solid var(--line);margin:6px 0 16px}
+.tabs a{position:relative;color:var(--muted);text-decoration:none;padding:9px 0;font-weight:600;border-bottom:2px solid transparent;font-size:14px;cursor:pointer}
+.tabs a.on{color:var(--txt);border-bottom-color:var(--red)}
+.tabdot{position:absolute;top:4px;right:-9px;width:8px;height:8px;border-radius:50%;display:none;box-shadow:0 0 0 2px var(--bg)}
+.tabdot.amber{background:var(--amber);display:block}
+.tabdot.red{background:var(--red);display:block}
+.ctrls button{background:var(--panel2);border:1px solid var(--line);color:var(--muted);border-radius:8px;padding:4px 10px;font-size:12px;cursor:pointer}
+.ctrls button.on{color:var(--txt);border-color:var(--accent)}
+/* provider group */
+.group{margin-bottom:18px}
+.ghead{display:flex;align-items:center;gap:10px;margin:2px 0 10px}
+.gtitle{display:flex;align-items:center;gap:8px;font-weight:600}
+.gprov{width:18px;height:18px;border-radius:5px;background:#9b6cff;display:grid;place-items:center;font-size:11px;color:#fff;font-weight:700}
+/* compact per-provider health tag — one small element next to the group title */
+.htag{font-size:11.5px;font-weight:600;border-radius:999px;padding:2px 9px;display:inline-flex;align-items:center;gap:6px}
+.htag .d{width:7px;height:7px;border-radius:50%}
+.htag.ok{color:var(--green);background:#e6f7ee;border:1px solid #a8e0c2}.htag.ok .d{background:var(--green)}
+.htag.amber{color:var(--amber);background:#fbf1de;border:1px solid #ecd29a}.htag.amber .d{background:var(--amber)}
+.htag.red{color:var(--red);background:#fce8e6;border:1px solid #f3b6ad}.htag.red .d{background:var(--red)}
+.gowed{margin-left:auto;font-size:12.5px;color:var(--red);font-weight:600}
+.card{background:var(--panel);border:1px solid #f3d6d2;border-left:3px solid var(--red);border-radius:13px;padding:13px 14px;margin-bottom:9px;display:flex;align-items:center;justify-content:space-between;cursor:pointer;box-shadow:0 1px 2px rgba(20,30,60,.04)}
+.left{display:flex;align-items:center;gap:12px}
+.coin{width:34px;height:34px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:13px}
+.usdc{background:#2775ca;color:#fff}.usdt{background:#26a17b;color:#fff}
+.name{font-weight:600}.sub{font-size:11.5px;color:var(--muted);margin-top:2px}
+.right{text-align:right}
+.amt{font-weight:600;color:var(--red)}
+.rate{font-size:12px;color:var(--amber);margin-top:2px}
+.fiat{font-size:12px;color:var(--red)}
+</style></head><body>
+<div class="wfbar">
+  <span class="tag">Wireframe — controls below are not part of the UI</span>
+  <div>Assets page, <b>Liabilities</b> tab. Grouped <b>by provider</b> (health factor is per-provider). The health status is a single compact, colour-coded tag next to the provider group title — no big banner here (that lives large on the provider page).</div>
+  <div class="ctrls"><span>Demo · Liquidium health:</span>
+    <button data-h="68" class="on">Healthy</button>
+    <button data-h="16">At risk</button>
+    <button data-h="7">Critical</button>
+  </div>
+</div>
+<div class="wrap">
+  <div class="hero"><div class="lbl">Net worth</div><div class="tot">$112,438.20</div></div>
+  <div class="tabs">
+    <a onclick="location.href='earning-tab.html'">Tokens</a>
+    <a onclick="location.href='earning-tab.html'">NFTs</a>
+    <a onclick="location.href='earning-tab.html'">Earning</a>
+    <a class="on">Liabilities<span class="tabdot" id="tabdot"></span></a>
+  </div>
+
+  <div class="group">
+    <div class="ghead">
+      <div class="gtitle"><span class="gprov">L</span>Liquidium</div>
+      <span class="htag ok" id="htag"><span class="d"></span><span id="htagText">Healthy at 68%</span></span>
+      <span class="gowed">−$35,000.00</span>
+    </div>
+
+    <div class="card">
+      <div class="left"><div class="coin usdc">U</div><div><div class="name">USDC</div><div class="sub">Borrowed</div></div></div>
+      <div class="right"><div class="amt">−20,000 USDC</div><div class="rate">Borrow rate · 7.40%</div><div class="fiat">−$20,000.00</div></div>
+    </div>
+    <div class="card">
+      <div class="left"><div class="coin usdt">T</div><div><div class="name">USDT</div><div class="sub">Borrowed</div></div></div>
+      <div class="right"><div class="amt">−15,000 USDT</div><div class="rate">Borrow rate · 7.25%</div><div class="fiat">−$15,000.00</div></div>
+    </div>
+  </div>
+
+  <!-- A second borrow provider, when one exists, would be its own group with its own health tag. -->
+</div>
+<script>
+  function band(h){return h<12?'red':h<40?'amber':'ok';}
+  function word(h){return h<12?'Critical':h<40?'At risk':'Healthy';}
+  function setHealth(h){
+    const b=band(h);
+    const t=document.getElementById('htag');
+    t.className='htag '+b;
+    document.getElementById('htagText').textContent=word(h)+' at '+h+'%';
+    // tab-label indicator: worst provider health across all groups (one provider here).
+    // hidden when healthy, amber at risk, red critical.
+    document.getElementById('tabdot').className='tabdot'+(b==='ok'?'':' '+b);
+  }
+  document.querySelectorAll('.ctrls button').forEach(b=>b.addEventListener('click',()=>{
+    document.querySelectorAll('.ctrls button').forEach(x=>x.classList.remove('on'));
+    b.classList.add('on');setHealth(+b.dataset.h);
+  }));
+  setHealth(68);
+</script>
+</body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/liabilities-tab.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/liabilities-tab.html
@@ -1,97 +1,358 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Assets · Liabilities tab — wireframe</title>
-<style>
-:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
-.wfbar{max-width:520px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.wfbar .tag{display:inline-block;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:#6b7787;border:1px solid #b9c4dd;border-radius:5px;padding:1px 6px;margin-bottom:7px}
-.wfbar .ctrls{display:flex;gap:6px;align-items:center;margin-top:10px;flex-wrap:wrap;padding-top:9px;border-top:1px solid #eef1f7}
-.wrap{max-width:520px;margin:0 auto;padding:14px 18px 28px}
-.hero{padding:6px 2px 12px}.hero .lbl{color:var(--muted);font-size:12px}.hero .tot{font-size:30px;font-weight:700}
-.tabs{display:flex;gap:18px;border-bottom:1px solid var(--line);margin:6px 0 16px}
-.tabs a{position:relative;color:var(--muted);text-decoration:none;padding:9px 0;font-weight:600;border-bottom:2px solid transparent;font-size:14px;cursor:pointer}
-.tabs a.on{color:var(--txt);border-bottom-color:var(--red)}
-.tabdot{position:absolute;top:4px;right:-9px;width:8px;height:8px;border-radius:50%;display:none;box-shadow:0 0 0 2px var(--bg)}
-.tabdot.amber{background:var(--amber);display:block}
-.tabdot.red{background:var(--red);display:block}
-.ctrls button{background:var(--panel2);border:1px solid var(--line);color:var(--muted);border-radius:8px;padding:4px 10px;font-size:12px;cursor:pointer}
-.ctrls button.on{color:var(--txt);border-color:var(--accent)}
-/* provider group */
-.group{margin-bottom:18px}
-.ghead{display:flex;align-items:center;gap:10px;margin:2px 0 10px}
-.gtitle{display:flex;align-items:center;gap:8px;font-weight:600}
-.gprov{width:18px;height:18px;border-radius:5px;background:#9b6cff;display:grid;place-items:center;font-size:11px;color:#fff;font-weight:700}
-/* compact per-provider health tag — one small element next to the group title */
-.htag{font-size:11.5px;font-weight:600;border-radius:999px;padding:2px 9px;display:inline-flex;align-items:center;gap:6px}
-.htag .d{width:7px;height:7px;border-radius:50%}
-.htag.ok{color:var(--green);background:#e6f7ee;border:1px solid #a8e0c2}.htag.ok .d{background:var(--green)}
-.htag.amber{color:var(--amber);background:#fbf1de;border:1px solid #ecd29a}.htag.amber .d{background:var(--amber)}
-.htag.red{color:var(--red);background:#fce8e6;border:1px solid #f3b6ad}.htag.red .d{background:var(--red)}
-.gowed{margin-left:auto;font-size:12.5px;color:var(--red);font-weight:600}
-.card{background:var(--panel);border:1px solid #f3d6d2;border-left:3px solid var(--red);border-radius:13px;padding:13px 14px;margin-bottom:9px;display:flex;align-items:center;justify-content:space-between;cursor:pointer;box-shadow:0 1px 2px rgba(20,30,60,.04)}
-.left{display:flex;align-items:center;gap:12px}
-.coin{width:34px;height:34px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:13px}
-.usdc{background:#2775ca;color:#fff}.usdt{background:#26a17b;color:#fff}
-.name{font-weight:600}.sub{font-size:11.5px;color:var(--muted);margin-top:2px}
-.right{text-align:right}
-.amt{font-weight:600;color:var(--red)}
-.rate{font-size:12px;color:var(--amber);margin-top:2px}
-.fiat{font-size:12px;color:var(--red)}
-</style></head><body>
-<div class="wfbar">
-  <span class="tag">Wireframe — controls below are not part of the UI</span>
-  <div>Assets page, <b>Liabilities</b> tab. Grouped <b>by provider</b> (health factor is per-provider). The health status is a single compact, colour-coded tag next to the provider group title — no big banner here (that lives large on the provider page).</div>
-  <div class="ctrls"><span>Demo · Liquidium health:</span>
-    <button data-h="68" class="on">Healthy</button>
-    <button data-h="16">At risk</button>
-    <button data-h="7">Critical</button>
-  </div>
-</div>
-<div class="wrap">
-  <div class="hero"><div class="lbl">Net worth</div><div class="tot">$112,438.20</div></div>
-  <div class="tabs">
-    <a onclick="location.href='earning-tab.html'">Tokens</a>
-    <a onclick="location.href='earning-tab.html'">NFTs</a>
-    <a onclick="location.href='earning-tab.html'">Earning</a>
-    <a class="on">Liabilities<span class="tabdot" id="tabdot"></span></a>
-  </div>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Assets · Liabilities tab — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--panel: #ffffff;
+				--panel2: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--accent: #2f6df6;
+				--green: #15a35b;
+				--amber: #d8890a;
+				--red: #df4a3c;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+			}
+			.wfbar {
+				max-width: 520px;
+				margin: 14px auto 0;
+				background: #ffffff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.wfbar .tag {
+				display: inline-block;
+				font-size: 10px;
+				letter-spacing: 0.08em;
+				text-transform: uppercase;
+				color: #6b7787;
+				border: 1px solid #b9c4dd;
+				border-radius: 5px;
+				padding: 1px 6px;
+				margin-bottom: 7px;
+			}
+			.wfbar .ctrls {
+				display: flex;
+				gap: 6px;
+				align-items: center;
+				margin-top: 10px;
+				flex-wrap: wrap;
+				padding-top: 9px;
+				border-top: 1px solid #eef1f7;
+			}
+			.wrap {
+				max-width: 520px;
+				margin: 0 auto;
+				padding: 14px 18px 28px;
+			}
+			.hero {
+				padding: 6px 2px 12px;
+			}
+			.hero .lbl {
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.hero .tot {
+				font-size: 30px;
+				font-weight: 700;
+			}
+			.tabs {
+				display: flex;
+				gap: 18px;
+				border-bottom: 1px solid var(--line);
+				margin: 6px 0 16px;
+			}
+			.tabs a {
+				position: relative;
+				color: var(--muted);
+				text-decoration: none;
+				padding: 9px 0;
+				font-weight: 600;
+				border-bottom: 2px solid transparent;
+				font-size: 14px;
+				cursor: pointer;
+			}
+			.tabs a.on {
+				color: var(--txt);
+				border-bottom-color: var(--red);
+			}
+			.tabdot {
+				position: absolute;
+				top: 4px;
+				right: -9px;
+				width: 8px;
+				height: 8px;
+				border-radius: 50%;
+				display: none;
+				box-shadow: 0 0 0 2px var(--bg);
+			}
+			.tabdot.amber {
+				background: var(--amber);
+				display: block;
+			}
+			.tabdot.red {
+				background: var(--red);
+				display: block;
+			}
+			.ctrls button {
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				color: var(--muted);
+				border-radius: 8px;
+				padding: 4px 10px;
+				font-size: 12px;
+				cursor: pointer;
+			}
+			.ctrls button.on {
+				color: var(--txt);
+				border-color: var(--accent);
+			}
+			/* provider group */
+			.group {
+				margin-bottom: 18px;
+			}
+			.ghead {
+				display: flex;
+				align-items: center;
+				gap: 10px;
+				margin: 2px 0 10px;
+			}
+			.gtitle {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				font-weight: 600;
+			}
+			.gprov {
+				width: 18px;
+				height: 18px;
+				border-radius: 5px;
+				background: #9b6cff;
+				display: grid;
+				place-items: center;
+				font-size: 11px;
+				color: #fff;
+				font-weight: 700;
+			}
+			/* compact per-provider health tag — one small element next to the group title */
+			.htag {
+				font-size: 11.5px;
+				font-weight: 600;
+				border-radius: 999px;
+				padding: 2px 9px;
+				display: inline-flex;
+				align-items: center;
+				gap: 6px;
+			}
+			.htag .d {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+			}
+			.htag.ok {
+				color: var(--green);
+				background: #e6f7ee;
+				border: 1px solid #a8e0c2;
+			}
+			.htag.ok .d {
+				background: var(--green);
+			}
+			.htag.amber {
+				color: var(--amber);
+				background: #fbf1de;
+				border: 1px solid #ecd29a;
+			}
+			.htag.amber .d {
+				background: var(--amber);
+			}
+			.htag.red {
+				color: var(--red);
+				background: #fce8e6;
+				border: 1px solid #f3b6ad;
+			}
+			.htag.red .d {
+				background: var(--red);
+			}
+			.gowed {
+				margin-left: auto;
+				font-size: 12.5px;
+				color: var(--red);
+				font-weight: 600;
+			}
+			.card {
+				background: var(--panel);
+				border: 1px solid #f3d6d2;
+				border-left: 3px solid var(--red);
+				border-radius: 13px;
+				padding: 13px 14px;
+				margin-bottom: 9px;
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				cursor: pointer;
+				box-shadow: 0 1px 2px rgba(20, 30, 60, 0.04);
+			}
+			.left {
+				display: flex;
+				align-items: center;
+				gap: 12px;
+			}
+			.coin {
+				width: 34px;
+				height: 34px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				font-size: 13px;
+			}
+			.usdc {
+				background: #2775ca;
+				color: #fff;
+			}
+			.usdt {
+				background: #26a17b;
+				color: #fff;
+			}
+			.name {
+				font-weight: 600;
+			}
+			.sub {
+				font-size: 11.5px;
+				color: var(--muted);
+				margin-top: 2px;
+			}
+			.right {
+				text-align: right;
+			}
+			.amt {
+				font-weight: 600;
+				color: var(--red);
+			}
+			.rate {
+				font-size: 12px;
+				color: var(--amber);
+				margin-top: 2px;
+			}
+			.fiat {
+				font-size: 12px;
+				color: var(--red);
+			}
+		</style>
+	</head>
+	<body>
+		<div class="wfbar">
+			<span class="tag">Wireframe — controls below are not part of the UI</span>
+			<div>
+				Assets page, <b>Liabilities</b> tab. Grouped <b>by provider</b> (health factor is
+				per-provider). The health status is a single compact, colour-coded tag next to the provider
+				group title — no big banner here (that lives large on the provider page).
+			</div>
+			<div class="ctrls">
+				<span>Demo · Liquidium health:</span>
+				<button data-h="68" class="on">Healthy</button>
+				<button data-h="16">At risk</button>
+				<button data-h="7">Critical</button>
+			</div>
+		</div>
+		<div class="wrap">
+			<div class="hero">
+				<div class="lbl">Net worth</div>
+				<div class="tot">$112,438.20</div>
+			</div>
+			<div class="tabs">
+				<a onclick="location.href = 'earning-tab.html'">Tokens</a>
+				<a onclick="location.href = 'earning-tab.html'">NFTs</a>
+				<a onclick="location.href = 'earning-tab.html'">Earning</a>
+				<a class="on">Liabilities<span class="tabdot" id="tabdot"></span></a>
+			</div>
 
-  <div class="group">
-    <div class="ghead">
-      <div class="gtitle"><span class="gprov">L</span>Liquidium</div>
-      <span class="htag ok" id="htag"><span class="d"></span><span id="htagText">Healthy at 68%</span></span>
-      <span class="gowed">−$35,000.00</span>
-    </div>
+			<div class="group">
+				<div class="ghead">
+					<div class="gtitle"><span class="gprov">L</span>Liquidium</div>
+					<span class="htag ok" id="htag"
+						><span class="d"></span><span id="htagText">Healthy at 68%</span></span
+					>
+					<span class="gowed">−$35,000.00</span>
+				</div>
 
-    <div class="card">
-      <div class="left"><div class="coin usdc">U</div><div><div class="name">USDC</div><div class="sub">Borrowed</div></div></div>
-      <div class="right"><div class="amt">−20,000 USDC</div><div class="rate">Borrow rate · 7.40%</div><div class="fiat">−$20,000.00</div></div>
-    </div>
-    <div class="card">
-      <div class="left"><div class="coin usdt">T</div><div><div class="name">USDT</div><div class="sub">Borrowed</div></div></div>
-      <div class="right"><div class="amt">−15,000 USDT</div><div class="rate">Borrow rate · 7.25%</div><div class="fiat">−$15,000.00</div></div>
-    </div>
-  </div>
+				<div class="card">
+					<div class="left">
+						<div class="coin usdc">U</div>
+						<div>
+							<div class="name">USDC</div>
+							<div class="sub">Borrowed</div>
+						</div>
+					</div>
+					<div class="right">
+						<div class="amt">−20,000 USDC</div>
+						<div class="rate">Borrow rate · 7.40%</div>
+						<div class="fiat">−$20,000.00</div>
+					</div>
+				</div>
+				<div class="card">
+					<div class="left">
+						<div class="coin usdt">T</div>
+						<div>
+							<div class="name">USDT</div>
+							<div class="sub">Borrowed</div>
+						</div>
+					</div>
+					<div class="right">
+						<div class="amt">−15,000 USDT</div>
+						<div class="rate">Borrow rate · 7.25%</div>
+						<div class="fiat">−$15,000.00</div>
+					</div>
+				</div>
+			</div>
 
-  <!-- A second borrow provider, when one exists, would be its own group with its own health tag. -->
-</div>
-<script>
-  function band(h){return h<12?'red':h<40?'amber':'ok';}
-  function word(h){return h<12?'Critical':h<40?'At risk':'Healthy';}
-  function setHealth(h){
-    const b=band(h);
-    const t=document.getElementById('htag');
-    t.className='htag '+b;
-    document.getElementById('htagText').textContent=word(h)+' at '+h+'%';
-    // tab-label indicator: worst provider health across all groups (one provider here).
-    // hidden when healthy, amber at risk, red critical.
-    document.getElementById('tabdot').className='tabdot'+(b==='ok'?'':' '+b);
-  }
-  document.querySelectorAll('.ctrls button').forEach(b=>b.addEventListener('click',()=>{
-    document.querySelectorAll('.ctrls button').forEach(x=>x.classList.remove('on'));
-    b.classList.add('on');setHealth(+b.dataset.h);
-  }));
-  setHealth(68);
-</script>
-</body></html>
+			<!-- A second borrow provider, when one exists, would be its own group with its own health tag. -->
+		</div>
+		<script>
+			function band(h) {
+				return h < 12 ? 'red' : h < 40 ? 'amber' : 'ok';
+			}
+			function word(h) {
+				return h < 12 ? 'Critical' : h < 40 ? 'At risk' : 'Healthy';
+			}
+			function setHealth(h) {
+				const b = band(h);
+				const t = document.getElementById('htag');
+				t.className = 'htag ' + b;
+				document.getElementById('htagText').textContent = word(h) + ' at ' + h + '%';
+				// tab-label indicator: worst provider health across all groups (one provider here).
+				// hidden when healthy, amber at risk, red critical.
+				document.getElementById('tabdot').className = 'tabdot' + (b === 'ok' ? '' : ' ' + b);
+			}
+			document.querySelectorAll('.ctrls button').forEach((b) =>
+				b.addEventListener('click', () => {
+					document.querySelectorAll('.ctrls button').forEach((x) => x.classList.remove('on'));
+					b.classList.add('on');
+					setHealth(+b.dataset.h);
+				})
+			);
+			setHealth(68);
+		</script>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/repay.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/repay.html
@@ -1,64 +1,352 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Repay flow — wireframe</title>
-<style>
-:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
-.note{max-width:460px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.modal{max-width:460px;margin:14px auto;background:var(--panel);border:1px solid var(--line);border-radius:16px;overflow:hidden}
-.head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}.head h2{font-size:16px;margin:0}
-.steps{display:flex;gap:6px}.dot{width:7px;height:7px;border-radius:50%;background:var(--line)}.dot.on{background:var(--accent)}
-.body{padding:16px}
-.field{background:var(--panel2);border:1px solid var(--line);border-radius:12px;padding:12px;margin-bottom:12px}
-.field .top{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}.field .mid{display:flex;align-items:center;justify-content:space-between;margin-top:6px}
-input[type=number]{background:transparent;border:0;color:var(--txt);font-size:24px;width:60%;outline:none}
-.selpill{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-weight:600}
-.coin{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:11px;background:#2775ca;color:#fff}
-.infoline{display:flex;justify-content:space-between;font-size:12.5px;color:var(--muted);padding:6px 2px}.infoline b{color:var(--txt)}
-.max{color:var(--accent);cursor:pointer}
-button{font:inherit;cursor:pointer}.btn{width:100%;background:var(--accent);color:#fff;border:0;border-radius:11px;padding:13px;font-weight:600;font-size:15px}.btn:disabled{opacity:.4}
-.foot{padding:0 16px 16px;display:flex;gap:10px}.btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
-.hero{text-align:center;padding:8px 0 14px}.hero .big{font-size:30px;font-weight:700}
-.hide{display:none}.rr{display:flex;justify-content:space-between;padding:9px 0;border-top:1px solid var(--line);font-size:13.5px}.rr:first-child{border-top:0}
-.hfbar{height:8px;border-radius:6px;background:linear-gradient(90deg,#ef5d5d,var(--amber) 45%,var(--green));position:relative;margin:8px 0}.hfbar .mark{position:absolute;top:-3px;width:3px;height:14px;background:#fff;border-radius:2px;transition:left .15s}
-.spin{width:34px;height:34px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;margin:18px auto;animation:s 1s linear infinite}@keyframes s{to{transform:rotate(360deg)}}
-</style></head><body>
-<div class="note">Wireframe — Repay flow. Current debt: 35,000 USDC. "Max (full debt)" fills principal + accrued interest. Repaying improves the projected health factor.</div>
-<div class="modal">
-  <div class="head"><h2 id="title">Repay</h2><div class="steps"><span class="dot on" id="d0"></span><span class="dot" id="d1"></span><span class="dot" id="d2"></span></div></div>
-  <div id="form"><div class="body">
-    <div class="field"><div class="top"><span>You repay</span><span class="max" id="max">Max (full debt) 35,000 USDC</span></div>
-      <div class="mid"><input id="amt" type="number" value="15000"/><span class="selpill"><span class="coin">U</span>USDC</span></div>
-      <div class="infoline" style="padding-top:8px"><span id="fiat">$15,000.00</span><span>Wallet: 40,000 USDC</span></div></div>
-    <div class="infoline"><span>Current debt</span><b>35,000 USDC</b></div>
-    <div class="infoline"><span>Debt after repay</span><b id="after">20,000 USDC</b></div>
-    <div class="infoline"><span>Projected health factor</span><b id="hf" style="color:var(--green)">82%</b></div>
-    <div class="hfbar"><div class="mark" id="mark" style="left:82%"></div></div>
-  </div><div class="foot"><button class="btn" id="toReview">Review</button></div></div>
-  <div id="review" class="hide"><div class="body">
-    <div class="hero"><div class="muted">You repay</div><div class="big" id="rAmt">15,000 USDC</div><div class="muted" id="rFiat">$15,000.00</div></div>
-    <div class="rr"><span class="muted">Remaining debt</span><b id="rAfter">20,000 USDC</b></div>
-    <div class="rr"><span class="muted">Projected health factor</span><b id="rHf" style="color:var(--green)">82%</b></div>
-    <div class="rr"><span class="muted">Provider</span><b>Liquidium</b></div>
-  </div><div class="foot"><button class="btn ghost" id="back">Back</button><button class="btn" id="go">Repay</button></div></div>
-  <div id="progress" class="hide"><div class="body" style="text-align:center"><div class="spin"></div><div id="ptext">Submitting repayment…</div></div></div>
-</div>
-<script>
-const amt=document.getElementById('amt'),DEBT=35000,COLLAT=67170,LIQ=0.80;
-function hfFor(remaining){const ltv=remaining/COLLAT;return Math.max(0,Math.round((1-ltv/LIQ)*100));}
-function col(h){return h<20?'#ef5d5d':h<45?'var(--amber)':'var(--green)';}
-function upd(){const v=Math.min(DEBT,+amt.value||0);const rem=DEBT-v;
-  document.getElementById('fiat').textContent='$'+v.toLocaleString('en-US',{minimumFractionDigits:2});
-  document.getElementById('after').textContent=rem.toLocaleString('en-US')+' USDC';
-  const h=hfFor(rem);const hf=document.getElementById('hf');hf.textContent=h+'%';hf.style.color=col(h);document.getElementById('mark').style.left=h+'%';}
-amt.addEventListener('input',upd);
-document.getElementById('max').onclick=()=>{amt.value=DEBT;upd();};
-function show(id){['form','review','progress'].forEach((s,i)=>{document.getElementById(s).classList.toggle('hide',s!==id);document.getElementById('d'+i).classList.toggle('on',['form','review','progress'].indexOf(id)>=i);});}
-document.getElementById('toReview').onclick=()=>{const v=Math.min(DEBT,+amt.value||0),rem=DEBT-v,h=hfFor(rem);
-  document.getElementById('rAmt').textContent=v.toLocaleString('en-US')+' USDC';document.getElementById('rFiat').textContent='$'+v.toLocaleString('en-US',{minimumFractionDigits:2});
-  document.getElementById('rAfter').textContent=rem.toLocaleString('en-US')+' USDC';const rh=document.getElementById('rHf');rh.textContent=h+'%';rh.style.color=col(h);
-  document.getElementById('title').textContent='Review repay';show('review');};
-document.getElementById('back').onclick=()=>{document.getElementById('title').textContent='Repay';show('form');};
-document.getElementById('go').onclick=()=>{document.getElementById('title').textContent='Repaying';show('progress');setTimeout(()=>{document.getElementById('ptext').textContent='Done — debt reduced, health factor improved.';document.querySelector('.spin').style.display='none';},1500);};
-upd();
-</script></body></html>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Repay flow — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--panel: #ffffff;
+				--panel2: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--accent: #2f6df6;
+				--green: #15a35b;
+				--amber: #d8890a;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+			}
+			.note {
+				max-width: 460px;
+				margin: 14px auto 0;
+				background: #ffffff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.modal {
+				max-width: 460px;
+				margin: 14px auto;
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 16px;
+				overflow: hidden;
+			}
+			.head {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 14px 16px;
+				border-bottom: 1px solid var(--line);
+			}
+			.head h2 {
+				font-size: 16px;
+				margin: 0;
+			}
+			.steps {
+				display: flex;
+				gap: 6px;
+			}
+			.dot {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+				background: var(--line);
+			}
+			.dot.on {
+				background: var(--accent);
+			}
+			.body {
+				padding: 16px;
+			}
+			.field {
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				border-radius: 12px;
+				padding: 12px;
+				margin-bottom: 12px;
+			}
+			.field .top {
+				display: flex;
+				justify-content: space-between;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.field .mid {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				margin-top: 6px;
+			}
+			input[type='number'] {
+				background: transparent;
+				border: 0;
+				color: var(--txt);
+				font-size: 24px;
+				width: 60%;
+				outline: none;
+			}
+			.selpill {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 999px;
+				padding: 6px 12px;
+				font-weight: 600;
+			}
+			.coin {
+				width: 24px;
+				height: 24px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				font-size: 11px;
+				background: #2775ca;
+				color: #fff;
+			}
+			.infoline {
+				display: flex;
+				justify-content: space-between;
+				font-size: 12.5px;
+				color: var(--muted);
+				padding: 6px 2px;
+			}
+			.infoline b {
+				color: var(--txt);
+			}
+			.max {
+				color: var(--accent);
+				cursor: pointer;
+			}
+			button {
+				font: inherit;
+				cursor: pointer;
+			}
+			.btn {
+				width: 100%;
+				background: var(--accent);
+				color: #fff;
+				border: 0;
+				border-radius: 11px;
+				padding: 13px;
+				font-weight: 600;
+				font-size: 15px;
+			}
+			.btn:disabled {
+				opacity: 0.4;
+			}
+			.foot {
+				padding: 0 16px 16px;
+				display: flex;
+				gap: 10px;
+			}
+			.btn.ghost {
+				background: transparent;
+				border: 1px solid var(--line);
+				color: var(--txt);
+			}
+			.hero {
+				text-align: center;
+				padding: 8px 0 14px;
+			}
+			.hero .big {
+				font-size: 30px;
+				font-weight: 700;
+			}
+			.hide {
+				display: none;
+			}
+			.rr {
+				display: flex;
+				justify-content: space-between;
+				padding: 9px 0;
+				border-top: 1px solid var(--line);
+				font-size: 13.5px;
+			}
+			.rr:first-child {
+				border-top: 0;
+			}
+			.hfbar {
+				height: 8px;
+				border-radius: 6px;
+				background: linear-gradient(90deg, #ef5d5d, var(--amber) 45%, var(--green));
+				position: relative;
+				margin: 8px 0;
+			}
+			.hfbar .mark {
+				position: absolute;
+				top: -3px;
+				width: 3px;
+				height: 14px;
+				background: #fff;
+				border-radius: 2px;
+				transition: left 0.15s;
+			}
+			.spin {
+				width: 34px;
+				height: 34px;
+				border: 3px solid var(--line);
+				border-top-color: var(--accent);
+				border-radius: 50%;
+				margin: 18px auto;
+				animation: s 1s linear infinite;
+			}
+			@keyframes s {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div class="note">
+			Wireframe — Repay flow. Current debt: 35,000 USDC. "Max (full debt)" fills principal + accrued
+			interest. Repaying improves the projected health factor.
+		</div>
+		<div class="modal">
+			<div class="head">
+				<h2 id="title">Repay</h2>
+				<div class="steps">
+					<span class="dot on" id="d0"></span><span class="dot" id="d1"></span
+					><span class="dot" id="d2"></span>
+				</div>
+			</div>
+			<div id="form">
+				<div class="body">
+					<div class="field">
+						<div class="top">
+							<span>You repay</span><span class="max" id="max">Max (full debt) 35,000 USDC</span>
+						</div>
+						<div class="mid">
+							<input id="amt" type="number" value="15000" /><span class="selpill"
+								><span class="coin">U</span>USDC</span
+							>
+						</div>
+						<div class="infoline" style="padding-top: 8px">
+							<span id="fiat">$15,000.00</span><span>Wallet: 40,000 USDC</span>
+						</div>
+					</div>
+					<div class="infoline"><span>Current debt</span><b>35,000 USDC</b></div>
+					<div class="infoline"><span>Debt after repay</span><b id="after">20,000 USDC</b></div>
+					<div class="infoline">
+						<span>Projected health factor</span><b id="hf" style="color: var(--green)">82%</b>
+					</div>
+					<div class="hfbar"><div class="mark" id="mark" style="left: 82%"></div></div>
+				</div>
+				<div class="foot"><button class="btn" id="toReview">Review</button></div>
+			</div>
+			<div id="review" class="hide">
+				<div class="body">
+					<div class="hero">
+						<div class="muted">You repay</div>
+						<div class="big" id="rAmt">15,000 USDC</div>
+						<div class="muted" id="rFiat">$15,000.00</div>
+					</div>
+					<div class="rr">
+						<span class="muted">Remaining debt</span><b id="rAfter">20,000 USDC</b>
+					</div>
+					<div class="rr">
+						<span class="muted">Projected health factor</span
+						><b id="rHf" style="color: var(--green)">82%</b>
+					</div>
+					<div class="rr"><span class="muted">Provider</span><b>Liquidium</b></div>
+				</div>
+				<div class="foot">
+					<button class="btn ghost" id="back">Back</button
+					><button class="btn" id="go">Repay</button>
+				</div>
+			</div>
+			<div id="progress" class="hide">
+				<div class="body" style="text-align: center">
+					<div class="spin"></div>
+					<div id="ptext">Submitting repayment…</div>
+				</div>
+			</div>
+		</div>
+		<script>
+			const amt = document.getElementById('amt'),
+				DEBT = 35000,
+				COLLAT = 67170,
+				LIQ = 0.8;
+			function hfFor(remaining) {
+				const ltv = remaining / COLLAT;
+				return Math.max(0, Math.round((1 - ltv / LIQ) * 100));
+			}
+			function col(h) {
+				return h < 20 ? '#ef5d5d' : h < 45 ? 'var(--amber)' : 'var(--green)';
+			}
+			function upd() {
+				const v = Math.min(DEBT, +amt.value || 0);
+				const rem = DEBT - v;
+				document.getElementById('fiat').textContent =
+					'$' + v.toLocaleString('en-US', { minimumFractionDigits: 2 });
+				document.getElementById('after').textContent = rem.toLocaleString('en-US') + ' USDC';
+				const h = hfFor(rem);
+				const hf = document.getElementById('hf');
+				hf.textContent = h + '%';
+				hf.style.color = col(h);
+				document.getElementById('mark').style.left = h + '%';
+			}
+			amt.addEventListener('input', upd);
+			document.getElementById('max').onclick = () => {
+				amt.value = DEBT;
+				upd();
+			};
+			function show(id) {
+				['form', 'review', 'progress'].forEach((s, i) => {
+					document.getElementById(s).classList.toggle('hide', s !== id);
+					document
+						.getElementById('d' + i)
+						.classList.toggle('on', ['form', 'review', 'progress'].indexOf(id) >= i);
+				});
+			}
+			document.getElementById('toReview').onclick = () => {
+				const v = Math.min(DEBT, +amt.value || 0),
+					rem = DEBT - v,
+					h = hfFor(rem);
+				document.getElementById('rAmt').textContent = v.toLocaleString('en-US') + ' USDC';
+				document.getElementById('rFiat').textContent =
+					'$' + v.toLocaleString('en-US', { minimumFractionDigits: 2 });
+				document.getElementById('rAfter').textContent = rem.toLocaleString('en-US') + ' USDC';
+				const rh = document.getElementById('rHf');
+				rh.textContent = h + '%';
+				rh.style.color = col(h);
+				document.getElementById('title').textContent = 'Review repay';
+				show('review');
+			};
+			document.getElementById('back').onclick = () => {
+				document.getElementById('title').textContent = 'Repay';
+				show('form');
+			};
+			document.getElementById('go').onclick = () => {
+				document.getElementById('title').textContent = 'Repaying';
+				show('progress');
+				setTimeout(() => {
+					document.getElementById('ptext').textContent =
+						'Done — debt reduced, health factor improved.';
+					document.querySelector('.spin').style.display = 'none';
+				}, 1500);
+			};
+			upd();
+		</script>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/repay.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/repay.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Repay flow — wireframe</title>
+<style>
+:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
+.note{max-width:460px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.modal{max-width:460px;margin:14px auto;background:var(--panel);border:1px solid var(--line);border-radius:16px;overflow:hidden}
+.head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}.head h2{font-size:16px;margin:0}
+.steps{display:flex;gap:6px}.dot{width:7px;height:7px;border-radius:50%;background:var(--line)}.dot.on{background:var(--accent)}
+.body{padding:16px}
+.field{background:var(--panel2);border:1px solid var(--line);border-radius:12px;padding:12px;margin-bottom:12px}
+.field .top{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}.field .mid{display:flex;align-items:center;justify-content:space-between;margin-top:6px}
+input[type=number]{background:transparent;border:0;color:var(--txt);font-size:24px;width:60%;outline:none}
+.selpill{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-weight:600}
+.coin{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:11px;background:#2775ca;color:#fff}
+.infoline{display:flex;justify-content:space-between;font-size:12.5px;color:var(--muted);padding:6px 2px}.infoline b{color:var(--txt)}
+.max{color:var(--accent);cursor:pointer}
+button{font:inherit;cursor:pointer}.btn{width:100%;background:var(--accent);color:#fff;border:0;border-radius:11px;padding:13px;font-weight:600;font-size:15px}.btn:disabled{opacity:.4}
+.foot{padding:0 16px 16px;display:flex;gap:10px}.btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
+.hero{text-align:center;padding:8px 0 14px}.hero .big{font-size:30px;font-weight:700}
+.hide{display:none}.rr{display:flex;justify-content:space-between;padding:9px 0;border-top:1px solid var(--line);font-size:13.5px}.rr:first-child{border-top:0}
+.hfbar{height:8px;border-radius:6px;background:linear-gradient(90deg,#ef5d5d,var(--amber) 45%,var(--green));position:relative;margin:8px 0}.hfbar .mark{position:absolute;top:-3px;width:3px;height:14px;background:#fff;border-radius:2px;transition:left .15s}
+.spin{width:34px;height:34px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;margin:18px auto;animation:s 1s linear infinite}@keyframes s{to{transform:rotate(360deg)}}
+</style></head><body>
+<div class="note">Wireframe — Repay flow. Current debt: 35,000 USDC. "Max (full debt)" fills principal + accrued interest. Repaying improves the projected health factor.</div>
+<div class="modal">
+  <div class="head"><h2 id="title">Repay</h2><div class="steps"><span class="dot on" id="d0"></span><span class="dot" id="d1"></span><span class="dot" id="d2"></span></div></div>
+  <div id="form"><div class="body">
+    <div class="field"><div class="top"><span>You repay</span><span class="max" id="max">Max (full debt) 35,000 USDC</span></div>
+      <div class="mid"><input id="amt" type="number" value="15000"/><span class="selpill"><span class="coin">U</span>USDC</span></div>
+      <div class="infoline" style="padding-top:8px"><span id="fiat">$15,000.00</span><span>Wallet: 40,000 USDC</span></div></div>
+    <div class="infoline"><span>Current debt</span><b>35,000 USDC</b></div>
+    <div class="infoline"><span>Debt after repay</span><b id="after">20,000 USDC</b></div>
+    <div class="infoline"><span>Projected health factor</span><b id="hf" style="color:var(--green)">82%</b></div>
+    <div class="hfbar"><div class="mark" id="mark" style="left:82%"></div></div>
+  </div><div class="foot"><button class="btn" id="toReview">Review</button></div></div>
+  <div id="review" class="hide"><div class="body">
+    <div class="hero"><div class="muted">You repay</div><div class="big" id="rAmt">15,000 USDC</div><div class="muted" id="rFiat">$15,000.00</div></div>
+    <div class="rr"><span class="muted">Remaining debt</span><b id="rAfter">20,000 USDC</b></div>
+    <div class="rr"><span class="muted">Projected health factor</span><b id="rHf" style="color:var(--green)">82%</b></div>
+    <div class="rr"><span class="muted">Provider</span><b>Liquidium</b></div>
+  </div><div class="foot"><button class="btn ghost" id="back">Back</button><button class="btn" id="go">Repay</button></div></div>
+  <div id="progress" class="hide"><div class="body" style="text-align:center"><div class="spin"></div><div id="ptext">Submitting repayment…</div></div></div>
+</div>
+<script>
+const amt=document.getElementById('amt'),DEBT=35000,COLLAT=67170,LIQ=0.80;
+function hfFor(remaining){const ltv=remaining/COLLAT;return Math.max(0,Math.round((1-ltv/LIQ)*100));}
+function col(h){return h<20?'#ef5d5d':h<45?'var(--amber)':'var(--green)';}
+function upd(){const v=Math.min(DEBT,+amt.value||0);const rem=DEBT-v;
+  document.getElementById('fiat').textContent='$'+v.toLocaleString('en-US',{minimumFractionDigits:2});
+  document.getElementById('after').textContent=rem.toLocaleString('en-US')+' USDC';
+  const h=hfFor(rem);const hf=document.getElementById('hf');hf.textContent=h+'%';hf.style.color=col(h);document.getElementById('mark').style.left=h+'%';}
+amt.addEventListener('input',upd);
+document.getElementById('max').onclick=()=>{amt.value=DEBT;upd();};
+function show(id){['form','review','progress'].forEach((s,i)=>{document.getElementById(s).classList.toggle('hide',s!==id);document.getElementById('d'+i).classList.toggle('on',['form','review','progress'].indexOf(id)>=i);});}
+document.getElementById('toReview').onclick=()=>{const v=Math.min(DEBT,+amt.value||0),rem=DEBT-v,h=hfFor(rem);
+  document.getElementById('rAmt').textContent=v.toLocaleString('en-US')+' USDC';document.getElementById('rFiat').textContent='$'+v.toLocaleString('en-US',{minimumFractionDigits:2});
+  document.getElementById('rAfter').textContent=rem.toLocaleString('en-US')+' USDC';const rh=document.getElementById('rHf');rh.textContent=h+'%';rh.style.color=col(h);
+  document.getElementById('title').textContent='Review repay';show('review');};
+document.getElementById('back').onclick=()=>{document.getElementById('title').textContent='Repay';show('form');};
+document.getElementById('go').onclick=()=>{document.getElementById('title').textContent='Repaying';show('progress');setTimeout(()=>{document.getElementById('ptext').textContent='Done — debt reduced, health factor improved.';document.querySelector('.spin').style.display='none';},1500);};
+upd();
+</script></body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/supply.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/supply.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Supply flow — wireframe</title>
+<style>
+:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
+.note{max-width:460px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.modal{max-width:460px;margin:14px auto;background:var(--panel);border:1px solid var(--line);border-radius:16px;overflow:hidden}
+.head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}.head h2{font-size:16px;margin:0}
+.steps{display:flex;gap:6px}.dot{width:7px;height:7px;border-radius:50%;background:var(--line)}.dot.on{background:var(--accent)}
+.body{padding:16px}
+.field{background:var(--panel2);border:1px solid var(--line);border-radius:12px;padding:12px;margin-bottom:12px}
+.field .top{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}.field .mid{display:flex;align-items:center;justify-content:space-between;margin-top:6px}
+input[type=number]{background:transparent;border:0;color:var(--txt);font-size:24px;width:60%;outline:none}
+.selpill{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-weight:600}
+.coin{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:11px;background:#f7931a;color:#0e1218}
+.infoline{display:flex;justify-content:space-between;font-size:12.5px;color:var(--muted);padding:6px 2px}.infoline b{color:var(--txt)}
+.max{color:var(--accent);cursor:pointer}
+.fee{background:var(--panel2);border:1px solid var(--line);border-radius:10px;padding:10px 12px;margin:10px 0;font-size:12.5px}
+.fee summary{cursor:pointer;display:flex;justify-content:space-between;list-style:none}
+.fee .ln{display:flex;justify-content:space-between;color:var(--muted);margin-top:6px}
+label.agree{display:flex;gap:8px;align-items:flex-start;font-size:12.5px;color:var(--muted);margin:8px 2px;cursor:pointer}
+button{font:inherit;cursor:pointer}.btn{width:100%;background:var(--accent);color:#fff;border:0;border-radius:11px;padding:13px;font-weight:600;font-size:15px}.btn:disabled{opacity:.4;cursor:not-allowed}
+.foot{padding:0 16px 16px;display:flex;gap:10px}.btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
+.hero{text-align:center;padding:8px 0 14px}.hero .big{font-size:30px;font-weight:700}
+.hide{display:none}.rr{display:flex;justify-content:space-between;padding:9px 0;border-top:1px solid var(--line);font-size:13.5px}.rr:first-child{border-top:0}
+.spin{width:34px;height:34px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;margin:18px auto;animation:s 1s linear infinite}@keyframes s{to{transform:rotate(360deg)}}
+.apy{color:var(--green)}
+</style></head><body>
+<div class="note">Wireframe — Supply (lend) flow. Supplying earns yield and also becomes collateral. Form → Review → Progress, mirroring oisy's swap wizard.</div>
+<div class="modal">
+  <div class="head"><h2 id="title">Supply</h2><div class="steps"><span class="dot on" id="d0"></span><span class="dot" id="d1"></span><span class="dot" id="d2"></span></div></div>
+  <div id="form"><div class="body">
+    <div class="field"><div class="top"><span>You supply</span><span>Wallet: <span class="max" id="max">1.5 BTC</span></span></div>
+      <div class="mid"><input id="amt" type="number" value="1" step="0.01"/><span class="selpill"><span class="coin">B</span>BTC</span></div>
+      <div class="infoline" style="padding-top:8px"><span id="fiat">$67,170.00</span><span>Supply APY <b class="apy">1.94%</b></span></div></div>
+    <div class="infoline" style="color:var(--muted)">Supplied BTC also serves as collateral you can borrow against.</div>
+    <details class="fee"><summary><span>Transaction fee</span><b>&lt;$0.01</b></summary><div class="ln"><span>Network / transfer fee</span><span>0.0000001 BTC</span></div></details>
+    <label class="agree"><input type="checkbox" id="agree"/> I understand my assets will be supplied to the Liquidium protocol and are subject to on-chain smart-contract risk.</label>
+  </div><div class="foot"><button class="btn" id="toReview" disabled>Review</button></div></div>
+  <div id="review" class="hide"><div class="body">
+    <div class="hero"><div class="muted">You supply</div><div class="big" id="rAmt">1 BTC</div><div class="muted" id="rFiat">$67,170.00</div></div>
+    <div class="rr"><span class="muted">To</span><b>Liquidium</b></div>
+    <div class="rr"><span class="muted">Supply APY</span><b class="apy">1.94%</b></div>
+    <div class="rr"><span class="muted">Transaction fee</span><b>&lt;$0.01</b></div>
+  </div><div class="foot"><button class="btn ghost" id="back">Back</button><button class="btn" id="go">Supply</button></div></div>
+  <div id="progress" class="hide"><div class="body" style="text-align:center"><div class="spin"></div><div id="ptext">Supplying to Liquidium…</div><div class="muted" style="font-size:12px;margin-top:6px">client.lending.supply(...)</div></div></div>
+</div>
+<script>
+const amt=document.getElementById('amt'),PR=67170;
+function fiat(){document.getElementById('fiat').textContent='$'+((+amt.value||0)*PR).toLocaleString('en-US',{minimumFractionDigits:2});}
+amt.addEventListener('input',fiat);
+document.getElementById('max').onclick=()=>{amt.value=1.5;fiat();};
+document.getElementById('agree').addEventListener('change',e=>document.getElementById('toReview').disabled=!e.target.checked);
+function show(id){['form','review','progress'].forEach((s,i)=>{document.getElementById(s).classList.toggle('hide',s!==id);document.getElementById('d'+i).classList.toggle('on',['form','review','progress'].indexOf(id)>=i);});}
+document.getElementById('toReview').onclick=()=>{const v=+amt.value||0;document.getElementById('rAmt').textContent=v+' BTC';document.getElementById('rFiat').textContent='$'+(v*PR).toLocaleString('en-US',{minimumFractionDigits:2});document.getElementById('title').textContent='Review supply';show('review');};
+document.getElementById('back').onclick=()=>{document.getElementById('title').textContent='Supply';show('form');};
+document.getElementById('go').onclick=()=>{document.getElementById('title').textContent='Supplying';show('progress');setTimeout(()=>{document.getElementById('ptext').textContent='Done — position updated.';document.querySelector('.spin').style.display='none';},1500);};
+fiat();
+</script></body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/supply.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/supply.html
@@ -1,60 +1,353 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Supply flow — wireframe</title>
-<style>
-:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
-.note{max-width:460px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.modal{max-width:460px;margin:14px auto;background:var(--panel);border:1px solid var(--line);border-radius:16px;overflow:hidden}
-.head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}.head h2{font-size:16px;margin:0}
-.steps{display:flex;gap:6px}.dot{width:7px;height:7px;border-radius:50%;background:var(--line)}.dot.on{background:var(--accent)}
-.body{padding:16px}
-.field{background:var(--panel2);border:1px solid var(--line);border-radius:12px;padding:12px;margin-bottom:12px}
-.field .top{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}.field .mid{display:flex;align-items:center;justify-content:space-between;margin-top:6px}
-input[type=number]{background:transparent;border:0;color:var(--txt);font-size:24px;width:60%;outline:none}
-.selpill{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-weight:600}
-.coin{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:11px;background:#f7931a;color:#0e1218}
-.infoline{display:flex;justify-content:space-between;font-size:12.5px;color:var(--muted);padding:6px 2px}.infoline b{color:var(--txt)}
-.max{color:var(--accent);cursor:pointer}
-.fee{background:var(--panel2);border:1px solid var(--line);border-radius:10px;padding:10px 12px;margin:10px 0;font-size:12.5px}
-.fee summary{cursor:pointer;display:flex;justify-content:space-between;list-style:none}
-.fee .ln{display:flex;justify-content:space-between;color:var(--muted);margin-top:6px}
-label.agree{display:flex;gap:8px;align-items:flex-start;font-size:12.5px;color:var(--muted);margin:8px 2px;cursor:pointer}
-button{font:inherit;cursor:pointer}.btn{width:100%;background:var(--accent);color:#fff;border:0;border-radius:11px;padding:13px;font-weight:600;font-size:15px}.btn:disabled{opacity:.4;cursor:not-allowed}
-.foot{padding:0 16px 16px;display:flex;gap:10px}.btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
-.hero{text-align:center;padding:8px 0 14px}.hero .big{font-size:30px;font-weight:700}
-.hide{display:none}.rr{display:flex;justify-content:space-between;padding:9px 0;border-top:1px solid var(--line);font-size:13.5px}.rr:first-child{border-top:0}
-.spin{width:34px;height:34px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;margin:18px auto;animation:s 1s linear infinite}@keyframes s{to{transform:rotate(360deg)}}
-.apy{color:var(--green)}
-</style></head><body>
-<div class="note">Wireframe — Supply (lend) flow. Supplying earns yield and also becomes collateral. Form → Review → Progress, mirroring oisy's swap wizard.</div>
-<div class="modal">
-  <div class="head"><h2 id="title">Supply</h2><div class="steps"><span class="dot on" id="d0"></span><span class="dot" id="d1"></span><span class="dot" id="d2"></span></div></div>
-  <div id="form"><div class="body">
-    <div class="field"><div class="top"><span>You supply</span><span>Wallet: <span class="max" id="max">1.5 BTC</span></span></div>
-      <div class="mid"><input id="amt" type="number" value="1" step="0.01"/><span class="selpill"><span class="coin">B</span>BTC</span></div>
-      <div class="infoline" style="padding-top:8px"><span id="fiat">$67,170.00</span><span>Supply APY <b class="apy">1.94%</b></span></div></div>
-    <div class="infoline" style="color:var(--muted)">Supplied BTC also serves as collateral you can borrow against.</div>
-    <details class="fee"><summary><span>Transaction fee</span><b>&lt;$0.01</b></summary><div class="ln"><span>Network / transfer fee</span><span>0.0000001 BTC</span></div></details>
-    <label class="agree"><input type="checkbox" id="agree"/> I understand my assets will be supplied to the Liquidium protocol and are subject to on-chain smart-contract risk.</label>
-  </div><div class="foot"><button class="btn" id="toReview" disabled>Review</button></div></div>
-  <div id="review" class="hide"><div class="body">
-    <div class="hero"><div class="muted">You supply</div><div class="big" id="rAmt">1 BTC</div><div class="muted" id="rFiat">$67,170.00</div></div>
-    <div class="rr"><span class="muted">To</span><b>Liquidium</b></div>
-    <div class="rr"><span class="muted">Supply APY</span><b class="apy">1.94%</b></div>
-    <div class="rr"><span class="muted">Transaction fee</span><b>&lt;$0.01</b></div>
-  </div><div class="foot"><button class="btn ghost" id="back">Back</button><button class="btn" id="go">Supply</button></div></div>
-  <div id="progress" class="hide"><div class="body" style="text-align:center"><div class="spin"></div><div id="ptext">Supplying to Liquidium…</div><div class="muted" style="font-size:12px;margin-top:6px">client.lending.supply(...)</div></div></div>
-</div>
-<script>
-const amt=document.getElementById('amt'),PR=67170;
-function fiat(){document.getElementById('fiat').textContent='$'+((+amt.value||0)*PR).toLocaleString('en-US',{minimumFractionDigits:2});}
-amt.addEventListener('input',fiat);
-document.getElementById('max').onclick=()=>{amt.value=1.5;fiat();};
-document.getElementById('agree').addEventListener('change',e=>document.getElementById('toReview').disabled=!e.target.checked);
-function show(id){['form','review','progress'].forEach((s,i)=>{document.getElementById(s).classList.toggle('hide',s!==id);document.getElementById('d'+i).classList.toggle('on',['form','review','progress'].indexOf(id)>=i);});}
-document.getElementById('toReview').onclick=()=>{const v=+amt.value||0;document.getElementById('rAmt').textContent=v+' BTC';document.getElementById('rFiat').textContent='$'+(v*PR).toLocaleString('en-US',{minimumFractionDigits:2});document.getElementById('title').textContent='Review supply';show('review');};
-document.getElementById('back').onclick=()=>{document.getElementById('title').textContent='Supply';show('form');};
-document.getElementById('go').onclick=()=>{document.getElementById('title').textContent='Supplying';show('progress');setTimeout(()=>{document.getElementById('ptext').textContent='Done — position updated.';document.querySelector('.spin').style.display='none';},1500);};
-fiat();
-</script></body></html>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Supply flow — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--panel: #ffffff;
+				--panel2: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--accent: #2f6df6;
+				--green: #15a35b;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+			}
+			.note {
+				max-width: 460px;
+				margin: 14px auto 0;
+				background: #ffffff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.modal {
+				max-width: 460px;
+				margin: 14px auto;
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 16px;
+				overflow: hidden;
+			}
+			.head {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 14px 16px;
+				border-bottom: 1px solid var(--line);
+			}
+			.head h2 {
+				font-size: 16px;
+				margin: 0;
+			}
+			.steps {
+				display: flex;
+				gap: 6px;
+			}
+			.dot {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+				background: var(--line);
+			}
+			.dot.on {
+				background: var(--accent);
+			}
+			.body {
+				padding: 16px;
+			}
+			.field {
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				border-radius: 12px;
+				padding: 12px;
+				margin-bottom: 12px;
+			}
+			.field .top {
+				display: flex;
+				justify-content: space-between;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.field .mid {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				margin-top: 6px;
+			}
+			input[type='number'] {
+				background: transparent;
+				border: 0;
+				color: var(--txt);
+				font-size: 24px;
+				width: 60%;
+				outline: none;
+			}
+			.selpill {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 999px;
+				padding: 6px 12px;
+				font-weight: 600;
+			}
+			.coin {
+				width: 24px;
+				height: 24px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				font-size: 11px;
+				background: #f7931a;
+				color: #0e1218;
+			}
+			.infoline {
+				display: flex;
+				justify-content: space-between;
+				font-size: 12.5px;
+				color: var(--muted);
+				padding: 6px 2px;
+			}
+			.infoline b {
+				color: var(--txt);
+			}
+			.max {
+				color: var(--accent);
+				cursor: pointer;
+			}
+			.fee {
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				border-radius: 10px;
+				padding: 10px 12px;
+				margin: 10px 0;
+				font-size: 12.5px;
+			}
+			.fee summary {
+				cursor: pointer;
+				display: flex;
+				justify-content: space-between;
+				list-style: none;
+			}
+			.fee .ln {
+				display: flex;
+				justify-content: space-between;
+				color: var(--muted);
+				margin-top: 6px;
+			}
+			label.agree {
+				display: flex;
+				gap: 8px;
+				align-items: flex-start;
+				font-size: 12.5px;
+				color: var(--muted);
+				margin: 8px 2px;
+				cursor: pointer;
+			}
+			button {
+				font: inherit;
+				cursor: pointer;
+			}
+			.btn {
+				width: 100%;
+				background: var(--accent);
+				color: #fff;
+				border: 0;
+				border-radius: 11px;
+				padding: 13px;
+				font-weight: 600;
+				font-size: 15px;
+			}
+			.btn:disabled {
+				opacity: 0.4;
+				cursor: not-allowed;
+			}
+			.foot {
+				padding: 0 16px 16px;
+				display: flex;
+				gap: 10px;
+			}
+			.btn.ghost {
+				background: transparent;
+				border: 1px solid var(--line);
+				color: var(--txt);
+			}
+			.hero {
+				text-align: center;
+				padding: 8px 0 14px;
+			}
+			.hero .big {
+				font-size: 30px;
+				font-weight: 700;
+			}
+			.hide {
+				display: none;
+			}
+			.rr {
+				display: flex;
+				justify-content: space-between;
+				padding: 9px 0;
+				border-top: 1px solid var(--line);
+				font-size: 13.5px;
+			}
+			.rr:first-child {
+				border-top: 0;
+			}
+			.spin {
+				width: 34px;
+				height: 34px;
+				border: 3px solid var(--line);
+				border-top-color: var(--accent);
+				border-radius: 50%;
+				margin: 18px auto;
+				animation: s 1s linear infinite;
+			}
+			@keyframes s {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			.apy {
+				color: var(--green);
+			}
+		</style>
+	</head>
+	<body>
+		<div class="note">
+			Wireframe — Supply (lend) flow. Supplying earns yield and also becomes collateral. Form →
+			Review → Progress, mirroring oisy's swap wizard.
+		</div>
+		<div class="modal">
+			<div class="head">
+				<h2 id="title">Supply</h2>
+				<div class="steps">
+					<span class="dot on" id="d0"></span><span class="dot" id="d1"></span
+					><span class="dot" id="d2"></span>
+				</div>
+			</div>
+			<div id="form">
+				<div class="body">
+					<div class="field">
+						<div class="top">
+							<span>You supply</span><span>Wallet: <span class="max" id="max">1.5 BTC</span></span>
+						</div>
+						<div class="mid">
+							<input id="amt" type="number" value="1" step="0.01" /><span class="selpill"
+								><span class="coin">B</span>BTC</span
+							>
+						</div>
+						<div class="infoline" style="padding-top: 8px">
+							<span id="fiat">$67,170.00</span><span>Supply APY <b class="apy">1.94%</b></span>
+						</div>
+					</div>
+					<div class="infoline" style="color: var(--muted)">
+						Supplied BTC also serves as collateral you can borrow against.
+					</div>
+					<details class="fee">
+						<summary><span>Transaction fee</span><b>&lt;$0.01</b></summary>
+						<div class="ln"><span>Network / transfer fee</span><span>0.0000001 BTC</span></div>
+					</details>
+					<label class="agree"
+						><input type="checkbox" id="agree" /> I understand my assets will be supplied to the
+						Liquidium protocol and are subject to on-chain smart-contract risk.</label
+					>
+				</div>
+				<div class="foot"><button class="btn" id="toReview" disabled>Review</button></div>
+			</div>
+			<div id="review" class="hide">
+				<div class="body">
+					<div class="hero">
+						<div class="muted">You supply</div>
+						<div class="big" id="rAmt">1 BTC</div>
+						<div class="muted" id="rFiat">$67,170.00</div>
+					</div>
+					<div class="rr"><span class="muted">To</span><b>Liquidium</b></div>
+					<div class="rr"><span class="muted">Supply APY</span><b class="apy">1.94%</b></div>
+					<div class="rr"><span class="muted">Transaction fee</span><b>&lt;$0.01</b></div>
+				</div>
+				<div class="foot">
+					<button class="btn ghost" id="back">Back</button
+					><button class="btn" id="go">Supply</button>
+				</div>
+			</div>
+			<div id="progress" class="hide">
+				<div class="body" style="text-align: center">
+					<div class="spin"></div>
+					<div id="ptext">Supplying to Liquidium…</div>
+					<div class="muted" style="font-size: 12px; margin-top: 6px">
+						client.lending.supply(...)
+					</div>
+				</div>
+			</div>
+		</div>
+		<script>
+			const amt = document.getElementById('amt'),
+				PR = 67170;
+			function fiat() {
+				document.getElementById('fiat').textContent =
+					'$' + ((+amt.value || 0) * PR).toLocaleString('en-US', { minimumFractionDigits: 2 });
+			}
+			amt.addEventListener('input', fiat);
+			document.getElementById('max').onclick = () => {
+				amt.value = 1.5;
+				fiat();
+			};
+			document
+				.getElementById('agree')
+				.addEventListener(
+					'change',
+					(e) => (document.getElementById('toReview').disabled = !e.target.checked)
+				);
+			function show(id) {
+				['form', 'review', 'progress'].forEach((s, i) => {
+					document.getElementById(s).classList.toggle('hide', s !== id);
+					document
+						.getElementById('d' + i)
+						.classList.toggle('on', ['form', 'review', 'progress'].indexOf(id) >= i);
+				});
+			}
+			document.getElementById('toReview').onclick = () => {
+				const v = +amt.value || 0;
+				document.getElementById('rAmt').textContent = v + ' BTC';
+				document.getElementById('rFiat').textContent =
+					'$' + (v * PR).toLocaleString('en-US', { minimumFractionDigits: 2 });
+				document.getElementById('title').textContent = 'Review supply';
+				show('review');
+			};
+			document.getElementById('back').onclick = () => {
+				document.getElementById('title').textContent = 'Supply';
+				show('form');
+			};
+			document.getElementById('go').onclick = () => {
+				document.getElementById('title').textContent = 'Supplying';
+				show('progress');
+				setTimeout(() => {
+					document.getElementById('ptext').textContent = 'Done — position updated.';
+					document.querySelector('.spin').style.display = 'none';
+				}, 1500);
+			};
+			fiat();
+		</script>
+	</body>
+</html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/withdraw.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/withdraw.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Withdraw flow — wireframe</title>
+<style>
+:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
+.note{max-width:460px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
+.modal{max-width:460px;margin:14px auto;background:var(--panel);border:1px solid var(--line);border-radius:16px;overflow:hidden}
+.head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}.head h2{font-size:16px;margin:0}
+.steps{display:flex;gap:6px}.dot{width:7px;height:7px;border-radius:50%;background:var(--line)}.dot.on{background:var(--accent)}
+.body{padding:16px}
+.field{background:var(--panel2);border:1px solid var(--line);border-radius:12px;padding:12px;margin-bottom:12px}
+.field .top{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}.field .mid{display:flex;align-items:center;justify-content:space-between;margin-top:6px}
+input[type=number]{background:transparent;border:0;color:var(--txt);font-size:24px;width:60%;outline:none}
+.selpill{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-weight:600}
+.coin{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:11px;background:#f7931a;color:#0e1218}
+.infoline{display:flex;justify-content:space-between;font-size:12.5px;color:var(--muted);padding:6px 2px}.infoline b{color:var(--txt)}
+.max{color:var(--accent);cursor:pointer}
+button{font:inherit;cursor:pointer}.btn{width:100%;background:var(--accent);color:#fff;border:0;border-radius:11px;padding:13px;font-weight:600;font-size:15px}.btn:disabled{opacity:.4}
+.foot{padding:0 16px 16px;display:flex;gap:10px}.btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
+.hero{text-align:center;padding:8px 0 14px}.hero .big{font-size:30px;font-weight:700}
+.hide{display:none}.rr{display:flex;justify-content:space-between;padding:9px 0;border-top:1px solid var(--line);font-size:13.5px}.rr:first-child{border-top:0}
+.hfbar{height:8px;border-radius:6px;background:linear-gradient(90deg,var(--red),var(--amber) 45%,var(--green));position:relative;margin:8px 0}.hfbar .mark{position:absolute;top:-3px;width:3px;height:14px;background:#fff;border-radius:2px;transition:left .15s}
+.warn{border-radius:10px;padding:10px 12px;font-size:12.5px;margin:10px 0;display:none}.warn.amber{background:#fbf1de;border:1px solid #ecd29a;color:#8a5d05;display:block}.warn.red{background:#fce8e6;border:1px solid #f3b6ad;color:#b5392c;display:block}
+.warn label{display:flex;gap:8px;margin-top:8px;cursor:pointer}
+.err{color:var(--red);font-size:12px;margin:4px 2px;display:none}
+.spin{width:34px;height:34px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;margin:18px auto;animation:s 1s linear infinite}@keyframes s{to{transform:rotate(360deg)}}
+</style></head><body>
+<div class="note">Wireframe — Withdraw flow. Supplied 1 BTC, with 20,000 USDC of debt. The withdrawable cap is the free (non-collateralising) portion; pulling more lowers the projected health factor and triggers warnings.</div>
+<div class="modal">
+  <div class="head"><h2 id="title">Withdraw</h2><div class="steps"><span class="dot on" id="d0"></span><span class="dot" id="d1"></span><span class="dot" id="d2"></span></div></div>
+  <div id="form"><div class="body">
+    <div class="field"><div class="top"><span>You withdraw</span><span class="max" id="max">Max 0.575 BTC</span></div>
+      <div class="mid"><input id="amt" type="number" value="0.3" step="0.01"/><span class="selpill"><span class="coin">B</span>BTC</span></div>
+      <div class="infoline" style="padding-top:8px"><span id="fiat">$20,151.00</span><span>Supplied: 1 BTC</span></div></div>
+    <div class="infoline"><span>Reserved by open debt</span><b>0.425 BTC</b></div>
+    <div class="infoline"><span>Projected health factor</span><b id="hf" style="color:var(--green)">62%</b></div>
+    <div class="hfbar"><div class="mark" id="mark" style="left:62%"></div></div>
+    <div class="err" id="err">Cannot withdraw more than your free collateral while debt is open.</div>
+    <div class="warn" id="warn"><span id="wt"></span><label id="cw" class="hide"><input type="checkbox" id="cb"/> I understand this withdrawal puts my position at high liquidation risk.</label></div>
+  </div><div class="foot"><button class="btn" id="toReview">Review</button></div></div>
+  <div id="review" class="hide"><div class="body">
+    <div class="hero"><div class="muted">You withdraw</div><div class="big" id="rAmt">0.3 BTC</div><div class="muted" id="rFiat">$20,151.00</div></div>
+    <div class="rr"><span class="muted">From</span><b>Liquidium</b></div>
+    <div class="rr"><span class="muted">Transfer fee</span><b>0.0000001 BTC</b></div>
+    <div class="rr"><span class="muted">You receive</span><b id="recv">0.2999999 BTC</b></div>
+    <div class="rr"><span class="muted">Projected health factor</span><b id="rHf" style="color:var(--green)">62%</b></div>
+  </div><div class="foot"><button class="btn ghost" id="back">Back</button><button class="btn" id="go">Withdraw</button></div></div>
+  <div id="progress" class="hide"><div class="body" style="text-align:center"><div class="spin"></div><div id="ptext">Withdrawing from Liquidium…</div><div class="muted" style="font-size:12px;margin-top:6px">client.lending.withdraw(...)</div></div></div>
+</div>
+<script>
+const amt=document.getElementById('amt'),PR=67170,SUPPLIED=1,DEBT_USD=20000,LIQ=0.80,MAXW=0.575;
+function calc(w){const collat=(SUPPLIED-w)*PR;const ltv=collat>0?DEBT_USD/collat:99;const hf=Math.max(0,Math.round((1-ltv/LIQ)*100));return hf;}
+function col(h){return h<20?'var(--red)':h<45?'var(--amber)':'var(--green)';}
+function band(h){return h<20?'red':h<45?'amber':'ok';}
+function upd(){const w=+amt.value||0;document.getElementById('fiat').textContent='$'+(w*PR).toLocaleString('en-US',{minimumFractionDigits:2});
+  const over=w>MAXW;document.getElementById('err').style.display=over?'block':'none';
+  const h=calc(w);const hf=document.getElementById('hf');hf.textContent=over?'—':h+'%';hf.style.color=col(h);document.getElementById('mark').style.left=(over?0:h)+'%';
+  const wn=document.getElementById('warn'),wt=document.getElementById('wt'),cw=document.getElementById('cw'),cb=document.getElementById('cb');const b=band(h);
+  wn.className='warn'+(over?'':(b==='red'?' red':b==='amber'?' amber':''));
+  if(!over&&b==='red'){wt.textContent='This withdrawal puts your position close to liquidation. ';cw.classList.remove('hide');}
+  else if(!over&&b==='amber'){wt.textContent='This withdrawal lowers your health factor.';cw.classList.add('hide');cb.checked=false;}
+  else{cw.classList.add('hide');cb.checked=false;}
+  document.getElementById('toReview').disabled=over||w<=0||(b==='red'&&!cb.checked);}
+amt.addEventListener('input',upd);document.getElementById('cb').addEventListener('change',upd);
+document.getElementById('max').onclick=()=>{amt.value=MAXW;upd();};
+function show(id){['form','review','progress'].forEach((s,i)=>{document.getElementById(s).classList.toggle('hide',s!==id);document.getElementById('d'+i).classList.toggle('on',['form','review','progress'].indexOf(id)>=i);});}
+document.getElementById('toReview').onclick=()=>{const w=+amt.value||0,h=calc(w);
+  document.getElementById('rAmt').textContent=w+' BTC';document.getElementById('rFiat').textContent='$'+(w*PR).toLocaleString('en-US',{minimumFractionDigits:2});
+  document.getElementById('recv').textContent=(w-0.0000001).toFixed(7)+' BTC';const rh=document.getElementById('rHf');rh.textContent=h+'%';rh.style.color=col(h);
+  document.getElementById('title').textContent='Review withdraw';show('review');};
+document.getElementById('back').onclick=()=>{document.getElementById('title').textContent='Withdraw';show('form');};
+document.getElementById('go').onclick=()=>{document.getElementById('title').textContent='Withdrawing';show('progress');setTimeout(()=>{document.getElementById('ptext').textContent='Done — funds returned to your wallet.';document.querySelector('.spin').style.display='none';},1500);};
+upd();
+</script></body></html>

--- a/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/withdraw.html
+++ b/docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow/wireframes/withdraw.html
@@ -1,75 +1,421 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Withdraw flow — wireframe</title>
-<style>
-:root{--bg:#e9eefb;--panel:#ffffff;--panel2:#f4f6fb;--line:#e5e9f2;--txt:#16203a;--muted:#6b7787;--accent:#2f6df6;--green:#15a35b;--amber:#d8890a;--red:#df4a3c}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--txt);font:14px/1.5 -apple-system,Segoe UI,Roboto,Arial,sans-serif}
-.note{max-width:460px;margin:14px auto 0;background:#ffffff;border:1px dashed #b9c4dd;border-radius:10px;padding:10px 14px;color:var(--muted);font-size:12px}
-.modal{max-width:460px;margin:14px auto;background:var(--panel);border:1px solid var(--line);border-radius:16px;overflow:hidden}
-.head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--line)}.head h2{font-size:16px;margin:0}
-.steps{display:flex;gap:6px}.dot{width:7px;height:7px;border-radius:50%;background:var(--line)}.dot.on{background:var(--accent)}
-.body{padding:16px}
-.field{background:var(--panel2);border:1px solid var(--line);border-radius:12px;padding:12px;margin-bottom:12px}
-.field .top{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}.field .mid{display:flex;align-items:center;justify-content:space-between;margin-top:6px}
-input[type=number]{background:transparent;border:0;color:var(--txt);font-size:24px;width:60%;outline:none}
-.selpill{display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:6px 12px;font-weight:600}
-.coin{width:24px;height:24px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:11px;background:#f7931a;color:#0e1218}
-.infoline{display:flex;justify-content:space-between;font-size:12.5px;color:var(--muted);padding:6px 2px}.infoline b{color:var(--txt)}
-.max{color:var(--accent);cursor:pointer}
-button{font:inherit;cursor:pointer}.btn{width:100%;background:var(--accent);color:#fff;border:0;border-radius:11px;padding:13px;font-weight:600;font-size:15px}.btn:disabled{opacity:.4}
-.foot{padding:0 16px 16px;display:flex;gap:10px}.btn.ghost{background:transparent;border:1px solid var(--line);color:var(--txt)}
-.hero{text-align:center;padding:8px 0 14px}.hero .big{font-size:30px;font-weight:700}
-.hide{display:none}.rr{display:flex;justify-content:space-between;padding:9px 0;border-top:1px solid var(--line);font-size:13.5px}.rr:first-child{border-top:0}
-.hfbar{height:8px;border-radius:6px;background:linear-gradient(90deg,var(--red),var(--amber) 45%,var(--green));position:relative;margin:8px 0}.hfbar .mark{position:absolute;top:-3px;width:3px;height:14px;background:#fff;border-radius:2px;transition:left .15s}
-.warn{border-radius:10px;padding:10px 12px;font-size:12.5px;margin:10px 0;display:none}.warn.amber{background:#fbf1de;border:1px solid #ecd29a;color:#8a5d05;display:block}.warn.red{background:#fce8e6;border:1px solid #f3b6ad;color:#b5392c;display:block}
-.warn label{display:flex;gap:8px;margin-top:8px;cursor:pointer}
-.err{color:var(--red);font-size:12px;margin:4px 2px;display:none}
-.spin{width:34px;height:34px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;margin:18px auto;animation:s 1s linear infinite}@keyframes s{to{transform:rotate(360deg)}}
-</style></head><body>
-<div class="note">Wireframe — Withdraw flow. Supplied 1 BTC, with 20,000 USDC of debt. The withdrawable cap is the free (non-collateralising) portion; pulling more lowers the projected health factor and triggers warnings.</div>
-<div class="modal">
-  <div class="head"><h2 id="title">Withdraw</h2><div class="steps"><span class="dot on" id="d0"></span><span class="dot" id="d1"></span><span class="dot" id="d2"></span></div></div>
-  <div id="form"><div class="body">
-    <div class="field"><div class="top"><span>You withdraw</span><span class="max" id="max">Max 0.575 BTC</span></div>
-      <div class="mid"><input id="amt" type="number" value="0.3" step="0.01"/><span class="selpill"><span class="coin">B</span>BTC</span></div>
-      <div class="infoline" style="padding-top:8px"><span id="fiat">$20,151.00</span><span>Supplied: 1 BTC</span></div></div>
-    <div class="infoline"><span>Reserved by open debt</span><b>0.425 BTC</b></div>
-    <div class="infoline"><span>Projected health factor</span><b id="hf" style="color:var(--green)">62%</b></div>
-    <div class="hfbar"><div class="mark" id="mark" style="left:62%"></div></div>
-    <div class="err" id="err">Cannot withdraw more than your free collateral while debt is open.</div>
-    <div class="warn" id="warn"><span id="wt"></span><label id="cw" class="hide"><input type="checkbox" id="cb"/> I understand this withdrawal puts my position at high liquidation risk.</label></div>
-  </div><div class="foot"><button class="btn" id="toReview">Review</button></div></div>
-  <div id="review" class="hide"><div class="body">
-    <div class="hero"><div class="muted">You withdraw</div><div class="big" id="rAmt">0.3 BTC</div><div class="muted" id="rFiat">$20,151.00</div></div>
-    <div class="rr"><span class="muted">From</span><b>Liquidium</b></div>
-    <div class="rr"><span class="muted">Transfer fee</span><b>0.0000001 BTC</b></div>
-    <div class="rr"><span class="muted">You receive</span><b id="recv">0.2999999 BTC</b></div>
-    <div class="rr"><span class="muted">Projected health factor</span><b id="rHf" style="color:var(--green)">62%</b></div>
-  </div><div class="foot"><button class="btn ghost" id="back">Back</button><button class="btn" id="go">Withdraw</button></div></div>
-  <div id="progress" class="hide"><div class="body" style="text-align:center"><div class="spin"></div><div id="ptext">Withdrawing from Liquidium…</div><div class="muted" style="font-size:12px;margin-top:6px">client.lending.withdraw(...)</div></div></div>
-</div>
-<script>
-const amt=document.getElementById('amt'),PR=67170,SUPPLIED=1,DEBT_USD=20000,LIQ=0.80,MAXW=0.575;
-function calc(w){const collat=(SUPPLIED-w)*PR;const ltv=collat>0?DEBT_USD/collat:99;const hf=Math.max(0,Math.round((1-ltv/LIQ)*100));return hf;}
-function col(h){return h<20?'var(--red)':h<45?'var(--amber)':'var(--green)';}
-function band(h){return h<20?'red':h<45?'amber':'ok';}
-function upd(){const w=+amt.value||0;document.getElementById('fiat').textContent='$'+(w*PR).toLocaleString('en-US',{minimumFractionDigits:2});
-  const over=w>MAXW;document.getElementById('err').style.display=over?'block':'none';
-  const h=calc(w);const hf=document.getElementById('hf');hf.textContent=over?'—':h+'%';hf.style.color=col(h);document.getElementById('mark').style.left=(over?0:h)+'%';
-  const wn=document.getElementById('warn'),wt=document.getElementById('wt'),cw=document.getElementById('cw'),cb=document.getElementById('cb');const b=band(h);
-  wn.className='warn'+(over?'':(b==='red'?' red':b==='amber'?' amber':''));
-  if(!over&&b==='red'){wt.textContent='This withdrawal puts your position close to liquidation. ';cw.classList.remove('hide');}
-  else if(!over&&b==='amber'){wt.textContent='This withdrawal lowers your health factor.';cw.classList.add('hide');cb.checked=false;}
-  else{cw.classList.add('hide');cb.checked=false;}
-  document.getElementById('toReview').disabled=over||w<=0||(b==='red'&&!cb.checked);}
-amt.addEventListener('input',upd);document.getElementById('cb').addEventListener('change',upd);
-document.getElementById('max').onclick=()=>{amt.value=MAXW;upd();};
-function show(id){['form','review','progress'].forEach((s,i)=>{document.getElementById(s).classList.toggle('hide',s!==id);document.getElementById('d'+i).classList.toggle('on',['form','review','progress'].indexOf(id)>=i);});}
-document.getElementById('toReview').onclick=()=>{const w=+amt.value||0,h=calc(w);
-  document.getElementById('rAmt').textContent=w+' BTC';document.getElementById('rFiat').textContent='$'+(w*PR).toLocaleString('en-US',{minimumFractionDigits:2});
-  document.getElementById('recv').textContent=(w-0.0000001).toFixed(7)+' BTC';const rh=document.getElementById('rHf');rh.textContent=h+'%';rh.style.color=col(h);
-  document.getElementById('title').textContent='Review withdraw';show('review');};
-document.getElementById('back').onclick=()=>{document.getElementById('title').textContent='Withdraw';show('form');};
-document.getElementById('go').onclick=()=>{document.getElementById('title').textContent='Withdrawing';show('progress');setTimeout(()=>{document.getElementById('ptext').textContent='Done — funds returned to your wallet.';document.querySelector('.spin').style.display='none';},1500);};
-upd();
-</script></body></html>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Withdraw flow — wireframe</title>
+		<style>
+			:root {
+				--bg: #e9eefb;
+				--panel: #ffffff;
+				--panel2: #f4f6fb;
+				--line: #e5e9f2;
+				--txt: #16203a;
+				--muted: #6b7787;
+				--accent: #2f6df6;
+				--green: #15a35b;
+				--amber: #d8890a;
+				--red: #df4a3c;
+			}
+			* {
+				box-sizing: border-box;
+			}
+			body {
+				margin: 0;
+				background: var(--bg);
+				color: var(--txt);
+				font:
+					14px/1.5 -apple-system,
+					Segoe UI,
+					Roboto,
+					Arial,
+					sans-serif;
+			}
+			.note {
+				max-width: 460px;
+				margin: 14px auto 0;
+				background: #ffffff;
+				border: 1px dashed #b9c4dd;
+				border-radius: 10px;
+				padding: 10px 14px;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.modal {
+				max-width: 460px;
+				margin: 14px auto;
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 16px;
+				overflow: hidden;
+			}
+			.head {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 14px 16px;
+				border-bottom: 1px solid var(--line);
+			}
+			.head h2 {
+				font-size: 16px;
+				margin: 0;
+			}
+			.steps {
+				display: flex;
+				gap: 6px;
+			}
+			.dot {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+				background: var(--line);
+			}
+			.dot.on {
+				background: var(--accent);
+			}
+			.body {
+				padding: 16px;
+			}
+			.field {
+				background: var(--panel2);
+				border: 1px solid var(--line);
+				border-radius: 12px;
+				padding: 12px;
+				margin-bottom: 12px;
+			}
+			.field .top {
+				display: flex;
+				justify-content: space-between;
+				color: var(--muted);
+				font-size: 12px;
+			}
+			.field .mid {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				margin-top: 6px;
+			}
+			input[type='number'] {
+				background: transparent;
+				border: 0;
+				color: var(--txt);
+				font-size: 24px;
+				width: 60%;
+				outline: none;
+			}
+			.selpill {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				background: var(--panel);
+				border: 1px solid var(--line);
+				border-radius: 999px;
+				padding: 6px 12px;
+				font-weight: 600;
+			}
+			.coin {
+				width: 24px;
+				height: 24px;
+				border-radius: 50%;
+				display: grid;
+				place-items: center;
+				font-weight: 700;
+				font-size: 11px;
+				background: #f7931a;
+				color: #0e1218;
+			}
+			.infoline {
+				display: flex;
+				justify-content: space-between;
+				font-size: 12.5px;
+				color: var(--muted);
+				padding: 6px 2px;
+			}
+			.infoline b {
+				color: var(--txt);
+			}
+			.max {
+				color: var(--accent);
+				cursor: pointer;
+			}
+			button {
+				font: inherit;
+				cursor: pointer;
+			}
+			.btn {
+				width: 100%;
+				background: var(--accent);
+				color: #fff;
+				border: 0;
+				border-radius: 11px;
+				padding: 13px;
+				font-weight: 600;
+				font-size: 15px;
+			}
+			.btn:disabled {
+				opacity: 0.4;
+			}
+			.foot {
+				padding: 0 16px 16px;
+				display: flex;
+				gap: 10px;
+			}
+			.btn.ghost {
+				background: transparent;
+				border: 1px solid var(--line);
+				color: var(--txt);
+			}
+			.hero {
+				text-align: center;
+				padding: 8px 0 14px;
+			}
+			.hero .big {
+				font-size: 30px;
+				font-weight: 700;
+			}
+			.hide {
+				display: none;
+			}
+			.rr {
+				display: flex;
+				justify-content: space-between;
+				padding: 9px 0;
+				border-top: 1px solid var(--line);
+				font-size: 13.5px;
+			}
+			.rr:first-child {
+				border-top: 0;
+			}
+			.hfbar {
+				height: 8px;
+				border-radius: 6px;
+				background: linear-gradient(90deg, var(--red), var(--amber) 45%, var(--green));
+				position: relative;
+				margin: 8px 0;
+			}
+			.hfbar .mark {
+				position: absolute;
+				top: -3px;
+				width: 3px;
+				height: 14px;
+				background: #fff;
+				border-radius: 2px;
+				transition: left 0.15s;
+			}
+			.warn {
+				border-radius: 10px;
+				padding: 10px 12px;
+				font-size: 12.5px;
+				margin: 10px 0;
+				display: none;
+			}
+			.warn.amber {
+				background: #fbf1de;
+				border: 1px solid #ecd29a;
+				color: #8a5d05;
+				display: block;
+			}
+			.warn.red {
+				background: #fce8e6;
+				border: 1px solid #f3b6ad;
+				color: #b5392c;
+				display: block;
+			}
+			.warn label {
+				display: flex;
+				gap: 8px;
+				margin-top: 8px;
+				cursor: pointer;
+			}
+			.err {
+				color: var(--red);
+				font-size: 12px;
+				margin: 4px 2px;
+				display: none;
+			}
+			.spin {
+				width: 34px;
+				height: 34px;
+				border: 3px solid var(--line);
+				border-top-color: var(--accent);
+				border-radius: 50%;
+				margin: 18px auto;
+				animation: s 1s linear infinite;
+			}
+			@keyframes s {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div class="note">
+			Wireframe — Withdraw flow. Supplied 1 BTC, with 20,000 USDC of debt. The withdrawable cap is
+			the free (non-collateralising) portion; pulling more lowers the projected health factor and
+			triggers warnings.
+		</div>
+		<div class="modal">
+			<div class="head">
+				<h2 id="title">Withdraw</h2>
+				<div class="steps">
+					<span class="dot on" id="d0"></span><span class="dot" id="d1"></span
+					><span class="dot" id="d2"></span>
+				</div>
+			</div>
+			<div id="form">
+				<div class="body">
+					<div class="field">
+						<div class="top">
+							<span>You withdraw</span><span class="max" id="max">Max 0.575 BTC</span>
+						</div>
+						<div class="mid">
+							<input id="amt" type="number" value="0.3" step="0.01" /><span class="selpill"
+								><span class="coin">B</span>BTC</span
+							>
+						</div>
+						<div class="infoline" style="padding-top: 8px">
+							<span id="fiat">$20,151.00</span><span>Supplied: 1 BTC</span>
+						</div>
+					</div>
+					<div class="infoline"><span>Reserved by open debt</span><b>0.425 BTC</b></div>
+					<div class="infoline">
+						<span>Projected health factor</span><b id="hf" style="color: var(--green)">62%</b>
+					</div>
+					<div class="hfbar"><div class="mark" id="mark" style="left: 62%"></div></div>
+					<div class="err" id="err">
+						Cannot withdraw more than your free collateral while debt is open.
+					</div>
+					<div class="warn" id="warn">
+						<span id="wt"></span
+						><label id="cw" class="hide"
+							><input type="checkbox" id="cb" /> I understand this withdrawal puts my position at
+							high liquidation risk.</label
+						>
+					</div>
+				</div>
+				<div class="foot"><button class="btn" id="toReview">Review</button></div>
+			</div>
+			<div id="review" class="hide">
+				<div class="body">
+					<div class="hero">
+						<div class="muted">You withdraw</div>
+						<div class="big" id="rAmt">0.3 BTC</div>
+						<div class="muted" id="rFiat">$20,151.00</div>
+					</div>
+					<div class="rr"><span class="muted">From</span><b>Liquidium</b></div>
+					<div class="rr"><span class="muted">Transfer fee</span><b>0.0000001 BTC</b></div>
+					<div class="rr"><span class="muted">You receive</span><b id="recv">0.2999999 BTC</b></div>
+					<div class="rr">
+						<span class="muted">Projected health factor</span
+						><b id="rHf" style="color: var(--green)">62%</b>
+					</div>
+				</div>
+				<div class="foot">
+					<button class="btn ghost" id="back">Back</button
+					><button class="btn" id="go">Withdraw</button>
+				</div>
+			</div>
+			<div id="progress" class="hide">
+				<div class="body" style="text-align: center">
+					<div class="spin"></div>
+					<div id="ptext">Withdrawing from Liquidium…</div>
+					<div class="muted" style="font-size: 12px; margin-top: 6px">
+						client.lending.withdraw(...)
+					</div>
+				</div>
+			</div>
+		</div>
+		<script>
+			const amt = document.getElementById('amt'),
+				PR = 67170,
+				SUPPLIED = 1,
+				DEBT_USD = 20000,
+				LIQ = 0.8,
+				MAXW = 0.575;
+			function calc(w) {
+				const collat = (SUPPLIED - w) * PR;
+				const ltv = collat > 0 ? DEBT_USD / collat : 99;
+				const hf = Math.max(0, Math.round((1 - ltv / LIQ) * 100));
+				return hf;
+			}
+			function col(h) {
+				return h < 20 ? 'var(--red)' : h < 45 ? 'var(--amber)' : 'var(--green)';
+			}
+			function band(h) {
+				return h < 20 ? 'red' : h < 45 ? 'amber' : 'ok';
+			}
+			function upd() {
+				const w = +amt.value || 0;
+				document.getElementById('fiat').textContent =
+					'$' + (w * PR).toLocaleString('en-US', { minimumFractionDigits: 2 });
+				const over = w > MAXW;
+				document.getElementById('err').style.display = over ? 'block' : 'none';
+				const h = calc(w);
+				const hf = document.getElementById('hf');
+				hf.textContent = over ? '—' : h + '%';
+				hf.style.color = col(h);
+				document.getElementById('mark').style.left = (over ? 0 : h) + '%';
+				const wn = document.getElementById('warn'),
+					wt = document.getElementById('wt'),
+					cw = document.getElementById('cw'),
+					cb = document.getElementById('cb');
+				const b = band(h);
+				wn.className = 'warn' + (over ? '' : b === 'red' ? ' red' : b === 'amber' ? ' amber' : '');
+				if (!over && b === 'red') {
+					wt.textContent = 'This withdrawal puts your position close to liquidation. ';
+					cw.classList.remove('hide');
+				} else if (!over && b === 'amber') {
+					wt.textContent = 'This withdrawal lowers your health factor.';
+					cw.classList.add('hide');
+					cb.checked = false;
+				} else {
+					cw.classList.add('hide');
+					cb.checked = false;
+				}
+				document.getElementById('toReview').disabled =
+					over || w <= 0 || (b === 'red' && !cb.checked);
+			}
+			amt.addEventListener('input', upd);
+			document.getElementById('cb').addEventListener('change', upd);
+			document.getElementById('max').onclick = () => {
+				amt.value = MAXW;
+				upd();
+			};
+			function show(id) {
+				['form', 'review', 'progress'].forEach((s, i) => {
+					document.getElementById(s).classList.toggle('hide', s !== id);
+					document
+						.getElementById('d' + i)
+						.classList.toggle('on', ['form', 'review', 'progress'].indexOf(id) >= i);
+				});
+			}
+			document.getElementById('toReview').onclick = () => {
+				const w = +amt.value || 0,
+					h = calc(w);
+				document.getElementById('rAmt').textContent = w + ' BTC';
+				document.getElementById('rFiat').textContent =
+					'$' + (w * PR).toLocaleString('en-US', { minimumFractionDigits: 2 });
+				document.getElementById('recv').textContent = (w - 0.0000001).toFixed(7) + ' BTC';
+				const rh = document.getElementById('rHf');
+				rh.textContent = h + '%';
+				rh.style.color = col(h);
+				document.getElementById('title').textContent = 'Review withdraw';
+				show('review');
+			};
+			document.getElementById('back').onclick = () => {
+				document.getElementById('title').textContent = 'Withdraw';
+				show('form');
+			};
+			document.getElementById('go').onclick = () => {
+				document.getElementById('title').textContent = 'Withdrawing';
+				show('progress');
+				setTimeout(() => {
+					document.getElementById('ptext').textContent = 'Done — funds returned to your wallet.';
+					document.querySelector('.spin').style.display = 'none';
+				}, 1500);
+			};
+			upd();
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
# Motivation

We are speccing a new feature — **Lend & Borrow via [Liquidium](https://liquidium.fi)** — through the spec-driven development workflow (`docs/ai/spec-driven-development/workflow.md`), and want to land the spec early so the team can start a first technical analysis while the spec is still being finalised in Cowork.

This is the **Step 3 handoff** artifact: it brings the Cowork-authored spec and its HTML wireframes into the repo as durable, version-controlled context. It is **spec only — no implementation** in this PR.

# Changes

- Add the spec `docs/ai/spec-driven-development/specs/2026-06-07-feat-liquidium-lend-borrow.md`.
- Add its sibling wireframes folder `2026-06-07-feat-liquidium-lend-borrow/wireframes/` (12 HTML mocks: earn card, borrow page, provider dashboard, the four action flows — supply/borrow/repay/withdraw — earning & liabilities tabs, active transactions, carousel slide), per the spec-assets folder convention.

The spec covers: an account-based Liquidium SDK integration behind a `LIQUIDIUM_ENABLED` flag, a new top-level **Borrow** entry (with Settings moving to the user menu), a shared `/providers/liquidium/` management page, a new **Liabilities** tab on Assets, and reuse of the swap-wizard and active-user-transactions patterns.

**Still open (in the spec, not this PR):** the spec carries unresolved **Open questions** (e.g. the supply rail per asset — `icrcAccount` vs `nativeAddress`, the repay SDK entry point, health-factor band thresholds) and **Pending decisions** (e.g. profile ownership, the backend `ActiveUserTransactionData` variant). These are to be resolved before/during the build.

> Note: the spec links to a sibling `2026-06-04-feat-limit-orders.md` spec that is not yet on `main`; that reference will resolve once the limit-orders spec lands.

# Tests

Not applicable — this PR adds planning documents (spec + wireframes) only, with no code or behaviour change. `PRODUCT.md` is intentionally **not** touched here; per the workflow it is updated in the same PR as the eventual behaviour change, not at spec time.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)
