### PR TITLE
docs(frontend): document QuickNode integration

### DIFF
--- a/docs/ai/integrations/README.md
+++ b/docs/ai/integrations/README.md
@@ -9,7 +9,7 @@ provider gets its own file so the docs scale as more integrations are added.
 | [Alchemy](./alchemy.md)     | viem `PublicClient` + NFT API v3 + WS | EVM + Solana | NFT indexing, real-time tx subscriptions, Solana HTTP RPC                          |
 | [Infura](./infura.md)       | ethers.js `InfuraProvider` + Gas REST | EVM          | Primary EVM JSON-RPC: balances, fees/gas, contract reads, tx broadcast, ckETH logs |
 | [Etherscan](./etherscan.md) | ethers.js `EtherscanProvider` (REST)  | EVM          | EVM transaction history (native, internal, ERC-20/721/1155 transfers)              |
-| [QuickNode](./quicknode.md) | `@solana/kit` WSS + HTTP JSON-RPC       | Solana       | Solana WS tx confirmation (mainnet) + SPL token metadata (`getAsset`)              |
+| [QuickNode](./quicknode.md) | `@solana/kit` WSS + HTTP JSON-RPC     | Solana       | Solana WS tx confirmation (mainnet) + SPL token metadata (`getAsset`)              |
 | [OnRamper](./onramper.md)   | Backend HMAC signing                  | —            | Buy-widget URL signing (backend runbook)                                           |
 
 ## Future work

--- a/docs/ai/integrations/README.md
+++ b/docs/ai/integrations/README.md
@@ -9,4 +9,5 @@ provider gets its own file so the docs scale as more integrations are added.
 | [Alchemy](./alchemy.md)     | viem `PublicClient` + NFT API v3 + WS | EVM + Solana | NFT indexing, real-time tx subscriptions, Solana HTTP RPC                          |
 | [Infura](./infura.md)       | ethers.js `InfuraProvider` + Gas REST | EVM          | Primary EVM JSON-RPC: balances, fees/gas, contract reads, tx broadcast, ckETH logs |
 | [Etherscan](./etherscan.md) | ethers.js `EtherscanProvider` (REST)  | EVM          | EVM transaction history (native, internal, ERC-20/721/1155 transfers)              |
+| [QuickNode](./quicknode.md) | `@solana/kit` WSS + REST              | Solana       | Solana WS tx confirmation (mainnet) + SPL token metadata (`getAsset`)              |
 | [OnRamper](./onramper.md)   | Backend HMAC signing                  | —            | Buy-widget URL signing (backend runbook)                                           |

--- a/docs/ai/integrations/README.md
+++ b/docs/ai/integrations/README.md
@@ -11,3 +11,55 @@ provider gets its own file so the docs scale as more integrations are added.
 | [Etherscan](./etherscan.md) | ethers.js `EtherscanProvider` (REST)  | EVM          | EVM transaction history (native, internal, ERC-20/721/1155 transfers)              |
 | [QuickNode](./quicknode.md) | `@solana/kit` WSS + REST              | Solana       | Solana WS tx confirmation (mainnet) + SPL token metadata (`getAsset`)              |
 | [OnRamper](./onramper.md)   | Backend HMAC signing                  | —            | Buy-widget URL signing (backend runbook)                                           |
