### PR TITLE
refactor(frontend): vendor keyboard.utils (handleKeyPress) shared util

### DIFF
--- a/src/frontend/src/lib/utils/keyboard.utils.ts
+++ b/src/frontend/src/lib/utils/keyboard.utils.ts
@@ -1,0 +1,13 @@
+export const handleKeyPress = ({
+	$event: { code },
+	callback
+}: {
+	$event: KeyboardEvent;
+	callback: () => void;
+}) => {
+	if (!['Enter', 'Space'].includes(code)) {
+		return;
+	}
+
+	callback();
+};


### PR DESCRIPTION
# Motivation

Shared `handleKeyPress` helper used by the gix components being brought in-house (Backdrop, Checkbox, Collapsible, …). It was added to the shared-mixins gate branch *after* that PR squash-merged, so it never reached `main` — this re-lands it directly.

# Changes

- Vendor `$lib/utils/keyboard.utils.ts` (pure, dependency-free).

# Tests

- Prettier clean; pure util, type-checked via consumers.