### PR TITLE
test(frontend): migrate btc specs to context test-utils

### DIFF
--- a/src/frontend/src/tests/btc/components/fee/UtxosFeeLoader.spec.ts
+++ b/src/frontend/src/tests/btc/components/fee/UtxosFeeLoader.spec.ts
@@ -5,17 +5,15 @@ import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
-import {
-	UTXOS_FEE_CONTEXT_KEY,
-	initUtxosFeeStore,
-	type UtxosFeeStore
-} from '$btc/stores/utxos-fee.store';
+import { initUtxosFeeStore, type UtxosFeeStore } from '$btc/stores/utxos-fee.store';
 import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import * as bitcoinApi from '$icp/api/bitcoin.api';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockBtcAddress, mockUtxo } from '$tests/mocks/btc.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockUtxosFeeContextEntry } from '$tests/utils/fee.context.test-utils';
 import { render, waitFor } from '@testing-library/svelte';
 
 describe('UtxosFeeLoader', () => {
@@ -26,7 +24,7 @@ describe('UtxosFeeLoader', () => {
 	const mockFeeRateFromPercentiles = 5000n;
 
 	const mockContext = ({ utxosFeeStore }: { utxosFeeStore: UtxosFeeStore }) =>
-		new Map([[UTXOS_FEE_CONTEXT_KEY, { store: utxosFeeStore }]]);
+		mockContextMap([mockUtxosFeeContextEntry(utxosFeeStore)]);
 
 	const mockBtcReviewResult = {
 		feeSatoshis: 700n,

--- a/src/frontend/src/tests/btc/components/send/BtcSendAmount.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendAmount.spec.ts
@@ -1,28 +1,23 @@
 import BtcSendAmount from '$btc/components/send/BtcSendAmount.svelte';
 import { BTC_MINIMUM_AMOUNT } from '$btc/constants/btc.constants';
-import { initUtxosFeeStore, UTXOS_FEE_CONTEXT_KEY } from '$btc/stores/utxos-fee.store';
 import { convertSatoshisToBtc } from '$btc/utils/btc-send.utils';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { TOKEN_INPUT_CURRENCY_TOKEN } from '$lib/constants/test-ids.constants';
 import { balancesStore } from '$lib/stores/balances.store';
-import { initSendContext, SEND_CONTEXT_KEY } from '$lib/stores/send.store';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import en from '$tests/mocks/i18n.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockUtxosFeeContextEntry } from '$tests/utils/fee.context.test-utils';
+import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
 import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 
 describe('BtcSendAmount', () => {
-	const createMockContext = () => {
-		const mockContext = new Map([]);
-		mockContext.set(
-			SEND_CONTEXT_KEY,
-			initSendContext({
-				token: BTC_MAINNET_TOKEN
-			})
-		);
-		mockContext.set(UTXOS_FEE_CONTEXT_KEY, { store: initUtxosFeeStore() });
-		return mockContext;
-	};
+	const createMockContext = () =>
+		mockContextMap([
+			mockSendContextEntry({ token: BTC_MAINNET_TOKEN }),
+			mockUtxosFeeContextEntry()
+		]);
 
 	const props = {
 		amount: 1000,

--- a/src/frontend/src/tests/btc/components/send/BtcSendReview.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendReview.spec.ts
@@ -1,13 +1,14 @@
 import BtcSendReview from '$btc/components/send/BtcSendReview.svelte';
-import { initUtxosFeeStore, UTXOS_FEE_CONTEXT_KEY } from '$btc/stores/utxos-fee.store';
+import { initUtxosFeeStore } from '$btc/stores/utxos-fee.store';
 import type { UtxosFee } from '$btc/types/btc-send';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { REVIEW_FORM_SEND_BUTTON } from '$lib/constants/test-ids.constants';
-import { SEND_CONTEXT_KEY } from '$lib/stores/send.store';
 import { mockBtcAddress, mockUtxosFee } from '$tests/mocks/btc.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockUtxosFeeContextEntry } from '$tests/utils/fee.context.test-utils';
+import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
 import { render } from '@testing-library/svelte';
-import { readable } from 'svelte/store';
 
 describe('BtcSendReview', () => {
 	const defaultBalance = 1000000n;
@@ -21,21 +22,9 @@ describe('BtcSendReview', () => {
 		const utxosFeeStore = initUtxosFeeStore();
 		utxosFeeStore.setUtxosFee({ utxosFee });
 
-		return new Map([
-			[
-				SEND_CONTEXT_KEY,
-				{
-					sendToken: readable(BTC_MAINNET_TOKEN),
-					sendTokenDecimals: readable(BTC_MAINNET_TOKEN.decimals),
-					sendTokenId: readable(BTC_MAINNET_TOKEN.id),
-					sendTokenStandard: readable(BTC_MAINNET_TOKEN.standard),
-					sendTokenSymbol: readable(BTC_MAINNET_TOKEN.symbol),
-					sendTokenNetworkId: readable(BTC_MAINNET_TOKEN.network.id),
-					sendTokenExchangeRate: readable(),
-					sendBalance: readable(balance)
-				}
-			],
-			[UTXOS_FEE_CONTEXT_KEY, { store: utxosFeeStore }]
+		return mockContextMap([
+			mockSendContextEntry({ token: BTC_MAINNET_TOKEN, customSendBalance: balance }),
+			mockUtxosFeeContextEntry(utxosFeeStore)
 		]);
 	};
 	const props = {

--- a/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
@@ -5,12 +5,8 @@ import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
+import type { UtxosFeeStore } from '$btc/stores/utxos-fee.store';
 import * as utxosFeeStore from '$btc/stores/utxos-fee.store';
-import {
-	UTXOS_FEE_CONTEXT_KEY,
-	type UtxosFeeContext,
-	type UtxosFeeStore
-} from '$btc/stores/utxos-fee.store';
 import type { UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
@@ -21,7 +17,6 @@ import * as signerApi from '$lib/api/signer.api';
 import * as addressesStore from '$lib/derived/address.derived';
 import { ProgressStepsSendBtc } from '$lib/enums/progress-steps';
 import { WizardStepsSend } from '$lib/enums/wizard-steps';
-import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
 import type { AddPendingTransactionOutcome } from '$lib/types/api';
 import type { Token } from '$lib/types/token';
 import { mapToSignerBitcoinNetwork } from '$lib/utils/network.utils';
@@ -30,6 +25,9 @@ import { mockBtcAddress, mockUtxosFee } from '$tests/mocks/btc.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockPage } from '$tests/mocks/page.store.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockUtxosFeeContextEntry } from '$tests/utils/fee.context.test-utils';
+import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
 import { assertNonNullish, toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
@@ -46,10 +44,7 @@ describe('BtcSendTokenWizard', () => {
 		token?: Token;
 		mockUtxosFeeStore: UtxosFeeStore;
 	}) =>
-		new Map<symbol, SendContext | UtxosFeeContext>([
-			[UTXOS_FEE_CONTEXT_KEY, { store: mockUtxosFeeStore }],
-			[SEND_CONTEXT_KEY, initSendContext({ token })]
-		]);
+		mockContextMap([mockUtxosFeeContextEntry(mockUtxosFeeStore), mockSendContextEntry({ token })]);
 
 	const onBack = vi.fn();
 	const onClose = vi.fn();

--- a/src/frontend/src/tests/btc/components/send/BtcUtxosFeeDisplay.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcUtxosFeeDisplay.spec.ts
@@ -1,14 +1,12 @@
 import BtcUtxosFeeDisplay from '$btc/components/send/BtcUtxosFeeDisplay.svelte';
-import {
-	initUtxosFeeStore,
-	UTXOS_FEE_CONTEXT_KEY,
-	type UtxosFeeStore
-} from '$btc/stores/utxos-fee.store';
+import { initUtxosFeeStore, type UtxosFeeStore } from '$btc/stores/utxos-fee.store';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ZERO } from '$lib/constants/app.constants';
 import { SEND_CONTEXT_KEY } from '$lib/stores/send.store';
 import { formatToken } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockUtxosFeeContextEntry } from '$tests/utils/fee.context.test-utils';
 import { render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
@@ -25,7 +23,7 @@ describe('BtcUtxosFeeDisplay', () => {
 		utxosFeeStore: UtxosFeeStore;
 		exchangeRate?: number;
 	}) =>
-		new Map([
+		mockContextMap([
 			[
 				SEND_CONTEXT_KEY,
 				{
@@ -38,7 +36,7 @@ describe('BtcUtxosFeeDisplay', () => {
 					sendTokenExchangeRate: readable(exchangeRate)
 				}
 			],
-			[UTXOS_FEE_CONTEXT_KEY, { store: utxosFeeStore }]
+			mockUtxosFeeContextEntry(utxosFeeStore)
 		]);
 
 	beforeEach(() => {


### PR DESCRIPTION
# Motivation
Part of Wave 2: move btc component specs off hand-rolled `new Map()` context setup onto the shared context test-utils (#13094).

# Changes
Migrates 5 btc send/fee specs to `mockContextMap` + `mockSendContextEntry` / `mockUtxosFeeContextEntry`. Behavior-preserving. BtcUtxosFeeDisplay keeps its custom send context inline (needs a custom exchange rate the factory doesn't express) and migrates only its fee entry.

# Tests
All 5 migrated specs pass; tsc + eslint clean.