### PR TITLE
feat(backend)!: add Liquidium variant to ActiveUserTransactionData

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -24,7 +24,10 @@ type ActiveUserTransaction = record {
 // every new provider integration.
 type ActiveUserTransactionData = variant {
 	OneSecEvmToIcp : OneSecEvmToIcpData;
-	OneSecIcpToEvm : OneSecIcpToEvmData
+	OneSecIcpToEvm : OneSecIcpToEvmData;
+	// Liquidium lend/borrow flow. A single variant covers all four actions
+	// (supply, borrow, repay, withdraw).
+	Liquidium : LiquidiumData
 };
 type ActiveUserTransactionError = variant {
 	InvalidId;
@@ -707,6 +710,17 @@ type InitArg = record {
 	// `None` is treated as "allowed" (the default), ensuring backward compatibility with
 	// deployments that pre-date this field.
 	new_user_signups_allowed : opt bool
+};
+// Which Liquidium lend/borrow action an active transaction tracks.
+type LiquidiumAction = variant { Withdraw; Repay; Borrow; Supply };
+type LiquidiumData = record {
+	// The asset moved by this action (supplied, borrowed, repaid, withdrawn).
+	token : TokenId;
+	action : LiquidiumAction;
+	// Liquidium pool canister id (principal text), treated as an opaque key.
+	pool_id : text;
+	// Amount in the token's base units.
+	amount : nat
 };
 // Bitcoin Network.
 type Network = variant {

--- a/src/backend/src/active_user_transactions/model.rs
+++ b/src/backend/src/active_user_transactions/model.rs
@@ -8,7 +8,7 @@ use shared::types::active_user_transaction::{
     MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_ACTIVE_USER_TRANSACTION_ERROR_LEN,
     MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REFS, MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_KEY_LEN,
     MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_VALUE_LEN, MAX_ACTIVE_USER_TRANSACTION_ID_LEN,
-    MAX_ACTIVE_USER_TRANSACTION_PROGRESS_STEP_LEN, MAX_EVM_ADDRESS_LEN,
+    MAX_ACTIVE_USER_TRANSACTION_PROGRESS_STEP_LEN, MAX_EVM_ADDRESS_LEN, MAX_LIQUIDIUM_POOL_ID_LEN,
 };
 
 use crate::types::{ActiveUserTransactionKey, ActiveUserTransactionsMap, Candid, StoredPrincipal};
@@ -222,6 +222,10 @@ fn validate_data(data: &ActiveUserTransactionData) -> Result<(), ActiveUserTrans
                 ));
             }
         }
+        ActiveUserTransactionData::Liquidium(d) => {
+            require_positive_amount(&d.amount)?;
+            require_pool_id(&d.pool_id)?;
+        }
     }
     Ok(())
 }
