### PR TITLE
feat(frontend): restrict ONRAMPER_ENABLED to LOCAL/STAGING builds

### DIFF
--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -1,8 +1,8 @@
-import { BETA, LOCAL, STAGING } from '$lib/constants/app.constants';
+import { LOCAL, STAGING } from '$lib/constants/app.constants';
 
-// Feature flag: the OnRamper buy widget is enabled only on local, staging and beta — not on
+// Feature flag: the OnRamper buy widget is enabled only on local and staging — not on beta nor
 // production (ic). `STAGING` already covers the test_fe / audit / e2e environments.
-export const ONRAMPER_ENABLED = LOCAL || STAGING || BETA;
+export const ONRAMPER_ENABLED = LOCAL || STAGING;
 
 // Optimistic fallback for the runtime `onramper_enabled` backend query: assume the widget is
 // available when the query cannot be reached, since the widget self-disables on a missing secret.


### PR DESCRIPTION
# Motivation

The OnRamper buy widget should not be exposed on beta. Restrict the `ONRAMPER_ENABLED` feature flag to local and staging builds only.

# Changes

- Drop `BETA` from the `ONRAMPER_ENABLED` flag in `onramper.env.ts`.

# Tests

Existing Onramper unit tests pass.