### PR TITLE
feat(shared): add OnRamper signing types

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -150,6 +150,10 @@ type ApiKeys = record {
 	// `Some(true)`; `None` (the default) and `Some(false)` both mean non-replicated.
 	exchange_rate_replicated : opt bool;
 	coingecko_api_key : opt text;
+	// HMAC-SHA256 secret used to sign `OnRamper` widget URLs. Provided by `OnRamper` support and
+	// rotated via `set_api_keys`. When `None`, the signing endpoint reports the secret as
+	// missing and the `OnRamper` widget cannot be loaded.
+	onramper_signing_secret : opt text;
 	infura_api_key : opt text
 };
 type ApproveError = variant {

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -150,6 +150,10 @@ type ApiKeys = record {
 	// `Some(true)`; `None` (the default) and `Some(false)` both mean non-replicated.
 	exchange_rate_replicated : opt bool;
 	coingecko_api_key : opt text;
+	// HMAC-SHA256 secret used to sign `OnRamper` widget URLs. Provided by `OnRamper` support and
+	// rotated via `set_api_keys`. When `None`, the signing endpoint reports the secret as
+	// missing and the `OnRamper` widget cannot be loaded.
+	onramper_signing_secret : opt text;
 	infura_api_key : opt text
 };
 type ApproveError = variant {

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -216,6 +216,12 @@ export interface ApiKeys {
 	 */
 	exchange_rate_replicated: [] | [boolean];
 	coingecko_api_key: [] | [string];
+	/**
+	 * HMAC-SHA256 secret used to sign `OnRamper` widget URLs. Provided by `OnRamper` support and
+	 * rotated via `set_api_keys`. When `None`, the signing endpoint reports the secret as
+	 * missing and the `OnRamper` widget cannot be loaded.
+	 */
+	onramper_signing_secret: [] | [string];
 	infura_api_key: [] | [string];
 }
 export type ApproveError =

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -450,6 +450,7 @@ export const idlFactory = ({ IDL }) => {
 		etherscan_api_key: IDL.Opt(IDL.Text),
 		exchange_rate_replicated: IDL.Opt(IDL.Bool),
 		coingecko_api_key: IDL.Opt(IDL.Text),
+		onramper_signing_secret: IDL.Opt(IDL.Text),
 		infura_api_key: IDL.Opt(IDL.Text)
 	});
 	const CanisterStatusType = IDL.Variant({

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -450,6 +450,7 @@ export const idlFactory = ({ IDL }) => {
 		etherscan_api_key: IDL.Opt(IDL.Text),
 		exchange_rate_replicated: IDL.Opt(IDL.Bool),
 		coingecko_api_key: IDL.Opt(IDL.Text),
+		onramper_signing_secret: IDL.Opt(IDL.Text),
 		infura_api_key: IDL.Opt(IDL.Text)
 	});
 	const CanisterStatusType = IDL.Variant({

--- a/src/shared/src/types.rs
+++ b/src/shared/src/types.rs
@@ -19,6 +19,7 @@ pub mod experimental_feature;
 pub mod network;
 pub mod notification;
 pub mod number;
+pub mod onramper;
 pub mod pow;
 pub mod result_types;
 pub mod settings;

--- a/src/shared/src/types/api_keys.rs
+++ b/src/shared/src/types/api_keys.rs
@@ -16,6 +16,10 @@ pub struct ApiKeys {
     /// issues the request) or *non-replicated* (a single replica). Replicated only when explicitly
     /// `Some(true)`; `None` (the default) and `Some(false)` both mean non-replicated.
     pub exchange_rate_replicated: Option<bool>,
+    /// HMAC-SHA256 secret used to sign `OnRamper` widget URLs. Provided by `OnRamper` support and
+    /// rotated via `set_api_keys`. When `None`, the signing endpoint reports the secret as
+    /// missing and the `OnRamper` widget cannot be loaded.
+    pub onramper_signing_secret: Option<String>,
 }
 
 impl Debug for ApiKeys {
@@ -29,6 +33,10 @@ impl Debug for ApiKeys {
             .field("coingecko_api_key", &redact(&self.coingecko_api_key))
             .field("exchange_rate_enabled", &self.exchange_rate_enabled)
             .field("exchange_rate_replicated", &self.exchange_rate_replicated)
+            .field(
+                "onramper_signing_secret",
+                &redact(&self.onramper_signing_secret),
+            )
             .finish()
     }
 }

--- a/src/shared/src/types/onramper.rs
+++ b/src/shared/src/types/onramper.rs
@@ -1,0 +1,44 @@
+//! Types for the `OnRamper` widget URL signing endpoint.
+//!
+//! `OnRamper` requires widget URLs to carry an HMAC-SHA256 signature over the three sensitive
+//! parameters (`wallets`, `walletAddressTags`, `networkWallets`). The signed string follows
+//! `OnRamper`'s canonicalization rules (alphabetical sort, lowercase crypto / network ids,
+//! no URL encoding). See <https://docs.onramper.com/docs/signing-widget-url>.
+
+use candid::{CandidType, Deserialize};
+
+use crate::types::signer::RateLimitError;
+
+/// A `(key, value)` entry of an `OnRamper` signed parameter — e.g. `(btc, <address>)` inside
+/// `wallets`, or `(ethereum, <address>)` inside `networkWallets`. The canister normalizes the
+/// `key` to lowercase before signing.
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub struct OnramperSignedEntry {
+    pub key: String,
+    pub value: String,
+}
+
+/// Request body for `sign_onramper_widget_url`. Each field maps directly to one of `OnRamper`'s
+/// signed query parameters. Empty fields are omitted from the canonicalized sign-content.
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug, Default)]
+pub struct SignOnramperWidgetUrlRequest {
+    /// `<cryptoId>:<address>` pairs that map to the `wallets=` query parameter.
+    pub wallets: Vec<OnramperSignedEntry>,
+    /// `<networkId>:<address>` pairs that map to the `networkWallets=` query parameter.
+    pub network_wallets: Vec<OnramperSignedEntry>,
+    /// `<cryptoId>:<tag>` pairs that map to the `walletAddressTags=` query parameter.
+    pub wallet_address_tags: Vec<OnramperSignedEntry>,
+}
+
+/// Errors returned by `sign_onramper_widget_url`.
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum SignOnramperWidgetUrlError {
+    /// Controllers have not yet provisioned the `OnRamper` signing secret via `set_api_keys`. The
+    /// frontend should treat this the same as a hard failure: the widget cannot be opened until
+    /// the secret is configured.
+    SecretNotConfigured,
+    /// The caller exceeded the per-principal rate limit for signing requests. The endpoint signs
+    /// arbitrary caller-supplied parameters with a shared secret, so the limit bounds its use as a
+    /// signing oracle.
+    RateLimited(RateLimitError),
+}

--- a/src/shared/src/types/result_types.rs
+++ b/src/shared/src/types/result_types.rs
@@ -21,6 +21,7 @@ use crate::types::{
     contact::{Contact, ContactError},
     experimental_feature::UpdateExperimentalFeaturesSettingsError,
     network::{SetTestnetsSettingsError, UpdateNetworksSettingsError},
+    onramper::SignOnramperWidgetUrlError,
     transaction_settings::UpdateTransactionFilterSettingsError,
     user_transaction::{GetUserTransactionsResponse, UserTransactionError},
 };
@@ -443,6 +444,21 @@ impl From<Result<(), ActiveUserTransactionError>> for DeleteActiveUserTransactio
         match result {
             Ok(()) => DeleteActiveUserTransactionResult::Ok(()),
             Err(err) => DeleteActiveUserTransactionResult::Err(err),
+        }
+    }
+}
+
+#[derive(CandidType, Deserialize, Clone, Eq, PartialEq, Debug)]
+pub enum SignOnramperWidgetUrlResult {
+    /// Hex-encoded HMAC-SHA256 signature over the canonicalized signed parameters.
+    Ok(String),
+    Err(SignOnramperWidgetUrlError),
+}
+impl From<Result<String, SignOnramperWidgetUrlError>> for SignOnramperWidgetUrlResult {
+    fn from(result: Result<String, SignOnramperWidgetUrlError>) -> Self {
+        match result {
+            Ok(signature) => SignOnramperWidgetUrlResult::Ok(signature),
+            Err(err) => SignOnramperWidgetUrlResult::Err(err),
         }
     }
 }


### PR DESCRIPTION
# Motivation

OnRamper requires HMAC-SHA256 signatures on widget URLs — unsigned requests are rejected with `Invalid Signature` ([migration notice](https://knowledge.onramper.com/migration/url-signing)), which is why the buy widget is currently disabled. The signing will happen in the backend canister so the HMAC secret never enters the frontend bundle. This PR adds the shared types that the backend endpoint and its candid interface will be built on.

# Changes

- `ApiKeys` gains `onramper_signing_secret: Option<String>` (controller-managed cell). The field is redacted in the `Debug` impl so the secret never reaches canister logs.
- New `shared::types::onramper` module with the `SignOnramperWidgetUrlRequest` parameter types (wallets, network wallets, address tags as key/value entries) and the `SignOnramperWidgetUrlError` variants (`SecretNotConfigured`, `RateLimited`).
- `SignOnramperWidgetUrlResult` added to `result_types`.

# Tests

- Type-only change: `cargo check`, `cargo clippy -D warnings` and `cargo fmt --check` pass. Behavior is covered by unit and pocket-ic tests in the follow-up backend PR.