@@ -230,6 +234,15 @@ fn require_positive_amount(amount: &Nat) -> Result<(), ActiveUserTransactionErro
     if amount.0 == 0u32.into() {
         return Err(ActiveUserTransactionError::InvalidData(
             "amount must be greater than zero".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn require_pool_id(pool_id: &str) -> Result<(), ActiveUserTransactionError> {
+    if pool_id.is_empty() || pool_id.len() > MAX_LIQUIDIUM_POOL_ID_LEN {
+        return Err(ActiveUserTransactionError::InvalidData(
+            "pool_id invalid length".to_string(),
         ));
     }
     Ok(())
@@ -288,8 +301,9 @@ mod tests {
     use shared::types::{
         active_user_transaction::{
             ActiveUserTransactionData, ActiveUserTransactionError, ActiveUserTransactionRef,
-            ActiveUserTransactionStatus, CreateActiveUserTransactionRequest, OneSecIcpToEvmData,
-            UpdateActiveUserTransactionRequest, MAX_ACTIVE_USER_TRANSACTIONS_PER_USER,
+            ActiveUserTransactionStatus, CreateActiveUserTransactionRequest, LiquidiumAction,
+            LiquidiumData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
+            MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_LIQUIDIUM_POOL_ID_LEN,
         },
         token_id::TokenId,
     };
@@ -395,6 +409,57 @@ mod tests {
             amount: Nat::from(1u32),
             recipient_evm_address: "not-an-address".to_string(),
         });
+        let err = create(&mut map, principal(), req, 1).unwrap_err();
+        assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    fn liquidium_data(amount: u64, pool_id: &str) -> ActiveUserTransactionData {
+        ActiveUserTransactionData::Liquidium(LiquidiumData {
+            action: LiquidiumAction::Supply,
+            pool_id: pool_id.to_string(),
+            token: TokenId::Icrc(Principal::from_text("mxzaz-hqaaa-aaaar-qaada-cai").unwrap()),
+            amount: Nat::from(amount),
+        })
+    }
+
+    #[test]
+    fn liquidium_create_roundtrip() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("liq-1");
+        req.data = liquidium_data(5_100, "mxzaz-hqaaa-aaaar-qaada-cai");
+        let tx = create(&mut map, principal(), req, 1).expect("create");
+        assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+        assert_eq!(
+            tx.data,
+            liquidium_data(5_100, "mxzaz-hqaaa-aaaar-qaada-cai")
+        );
+    }
+
+    #[test]
+    fn liquidium_zero_amount_rejected() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("liq-1");
+        req.data = liquidium_data(0, "mxzaz-hqaaa-aaaar-qaada-cai");
+        let err = create(&mut map, principal(), req, 1).unwrap_err();
+        assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    #[test]
+    fn liquidium_empty_pool_id_rejected() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("liq-1");
+        req.data = liquidium_data(5_100, "");
+        let err = create(&mut map, principal(), req, 1).unwrap_err();
+        assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    #[test]
+    fn liquidium_overlong_pool_id_rejected() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("liq-1");
+        // A canister principal text is at most 63 chars; anything longer can
+        // never be a valid pool id.
+        req.data = liquidium_data(5_100, &"a".repeat(MAX_LIQUIDIUM_POOL_ID_LEN + 1));
         let err = create(&mut map, principal(), req, 1).unwrap_err();
         assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
     }

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -24,7 +24,10 @@ type ActiveUserTransaction = record {
 // every new provider integration.
 type ActiveUserTransactionData = variant {
 	OneSecEvmToIcp : OneSecEvmToIcpData;
-	OneSecIcpToEvm : OneSecIcpToEvmData
+	OneSecIcpToEvm : OneSecIcpToEvmData;
+	// Liquidium lend/borrow flow. A single variant covers all four actions
+	// (supply, borrow, repay, withdraw).
+	Liquidium : LiquidiumData
 };
 type ActiveUserTransactionError = variant {
 	InvalidId;
@@ -707,6 +710,17 @@ type InitArg = record {
 	// `None` is treated as "allowed" (the default), ensuring backward compatibility with
 	// deployments that pre-date this field.
 	new_user_signups_allowed : opt bool
+};
+// Which Liquidium lend/borrow action an active transaction tracks.
+type LiquidiumAction = variant { Withdraw; Repay; Borrow; Supply };
+type LiquidiumData = record {
+	// The asset moved by this action (supplied, borrowed, repaid, withdrawn).
+	token : TokenId;
+	action : LiquidiumAction;
+	// Liquidium pool canister id (principal text), treated as an opaque key.
+	pool_id : text;
+	// Amount in the token's base units.
+	amount : nat
 };
 // Bitcoin Network.
 type Network = variant {

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -50,7 +50,14 @@ export type ActiveUserTransactionData =
 	| {
 			OneSecEvmToIcp: OneSecEvmToIcpData;
 	  }
-	| { OneSecIcpToEvm: OneSecIcpToEvmData };
+	| { OneSecIcpToEvm: OneSecIcpToEvmData }
+	| {
+			/**
+			 * Liquidium lend/borrow flow. A single variant covers all four actions
+			 * (supply, borrow, repay, withdraw).
+			 */
+			Liquidium: LiquidiumData;
+	  };
 export type ActiveUserTransactionError =
 	| { InvalidId: null }
 	| { NotFound: null }
@@ -1055,6 +1062,29 @@ export interface InitArg {
 	 * deployments that pre-date this field.
 	 */
 	new_user_signups_allowed: [] | [boolean];
+}
+/**
+ * Which Liquidium lend/borrow action an active transaction tracks.
+ */
+export type LiquidiumAction =
+	| { Withdraw: null }
+	| { Repay: null }
+	| { Borrow: null }
+	| { Supply: null };
+export interface LiquidiumData {
+	/**
+	 * The asset moved by this action (supplied, borrowed, repaid, withdrawn).
+	 */
+	token: TokenId;
+	action: LiquidiumAction;
+	/**
+	 * Liquidium pool canister id (principal text), treated as an opaque key.
+	 */
+	pool_id: string;
+	/**
+	 * Amount in the token's base units.
+	 */
+	amount: bigint;
 }
 /**
  * Bitcoin Network.

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -228,9 +228,22 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const LiquidiumAction = IDL.Variant({
+		Withdraw: IDL.Null,
+		Repay: IDL.Null,
+		Borrow: IDL.Null,
+		Supply: IDL.Null
+	});
+	const LiquidiumData = IDL.Record({
+		token: TokenId,
+		action: LiquidiumAction,
+		pool_id: IDL.Text,
+		amount: IDL.Nat
+	});
 	const ActiveUserTransactionData = IDL.Variant({
 		OneSecEvmToIcp: OneSecEvmToIcpData,
-		OneSecIcpToEvm: OneSecIcpToEvmData
+		OneSecIcpToEvm: OneSecIcpToEvmData,
+		Liquidium: LiquidiumData
 	});
 	const CreateActiveUserTransactionRequest = IDL.Record({
 		id: IDL.Text,

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -228,9 +228,22 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const LiquidiumAction = IDL.Variant({
+		Withdraw: IDL.Null,
+		Repay: IDL.Null,
+		Borrow: IDL.Null,
+		Supply: IDL.Null
+	});
+	const LiquidiumData = IDL.Record({
+		token: TokenId,
+		action: LiquidiumAction,
+		pool_id: IDL.Text,
+		amount: IDL.Nat
+	});
 	const ActiveUserTransactionData = IDL.Variant({
 		OneSecEvmToIcp: OneSecEvmToIcpData,
-		OneSecIcpToEvm: OneSecIcpToEvmData
+		OneSecIcpToEvm: OneSecIcpToEvmData,
+		Liquidium: LiquidiumData
 	});
 	const CreateActiveUserTransactionRequest = IDL.Record({
 		id: IDL.Text,

--- a/src/frontend/src/lib/utils/onesec-swap.utils.ts
+++ b/src/frontend/src/lib/utils/onesec-swap.utils.ts
@@ -211,7 +211,17 @@ export const findMatchingOneSecTransfer = ({
 	data: ActiveUserTransactionData;
 }): Transfer | undefined => {
 	const isIcpToEvm = 'OneSecIcpToEvm' in data;
-	const amount = isIcpToEvm ? data.OneSecIcpToEvm.amount : data.OneSecEvmToIcp.amount;
+	const isEvmToIcp = 'OneSecEvmToIcp' in data;
+
+	const amount = isIcpToEvm
+		? data.OneSecIcpToEvm.amount
+		: isEvmToIcp
+			? data.OneSecEvmToIcp.amount
+			: undefined;
+
+	if (isNullish(amount)) {
+		return undefined;
+	}
 
 	return transfers.find((t) => {
 		if (isNullish(t.source.amount) || t.source.amount !== amount) {

--- a/src/shared/src/types/active_user_transaction.rs
+++ b/src/shared/src/types/active_user_transaction.rs
@@ -29,6 +29,10 @@ pub const MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_VALUE_LEN: usize = 256;
 /// Maximum length of a recipient EVM address (`0x` + 40 hex characters).
 pub const MAX_EVM_ADDRESS_LEN: usize = 42;
 
+/// Maximum length of a Liquidium `pool_id`. A canister principal in text form
+/// is at most 63 characters, so anything longer can never be a valid pool id.
+pub const MAX_LIQUIDIUM_POOL_ID_LEN: usize = 63;
+
 /// Learned-mid-flow `(key, value)` reference attached to an active transaction,
 /// e.g. `{ key: "tx_hash", value: "0x…" }`. Modelled as a named record (not a
 /// tuple) so the generated TS bindings expose `.key` / `.value` instead of
@@ -70,6 +74,9 @@ impl ActiveUserTransactionStatus {
 pub enum ActiveUserTransactionData {
     OneSecIcpToEvm(OneSecIcpToEvmData),
     OneSecEvmToIcp(OneSecEvmToIcpData),
+    /// Liquidium lend/borrow flow. A single variant covers all four actions
+    /// (supply, borrow, repay, withdraw).
+    Liquidium(LiquidiumData),
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -86,6 +93,26 @@ pub struct OneSecEvmToIcpData {
     pub dest_token: TokenId,
     pub amount: Nat,
     pub recipient_principal: Principal,
+}
+
+/// Which Liquidium lend/borrow action an active transaction tracks.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum LiquidiumAction {
+    Supply,
+    Borrow,
+    Repay,
+    Withdraw,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct LiquidiumData {
+    pub action: LiquidiumAction,
+    /// Liquidium pool canister id (principal text), treated as an opaque key.
+    pub pool_id: String,
+    /// The asset moved by this action (supplied, borrowed, repaid, withdrawn).
+    pub token: TokenId,
+    /// Amount in the token's base units.
+    pub amount: Nat,
 }
 
 /// In-flight high-level user operation, persisted so the FE can resume polling
@@ -154,8 +181,8 @@ mod tests {
     use super::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
         ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
-        GetActiveUserTransactionsResponse, OneSecEvmToIcpData, OneSecIcpToEvmData,
-        UpdateActiveUserTransactionRequest,
+        GetActiveUserTransactionsResponse, LiquidiumAction, LiquidiumData, OneSecEvmToIcpData,
+        OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
     };
     use crate::types::token_id::TokenId;
 
@@ -204,6 +231,17 @@ mod tests {
                 "7blps-itamd-lzszp-7lbda-4nngn-fev5u-2jvpn-6y3ap-eunp7-kz57e-fqe",
             )
             .unwrap(),
+        });
+        assert_eq!(roundtrip(&original), original);
+    }
+
+    #[test]
+    fn liquidium_variant_roundtrips() {
+        let original = ActiveUserTransactionData::Liquidium(LiquidiumData {
+            action: LiquidiumAction::Borrow,
+            pool_id: "mxzaz-hqaaa-aaaar-qaada-cai".to_string(),
+            token: TokenId::Icrc(Principal::from_text("mxzaz-hqaaa-aaaar-qaada-cai").unwrap()),
+            amount: Nat::from(5_100u64),
         });
         assert_eq!(roundtrip(&original), original);
     }


### PR DESCRIPTION
BREAKING CHANGE: The backend API is now incompatible with production.

# Motivation

The Liquidium lend & borrow integration tracks its Supply / Borrow / Repay / Withdraw flows through the existing active-user-transactions mechanism, so each action can close its modal before settlement and resolve via the global poller. That mechanism's `ActiveUserTransactionData` Candid type is currently OneSec-only, so it cannot represent a Liquidium action. This is the backend prerequisite that must land before any of the Liquidium frontend wiring.

