### PR TITLE
refactor(frontend): own gix Spinner as LoaderSpinner, detach from gix

### DIFF
--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Spinner } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 	import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
@@ -17,6 +16,7 @@
 		OnramperSecretNotConfiguredError
 	} from '$lib/canisters/errors';
 	import BuyUnavailableNotice from '$lib/components/buy/BuyUnavailableNotice.svelte';
+	import LoaderSpinner from '$lib/components/ui/LoaderSpinner.svelte';
 	import { BUY_MODAL_ONRAMPER_IFRAME } from '$lib/constants/test-ids.constants';
 	import { btcAddressMainnet, ethAddress, solAddressMainnet } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -203,7 +203,7 @@
 		class:opacity-0={themeLoaded && nonNullish(src)}
 		class:opacity-100={!themeLoaded || !nonNullish(src)}
 	>
-		<Spinner inline />
+		<LoaderSpinner inline />
 	</div>
 
 	{#if nonNullish(src)}

--- a/src/frontend/src/lib/components/signer/SignerLoading.svelte
+++ b/src/frontend/src/lib/components/signer/SignerLoading.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Spinner } from '@dfinity/gix-components';
 	import type { Snippet } from 'svelte';
 	import SignerCenteredContent from '$lib/components/signer/SignerCenteredContent.svelte';
+	import LoaderSpinner from '$lib/components/ui/LoaderSpinner.svelte';
 
 	interface Props {
 		children: Snippet;
@@ -12,7 +12,7 @@
 
 <SignerCenteredContent>
 	<div class="text-brand-primary">
-		<Spinner inline />
+		<LoaderSpinner inline />
 	</div>
 	<span>{@render children()}</span>
 </SignerCenteredContent>

--- a/src/frontend/src/lib/components/ui/Busy.svelte
+++ b/src/frontend/src/lib/components/ui/Busy.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Spinner } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
+	import LoaderSpinner from '$lib/components/ui/LoaderSpinner.svelte';
 	import { busy } from '$lib/stores/busy.store';
 	import { stopPropagation } from '$lib/utils/event-modifiers.utils';
 
