### PR TITLE
feat(frontend): reusable primitives for Liquidium supply

### DIFF
--- a/src/frontend/src/btc/components/send/BtcUtxosFeeDisplay.svelte
+++ b/src/frontend/src/btc/components/send/BtcUtxosFeeDisplay.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext, type Snippet } from 'svelte';
 	import { UTXOS_FEE_CONTEXT_KEY, type UtxosFeeContext } from '$btc/stores/utxos-fee.store';
 	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+
+	interface Props {
+		label?: Snippet;
+	}
+
+	let { label: labelSnippet }: Props = $props();
 
 	const { sendTokenExchangeRate, sendToken, sendTokenSymbol } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
@@ -19,5 +26,11 @@
 	feeAmount={satoshisFee}
 	symbol={$sendTokenSymbol}
 >
-	{#snippet label()}{$i18n.fee.text.fee}{/snippet}
+	{#snippet label()}
+		{#if nonNullish(labelSnippet)}
+			{@render labelSnippet()}
+		{:else}
+			{$i18n.fee.text.fee}
+		{/if}
+	{/snippet}
 </FeeDisplay>

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -236,7 +236,7 @@ export const sendBtc = async ({
 	identity,
 	onProgress,
 	...rest
-}: SendBtcParams): Promise<void> => {
+}: SendBtcParams): Promise<string> => {
 	const { txid } = await send({ onProgress, utxosFee, network, identity, ...rest });
 
 	await addPendingBtcTransaction({
@@ -250,6 +250,8 @@ export const sendBtc = async ({
 	onProgress?.();
 
 	await waitAndTriggerWallet();
+
+	return txid;
 };
 
 const send = async ({

--- a/src/frontend/src/eth/providers/alchemy.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy.providers.ts
@@ -310,6 +310,12 @@ export class AlchemyProvider {
 		this.nftBaseUrl = `${new URL(this.alchemyJsonRpcUrl).origin}/nft/v3/${ALCHEMY_API_KEY}`;
 	}
 
+	// Exposes the viem read client for callers that need raw `readContract` access
+	// (e.g. the Liquidium SDK's `evmPublicClient`) while keeping the full provider private.
+	get readContractClient(): Pick<PublicClient, 'readContract'> {
+		return this.provider;
+	}
+
 	private fetchNftApi = async <T>({
 		path,
 		params

--- a/src/frontend/src/lib/components/stake/StakeContentCard.svelte
+++ b/src/frontend/src/lib/components/stake/StakeContentCard.svelte
@@ -6,13 +6,16 @@
 		content: Snippet;
 		buttons?: Snippet;
 		primaryStyle?: boolean;
+		// Responsive width of the card within its flex row. Defaults to half-width
+		// (two cards per row); pass e.g. `sm:w-1/3` for a three-up layout.
+		widthClass?: string;
 	}
 
-	let { content, buttons, primaryStyle = false }: Props = $props();
+	let { content, buttons, primaryStyle = false, widthClass = 'sm:w-1/2' }: Props = $props();
 </script>
 
 <div
-	class="flex w-full flex-col items-center justify-between rounded-xl border-solid border-disabled p-4 sm:w-1/2"
+	class={`flex w-full flex-col items-center justify-between rounded-xl border-solid border-disabled p-4 ${widthClass}`}
 	class:bg-brand-subtle-10={primaryStyle}
 	class:bg-secondary={!primaryStyle}
 	class:border={!primaryStyle}

--- a/src/frontend/src/lib/components/stake/StakeForm.svelte
+++ b/src/frontend/src/lib/components/stake/StakeForm.svelte
@@ -10,6 +10,7 @@
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { STAKE_FORM_REVIEW_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
@@ -25,8 +26,14 @@
 		disabled?: boolean;
 		destination?: Address;
 		totalFee?: bigint;
+		// Fee charged in the amount's own token (e.g. a provider fee), always
+		// reserved from the Max balance regardless of token standard — unlike
+		// `totalFee`, which `getMaxTransactionAmount` only subtracts for native tokens.
+		providerFee?: bigint;
 		errorType?: TokenActionErrorType;
+		error?: Error;
 		onCustomValidate?: (userAmount: bigint) => TokenActionErrorType;
+		onCustomErrorValidate?: (userAmount: bigint) => Error | undefined;
 		onClose: () => void;
 		onNext: () => void;
 		content?: Snippet;
@@ -38,8 +45,11 @@
 		disabled,
 		destination,
 		totalFee,
+		providerFee = ZERO,
 		errorType = $bindable(),
+		error = $bindable(),
 		onCustomValidate,
+		onCustomErrorValidate,
 		onClose,
 		onNext,
 		content
@@ -50,8 +60,22 @@
 	let exchangeValueUnit = $state<DisplayUnit>('usd');
 	let inputUnit = $derived<DisplayUnit>(exchangeValueUnit === 'token' ? 'usd' : 'token');
 
+	// Reserve the provider fee (charged in the amount token) from the spendable
+	// balance, so "Max" never selects more than amount + fee the wallet can cover.
+	let maxBalance = $derived(
+		nonNullish($sendBalance)
+			? $sendBalance > providerFee
+				? $sendBalance - providerFee
+				: ZERO
+			: $sendBalance
+	);
+
 	let invalid = $derived(
-		invalidAmount(amount) || Number(amount) === 0 || nonNullish(errorType) || disabled
+		invalidAmount(amount) ||
+			Number(amount) === 0 ||
+			nonNullish(errorType) ||
+			nonNullish(error) ||
+			disabled
 	);
 </script>
 
@@ -61,11 +85,13 @@
 			displayUnit={inputUnit}
 			exchangeRate={$sendTokenExchangeRate}
 			isSelectable={false}
+			{onCustomErrorValidate}
 			{onCustomValidate}
 			showTokenNetwork
 			token={$sendToken}
 			bind:amount
 			bind:errorType
+			bind:error
 			bind:amountSetToMax
 		>
 			{#snippet title()}{$i18n.core.text.amount}{/snippet}
@@ -83,7 +109,7 @@
 
 			{#snippet balance()}
 				<MaxBalanceButton
-					balance={$sendBalance}
+					balance={maxBalance}
 					error={nonNullish(errorType)}
 					fee={totalFee}
 					token={$sendToken}

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -132,7 +132,9 @@ describe('btc-send.services', () => {
 				.mockReturnValue(new Uint8Array());
 			const onProgressSpy = vi.spyOn(defaultParams, 'onProgress');
 
-			await sendBtc(defaultParams);
+			const result = await sendBtc(defaultParams);
+
+			expect(result).toBe(txid);
 
 			expect(onProgressSpy).toHaveBeenCalled();
 


### PR DESCRIPTION
# Motivation

PR 1 of the Liquidium "Supply" stack. Backward-compatible enhancements to a few shared building blocks, extracted ahead of the feature so the supply flow can reuse them. **No new feature surface and no flag** — these are generic primitives.

# Changes

- **`sendBtc` returns the signer txid** (`btc/services/btc-send.services.ts`). The txid was previously computed and discarded; it's now returned so callers can correlate a broadcast (the supply flow's active-transaction tracking needs it). Return type widens `Promise<void> → Promise<string>`; the three existing callers (`BtcSendTokenWizard`, `BtcConvertTokenWizard`, `AiAssistantReviewSendBtcToken`) ignore the value, so behavior is unchanged.
- **`BtcUtxosFeeDisplay` accepts an optional `label` snippet**(`btc/components/send/BtcUtxosFeeDisplay.svelte`). Defaults to the existing "Fee" text when omitted — no change for current callers.
- **`StakeForm` gains `providerFee`, `error`, and `onCustomErrorValidate`** (`lib/components/stake/StakeForm.svelte`). `providerFee` (in the amount's own token) is reserved from the "Max" balance regardless of token standard; `error` / `onCustomErrorValidate` pass through to `TokenInput` for async fee/balance validation. All default to no-ops, so existing stake usage is byte-for-byte equivalent (`providerFee = 0` reduces `maxBalance` to the prior `$sendBalance`).
- **`StakeContentCard` gains a `widthClass` prop** (`lib/components/stake/StakeContentCard.svelte`). Defaults to `sm:w-1/2` (the current two-up layout); the provider page uses `sm:w-1/3` for a three-up row.
- **`AlchemyProvider` exposes a `readContractClient` getter** (`eth/providers/alchemy.providers.ts`). Returns the existing viem public client narrowed to `readContract`, so the Liquidium SDK can reuse oisy's Alchemy config as its `evmPublicClient` (no new RPC secret). Purely additive.
