### PR TITLE
fix(frontend): surface unreviewed Solana WC instructions instead of rejecting

### DIFF
--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1577,6 +1577,7 @@
 			"network": "",
 			"amount": "",
 			"hex_data": "بيانات HEX",
+			"unreviewed_instructions": "",
 			"raw_copied": "تم نسخ بيانات المعاملة الخام إلى الحافظة.",
 			"sign_message": "توقيع الرسالة",
 			"connected_apps": "التطبيقات المتصلة",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1577,6 +1577,7 @@
 			"network": "Síť",
 			"amount": "Částka",
 			"hex_data": "HEX data",
+			"unreviewed_instructions": "",
 			"raw_copied": "Nezpracovaná data transakce zkopírována do schránky.",
 			"sign_message": "Podepsat zprávu",
 			"connected_apps": "Připojené aplikace",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1577,6 +1577,7 @@
 			"network": "",
 			"amount": "",
 			"hex_data": "HEX-Daten",
+			"unreviewed_instructions": "",
 			"raw_copied": "Transaktions-Rohdaten in die Zwischenablage kopiert.",
 			"sign_message": "Nachricht signieren",
 			"connected_apps": "Verbundene Apps",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1577,6 +1577,7 @@
 			"network": "Network",
 			"amount": "Amount",
 			"hex_data": "HEX Data",
+			"unreviewed_instructions": "This transaction contains instructions OISY can't decode, so the review below may be incomplete. Only sign if you trust this app.",
 			"raw_copied": "Raw transaction data copied to clipboard.",
 			"sign_message": "Sign Message",
 			"connected_apps": "Connected Apps",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1577,6 +1577,7 @@
 			"network": "Red",
 			"amount": "Cantidad",
 			"hex_data": "Datos HEX",
+			"unreviewed_instructions": "",
 			"raw_copied": "Datos brutos de la transacción copiados al portapapeles.",
 			"sign_message": "Firmar Mensaje",
 			"connected_apps": "Aplicaciones conectadas",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1577,6 +1577,7 @@
 			"network": "Réseau",
 			"amount": "Montant",
 			"hex_data": "Données HEX",
+			"unreviewed_instructions": "",
 			"raw_copied": "Données brutes de la transaction copiées dans le presse-papiers.",
 			"sign_message": "Signer le message",
 			"connected_apps": "Applications connectées",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1577,6 +1577,7 @@
 			"network": "",
 			"amount": "",
 			"hex_data": "हेक्स डेटा",
+			"unreviewed_instructions": "",
 			"raw_copied": "कच्चा लेनदेन डेटा क्लिपबोर्ड पर कॉपी किया गया।",
 			"sign_message": "संदेश पर हस्ताक्षर करें",
 			"connected_apps": "जुड़े हुए ऐप्स",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1577,6 +1577,7 @@
 			"network": "",
 			"amount": "",
 			"hex_data": "Dati HEX",
+			"unreviewed_instructions": "",
 			"raw_copied": "Dati transazione raw copiati negli appunti.",
 			"sign_message": "Firma messaggio",
 			"connected_apps": "App connesse",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1577,6 +1577,7 @@
 			"network": "ネットワーク",
 			"amount": "数量",
 			"hex_data": "HEXデータ",
+			"unreviewed_instructions": "",
 			"raw_copied": "生のトランザクションデータをクリップボードにコピーしました。",
 			"sign_message": "メッセージに署名",
 			"connected_apps": "接続済みアプリ",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1577,6 +1577,7 @@
 			"network": "네트워크",
 			"amount": "금액",
 			"hex_data": "HEX 데이터",
+			"unreviewed_instructions": "",
 			"raw_copied": "원시 트랜잭션 데이터가 클립보드에 복사되었습니다.",
 			"sign_message": "메시지 서명",
 			"connected_apps": "연결된 앱",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1577,6 +1577,7 @@
 			"network": "",
 			"amount": "",
 			"hex_data": "Dane HEX",
+			"unreviewed_instructions": "",
 			"raw_copied": "Surowe dane transakcji skopiowane do schowka.",
 			"sign_message": "Podpisz wiadomość",
 			"connected_apps": "Połączone aplikacje",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1577,6 +1577,7 @@
 			"network": "",
 			"amount": "",
 			"hex_data": "Dados HEX",
+			"unreviewed_instructions": "",
 			"raw_copied": "Dados da transação brutos copiados para a área de transferência.",
 			"sign_message": "Assinar Mensagem",
 			"connected_apps": "Aplicativos conectados",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1577,6 +1577,7 @@
 			"network": "Сеть",
 			"amount": "Сумма",
 			"hex_data": "HEX-данные",
+			"unreviewed_instructions": "",
 			"raw_copied": "Необработанные данные транзакции скопированы в буфер обмена.",
 			"sign_message": "Подписать сообщение",
 			"connected_apps": "Подключённые приложения",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1577,6 +1577,7 @@
 			"network": "",
 			"amount": "",
 			"hex_data": "Dữ liệu HEX",
