### PR TITLE
test(frontend): assert i18n keys instead of hard-coded copy

### DIFF
--- a/src/frontend/src/tests/eth/components/swap/SwapEthForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/swap/SwapEthForm.spec.ts
@@ -6,11 +6,12 @@ import {
 	SWAP_SWITCH_TOKENS_BUTTON,
 	TOKEN_INPUT_CURRENCY_TOKEN
 } from '$lib/constants/test-ids.constants';
+import { i18n } from '$lib/stores/i18n.store';
 import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY, initSwapContext } from '$lib/stores/swap.store';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { render } from '@testing-library/svelte';
-import { readable, writable } from 'svelte/store';
+import { get, readable, writable } from 'svelte/store';
 
 vi.mock('$lib/utils/parse.utils', () => ({
 	parseToken: vi.fn()
@@ -87,7 +88,7 @@ describe('SwapFormEth', () => {
 
 		expect(getByTestId(SWAP_SWITCH_TOKENS_BUTTON)).toBeInTheDocument();
 
-		expect(getByText('Total fee')).toBeInTheDocument();
+		expect(getByText(get(i18n).fee.text.total_fee)).toBeInTheDocument();
 
 		const switchButton: HTMLButtonElement | null = container.querySelector(switchButtonSelector);
 
@@ -127,7 +128,7 @@ describe('SwapFormEth', () => {
 			context: contextWithoutDestination
 		});
 
-		expect(queryByText('Total fee')).not.toBeInTheDocument();
+		expect(queryByText(get(i18n).fee.text.total_fee)).not.toBeInTheDocument();
 	});
 
 	it('should handle loading state', () => {
@@ -170,8 +171,8 @@ describe('SwapFormEth', () => {
 			context: mockContext
 		});
 
-		expect(getByText('Cancel')).toBeInTheDocument();
-		expect(getByText('Review swap')).toBeInTheDocument();
+		expect(getByText(get(i18n).core.text.cancel)).toBeInTheDocument();
+		expect(getByText(get(i18n).swap.text.review_button)).toBeInTheDocument();
 	});
 
 	it('should show fee info message', () => {

--- a/src/frontend/src/tests/eth/components/swap/SwapEthForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/swap/SwapEthForm.spec.ts
@@ -182,6 +182,8 @@ describe('SwapFormEth', () => {
 		});
 
 		expect(container.querySelector('[data-tid="swap-fee-info"]')).toBeInTheDocument();
-		expect(getByText(/Fee will be paid in ETH/)).toBeInTheDocument();
+		expect(
+			getByText(new RegExp(`${get(i18n).send.info.fee_info.split('$feeSymbol')[0]}ETH`))
+		).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
@@ -176,7 +176,7 @@ describe('SwapEthWizard', () => {
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
 			expect(getByText(en.tokens.text.source_token_title)).toBeInTheDocument();
-			expect(getByText('You receive')).toBeInTheDocument();
+			expect(getByText(en.tokens.text.destination_token_title)).toBeInTheDocument();
 			expect(getByText(en.swap.text.review_button)).toBeInTheDocument();
 			expect(getByText(en.core.text.cancel)).toBeInTheDocument();
 		});

--- a/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
@@ -175,10 +175,10 @@ describe('SwapEthWizard', () => {
 
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(getByText('You pay')).toBeInTheDocument();
+			expect(getByText(en.tokens.text.source_token_title)).toBeInTheDocument();
 			expect(getByText('You receive')).toBeInTheDocument();
-			expect(getByText('Review swap')).toBeInTheDocument();
-			expect(getByText('Cancel')).toBeInTheDocument();
+			expect(getByText(en.swap.text.review_button)).toBeInTheDocument();
+			expect(getByText(en.core.text.cancel)).toBeInTheDocument();
 		});
 
 		it('renders slippage section', () => {
@@ -189,7 +189,7 @@ describe('SwapEthWizard', () => {
 
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(getByText('Max slippage')).toBeInTheDocument();
+			expect(getByText(en.swap.text.max_slippage)).toBeInTheDocument();
 		});
 
 		it('renders swap provider information', () => {
@@ -200,7 +200,7 @@ describe('SwapEthWizard', () => {
 
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(getByText('Swap provider')).toBeInTheDocument();
+			expect(getByText(en.swap.text.swap_provider)).toBeInTheDocument();
 		});
 
 		it('renders fee information', () => {
@@ -211,7 +211,7 @@ describe('SwapEthWizard', () => {
 
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(getByText('Total fee')).toBeInTheDocument();
+			expect(getByText(en.fee.text.total_fee)).toBeInTheDocument();
 		});
 
 		it('renders token input fields', () => {
@@ -266,7 +266,7 @@ describe('SwapEthWizard', () => {
 
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(getByText('Total fee')).toBeInTheDocument();
+			expect(getByText(en.fee.text.total_fee)).toBeInTheDocument();
 		});
 
 		it('shows gasless fee when Velora DELTA is selected and permit is supported', () => {
@@ -278,7 +278,7 @@ describe('SwapEthWizard', () => {
 
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(getByText('Gasless')).toBeInTheDocument();
+			expect(getByText(en.swap.text.gasless)).toBeInTheDocument();
 		});
 
 		it('does not show gasless fee when Velora MARKET is selected', () => {
@@ -290,7 +290,7 @@ describe('SwapEthWizard', () => {
 
 			const { queryByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(queryByText('Gasless')).not.toBeInTheDocument();
+			expect(queryByText(en.swap.text.gasless)).not.toBeInTheDocument();
 		});
 
 		it('does not show gasless fee when NEAR Intents is selected even with permit support', () => {
@@ -302,7 +302,7 @@ describe('SwapEthWizard', () => {
 
 			const { queryByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(queryByText('Gasless')).not.toBeInTheDocument();
+			expect(queryByText(en.swap.text.gasless)).not.toBeInTheDocument();
 		});
 
 		it('derives isApproveNeeded from selectedProvider, not swaps[0]', () => {
@@ -313,7 +313,7 @@ describe('SwapEthWizard', () => {
 
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(getByText('Total fee')).toBeInTheDocument();
+			expect(getByText(en.fee.text.total_fee)).toBeInTheDocument();
 		});
 
 		it('derives isGasless from selectedProvider, not swaps[0]', () => {
@@ -325,7 +325,7 @@ describe('SwapEthWizard', () => {
 
 			const { getByText } = renderWithStep({ step: WizardStepsSwap.SWAP, context: mockContext });
 
-			expect(getByText('Gasless')).toBeInTheDocument();
+			expect(getByText(en.swap.text.gasless)).toBeInTheDocument();
 		});
 	});
 
@@ -450,7 +450,7 @@ describe('SwapEthWizard', () => {
 				await fireEvent.click(getByRole('checkbox'));
 			}
 
-			await fireEvent.click(getByText('Swap now'));
+			await fireEvent.click(getByText(en.swap.text.swap_button));
 			await vi.runOnlyPendingTimersAsync();
 
 			expect(swapServices.fetchVeloraMarketSwap).toHaveBeenCalledOnce();
@@ -469,7 +469,7 @@ describe('SwapEthWizard', () => {
 				await fireEvent.click(getByRole('checkbox'));
 			}
 
-			await fireEvent.click(getByText('Swap now'));
+			await fireEvent.click(getByText(en.swap.text.swap_button));
 			await vi.runOnlyPendingTimersAsync();
 
 			expect(onBack).toHaveBeenCalledOnce();
@@ -495,7 +495,7 @@ describe('SwapEthWizard', () => {
 				await fireEvent.click(getByRole('checkbox'));
 			}
 
-			await fireEvent.click(getByText('Swap now'));
+			await fireEvent.click(getByText(en.swap.text.swap_button));
 			await vi.runOnlyPendingTimersAsync();
 
 			expect(toasts.toastsError).not.toHaveBeenCalledWith(
@@ -526,7 +526,7 @@ describe('SwapEthWizard', () => {
 				context: createExecutionContext().ctx
 			});
 
-			const swapButton = getByText('Swap now').closest('button');
+			const swapButton = getByText(en.swap.text.swap_button).closest('button');
 
 			expect(swapButton).toBeDisabled();
 

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
@@ -105,7 +105,7 @@ describe('SwapIcpWizard', () => {
 		const { getByText } = renderWithStep(WizardStepsSwap.SWAP);
 
 		expect(getByText(en.tokens.text.source_token_title)).toBeInTheDocument();
-		expect(getByText('You receive')).toBeInTheDocument();
+		expect(getByText(en.tokens.text.destination_token_title)).toBeInTheDocument();
 		expect(getByText(en.swap.text.review_button)).toBeInTheDocument();
 		expect(getByText(en.core.text.cancel)).toBeInTheDocument();
 	});

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
@@ -11,6 +11,7 @@ import * as toasts from '$lib/stores/toasts.store';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
+import en from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockOneSecProvider, mockSwapProviders } from '$tests/mocks/swap.mocks';
 import { fireEvent, render } from '@testing-library/svelte';
@@ -103,28 +104,28 @@ describe('SwapIcpWizard', () => {
 	it('renders SwapIcpForm on SWAP step', () => {
 		const { getByText } = renderWithStep(WizardStepsSwap.SWAP);
 
-		expect(getByText('You pay')).toBeInTheDocument();
+		expect(getByText(en.tokens.text.source_token_title)).toBeInTheDocument();
 		expect(getByText('You receive')).toBeInTheDocument();
-		expect(getByText('Review swap')).toBeInTheDocument();
-		expect(getByText('Cancel')).toBeInTheDocument();
+		expect(getByText(en.swap.text.review_button)).toBeInTheDocument();
+		expect(getByText(en.core.text.cancel)).toBeInTheDocument();
 	});
 
 	it('renders slippage section', () => {
 		const { getByText } = renderWithStep(WizardStepsSwap.SWAP);
 
-		expect(getByText('Max slippage')).toBeInTheDocument();
+		expect(getByText(en.swap.text.max_slippage)).toBeInTheDocument();
 	});
 
 	it('renders swap provider information', () => {
 		const { getByText } = renderWithStep(WizardStepsSwap.SWAP);
 
-		expect(getByText('Swap provider')).toBeInTheDocument();
+		expect(getByText(en.swap.text.swap_provider)).toBeInTheDocument();
 	});
 
 	it('renders fee information', () => {
 		const { getByText } = renderWithStep(WizardStepsSwap.SWAP);
 
-		expect(getByText('Total estimated fee')).toBeInTheDocument();
+		expect(getByText(en.swap.text.total_fee)).toBeInTheDocument();
 	});
 
 	it('renders token input fields', () => {
@@ -189,7 +190,7 @@ describe('SwapIcpWizard', () => {
 				await fireEvent.click(getByRole('checkbox'));
 			}
 
-			await fireEvent.click(getByText('Swap now'));
+			await fireEvent.click(getByText(en.swap.text.swap_button));
 			await vi.runOnlyPendingTimersAsync();
 
 			expect(mockSwapFn).toHaveBeenCalledOnce();
@@ -207,7 +208,7 @@ describe('SwapIcpWizard', () => {
 				await fireEvent.click(getByRole('checkbox'));
 			}
 
-			await fireEvent.click(getByText('Swap now'));
+			await fireEvent.click(getByText(en.swap.text.swap_button));
 			await vi.runOnlyPendingTimersAsync();
 
 			expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
@@ -231,7 +232,7 @@ describe('SwapIcpWizard', () => {
 				context: errorContext
 			});
 
-			const swapButton = getByText('Swap now').closest('button');
+			const swapButton = getByText(en.swap.text.swap_button).closest('button');
 
 			expect(swapButton).toBeDisabled();
 
@@ -272,7 +273,7 @@ describe('SwapIcpWizard', () => {
 					await fireEvent.click(valueDifferenceCheckbox);
 				}
 
-				await fireEvent.click(getByText('Swap now'));
+				await fireEvent.click(getByText(en.swap.text.swap_button));
 				await vi.runOnlyPendingTimersAsync();
 
 				expect(mockOneSecFn).toHaveBeenCalledExactlyOnceWith(
@@ -297,7 +298,7 @@ describe('SwapIcpWizard', () => {
 					await fireEvent.click(valueDifferenceCheckbox);
 				}
 
-				await fireEvent.click(getByText('Swap now'));
+				await fireEvent.click(getByText(en.swap.text.swap_button));
 				await vi.runOnlyPendingTimersAsync();
 
 				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
@@ -315,7 +316,7 @@ describe('SwapIcpWizard', () => {
 					await fireEvent.click(valueDifferenceCheckbox);
 				}
 
-				await fireEvent.click(getByText('Swap now'));
+				await fireEvent.click(getByText(en.swap.text.swap_button));
 				await vi.runOnlyPendingTimersAsync();
 
 				expect(mockOneSecFn).not.toHaveBeenCalled();
@@ -333,7 +334,7 @@ describe('SwapIcpWizard', () => {
 					await fireEvent.click(valueDifferenceCheckbox);
 				}
 
-				await fireEvent.click(getByText('Swap now'));
+				await fireEvent.click(getByText(en.swap.text.swap_button));
 				await vi.runOnlyPendingTimersAsync();
 
 				expect(mockOneSecFn).not.toHaveBeenCalled();

--- a/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
+++ b/src/frontend/src/tests/lib/components/address-book/EditAddressStep.spec.ts
@@ -214,7 +214,7 @@ describe('EditAddressStep', () => {
 		});
 
 		const resetButtons = screen.getAllByRole('button', {
-			name: 'Reset input value'
+			name: en.convert.text.input_reset_button
 		});
 
 		expect(resetButtons).toHaveLength(2);

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeBalance.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeBalance.spec.ts
@@ -13,6 +13,7 @@ import { HERO_CONTEXT_KEY, initHeroContext, type HeroContext } from '$lib/stores
 import type { TokenUi } from '$lib/types/token-ui';
 import * as formatUtils from '$lib/utils/format.utils';
 import * as privacyUtils from '$lib/utils/privacy.utils';
+import en from '$tests/mocks/i18n.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { mockValidToken } from '$tests/mocks/tokens.mock';
 import { assertNonNullish } from '@dfinity/utils';
@@ -94,7 +95,7 @@ describe('ExchangeBalance', () => {
 		it('should render "Your balance" label when balances are not all zero', () => {
 			const { getByText } = renderComponent();
 
-			expect(getByText('Your balance')).toBeInTheDocument();
+			expect(getByText(en.hero.text.available_balance)).toBeInTheDocument();
 		});
 
 		it('should render "Top up your wallet" label when all balances are zero', () => {
@@ -102,13 +103,13 @@ describe('ExchangeBalance', () => {
 
 			const { getByText } = renderComponent();
 
-			expect(getByText('Top up your wallet to start using it!')).toBeInTheDocument();
+			expect(getByText(en.hero.text.top_up)).toBeInTheDocument();
 		});
 
 		it('should render "hidden balance" message when hideBalance is true', () => {
 			const { getByText } = renderComponent({ hideBalance: true });
 
-			expect(getByText('Your balance is hidden')).toBeInTheDocument();
+			expect(getByText(en.hero.text.hidden_balance)).toBeInTheDocument();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/components/swap/SwapProviderListModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapProviderListModal.spec.ts
@@ -1,5 +1,6 @@
 import SwapProviderListModal from '$lib/components/swap/SwapProviderListModal.svelte';
 import * as ExchangeDerived from '$lib/derived/exchange.derived';
+import { i18n } from '$lib/stores/i18n.store';
 import { SWAP_AMOUNTS_CONTEXT_KEY } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
 import type { ExchangesData } from '$lib/types/exchange';
@@ -7,7 +8,7 @@ import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.moc
 import { mockSwapProviders } from '$tests/mocks/swap.mocks';
 import { queryAllByTestId, render } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { derived, readable, writable } from 'svelte/store';
+import { derived, get, readable, writable } from 'svelte/store';
 
 vi.mock('$env/dapp-descriptions.env', () => ({
 	dAppDescriptions: [
@@ -51,7 +52,7 @@ describe('SwapProviderListModal', () => {
 			context: mockContext
 		});
 
-		expect(getByText('Swap provider')).toBeInTheDocument();
+		expect(getByText(get(i18n).swap.text.swap_provider)).toBeInTheDocument();
 		expect(getByText('You receive')).toBeInTheDocument();
 	});
 

--- a/src/frontend/src/tests/lib/components/swap/SwapProviderListModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapProviderListModal.spec.ts
@@ -53,7 +53,7 @@ describe('SwapProviderListModal', () => {
 		});
 
 		expect(getByText(get(i18n).swap.text.swap_provider)).toBeInTheDocument();
-		expect(getByText('You receive')).toBeInTheDocument();
+		expect(getByText(get(i18n).swap.text.you_receive)).toBeInTheDocument();
 	});
 
 	it('renders all provider rows with USD values', () => {

--- a/src/frontend/src/tests/lib/components/ui/Busy.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/Busy.spec.ts
@@ -1,5 +1,6 @@
 import Busy from '$lib/components/ui/Busy.svelte';
 import { busy } from '$lib/stores/busy.store';
+import { i18n } from '$lib/stores/i18n.store';
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 
@@ -58,7 +59,7 @@ describe('Busy', () => {
 
 		const { queryByText } = render(Busy);
 
-		expect(queryByText('Cancel')).not.toBeInTheDocument();
+		expect(queryByText(get(i18n).core.text.cancel)).not.toBeInTheDocument();
 	});
 
 	it('should not add close class when close is false', () => {


### PR DESCRIPTION
# Motivation
The frontend testing convention (`docs/ai/frontend/testing.md`) forbids hard-coding English copy in assertions when an i18n key exists for it; tests should reference `get(i18n).<bucket>.<purpose>.<key>` (or the `en` i18n mock) so they stay in sync with the source of truth.

# Changes
Replaced hard-coded English literals with their i18n key references in 38 `getByText`/`queryByText`/`getAllByRole` assertion sites across 7 spec files. Each literal was matched exactly against the English i18n source (`src/frontend/src/lib/i18n/en.json`) and mapped to its unique key. Numeric/currency/address literals and strings that match more than one i18n key were left untouched.

# Tests
`npx vitest run` on all 7 changed spec files: 94 tests pass (proves each key resolves to the identical string). `prettier` and `eslint --max-warnings 0` clean.