### PR TITLE
refactor(frontend): own Html natively, detach from gix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"browser-image-compression": "^2.0.2",
 				"buffer": "^6.0.3",
 				"decimal.js": "^10.6.0",
+				"dompurify": "^3.4.10",
 				"ethers": "^6.16.0",
 				"idb-keyval": "6.2.4",
 				"onesec-bridge": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
 		"browser-image-compression": "^2.0.2",
 		"buffer": "^6.0.3",
 		"decimal.js": "^10.6.0",
+		"dompurify": "^3.4.10",
 		"ethers": "^6.16.0",
 		"idb-keyval": "6.2.4",
 		"onesec-bridge": "^0.12.0",

--- a/src/frontend/src/eth/components/convert/EthConvertForm.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { getContext, type Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
@@ -7,6 +6,7 @@
 	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import { ckUsdcConversionDisabled } from '$icp-eth/derived/cketh.derived';
 	import ConvertForm from '$lib/components/convert/ConvertForm.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { ETH_CONVERT_FORM_TEST_ID } from '$lib/constants/test-ids.constants';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';

--- a/src/frontend/src/eth/components/convert/EthConvertReview.svelte
+++ b/src/frontend/src/eth/components/convert/EthConvertReview.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { getContext, type Snippet } from 'svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
 	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import ConvertReview from '$lib/components/convert/ConvertReview.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { CONVERT_CONTEXT_KEY, type ConvertContext } from '$lib/stores/convert.store';
 	import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/eth/components/send/EthSendForm.svelte
+++ b/src/frontend/src/eth/components/send/EthSendForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { isNullish } from '@dfinity/utils';
 	import { getContext, type Snippet } from 'svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
@@ -8,6 +7,7 @@
 	import { isEthAddress } from '$eth/utils/account.utils';
 	import SendFeeInfo from '$lib/components/send/SendFeeInfo.svelte';
 	import SendForm from '$lib/components/send/SendForm.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactUi } from '$lib/types/contact';
 	import type { OptionAmount } from '$lib/types/send';

--- a/src/frontend/src/eth/components/send/EthSendReview.svelte
+++ b/src/frontend/src/eth/components/send/EthSendReview.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { isNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
@@ -7,6 +6,7 @@
 	import { isEthAddress } from '$eth/utils/account.utils';
 	import ReviewNetwork from '$lib/components/send/ReviewNetwork.svelte';
 	import SendReview from '$lib/components/send/SendReview.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { ContactUi } from '$lib/types/contact';

--- a/src/frontend/src/eth/components/stake/harvest-autopilot/HarvestStakeAgreement.svelte
+++ b/src/frontend/src/eth/components/stake/harvest-autopilot/HarvestStakeAgreement.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
 	interface Props {

--- a/src/frontend/src/eth/components/swap/SwapEthFeeInfo.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthFeeInfo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { SWAP_FEE_INFO } from '$lib/constants/test-ids.constants';

--- a/src/frontend/src/eth/components/swap/SwapEthForm.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
@@ -11,6 +10,7 @@
 	import SwapGaslessFee from '$lib/components/swap/SwapGaslessFee.svelte';
 	import SwapProvider from '$lib/components/swap/SwapProvider.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
@@ -23,6 +22,7 @@
 	import SwapGaslessFee from '$lib/components/swap/SwapGaslessFee.svelte';
 	import SwapProgress from '$lib/components/swap/SwapProgress.svelte';
 	import SwapReview from '$lib/components/swap/SwapReview.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import {
 		TRACK_COUNT_SWAP_ERROR,
 		TRACK_COUNT_SWAP_SUBMITTED,

--- a/src/frontend/src/lib/components/about/AboutFeatureItem.svelte
+++ b/src/frontend/src/lib/components/about/AboutFeatureItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import type { Snippet } from 'svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
 	interface Props {

--- a/src/frontend/src/lib/components/address-book/DeleteAddressConfirmContent.svelte
+++ b/src/frontend/src/lib/components/address-book/DeleteAddressConfirmContent.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { ContactAddressUi, ContactUi } from '$lib/types/contact';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';

--- a/src/frontend/src/lib/components/agreements/AgreementsBanner.svelte
+++ b/src/frontend/src/lib/components/agreements/AgreementsBanner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { Html, IconClose } from '@dfinity/gix-components';
+	import { IconClose } from '@dfinity/gix-components';
 	import { notEmptyString } from '@dfinity/utils';
+	import Html from '$lib/components/ui/Html.svelte';
 	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import {
 		AGREEMENTS_WARNING_BANNER,

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendEthToken.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantReviewSendEthToken.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 	import { getContext, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
@@ -23,6 +22,7 @@
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { mapAddressStartsWith0x } from '$icp-eth/utils/eth.utils';
 	import Button from '$lib/components/ui/Button.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import {
 		AI_ASSISTANT_REVIEW_SEND_TOOL_CONFIRMATION,
 		AI_ASSISTANT_SEND_TOKEN_SOURCE,

--- a/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
+++ b/src/frontend/src/lib/components/auth/ButtonAuthenticateWithHelp.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import ButtonsSignIn from '$lib/components/auth/ButtonsSignIn.svelte';
 	import SigningInHelpLink from '$lib/components/auth/SigningInHelpLink.svelte';
 	import TermsOfUseLink from '$lib/components/terms-of-use/TermsOfUseLink.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { AUTH_SIGNING_IN_HELP_LINK } from '$lib/constants/test-ids.constants';
 	import { signIn } from '$lib/services/auth.services';
 	import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/lib/components/core/PwaBanner.svelte
+++ b/src/frontend/src/lib/components/core/PwaBanner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Html, IconClose } from '@dfinity/gix-components';
+	import { IconClose } from '@dfinity/gix-components';
+	import Html from '$lib/components/ui/Html.svelte';
 	import InfoBanner from '$lib/components/ui/InfoBanner.svelte';
 	import {
 		PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID,

--- a/src/frontend/src/lib/components/dapps/DappModal.svelte
+++ b/src/frontend/src/lib/components/dapps/DappModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Html, Modal } from '@dfinity/gix-components';
+	import { Modal } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import DappTags from '$lib/components/dapps/DappTags.svelte';
 	import IconGitHub from '$lib/components/icons/IconGitHub.svelte';
@@ -9,6 +9,7 @@
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import ExternalLinkIcon from '$lib/components/ui/ExternalLinkIcon.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import ImgBanner from '$lib/components/ui/ImgBanner.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { TRACK_COUNT_DAPP_MODAL_OPEN_HYPERLINK } from '$lib/constants/analytics.constants';

--- a/src/frontend/src/lib/components/nfts/NftHideButton.svelte
+++ b/src/frontend/src/lib/components/nfts/NftHideButton.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import IconEye from '$lib/components/icons/lucide/IconEye.svelte';
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
 	import NftActionButton from '$lib/components/nfts/NftActionButton.svelte';
 	import ConfirmButtonWithModal from '$lib/components/ui/ConfirmButtonWithModal.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import {
 		CONFIRMATION_MODAL,
 		NFT_COLLECTION_ACTION_HIDE,

--- a/src/frontend/src/lib/components/nfts/NftSpamButton.svelte
+++ b/src/frontend/src/lib/components/nfts/NftSpamButton.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import IconAlertOctagon from '$lib/components/icons/lucide/IconAlertOctagon.svelte';
 	import NftActionButton from '$lib/components/nfts/NftActionButton.svelte';
 	import ConfirmButtonWithModal from '$lib/components/ui/ConfirmButtonWithModal.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import {
 		CONFIRMATION_MODAL,
 		NFT_COLLECTION_ACTION_NOT_SPAM,

--- a/src/frontend/src/lib/components/pay/PayDialogContent.svelte
+++ b/src/frontend/src/lib/components/pay/PayDialogContent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { OPEN_CRYPTO_PAY_ECOSYSTEM_URL } from '$lib/constants/open-crypto-pay.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';

--- a/src/frontend/src/lib/components/rewards/RewardCard.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardCard.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import EligibilityBadge from '$lib/components/rewards/EligibilityBadge.svelte';
 	import NetworkBonusImage from '$lib/components/rewards/NetworkBonusImage.svelte';
 	import RewardDateBadge from '$lib/components/rewards/RewardDateBadge.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import { NETWORK_BONUS_MULTIPLIER_DEFAULT } from '$lib/constants/app.constants';
 	import { REWARDS_BANNER, REWARDS_STATUS_BUTTON } from '$lib/constants/test-ids.constants';

--- a/src/frontend/src/lib/components/rewards/RewardModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Html, Modal } from '@dfinity/gix-components';
+	import { Modal } from '@dfinity/gix-components';
 	import { isNullish } from '@dfinity/utils';
 	import { getContext, onMount } from 'svelte';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
@@ -10,6 +10,7 @@
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Share from '$lib/components/ui/Share.svelte';
 	import {
 		TRACK_REWARD_CAMPAIGN_LEARN_MORE,

--- a/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardStateModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Html, Modal } from '@dfinity/gix-components';
+	import { Modal } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import Sprinkles from '$lib/components/sprinkles/Sprinkles.svelte';
@@ -7,6 +7,7 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import Share from '$lib/components/ui/Share.svelte';
 	import {

--- a/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardsGroup.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import RewardCard from '$lib/components/rewards/RewardCard.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import { TRACK_REWARD_CAMPAIGN_OPEN } from '$lib/constants/analytics.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';

--- a/src/frontend/src/lib/components/scanner/ScannerInfo.svelte
+++ b/src/frontend/src/lib/components/scanner/ScannerInfo.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import OisyScanPayImg from '$lib/assets/oisy-scan-pay-img.webp';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import ImgBanner from '$lib/components/ui/ImgBanner.svelte';
 	import { OISY_SCAN_URL, OISY_PAY_URL } from '$lib/constants/oisy.constants';
 	import {

--- a/src/frontend/src/lib/components/send/SendFeeInfo.svelte
+++ b/src/frontend/src/lib/components/send/SendFeeInfo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { SEND_FEE_INFO } from '$lib/constants/test-ids.constants';

--- a/src/frontend/src/lib/components/stake/StakeProviderContainer.svelte
+++ b/src/frontend/src/lib/components/stake/StakeProviderContainer.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { STAKE_PROVIDER_LOGO } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/lib/components/swap/SwapCrossChainInfo.svelte
+++ b/src/frontend/src/lib/components/swap/SwapCrossChainInfo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';

--- a/src/frontend/src/lib/components/swap/SwapNearIntentsTos.svelte
+++ b/src/frontend/src/lib/components/swap/SwapNearIntentsTos.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { NEAR_INTENTS_TOS_LINK } from '$lib/constants/swap.constants';
 	import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/lib/components/swap/SwapReview.svelte
+++ b/src/frontend/src/lib/components/swap/SwapReview.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { isEmptyString, isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext, type Snippet, untrack } from 'svelte';
 	import { NEAR_INTENTS_SWAP_ENABLED } from '$env/rest/near-intents.env';
@@ -14,6 +13,7 @@
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import {

--- a/src/frontend/src/lib/components/tokens/AddTokenWarning.svelte
+++ b/src/frontend/src/lib/components/tokens/AddTokenWarning.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>

--- a/src/frontend/src/lib/components/tokens/HideTokenReview.svelte
+++ b/src/frontend/src/lib/components/tokens/HideTokenReview.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { token } from '$lib/stores/token.store';

--- a/src/frontend/src/lib/components/tokens/NothingFoundPlaceholder.svelte
+++ b/src/frontend/src/lib/components/tokens/NothingFoundPlaceholder.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { notEmptyString } from '@dfinity/utils';
 	import shocked from '$lib/assets/shocked.svg';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 

--- a/src/frontend/src/lib/components/tokens/TokenModalDeleteConfirmation.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModalDeleteConfirmation.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import { TOKEN_MODAL_DELETE_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionToken } from '$lib/types/token';

--- a/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
+++ b/src/frontend/src/lib/components/transactions/HiddenMicroTransactionsInfoBox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import type { DismissedNotification } from '$declarations/backend/backend.did';
 	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { NOTIFICATION_VERSIONS } from '$lib/constants/notification.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';

--- a/src/frontend/src/lib/components/ui/Html.svelte
+++ b/src/frontend/src/lib/components/ui/Html.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { onMount } from 'svelte';
+	import { sanitize } from '$lib/utils/html.utils';
+
+	interface Props {
+		text?: string;
+	}
+
+	let { text }: Props = $props();
+
+	// force to rerender after SSR
+	let mounted = $state(false);
+	onMount(() => (mounted = true));
+</script>
+
+{#if mounted && nonNullish(text)}
+	<!-- eslint-disable svelte/no-at-html-tags -->
+	{@html sanitize(text)}
+{/if}

--- a/src/frontend/src/lib/components/welcome/WelcomeModal.svelte
+++ b/src/frontend/src/lib/components/welcome/WelcomeModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Modal, Html } from '@dfinity/gix-components';
+	import { Modal } from '@dfinity/gix-components';
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import episodeFour from '$lib/assets/oisy-episode-four.svg';
@@ -7,6 +7,7 @@
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Img from '$lib/components/ui/Img.svelte';
 	import Share from '$lib/components/ui/Share.svelte';
 	import { OISY_REWARDS_URL, OISY_WELCOME_TWITTER_URL } from '$lib/constants/oisy.constants';

--- a/src/frontend/src/lib/utils/html.utils.ts
+++ b/src/frontend/src/lib/utils/html.utils.ts
@@ -46,7 +46,7 @@ export const sanitize = (text: string): string => {
 		if (isNullish(domPurify)) {
 			domPurify = DOMPurify;
 
-			// Preserve target="blank" workaround
+			// Preserve target="_blank" (flagged via data-target) across sanitization
 			domPurify.addHook('beforeSanitizeAttributes', flagTargetAttributeHook);
 			domPurify.addHook('afterSanitizeAttributes', restoreTargetAttributeHook);
 		}

--- a/src/frontend/src/lib/utils/html.utils.ts
+++ b/src/frontend/src/lib/utils/html.utils.ts
@@ -1,3 +1,64 @@
+import { consoleError } from '$lib/utils/console.utils';
+import { isNullish } from '@dfinity/utils';
+import DOMPurify from 'dompurify';
+
+let domPurify: typeof DOMPurify | undefined = undefined;
+
+/**
+ * A workaround to preserve target="_blank" attribute from sanitizer.
+ * Utilizes data-target flag (set by flagTargetAttributeHook).
+ *
+ * Inspired by https://github.com/cure53/DOMPurify/issues/317#issuecomment-912474068
+ */
+const restoreTargetAttributeHook = (node: Element) => {
+	if (node.getAttribute('data-target') === 'blank') {
+		// Use provided "rel" value if it contains "noopener" or "noreferrer" (https://web.dev/external-anchors-use-rel-noopener/)
+		// otherwise add "noopener".
+		// split() to avoid invalid values (e.g. "noopenernoreferrer")
+		const originRel = node.getAttribute('rel') ?? '';
+		const parts = originRel.split(/\s+/);
+		const rel = parts.includes('noopener') || parts.includes('noreferrer') ? originRel : 'noopener';
+
+		node.setAttribute('target', '_blank');
+		node.setAttribute('rel', rel);
+
+		// remove the flag
+		node.removeAttribute('data-target');
+	}
+};
+
+/**
+ * Add the data attribute because "target" will be removed by sanitizer
+ */
+const flagTargetAttributeHook = (node: Element) => {
+	if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+		node.setAttribute('data-target', 'blank');
+	}
+	return node;
+};
+
+/**
+ * Sanitize a text with DOMPurify.
+ */
+export const sanitize = (text: string): string => {
+	try {
+		// DOMPurify initialization
+		if (isNullish(domPurify)) {
+			domPurify = DOMPurify;
+
+			// Preserve target="blank" workaround
+			domPurify.addHook('beforeSanitizeAttributes', flagTargetAttributeHook);
+			domPurify.addHook('afterSanitizeAttributes', restoreTargetAttributeHook);
+		}
+
+		return domPurify.sanitize(text);
+	} catch (err: unknown) {
+		consoleError('Failed to sanitize HTML content', err);
+	}
+
+	return '';
+};
+
 let elementsCounters: Record<string, number> = {};
 
 export const nextElementId = (prefix: string): string => {


### PR DESCRIPTION
# Motivation

Detaching OISY from `@dfinity/gix-components` (now maintenance-mode). The `Html` primitive (sanitized `{@html}`) in-housed as a native OISY component.

# Changes

- New `$lib/components/ui/Html.svelte` — gix source already Svelte 5.
- Add `sanitize()` + the `target="_blank"` preservation hooks to `$lib/utils/html.utils` (uses OISY's `consoleError`; DOMPurify works directly under jsdom, so gix's Node/global fallback is dropped).
- Promote **`dompurify ^3.4.10`** to a direct dependency (already present transitively via gix; matches the locked version — a clean install can float to the latest 3.4.x).
- Rewire all 34 `Html` consumers off gix.
- No behavioral change.

# Tests

- `lint --max-warnings 0` clean; `check` clean
- RewardCard + SwapReview (Html consumers) specs pass (39)