### PR TITLE
fix(scripts): make onramper signing-secret provisioning robust

### DIFF
--- a/scripts/provision-onramper-signing-secret.sh
+++ b/scripts/provision-onramper-signing-secret.sh
@@ -37,6 +37,10 @@ clap.define short=s long=secret desc="OnRamper signing secret (prefer env var / 
 clap.define short=i long=identity desc="dfx identity to call with (must be a controller)" variable=IDENTITY default="default"
 clap.define short=c long=clear desc="Clear the secret instead of setting it" variable=CLEAR default="false" nargs=0
 # Source the output file ----------------------------------------------------------
+# `SECRET` is a common env-var name and clap only seeds variables with a non-empty default, so
+# without this an inherited/exported $SECRET would leak in and bypass the documented precedence
+# (--secret flag → ONRAMPER_SIGNING_SECRET → prompt). Unset it so only --secret can set it.
+unset SECRET
 source "$(clap.build)"
 
 if [[ "$CLEAR" == "true" ]]; then

--- a/scripts/provision-onramper-signing-secret.sh
+++ b/scripts/provision-onramper-signing-secret.sh
@@ -35,7 +35,7 @@ source "$SOURCE_DIR/clap.bash"
 clap.define short=n long=network desc="dfx network to use" variable=NETWORK default="local"
 clap.define short=s long=secret desc="OnRamper signing secret (prefer env var / prompt)" variable=SECRET default=""
 clap.define short=i long=identity desc="dfx identity to call with (must be a controller)" variable=IDENTITY default="default"
-clap.define short=c long=clear desc="Clear the secret instead of setting it" variable=CLEAR default="false"
+clap.define short=c long=clear desc="Clear the secret instead of setting it" variable=CLEAR default="false" nargs=0
 # Source the output file ----------------------------------------------------------
 source "$(clap.build)"
 
@@ -43,11 +43,14 @@ if [[ "$CLEAR" == "true" ]]; then
   echo "Clearing the OnRamper signing secret on network '$NETWORK'..."
   dfx canister call --identity "$IDENTITY" --network "$NETWORK" backend set_onramper_signing_secret '(null)'
 else
-  if [[ -z "$SECRET" ]]; then
+  # clap only initializes variables with a non-empty default, so under `set -u` an unset
+  # --secret leaves $SECRET unbound; guard the read so the env-var / prompt fallbacks work.
+  if [[ -z "${SECRET:-}" ]]; then
     SECRET="${ONRAMPER_SIGNING_SECRET:-}"
   fi
   if [[ -z "$SECRET" ]]; then
-    read -rs -p "OnRamper signing secret: " SECRET
+    # `|| true` so EOF (e.g. empty stdin) doesn't abort under `set -e` before the check below.
+    read -rs -p "OnRamper signing secret: " SECRET || true
     echo
   fi
   [[ -n "$SECRET" ]] || {


### PR DESCRIPTION
# Motivation

`scripts/provision-onramper-signing-secret.sh` failed on its documented usages under `set -euo pipefail`:

- The "preferred" env-var path (`ONRAMPER_SIGNING_SECRET=… ./scripts/provision-onramper-signing-secret.sh --network beta`) crashed with `line 46: SECRET: unbound variable`. `clap` only emits an initializer for variables with a **non-empty** default, so `--secret` (default `""`) was left unbound when the flag wasn't passed.
- `--clear` was missing `nargs=0`, so `clap` parsed it as a value-taking option — it silently swallowed the following argument (e.g. `CLEAR=--network`), or hit `set -u` when it was the last argument. The documented `--clear` usage never reached the clear branch.
- With no secret on empty stdin, `read` hit EOF and `set -e` aborted before the script's own `no secret provided` error could report.

# Changes

- Guard the secret read with `${SECRET:-}` so the env-var and prompt fallbacks work under `set -u`.
- Add `nargs=0` to the `--clear` `clap.define` so it is a proper boolean flag, matching the existing `[[ "$CLEAR" == "true" ]]` check.
- Add `|| true` to the interactive `read` so EOF doesn't abort before the `no secret provided` guard fires.

# Tests

Manual verification of every input path (using a bogus `--network nope` to exercise parsing up to the `dfx` call):

- env-var path → reaches `Setting…` (previously crashed with unbound variable) ✅
- `--secret` flag → reaches `Setting…` ✅
- prompt path (secret on stdin) → reaches `Setting…` ✅
- `--clear` → reaches `Clearing…` and calls `set_onramper_signing_secret '(null)'` (no longer eats the next arg) ✅
- no secret / empty stdin → graceful `ERROR: no secret provided.` ✅
- `bash -n` syntax check passes; `shellcheck -x` reports only the pre-existing SC1090/SC1091 dynamic-`source` notes common to all clap-based scripts.