+			"unreviewed_instructions": "",
 			"raw_copied": "Dữ liệu giao dịch thô đã được sao chép vào khay nhớ tạm.",
 			"sign_message": "Ký Tin Nhắn",
 			"connected_apps": "Ứng dụng đã kết nối",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1577,6 +1577,7 @@
 			"network": "网络",
 			"amount": "金额",
 			"hex_data": "HEX 数据",
+			"unreviewed_instructions": "",
 			"raw_copied": "原始交易数据已复制到剪贴板。",
 			"sign_message": "签署消息",
 			"connected_apps": "已连接的应用",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1250,6 +1250,7 @@ interface I18nWallet_connect {
 		network: string;
 		amount: string;
 		hex_data: string;
+		unreviewed_instructions: string;
 		raw_copied: string;
 		sign_message: string;
 		connected_apps: string;

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -74,9 +74,10 @@
 	let destination = $state<OptionSolAddress>();
 	let tokenAddress = $state<OptionSolAddress>();
 	let isApproval = $state<boolean | undefined>();
+	let unreviewed = $state<boolean | undefined>();
 
 	const updateData = async () => {
-		({ amount, destination, tokenAddress, isApproval } = await decodeService({
+		({ amount, destination, tokenAddress, isApproval, unreviewed } = await decodeService({
 			base64EncodedTransactionMessage: data,
 			networkId
 		}));
@@ -188,6 +189,7 @@
 				onReject={reject}
 				source={address ?? ''}
 				token={reviewToken}
+				unreviewed={unreviewed ?? false}
 			/>
 		{/if}
 	{/key}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -3,6 +3,7 @@
 	import SendData from '$lib/components/send/SendData.svelte';
 	import SendDataSpender from '$lib/components/send/SendDataSpender.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
 	import WalletConnectData from '$lib/components/wallet-connect/WalletConnectData.svelte';
 	import { balancesStore } from '$lib/stores/balances.store';
@@ -17,6 +18,7 @@
 		data?: string;
 		token: Token;
 		isApproval?: boolean;
+		unreviewed?: boolean;
 		onApprove: () => void;
 		onReject: () => void;
 	}
@@ -29,6 +31,7 @@
 		data,
 		token,
 		isApproval = false,
+		unreviewed = false,
 		onApprove,
 		onReject
 	}: Props = $props();
@@ -47,6 +50,10 @@
 	>
 		{#if isApproval}
 			<SendDataSpender spender={destination} />
+		{/if}
+
+		{#if unreviewed}
+			<MessageBox level="warning">{$i18n.wallet_connect.text.unreviewed_instructions}</MessageBox>
 		{/if}
 
 		<WalletConnectData {data} label={$i18n.wallet_connect.text.hex_data} />

--- a/src/frontend/src/sol/types/sol-transaction.ts
+++ b/src/frontend/src/sol/types/sol-transaction.ts
@@ -80,14 +80,14 @@ export interface MappedSolTransaction {
 	// rather than transferring funds. The `destination` then holds the delegate (spender),
 	// so the review must label it as an approval, not a send.
 	isApproval?: boolean;
-	// `true` when an instruction was parsed enough to know that the current
-	// review screen does not display its effects.
+	// `true` when the message contains at least one instruction whose effects the
+	// review screen cannot display. Unlike `ambiguous`, this does not block signing:
+	// it surfaces a warning so the user knows the review is incomplete and can decide.
 	unreviewed?: boolean;
 	// `true` when the message bundles instructions that disagree on source,
-	// destination or payer, or includes an unreviewed instruction. The summary
-	// keeps a single value per field, so such a transaction cannot be faithfully
-	// represented on the review screen and must not be signed without the user
-	// seeing every fund movement.
+	// destination or payer. The summary keeps a single value per field, so such
+	// a transaction cannot be faithfully represented on the review screen and
+	// must not be signed without the user seeing every fund movement.
 	ambiguous?: boolean;
 }
 

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -53,20 +53,24 @@ export const mapSolTransactionMessage = ({
 
 			// The summary holds a single value per field, so any later instruction that
 			// disagrees on source, destination or payer would be silently dropped from the
-			// review screen. Likewise, an unreviewed instruction may hide arbitrary side
-			// effects. We flag either case, leaving it to the signing flow to refuse a
+			// review screen. We flag those as ambiguous so the signing flow refuses a
 			// transaction it cannot display faithfully.
 			//
 			// The same applies to the token: the summary shows a single token's metadata and
 			// sums every amount into one figure. Bundling movements of different mints — or
 			// mixing a known SPL token with a native/unknown one — cannot be shown faithfully.
+			//
+			// An unreviewed instruction is different: it does not corrupt the summary, it
+			// simply has effects we cannot describe. Rejecting every such transaction would
+			// break most real dApp interactions (swaps, staking, NFT mints all carry
+			// instructions we don't decode). We surface it as a warning instead, so the user
+			// is told the review is incomplete and can decide.
 			const mixesTokenWithNonToken =
 				(nonNullish(tokenAddress) && nonNullish(acc.amount) && isNullish(acc.tokenAddress)) ||
 				(isNullish(tokenAddress) && nonNullish(amount) && nonNullish(acc.tokenAddress));
 
 			const ambiguous =
 				(acc.ambiguous ?? false) ||
-				(unreviewed ?? false) ||
 				conflicts({ current: acc.source, next: source }) ||
 				conflicts({ current: acc.destination, next: destination }) ||
 				conflicts({ current: acc.payer, next: payer }) ||
@@ -81,6 +85,7 @@ export const mapSolTransactionMessage = ({
 				...(nonNullish(payer) && { payer }),
 				...(nonNullish(tokenAddress) && { tokenAddress }),
 				...((isApproval ?? acc.isApproval) && { isApproval: true }),
+				...((unreviewed ?? acc.unreviewed) && { unreviewed: true }),
 				...(ambiguous && { ambiguous })
 			};
 		},

--- a/src/frontend/src/tests/sol/utils/sol-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transactions.utils.spec.ts
@@ -32,7 +32,7 @@ describe('sol-transactions.utils', () => {
 		it('should map a sol transaction message', () => {
 			expect(mapSolTransactionMessage(mockSolParsedTransactionMessage)).toStrictEqual({
 				amount: 2044380n,
-				ambiguous: true,
+				unreviewed: true,
 				destination: 'ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49',
 				payer: '5Dqoon9MdWRgwmJ839FJ2ZTpTAcc1MMprZeNyaxpaV1Q',
 				source: '5Dqoon9MdWRgwmJ839FJ2ZTpTAcc1MMprZeNyaxpaV1Q'
@@ -171,7 +171,7 @@ describe('sol-transactions.utils', () => {
 			});
 		});
 
-		it('should flag a transaction with an unreviewed instruction as ambiguous', () => {
+		it('should surface an unreviewed instruction as a warning, not reject it', () => {
 			spyMapSolInstruction
 				.mockReturnValueOnce({
 					amount: 1n,
@@ -189,8 +189,21 @@ describe('sol-transactions.utils', () => {
 				amount: 1n,
 				source: mockSolAddress,
 				destination: mockSolAddress2,
-				ambiguous: true
+				unreviewed: true
 			});
+		});
+
+		it('should surface a wholly unreviewed transaction as unreviewed without an amount', () => {
+			spyMapSolInstruction
+				.mockReturnValueOnce({ amount: undefined, unreviewed: true })
+				.mockReturnValueOnce({ amount: undefined, unreviewed: true });
+
+			expect(
+				mapSolTransactionMessage({
+					...mockSolParsedTransactionMessage,
+					instructions: [instruction1, instruction2]
+				})
+			).toStrictEqual({ amount: undefined, unreviewed: true });
 		});
 
 		it('should ignore instructions with undefined amount (no change to accumulator)', () => {


### PR DESCRIPTION
# Motivation

#13046 marks any transaction containing an unparsed/unknown instruction as `ambiguous`, and the WalletConnect signing guard refuses anything ambiguous. The intent was right — don't let a hidden instruction ride along behind a benign-looking summary — but the remedy is too broad: it rejects **most real dApp WalletConnect transactions**. Swaps, staking, NFT mints, governance, even a Memo instruction all carry a program instruction we don't decode, so they'd all be refused. That's the same over-blocking problem as the earlier "refuse SPL transfers" approach, one layer down.

# Changes

- An unreviewed instruction no longer makes a transaction `ambiguous`. It does not corrupt the single-value summary — it simply has effects we can't describe — so rejecting outright isn't warranted.
- The mapped summary now carries an `unreviewed` flag, propagated through `mapSolTransactionMessage`.
- The review screen shows a warning ("This transaction contains instructions OISY can't decode, so the review below may be incomplete. Only sign if you trust this app.") when `unreviewed`, so the user is informed and decides.
- Genuine ambiguity still rejects as before: conflicting source/destination/payer, multiple/mixed SPL mints, token-vs-native mixing.

This keeps the protection #13046 was after (the user is now told when the review is incomplete, so a benign summary can't silently hide an extra instruction) while restoring WalletConnect usability for legitimate dApp transactions.

# Tests

- Updated the transaction-mapper tests: an unreviewed instruction is surfaced as `unreviewed` (not `ambiguous`); a wholly-unreviewed transaction is `unreviewed` with no amount.
- `sol-transactions.utils.spec.ts`, `sol-instructions.utils.spec.ts`, `wallet-connect.services.spec.ts` pass (80).

Note: local `lint`/`check` currently report unrelated failures from an in-progress `eslint-config` and dependency bump on the shared checkout; none touch the files in this PR. CI runs the authoritative gates.
