### PR TITLE
feat(frontend): enable OnRamper buy widget on beta

### DIFF
--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -1,8 +1,8 @@
-import { LOCAL, STAGING } from '$lib/constants/app.constants';
+import { BETA, LOCAL, STAGING } from '$lib/constants/app.constants';
 
-// Feature flag: the OnRamper buy widget is enabled only on local and staging — not on beta nor
+// Feature flag: the OnRamper buy widget is enabled on local, staging and beta — not on
 // production (ic). `STAGING` already covers the test_fe / audit / e2e environments.
-export const ONRAMPER_ENABLED = LOCAL || STAGING;
+export const ONRAMPER_ENABLED = LOCAL || STAGING || BETA;
 
 // Optimistic fallback for the runtime `onramper_enabled` backend query: assume the widget is
 // available when the query cannot be reached, since the widget self-disables on a missing secret.


### PR DESCRIPTION
# Motivation

We wanted to test the OnRamper buy flow (BTC and the other configured cryptos) on **beta**, against the real **prod** OnRamper widget (`buy.onramper.com` + the prod `apiKey`).

The buy widget was gated to local + staging only (`ONRAMPER_ENABLED = LOCAL || STAGING`), so it never appeared on beta. Notably, the integration doc already documents the intended state as `LOCAL || STAGING || BETA` (`docs/ai/integrations/onramper.md`), so the code was lagging the docs — this change reconciles them.

# Changes

- `src/frontend/src/env/rest/onramper.env.ts`: enable the widget on beta — `ONRAMPER_ENABLED = LOCAL || STAGING || BETA` (and import `BETA`). On beta the env selector still resolves to `prod`, so it uses `buy.onramper.com` + the prod `apiKey` (no dev/sandbox change).

No doc change needed: `docs/ai/integrations/onramper.md` already states `LOCAL || STAGING || BETA`.

# Tests

Deployed this branch to beta (frontend + backend) and exercised the real flow:

- Provisioned the prod OnRamper HMAC signing secret on the beta backend (`yrinv-sqaaa-aaaan-qzmxq-cai`) via `set_onramper_signing_secret`; `onramper_enabled` now returns `(true)`. (Out-of-band controller call — not part of this diff; the secret lives in canister state, never in the bundle.)
- Opened Buy → BTC on beta: the OnRamper widget loads and renders the live quote — no "Invalid Signature" error and no "Buy unavailable" notice. Per OnRamper, the signature is validated on widget open, so a successful open is the pass condition (no purchase required).
- Cryptographically verified the signed URL: recomputed HMAC-SHA256 over the canonical sign-content (`networkWallets=…`, sorted, values verbatim) with the provisioned secret — it matches the `signature=` in the live widget URL byte-for-byte.

Note: merging this enables the buy widget for all beta users (real-money prod widget). It only renders while the prod signing secret remains provisioned on the beta backend (runtime `onramper_enabled` gate).