### PR TITLE
chore(frontend): two buy buttons — unsigned vs signed OnRamper URL (demo, not for merge)

### DIFF
--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -1,8 +1,9 @@
 import { LOCAL, STAGING } from '$lib/constants/app.constants';
 
-// Feature flag: the OnRamper buy widget is enabled only on local and staging — not on beta nor
-// production (ic). `STAGING` already covers the test_fe / audit / e2e environments.
-export const ONRAMPER_ENABLED = LOCAL || STAGING;
+// DEMO BRANCH — NOT FOR MERGE: force-enable the OnRamper buy widget on every environment
+// (production would normally restrict it to local and staging) so this demo can be deployed to
+// beta. `true as boolean` keeps the flag mockable in tests (eslint --fix strips a `: boolean`).
+export const ONRAMPER_ENABLED = true as boolean;
 
 // Optimistic fallback for the runtime `onramper_enabled` backend query: assume the widget is
 // available when the query cannot be reached, since the widget self-disables on a missing secret.

--- a/src/frontend/src/lib/components/buy/Buy.svelte
+++ b/src/frontend/src/lib/components/buy/Buy.svelte
@@ -13,10 +13,14 @@
 	import { modalStore } from '$lib/stores/modal.store';
 
 	const modalId = Symbol();
-</script>
 
