### PR TITLE
test(frontend): add reusable Svelte-context test factories

### DIFF
--- a/docs/ai/frontend/testing.md
+++ b/docs/ai/frontend/testing.md
@@ -34,6 +34,11 @@ src/frontend/src/btc/services/btc-send.services.ts
 
 - Reusable mocks → `src/frontend/src/tests/mocks/<thing>.mock.ts`.
 - Reusable test utilities → `src/frontend/src/tests/utils/<thing>.test-utils.ts`.
+- Reusable Svelte-context factories →
+  `src/frontend/src/tests/utils/<area>.context.test-utils.ts`. Each exports a
+  `mock<Area>ContextEntry(...)` returning a `[key, value]` tuple; assemble them
+  with `mockContextMap([...])` from `$tests/utils/context.test-utils` instead of
+  hand-rolling a `new Map()` per spec.
 - Reusable fixtures → `src/frontend/src/tests/fixtures/<area>/`.
 - Test-only types → `src/frontend/src/tests/types/`.
 

--- a/src/frontend/src/tests/btc/components/send/BtcSendForm.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendForm.spec.ts
@@ -1,28 +1,23 @@
 import BtcSendForm from '$btc/components/send/BtcSendForm.svelte';
-import { initUtxosFeeStore, UTXOS_FEE_CONTEXT_KEY } from '$btc/stores/utxos-fee.store';
 import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import {
 	SEND_DESTINATION_SECTION,
 	TOKEN_INPUT_CURRENCY_TOKEN
 } from '$lib/constants/test-ids.constants';
-import { initSendContext, SEND_CONTEXT_KEY } from '$lib/stores/send.store';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockUtxosFeeContextEntry } from '$tests/utils/fee.context.test-utils';
+import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
 import { render } from '@testing-library/svelte';
 
 describe('BtcSendForm', () => {
-	const createMockContext = () => {
-		const mockContext = new Map([]);
-		mockContext.set(
-			SEND_CONTEXT_KEY,
-			initSendContext({
-				token: BTC_MAINNET_TOKEN
-			})
-		);
-		mockContext.set(UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() });
-		return mockContext;
-	};
+	const createMockContext = () =>
+		mockContextMap([
+			mockSendContextEntry({ token: BTC_MAINNET_TOKEN }),
+			mockUtxosFeeContextEntry()
+		]);
 
 	const props = {
 		destination: mockBtcAddress,

--- a/src/frontend/src/tests/utils/context.test-utils.spec.ts
+++ b/src/frontend/src/tests/utils/context.test-utils.spec.ts
@@ -1,0 +1,40 @@
+import { UTXOS_FEE_CONTEXT_KEY } from '$btc/stores/utxos-fee.store';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { SEND_CONTEXT_KEY } from '$lib/stores/send.store';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockUtxosFeeContextEntry } from '$tests/utils/fee.context.test-utils';
+import { mockSendContext, mockSendContextEntry } from '$tests/utils/send.context.test-utils';
+import { get } from 'svelte/store';
+
+describe('context.test-utils', () => {
+	describe('mockContextMap', () => {
+		it('assembles entries into a context Map keyed by context symbol', () => {
+			const map = mockContextMap([
+				mockSendContextEntry({ token: BTC_MAINNET_TOKEN }),
+				mockUtxosFeeContextEntry()
+			]);
+
+			expect(map).toBeInstanceOf(Map);
+			expect(map.has(SEND_CONTEXT_KEY)).toBeTruthy();
+			expect(map.has(UTXOS_FEE_CONTEXT_KEY)).toBeTruthy();
+		});
+	});
+
+	describe('mockSendContext', () => {
+		it('builds a SendContext seeded with the provided token', () => {
+			const context = mockSendContext({ token: BTC_MAINNET_TOKEN });
+
+			expect(get(context.sendToken)).toStrictEqual(BTC_MAINNET_TOKEN);
+			expect(get(context.sendTokenId)).toStrictEqual(BTC_MAINNET_TOKEN.id);
+		});
+	});
+
+	describe('mockUtxosFeeContextEntry', () => {
+		it('returns an entry holding a usable UTXOs fee store', () => {
+			const [key, value] = mockUtxosFeeContextEntry();
+
+			expect(key).toBe(UTXOS_FEE_CONTEXT_KEY);
+			expect(get((value as { store: { subscribe: unknown } }).store)).toBeUndefined();
+		});
+	});
+});

--- a/src/frontend/src/tests/utils/context.test-utils.spec.ts
+++ b/src/frontend/src/tests/utils/context.test-utils.spec.ts
@@ -1,4 +1,4 @@
-import { UTXOS_FEE_CONTEXT_KEY } from '$btc/stores/utxos-fee.store';
+import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeStore } from '$btc/stores/utxos-fee.store';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { SEND_CONTEXT_KEY } from '$lib/stores/send.store';
 import { mockContextMap } from '$tests/utils/context.test-utils';
@@ -34,7 +34,10 @@ describe('context.test-utils', () => {
 			const [key, value] = mockUtxosFeeContextEntry();
 
 			expect(key).toBe(UTXOS_FEE_CONTEXT_KEY);
-			expect(get((value as { store: { subscribe: unknown } }).store)).toBeUndefined();
+
+			const { store } = value as { store: UtxosFeeStore };
+
+			expect(get(store)).toBeUndefined();
 		});
 	});
 });

