### PR TITLE
test(frontend): cover bip122 WalletConnect namespace + document BTC support

### DIFF
--- a/docs/ai/PRODUCT.md
+++ b/docs/ai/PRODUCT.md
@@ -99,6 +99,18 @@ The **currency** selector does **not** appear in the user menu — it is always 
 
 ---
 
+## WalletConnect
+
+OISY connects to external dApps over WalletConnect (Reown WalletKit). When a dApp proposes a session, OISY advertises one namespace per chain family for which the signed-in user has a loaded address, so a single connection can span Ethereum, Solana, and Bitcoin at once.
+
+- **Ethereum (`eip155`)** — supports `eth_sendTransaction`, `eth_sign`, `personal_sign`, `eth_signTypedData_v4`, and `eth_signTypedData` (legacy).
+- **Solana (`solana`)** — supports `solana_signTransaction`, `solana_signAndSendTransaction`, and `solana_signMessage`, advertised for the mainnet and devnet addresses that are present (including the legacy CAIP-10 namespaces for compatibility).
+- **Bitcoin (`bip122`)** — supports `getAccountAddresses`, `signMessage`, and `signPsbt`. The namespace is advertised whenever any BTC address (mainnet, testnet, or regtest) is loaded, with one `bip122:<genesis>` chain and matching `bip122:<genesis>:<address>` account per present network, and the `bip122_addressesChanged` event.
+
+`signPsbt` is **sign-only**: OISY signs the PSBT the dApp provides and returns it, but does not broadcast the resulting transaction itself. Broadcasting is deferred to the dApp (and the `sendTransfer` method is intentionally not offered) so OISY never broadcasts a transaction it cannot fully account for — see the spec's broadcast-atomicity rationale.
+
+---
+
 ## Bitcoin
 
 ### Pending-transaction reservation

--- a/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
+++ b/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
@@ -1,3 +1,13 @@
+import {
+	SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
+	SESSION_REQUEST_BTC_SIGN_MESSAGE,
+	SESSION_REQUEST_BTC_SIGN_PSBT
+} from '$btc/constants/wallet-connect.constants';
+import {
+	BIP122_MAINNET_CHAINS_KEYS,
+	BIP122_REGTEST_CHAINS_KEYS,
+	BIP122_TESTNET_CHAINS_KEYS
+} from '$env/bip122-chains.env';
 import { UNEXPECTED_ERROR, WALLET_CONNECT_METADATA } from '$lib/constants/wallet-connect.constants';
 import { WalletConnectClient } from '$lib/providers/wallet-connect.providers';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
@@ -5,7 +15,17 @@ import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
 import { WalletKit, type WalletKitTypes } from '@reown/walletkit';
 import { Core } from '@walletconnect/core';
