### PR TITLE
feat(frontend): extend the button open-state to muted popover triggers and the nav menu

### DIFF
--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -101,6 +101,7 @@
 <ButtonIcon
 	ariaLabel={$i18n.navigation.alt.menu}
 	colorStyle="tertiary-alt"
+	expanded={visible}
 	link={false}
 	onclick={() => (visible = true)}
 	testId={NAVIGATION_MENU_BUTTON}

--- a/src/frontend/src/lib/components/nfts/NftSettingsMenu.svelte
+++ b/src/frontend/src/lib/components/nfts/NftSettingsMenu.svelte
@@ -78,9 +78,9 @@
 <ButtonIcon
 	ariaLabel={$i18n.navigation.alt.menu}
 	colorStyle="muted"
+	expanded={visible}
 	link={false}
 	onclick={() => (visible = true)}
-	styleClass={visible ? 'active' : ''}
 	bind:button
 >
 	{#snippet icon()}

--- a/src/frontend/src/lib/components/nfts/NftSortMenu.svelte
+++ b/src/frontend/src/lib/components/nfts/NftSortMenu.svelte
@@ -41,9 +41,9 @@
 <ButtonIcon
 	ariaLabel={$i18n.navigation.alt.menu}
 	colorStyle="muted"
+	expanded={visible}
 	link={false}
 	onclick={() => (visible = true)}
-	styleClass={visible ? 'active' : ''}
 	bind:button
 >
 	{#snippet icon()}

--- a/src/frontend/src/lib/components/tokens/TokensMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensMenu.svelte
@@ -35,9 +35,9 @@
 <ButtonIcon
 	ariaLabel={$i18n.navigation.alt.menu}
 	colorStyle="muted"
+	expanded={visible}
 	link={false}
 	onclick={() => (visible = true)}
-	styleClass={visible ? 'active' : ''}
 	bind:button
 >
 	{#snippet icon()}

--- a/src/frontend/src/lib/components/tokens/TokensSortMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensSortMenu.svelte
@@ -39,9 +39,9 @@
 <ButtonIcon
 	ariaLabel={$i18n.navigation.alt.menu}
 	colorStyle="muted"
+	expanded={visible}
 	link={false}
 	onclick={() => (visible = true)}
-	styleClass={visible ? 'active' : ''}
 	bind:button
 >
 	{#snippet icon()}

--- a/src/frontend/src/lib/components/ui/SlidingInput.svelte
+++ b/src/frontend/src/lib/components/ui/SlidingInput.svelte
@@ -133,9 +133,10 @@
 			{ariaLabel}
 			colorStyle="muted"
 			{disabled}
+			expanded={visible}
 			link={false}
 			onclick={handleToggle}
-			styleClass={`absolute right-[5px] ${visible ? 'active' : ''}`}
+			styleClass="absolute right-[5px]"
 			testId={`${testIdPrefix}-open-btn`}
 			bind:button
 		>

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -341,13 +341,20 @@ a.as-button {
 			@apply bg-primary;
 		}
 
-		&:active,
-		&.active {
+		&:active {
 			@apply text-secondary;
 			@apply bg-disabled;
 		}
 
 		&:focus-visible {
+			@apply text-secondary;
+			@apply bg-disabled;
+		}
+
+		// Keep the active background while the linked popover/input is open, the
+		// same way tertiary-alt does. Placed last so it also wins over the
+		// focus-visible reset when opened via keyboard.
+		&.opened {
 			@apply text-secondary;
 			@apply bg-disabled;
 		}

--- a/src/frontend/src/tests/lib/components/core/Menu.spec.ts
+++ b/src/frontend/src/tests/lib/components/core/Menu.spec.ts
@@ -95,6 +95,24 @@ describe('Menu', () => {
 			return element;
 		});
 
+	it('keeps the menu button highlighted while the popover is open', async () => {
+		({ container } = render(Menu));
+
+		const menuButton: HTMLButtonElement | null = container.querySelector(menuButtonSelector);
+
+		assertNonNullish(menuButton);
+
+		expect(menuButton).not.toHaveClass('opened');
+		expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+
+		menuButton.click();
+
+		await waitFor(() => {
+			expect(menuButton).toHaveClass('opened');
+			expect(menuButton).toHaveAttribute('aria-expanded', 'true');
+		});
+	});
+
 	it('renders the privacy mode menu item', async () => {
 		await openMenu();
 		await waitForElement({ selector: menuItemPrivacyModeButtonSelector });

--- a/src/frontend/src/tests/lib/components/nfts/NftSettingsMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftSettingsMenu.spec.ts
@@ -207,19 +207,21 @@ describe('NftsSettingsMenu', () => {
 		});
 	});
 
-	it('should apply active class to button when popover is visible', async () => {
+	it('should mark the button as opened when popover is visible', async () => {
 		const { container } = render(NftsSettingsMenu);
 
 		const button = container.querySelector('button');
 
-		expect(button).not.toHaveClass('active');
+		expect(button).not.toHaveClass('opened');
+		expect(button).toHaveAttribute('aria-expanded', 'false');
 
 		assertNonNullish(button);
 
 		await fireEvent.click(button);
 
 		await waitFor(() => {
-			expect(button).toHaveClass('active');
+			expect(button).toHaveClass('opened');
+			expect(button).toHaveAttribute('aria-expanded', 'true');
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/nfts/NftSettingsMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftSettingsMenu.spec.ts
@@ -212,10 +212,10 @@ describe('NftsSettingsMenu', () => {
 
 		const button = container.querySelector('button');
 
+		assertNonNullish(button);
+
 		expect(button).not.toHaveClass('opened');
 		expect(button).toHaveAttribute('aria-expanded', 'false');
-
-		assertNonNullish(button);
 
 		await fireEvent.click(button);
 

--- a/src/frontend/src/tests/lib/components/nfts/NftSortMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftSortMenu.spec.ts
@@ -199,10 +199,10 @@ describe('NftSorting', () => {
 
 		const button = container.querySelector('button');
 
+		assertNonNullish(button);
+
 		expect(button).not.toHaveClass('opened');
 		expect(button).toHaveAttribute('aria-expanded', 'false');
-
-		assertNonNullish(button);
 
 		await fireEvent.click(button);
 

--- a/src/frontend/src/tests/lib/components/nfts/NftSortMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/nfts/NftSortMenu.spec.ts
@@ -194,19 +194,21 @@ describe('NftSorting', () => {
 		});
 	});
 
-	it('should apply active class to button when popover is visible', async () => {
+	it('should mark the button as opened when popover is visible', async () => {
 		const { container } = render(NftSorting);
 
 		const button = container.querySelector('button');
 
-		expect(button).not.toHaveClass('active');
+		expect(button).not.toHaveClass('opened');
+		expect(button).toHaveAttribute('aria-expanded', 'false');
 
 		assertNonNullish(button);
 
 		await fireEvent.click(button);
 
 		await waitFor(() => {
-			expect(button).toHaveClass('active');
+			expect(button).toHaveClass('opened');
+			expect(button).toHaveAttribute('aria-expanded', 'true');
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/tokens/TokensMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensMenu.spec.ts
@@ -39,10 +39,10 @@ describe('TokensMenu', () => {
 
 		const button = container.querySelector('button');
 
+		assertNonNullish(button);
+
 		expect(button).not.toHaveClass('opened');
 		expect(button).toHaveAttribute('aria-expanded', 'false');
-
-		assertNonNullish(button);
 
 		await fireEvent.click(button);
 

--- a/src/frontend/src/tests/lib/components/tokens/TokensMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensMenu.spec.ts
@@ -34,6 +34,24 @@ describe('TokensMenu', () => {
 		});
 	});
 
+	it('should mark the button as opened when popover is visible', async () => {
+		const { container } = render(TokensMenu);
+
+		const button = container.querySelector('button');
+
+		expect(button).not.toHaveClass('opened');
+		expect(button).toHaveAttribute('aria-expanded', 'false');
+
+		assertNonNullish(button);
+
+		await fireEvent.click(button);
+
+		await waitFor(() => {
+			expect(button).toHaveClass('opened');
+			expect(button).toHaveAttribute('aria-expanded', 'true');
+		});
+	});
+
 	describe('notification blob', () => {
 		const getNotificationBlob = (container: HTMLElement) =>
 			container.querySelector('.rounded-full.bg-brand-primary');

--- a/src/frontend/src/tests/lib/components/tokens/TokensSortMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensSortMenu.spec.ts
@@ -160,19 +160,21 @@ describe('TokensSortMenu', () => {
 		});
 	});
 
-	it('should apply active class to button when popover is visible', async () => {
+	it('should mark the button as opened when popover is visible', async () => {
 		const { container } = render(TokensSortMenu);
 
 		const button = container.querySelector('button');
 
-		expect(button).not.toHaveClass('active');
+		expect(button).not.toHaveClass('opened');
+		expect(button).toHaveAttribute('aria-expanded', 'false');
 
 		assertNonNullish(button);
 
 		await fireEvent.click(button);
 
 		await waitFor(() => {
-			expect(button).toHaveClass('active');
+			expect(button).toHaveClass('opened');
+			expect(button).toHaveAttribute('aria-expanded', 'true');
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/tokens/TokensSortMenu.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensSortMenu.spec.ts
@@ -165,10 +165,10 @@ describe('TokensSortMenu', () => {
 
 		const button = container.querySelector('button');
 
+		assertNonNullish(button);
+
 		expect(button).not.toHaveClass('opened');
 		expect(button).toHaveAttribute('aria-expanded', 'false');
-
-		assertNonNullish(button);
 
 		await fireEvent.click(button);
 


### PR DESCRIPTION
# Motivation

Follow-up to #13133 (already merged). That PR added the `.opened` open-state to `ButtonIcon` via the `expanded` prop, but wired it only for the `tertiary-alt` button style — the single popover trigger it touched. Reviewer feedback asked to extend the open-state to the other button styles, on demand, as real consumers appear ([discussion](https://github.com/dfinity/oisy-wallet/pull/13133#discussion_r3428415676)).

This extends the open-state to the button styles that actually drive popovers/dropdowns today, rather than a blanket sweep of styles that are never triggers.

# Changes

- `button.scss`: add a `muted.opened` rule, mirroring `tertiary-alt.opened` (placed after the `:focus-visible` reset so it also wins for keyboard-opened controls). It uses `muted`'s own active tokens (`text-secondary` + `bg-disabled`), so there is no visual change — only the mechanism is unified. Dropped the now-unused `&.active` selector from the `muted` block.
- Migrated the five `muted` open-state consumers from the ad-hoc `styleClass={visible ? 'active' : ''}` toggle to the standardized `expanded` prop, which also emits `aria-expanded`: `NftSettingsMenu`, `NftSortMenu`, `TokensSortMenu`, `TokensMenu`, and `SlidingInput`.
- `core/Menu`: the navigation menu button is a `tertiary-alt` popover trigger that never passed `expanded`, so it reverted to the default background while open. Wired `expanded={visible}` so it stays highlighted, consistent with the other triggers (no SCSS change needed).

Action-only styles (`primary`, `secondary`, `error`, …) are intentionally left untouched since they are not popover/dropdown triggers — `.opened` can be added to any of them the first time one becomes a trigger.

# Tests

- Updated the `NftSettingsMenu`, `NftSortMenu`, and `TokensSortMenu` specs from asserting the old `.active` class to `.opened` + `aria-expanded`.
- Added open-state coverage to `TokensMenu.spec` and `Menu.spec`.
- Post-review (Copilot): moved `assertNonNullish(button)` ahead of the `toHaveClass` / `toHaveAttribute` matchers in the menu specs so the null guard runs before them.
- `npm run format`, `npm run lint`, and `npm run check` pass for the touched files; the muted/`ButtonIcon` specs (40 tests) are green on the latest `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — claude-opus-4-8