+
+## Future work
+
+> Status: ideas only — not started. Captured here because they span more than one
+> provider. A change of this size should go through the
+> [spec-driven workflow](../spec-driven-development/workflow.md) as its own spec
+> before any code is touched.
+
+### Multi-provider strategy & resilience
+
+Today each provider is a single point of failure for its jobs (e.g. Solana
+mainnet WS for send-confirmation runs through QuickNode only; EVM JSON-RPC through
+Infura, with Alchemy configured alongside). Several capabilities now overlap
+across providers, which opens up a deliberate multi-provider strategy.
+
+**Triggering context (verified 2026-06-15):** the original reason the Solana stack
+is split — Alchemy lacked Solana WebSockets (checked 2025-01-22) — no longer holds.
+Alchemy now supports both of [QuickNode](./quicknode.md)'s Solana roles:
+
+- Solana WebSocket subscriptions, GA, including `signatureSubscribe` and
+  `slotSubscribe` (the methods the send-confirmation flow uses). Docs:
+  <https://www.alchemy.com/docs/reference/solana-subscription-api-endpoints>
+- SPL token metadata via the DAS `getAsset` method — **Beta**, field parity with
+  QuickNode (`name` / `symbol` / `links.image`) not yet validated. Docs:
+  <https://www.alchemy.com/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-asset>
+
+**Options to weigh in the spec:**
+
+1. **Consolidate** onto Alchemy and drop QuickNode (remove `VITE_QUICKNODE_API_KEY`,
+   `quicknode.env.ts`, `quicknode.rest.ts`). Simplest, one fewer vendor — but loses
+   redundancy and leans on a Beta API for metadata.
+2. **Keep both as primary + failover** for resilience on the critical paths (Solana
+   send-confirmation, and potentially EVM/Solana RPC generally). No single point of
+   failure, at the cost of failover logic, health checks, and a per-job provider
+   capability matrix.
+3. **Hybrid** — failover where it matters (the money-movement confirmation path),
+   single provider where redundancy is cheap to skip (best-effort token metadata).
+
+**Constraints / principles for whoever designs this:**
+
+- **Pricing decides direction.** A usage-billed provider is the ideal _fallback_
+  (idle cost ≈ 0, pay only during failover); a flat/committed-plan provider is the
+  ideal _primary_. Public pricing puts Alchemy as usage-based and QuickNode as
+  plan-tiered → cost-optimal shape is QuickNode primary / Alchemy fallback. **Verify
+  against OISY's actual contracts before relying on this.**
+- **Commodity vs. proprietary.** Standard JSON-RPC (EVM RPC, Solana HTTP/WS) is
+  interchangeable across providers, so failover is realistic. Proprietary/enriched
+  APIs (Alchemy NFT API v3, the custom `alchemy_minedTransactions` /
+  `alchemy_pendingTransactions` subscriptions) have no drop-in equivalent and would
+  need per-provider adapters — so "fallback for everything" is not free.
+- A natural home for any failover wrapper is `sol-rpc.providers.ts` (Solana) and the
+  EVM provider layer, which already centralize provider selection.

--- a/docs/ai/integrations/README.md
+++ b/docs/ai/integrations/README.md
@@ -9,7 +9,7 @@ provider gets its own file so the docs scale as more integrations are added.
 | [Alchemy](./alchemy.md)     | viem `PublicClient` + NFT API v3 + WS | EVM + Solana | NFT indexing, real-time tx subscriptions, Solana HTTP RPC                          |
 | [Infura](./infura.md)       | ethers.js `InfuraProvider` + Gas REST | EVM          | Primary EVM JSON-RPC: balances, fees/gas, contract reads, tx broadcast, ckETH logs |
 | [Etherscan](./etherscan.md) | ethers.js `EtherscanProvider` (REST)  | EVM          | EVM transaction history (native, internal, ERC-20/721/1155 transfers)              |