-import { getSdkError } from '@walletconnect/utils';
+import type * as WalletConnectUtils from '@walletconnect/utils';
+import { buildApprovedNamespaces, getSdkError } from '@walletconnect/utils';
+
+vi.mock('@walletconnect/utils', async (importOriginal) => {
+	const actual = await importOriginal<typeof WalletConnectUtils>();
+
+	return {
+		...actual,
+		buildApprovedNamespaces: vi.fn()
+	};
+});
 
 describe('wallet-connect.providers', () => {
 	describe('WalletConnectClient', () => {
@@ -41,6 +61,7 @@ describe('wallet-connect.providers', () => {
 		const mockGetActiveSessions = vi.fn();
 		const mockDisconnectSession = vi.fn();
 		const mockRejectSession = vi.fn();
+		const mockApproveSession = vi.fn();
 		const mockRespondSessionRequest = vi.fn();
 		const mockPair = vi.fn();
 		const mockOn = vi.fn();
@@ -51,6 +72,7 @@ describe('wallet-connect.providers', () => {
 			getActiveSessions: mockGetActiveSessions,
 			disconnectSession: mockDisconnectSession,
 			rejectSession: mockRejectSession,
+			approveSession: mockApproveSession,
 			respondSessionRequest: mockRespondSessionRequest,
 			core: {
 				pairing: { pair: mockPair }
@@ -140,7 +162,84 @@ describe('wallet-connect.providers', () => {
 			});
 		});
 
-		describe.todo('approveSession', () => {});
+		describe('approveSession', () => {
+			const buildApprovedNamespacesMock = vi.mocked(buildApprovedNamespaces);
+
+			beforeEach(() => {
+				buildApprovedNamespacesMock.mockReturnValue({});
+			});
+
+			const approveAndGetSupportedNamespaces = async (
+				params: Parameters<typeof WalletConnectClient.init>[0]
+			) => {
+				const listener = await WalletConnectClient.init(params);
+
+				await listener.approveSession(mockProposal);
+
+				expect(buildApprovedNamespacesMock).toHaveBeenCalledOnce();
+
+				const [[{ supportedNamespaces }]] = buildApprovedNamespacesMock.mock.calls;
+
+				return supportedNamespaces;
+			};
+
+			it('should advertise a bip122 namespace when a BTC address is present', async () => {
+				const supportedNamespaces = await approveAndGetSupportedNamespaces(mockParams);
+
+				expect(supportedNamespaces.bip122).toEqual({
+					chains: BIP122_MAINNET_CHAINS_KEYS,
+					methods: [
+						SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
+						SESSION_REQUEST_BTC_SIGN_MESSAGE,
+						SESSION_REQUEST_BTC_SIGN_PSBT
+					],
+					events: ['bip122_addressesChanged'],
+					accounts: BIP122_MAINNET_CHAINS_KEYS.map((chain) => `${chain}:${mockBtcAddress}`)
+				});
+			});
+
+			it('should advertise the chains and accounts for every present BTC network', async () => {
+				const supportedNamespaces = await approveAndGetSupportedNamespaces({
+					...mockParams,
+					btcAddressTestnet: mockBtcAddress,
+					btcAddressRegtest: mockBtcAddress
+				});
+
+				expect(supportedNamespaces.bip122.chains).toEqual([
+					...BIP122_MAINNET_CHAINS_KEYS,
+					...BIP122_TESTNET_CHAINS_KEYS,
+					...BIP122_REGTEST_CHAINS_KEYS
+				]);
+
+				expect(supportedNamespaces.bip122.accounts).toEqual([
+					...BIP122_MAINNET_CHAINS_KEYS.map((chain) => `${chain}:${mockBtcAddress}`),
+					...BIP122_TESTNET_CHAINS_KEYS.map((chain) => `${chain}:${mockBtcAddress}`),
+					...BIP122_REGTEST_CHAINS_KEYS.map((chain) => `${chain}:${mockBtcAddress}`)
+				]);
+			});
+
+			it('should not advertise a bip122 namespace when no BTC address is present', async () => {
+				const supportedNamespaces = await approveAndGetSupportedNamespaces({
+					...mockParams,
+					btcAddressMainnet: undefined,
+					btcAddressTestnet: undefined,
+					btcAddressRegtest: undefined
+				});
+
+				expect(supportedNamespaces.bip122).toBeUndefined();
+			});
+
+			it('should approve the session with the built namespaces', async () => {
+				const listener = await WalletConnectClient.init(mockParams);
+
+				await listener.approveSession(mockProposal);
+
+				expect(mockApproveSession).toHaveBeenCalledExactlyOnceWith({
+					id: mockProposal.id,
+					namespaces: {}
+				});
+			});
+		});
 
 		describe('rejectSession', () => {
 			it('should call rejectSession with the correct params', async () => {


### PR DESCRIPTION
# Motivation

Cover the bip122 WalletConnect namespace and document BTC support.

# Changes

- Add `approveSession` tests asserting the bip122 chains, methods, event, and accounts.
- Add a WalletConnect section to PRODUCT.md (eip155, solana, bip122; signPsbt sign-only).

# Tests

Provider spec passes; eslint and prettier clean.