--- a/src/frontend/src/tests/utils/context.test-utils.ts
+++ b/src/frontend/src/tests/utils/context.test-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared building blocks for mocking Svelte component contexts in tests.
+ *
+ * Component specs render under one or more contexts (`SEND_CONTEXT_KEY`,
+ * `*_FEE_CONTEXT_KEY`, …). Historically every spec rebuilt the same context
+ * `Map` inline under ad-hoc local names (`mockContext`, `createMockContext`,
+ * `mockSendContext`). The `*.context.test-utils.ts` factories return a typed
+ * `[key, value]` entry each, and `mockContextMap` assembles them — so a spec
+ * composes contexts in one expression instead of hand-rolling a `Map`.
+ */
+
+export type MockContextEntry = [symbol, unknown];
+
+export const mockContextMap = (entries: MockContextEntry[]): Map<symbol, unknown> =>
+	new Map(entries);

--- a/src/frontend/src/tests/utils/context.test-utils.ts
+++ b/src/frontend/src/tests/utils/context.test-utils.ts
@@ -9,7 +9,7 @@
  * composes contexts in one expression instead of hand-rolling a `Map`.
  */
 
-export type MockContextEntry = [symbol, unknown];
+export type MockContextEntry = [symbol | string, unknown];
 
-export const mockContextMap = (entries: MockContextEntry[]): Map<symbol, unknown> =>
+export const mockContextMap = (entries: MockContextEntry[]): Map<symbol | string, unknown> =>
 	new Map(entries);

--- a/src/frontend/src/tests/utils/fee.context.test-utils.ts
+++ b/src/frontend/src/tests/utils/fee.context.test-utils.ts
@@ -20,10 +20,9 @@ export const mockIcTokenFeeContextEntry = (
 	store: IcTokenFeeStore = icTokenFeeStore
 ): MockContextEntry => [IC_TOKEN_FEE_CONTEXT_KEY, { store }];
 
-export const mockEthFeeContextEntry = (context: EthFeeContext): MockContextEntry => [
-	ETH_FEE_CONTEXT_KEY,
-	context
-];
+export const mockEthFeeContextEntry = (
+	context: Partial<EthFeeContext> & Pick<EthFeeContext, 'feeStore'>
+): MockContextEntry => [ETH_FEE_CONTEXT_KEY, context];
 
 export const mockSolFeeContextEntry = (context: SolFeeContext): MockContextEntry => [
 	SOL_FEE_CONTEXT_KEY,

--- a/src/frontend/src/tests/utils/fee.context.test-utils.ts
+++ b/src/frontend/src/tests/utils/fee.context.test-utils.ts
@@ -1,0 +1,31 @@
+import {
+	initUtxosFeeStore,
+	UTXOS_FEE_CONTEXT_KEY,
+	type UtxosFeeStore
+} from '$btc/stores/utxos-fee.store';
+import { ETH_FEE_CONTEXT_KEY, type EthFeeContext } from '$eth/stores/eth-fee.store';
+import {
+	IC_TOKEN_FEE_CONTEXT_KEY,
+	icTokenFeeStore,
+	type IcTokenFeeStore
+} from '$icp/stores/ic-token-fee.store';
+import { SOL_FEE_CONTEXT_KEY, type FeeContext as SolFeeContext } from '$sol/stores/sol-fee.store';
+import type { MockContextEntry } from '$tests/utils/context.test-utils';
+
+export const mockUtxosFeeContextEntry = (
+	store: UtxosFeeStore = initUtxosFeeStore()
+): MockContextEntry => [UTXOS_FEE_CONTEXT_KEY, { store }];
+
+export const mockIcTokenFeeContextEntry = (
+	store: IcTokenFeeStore = icTokenFeeStore
+): MockContextEntry => [IC_TOKEN_FEE_CONTEXT_KEY, { store }];
+
+export const mockEthFeeContextEntry = (context: EthFeeContext): MockContextEntry => [
+	ETH_FEE_CONTEXT_KEY,
+	context
+];
+
+export const mockSolFeeContextEntry = (context: SolFeeContext): MockContextEntry => [
+	SOL_FEE_CONTEXT_KEY,
+	context
+];

--- a/src/frontend/src/tests/utils/send.context.test-utils.ts
+++ b/src/frontend/src/tests/utils/send.context.test-utils.ts
@@ -1,0 +1,9 @@
+import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+import type { MockContextEntry } from '$tests/utils/context.test-utils';
+
+export const mockSendContext = (params: Parameters<typeof initSendContext>[0]): SendContext =>
+	initSendContext(params);
+
+export const mockSendContextEntry = (
+	params: Parameters<typeof initSendContext>[0]
+): MockContextEntry => [SEND_CONTEXT_KEY, mockSendContext(params)];


### PR DESCRIPTION
# Motivation
Component specs each hand-roll a `new Map()` of Svelte contexts under ad-hoc local names (`mockContext`, `createMockContext`, `mockSendContext`). ~135 inline reconstructions of ~8 contexts.

# Changes
Adds `tests/utils/context.test-utils.ts` (`mockContextMap` + `MockContextEntry`) and per-area factories for `send` and `fee` contexts. Migrates `BtcSendForm` as the reference. Documents the convention in `testing.md`.

Foundation PR 1/3 (send+fee). Swap and convert+misc factories follow in stacked PRs; spec migrations follow per-area once these land.

# Tests
New `context.test-utils.spec.ts`; migrated `BtcSendForm.spec.ts` passes.