### PR TITLE
fix(frontend): don't set network filter from token view URL on reload

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 	} from '$lib/constants/analytics.constants';
 	import { authNotSignedIn } from '$lib/derived/auth.derived';
 	import { isLocked } from '$lib/derived/locked.derived';
+	import { routeToken } from '$lib/derived/nav.derived';
 	import { networkId } from '$lib/derived/network.derived';
 	import { AuthBroadcastChannel } from '$lib/providers/auth-broadcast.providers';
 	import { initPlausibleAnalytics, trackEvent } from '$lib/services/analytics.services';
@@ -186,7 +187,14 @@
 	// which is only updated through explicit user actions.
 	// We initialise the store from the URL on first load to preserve navigation
 	// context without promoting the route to the source of truth.
+	// The token view carries a network purely to identify the token, not as a
+	// filter choice, so we skip it there to avoid leaking that network into the
+	// asset list filter after a reload.
 	onMount(() => {
+		if (nonNullish($routeToken)) {
+			return;
+		}
+
 		userSelectedNetworkStore.set($networkId);
 	});
 </script>

--- a/src/frontend/src/tests/routes/layout.spec.ts
+++ b/src/frontend/src/tests/routes/layout.spec.ts
@@ -1,3 +1,4 @@
+import { ICP_NETWORK, ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { OISY_URL } from '$lib/constants/oisy.constants';
 import { AuthBroadcastChannel } from '$lib/providers/auth-broadcast.providers';
 import * as analytics from '$lib/services/analytics.services';
@@ -5,8 +6,10 @@ import { authLoggedInAnotherTabStore, authStore } from '$lib/stores/auth.store';
 import { i18n } from '$lib/stores/i18n.store';
 import * as toastsStore from '$lib/stores/toasts.store';
 import { toastsShow } from '$lib/stores/toasts.store';
+import { userSelectedNetworkStore } from '$lib/stores/user-selected-network.store';
 import App from '$routes/+layout.svelte';
 import { mockAuthSignedIn } from '$tests/mocks/auth.mock';
+import { mockPage } from '$tests/mocks/page.store.mock';
 import { mockSnippet } from '$tests/mocks/snippet.mock';
 import { render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
@@ -66,6 +69,33 @@ describe('App Layout', () => {
 		render(App, { children: mockSnippet });
 
 		expect(spy).toHaveBeenCalledOnce();
+	});
+
+	describe('user selected network initialization on mount', () => {
+		beforeEach(() => {
+			userSelectedNetworkStore.set(undefined);
+			mockPage.reset();
+		});
+
+		afterEach(() => {
+			mockPage.reset();
+		});
+
+		it('should initialize the network filter from a network-only deep link', () => {
+			mockPage.mock({ network: ICP_NETWORK.id.description });
+
+			render(App, { children: mockSnippet });
+
+			expect(get(userSelectedNetworkStore)).toEqual(ICP_NETWORK_ID);
+		});
+
+		it('should not initialize the network filter from the token view network on reload', () => {
+			mockPage.mock({ token: 'ICP', network: ICP_NETWORK.id.description });
+
+			render(App, { children: mockSnippet });
+
+			expect(get(userSelectedNetworkStore)).toBeUndefined();
+		});
 	});
 
 	describe('when handling AuthBroadcastChannel', () => {


### PR DESCRIPTION
# Motivation

When you open the token view for a token on network X (URL `?network=X&token=Y`), reload the page, then click the **Assets** nav link, network X ends up applied as the asset-list network filter — which is wrong. The token view's network identifies the token being viewed, not a filter choice.

The root layout initialises `userSelectedNetworkStore` from the URL `network` param on mount. This was added in #11459 to preserve the network filter for NFT breadcrumb deep links (which carry only a `network` param). The token view URL also carries a `network`, so on reload that network leaks into the asset-list filter.

# Changes

- `src/frontend/src/routes/+layout.svelte`: skip the on-mount `userSelectedNetworkStore` initialisation when a `token` route param is present. NFT deep links (`nft`/`collection` params, no `token`) are unaffected, so their breadcrumb filter is preserved.

# Tests

- Added two cases to `src/frontend/src/tests/routes/layout.spec.ts`:
  - a network-only deep link still initialises the filter;
  - a token-view URL with a network does **not** initialise the filter.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, and the layout spec all pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (claude-opus-4-8)