### PR TITLE
docs(backend): add OnRamper signing runbook and provisioning script

### DIFF
--- a/docs/onramper-signing.md
+++ b/docs/onramper-signing.md
@@ -67,8 +67,9 @@ needs it re-provisioned.
 ## Manual fallback (no script)
 
 `set_onramper_signing_secret` is the safe path. **Avoid** raw `set_api_keys` for this — it
-overwrites the entire `ApiKeys` record and would wipe `coingecko_api_key` / `exchange_rate_enabled`.
-If you must use it, first read the current record with `get_api_keys` and merge.
+replaces the key fields and would wipe `coingecko_api_key` (only `exchange_rate_enabled` /
+`exchange_rate_replicated` are preserved when left unset). If you must use it, first read the
+current record with `get_api_keys` and merge.
 
 ```bash
 dfx canister call --network ic backend set_onramper_signing_secret '(opt "sk_...")'

--- a/docs/onramper-signing.md
+++ b/docs/onramper-signing.md
@@ -1,0 +1,75 @@
+# OnRamper widget URL signing
+
+OnRamper rejects unsigned widget URLs (`Invalid Signature`) since April 2025. OISY signs the
+sensitive URL parameters with an HMAC-SHA256 secret held **only in the backend canister**, so the
+secret never ships in the frontend bundle.
+
+## Two distinct credentials — don't confuse them
+
+| Credential                            | What it is                                         | Where it lives              | How it's set                                                    |
+| ------------------------------------- | -------------------------------------------------- | --------------------------- | --------------------------------------------------------------- |
+| `VITE_ONRAMPER_API_KEY_DEV` / `_PROD` | Public widget `apiKey` (the `?apiKey=` in the URL) | Frontend bundle             | Build-time env / GitHub secrets, like every other `VITE_*` key  |
+| `onramper_signing_secret`             | HMAC secret used to sign URLs                      | Backend canister state only | Controller call to `set_onramper_signing_secret` (this runbook) |
+
+## Availability (feature flag)
+
+The buy widget is gated by `ONRAMPER_ENABLED` (`src/frontend/src/env/rest/onramper.env.ts`), which
+is enabled only on **local, staging and beta** — `LOCAL || STAGING || BETA` (`STAGING` covers the
+`test_fe_*` / `audit` / `e2e` environments). On **production (`ic`)** the flag is `false`, so the
+buy flow shows the unavailable notice regardless of backend state. Within the enabled environments,
+the widget is additionally gated on `onramper_enabled` (secret provisioned) — see below.
+
+## Runtime behavior
+
+- `sign_onramper_widget_url` (update, authenticated, rate-limited): signs the caller's
+  `wallets` / `networkWallets` / `walletAddressTags` and returns the hex HMAC.
+- `onramper_enabled` (query, public): returns `true` iff the secret is configured. The frontend
+  gates the buy widget on it (`BuyModalContent.svelte`), so a missing secret shows the
+  "buy unavailable" notice instead of a widget that would fail on open.
+- If the secret is missing, `sign_onramper_widget_url` returns `SecretNotConfigured` and the widget
+  self-disables — defense in depth behind `onramper_enabled`.
+
+**Until the secret is provisioned on an environment, the buy widget stays unavailable there**, even
+with `ONRAMPER_ENABLED = true`.
+
+## Provisioning the secret
+
+Prerequisite: obtain the signing secret from OnRamper support.
+
+Use the helper script — it calls the dedicated `set_onramper_signing_secret` endpoint, which mutates
+a **single field** and therefore does **not** clobber the other configured API keys (e.g. the
+CoinGecko key) the way a raw `set_api_keys` call would:
+
+```bash
+# Preferred: secret via env var (kept out of shell history); controller identity required.
+ONRAMPER_SIGNING_SECRET='sk_...' ./scripts/provision-onramper-signing-secret.sh --network ic
+
+# Or be prompted (non-echoed):
+./scripts/provision-onramper-signing-secret.sh --network staging --identity <controller-identity>
+```
+
+The script prints `onramper_enabled` afterward; expect `(true)`.
+
+On `ic` / `beta`, the controller is governance — provisioning goes through the appropriate ops /
+proposal path rather than a personal `dfx` identity.
+
+### Rotating / clearing
+
+```bash
+# Rotate: same command with the new secret.
+# Clear (disables the widget):
+./scripts/provision-onramper-signing-secret.sh --network ic --clear
+```
+
+The secret survives canister upgrades (it lives in the `ApiKeys` stable cell); only a fresh install
+needs it re-provisioned.
+
+## Manual fallback (no script)
+
+`set_onramper_signing_secret` is the safe path. **Avoid** raw `set_api_keys` for this — it
+overwrites the entire `ApiKeys` record and would wipe `coingecko_api_key` / `exchange_rate_enabled`.
+If you must use it, first read the current record with `get_api_keys` and merge.
+
+```bash
+dfx canister call --network ic backend set_onramper_signing_secret '(opt "sk_...")'
+```

--- a/scripts/provision-onramper-signing-secret.sh
+++ b/scripts/provision-onramper-signing-secret.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+print_help() {
+  cat <<-EOF
+
+	Provisions (or rotates) the OnRamper widget signing secret on the backend canister.
+
+	The secret is held only in canister state and used by 'sign_onramper_widget_url' to sign
+	OnRamper widget URLs — it never reaches the frontend bundle. Until it is set, the buy widget
+	reports itself unavailable (see 'onramper_enabled').
+
+	This calls the dedicated 'set_onramper_signing_secret' endpoint, which mutates a single field
+	and therefore does NOT clobber the other configured API keys (e.g. the CoinGecko key), unlike
+	a raw 'set_api_keys' call. Controller identity required.
+
+	The secret is read from (in order of precedence):
+	  1) the --secret flag (avoid on shared machines: it lands in shell history)
+	  2) the ONRAMPER_SIGNING_SECRET environment variable
+	  3) an interactive, non-echoed prompt
+
+	Examples:
+	  ONRAMPER_SIGNING_SECRET=sk_... ./scripts/provision-onramper-signing-secret.sh --network ic
+	  ./scripts/provision-onramper-signing-secret.sh --network staging   # prompts for the secret
+
+	To clear the secret (disable the widget): pass --clear.
+	EOF
+}
+
+# Source the clap.bash file ---------------------------------------------------
+source "$SOURCE_DIR/clap.bash"
+# Define options
+clap.define short=n long=network desc="dfx network to use" variable=NETWORK default="local"
+clap.define short=s long=secret desc="OnRamper signing secret (prefer env var / prompt)" variable=SECRET default=""
+clap.define short=i long=identity desc="dfx identity to call with (must be a controller)" variable=IDENTITY default="default"
+clap.define short=c long=clear desc="Clear the secret instead of setting it" variable=CLEAR default="false"
+# Source the output file ----------------------------------------------------------
+source "$(clap.build)"
+
+if [[ "$CLEAR" == "true" ]]; then
+  echo "Clearing the OnRamper signing secret on network '$NETWORK'..."
+  dfx canister call --identity "$IDENTITY" --network "$NETWORK" backend set_onramper_signing_secret '(null)'
+else
+  if [[ -z "$SECRET" ]]; then
+    SECRET="${ONRAMPER_SIGNING_SECRET:-}"
+  fi
+  if [[ -z "$SECRET" ]]; then
+    read -rs -p "OnRamper signing secret: " SECRET
+    echo
+  fi
+  [[ -n "$SECRET" ]] || {
+    echo "ERROR: no secret provided." >&2
+    print_help
+    exit 1
+  }
+
+  # Escape backslashes and double quotes for the Candid string literal.
+  ESCAPED="${SECRET//\\/\\\\}"
+  ESCAPED="${ESCAPED//\"/\\\"}"
+
+  echo "Setting the OnRamper signing secret on network '$NETWORK'..."
+  dfx canister call --identity "$IDENTITY" --network "$NETWORK" backend set_onramper_signing_secret "(opt \"$ESCAPED\")"
+fi
+
+echo -n "onramper_enabled now reports: "
+dfx canister call --identity "$IDENTITY" --network "$NETWORK" backend onramper_enabled


### PR DESCRIPTION
# Motivation

The OnRamper widget-URL signing endpoint reads its HMAC secret from a controller-managed cell in the backend canister. Operators need a documented, safe way to provision, rotate and clear that secret per environment — without clobbering the other configured API keys.

# Changes

- `docs/onramper-signing.md` — runbook covering the two distinct OnRamper credentials (public API key vs signing secret), the runtime behavior when the secret is missing (`onramper_enabled` returns `false` and the buy flow reports itself unavailable), and per-environment provisioning steps.
- `scripts/provision-onramper-signing-secret.sh` — controller-only helper to set / rotate / clear the secret via the dedicated non-clobbering endpoint. Reads the secret from `--secret`, `ONRAMPER_SIGNING_SECRET`, or a non-echoed prompt so it never lands in shell history.

# Tests

- Docs + ops script only; no canister or frontend code changes. `bash -n`, shellcheck and prettier pass.

> [!NOTE]
> Documents the interface introduced in #13078 (backend endpoints) and #13079 (frontend flag). Merge after those two.