@@ -36,7 +36,7 @@
 		<div class="content">
 			{#if $busy.spinner}
 				<div class="spinner text-off-white">
-					<Spinner />
+					<LoaderSpinner />
 				</div>
 			{/if}
 

--- a/src/frontend/src/lib/components/ui/LoaderSpinner.svelte
+++ b/src/frontend/src/lib/components/ui/LoaderSpinner.svelte
@@ -1,0 +1,158 @@
+<!-- adapted source: https://github.com/angular/components/tree/master/src/material/progress-spinner -->
+<script lang="ts">
+	interface Props {
+		inline?: boolean;
+		size?: 'tiny' | 'small' | 'medium';
+	}
+
+	let { inline = false, size = 'medium' }: Props = $props();
+</script>
+
+<svg
+	class={size}
+	class:inline
+	aria-hidden="true"
+	data-tid="spinner"
+	focusable="false"
+	preserveAspectRatio="xMidYMid meet"
+	viewBox="0 0 100 100"><circle cx="50%" cy="50%" r="45" /></svg
+>
+
+<style lang="scss">
+	@use 'sass:math';
+
+	.medium {
+		--spinner-size: 30px;
+	}
+
+	.small {
+		--spinner-size: calc(var(--line-height-standard) * 1rem);
+	}
+
+	.tiny {
+		--spinner-size: calc(var(--line-height-standard) * 0.5rem);
+	}
+
+	svg {
+		width: var(--spinner-size);
+		height: var(--spinner-size);
+
+		animation: spinner-linear-rotate 2000ms linear infinite;
+
+		position: absolute;
+		top: calc(50% - (var(--spinner-size) / 2));
+		left: calc(50% - (var(--spinner-size) / 2));
+
+		// same as <circle r=""/> attribute
+		--radius: 45px;
+		--circumference: calc(#{math.$pi} * var(--radius) * 2);
+
+		// start the animation at 5%
+		--start: calc((1 - 0.05) * var(--circumference));
+		--end: calc((1 - 0.8) * var(--circumference));
+
+		&.inline {
+			display: inline-block;
+			position: relative;
+		}
+	}
+
+	circle {
+		stroke-dasharray: var(--circumference);
+		stroke-width: 10%;
+		transform-origin: 50% 50% 0;
+
+		transition-property: stroke;
+
+		animation-name: spinner-stroke-rotate-100;
+		animation-duration: 4000ms;
+		animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1);
+		animation-iteration-count: infinite;
+
+		fill: transparent;
+		stroke: currentColor;
+
+		transition: stroke-dashoffset 225ms linear;
+	}
+
+	/* -global- */
+	@keyframes -global-spinner-linear-rotate {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+
+	/* -global- */
+	@keyframes -global-spinner-stroke-rotate-100 {
+		0% {
+			stroke-dashoffset: var(--start);
+			transform: rotate(0);
+		}
+		12.5% {
+			stroke-dashoffset: var(--end);
+			transform: rotate(0);
+		}
+		12.5001% {
+			stroke-dashoffset: var(--end);
+			transform: rotateX(180deg) rotate(72.5deg);
+		}
+		25% {
+			stroke-dashoffset: var(--start);
+			transform: rotateX(180deg) rotate(72.5deg);
+		}
+
+		25.0001% {
+			stroke-dashoffset: var(--start);
+			transform: rotate(270deg);
+		}
+		37.5% {
+			stroke-dashoffset: var(--end);
+			transform: rotate(270deg);
+		}
+		37.5001% {
+			stroke-dashoffset: var(--end);
+			transform: rotateX(180deg) rotate(161.5deg);
+		}
+		50% {
+			stroke-dashoffset: var(--start);
+			transform: rotateX(180deg) rotate(161.5deg);
+		}
+
+		50.0001% {
+			stroke-dashoffset: var(--start);
+			transform: rotate(180deg);
+		}
+		62.5% {
+			stroke-dashoffset: var(--end);
+			transform: rotate(180deg);
+		}
+		62.5001% {
+			stroke-dashoffset: var(--end);
+			transform: rotateX(180deg) rotate(251.5deg);
+		}
+		75% {
+			stroke-dashoffset: var(--start);
+			transform: rotateX(180deg) rotate(251.5deg);
+		}
+
+		75.0001% {
+			stroke-dashoffset: var(--start);
+			transform: rotate(90deg);
+		}
+		87.5% {
+			stroke-dashoffset: var(--end);
+			transform: rotate(90deg);
+		}
+		87.5001% {
+			stroke-dashoffset: var(--end);
+			transform: rotateX(180deg) rotate(341.5deg);
+		}
+		100% {
+			stroke-dashoffset: var(--start);
+			transform: rotateX(180deg) rotate(341.5deg);
+		}
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/LoaderWithOverlay.svelte
+++ b/src/frontend/src/lib/components/ui/LoaderWithOverlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Spinner } from '@dfinity/gix-components';
+	import LoaderSpinner from '$lib/components/ui/LoaderSpinner.svelte';
 
 	interface Props {
 		testId?: string;
@@ -16,7 +16,7 @@
 	data-tid={testId}
 	role="status"
 >
-	<Spinner />
+	<LoaderSpinner />
 </div>
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectReview.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectReview.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Spinner } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { WalletKitTypes } from '@reown/walletkit';
 	import { onDestroy, onMount } from 'svelte';
@@ -9,6 +8,7 @@
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import LoaderSpinner from '$lib/components/ui/LoaderSpinner.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
 	import WalletConnectDomainVerification from '$lib/components/wallet-connect/WalletConnectDomainVerification.svelte';
 	import { isBusy } from '$lib/derived/busy.derived';
@@ -174,7 +174,7 @@
 		<div class="stretch">
 			<div class="flex h-[100%] min-h-[30vh] flex-col items-center justify-center gap-2 pt-8">
 				<div>
-					<Spinner inline />
+					<LoaderSpinner inline />
 				</div>
 				<p>{$i18n.wallet_connect.text.connecting}</p>
 			</div>

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import { Spinner, SystemThemeListener, Toasts } from '@dfinity/gix-components';
+	import { SystemThemeListener, Toasts } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { onDestroy, onMount, type Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { browser } from '$app/environment';
 	import Banner from '$lib/components/core/Banner.svelte';
 	import Busy from '$lib/components/ui/Busy.svelte';
+	import LoaderSpinner from '$lib/components/ui/LoaderSpinner.svelte';
 	import ModalExitHandler from '$lib/components/ui/ModalExitHandler.svelte';
 	import ResponsiveListener from '$lib/components/ui/ResponsiveListener.svelte';
 	import {
@@ -193,7 +194,7 @@
 
 {#await init()}
 	<div class="text-brand-primary" in:fade>
-		<Spinner />
+		<LoaderSpinner />
 	</div>
 {:then _}
 	{@render children()}


### PR DESCRIPTION
# Motivation

Detaching OISY from `@dfinity/gix-components` (now maintenance-mode). gix's `Spinner` (Material progress-spinner used for overlay/page loading) **collides by name** with OISY's own simple `ui/Spinner`, so it's brought in-house as a distinct native component, **`LoaderSpinner`**.

# Changes

- New `$lib/components/ui/LoaderSpinner.svelte` — gix's source is already Svelte 5; self-contained styles + `@keyframes`, kept `data-tid="spinner"` for parity (LoaderWithOverlay's spec queries it).
- Rewire the 6 gix `Spinner` consumers (`Busy`, `SignerLoading`, `LoaderWithOverlay`, `WalletConnectReview`, `OnramperWidget`, `+layout`) to `LoaderSpinner`.
- OISY's existing `ui/Spinner` (different, simpler) is untouched.
- No new deps, no behavioral change.

# Tests

- `lint --max-warnings 0` clean; `check` clean (only the pre-existing unrelated `sol-instructions-system` error)
- LoaderWithOverlay + Busy specs pass (14)