### PR TITLE
fix(frontend): keep active-transactions button highlighted while its popover is open

### DIFF
--- a/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionsButton.svelte
+++ b/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionsButton.svelte
@@ -46,6 +46,7 @@
 		<ButtonIcon
 			ariaLabel={$i18n.active_user_transactions.text.open_aria_label}
 			colorStyle="tertiary-alt"
+			expanded={visible}
 			link={false}
 			onclick={() => (visible = true)}
 			bind:button

--- a/src/frontend/src/lib/components/ui/ButtonIcon.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonIcon.svelte
@@ -19,6 +19,7 @@
 		width?: 'w-6' | 'w-8' | 'w-10' | 'w-16';
 		height?: 'h-6' | 'h-8' | 'h-10';
 		transparent?: boolean;
+		expanded?: boolean;
 	}
 
 	let {
@@ -35,7 +36,9 @@
 		styleClass = '',
 		width = 'w-10',
 		height = 'h-10',
-		transparent = false
+		transparent = false,
+		// Left undefined for non-expander buttons so no `aria-expanded` is emitted.
+		expanded
 	}: Props = $props();
 </script>
 
@@ -48,8 +51,10 @@
 	class:ease-in-out={loading}
 	class:link
 	class:loading
+	class:opened={expanded}
 	class:transition={loading}
 	class:transparent
+	aria-expanded={expanded}
 	aria-label={ariaLabel}
 	data-tid={testId}
 	disabled={disabled ?? loading}

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -272,6 +272,14 @@ a.as-button {
 			@apply text-primary;
 			@apply bg-primary;
 		}
+
+		// Keep the active background while the linked popover is open, the way
+		// the network switcher dropdown does. Placed last so it also wins over
+		// the focus-visible reset when opened via keyboard.
+		&.opened {
+			@apply text-brand-primary-alt;
+			@apply bg-brand-subtle-30;
+		}
 	}
 
 	&.tertiary-alt.disabled:not(.loading):not(.link),

--- a/src/frontend/src/tests/lib/components/ui/ButtonIcon.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/ButtonIcon.spec.ts
@@ -28,6 +28,35 @@ describe('ButtonIcon', () => {
 		expect(getByTestId(mockSnippetTestId).parentElement).toHaveClass('visually-hidden');
 	});
 
+	describe('when expanded', () => {
+		it('should not emit aria-expanded nor the opened class by default', () => {
+			const { getByRole } = render(ButtonIcon, { props });
+
+			const button = getByRole('button');
+
+			expect(button).not.toHaveClass('opened');
+			expect(button).not.toHaveAttribute('aria-expanded');
+		});
+
+		it('should mark the button as collapsed when expanded is false', () => {
+			const { getByRole } = render(ButtonIcon, { props: { ...props, expanded: false } });
+
+			const button = getByRole('button');
+
+			expect(button).not.toHaveClass('opened');
+			expect(button).toHaveAttribute('aria-expanded', 'false');
+		});
+
+		it('should mark the button as opened', () => {
+			const { getByRole } = render(ButtonIcon, { props: { ...props, expanded: true } });
+
+			const button = getByRole('button');
+
+			expect(button).toHaveClass('opened');
+			expect(button).toHaveAttribute('aria-expanded', 'true');
+		});
+	});
+
 	describe('when the button is loading', () => {
 		it('should render the loading spinner', () => {
 			const { getByTestId } = render(ButtonIcon, { props: { ...props, loading: true } });

--- a/src/frontend/src/tests/lib/components/ui/ButtonIcon.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/ButtonIcon.spec.ts
@@ -28,8 +28,8 @@ describe('ButtonIcon', () => {
 		expect(getByTestId(mockSnippetTestId).parentElement).toHaveClass('visually-hidden');
 	});
 
-	describe('when expanded', () => {
-		it('should not emit aria-expanded nor the opened class by default', () => {
+	describe('expanded prop', () => {
+		it('should not emit aria-expanded nor the opened class when expanded is undefined', () => {
 			const { getByRole } = render(ButtonIcon, { props });
 
 			const button = getByRole('button');


### PR DESCRIPTION
# Motivation

When the user has active transactions, an icon button appears in the top-right header; pressing it opens a popover listing those transactions. While the popover is open the button reverts to a white background, unlike the network switcher filter, which keeps its blue (`bg-brand-subtle-30`) background while its dropdown is open. The two controls sit next to each other, so the inconsistency is noticeable.

This makes the active-transactions button keep the same highlighted background while its popover is open.

# Changes

- `ButtonIcon`: add an optional `expanded` prop. When set it adds the `.opened` class and exposes `aria-expanded`. The prop is left `undefined` by default, so non-expander icon buttons emit neither the class nor `aria-expanded`.
- `button.scss`: give `tertiary-alt.opened` the active `bg-brand-subtle-30` background, the same token the network switcher `DropdownButton` uses for its open state. Placed after the `:focus-visible` reset so the open background also wins when the control is opened via keyboard.
- `ActiveUserTransactionsButton`: pass `expanded={visible}` so the button stays highlighted while its popover is open.

# Tests

- Extended `ButtonIcon.spec.ts`: covers the undefined case (no `aria-expanded`/`.opened`), the collapsed state (`expanded={false}`), and the open state (`expanded={true}`).
- `npm run format`, `npm run lint -- --max-warnings 0`, and `npm run check` pass for the touched files.
- Visual: not exercised in a running app — the change is a CSS class toggle plus a prop, covered by the unit tests above and consistent with the existing `DropdownButton` open-state styling.

|Before|After|
|---|---|
|<img width="622" height="225" alt="image" src="https://github.com/user-attachments/assets/8c12a1a2-e45f-4cf4-84cd-37c2ab9293b4" />|<img width="622" height="225" alt="image" src="https://github.com/user-attachments/assets/595c4a60-c723-423a-bb53-6aa36b1be22a" />|


---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — claude-opus-4-8
