### PR TITLE
feat(frontend): add bip122 namespace + chain registry to WalletConnect (OISY-2990)

### DIFF
--- a/src/frontend/src/btc/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/btc/constants/wallet-connect.constants.ts
@@ -1,0 +1,4 @@
+// Bitcoin (bip122) methods — https://docs.reown.com/advanced/multichain/rpc-reference/bitcoin-rpc
+export const SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES = 'getAccountAddresses';
+export const SESSION_REQUEST_BTC_SIGN_MESSAGE = 'signMessage';
+export const SESSION_REQUEST_BTC_SIGN_PSBT = 'signPsbt';

--- a/src/frontend/src/env/bip122-chains.env.ts
+++ b/src/frontend/src/env/bip122-chains.env.ts
@@ -1,0 +1,43 @@
+import {
+	BTC_MAINNET_NETWORK_ID,
+	BTC_REGTEST_NETWORK_ID,
+	BTC_TESTNET_NETWORK_ID,
+	SUPPORTED_BITCOIN_NETWORKS
+} from '$env/networks/networks.btc.env';
+import type { NetworkId } from '$lib/types/network';
+import { nonNullish } from '@dfinity/utils';
+
+// CAIP-2 chain IDs for the bip122 namespace are the first 32 hex chars of each
+// network's genesis block hash — https://docs.reown.com/advanced/multichain/rpc-reference/bitcoin-rpc
+const BIP122_GENESIS_BLOCK_HASHES = new Map<NetworkId, string>([
+	[BTC_MAINNET_NETWORK_ID, '000000000019d6689c085ae165831e93'],
+	[BTC_TESTNET_NETWORK_ID, '000000000933ea01ad0ee984209779ba'],
+	[BTC_REGTEST_NETWORK_ID, '0f9188f13cb7b2c71f2a335e3a4fc328']
+]);
+
+export const BIP122_CHAINS: Record<
+	string,
+	{ genesis: string; name: string; networkId: NetworkId }
+> = SUPPORTED_BITCOIN_NETWORKS.reduce<
+	Record<string, { genesis: string; name: string; networkId: NetworkId }>
+>((acc, { id, name }) => {
+	const genesis = BIP122_GENESIS_BLOCK_HASHES.get(id);
+
+	return nonNullish(genesis)
+		? { ...acc, [`bip122:${genesis}`]: { genesis, name, networkId: id } }
+		: acc;
+}, {});
+
+const BIP122_CHAINS_KEYS = Object.keys(BIP122_CHAINS);
+
+export const BIP122_MAINNET_CHAINS_KEYS = BIP122_CHAINS_KEYS.filter(
+	(key) => BIP122_CHAINS[key].networkId === BTC_MAINNET_NETWORK_ID
+);
+
+export const BIP122_TESTNET_CHAINS_KEYS = BIP122_CHAINS_KEYS.filter(
+	(key) => BIP122_CHAINS[key].networkId === BTC_TESTNET_NETWORK_ID
+);
+
+export const BIP122_REGTEST_CHAINS_KEYS = BIP122_CHAINS_KEYS.filter(
+	(key) => BIP122_CHAINS[key].networkId === BTC_REGTEST_NETWORK_ID
+);

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSession.svelte
@@ -6,7 +6,14 @@
 	import { walletConnectUri } from '$eth/derived/wallet-connect.derived';
 	import { walletConnectPaired, walletConnectReconnecting } from '$eth/stores/wallet-connect.store';
 	import { URI_PARAM } from '$lib/constants/routes.constants';
-	import { ethAddress, solAddressDevnet, solAddressMainnet } from '$lib/derived/address.derived';
+	import {
+		btcAddressMainnet,
+		btcAddressRegtest,
+		btcAddressTestnet,
+		ethAddress,
+		solAddressDevnet,
+		solAddressMainnet
+	} from '$lib/derived/address.derived';
 	import { authNotSignedIn } from '$lib/derived/auth.derived';
 	import { modalUniversalScannerOpen } from '$lib/derived/modal.derived';
 	import { WalletConnectClient } from '$lib/providers/wallet-connect.providers';
@@ -111,6 +118,9 @@
 				ethAddress: $ethAddress,
 				solAddressMainnet: $solAddressMainnet,
 				solAddressDevnet: $solAddressDevnet,