-<BuyButton
-	onclick={() => {
+	// DEMO BRANCH — NOT FOR MERGE: two buy buttons — the default one opens the widget with an
+	// unsigned URL, "Buy S" opens it with the production signed URL (resolved via the backend).
+	let signed = $state(false);
+
+	const openBuy = (isSigned: boolean) => {
+		signed = isSigned;
+
 		trackEvent({
 			name: TRACK_BUY_TOKEN,
 			metadata: nonNullish($pageToken)
@@ -29,9 +33,16 @@
 		});
 
 		modalStore.openBuy(modalId);
-	}}
+	};
+</script>
+
+<BuyButton onclick={() => openBuy(false)} />
+<BuyButton
+	buttonLabel="Buy S"
+	onclick={() => openBuy(true)}
+	testId="buy-tokens-modal-open-button-signed"
 />
 
 {#if $modalBuy && $modalStore?.id === modalId}
-	<BuyModal />
+	<BuyModal {signed} />
 {/if}

--- a/src/frontend/src/lib/components/buy/BuyButton.svelte
+++ b/src/frontend/src/lib/components/buy/BuyButton.svelte
@@ -11,26 +11,30 @@
 
 	interface Props {
 		onclick: () => void;
+		// DEMO BRANCH — NOT FOR MERGE: optional overrides so a second "signed" buy button can render
+		// alongside the default one with a distinct label and test id.
+		buttonLabel?: string;
+		testId?: string;
 	}
 
-	let { onclick }: Props = $props();
+	let { onclick, buttonLabel, testId = BUY_TOKENS_MODAL_OPEN_BUTTON }: Props = $props();
 
 	const { inflowActionsDisabled } = getContext<HeroContext>(HERO_CONTEXT_KEY);
 </script>
 
 <!-- API-key gate only matters while OnRamper is enabled; with the flag off, the modal shows the notice and doesn't need the key. -->
 <ButtonHero
-	ariaLabel={$i18n.buy.text.buy}
+	ariaLabel={buttonLabel ?? $i18n.buy.text.buy}
 	disabled={$isBusy ||
 		(ONRAMPER_ENABLED && isNullishOrEmpty(ONRAMPER_API_KEY)) ||
 		$inflowActionsDisabled}
 	{onclick}
-	testId={BUY_TOKENS_MODAL_OPEN_BUTTON}
+	{testId}
 >
 	{#snippet icon()}
 		<IconlyBuy size="24" />
 	{/snippet}
 	{#snippet label()}
-		{$i18n.buy.text.buy}
+		{buttonLabel ?? $i18n.buy.text.buy}
 	{/snippet}
 </ButtonHero>

--- a/src/frontend/src/lib/components/buy/BuyModal.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModal.svelte
@@ -4,12 +4,15 @@
 	import BuyModalContent from '$lib/components/buy/BuyModalContent.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
+
+	// DEMO BRANCH — NOT FOR MERGE: `signed` is forwarded to the widget to pick signed vs unsigned URL.
+	let { signed = false }: { signed?: boolean } = $props();
 </script>
 
 <Modal onClose={modalStore.close}>
 	{#snippet title()}
-		{isOnRamperDev ? $i18n.buy.text.buy_dev : $i18n.buy.text.buy}
+		{isOnRamperDev ? $i18n.buy.text.buy_dev : $i18n.buy.text.buy}{signed ? ' — signed' : ''}
 	{/snippet}
 
-	<BuyModalContent />
+	<BuyModalContent {signed} />
 </Modal>

--- a/src/frontend/src/lib/components/buy/BuyModalContent.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModalContent.svelte
@@ -5,13 +5,14 @@
 
 	// DEMO BRANCH — NOT FOR MERGE: the runtime `onramper_enabled` backend check (which requires the
 	// signing secret to be provisioned) is intentionally dropped here so the widget opens on the
-	// build-time flag alone, without any backend dependency.
+	// build-time flag alone. `signed` selects between the production signed URL and the unsigned one.
+	let { signed = false }: { signed?: boolean } = $props();
 </script>
 
 {#if ONRAMPER_ENABLED}
 	<div class="stretch flex overflow-hidden">
 		<div class="w-full overflow-auto">
-			<OnramperWidget />
+			<OnramperWidget {signed} />
 		</div>
 	</div>
 {:else}

--- a/src/frontend/src/lib/components/buy/BuyModalContent.svelte
+++ b/src/frontend/src/lib/components/buy/BuyModalContent.svelte
@@ -1,26 +1,14 @@
 <script lang="ts">
-	import { BACKEND_ONRAMPER_ENABLED, ONRAMPER_ENABLED } from '$env/rest/onramper.env';
+	import { ONRAMPER_ENABLED } from '$env/rest/onramper.env';
 	import BuyUnavailableNotice from '$lib/components/buy/BuyUnavailableNotice.svelte';
 	import OnramperWidget from '$lib/components/onramper/OnramperWidget.svelte';
-	import { loadBackendOnramperEnabled } from '$lib/services/backend-onramper-enabled.services';
 
-	// Whether the backend has the OnRamper signing secret provisioned. Resolved at runtime so a
-	// missing secret shows the unavailable notice up front instead of a widget that fails on open.
-	let backendOnramperEnabled = $state<boolean>(BACKEND_ONRAMPER_ENABLED);
-
-	$effect(() => {
-		// Skip the backend round-trip entirely when the build-time flag already hides the widget.
-		if (!ONRAMPER_ENABLED) {
-			return;
-		}
-
-		void loadBackendOnramperEnabled().then((enabled) => {
-			backendOnramperEnabled = enabled;
-		});
-	});
+	// DEMO BRANCH — NOT FOR MERGE: the runtime `onramper_enabled` backend check (which requires the
+	// signing secret to be provisioned) is intentionally dropped here so the widget opens on the
+	// build-time flag alone, without any backend dependency.
 </script>
 
-{#if ONRAMPER_ENABLED && backendOnramperEnabled}
+{#if ONRAMPER_ENABLED}
 	<div class="stretch flex overflow-hidden">
 		<div class="w-full overflow-auto">
 			<OnramperWidget />

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -12,7 +12,6 @@
 	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { harvestAutopilots } from '$eth/derived/harvest-autopilots.derived';
 	import { icpAccountIdentifierText } from '$icp/derived/ic.derived';
-	import BuyUnavailableNotice from '$lib/components/buy/BuyUnavailableNotice.svelte';
 	import { BUY_MODAL_ONRAMPER_IFRAME } from '$lib/constants/test-ids.constants';
 	import { btcAddressMainnet, ethAddress, solAddressMainnet } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -71,25 +70,18 @@
 	);
 
 	let src = $state<string | undefined>(undefined);
-	let signingFailed = $state(false);
 
-	// Resolve the signed widget URL through the backend canister whenever the inputs change. Build
-	// the link asynchronously (the canister returns the HMAC over the sensitive parameters) and
-	// guard against late resolutions overwriting newer state via a cancellation token.
+	// DEMO BRANCH — NOT FOR MERGE: build the widget URL synchronously and unsigned. Production
+	// resolves a signed URL through the backend canister (see `buildOnramperLink`); here we skip
+	// the backend round-trip so the widget opens with the composed URL even without the signing
+	// secret. Still gate on an authenticated identity so the wallet addresses are available.
 	$effect(() => {
-		const currentIdentity = $authIdentity;
-		if (!nonNullish(currentIdentity)) {
+		if (!nonNullish($authIdentity)) {
 			src = undefined;
-			signingFailed = false;
 			return;
 		}
 
-		let cancelled = false;
-		src = undefined;
-		signingFailed = false;
-
-		buildOnramperLink({
-			identity: currentIdentity,
+		src = buildOnramperLink({
 			mode: 'buy',
 			defaultFiat: $currentCurrency,
 			defaultCrypto,
@@ -100,22 +92,7 @@
 			supportRecurringPayments: true,
 			enableCountrySelector: true,
 			themeName: 'dark' // we always pass dark, as some card elements aren't styled correctly (white text on white background) in light theme / onramper bug?
-		})
-			.then((url) => {
-				if (!cancelled) {
-					src = url;
-				}
-			})
-			.catch((error: unknown) => {
-				if (!cancelled) {
-					consoleError('Could not sign OnRamper widget URL', error);
-					signingFailed = true;
-				}
-			});
-
-		return () => {
-			cancelled = true;
-		};
+		});
 	});
 
 	let themeLoaded = $state(false);
@@ -154,28 +131,24 @@
 <!-- When Onramper engineers were inquired about the reason, they answered: -->
 <!-- "In order to do customer verification before purchase, we require the following permissions to be given to the app. So this is definitely merely for the KYC  and also for fraud detection algorithms i suppose" -->
 
-{#if signingFailed}
-	<BuyUnavailableNotice />
-{:else}
-	<div
-		class="absolute top-0 right-0 bottom-0 left-0 bg-surface text-brand-primary transition-all duration-500 ease-in-out"
-		class:invisible={themeLoaded && nonNullish(src)}
-		class:opacity-0={themeLoaded && nonNullish(src)}
-		class:opacity-100={!themeLoaded || !nonNullish(src)}
-	>
-		<Spinner inline />
-	</div>
+<div
+	class="absolute top-0 right-0 bottom-0 left-0 bg-surface text-brand-primary transition-all duration-500 ease-in-out"
+	class:invisible={themeLoaded && nonNullish(src)}
+	class:opacity-0={themeLoaded && nonNullish(src)}
+	class:opacity-100={!themeLoaded || !nonNullish(src)}
+>
+	<Spinner inline />
+</div>
 
-	{#if nonNullish(src)}
-		<iframe
-			allow="accelerometer; autoplay; camera; gyroscope; payment; microphone"
-			data-tid={BUY_MODAL_ONRAMPER_IFRAME}
-			height="680px"
-			onload={changeThemeOnIframeLoad}
-			sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
-			{src}
-			title={$i18n.buy.onramper.title}
-			width="100%"
-		></iframe>
-	{/if}
+{#if nonNullish(src)}
+	<iframe
+		allow="accelerometer; autoplay; camera; gyroscope; payment; microphone"
+		data-tid={BUY_MODAL_ONRAMPER_IFRAME}
+		height="680px"
+		onload={changeThemeOnIframeLoad}
+		sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
+		{src}
+		title={$i18n.buy.onramper.title}
+		width="100%"
+	></iframe>
 {/if}

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -12,6 +12,7 @@
 	import { erc20Tokens } from '$eth/derived/erc20.derived';
 	import { harvestAutopilots } from '$eth/derived/harvest-autopilots.derived';
 	import { icpAccountIdentifierText } from '$icp/derived/ic.derived';
+	import BuyUnavailableNotice from '$lib/components/buy/BuyUnavailableNotice.svelte';
 	import { BUY_MODAL_ONRAMPER_IFRAME } from '$lib/constants/test-ids.constants';
 	import { btcAddressMainnet, ethAddress, solAddressMainnet } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -23,7 +24,16 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { token } from '$lib/stores/token.store';
 	import { consoleError } from '$lib/utils/console.utils';
-	import { buildOnramperLink, mapOnramperNetworkWallets } from '$lib/utils/onramper.utils';
+	import {
+		buildOnramperLink,
+		buildUnsignedOnramperLink,
+		mapOnramperNetworkWallets,
+		type BuildOnramperLinkParams
+	} from '$lib/utils/onramper.utils';
+
+	// DEMO BRANCH — NOT FOR MERGE: `signed` selects between the production signed URL (resolved via
+	// the backend canister) and the unsigned URL composed entirely on the frontend.
+	let { signed = false }: { signed?: boolean } = $props();
 
 	let vault = $derived(
 		$harvestAutopilots.find(({ token: { address } }) => address === $routeAutopilotVault)
@@ -70,18 +80,21 @@
 	);
 
 	let src = $state<string | undefined>(undefined);
+	let signingFailed = $state(false);
 
-	// DEMO BRANCH — NOT FOR MERGE: build the widget URL synchronously and unsigned. Production
-	// resolves a signed URL through the backend canister (see `buildOnramperLink`); here we skip
-	// the backend round-trip so the widget opens with the composed URL even without the signing
-	// secret. Still gate on an authenticated identity so the wallet addresses are available.
+	// DEMO BRANCH — NOT FOR MERGE: resolve the widget URL whenever the inputs change. In `signed`
+	// mode the link is built through the backend canister (the HMAC over the sensitive parameters),
+	// guarded against late resolutions via a cancellation token; in unsigned mode the link is
+	// composed synchronously on the frontend without any backend dependency.
 	$effect(() => {
-		if (!nonNullish($authIdentity)) {
+		const currentIdentity = $authIdentity;
+		if (!nonNullish(currentIdentity)) {
 			src = undefined;
+			signingFailed = false;
 			return;
 		}
 
-		src = buildOnramperLink({
+		const params: Omit<BuildOnramperLinkParams, 'identity'> = {
 			mode: 'buy',
 			defaultFiat: $currentCurrency,
 			defaultCrypto,
@@ -92,7 +105,34 @@
 			supportRecurringPayments: true,
 			enableCountrySelector: true,
 			themeName: 'dark' // we always pass dark, as some card elements aren't styled correctly (white text on white background) in light theme / onramper bug?
-		});
+		};
+
+		if (!signed) {
+			src = buildUnsignedOnramperLink(params);
+			signingFailed = false;
+			return;
+		}
+
+		let cancelled = false;
+		src = undefined;
+		signingFailed = false;
+
+		buildOnramperLink({ identity: currentIdentity, ...params })
+			.then((url) => {
+				if (!cancelled) {
+					src = url;
+				}
+			})
+			.catch((error: unknown) => {
+				if (!cancelled) {
+					consoleError('Could not sign OnRamper widget URL', error);
+					signingFailed = true;
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
 	});
 
 	let themeLoaded = $state(false);
@@ -131,24 +171,28 @@
 <!-- When Onramper engineers were inquired about the reason, they answered: -->
 <!-- "In order to do customer verification before purchase, we require the following permissions to be given to the app. So this is definitely merely for the KYC  and also for fraud detection algorithms i suppose" -->
 
-<div
-	class="absolute top-0 right-0 bottom-0 left-0 bg-surface text-brand-primary transition-all duration-500 ease-in-out"
-	class:invisible={themeLoaded && nonNullish(src)}
-	class:opacity-0={themeLoaded && nonNullish(src)}
-	class:opacity-100={!themeLoaded || !nonNullish(src)}
->
-	<Spinner inline />
-</div>
+{#if signingFailed}
+	<BuyUnavailableNotice />
+{:else}
+	<div
+		class="absolute top-0 right-0 bottom-0 left-0 bg-surface text-brand-primary transition-all duration-500 ease-in-out"
+		class:invisible={themeLoaded && nonNullish(src)}
+		class:opacity-0={themeLoaded && nonNullish(src)}
+		class:opacity-100={!themeLoaded || !nonNullish(src)}
+	>
+		<Spinner inline />
+	</div>
 
-{#if nonNullish(src)}
-	<iframe
-		allow="accelerometer; autoplay; camera; gyroscope; payment; microphone"
-		data-tid={BUY_MODAL_ONRAMPER_IFRAME}
-		height="680px"
-		onload={changeThemeOnIframeLoad}
-		sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
-		{src}
-		title={$i18n.buy.onramper.title}
-		width="100%"
-	></iframe>
+	{#if nonNullish(src)}
+		<iframe
+			allow="accelerometer; autoplay; camera; gyroscope; payment; microphone"
+			data-tid={BUY_MODAL_ONRAMPER_IFRAME}
+			height="680px"
+			onload={changeThemeOnIframeLoad}
+			sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
+			{src}
+			title={$i18n.buy.onramper.title}
+			width="100%"
+		></iframe>
+	{/if}
 {/if}

--- a/src/frontend/src/lib/utils/onramper.utils.ts
+++ b/src/frontend/src/lib/utils/onramper.utils.ts
@@ -1,4 +1,5 @@
 import { ONRAMPER_API_KEY, ONRAMPER_BASE_URL } from '$env/rest/onramper.env';
+import { signOnramperWidgetUrl } from '$lib/api/backend.api';
 import type { Network } from '$lib/types/network';
 import type {
 	OnramperCryptoWallet,
@@ -11,8 +12,10 @@ import type {
 } from '$lib/types/onramper';
 import { nonNullish } from '@dfinity/utils';
 import type { Nullish } from '@dfinity/zod-schemas';
+import type { Identity } from '@icp-sdk/core/agent';
 
 export interface BuildOnramperLinkParams {
+	identity: Identity;
 	mode: OnramperMode;
 	defaultFiat: OnramperFiatId;
 	defaultCrypto?: OnramperId;
@@ -33,7 +36,9 @@ const walletToParam = ({ wallet, ...rest }: OnramperCryptoWallet | OnramperNetwo
 const walletsToParam = (wallets: OnramperCryptoWallet[] | OnramperNetworkWallet[]) =>
 	arrayToParam(wallets.map(walletToParam));
 
-const toQueryString = (params: Omit<BuildOnramperLinkParams, 'wallets' | 'networkWallets'>) =>
+const toQueryString = (
+	params: Omit<BuildOnramperLinkParams, 'identity' | 'wallets' | 'networkWallets'>
+) =>
 	Object.entries(params)
 		.reduce<string[]>(
 			(acc, [key, value]) =>
@@ -48,20 +53,36 @@ const toQueryString = (params: Omit<BuildOnramperLinkParams, 'wallets' | 'networ
 		)
 		.join('&');
 
+const composeOnramperUrl = ({
+	wallets,
+	networkWallets,
+	params
+}: {
+	wallets: OnramperCryptoWallet[];
+	networkWallets: OnramperNetworkWallet[];
+	params: Omit<BuildOnramperLinkParams, 'identity' | 'wallets' | 'networkWallets'>;
+}): string => {
+	const walletsParam = wallets.length > 0 ? `&wallets=${walletsToParam(wallets)}` : '';
+	const networkWalletsParam =
+		networkWallets.length > 0 ? `&networkWallets=${walletsToParam(networkWallets)}` : '';
+
+	return `${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}&${toQueryString(params)}${walletsParam}${networkWalletsParam}`;
+};
+
 /**
- * Build a source link for the OnRamper widget, given a set of parameters.
+ * Build a signed source link for the OnRamper widget, given a set of parameters.
  *
- * DEMO BRANCH — NOT FOR MERGE: OnRamper requires widget URLs to carry an HMAC-SHA256 signature
- * over the sensitive parameters (`wallets`, `networkWallets`, `walletAddressTags`) since April
- * 2025; production obtains that signature from the backend canister (which holds the secret) and
- * appends it as `&signature=<hex>`. This variant skips the backend round-trip entirely and returns
- * the composed URL unsigned, so the widget can be opened without provisioning the signing secret.
- * OnRamper will likely reject the unsigned URL with `Invalid Signature` inside the iframe.
+ * OnRamper requires widget URLs to carry an HMAC-SHA256 signature over the three sensitive
+ * parameters (`wallets`, `networkWallets`, `walletAddressTags`) since April 2025 — unsigned
+ * requests are rejected with `Invalid Signature`. The signing secret is held by the backend
+ * canister so it never reaches the frontend bundle; this function calls the canister to obtain
+ * the signature and appends it as `&signature=<hex>` to the otherwise-unchanged URL.
  *
  * The documentation for the OnRamper widget's parameters can be found here:
  * https://docs.onramper.com/docs/supported-widget-parameters
  *
  * @param params - The parameters to build the link with.
+ * @param params.identity - The authenticated identity used to call the backend signing endpoint.
  * @param params.mode - The mode of the widget (buy or sell).
  * @param params.defaultFiat - The default fiat currency.
  * @param params.defaultCrypto - The optional default cryptocurrency.
@@ -71,19 +92,41 @@ const toQueryString = (params: Omit<BuildOnramperLinkParams, 'wallets' | 'networ
  * @param params.networkWallets - The list of combination of network and wallet addresses.
  * @param params.supportRecurringPayments - Whether to support recurring payments.
  * @param params.enableCountrySelector - Whether to enable the country selector.
- * @returns The unsigned OnRamper source link.
+ * @returns The signed OnRamper source link.
+ * @throws If the backend signing call fails (e.g. the OnRamper signing secret is not configured).
  */
-export const buildOnramperLink = ({
+export const buildOnramperLink = async ({
+	identity,
 	wallets,
 	networkWallets,
 	...params
-}: BuildOnramperLinkParams): string => {
-	const walletsParam = wallets.length > 0 ? `&wallets=${walletsToParam(wallets)}` : '';
-	const networkWalletsParam =
-		networkWallets.length > 0 ? `&networkWallets=${walletsToParam(networkWallets)}` : '';
+}: BuildOnramperLinkParams): Promise<string> => {
+	const signature = await signOnramperWidgetUrl({
+		identity,
+		wallets,
+		networkWallets
+	});
 
-	return `${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}&${toQueryString(params)}${walletsParam}${networkWalletsParam}`;
+	return `${composeOnramperUrl({ wallets, networkWallets, params })}&signature=${signature}`;
 };
+
+/**
+ * DEMO BRANCH — NOT FOR MERGE: build the OnRamper widget link WITHOUT the backend HMAC signature.
+ *
+ * Identical to {@link buildOnramperLink} but skips the backend signing round-trip and omits the
+ * `&signature=<hex>` parameter, so the widget can be opened without provisioning the signing
+ * secret. OnRamper will likely reject the unsigned URL with `Invalid Signature` inside the iframe.
+ *
+ * @param params - The same parameters as {@link buildOnramperLink}, minus `identity` (no backend
+ *   call is made).
+ * @returns The unsigned OnRamper source link.
+ */
+export const buildUnsignedOnramperLink = ({
+	wallets,
+	networkWallets,
+	...params
+}: Omit<BuildOnramperLinkParams, 'identity'>): string =>
+	composeOnramperUrl({ wallets, networkWallets, params });
 
 /** Map a list of networks to a list of Onramper wallets.
  *

--- a/src/frontend/src/lib/utils/onramper.utils.ts
+++ b/src/frontend/src/lib/utils/onramper.utils.ts
@@ -1,5 +1,4 @@
 import { ONRAMPER_API_KEY, ONRAMPER_BASE_URL } from '$env/rest/onramper.env';
-import { signOnramperWidgetUrl } from '$lib/api/backend.api';
 import type { Network } from '$lib/types/network';
 import type {
 	OnramperCryptoWallet,
@@ -12,10 +11,8 @@ import type {
 } from '$lib/types/onramper';
 import { nonNullish } from '@dfinity/utils';
 import type { Nullish } from '@dfinity/zod-schemas';
-import type { Identity } from '@icp-sdk/core/agent';
 
 export interface BuildOnramperLinkParams {
-	identity: Identity;
 	mode: OnramperMode;
 	defaultFiat: OnramperFiatId;
 	defaultCrypto?: OnramperId;
@@ -36,9 +33,7 @@ const walletToParam = ({ wallet, ...rest }: OnramperCryptoWallet | OnramperNetwo
 const walletsToParam = (wallets: OnramperCryptoWallet[] | OnramperNetworkWallet[]) =>
 	arrayToParam(wallets.map(walletToParam));
 
-const toQueryString = (
-	params: Omit<BuildOnramperLinkParams, 'identity' | 'wallets' | 'networkWallets'>
-) =>
+const toQueryString = (params: Omit<BuildOnramperLinkParams, 'wallets' | 'networkWallets'>) =>
 	Object.entries(params)
 		.reduce<string[]>(
 			(acc, [key, value]) =>
@@ -54,19 +49,19 @@ const toQueryString = (
 		.join('&');
 
 /**
- * Build a signed source link for the OnRamper widget, given a set of parameters.
+ * Build a source link for the OnRamper widget, given a set of parameters.
  *
- * OnRamper requires widget URLs to carry an HMAC-SHA256 signature over the three sensitive
- * parameters (`wallets`, `networkWallets`, `walletAddressTags`) since April 2025 — unsigned
- * requests are rejected with `Invalid Signature`. The signing secret is held by the backend
- * canister so it never reaches the frontend bundle; this function calls the canister to obtain
- * the signature and appends it as `&signature=<hex>` to the otherwise-unchanged URL.
+ * DEMO BRANCH — NOT FOR MERGE: OnRamper requires widget URLs to carry an HMAC-SHA256 signature
+ * over the sensitive parameters (`wallets`, `networkWallets`, `walletAddressTags`) since April
+ * 2025; production obtains that signature from the backend canister (which holds the secret) and
+ * appends it as `&signature=<hex>`. This variant skips the backend round-trip entirely and returns
+ * the composed URL unsigned, so the widget can be opened without provisioning the signing secret.
+ * OnRamper will likely reject the unsigned URL with `Invalid Signature` inside the iframe.
  *
  * The documentation for the OnRamper widget's parameters can be found here:
  * https://docs.onramper.com/docs/supported-widget-parameters
  *
  * @param params - The parameters to build the link with.
- * @param params.identity - The authenticated identity used to call the backend signing endpoint.
  * @param params.mode - The mode of the widget (buy or sell).
  * @param params.defaultFiat - The default fiat currency.
  * @param params.defaultCrypto - The optional default cryptocurrency.
@@ -76,26 +71,18 @@ const toQueryString = (
  * @param params.networkWallets - The list of combination of network and wallet addresses.
  * @param params.supportRecurringPayments - Whether to support recurring payments.
  * @param params.enableCountrySelector - Whether to enable the country selector.
- * @returns The signed OnRamper source link.
- * @throws If the backend signing call fails (e.g. the OnRamper signing secret is not configured).
+ * @returns The unsigned OnRamper source link.
  */
-export const buildOnramperLink = async ({
-	identity,
+export const buildOnramperLink = ({
 	wallets,
 	networkWallets,
 	...params
-}: BuildOnramperLinkParams): Promise<string> => {
-	const signature = await signOnramperWidgetUrl({
-		identity,
-		wallets,
-		networkWallets
-	});
-
+}: BuildOnramperLinkParams): string => {
 	const walletsParam = wallets.length > 0 ? `&wallets=${walletsToParam(wallets)}` : '';
 	const networkWalletsParam =
 		networkWallets.length > 0 ? `&networkWallets=${walletsToParam(networkWallets)}` : '';
 
-	return `${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}&${toQueryString(params)}${walletsParam}${networkWalletsParam}&signature=${signature}`;
+	return `${ONRAMPER_BASE_URL}?apiKey=${ONRAMPER_API_KEY}&${toQueryString(params)}${walletsParam}${networkWalletsParam}`;
 };
 
 /** Map a list of networks to a list of Onramper wallets.

--- a/src/frontend/src/tests/lib/components/buy/BuyModalContent.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyModalContent.spec.ts
@@ -19,12 +19,11 @@ describe('BuyModalContent', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('renders the Onramper iframe when ONRAMPER_ENABLED is true', async () => {
+	it('renders the Onramper iframe in unsigned mode (default) when ONRAMPER_ENABLED is true', async () => {
 		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => true);
 
 		const { findByTestId } = render(BuyModalContent);
 
-		// The iframe is rendered only after the async signing call resolves.
 		await expect(findByTestId(BUY_MODAL_ONRAMPER_IFRAME)).resolves.toBeInTheDocument();
 	});
 
@@ -37,24 +36,34 @@ describe('BuyModalContent', () => {
 		expect(queryByTestId(BUY_MODAL_ONRAMPER_IFRAME)).not.toBeInTheDocument();
 	});
 
-	it('renders the unavailable notice when the backend reports onramper disabled', async () => {
+	it('renders the unsigned iframe without calling the backend, even if signing would fail', async () => {
 		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => true);
-		vi.spyOn(backendApi, 'onramperEnabled').mockResolvedValue(false);
+		const signSpy = vi
+			.spyOn(backendApi, 'signOnramperWidgetUrl')
+			.mockRejectedValue(new Error('signing must not be invoked in unsigned mode'));
 
-		const { findByText, queryByTestId } = render(BuyModalContent);
+		const { findByTestId } = render(BuyModalContent);
 
-		await expect(findByText(en.buy.text.unavailable_title)).resolves.toBeInTheDocument();
-
-		await waitFor(() => expect(queryByTestId(BUY_MODAL_ONRAMPER_IFRAME)).not.toBeInTheDocument());
+		await expect(findByTestId(BUY_MODAL_ONRAMPER_IFRAME)).resolves.toBeInTheDocument();
+		expect(signSpy).not.toHaveBeenCalled();
 	});
 
-	it('renders the unavailable notice when ONRAMPER_ENABLED is true but signing fails', async () => {
+	it('renders the signed iframe when ONRAMPER_ENABLED is true and signing succeeds', async () => {
+		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => true);
+
+		const { findByTestId } = render(BuyModalContent, { props: { signed: true } });
+
+		// The iframe is rendered only after the async backend signing call resolves.
+		await expect(findByTestId(BUY_MODAL_ONRAMPER_IFRAME)).resolves.toBeInTheDocument();
+	});
+
+	it('renders the unavailable notice in signed mode when signing fails', async () => {
 		vi.spyOn(onramperEnv, 'ONRAMPER_ENABLED', 'get').mockImplementation(() => true);
 		vi.spyOn(backendApi, 'signOnramperWidgetUrl').mockRejectedValue(
 			new Error('OnRamper signing secret is not configured on the backend canister.')
 		);
 
-		const { findByText, queryByTestId } = render(BuyModalContent);
+		const { findByText, queryByTestId } = render(BuyModalContent, { props: { signed: true } });
 
 		await expect(findByText(en.buy.text.unavailable_title)).resolves.toBeInTheDocument();
 


### PR DESCRIPTION
> ⚠️ **Demo branch — not intended for merge.** It adds a second buy button that deliberately bypasses the OnRamper URL-signing security mechanism, and force-enables the buy widget on every environment (including beta), to compare the signed and unsigned flows without provisioning the backend signing secret.

# Motivation

On staging the Buy button shows _"Buying tokens is temporarily unavailable … while we further improve the security of this process by introducing URL signing."_ even though the build-time `ONRAMPER_ENABLED` flag is on. The widget is additionally gated by a runtime backend check (`onramper_enabled`), which only returns `true` once a controller has provisioned the `onramper_signing_secret` on the backend canister. Until that secret exists, the widget stays hidden.

This branch lets us exercise the OnRamper widget (on staging or beta) before the signing secret is provisioned, and to compare the two URL flows side by side.

# Changes

Two buy buttons are rendered where there was one:

- **"Buy"** — opens the widget with the fully composed URL **unsigned**, with no backend dependency.
- **"Buy S"** — opens the widget with the production **signed** URL (HMAC obtained from the backend canister), exactly as the real flow works.

Implementation:

- `onramper.env.ts`: `ONRAMPER_ENABLED` is forced to always-true (was `LOCAL || STAGING`) so the widget is enabled on beta and production too — required to deploy this demo to beta.
- `onramper.utils.ts`: keeps the production signed `buildOnramperLink` (backend HMAC + `&signature=<hex>`) and adds `buildUnsignedOnramperLink` for the frontend-only variant; both share a private `composeOnramperUrl` helper.
- `OnramperWidget.svelte`: a `signed` prop selects between the async backend-signed URL (with the signing-failure notice fallback) and the synchronous unsigned URL.
- `BuyModalContent.svelte` / `BuyModal.svelte`: forward the `signed` flag from the button to the widget. The build-time `ONRAMPER_ENABLED` flag still gates the modal; the runtime `onramper_enabled` backend pre-check is dropped (signed mode now surfaces signing failures inside the widget instead).
- `Buy.svelte` / `BuyButton.svelte`: render the two buttons; `BuyButton` gains optional `buttonLabel` / `testId` overrides so "Buy S" is distinct.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0` and `npm run check` pass for the changed source files. (The unrelated pre-existing `svelte-check` errors in `sol`/`btc`/`ic-pub-key` modules come from local `node_modules` version skew and are not from this branch.)
- `onramper.utils.spec.ts` passes (the signed builder is unchanged from production). `BuyModalContent.spec.ts` was updated to the two-mode behavior: unsigned mode renders the iframe **without calling the backend**, signed mode renders it once signing succeeds, and signed mode falls back to the unavailable notice when signing fails. Affected suites: 37 tests green (`onramper.utils`, `BuyModalContent`, `BuyButton`, hero `Actions`).

⚠️ OnRamper rejects unsigned widget URLs (`Invalid Signature`) since April 2025, so the **"Buy"** (unsigned) button may show an error inside the iframe. The point is that the widget **opens with the full composed URL**, not that OnRamper accepts it. On a backend without the signing secret, **"Buy S"** will show the unavailable notice (signing fails) — the same behavior as production today.

⚠️ On **beta** (and production), OnRamper runs in its non-dev mode: the widget hits `https://buy.onramper.com` with the **prod** API key (`VITE_ONRAMPER_API_KEY_PROD`), not the dev endpoint used on staging.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)