-| [QuickNode](./quicknode.md) | `@solana/kit` WSS + REST              | Solana       | Solana WS tx confirmation (mainnet) + SPL token metadata (`getAsset`)              |
+| [QuickNode](./quicknode.md) | `@solana/kit` WSS + HTTP JSON-RPC       | Solana       | Solana WS tx confirmation (mainnet) + SPL token metadata (`getAsset`)              |
 | [OnRamper](./onramper.md)   | Backend HMAC signing                  | —            | Buy-widget URL signing (backend runbook)                                           |
 
 ## Future work

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -1,9 +1,6 @@
 # QuickNode API
 
 OISY uses [QuickNode](https://www.quicknode.com/) for two narrow **Solana**
-purposes that the primary Solana provider ([Alchemy](./alchemy.md), HTTP RPC)
-doesn't cover:
-
 purposes that we deliberately do not route through the primary Solana provider,
  ([Alchemy](./alchemy.md), HTTP RPC), because it was not supported at implementation time:
 

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -74,49 +74,8 @@ This split is the Solana mirror of how the EVM side mixes providers — see the 
 in `networks.sol.env.ts` to collapse to a single service once Alchemy supports
 Solana WebSockets.
 
-## Future work — consolidate QuickNode into Alchemy
-
-> Status: not started. The integration is intentionally left as-is for now; this
-> section is the entry point for a future task to pick it up.
-
-Both reasons we use QuickNode were re-checked on **2026-06-15** against Alchemy's
-current docs, and **both no longer hold** — Alchemy has since added Solana support
-for each. The opportunity is therefore to drop QuickNode entirely and serve both
-use cases from the existing Alchemy key, removing the second Solana provider (and
-`VITE_QUICKNODE_API_KEY`).
-
-### Item 1 — move Solana WS subscriptions to Alchemy (low risk)
-
-- Alchemy now offers Solana WebSocket subscriptions as a GA feature, including the
-  exact methods this code relies on: `signatureSubscribe` (signature confirmation)
-  and `slotSubscribe` (block-height / expiry tracking).
-- Change: point `SOLANA_RPC_WS_URL_MAINNET` (`src/frontend/src/env/networks/networks.sol.env.ts`)
-  at the Alchemy Solana WSS endpoint (`wss://solana-mainnet.g.alchemy.com/v2/<ALCHEMY_API_KEY>`)
-  instead of QuickNode. Devnet/local are unaffected (already non-QuickNode).
-- Verify: `sendSol` confirmation flow in `src/frontend/src/sol/services/sol-send.services.ts`
-  (`confirmSignedTransaction` → `waitForRecentTransactionConfirmation`) still
-  confirms transactions on mainnet.
-- Remove the "Last time checked Alchemy: 2025-01-22" TODO in `networks.sol.env.ts`.
-- Docs: <https://www.alchemy.com/docs/reference/solana-subscription-api-endpoints>
-
-### Item 2 — move SPL token metadata to Alchemy DAS `getAsset` (needs validation)
-
-- Alchemy now exposes a Solana DAS API with `getAsset` covering fungible tokens —
-  the same call shape as QuickNode's. **Caveat: it is in Beta** ("CU values may
-  change"), and field parity was not confirmable from the overview docs alone.
-- Before switching, validate that Alchemy's `getAsset` returns the fields
-  `splMetadata` maps (`src/frontend/src/sol/rest/quicknode.rest.ts`): token
-  `name`, `symbol`, and icon (`links.image`) for real mainnet **and** devnet SPL
-  mints.
-- Change (if validated): repoint `splMetadata` / `getSplMetadata`
-  (`src/frontend/src/sol/services/spl.services.ts`) at the Alchemy DAS endpoint and
-  drop `src/frontend/src/env/rest/quicknode.env.ts`.
-- Docs: <https://www.alchemy.com/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-asset>
-
-### Cleanup once both items land
-
-- Remove `VITE_QUICKNODE_API_KEY` from `.env.example` / `.env.test` and any deploy
-  secrets, delete `src/frontend/src/env/rest/quicknode.env.ts` and
-  `src/frontend/src/sol/rest/quicknode.rest.ts`, and remove this provider's row
-  from the integrations index (`README.md`) — or repurpose this doc as a historical
-  note.
+> As of 2026-06-15 that gap has closed — Alchemy now supports both of QuickNode's
+> Solana roles — which turns this split into a deliberate choice rather than a
+> constraint. That cross-provider decision (consolidate vs. keep both for
+> resilience) is tracked in the index's [Future work](./README.md#future-work),
+> not here.

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -2,7 +2,7 @@
 
 OISY uses [QuickNode](https://www.quicknode.com/) for two narrow **Solana**
 purposes that we deliberately do not route through the primary Solana provider,
- ([Alchemy](./alchemy.md), HTTP RPC), because it was not supported at implementation time:
+([Alchemy](./alchemy.md), HTTP RPC), because it was not supported at implementation time:
 
 1. **Solana WebSocket subscriptions** (mainnet only) — for transaction
    confirmation. This was originally because Alchemy did not support Solana WebSockets as

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -5,8 +5,8 @@ purposes that we deliberately do not route through the primary Solana provider,
  ([Alchemy](./alchemy.md), HTTP RPC), because it was not supported at implementation time:
 
 1. **Solana WebSocket subscriptions** (mainnet only) — for transaction
-   confirmation, because Alchemy did not support Solana WebSockets as of the last
-   check (2025-01-22). See the TODO in
+   confirmation. This was originally because Alchemy did not support Solana WebSockets as
+   of the last check (2025-01-22). See the TODO in
    `src/frontend/src/env/networks/networks.sol.env.ts`.
 2. **SPL token metadata** (mainnet + devnet) — via QuickNode's `getAsset` REST
    add-on.

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -71,7 +71,7 @@ The endpoint hostnames are hardcoded; only the key comes from the environment.
 | Why split | Alchemy lacked Solana WS support (checked 2025-01-22)       | Primary Solana HTTP RPC backend    |
 
 This split is the Solana mirror of how the EVM side mixes providers — see the
-[TODO](https://github.com/dfinity/oisy-wallet/blob/8728252ac98399b52f50537df39d6f7922fdef4d/src/frontend/src/env/networks/networks.sol.env.ts#L25-L27) in [`networks.sol.env.ts`](https://github.com/dfinity/oisy-wallet/blob/8728252ac98399b52f50537df39d6f7922fdef4d/src/frontend/src/env/networks/networks.sol.env.ts)
+[TODO](https://github.com/dfinity/oisy-wallet/blob/8728252ac98399b52f50537df39d6f7922fdef4d/src/frontend/src/env/networks/networks.sol.env.ts#L25-L27) in [`networks.sol.env.ts`](https://github.com/dfinity/oisy-wallet/blob/main/src/frontend/src/env/networks/networks.sol.env.ts)
 to collapse to a single service once Alchemy supports Solana WebSockets.
 
 > As of 2026-06-15 that gap has closed — Alchemy now supports both of QuickNode's

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -73,3 +73,50 @@ The endpoint hostnames are hardcoded; only the key comes from the environment.
 This split is the Solana mirror of how the EVM side mixes providers — see the TODO
 in `networks.sol.env.ts` to collapse to a single service once Alchemy supports
 Solana WebSockets.
+
+## Future work — consolidate QuickNode into Alchemy
+
+> Status: not started. The integration is intentionally left as-is for now; this
+> section is the entry point for a future task to pick it up.
+
+Both reasons we use QuickNode were re-checked on **2026-06-15** against Alchemy's
+current docs, and **both no longer hold** — Alchemy has since added Solana support
+for each. The opportunity is therefore to drop QuickNode entirely and serve both
+use cases from the existing Alchemy key, removing the second Solana provider (and
+`VITE_QUICKNODE_API_KEY`).
+
+### Item 1 — move Solana WS subscriptions to Alchemy (low risk)
+
+- Alchemy now offers Solana WebSocket subscriptions as a GA feature, including the
+  exact methods this code relies on: `signatureSubscribe` (signature confirmation)
+  and `slotSubscribe` (block-height / expiry tracking).
+- Change: point `SOLANA_RPC_WS_URL_MAINNET` (`src/frontend/src/env/networks/networks.sol.env.ts`)
+  at the Alchemy Solana WSS endpoint (`wss://solana-mainnet.g.alchemy.com/v2/<ALCHEMY_API_KEY>`)
+  instead of QuickNode. Devnet/local are unaffected (already non-QuickNode).
+- Verify: `sendSol` confirmation flow in `src/frontend/src/sol/services/sol-send.services.ts`
+  (`confirmSignedTransaction` → `waitForRecentTransactionConfirmation`) still
+  confirms transactions on mainnet.
+- Remove the "Last time checked Alchemy: 2025-01-22" TODO in `networks.sol.env.ts`.
+- Docs: <https://www.alchemy.com/docs/reference/solana-subscription-api-endpoints>
+
+### Item 2 — move SPL token metadata to Alchemy DAS `getAsset` (needs validation)
+
+- Alchemy now exposes a Solana DAS API with `getAsset` covering fungible tokens —
+  the same call shape as QuickNode's. **Caveat: it is in Beta** ("CU values may
+  change"), and field parity was not confirmable from the overview docs alone.
+- Before switching, validate that Alchemy's `getAsset` returns the fields
+  `splMetadata` maps (`src/frontend/src/sol/rest/quicknode.rest.ts`): token
+  `name`, `symbol`, and icon (`links.image`) for real mainnet **and** devnet SPL
+  mints.
+- Change (if validated): repoint `splMetadata` / `getSplMetadata`
+  (`src/frontend/src/sol/services/spl.services.ts`) at the Alchemy DAS endpoint and
+  drop `src/frontend/src/env/rest/quicknode.env.ts`.
+- Docs: <https://www.alchemy.com/docs/reference/alchemy-das-apis-for-solana/solana-das-api-endpoints/get-asset>
+
+### Cleanup once both items land
+
+- Remove `VITE_QUICKNODE_API_KEY` from `.env.example` / `.env.test` and any deploy
+  secrets, delete `src/frontend/src/env/rest/quicknode.env.ts` and
+  `src/frontend/src/sol/rest/quicknode.rest.ts`, and remove this provider's row
+  from the integrations index (`README.md`) — or repurpose this doc as a historical
+  note.

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -71,8 +71,8 @@ The endpoint hostnames are hardcoded; only the key comes from the environment.
 | Why split | Alchemy lacked Solana WS support (checked 2025-01-22)       | Primary Solana HTTP RPC backend    |
 
 This split is the Solana mirror of how the EVM side mixes providers — see the
-[TODO](https://github.com/dfinity/oisy-wallet/blob/8728252ac98399b52f50537df39d6f7922fdef4d/src/frontend/src/env/networks/networks.sol.env.ts#L25-L27) in [`networks.sol.env.ts`](https://github.com/dfinity/oisy-wallet/blob/main/src/frontend/src/env/networks/networks.sol.env.ts)
-to collapse to a single service once Alchemy supports Solana WebSockets.
+TODO in `src/frontend/src/env/networks/networks.sol.env.ts` to collapse to a
+single service once Alchemy supports Solana WebSockets.
 
 > As of 2026-06-15 that gap has closed — Alchemy now supports both of QuickNode's
 > Solana roles — which turns this split into a deliberate choice rather than a

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -71,7 +71,7 @@ The endpoint hostnames are hardcoded; only the key comes from the environment.
 | Why split | Alchemy lacked Solana WS support (checked 2025-01-22)       | Primary Solana HTTP RPC backend    |
 
 This split is the Solana mirror of how the EVM side mixes providers — see the
-[TODO in `networks.sol.env.ts`](https://github.com/dfinity/oisy-wallet/blob/8728252ac98399b52f50537df39d6f7922fdef4d/src/frontend/src/env/networks/networks.sol.env.ts#L25-L27)
+[TODO](https://github.com/dfinity/oisy-wallet/blob/8728252ac98399b52f50537df39d6f7922fdef4d/src/frontend/src/env/networks/networks.sol.env.ts#L25-L27) in [`networks.sol.env.ts`](https://github.com/dfinity/oisy-wallet/blob/8728252ac98399b52f50537df39d6f7922fdef4d/src/frontend/src/env/networks/networks.sol.env.ts)
 to collapse to a single service once Alchemy supports Solana WebSockets.
 
 > As of 2026-06-15 that gap has closed — Alchemy now supports both of QuickNode's

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -4,6 +4,9 @@ OISY uses [QuickNode](https://www.quicknode.com/) for two narrow **Solana**
 purposes that the primary Solana provider ([Alchemy](./alchemy.md), HTTP RPC)
 doesn't cover:
 
+purposes that we deliberately do not route through the primary Solana provider,
+ ([Alchemy](./alchemy.md), HTTP RPC), because it was not supported at implementation time:
+
 1. **Solana WebSocket subscriptions** (mainnet only) — for transaction
    confirmation, because Alchemy did not support Solana WebSockets as of the last
    check (2025-01-22). See the TODO in

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -70,9 +70,9 @@ The endpoint hostnames are hardcoded; only the key comes from the environment.
 | Role      | Solana WS subscriptions (mainnet) + SPL `getAsset` metadata | Solana HTTP RPC (mainnet + devnet) |
 | Why split | Alchemy lacked Solana WS support (checked 2025-01-22)       | Primary Solana HTTP RPC backend    |
 
-This split is the Solana mirror of how the EVM side mixes providers — see the TODO
-in `networks.sol.env.ts` to collapse to a single service once Alchemy supports
-Solana WebSockets.
+This split is the Solana mirror of how the EVM side mixes providers — see the
+[TODO in `networks.sol.env.ts`](https://github.com/dfinity/oisy-wallet/blob/8728252ac98399b52f50537df39d6f7922fdef4d/src/frontend/src/env/networks/networks.sol.env.ts#L25-L27)
+to collapse to a single service once Alchemy supports Solana WebSockets.
 
 > As of 2026-06-15 that gap has closed — Alchemy now supports both of QuickNode's
 > Solana roles — which turns this split into a deliberate choice rather than a

--- a/docs/ai/integrations/quicknode.md
+++ b/docs/ai/integrations/quicknode.md
@@ -1,0 +1,75 @@
+# QuickNode API
+
+OISY uses [QuickNode](https://www.quicknode.com/) for two narrow **Solana**
+purposes that the primary Solana provider ([Alchemy](./alchemy.md), HTTP RPC)
+doesn't cover:
+
+1. **Solana WebSocket subscriptions** (mainnet only) — for transaction
+   confirmation, because Alchemy did not support Solana WebSockets as of the last
+   check (2025-01-22). See the TODO in
+   `src/frontend/src/env/networks/networks.sol.env.ts`.
+2. **SPL token metadata** (mainnet + devnet) — via QuickNode's `getAsset` REST
+   add-on.
+
+QuickNode is **not** used for any EVM chain, nor for general Solana HTTP RPC
+(that is Alchemy). The same `VITE_QUICKNODE_API_KEY` authenticates both uses.
+
+## What we use it for
+
+| Area                    | Network                 | Transport           | Purpose                                     |
+| ----------------------- | ----------------------- | ------------------- | ------------------------------------------- |
+| WebSocket subscriptions | Solana mainnet          | WSS (`@solana/kit`) | Transaction-confirmation monitoring on send |
+| SPL token metadata      | Solana mainnet + devnet | HTTP POST JSON-RPC  | `getAsset` — token name, symbol, icon       |
+
+## WebSocket subscriptions (transaction confirmation)
+
+The Solana WebSocket subscription client is built by `solanaWebSocketRpc` in
+`src/frontend/src/sol/providers/sol-rpc.providers.ts` via
+`createSolanaRpcSubscriptions` (`@solana/kit`). **Only mainnet uses QuickNode**
+(`SOLANA_RPC_WS_URL_MAINNET`); devnet uses the public Solana endpoint and local
+uses `localhost` (`networks.sol.env.ts`).
+
+It is consumed solely in `src/frontend/src/sol/services/sol-send.services.ts`:
+`sendSol` builds the subscription client and calls `confirmSignedTransaction`,
+which waits for confirmation via:
+
+- `createRecentSignatureConfirmationPromiseFactory` — resolves when the
+  transaction signature reaches the target commitment (`confirmed`+).
+- `createBlockHeightExceedencePromiseFactory` — detects transaction expiry by
+  tracking block height.
+
+Both feed `waitForRecentTransactionConfirmation` during the send flow's `CONFIRM`
+step.
+
+## SPL token metadata (`getAsset`)
+
+`splMetadata` in `src/frontend/src/sol/rest/quicknode.rest.ts` issues a JSON-RPC
+`getAsset` POST (see <https://www.quicknode.com/docs/solana/getAsset>) and returns
+the token's **name, symbol, and icon** (from `metadata` / `links.image`). It
+selects the mainnet or devnet endpoint by network.
+
+Consumed by `getSplMetadata` in `src/frontend/src/sol/services/spl.services.ts`,
+which enriches custom SPL tokens (not in the default list) with metadata during
+token loading.
+
+## Configuration
+
+| Item             | Value                                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| API key env var  | `VITE_QUICKNODE_API_KEY` (`src/frontend/src/env/rest/quicknode.env.ts`)                |
+| Mainnet endpoint | `https://burned-little-dinghy.solana-mainnet.quiknode.pro/<key>`                       |
+| Devnet endpoint  | `https://burned-little-dinghy.solana-devnet.quiknode.pro/<key>`                        |
+| WSS (mainnet)    | `wss://burned-little-dinghy.solana-mainnet.quiknode.pro/<key>` (`networks.sol.env.ts`) |
+
+The endpoint hostnames are hardcoded; only the key comes from the environment.
+
+## QuickNode vs. Alchemy (Solana)
+
+|           | QuickNode                                                   | Alchemy                            |
+| --------- | ----------------------------------------------------------- | ---------------------------------- |
+| Role      | Solana WS subscriptions (mainnet) + SPL `getAsset` metadata | Solana HTTP RPC (mainnet + devnet) |
+| Why split | Alchemy lacked Solana WS support (checked 2025-01-22)       | Primary Solana HTTP RPC backend    |
+
+This split is the Solana mirror of how the EVM side mixes providers — see the TODO
+in `networks.sol.env.ts` to collapse to a single service once Alchemy supports
+Solana WebSockets.


### PR DESCRIPTION
# Motivation

Completing the `docs/ai/integrations/` series (Alchemy #13086, Infura #13087, Etherscan #13088), document QuickNode — the remaining external provider on the Solana side. Its usage was undocumented and split across the Solana RPC provider, the SPL metadata REST client, and the network env. This PR branches off `main` (the earlier series has merged), so it is not stacked.

# Changes

- Add `docs/ai/integrations/quicknode.md` — QuickNode's two Solana-only uses:
  - **WebSocket subscriptions (mainnet)** for transaction confirmation — `solanaWebSocketRpc` (`@solana/kit`), consumed by `confirmSignedTransaction` / `waitForRecentTransactionConfirmation` in `sol-send.services.ts`. Devnet uses the public endpoint, not QuickNode.
  - **SPL token metadata** via the `getAsset` REST add-on (mainnet + devnet) — `splMetadata` (`quicknode.rest.ts`) → `getSplMetadata` (`spl.services.ts`), enriching custom SPL tokens with name/symbol/icon.
  - Configuration (`VITE_QUICKNODE_API_KEY`, hardcoded endpoint hostnames) and a QuickNode-vs-Alchemy (Solana) comparison.
- Add a **Future work** section to the integrations index (`README.md`) — kept there, not in the provider doc, because it spans multiple providers:
  - **Multi-provider strategy & resilience**: triggered by the verified finding (2026-06-15) that Alchemy now covers both of QuickNode's Solana roles (WS GA; DAS `getAsset` Beta). Lays out three options — consolidate / keep-both-as-failover / hybrid — plus the pay-as-you-go-as-fallback pricing principle and the commodity-vs-proprietary-API caveat. Defers the actual design to a dedicated spec via the spec-driven workflow.
  - The QuickNode doc keeps only a back-pointer to this section (provider docs stay descriptive of current behavior).
- Add the QuickNode row to `docs/ai/integrations/README.md`.

# Tests

Docs-only change. Ran `prettier --write` on the new/changed files so they pass the Format CI gate. No code touched. Call sites (`solanaWebSocketRpc`, the `sol-send` confirmation factories, `splMetadata`/`getSplMetadata`, env/endpoint config) were verified against the source, and Alchemy's current Solana WS + DAS support was verified against Alchemy's docs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)