+				btcAddressMainnet: $btcAddressMainnet,
+				btcAddressTestnet: $btcAddressTestnet,
+				btcAddressRegtest: $btcAddressRegtest,
 				cleanSlate: false
 			});
 

--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -1,4 +1,15 @@
 import {
+	SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
+	SESSION_REQUEST_BTC_SIGN_MESSAGE,
+	SESSION_REQUEST_BTC_SIGN_PSBT
+} from '$btc/constants/wallet-connect.constants';
+import type { OptionBtcAddress } from '$btc/types/address';
+import {
+	BIP122_MAINNET_CHAINS_KEYS,
+	BIP122_REGTEST_CHAINS_KEYS,
+	BIP122_TESTNET_CHAINS_KEYS
+} from '$env/bip122-chains.env';
+import {
 	CAIP10_DEVNET_CHAINS_KEYS,
 	CAIP10_MAINNET_CHAINS_KEYS,
 	LEGACY_SOLANA_DEVNET_NAMESPACE,
@@ -62,6 +73,9 @@ export class WalletConnectClient extends WalletConnectListener {
 	readonly #ethAddress: OptionEthAddress;
 	readonly #solAddressMainnet: OptionSolAddress;
 	readonly #solAddressDevnet: OptionSolAddress;
+	readonly #btcAddressMainnet: OptionBtcAddress;
+	readonly #btcAddressTestnet: OptionBtcAddress;
+	readonly #btcAddressRegtest: OptionBtcAddress;
 
 	#onSessionProposalCallback: ((proposal: WalletKitTypes.SessionProposal) => void) | null = null;
 	#onSessionDeleteCallback: (() => void) | null = null;
@@ -72,12 +86,18 @@ export class WalletConnectClient extends WalletConnectListener {
 		walletKit,
 		ethAddress,
 		solAddressMainnet,
-		solAddressDevnet
+		solAddressDevnet,
+		btcAddressMainnet,
+		btcAddressTestnet,
+		btcAddressRegtest
 	}: {
 		walletKit: Awaited<ReturnType<typeof WalletKit.init>>;
 		ethAddress: OptionEthAddress;
 		solAddressMainnet: OptionSolAddress;
 		solAddressDevnet: OptionSolAddress;
+		btcAddressMainnet: OptionBtcAddress;
+		btcAddressTestnet: OptionBtcAddress;
+		btcAddressRegtest: OptionBtcAddress;
 	}) {
 		super();
 
@@ -85,6 +105,9 @@ export class WalletConnectClient extends WalletConnectListener {
 		this.#ethAddress = ethAddress;
 		this.#solAddressMainnet = solAddressMainnet;
 		this.#solAddressDevnet = solAddressDevnet;
+		this.#btcAddressMainnet = btcAddressMainnet;
+		this.#btcAddressTestnet = btcAddressTestnet;
+		this.#btcAddressRegtest = btcAddressRegtest;
 	}
 
 	static init = async ({
@@ -94,6 +117,9 @@ export class WalletConnectClient extends WalletConnectListener {
 		ethAddress: OptionEthAddress;
 		solAddressMainnet: OptionSolAddress;
 		solAddressDevnet: OptionSolAddress;
+		btcAddressMainnet: OptionBtcAddress;
+		btcAddressTestnet: OptionBtcAddress;
+		btcAddressRegtest: OptionBtcAddress;
 		cleanSlate?: boolean;
 	}): Promise<WalletConnectClient> => {
 		const clearLocalStorage = () => {
@@ -251,6 +277,42 @@ export class WalletConnectClient extends WalletConnectListener {
 												`solana:${SOLANA_DEVNET_NETWORK.chainId}:${this.#solAddressDevnet}`,
 												`${LEGACY_SOLANA_DEVNET_NAMESPACE}:${this.#solAddressDevnet}`
 											]
+										: [])
+								]
+							}
+						}
+					: {}),
+				...(nonNullish(this.#btcAddressMainnet) ||
+				nonNullish(this.#btcAddressTestnet) ||
+				nonNullish(this.#btcAddressRegtest)
+					? {
+							bip122: {
+								chains: [
+									...(nonNullish(this.#btcAddressMainnet) ? BIP122_MAINNET_CHAINS_KEYS : []),
+									...(nonNullish(this.#btcAddressTestnet) ? BIP122_TESTNET_CHAINS_KEYS : []),
+									...(nonNullish(this.#btcAddressRegtest) ? BIP122_REGTEST_CHAINS_KEYS : [])
+								],
+								methods: [
+									SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
+									SESSION_REQUEST_BTC_SIGN_MESSAGE,
+									SESSION_REQUEST_BTC_SIGN_PSBT
+								],
+								events: ['bip122_addressesChanged'],
+								accounts: [
+									...(nonNullish(this.#btcAddressMainnet)
+										? BIP122_MAINNET_CHAINS_KEYS.map(
+												(chain) => `${chain}:${this.#btcAddressMainnet}`
+											)
+										: []),
+									...(nonNullish(this.#btcAddressTestnet)
+										? BIP122_TESTNET_CHAINS_KEYS.map(
+												(chain) => `${chain}:${this.#btcAddressTestnet}`
+											)
+										: []),
+									...(nonNullish(this.#btcAddressRegtest)
+										? BIP122_REGTEST_CHAINS_KEYS.map(
+												(chain) => `${chain}:${this.#btcAddressRegtest}`
+											)
 										: [])
 								]
 							}

--- a/src/frontend/src/lib/services/wallet-connect.services.ts
+++ b/src/frontend/src/lib/services/wallet-connect.services.ts
@@ -1,4 +1,11 @@
-import { ethAddress, solAddressDevnet, solAddressMainnet } from '$lib/derived/address.derived';
+import {
+	btcAddressMainnet,
+	btcAddressRegtest,
+	btcAddressTestnet,
+	ethAddress,
+	solAddressDevnet,
+	solAddressMainnet
+} from '$lib/derived/address.derived';
 import { WalletConnectClient } from '$lib/providers/wallet-connect.providers';
 import {
 	onSessionDelete,
@@ -132,7 +139,13 @@ const initListener = async (): Promise<OptionWalletConnectListener> => {
 
 	try {
 		// Connect and disconnect buttons are disabled until at least one of the address is loaded; therefore, this should never happen.
-		if (isNullish(get(ethAddress)) && isNullish(get(solAddressMainnet))) {
+		if (
+			isNullish(get(ethAddress)) &&
+			isNullish(get(solAddressMainnet)) &&
+			isNullish(get(btcAddressMainnet)) &&
+			isNullish(get(btcAddressTestnet)) &&
+			isNullish(get(btcAddressRegtest))
+		) {
 			toastsError({
 				msg: { text: get(i18n).send.assertion.address_unknown }
 			});
@@ -142,7 +155,10 @@ const initListener = async (): Promise<OptionWalletConnectListener> => {
 		const newListener = await WalletConnectClient.init({
 			ethAddress: get(ethAddress),
 			solAddressMainnet: get(solAddressMainnet),
-			solAddressDevnet: get(solAddressDevnet)
+			solAddressDevnet: get(solAddressDevnet),
+			btcAddressMainnet: get(btcAddressMainnet),
+			btcAddressTestnet: get(btcAddressTestnet),
+			btcAddressRegtest: get(btcAddressRegtest)
 		});
 
 		walletConnectListenerStore.set(newListener);

--- a/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
+++ b/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
@@ -1,5 +1,6 @@
 import { UNEXPECTED_ERROR, WALLET_CONNECT_METADATA } from '$lib/constants/wallet-connect.constants';
 import { WalletConnectClient } from '$lib/providers/wallet-connect.providers';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
 import { WalletKit, type WalletKitTypes } from '@reown/walletkit';
@@ -24,7 +25,10 @@ describe('wallet-connect.providers', () => {
 		const mockParams = {
 			ethAddress: mockEthAddress,
 			solAddressMainnet: mockSolAddress,
-			solAddressDevnet: mockSolAddress2
+			solAddressDevnet: mockSolAddress2,
+			btcAddressMainnet: mockBtcAddress,
+			btcAddressTestnet: undefined,
+			btcAddressRegtest: undefined
 		};
 
 		const initParams = {


### PR DESCRIPTION
Implements OISY-2990: adds the Bitcoin `bip122` namespace + chain registry to WalletConnect, mirroring `eip155`/`solana`. First PR of the BTC WalletConnect epic; spec in #13090.
