### PR TITLE
feat(frontend): Liquidium core data layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@icp-sdk/auth": "^6.2.0",
 				"@icp-sdk/canisters": "~3.1.0",
 				"@icp-sdk/core": "^4.2.1",
-				"@liquidium/client": "^0.3.3",
+				"@liquidium/client": "^0.3.4",
 				"@metamask/detect-provider": "^2.0.0",
 				"@plausible-analytics/tracker": "^0.4.5",
 				"@reown/walletkit": "^1.5.5",
@@ -1077,9 +1077,9 @@
 			}
 		},
 		"node_modules/@liquidium/client": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@liquidium/client/-/client-0.3.3.tgz",
-			"integrity": "sha512-L+07+bK/jNiQ12WfR3IAEPaPbS0qG+RGPq8EmyV3A35513hg7mbgfekayw7qJFN3xO1a0OyvqEbztRVmnWVg6A==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@liquidium/client/-/client-0.3.4.tgz",
+			"integrity": "sha512-ZYZQQ8kT0g0qFaJyBpOaoUOkUeEaQ2FC45gUIhJ5zAD3Vb8xxkfo35jyNbbUBVE93Jj5ikU6mfx9kPM9Y3J/jw==",
 			"license": "MIT",
 			"dependencies": {
 				"@dfinity/utils": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
 		"@icp-sdk/auth": "^6.2.0",
 		"@icp-sdk/canisters": "~3.1.0",
 		"@icp-sdk/core": "^4.2.1",
-		"@liquidium/client": "^0.3.3",
+		"@liquidium/client": "^0.3.4",
 		"@metamask/detect-provider": "^2.0.0",
 		"@plausible-analytics/tracker": "^0.4.5",
 		"@reown/walletkit": "^1.5.5",

--- a/src/frontend/src/env/lend-borrow.ts
+++ b/src/frontend/src/env/lend-borrow.ts
@@ -1,0 +1,11 @@
+import { LIQUIDIUM_ENABLED } from '$env/liquidium';
+import { STAGING } from '$lib/constants/app.constants';
+
+// Route-level gate for the lend & borrow surface (provider pages, Borrow page,
+// Liabilities tab, nav). Layered over per-provider flags: a provider is active
+// only when both this and that provider are on.
+// TODO: broaden once the feature is complete.
+export const LEND_BORROW_ENABLED = STAGING;
+
+// At least one lend & borrow provider active (feature on AND provider on).
+export const anyLendBorrowProviderEnabled = LEND_BORROW_ENABLED && LIQUIDIUM_ENABLED;

--- a/src/frontend/src/env/liquidium.ts
+++ b/src/frontend/src/env/liquidium.ts
@@ -1,0 +1,5 @@
+import { STAGING } from '$lib/constants/app.constants';
+
+// Per-provider gate for Liquidium, layered under LEND_BORROW_ENABLED.
+// TODO: broaden once the integration is ready.
+export const LIQUIDIUM_ENABLED = STAGING;

--- a/src/frontend/src/lib/api/liquidium.api.ts
+++ b/src/frontend/src/lib/api/liquidium.api.ts
@@ -1,0 +1,22 @@
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { alchemyProviders } from '$eth/providers/alchemy.providers';
+import type { CanisterApiFunctionParams } from '$lib/types/canister';
+import { assertNonNullish } from '@dfinity/utils';
+import { LiquidiumClient, type LiquidiumClientConfig } from '@liquidium/client';
+
+// Liquidium SDK client for the signed-in identity, reusing oisy's Alchemy viem
+// client for the SDK's EVM reads (no extra RPC secret). Environment defaults to mainnet.
+export const liquidiumClient = ({
+	identity,
+	nullishIdentityErrorMessage
+}: CanisterApiFunctionParams): LiquidiumClient => {
+	assertNonNullish(identity, nullishIdentityErrorMessage);
+
+	return new LiquidiumClient({
+		// @icp-sdk/core v4 (oisy) ↔ v5 (SDK, isolated via package.json `overrides`) seam:
+		// the Identity types are structurally identical but nominally distinct, so the SDK
+		// boundary needs this cast — the one sanctioned exception to the no-`as unknown as` rule.
+		identity: identity as unknown as LiquidiumClientConfig['identity'],
+		evmPublicClient: alchemyProviders(ETHEREUM_NETWORK_ID).readContractClient
+	});
+};

--- a/src/frontend/src/lib/config/lend-borrow.config.ts
+++ b/src/frontend/src/lib/config/lend-borrow.config.ts
@@ -1,0 +1,32 @@
+import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import { LendBorrowProvider, type LendBorrowProviderConfig } from '$lib/types/lend-borrow';
+import type { WizardStepsParams } from '$lib/types/steps';
+import type { WizardSteps } from '@dfinity/gix-components';
+
+// Lend & borrow providers (mirrors `stakeProvidersConfig`): source of truth for
+// each provider's name/logo/url/description. Liquidium only for now.
+export const lendBorrowProvidersConfig: Record<LendBorrowProvider, LendBorrowProviderConfig> = {
+	[LendBorrowProvider.LIQUIDIUM]: {
+		name: 'Liquidium',
+		descriptionKey: 'liquidium.text.description',
+		logo: '/images/dapps/liquidium-logo.webp',
+		url: 'https://liquidium.fi/docs/quick-start/core-concepts'
+	}
+};
+
+export const liquidiumSupplyWizardSteps = ({
+	i18n
+}: WizardStepsParams): WizardSteps<WizardStepsLiquidiumSupply> => [
+	{
+		name: WizardStepsLiquidiumSupply.SUPPLY,
+		title: i18n.liquidium.text.action_supply
+	},
+	{
+		name: WizardStepsLiquidiumSupply.REVIEW,
+		title: i18n.liquidium.text.supply_review
+	},
+	{
+		name: WizardStepsLiquidiumSupply.SUPPLYING,
+		title: i18n.liquidium.text.supplying
+	}
+];

--- a/src/frontend/src/lib/constants/analytics.constants.ts
+++ b/src/frontend/src/lib/constants/analytics.constants.ts
@@ -74,6 +74,13 @@ export const TRACK_COUNT_SWAP_SUBMITTED = 'swap_submitted';
 export const TRACK_COUNT_SWAP_SUCCESS = 'swap_success';
 export const TRACK_COUNT_SWAP_ERROR = 'swap_error';
 
+// Liquidium (lend & borrow). Generic across actions — the action (supply/borrow/
+// …) rides in the event metadata — mirroring the swap submitted/success/error
+// lifecycle: submitted at action time, success/error from the AUT poller.
+export const TRACK_COUNT_LIQUIDIUM_SUBMITTED = 'liquidium_submitted';
+export const TRACK_COUNT_LIQUIDIUM_SUCCESS = 'liquidium_success';
+export const TRACK_COUNT_LIQUIDIUM_ERROR = 'liquidium_error';
+
 // Manage Tokens
 export const TRACK_COUNT_MANAGE_TOKENS_ENABLE_SUCCESS = 'manage_tokens_enable_success';
 export const TRACK_COUNT_MANAGE_TOKENS_DISABLE_SUCCESS = 'manage_tokens_disable_success';

--- a/src/frontend/src/lib/constants/liquidium.constants.ts
+++ b/src/frontend/src/lib/constants/liquidium.constants.ts
@@ -1,0 +1,42 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
+import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env';
+import {
+	IC_CKUSDC_LEDGER_CANISTER_ID,
+	IC_CKUSDT_LEDGER_CANISTER_ID
+} from '$env/tokens/tokens-icrc/tokens.icrc.ck.erc20.env';
+import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.eth.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import type { OptionCanisterIdText } from '$lib/types/canister';
+import type { Token } from '$lib/types/token';
+
+// Provider id for the earning-provider registry.
+export const LIQUIDIUM_PROVIDER_ID = 'liquidium';
+
+// Market asset symbol → oisy token (for logo/label); unmapped future assets fall
+// back to symbol-only.
+export const LIQUIDIUM_ASSET_TOKENS: Record<string, Token> = {
+	BTC: BTC_MAINNET_TOKEN,
+	ETH: ETHEREUM_TOKEN,
+	USDC: USDC_TOKEN,
+	USDT: USDT_TOKEN
+};
+
+// ck-ledger backing each asset, for the AUT's backend `TokenId`.
+export const LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS: Record<string, OptionCanisterIdText> = {
+	BTC: IC_CKBTC_LEDGER_CANISTER_ID,
+	ETH: IC_CKETH_LEDGER_CANISTER_ID,
+	USDC: IC_CKUSDC_LEDGER_CANISTER_ID,
+	USDT: IC_CKUSDT_LEDGER_CANISTER_ID
+};
+
+// Display bands — Liquidium publishes no discrete cut-offs, so oisy picks its own
+// (spec → Open question #7).
+export const LIQUIDIUM_HEALTH_AT_RISK_PERCENT = 50;
+export const LIQUIDIUM_HEALTH_CRITICAL_PERCENT = 15;
+
+export type LiquidiumHealthLevel = 'healthy' | 'at-risk' | 'critical';
+
+// Refresh cadence for markets + positions while the provider page is visible.
+export const LIQUIDIUM_POLL_INTERVAL_MILLIS = 30_000;

--- a/src/frontend/src/lib/constants/routes.constants.ts
+++ b/src/frontend/src/lib/constants/routes.constants.ts
@@ -11,6 +11,9 @@ export enum AppPath {
 	Earn = '/earn/',
 	EarnAutopilot = '/earn/autopilot/',
 	EarnRewards = '/earn/rewards/',
+	Borrow = '/borrow/',
+	Liabilities = '/liabilities/',
+	ProvidersLiquidium = '/providers/liquidium/',
 	LicenseAgreement = '/license-agreement/',
 	PrivacyPolicy = '/privacy-policy/',
 	TermsOfUse = '/terms-of-use/'

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -1,0 +1,79 @@
+import { goto } from '$app/navigation';
+import { EarningCardFields } from '$env/types/env.earning-cards';
+import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+import { AppPath } from '$lib/constants/routes.constants';
+import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import type { EarningProviderData } from '$lib/types/earning-provider';
+import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
+import type { Token } from '$lib/types/token';
+import { formatStakeApyNumber } from '$lib/utils/format.utils';
+import {
+	liquidiumMaxSupplyApy as computeMaxSupplyApy,
+	liquidiumNetInterestUsd
+} from '$lib/utils/liquidium.utils';
+import { nonNullish } from '@dfinity/utils';
+import { derived, type Readable } from 'svelte/store';
+
+export const liquidiumMarkets: Readable<LiquidiumMarket[]> = derived(
+	liquidiumStore,
+	({ markets }) => markets
+);
+
+export const liquidiumPortfolio: Readable<LiquidiumPortfolio | null> = derived(
+	liquidiumStore,
+	({ portfolio }) => portfolio
+);
+
+// Best supply APY across enterable pools (Earn card badge).
+export const liquidiumMaxSupplyApy: Readable<number> = derived(
+	liquidiumMarkets,
+	computeMaxSupplyApy
+);
+
+// Net value (Σ supplied − Σ borrowed); 0 when no positions.
+export const liquidiumNetValueUsd: Readable<number> = derived(
+	liquidiumPortfolio,
+	(portfolio) => portfolio?.netValueUsd ?? 0
+);
+
+// Portfolio health %, null when no positions.
+export const liquidiumHealthFactorPercent: Readable<number | null> = derived(
+	liquidiumPortfolio,
+	(portfolio) => (nonNullish(portfolio) ? portfolio.healthFactorPercent : null)
+);
+
+// Deduped icons for the advertised v1 asset set (Earn card Networks/Assets rows).
+const liquidiumCardIcons = (pick: (token: Token) => string | undefined): string[] => [
+	...Object.values(LIQUIDIUM_ASSET_TOKENS).reduce<Set<string>>((acc, token) => {
+		const icon = pick(token);
+		return nonNullish(icon) ? acc.add(icon) : acc;
+	}, new Set())
+];
+
+const liquidiumNetworkIcons = liquidiumCardIcons((token) => token.network.icon);
+const liquidiumAssetIcons = liquidiumCardIcons((token) => token.icon);
+
+// Earn-page provider card data (mirrors the Harvest card); action → provider page.
+export const liquidiumEarningData: Readable<EarningProviderData> = derived(
+	[liquidiumMaxSupplyApy, liquidiumPortfolio, enabledMainnetFungibleTokensUsdBalance],
+	([
+		$liquidiumMaxSupplyApy,
+		$liquidiumPortfolio,
+		$enabledMainnetFungibleTokensUsdBalance
+	]): EarningProviderData => ({
+		[EarningCardFields.APY]: formatStakeApyNumber($liquidiumMaxSupplyApy),
+		[EarningCardFields.NETWORKS]: liquidiumNetworkIcons,
+		[EarningCardFields.ASSETS]: liquidiumAssetIcons,
+		[EarningCardFields.CURRENT_EARNING]: liquidiumNetInterestUsd($liquidiumPortfolio),
+		[EarningCardFields.EARNING_POTENTIAL]: nonNullish($enabledMainnetFungibleTokensUsdBalance)
+			? (Math.max(
+					0,
+					$enabledMainnetFungibleTokensUsdBalance - ($liquidiumPortfolio?.totalSuppliedUsd ?? 0)
+				) *
+					$liquidiumMaxSupplyApy) /
+				100
+			: undefined,
+		action: () => goto(AppPath.ProvidersLiquidium)
+	})
+);

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -119,6 +119,13 @@ export enum ProgressStepsUnstake {
 	DONE = 'done'
 }
 
+export enum ProgressStepsLiquidiumSupply {
+	INITIALIZATION = 'initialization',
+	TRANSFER = 'transfer',
+	REGISTER = 'register',
+	DONE = 'done'
+}
+
 export enum ProgressStepsClaimStakingReward {
 	INITIALIZATION = 'initialization',
 	CLAIM = 'claim',

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -87,6 +87,12 @@ export enum WizardStepsUnstake {
 	UNSTAKING = 'Unstaking'
 }
 
+export enum WizardStepsLiquidiumSupply {
+	SUPPLY = 'Supply',
+	REVIEW = 'Review',
+	SUPPLYING = 'Supplying'
+}
+
 export enum WizardStepsClaimStakingReward {
 	REVIEW = 'Review',
 	CLAIMING = 'Claiming'

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2087,6 +2087,11 @@
 				"title": "",
 				"description": "",
 				"action": ""
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": ""
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Používejte OISY a VYDĚLÁVEJTE! Ep. 6 je živě 🎉",
 				"action": "Zkontrolovat stav"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Vydělávejte s Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Nutze OISY und VERDIENE! Ep. 6 ist live 🎉",
 				"action": "Status prüfen"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Mit Gold DAO verdienen"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Use OISY and EARN! Ep. 6 is live 🎉",
 				"action": "Check status"
+			},
+			"liquidium": {
+				"title": "Liquidium",
+				"description": "Lend your assets to earn yield, or borrow against them.",
+				"action": "Lend & Borrow"
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Earn with Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "Lend & borrow native BTC, ETH, USDC and USDT. Lending logic runs on Liquidium's canisters; $oisy_short provides the UX.",
+			"health_factor": "Health factor",
+			"net_value": "Net value",
+			"net_apy": "Net APY",
+			"my_positions": "My positions",
+			"markets": "Markets",
+			"supplied": "Supplied",
+			"borrowed": "Borrowed",
+			"apy_suffix": "APY",
+			"supply_label": "Supply",
+			"borrow_label": "Borrow",
+			"coming_soon": "Coming soon",
+			"action_supply": "Supply",
+			"action_borrow": "Borrow",
+			"action_repay": "Repay",
+			"action_withdraw": "Withdraw",
+			"transaction_failed": "Transaction failed",
+			"supply_review": "Review supply",
+			"supply_review_subtitle": "You supply",
+			"supplying": "Supplying",
+			"starting_to_supply": "Submitting your position...",
+			"supply_started": "The position is now being activated.",
+			"supply_apy": "Supply APY",
+			"supply_collateral_info": "Supplied assets also serve as collateral you can borrow against.",
+			"supply_agreement": "I understand my assets will be supplied to the Liquidium protocol and are subject to on-chain smart-contract risk.",
+			"provider_fee": "Provider fee",
+			"insufficient_funds_for_fee": "Insufficient balance to cover the amount and the provider fee."
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "¡Usa OISY y GANA! El episodio 6 está en vivo 🎉",
 				"action": "Ver estado"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Gana con Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Utilisez OISY et GAGNEZ ! L'épisode 6 est en direct 🎉",
 				"action": "Vérifier le statut"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Gagnez avec Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "OISY उपयोग करें और कमाएं! एपिसोड 6 लाइव है 🎉",
 				"action": "स्थिति जांचें"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Gold DAO के साथ कमाएं"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Usa OISY e GUADAGNA! L'episodio 6 è in diretta 🎉",
 				"action": "Controlla stato"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Guadagna con Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "OISYを使って稼ごう！エピソード6が公開中 🎉",
 				"action": "ステータスを確認"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Gold DAOで稼ぐ"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "OISY를 사용하고 수익을 창출하세요! 에피소드 6 공개 중 🎉",
 				"action": "상태 확인"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Gold DAO로 수익 창출"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Używaj OISY i ZARABIAJ! Odcinek 6 jest już dostępny 🎉",
 				"action": "Sprawdź status"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Zarabiaj z Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Use o OISY e GANHE! O episódio 6 está no ar 🎉",
 				"action": "Verificar status"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Ganhe com Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Используйте OISY и ЗАРАБАТЫВАЙТЕ! Эпизод 6 уже в эфире 🎉",
 				"action": "Проверить статус"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Зарабатывайте с Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "Dùng OISY và KIẾM TIỀN! Tập 6 đã ra mắt 🎉",
 				"action": "Kiểm tra trạng thái"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "Kiếm tiền với Gold DAO"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2087,6 +2087,11 @@
 				"title": "OISY Sprinkles",
 				"description": "使用OISY并赚取！第6集已上线 🎉",
 				"action": "查看状态"
+			},
+			"liquidium": {
+				"title": "",
+				"description": "",
+				"action": ""
 			}
 		},
 		"card_fields": {
@@ -2105,6 +2110,37 @@
 			"goldDaoStaking": {
 				"cardTitle": "通过Gold DAO赚取"
 			}
+		}
+	},
+	"liquidium": {
+		"text": {
+			"description": "",
+			"health_factor": "",
+			"net_value": "",
+			"net_apy": "",
+			"my_positions": "",
+			"markets": "",
+			"supplied": "",
+			"borrowed": "",
+			"apy_suffix": "",
+			"supply_label": "",
+			"borrow_label": "",
+			"coming_soon": "",
+			"action_supply": "",
+			"action_borrow": "",
+			"action_repay": "",
+			"action_withdraw": "",
+			"transaction_failed": "",
+			"supply_review": "",
+			"supply_review_subtitle": "",
+			"supplying": "",
+			"starting_to_supply": "",
+			"supply_started": "",
+			"supply_apy": "",
+			"supply_collateral_info": "",
+			"supply_agreement": "",
+			"provider_fee": "",
+			"insufficient_funds_for_fee": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/services/liquidium-active-tx.services.ts
+++ b/src/frontend/src/lib/services/liquidium-active-tx.services.ts
@@ -1,0 +1,100 @@
+import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import { liquidiumClient } from '$lib/api/liquidium.api';
+import { applyActiveUserTransactionPollUpdate } from '$lib/services/active-user-transactions.services';
+import { i18n } from '$lib/stores/i18n.store';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { advanceStatus } from '$lib/utils/active-user-transactions.utils';
+import { consoleError } from '$lib/utils/console.utils';
+import {
+	liquidiumActivityToStatus,
+	toLiquidiumExternalRefsMap
+} from '$lib/utils/liquidium-active-tx.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { ActivityFilter, ActivityStatus, type LiquidiumClient } from '@liquidium/client';
+import { get } from 'svelte/store';
+
+// Bridges `0x`/case differences between oisy's broadcast hash and the SDK's txid.
+const normalizeTxid = (value: string): string => value.toLowerCase().replace(/^0x/, '');
+
+const pollLiquidiumActiveUserTransaction = async ({
+	tx,
+	identity,
+	client
+}: {
+	tx: ActiveUserTransaction;
+	identity: Identity;
+	client: LiquidiumClient;
+}): Promise<void> => {
+	try {
+		const refs = toLiquidiumExternalRefsMap(tx.external_refs);
+		const profileId = refs[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID];
+		const txid = refs[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID];
+
+		// Both persisted at supply time; a row missing either isn't pollable yet.
+		if (isNullish(profileId) || isNullish(txid)) {
+			return;
+		}
+
+		const target = normalizeTxid(txid);
+		const activities = await client.activities.list({ profileId, filter: ActivityFilter.all });
+
+		// A unique on-chain txid pins the exact activity; `filter: all` includes
+		// completed legs, so a confirmed/failed one terminalizes the row.
+		const activity = activities.find(
+			({ txid: activityTxid, txids }) =>
+				(nonNullish(activityTxid) && normalizeTxid(activityTxid) === target) ||
+				(txids ?? []).some((t) => normalizeTxid(t) === target)
+		);
+
+		if (isNullish(activity)) {
+			return;
+		}
+
+		const candidate = liquidiumActivityToStatus(activity.status);
+
+		if (isNullish(candidate)) {
+			return;
+		}
+
+		const next = advanceStatus({ current: tx.status, candidate });
+
+		if (isNullish(next)) {
+			return;
+		}
+
+		const error =
+			activity.status === ActivityStatus.failed
+				? get(i18n).liquidium.text.transaction_failed
+				: undefined;
+
+		await applyActiveUserTransactionPollUpdate({
+			identity,
+			tx,
+			update: {
+				status: next,
+				...(nonNullish(error) ? { error } : {})
+			}
+		});
+	} catch (err: unknown) {
+		consoleError(err);
+	}
+};
+
+export const pollLiquidiumActiveUserTransactions = async ({
+	identity,
+	transactions
+}: {
+	identity: Identity;
+	transactions: ActiveUserTransaction[];
+}): Promise<void> => {
+	if (transactions.length === 0) {
+		return;
+	}
+
+	const client = liquidiumClient({ identity });
+
+	await Promise.all(
+		transactions.map((tx) => pollLiquidiumActiveUserTransaction({ tx, identity, client }))
+	);
+};

--- a/src/frontend/src/lib/services/liquidium-supply.services.ts
+++ b/src/frontend/src/lib/services/liquidium-supply.services.ts
@@ -31,12 +31,12 @@ export const estimateLiquidiumInflowFee = async ({
 	chain
 }: {
 	identity: Identity;
-	asset: string;
-	chain: string;
+	asset: Asset;
+	chain: Chain;
 }): Promise<bigint> => {
 	const { totalFee } = await liquidiumClient({ identity }).lending.estimateInflowFee({
-		asset: asset as Asset,
-		chain: chain as Chain
+		asset,
+		chain
 	});
 
 	return totalFee;
@@ -122,12 +122,19 @@ export const executeLiquidiumSupply = async ({
 
 	progress?.(ProgressStepsLiquidiumSupply.REGISTER);
 
-	// Point of no return: submit (txid indexing hint) + AUT row are best-effort.
-	// The protocol detects the inflow on-chain regardless and positions self-heal,
-	// so a failure here must not fail the supply (mirrors the OneSec swap flow).
+	// Point of no return: the SDK submit (a txid indexing hint) and the AUT row are
+	// both best-effort and independent. Each gets its own try/catch so a failure in
+	// one never skips the other — in particular a failed `flow.submit` must still
+	// leave an AUT row for the poller/analytics to correlate by txid. Neither fails
+	// the supply: the protocol detects the inflow on-chain regardless and positions
+	// self-heal from `client.positions` (mirrors the OneSec swap flow).
 	try {
 		await flow.submit({ txid });
+	} catch (err: unknown) {
+		consoleError(err);
+	}
 
+	try {
 		await createActiveUserTransaction({
 			identity,
 			id: crypto.randomUUID(),

--- a/src/frontend/src/lib/services/liquidium-supply.services.ts
+++ b/src/frontend/src/lib/services/liquidium-supply.services.ts
@@ -1,0 +1,155 @@
+import type { TokenId } from '$declarations/backend/backend.did';
+import type { EthAddress } from '$eth/types/address';
+import { liquidiumClient } from '$lib/api/liquidium.api';
+import { TRACK_COUNT_LIQUIDIUM_SUBMITTED } from '$lib/constants/analytics.constants';
+import { LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS } from '$lib/constants/liquidium.constants';
+import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+import { createActiveUserTransaction } from '$lib/services/active-user-transactions.services';
+import { trackEvent } from '$lib/services/analytics.services';
+import { getOrCreateLiquidiumProfile } from '$lib/services/liquidium.services';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { consoleError } from '$lib/utils/console.utils';
+import {
+	liquidiumTrackingMetadata,
+	toLiquidiumExternalRefs
+} from '$lib/utils/liquidium-active-tx.utils';
+import { assertNonNullish, nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { Principal } from '@icp-sdk/core/principal';
+import {
+	SupplyAction,
+	type Asset,
+	type Chain,
+	type NativeAddressSupplyTarget
+} from '@liquidium/client';
+
+// Liquidium's per-inflow processing fee (base units of `asset`), deducted by the
+// protocol from each inflow.
+export const estimateLiquidiumInflowFee = async ({
+	identity,
+	asset,
+	chain
+}: {
+	identity: Identity;
+	asset: string;
+	chain: string;
+}): Promise<bigint> => {
+	const { totalFee } = await liquidiumClient({ identity }).lending.estimateInflowFee({
+		asset: asset as Asset,
+		chain: chain as Chain
+	});
+
+	return totalFee;
+};
+
+// Broadcasts `amount` base units (gross = supply + provider fee) to the native
+// target and returns the txid the AUT poller correlates on. Implemented by the
+// wizard, which owns oisy's per-chain fee/UTXO machinery.
+export type LiquidiumSupplyBroadcast = (params: {
+	target: NativeAddressSupplyTarget;
+	amount: bigint;
+}) => Promise<string>;
+
+// Backend `TokenId` for the AUT record — the ck-asset ledger backing the asset.
+const liquidiumAssetTokenId = (asset: string): TokenId => {
+	const ledgerCanisterId = LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS[asset];
+
+	assertNonNullish(ledgerCanisterId, `No ICRC ledger configured for Liquidium asset ${asset}`);
+
+	return { Icrc: Principal.fromText(ledgerCanisterId) };
+};
+
+// Supplies `amount` (base units) of `asset`: resolve/create profile → broadcast the
+// transfer → record an AUT so the modal can close before settlement.
+//
+// The protocol deducts its inflow fee from the inflow, so we transfer
+// `amount + inflowFee` to credit the user's `amount` (the recorded position stays net).
+// Only the `nativeAddress` rail is supported (the only one v1 assets return via the
+// SDK's `resolveSupplyTarget`); `icrcAccount` would need contract-interaction, which we don't request.
+export const executeLiquidiumSupply = async ({
+	identity,
+	ethAddress,
+	poolId,
+	asset,
+	amount,
+	inflowFee,
+	displayAmount,
+	progressStep,
+	broadcast,
+	progress
+}: {
+	identity: Identity;
+	ethAddress: EthAddress;
+	poolId: string;
+	asset: string;
+	amount: bigint;
+	inflowFee: bigint;
+	displayAmount: string;
+	progressStep?: string;
+	broadcast: LiquidiumSupplyBroadcast;
+	progress?: (step: ProgressStepsLiquidiumSupply) => void;
+}): Promise<void> => {
+	progress?.(ProgressStepsLiquidiumSupply.INITIALIZATION);
+
+	const profileId = await getOrCreateLiquidiumProfile({ identity, ethAddress });
+
+	const flow = await liquidiumClient({ identity }).lending.supply({
+		profileId,
+		poolId,
+		action: SupplyAction.deposit
+	});
+
+	if (flow.target.type !== 'nativeAddress') {
+		throw new Error(
+			`Liquidium supply: unsupported "${flow.target.type}" target for ${asset} (only nativeAddress is supported)`
+		);
+	}
+
+	progress?.(ProgressStepsLiquidiumSupply.TRANSFER);
+
+	// Gross transfer = net supply + provider inflow fee (deducted on arrival).
+	const txid = await broadcast({ target: flow.target, amount: amount + inflowFee });
+
+	// Submitted on-chain; success/error events fire from the AUT poller once it settles.
+	trackEvent({
+		name: TRACK_COUNT_LIQUIDIUM_SUBMITTED,
+		metadata: liquidiumTrackingMetadata({
+			action: 'supply',
+			token: asset,
+			tokenAmount: displayAmount
+		})
+	});
+
+	progress?.(ProgressStepsLiquidiumSupply.REGISTER);
+
+	// Point of no return: submit (txid indexing hint) + AUT row are best-effort.
+	// The protocol detects the inflow on-chain regardless and positions self-heal,
+	// so a failure here must not fail the supply (mirrors the OneSec swap flow).
+	try {
+		await flow.submit({ txid });
+
+		await createActiveUserTransaction({
+			identity,
+			id: crypto.randomUUID(),
+			data: {
+				Liquidium: {
+					token: liquidiumAssetTokenId(asset),
+					action: { Supply: null },
+					pool_id: poolId,
+					amount
+				}
+			},
+			...(nonNullish(progressStep) ? { progressStep } : {}),
+			externalRefs: toLiquidiumExternalRefs({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.AMOUNT]: displayAmount,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL]: asset,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: txid
+			})
+		});
+	} catch (err: unknown) {
+		consoleError(err);
+	}
+
+	progress?.(ProgressStepsLiquidiumSupply.DONE);
+};

--- a/src/frontend/src/lib/services/liquidium-wallet-adapter.services.ts
+++ b/src/frontend/src/lib/services/liquidium-wallet-adapter.services.ts
@@ -1,0 +1,17 @@
+import { signMessage } from '$lib/api/signer.api';
+import type { Identity } from '@icp-sdk/core/agent';
+import { Chain, type SignMessageRequest, type WalletAdapter } from '@liquidium/client';
+
+// Liquidium signer bridge. Only `signMessage` is implemented: profiles are
+// ETH-owned because oisy can sign arbitrary messages only on the ETH key
+// (EIP-191; no BIP-322 for BTC), and supply broadcasts the transfer itself, so
+// the adapter's send/PSBT methods aren't needed.
+export const liquidiumWalletAdapter = ({ identity }: { identity: Identity }): WalletAdapter => ({
+	signMessage: async ({ chain, message }: SignMessageRequest): Promise<string> => {
+		if (chain !== Chain.ETH) {
+			throw new Error(`Liquidium signMessage requested for unsupported chain: ${chain}`);
+		}
+
+		return await signMessage({ identity, message });
+	}
+});

--- a/src/frontend/src/lib/services/liquidium.services.ts
+++ b/src/frontend/src/lib/services/liquidium.services.ts
@@ -1,0 +1,70 @@
+import type { EthAddress, OptionEthAddress } from '$eth/types/address';
+import { liquidiumClient } from '$lib/api/liquidium.api';
+import { liquidiumWalletAdapter } from '$lib/services/liquidium-wallet-adapter.services';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import type { NullishIdentity } from '$lib/types/identity';
+import { consoleError } from '$lib/utils/console.utils';
+import { mapLiquidiumMarket, mapLiquidiumPortfolio } from '$lib/utils/liquidium.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { Chain } from '@liquidium/client';
+
+// Resolves the (single, ETH-owned) Liquidium profile, creating one if absent.
+// Creation is signature-gated via the wallet adapter's `signMessage`.
+export const getOrCreateLiquidiumProfile = async ({
+	identity,
+	ethAddress
+}: {
+	identity: Identity;
+	ethAddress: EthAddress;
+}): Promise<string> => {
+	const { accounts } = liquidiumClient({ identity });
+
+	const profileId = await accounts.getProfileId(ethAddress);
+
+	if (nonNullish(profileId)) {
+		return profileId;
+	}
+
+	return accounts.createProfile({
+		account: ethAddress,
+		chain: Chain.ETH,
+		walletAdapter: liquidiumWalletAdapter({ identity })
+	});
+};
+
+// Best-effort load of markets + portfolio into `liquidiumStore`; errors are
+// logged so a transient SDK/RPC failure never breaks the dashboard. Read-only:
+// the profile is only created on the first write action.
+export const loadLiquidium = async ({
+	identity,
+	ethAddress
+}: {
+	identity: NullishIdentity;
+	ethAddress: OptionEthAddress;
+}): Promise<void> => {
+	if (isNullish(identity)) {
+		liquidiumStore.reset();
+		return;
+	}
+
+	try {
+		const { market, accounts, positions } = liquidiumClient({ identity });
+
+		const pools = await market.listPools();
+		const markets = pools.map(mapLiquidiumMarket);
+
+		const profileId = nonNullish(ethAddress) ? await accounts.getProfileId(ethAddress) : null;
+
+		const portfolio = nonNullish(profileId)
+			? mapLiquidiumPortfolio({
+					reserves: await positions.getUserReserves(profileId),
+					summary: await positions.getUserPositionSummary(profileId)
+				})
+			: null;
+
+		liquidiumStore.set({ markets, portfolio });
+	} catch (err: unknown) {
+		consoleError(err);
+	}
+};

--- a/src/frontend/src/lib/stores/liquidium.store.ts
+++ b/src/frontend/src/lib/stores/liquidium.store.ts
@@ -1,0 +1,20 @@
+import type { LiquidiumStoreData } from '$lib/types/liquidium';
+import { writable, type Readable } from 'svelte/store';
+
+export interface LiquidiumStore extends Readable<LiquidiumStoreData> {
+	set: (data: LiquidiumStoreData) => void;
+	reset: () => void;
+}
+
+const initLiquidiumStore = (): LiquidiumStore => {
+	const defaultStoreValue: LiquidiumStoreData = { markets: [], portfolio: null };
+	const { subscribe, set } = writable<LiquidiumStoreData>(defaultStoreValue);
+
+	return {
+		subscribe,
+		set,
+		reset: () => set(defaultStoreValue)
+	};
+};
+
+export const liquidiumStore = initLiquidiumStore();

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1634,6 +1634,7 @@ interface I18nEarning {
 	cards: {
 		harvest_autopilot: { title: string; description: string; action: string };
 		sprinkles: { title: string; description: string; action: string };
+		liquidium: { title: string; description: string; action: string };
 	};
 	card_fields: {
 		apy: string;
@@ -1646,6 +1647,38 @@ interface I18nEarning {
 	};
 	terms: { flexible: string };
 	providers: { goldDaoStaking: { cardTitle: string } };
+}
+
+interface I18nLiquidium {
+	text: {
+		description: string;
+		health_factor: string;
+		net_value: string;
+		net_apy: string;
+		my_positions: string;
+		markets: string;
+		supplied: string;
+		borrowed: string;
+		apy_suffix: string;
+		supply_label: string;
+		borrow_label: string;
+		coming_soon: string;
+		action_supply: string;
+		action_borrow: string;
+		action_repay: string;
+		action_withdraw: string;
+		transaction_failed: string;
+		supply_review: string;
+		supply_review_subtitle: string;
+		supplying: string;
+		starting_to_supply: string;
+		supply_started: string;
+		supply_apy: string;
+		supply_collateral_info: string;
+		supply_agreement: string;
+		provider_fee: string;
+		insufficient_funds_for_fee: string;
+	};
 }
 
 interface I18nVaults {
@@ -1864,6 +1897,7 @@ interface I18n {
 	privacy_policy: I18nPrivacy_policy;
 	activity: I18nActivity;
 	earning: I18nEarning;
+	liquidium: I18nLiquidium;
 	vaults: I18nVaults;
 	stake: I18nStake;
 	get_token: I18nGet_token;

--- a/src/frontend/src/lib/types/lend-borrow.ts
+++ b/src/frontend/src/lib/types/lend-borrow.ts
@@ -1,0 +1,12 @@
+export enum LendBorrowProvider {
+	LIQUIDIUM = 'liquidium'
+}
+
+export interface LendBorrowProviderConfig {
+	// Brand name (not i18n — identical in every locale).
+	name: string;
+	// i18n key path (resolved via `resolveText`).
+	descriptionKey: string;
+	logo: string;
+	url: string;
+}

--- a/src/frontend/src/lib/types/liquidium-active-tx.ts
+++ b/src/frontend/src/lib/types/liquidium-active-tx.ts
@@ -1,0 +1,15 @@
+// External-ref keys for a Liquidium AUT: status pointers + a display snapshot,
+// stored as opaque key/value pairs (no candid change), surviving refresh/resume.
+export const LIQUIDIUM_EXTERNAL_REF_KEYS = {
+	// Status pointers: profile scopes the activity listing, txid pins the activity.
+	PROFILE_ID: 'liquidium_profile_id',
+	TXID: 'liquidium_txid',
+	// Display snapshot for the row.
+	AMOUNT: 'amount',
+	ASSET_SYMBOL: 'asset_symbol'
+} as const;
+
+export type LiquidiumExternalRefKey =
+	(typeof LIQUIDIUM_EXTERNAL_REF_KEYS)[keyof typeof LIQUIDIUM_EXTERNAL_REF_KEYS];
+
+export type LiquidiumActionKey = 'supply' | 'borrow' | 'repay' | 'withdraw';

--- a/src/frontend/src/lib/types/liquidium.ts
+++ b/src/frontend/src/lib/types/liquidium.ts
@@ -1,0 +1,46 @@
+// oisy-side Liquidium model: SDK scaled bigints mapped to display numbers at the
+// service boundary; base-unit amounts stay bigint for the action wizards.
+
+// Protocol asset symbol (BTC, ETH, USDC, USDT).
+export type LiquidiumAsset = string;
+
+export interface LiquidiumMarket {
+	poolId: string;
+	asset: LiquidiumAsset;
+	chain: string;
+	supplyApy: number; // percent
+	borrowApy: number; // percent
+	frozen: boolean;
+	// Not frozen and under supply cap; else renders as "Coming soon".
+	available: boolean;
+}
+
+export interface LiquidiumReserve {
+	poolId: string;
+	asset: LiquidiumAsset;
+	chain: string;
+	supplyApy: number; // percent
+	borrowApy: number; // percent
+	deposited: bigint; // base units
+	depositedDecimals: number;
+	borrowed: bigint; // base units
+	borrowedDecimals: number;
+	suppliedUsd: number;
+	borrowedUsd: number;
+}
+
+export interface LiquidiumPortfolio {
+	reserves: LiquidiumReserve[];
+	totalSuppliedUsd: number;
+	totalBorrowedUsd: number;
+	netValueUsd: number; // collateral − debt (may be negative)
+	availableBorrowsUsd: number;
+	// 100% = no debt; near 0% = at risk.
+	healthFactorPercent: number;
+}
+
+export interface LiquidiumStoreData {
+	markets: LiquidiumMarket[];
+	// null when the user has no profile / no positions yet.
+	portfolio: LiquidiumPortfolio | null;
+}

--- a/src/frontend/src/lib/utils/liquidium-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium-active-tx.utils.ts
@@ -1,0 +1,105 @@
+import type {
+	ActiveUserTransaction,
+	ActiveUserTransactionRef,
+	ActiveUserTransactionStatus,
+	LiquidiumAction
+} from '$declarations/backend/backend.did';
+import { LIQUIDIUM_PROVIDER_ID } from '$lib/constants/liquidium.constants';
+import {
+	LIQUIDIUM_EXTERNAL_REF_KEYS,
+	type LiquidiumActionKey,
+	type LiquidiumExternalRefKey
+} from '$lib/types/liquidium-active-tx';
+import { nonNullish } from '@dfinity/utils';
+import { ActivityStatus, type Activity } from '@liquidium/client';
+
+export const isLiquidiumActiveUserTransaction = (tx: ActiveUserTransaction): boolean =>
+	'Liquidium' in tx.data;
+
+// Wire-format `(key, value)` array → keyed lookup.
+export const toLiquidiumExternalRefsMap = (
+	refs: ActiveUserTransactionRef[]
+): Partial<Record<LiquidiumExternalRefKey, string>> => {
+	const map: Partial<Record<LiquidiumExternalRefKey, string>> = {};
+
+	for (const { key, value } of refs) {
+		map[key as LiquidiumExternalRefKey] = value;
+	}
+
+	return map;
+};
+
+// Builds a deterministic `(key, value)` external-ref array, dropping empties.
+export const toLiquidiumExternalRefs = (
+	refs: Partial<Record<LiquidiumExternalRefKey, string>>
+): ActiveUserTransactionRef[] =>
+	(Object.keys(refs) as LiquidiumExternalRefKey[])
+		.filter((key) => refs[key] !== undefined && refs[key] !== '')
+		.sort()
+		.map((key) => ({ key, value: refs[key] as string }));
+
+export const liquidiumActionKey = (action: LiquidiumAction): LiquidiumActionKey =>
+	'Supply' in action
+		? 'supply'
+		: 'Borrow' in action
+			? 'borrow'
+			: 'Repay' in action
+				? 'repay'
+				: 'withdraw';
+
+// Analytics metadata for a Liquidium action — shared by the submitted and
+// success/error events so they line up for the same transaction.
+export const liquidiumTrackingMetadata = ({
+	action,
+	token,
+	tokenAmount,
+	error
+}: {
+	action: LiquidiumActionKey;
+	token: string;
+	tokenAmount: string;
+	error?: string;
+}): Record<string, string> => ({
+	dApp: LIQUIDIUM_PROVIDER_ID,
+	action,
+	token,
+	tokenAmount,
+	...(nonNullish(error) ? { error } : {})
+});
+
+// Terminal-row metadata, read off the `external_refs`/`data` snapshot so it
+// survives refresh/resume. Mirrors `buildOneSecSwapTrackingMetadata`.
+export const buildLiquidiumTrackingMetadata = ({
+	tx
+}: {
+	tx: ActiveUserTransaction;
+}): Record<string, string> => {
+	const refs = toLiquidiumExternalRefsMap(tx.external_refs);
+
+	return liquidiumTrackingMetadata({
+		action: 'Liquidium' in tx.data ? liquidiumActionKey(tx.data.Liquidium.action) : 'supply',
+		token: refs[LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL] ?? '',
+		tokenAmount: refs[LIQUIDIUM_EXTERNAL_REF_KEYS.AMOUNT] ?? '',
+		error: tx.error[0]
+	});
+};
+
+// Liquidium activity status → AUT status; `undefined` for statuses that don't advance the row.
+export const liquidiumActivityToStatus = (
+	status: Activity['status']
+): ActiveUserTransactionStatus | undefined => {
+	switch (status) {
+		case ActivityStatus.confirmed:
+			return { Succeeded: null };
+		case ActivityStatus.failed:
+			return { Failed: null };
+		case ActivityStatus.pending:
+		case ActivityStatus.detected:
+		case ActivityStatus.processing:
+		case ActivityStatus.sent:
+			return { Executing: null };
+		default:
+			// `requested` (and any unknown status) → no advance.
+			return undefined;
+	}
+};

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -1,0 +1,117 @@
+import {
+	LIQUIDIUM_HEALTH_AT_RISK_PERCENT,
+	LIQUIDIUM_HEALTH_CRITICAL_PERCENT,
+	type LiquidiumHealthLevel
+} from '$lib/constants/liquidium.constants';
+import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import { nonNullish } from '@dfinity/utils';
+import {
+	RATE_SCALE,
+	type Pool,
+	type UserPositionSummary,
+	type UserReserve
+} from '@liquidium/client';
+
+// Scaled protocol rate → percentage.
+const rateToPercent = ({ rate, rateDecimals }: { rate: bigint; rateDecimals: bigint }): number =>
+	(Number(rate) / 10 ** Number(rateDecimals)) * 100;
+
+const scaledUsdToNumber = ({ value, decimals }: { value: bigint; decimals: bigint }): number =>
+	Number(value) / 10 ** Number(decimals);
+
+// SDK health factor (scaled by RATE_SCALE) → percentage, clamped [0, 100] (100% = no debt).
+export const liquidiumHealthFactorToPercent = (healthFactor: bigint): number =>
+	Math.min(100, Math.max(0, (Number(healthFactor) / Number(RATE_SCALE)) * 100));
+
+export const liquidiumHealthLevel = (healthFactorPercent: number): LiquidiumHealthLevel =>
+	healthFactorPercent >= LIQUIDIUM_HEALTH_AT_RISK_PERCENT
+		? 'healthy'
+		: healthFactorPercent >= LIQUIDIUM_HEALTH_CRITICAL_PERCENT
+			? 'at-risk'
+			: 'critical';
+
+const isUnderSupplyCap = ({ totalSupply, supplyCap }: Pool): boolean =>
+	!nonNullish(supplyCap) || totalSupply < supplyCap;
+
+export const mapLiquidiumMarket = (pool: Pool): LiquidiumMarket => ({
+	poolId: pool.id,
+	asset: pool.asset,
+	chain: pool.chain,
+	supplyApy: rateToPercent({ rate: pool.lendingRate, rateDecimals: pool.rateDecimals }),
+	borrowApy: rateToPercent({ rate: pool.borrowingRate, rateDecimals: pool.rateDecimals }),
+	frozen: pool.frozen,
+	available: !pool.frozen && isUnderSupplyCap(pool)
+});
+
+export const mapLiquidiumReserve = ({
+	position,
+	pool,
+	suppliedUsd,
+	borrowedUsd,
+	usdDecimals
+}: UserReserve): LiquidiumReserve => ({
+	poolId: position.poolId,
+	asset: position.asset,
+	chain: pool.chain,
+	supplyApy: rateToPercent({ rate: pool.lendingRate, rateDecimals: pool.rateDecimals }),
+	borrowApy: rateToPercent({ rate: pool.borrowingRate, rateDecimals: pool.rateDecimals }),
+	deposited: position.deposited,
+	depositedDecimals: Number(position.depositedDecimals),
+	borrowed: position.borrowed,
+	borrowedDecimals: Number(position.borrowedDecimals),
+	suppliedUsd: scaledUsdToNumber({ value: suppliedUsd, decimals: usdDecimals }),
+	borrowedUsd: scaledUsdToNumber({ value: borrowedUsd, decimals: usdDecimals })
+});
+
+export const mapLiquidiumPortfolio = ({
+	reserves,
+	summary
+}: {
+	reserves: UserReserve[];
+	summary: UserPositionSummary;
+}): LiquidiumPortfolio => ({
+	reserves: reserves.map(mapLiquidiumReserve),
+	totalSuppliedUsd: scaledUsdToNumber({
+		value: summary.totalCollateralUsd,
+		decimals: summary.usdDecimals
+	}),
+	totalBorrowedUsd: scaledUsdToNumber({
+		value: summary.totalDebtUsd,
+		decimals: summary.usdDecimals
+	}),
+	netValueUsd: scaledUsdToNumber({ value: summary.netWorthUsd, decimals: summary.usdDecimals }),
+	availableBorrowsUsd: scaledUsdToNumber({
+		value: summary.availableBorrowsUsd,
+		decimals: summary.usdDecimals
+	}),
+	healthFactorPercent: liquidiumHealthFactorToPercent(summary.healthFactor)
+});
+
+export const liquidiumNetApy = ({ reserves, netValueUsd }: LiquidiumPortfolio): number | null => {
+	if (netValueUsd <= 0) {
+		return null;
+	}
+
+	const weighted = reserves.reduce(
+		(acc, { suppliedUsd, supplyApy, borrowedUsd, borrowApy }) =>
+			acc + suppliedUsd * supplyApy - borrowedUsd * borrowApy,
+		0
+	);
+
+	return weighted / netValueUsd;
+};
+
+// Best supply APY across enterable pools; 0 when none.
+export const liquidiumMaxSupplyApy = (markets: LiquidiumMarket[]): number =>
+	markets.reduce(
+		(max, { supplyApy, available }) => (available ? Math.max(max, supplyApy) : max),
+		0
+	);
+
+// Net yearly interest in USD (Σ suppliedUsd·supplyApy − Σ borrowedUsd·borrowApy, /100); 0 when no positions.
+export const liquidiumNetInterestUsd = (portfolio: LiquidiumPortfolio | null): number =>
+	(portfolio?.reserves ?? []).reduce(
+		(acc, { suppliedUsd, supplyApy, borrowedUsd, borrowApy }) =>
+			acc + (suppliedUsd * supplyApy - borrowedUsd * borrowApy) / 100,
+		0
+	);

--- a/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
@@ -1,0 +1,30 @@
+import {
+	lendBorrowProvidersConfig,
+	liquidiumSupplyWizardSteps
+} from '$lib/config/lend-borrow.config';
+import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import { LendBorrowProvider } from '$lib/types/lend-borrow';
+import en from '$tests/mocks/i18n.mock';
+
+describe('lend-borrow.config', () => {
+	describe('liquidiumSupplyWizardSteps', () => {
+		it('returns the supply wizard steps with expected names and titles', () => {
+			expect(liquidiumSupplyWizardSteps({ i18n: en })).toStrictEqual([
+				{ name: WizardStepsLiquidiumSupply.SUPPLY, title: en.liquidium.text.action_supply },
+				{ name: WizardStepsLiquidiumSupply.REVIEW, title: en.liquidium.text.supply_review },
+				{ name: WizardStepsLiquidiumSupply.SUPPLYING, title: en.liquidium.text.supplying }
+			]);
+		});
+	});
+
+	describe('lendBorrowProvidersConfig', () => {
+		it('exposes the Liquidium provider config', () => {
+			expect(lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM]).toStrictEqual({
+				name: 'Liquidium',
+				descriptionKey: 'liquidium.text.description',
+				logo: '/images/dapps/liquidium-logo.webp',
+				url: 'https://liquidium.fi/docs/quick-start/core-concepts'
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -1,0 +1,187 @@
+import { EarningCardFields } from '$env/types/env.earning-cards';
+import { ZERO } from '$lib/constants/app.constants';
+import { AppPath } from '$lib/constants/routes.constants';
+import {
+	liquidiumEarningData,
+	liquidiumHealthFactorPercent,
+	liquidiumMarkets,
+	liquidiumMaxSupplyApy,
+	liquidiumNetValueUsd,
+	liquidiumPortfolio
+} from '$lib/derived/liquidium.derived';
+import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
+import { formatStakeApyNumber } from '$lib/utils/format.utils';
+import { liquidiumNetInterestUsd } from '$lib/utils/liquidium.utils';
+import { get } from 'svelte/store';
+
+const mockGoto = vi.fn();
+vi.mock('$app/navigation', () => ({ goto: (...args: unknown[]) => mockGoto(...args) }));
+
+describe('liquidiumEarningData', () => {
+	const portfolio: LiquidiumPortfolio = {
+		reserves: [
+			{
+				poolId: 'pool-btc',
+				asset: 'BTC',
+				chain: 'BTC',
+				supplyApy: 5,
+				borrowApy: 0,
+				deposited: ZERO,
+				depositedDecimals: 8,
+				borrowed: ZERO,
+				borrowedDecimals: 8,
+				suppliedUsd: 1000,
+				borrowedUsd: 0
+			}
+		],
+		totalSuppliedUsd: 1000,
+		totalBorrowedUsd: 0,
+		netValueUsd: 1000,
+		availableBorrowsUsd: 0,
+		healthFactorPercent: 100
+	};
+
+	beforeEach(() => {
+		mockGoto.mockClear();
+		liquidiumStore.reset();
+	});
+
+	it('maps markets and portfolio into earning-card fields', () => {
+		liquidiumStore.set({
+			markets: [
+				{
+					poolId: 'pool-btc',
+					asset: 'BTC',
+					chain: 'BTC',
+					supplyApy: 5,
+					borrowApy: 9,
+					frozen: false,
+					available: true
+				}
+			],
+			portfolio
+		});
+
+		const data = get(liquidiumEarningData);
+		const balance = get(enabledMainnetFungibleTokensUsdBalance);
+
+		expect(data[EarningCardFields.APY]).toBe(formatStakeApyNumber(5));
+		expect(data[EarningCardFields.NETWORKS]).toEqual(expect.arrayContaining([expect.any(String)]));
+		expect(data[EarningCardFields.ASSETS]).toEqual(expect.arrayContaining([expect.any(String)]));
+		expect(data[EarningCardFields.CURRENT_EARNING]).toBeCloseTo(liquidiumNetInterestUsd(portfolio));
+		// Earning potential floors the idle balance at 0, so supplied > balance never goes negative.
+		expect(data[EarningCardFields.EARNING_POTENTIAL]).toBeCloseTo(
+			(Math.max(0, balance - portfolio.totalSuppliedUsd) * 5) / 100
+		);
+	});
+
+	it('navigates to the provider page on action', async () => {
+		await get(liquidiumEarningData).action();
+
+		expect(mockGoto).toHaveBeenCalledWith(AppPath.ProvidersLiquidium);
+	});
+});
+
+describe('liquidium derived stores', () => {
+	const market = (overrides: Partial<LiquidiumMarket> = {}): LiquidiumMarket => ({
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true,
+		...overrides
+	});
+
+	const portfolio: LiquidiumPortfolio = {
+		reserves: [],
+		totalSuppliedUsd: 1200,
+		totalBorrowedUsd: 200,
+		netValueUsd: 1000,
+		availableBorrowsUsd: 0,
+		healthFactorPercent: 73
+	};
+
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	describe('liquidiumMarkets', () => {
+		it('reflects the markets in the store', () => {
+			const markets = [market()];
+			liquidiumStore.set({ markets, portfolio: null });
+
+			expect(get(liquidiumMarkets)).toEqual(markets);
+		});
+
+		it('is empty by default', () => {
+			expect(get(liquidiumMarkets)).toEqual([]);
+		});
+	});
+
+	describe('liquidiumPortfolio', () => {
+		it('reflects the portfolio in the store', () => {
+			liquidiumStore.set({ markets: [], portfolio });
+
+			expect(get(liquidiumPortfolio)).toEqual(portfolio);
+		});
+
+		it('is null by default', () => {
+			expect(get(liquidiumPortfolio)).toBeNull();
+		});
+	});
+
+	describe('liquidiumMaxSupplyApy', () => {
+		it('returns the best APY across available pools', () => {
+			liquidiumStore.set({
+				markets: [market({ supplyApy: 5 }), market({ poolId: 'pool-eth', supplyApy: 7 })],
+				portfolio: null
+			});
+
+			expect(get(liquidiumMaxSupplyApy)).toBe(7);
+		});
+
+		it('ignores unavailable pools', () => {
+			liquidiumStore.set({
+				markets: [
+					market({ supplyApy: 5 }),
+					market({ poolId: 'pool-eth', supplyApy: 9, available: false })
+				],
+				portfolio: null
+			});
+
+			expect(get(liquidiumMaxSupplyApy)).toBe(5);
+		});
+
+		it('is 0 when there are no markets', () => {
+			expect(get(liquidiumMaxSupplyApy)).toBe(0);
+		});
+	});
+
+	describe('liquidiumNetValueUsd', () => {
+		it('reflects the portfolio net value', () => {
+			liquidiumStore.set({ markets: [], portfolio });
+
+			expect(get(liquidiumNetValueUsd)).toBe(1000);
+		});
+
+		it('is 0 when there is no portfolio', () => {
+			expect(get(liquidiumNetValueUsd)).toBe(0);
+		});
+	});
+
+	describe('liquidiumHealthFactorPercent', () => {
+		it('reflects the portfolio health factor', () => {
+			liquidiumStore.set({ markets: [], portfolio });
+
+			expect(get(liquidiumHealthFactorPercent)).toBe(73);
+		});
+
+		it('is null when there is no portfolio', () => {
+			expect(get(liquidiumHealthFactorPercent)).toBeNull();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/liquidium-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-active-tx.services.spec.ts
@@ -1,0 +1,191 @@
+import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import * as liquidiumApi from '$lib/api/liquidium.api';
+import { ZERO } from '$lib/constants/app.constants';
+import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
+import { pollLiquidiumActiveUserTransactions } from '$lib/services/liquidium-active-tx.services';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import {
+	ActivityDirection,
+	ActivityKind,
+	ActivityStatus,
+	type Activity,
+	type InflowActivity
+} from '@liquidium/client';
+
+vi.mock('$lib/api/liquidium.api', () => ({ liquidiumClient: vi.fn() }));
+vi.mock('$lib/services/active-user-transactions.services', () => ({
+	applyActiveUserTransactionPollUpdate: vi.fn()
+}));
+
+describe('liquidium-active-tx.services', () => {
+	const profileId = 'profile-1';
+	const poolId = 'pool-btc';
+	const txid = '0xabc123';
+
+	const list = vi.fn();
+	const apply = vi.mocked(activeUserTransactionsServices.applyActiveUserTransactionPollUpdate);
+
+	const buildTx = (refs: Record<string, string>): ActiveUserTransaction => ({
+		id: 'tx-1',
+		status: { Pending: null },
+		external_refs: Object.entries(refs).map(([key, value]) => ({ key, value })),
+		progress_step: [],
+		data: {
+			Liquidium: {
+				token: { SolNativeDevnet: null },
+				action: { Supply: null },
+				pool_id: poolId,
+				amount: 100n
+			}
+		},
+		updated_at_ns: ZERO,
+		error: [],
+		created_at_ns: ZERO
+	});
+
+	const buildActivity = (overrides: Partial<InflowActivity> = {}): Activity => ({
+		id: 'act-1',
+		poolId,
+		asset: 'BTC',
+		chain: 'BTC',
+		amount: 100n,
+		timestampMs: 0,
+		txid,
+		confirmations: null,
+		requiredConfirmations: null,
+		direction: ActivityDirection.inflow,
+		kind: ActivityKind.deposit,
+		status: ActivityStatus.pending,
+		...overrides
+	});
+
+	const poll = (tx: ActiveUserTransaction) =>
+		pollLiquidiumActiveUserTransactions({ identity: mockIdentity, transactions: [tx] });
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(liquidiumApi.liquidiumClient).mockReturnValue({
+			activities: { list }
+		} as unknown as ReturnType<typeof liquidiumApi.liquidiumClient>);
+	});
+
+	it('does nothing without a profile id', async () => {
+		await poll(buildTx({ [LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: txid }));
+
+		expect(apply).not.toHaveBeenCalled();
+		expect(list).not.toHaveBeenCalled();
+	});
+
+	it('does nothing without a txid', async () => {
+		await poll(buildTx({ [LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId }));
+
+		expect(apply).not.toHaveBeenCalled();
+		expect(list).not.toHaveBeenCalled();
+	});
+
+	it('terminalizes from the txid-matched activity', async () => {
+		list.mockResolvedValue([buildActivity({ status: ActivityStatus.confirmed })]);
+
+		await poll(
+			buildTx({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: txid
+			})
+		);
+
+		const [[{ update }]] = apply.mock.calls;
+
+		expect(update?.status).toEqual({ Succeeded: null });
+	});
+
+	it('surfaces an error from a failed activity', async () => {
+		list.mockResolvedValue([buildActivity({ status: ActivityStatus.failed })]);
+
+		await poll(
+			buildTx({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: txid
+			})
+		);
+
+		const [[{ update }]] = apply.mock.calls;
+
+		expect(update?.status).toEqual({ Failed: null });
+		expect(update?.error).toBeTruthy();
+	});
+
+	it('advances an in-flight activity to Executing', async () => {
+		list.mockResolvedValue([buildActivity({ status: ActivityStatus.detected })]);
+
+		await poll(
+			buildTx({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: txid
+			})
+		);
+
+		const [[{ update }]] = apply.mock.calls;
+
+		expect(update?.status).toEqual({ Executing: null });
+	});
+
+	it('does not advance for a non-progressing status', async () => {
+		list.mockResolvedValue([buildActivity({ status: ActivityStatus.requested })]);
+
+		await poll(
+			buildTx({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: txid
+			})
+		);
+
+		expect(apply).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when no activity matches the txid', async () => {
+		list.mockResolvedValue([buildActivity({ txid: '0xother', status: ActivityStatus.confirmed })]);
+
+		await poll(
+			buildTx({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: txid
+			})
+		);
+
+		expect(apply).not.toHaveBeenCalled();
+	});
+
+	it('matches txid ignoring case and a 0x prefix mismatch', async () => {
+		// Stored ref carries `0x` + uppercase; the SDK activity carries neither.
+		list.mockResolvedValue([buildActivity({ txid: 'abc123', status: ActivityStatus.confirmed })]);
+
+		await poll(
+			buildTx({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: '0xABC123'
+			})
+		);
+
+		const [[{ update }]] = apply.mock.calls;
+
+		expect(update?.status).toEqual({ Succeeded: null });
+	});
+
+	it('matches against the activity txids array', async () => {
+		list.mockResolvedValue([
+			buildActivity({ txid: null, txids: [txid], status: ActivityStatus.confirmed })
+		]);
+
+		await poll(
+			buildTx({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: txid
+			})
+		);
+
+		const [[{ update }]] = apply.mock.calls;
+
+		expect(update?.status).toEqual({ Succeeded: null });
+	});
+});

--- a/src/frontend/src/tests/lib/services/liquidium-supply.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-supply.services.spec.ts
@@ -129,6 +129,24 @@ describe('liquidium-supply.services', () => {
 		expect(broadcast).toHaveBeenCalledOnce();
 	});
 
+	it('still registers the AUT row when flow.submit fails (independent best-effort steps)', async () => {
+		supply.mockResolvedValue(buildFlow(nativeTarget));
+		broadcast.mockResolvedValue('0xhash');
+		// The SDK submit (a txid indexing hint) fails after funds were broadcast.
+		submit.mockRejectedValueOnce(new Error('rpc hiccup'));
+
+		await expect(run()).resolves.toBeUndefined();
+
+		// The AUT row must still be created so the poller/analytics can correlate by txid.
+		expect(createActiveUserTransaction).toHaveBeenCalledOnce();
+
+		const [[{ externalRefs }]] = createActiveUserTransaction.mock.calls;
+
+		expect(externalRefs).toEqual(
+			expect.arrayContaining([{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID, value: '0xhash' }])
+		);
+	});
+
 	it('rejects an icrcAccount target and registers nothing', async () => {
 		supply.mockResolvedValue(
 			buildFlow({

--- a/src/frontend/src/tests/lib/services/liquidium-supply.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-supply.services.spec.ts
@@ -1,0 +1,150 @@
+import type { EthAddress } from '$eth/types/address';
+import * as liquidiumApi from '$lib/api/liquidium.api';
+import { TRACK_COUNT_LIQUIDIUM_SUBMITTED } from '$lib/constants/analytics.constants';
+import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
+import * as analyticsServices from '$lib/services/analytics.services';
+import { executeLiquidiumSupply } from '$lib/services/liquidium-supply.services';
+import * as liquidiumServices from '$lib/services/liquidium.services';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import type { NativeAddressSupplyTarget, SupplyFlow, SupplyTarget } from '@liquidium/client';
+
+vi.mock('$lib/api/liquidium.api', () => ({ liquidiumClient: vi.fn() }));
+vi.mock('$lib/services/liquidium.services', () => ({ getOrCreateLiquidiumProfile: vi.fn() }));
+vi.mock('$lib/services/active-user-transactions.services', () => ({
+	createActiveUserTransaction: vi.fn()
+}));
+vi.mock('$lib/services/analytics.services', () => ({ trackEvent: vi.fn() }));
+
+describe('liquidium-supply.services', () => {
+	const ethAddress = '0x1111111111111111111111111111111111111111' as EthAddress;
+	const profileId = 'profile-1';
+	const poolId = 'pool-btc';
+
+	const supply = vi.fn();
+	const submit = vi.fn();
+	const broadcast = vi.fn();
+	const createActiveUserTransaction = vi.mocked(
+		activeUserTransactionsServices.createActiveUserTransaction
+	);
+
+	const nativeTarget: NativeAddressSupplyTarget = {
+		type: 'nativeAddress',
+		poolId,
+		asset: 'BTC',
+		chain: 'BTC',
+		action: 'deposit',
+		address: 'bc1qexample'
+	};
+
+	const buildFlow = (target: SupplyTarget): SupplyFlow => ({ type: 'transfer', target, submit });
+
+	const run = () =>
+		executeLiquidiumSupply({
+			identity: mockIdentity,
+			ethAddress,
+			poolId,
+			asset: 'BTC',
+			amount: 100_000_000n,
+			inflowFee: 50n,
+			displayAmount: '1',
+			progressStep: 'supplying',
+			broadcast
+		});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(liquidiumServices.getOrCreateLiquidiumProfile).mockResolvedValue(profileId);
+		vi.mocked(liquidiumApi.liquidiumClient).mockReturnValue({
+			lending: { supply }
+		} as unknown as ReturnType<typeof liquidiumApi.liquidiumClient>);
+		submit.mockResolvedValue({ success: true, txid: '0xhash' });
+	});
+
+	it('broadcasts on the native rail, submits the txid and registers the transaction', async () => {
+		supply.mockResolvedValue(buildFlow(nativeTarget));
+		broadcast.mockResolvedValue('0xhash');
+
+		await run();
+
+		expect(supply).toHaveBeenCalledExactlyOnceWith({ profileId, poolId, action: 'deposit' });
+		// Gross transfer = net supply (100_000_000) + provider inflow fee (50).
+		expect(broadcast).toHaveBeenCalledExactlyOnceWith({
+			target: nativeTarget,
+			amount: 100_000_050n
+		});
+		expect(submit).toHaveBeenCalledExactlyOnceWith({ txid: '0xhash' });
+
+		expect(analyticsServices.trackEvent).toHaveBeenCalledWith({
+			name: TRACK_COUNT_LIQUIDIUM_SUBMITTED,
+			metadata: { dApp: 'liquidium', action: 'supply', token: 'BTC', tokenAmount: '1' }
+		});
+
+		expect(createActiveUserTransaction).toHaveBeenCalledOnce();
+
+		const [[{ data, externalRefs }]] = createActiveUserTransaction.mock.calls;
+
+		expect(data).toEqual(
+			expect.objectContaining({
+				Liquidium: expect.objectContaining({
+					pool_id: poolId,
+					amount: 100_000_000n,
+					action: { Supply: null }
+				})
+			})
+		);
+		expect(externalRefs).toEqual(
+			expect.arrayContaining([
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID, value: profileId },
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL, value: 'BTC' },
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID, value: '0xhash' }
+			])
+		);
+	});
+
+	it('submits and persists a native BTC txid (no 0x prefix)', async () => {
+		supply.mockResolvedValue(buildFlow(nativeTarget));
+		broadcast.mockResolvedValue('deadbeef');
+
+		await run();
+
+		expect(submit).toHaveBeenCalledExactlyOnceWith({ txid: 'deadbeef' });
+
+		const [[{ externalRefs }]] = createActiveUserTransaction.mock.calls;
+
+		expect(externalRefs).toEqual(
+			expect.arrayContaining([{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID, value: 'deadbeef' }])
+		);
+	});
+
+	it('resolves even if post-broadcast bookkeeping fails (funds already sent)', async () => {
+		supply.mockResolvedValue(buildFlow(nativeTarget));
+		broadcast.mockResolvedValue('0xhash');
+		// The transfer is broadcast, but registering the txid / AUT row fails.
+		createActiveUserTransaction.mockRejectedValueOnce(new Error('backend unavailable'));
+
+		await expect(run()).resolves.toBeUndefined();
+
+		// The on-chain transfer still happened; the failure is swallowed.
+		expect(broadcast).toHaveBeenCalledOnce();
+	});
+
+	it('rejects an icrcAccount target and registers nothing', async () => {
+		supply.mockResolvedValue(
+			buildFlow({
+				type: 'icrcAccount',
+				poolId,
+				asset: 'BTC',
+				chain: 'BTC',
+				action: 'deposit',
+				owner: 'aaaaa-aa',
+				subaccount: new Uint8Array(),
+				account: 'icrc-account-text'
+			})
+		);
+
+		await expect(run()).rejects.toThrow('unsupported');
+		expect(broadcast).not.toHaveBeenCalled();
+		expect(createActiveUserTransaction).not.toHaveBeenCalled();
+	});
+});

--- a/src/frontend/src/tests/lib/services/liquidium-wallet-adapter.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-wallet-adapter.services.spec.ts
@@ -1,0 +1,46 @@
+import * as signerApi from '$lib/api/signer.api';
+import { liquidiumWalletAdapter } from '$lib/services/liquidium-wallet-adapter.services';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { Chain, type SignMessageRequest } from '@liquidium/client';
+
+vi.mock('$lib/api/signer.api', () => ({
+	signMessage: vi.fn()
+}));
+
+describe('liquidium-wallet-adapter.services', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const baseRequest: Omit<SignMessageRequest, 'chain'> = {
+		message: 'sign me',
+		actionType: 'create-account',
+		transferMode: 'native'
+	};
+
+	describe('signMessage', () => {
+		it('delegates an ETH message to the signer api with the identity', async () => {
+			const signature = '0xsignature';
+			vi.mocked(signerApi.signMessage).mockResolvedValue(signature);
+
+			const adapter = liquidiumWalletAdapter({ identity: mockIdentity });
+
+			const result = await adapter.signMessage?.({ ...baseRequest, chain: Chain.ETH });
+
+			expect(result).toBe(signature);
+			expect(signerApi.signMessage).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				message: baseRequest.message
+			});
+		});
+
+		it('throws for a non-ETH chain (no BIP-322 signing path)', async () => {
+			const adapter = liquidiumWalletAdapter({ identity: mockIdentity });
+
+			await expect(adapter.signMessage?.({ ...baseRequest, chain: Chain.BTC })).rejects.toThrow(
+				'unsupported chain'
+			);
+			expect(signerApi.signMessage).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/liquidium.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium.services.spec.ts
@@ -1,0 +1,127 @@
+import type { EthAddress } from '$eth/types/address';
+import * as liquidiumApi from '$lib/api/liquidium.api';
+import { getOrCreateLiquidiumProfile, loadLiquidium } from '$lib/services/liquidium.services';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
+import * as liquidiumUtils from '$lib/utils/liquidium.utils';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { get } from 'svelte/store';
+
+vi.mock('$lib/api/liquidium.api', () => ({
+	liquidiumClient: vi.fn()
+}));
+
+vi.mock('$lib/utils/liquidium.utils', () => ({
+	mapLiquidiumMarket: vi.fn(),
+	mapLiquidiumPortfolio: vi.fn()
+}));
+
+describe('liquidium.services', () => {
+	const ethAddress = '0x1111111111111111111111111111111111111111' as EthAddress;
+	const profileId = 'profile-principal-text';
+
+	const getProfileId = vi.fn();
+	const createProfile = vi.fn();
+	const listPools = vi.fn();
+	const getUserReserves = vi.fn();
+	const getUserPositionSummary = vi.fn();
+
+	const market: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+	const portfolio = { netValueUsd: 60 } as LiquidiumPortfolio;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		liquidiumStore.reset();
+		vi.mocked(liquidiumApi.liquidiumClient).mockReturnValue({
+			accounts: { getProfileId, createProfile },
+			market: { listPools },
+			positions: { getUserReserves, getUserPositionSummary }
+		} as unknown as ReturnType<typeof liquidiumApi.liquidiumClient>);
+		vi.mocked(liquidiumUtils.mapLiquidiumMarket).mockReturnValue(market);
+		vi.mocked(liquidiumUtils.mapLiquidiumPortfolio).mockReturnValue(portfolio);
+	});
+
+	describe('getOrCreateLiquidiumProfile', () => {
+		it('returns the existing profile without creating one', async () => {
+			getProfileId.mockResolvedValue(profileId);
+
+			const result = await getOrCreateLiquidiumProfile({ identity: mockIdentity, ethAddress });
+
+			expect(result).toBe(profileId);
+			expect(getProfileId).toHaveBeenCalledExactlyOnceWith(ethAddress);
+			expect(createProfile).not.toHaveBeenCalled();
+		});
+
+		it('creates an ETH-owned profile when none exists', async () => {
+			getProfileId.mockResolvedValue(null);
+			createProfile.mockResolvedValue(profileId);
+
+			const result = await getOrCreateLiquidiumProfile({ identity: mockIdentity, ethAddress });
+
+			expect(result).toBe(profileId);
+			expect(createProfile).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ account: ethAddress, chain: 'ETH' })
+			);
+		});
+	});
+
+	describe('loadLiquidium', () => {
+		it('resets the store and does not call the SDK when there is no identity', async () => {
+			liquidiumStore.set({ markets: [market], portfolio });
+
+			await loadLiquidium({ identity: null, ethAddress });
+
+			expect(get(liquidiumStore)).toEqual({ markets: [], portfolio: null });
+			expect(liquidiumApi.liquidiumClient).not.toHaveBeenCalled();
+		});
+
+		it('loads markets only when the user has no profile', async () => {
+			listPools.mockResolvedValue([{ id: 'pool-btc' }]);
+			getProfileId.mockResolvedValue(null);
+
+			await loadLiquidium({ identity: mockIdentity, ethAddress });
+
+			expect(get(liquidiumStore)).toEqual({ markets: [market], portfolio: null });
+			expect(getUserReserves).not.toHaveBeenCalled();
+			expect(getUserPositionSummary).not.toHaveBeenCalled();
+		});
+
+		it('skips the profile lookup entirely when no ETH address is available', async () => {
+			listPools.mockResolvedValue([{ id: 'pool-btc' }]);
+
+			await loadLiquidium({ identity: mockIdentity, ethAddress: undefined });
+
+			expect(get(liquidiumStore).portfolio).toBeNull();
+			expect(getProfileId).not.toHaveBeenCalled();
+		});
+
+		it('loads markets and portfolio when a profile exists', async () => {
+			listPools.mockResolvedValue([{ id: 'pool-btc' }]);
+			getProfileId.mockResolvedValue(profileId);
+			getUserReserves.mockResolvedValue([]);
+			getUserPositionSummary.mockResolvedValue({});
+
+			await loadLiquidium({ identity: mockIdentity, ethAddress });
+
+			expect(getUserReserves).toHaveBeenCalledExactlyOnceWith(profileId);
+			expect(getUserPositionSummary).toHaveBeenCalledExactlyOnceWith(profileId);
+			expect(get(liquidiumStore)).toEqual({ markets: [market], portfolio });
+		});
+
+		it('swallows SDK errors and leaves the store unchanged', async () => {
+			listPools.mockRejectedValue(new Error('rpc down'));
+
+			await expect(loadLiquidium({ identity: mockIdentity, ethAddress })).resolves.toBeUndefined();
+
+			expect(get(liquidiumStore)).toEqual({ markets: [], portfolio: null });
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/stores/liquidium.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/liquidium.store.spec.ts
@@ -1,0 +1,41 @@
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import type { LiquidiumStoreData } from '$lib/types/liquidium';
+import { get } from 'svelte/store';
+
+describe('liquidium.store', () => {
+	const data: LiquidiumStoreData = {
+		markets: [
+			{
+				poolId: 'pool-btc',
+				asset: 'BTC',
+				chain: 'BTC',
+				supplyApy: 5,
+				borrowApy: 9,
+				frozen: false,
+				available: true
+			}
+		],
+		portfolio: null
+	};
+
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('initializes with empty markets and no portfolio', () => {
+		expect(get(liquidiumStore)).toEqual({ markets: [], portfolio: null });
+	});
+
+	it('replaces the store data on set', () => {
+		liquidiumStore.set(data);
+
+		expect(get(liquidiumStore)).toEqual(data);
+	});
+
+	it('restores the default value on reset', () => {
+		liquidiumStore.set(data);
+		liquidiumStore.reset();
+
+		expect(get(liquidiumStore)).toEqual({ markets: [], portfolio: null });
+	});
+});

--- a/src/frontend/src/tests/lib/utils/liquidium-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium-active-tx.utils.spec.ts
@@ -1,0 +1,142 @@
+import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import { ZERO } from '$lib/constants/app.constants';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import {
+	buildLiquidiumTrackingMetadata,
+	isLiquidiumActiveUserTransaction,
+	liquidiumActionKey,
+	liquidiumActivityToStatus,
+	liquidiumTrackingMetadata,
+	toLiquidiumExternalRefs,
+	toLiquidiumExternalRefsMap
+} from '$lib/utils/liquidium-active-tx.utils';
+import { ActivityStatus } from '@liquidium/client';
+
+const liquidiumTx: ActiveUserTransaction = {
+	id: 'tx-1',
+	status: { Pending: null },
+	external_refs: [],
+	progress_step: [],
+	data: {
+		Liquidium: {
+			token: { SolNativeDevnet: null },
+			action: { Supply: null },
+			pool_id: 'pool-btc',
+			amount: 100n
+		}
+	},
+	updated_at_ns: ZERO,
+	error: [],
+	created_at_ns: ZERO
+};
+
+describe('liquidium-active-tx.utils', () => {
+	describe('isLiquidiumActiveUserTransaction', () => {
+		it('is true for a Liquidium transaction', () => {
+			expect(isLiquidiumActiveUserTransaction(liquidiumTx)).toBeTruthy();
+		});
+	});
+
+	describe('external refs round-trip', () => {
+		it('builds a sorted (key, value) array, dropping empties', () => {
+			const refs = toLiquidiumExternalRefs({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: 'profile-1',
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: '0xabc',
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.AMOUNT]: ''
+			});
+
+			expect(refs).toEqual([
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID, value: 'profile-1' },
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID, value: '0xabc' }
+			]);
+		});
+
+		it('maps a (key, value) array back to a keyed lookup', () => {
+			expect(
+				toLiquidiumExternalRefsMap([
+					{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID, value: 'profile-1' }
+				])
+			).toEqual({ [LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: 'profile-1' });
+		});
+	});
+
+	describe('liquidiumActionKey', () => {
+		it.each([
+			{ action: { Supply: null }, key: 'supply' },
+			{ action: { Borrow: null }, key: 'borrow' },
+			{ action: { Repay: null }, key: 'repay' },
+			{ action: { Withdraw: null }, key: 'withdraw' }
+		])('maps $key', ({ action, key }) => {
+			expect(liquidiumActionKey(action)).toBe(key);
+		});
+	});
+
+	describe('liquidiumActivityToStatus', () => {
+		it.each([
+			{ status: ActivityStatus.confirmed, expected: { Succeeded: null } },
+			{ status: ActivityStatus.failed, expected: { Failed: null } },
+			{ status: ActivityStatus.pending, expected: { Executing: null } },
+			{ status: ActivityStatus.detected, expected: { Executing: null } },
+			{ status: ActivityStatus.processing, expected: { Executing: null } },
+			{ status: ActivityStatus.sent, expected: { Executing: null } }
+		])('maps $status', ({ status, expected }) => {
+			expect(liquidiumActivityToStatus(status)).toEqual(expected);
+		});
+
+		it('does not advance on requested', () => {
+			expect(liquidiumActivityToStatus(ActivityStatus.requested)).toBeUndefined();
+		});
+	});
+
+	describe('liquidiumTrackingMetadata', () => {
+		it('builds the metadata shape', () => {
+			expect(
+				liquidiumTrackingMetadata({ action: 'supply', token: 'BTC', tokenAmount: '1' })
+			).toEqual({ dApp: 'liquidium', action: 'supply', token: 'BTC', tokenAmount: '1' });
+		});
+
+		it('includes the error when provided', () => {
+			expect(
+				liquidiumTrackingMetadata({
+					action: 'supply',
+					token: 'BTC',
+					tokenAmount: '1',
+					error: 'boom'
+				})
+			).toEqual({
+				dApp: 'liquidium',
+				action: 'supply',
+				token: 'BTC',
+				tokenAmount: '1',
+				error: 'boom'
+			});
+		});
+	});
+
+	describe('buildLiquidiumTrackingMetadata', () => {
+		it('builds metadata from the row refs and action', () => {
+			const tx: ActiveUserTransaction = {
+				...liquidiumTx,
+				external_refs: [
+					{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL, value: 'BTC' },
+					{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.AMOUNT, value: '1' }
+				]
+			};
+
+			expect(buildLiquidiumTrackingMetadata({ tx })).toEqual({
+				dApp: 'liquidium',
+				action: 'supply',
+				token: 'BTC',
+				tokenAmount: '1'
+			});
+		});
+
+		it('surfaces the row error', () => {
+			const tx: ActiveUserTransaction = { ...liquidiumTx, error: ['failed'] };
+
+			expect(buildLiquidiumTrackingMetadata({ tx })).toEqual(
+				expect.objectContaining({ error: 'failed' })
+			);
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -1,0 +1,304 @@
+import { ZERO } from '$lib/constants/app.constants';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import {
+	liquidiumHealthFactorToPercent,
+	liquidiumHealthLevel,
+	liquidiumMaxSupplyApy,
+	liquidiumNetApy,
+	liquidiumNetInterestUsd,
+	mapLiquidiumMarket,
+	mapLiquidiumPortfolio,
+	mapLiquidiumReserve
+} from '$lib/utils/liquidium.utils';
+import {
+	RATE_SCALE,
+	type Pool,
+	type Position,
+	type UserPositionSummary,
+	type UserReserve
+} from '@liquidium/client';
+
+// rateDecimals = 2 keeps the scaled rate fixtures readable (5n → 5%).
+const buildPool = (overrides: Partial<Pool> = {}): Pool => ({
+	id: 'pool-btc',
+	asset: 'BTC',
+	chain: 'BTC',
+	decimals: 8n,
+	frozen: false,
+	totalSupply: ZERO,
+	totalDebt: ZERO,
+	availableLiquidity: ZERO,
+	maxLtv: ZERO,
+	liquidationThreshold: ZERO,
+	liquidationBonus: ZERO,
+	protocolLiquidationFee: ZERO,
+	reserveFactor: ZERO,
+	rateDecimals: 2n,
+	lendingRate: 5n,
+	borrowingRate: 9n,
+	utilizationRate: ZERO,
+	baseRate: ZERO,
+	optimalUtilizationRate: ZERO,
+	rateSlopeBefore: ZERO,
+	rateSlopeAfter: ZERO,
+	lendingIndex: ZERO,
+	borrowIndex: ZERO,
+	sameAssetBorrowing: false,
+	...overrides
+});
+
+const buildPosition = (overrides: Partial<Position> = {}): Position => ({
+	poolId: 'pool-btc',
+	asset: 'BTC',
+	deposited: 100_000_000n,
+	depositedDecimals: 8n,
+	borrowed: ZERO,
+	borrowedDecimals: 8n,
+	earnedInterest: ZERO,
+	debtInterest: ZERO,
+	lastUpdate: ZERO,
+	...overrides
+});
+
+// healthFactor is scaled by RATE_SCALE: 60% → 0.6 * RATE_SCALE.
+const scaledHealth = (percent: bigint): bigint => (percent * RATE_SCALE) / 100n;
+
+describe('liquidium.utils', () => {
+	describe('mapLiquidiumMarket', () => {
+		it('maps rates to percentages and reports availability', () => {
+			expect(mapLiquidiumMarket(buildPool())).toEqual({
+				poolId: 'pool-btc',
+				asset: 'BTC',
+				chain: 'BTC',
+				supplyApy: expect.closeTo(5),
+				borrowApy: expect.closeTo(9),
+				frozen: false,
+				available: true
+			});
+		});
+
+		it('is unavailable when frozen', () => {
+			expect(mapLiquidiumMarket(buildPool({ frozen: true })).available).toBeFalsy();
+		});
+
+		it('is unavailable at or above the supply cap', () => {
+			expect(
+				mapLiquidiumMarket(buildPool({ totalSupply: 100n, supplyCap: 100n })).available
+			).toBeFalsy();
+			expect(
+				mapLiquidiumMarket(buildPool({ totalSupply: 50n, supplyCap: 100n })).available
+			).toBeTruthy();
+		});
+	});
+
+	describe('liquidiumMaxSupplyApy', () => {
+		it('returns the best APY across available pools, ignoring unavailable ones', () => {
+			const markets = [
+				mapLiquidiumMarket(buildPool({ id: 'a', lendingRate: 3n })),
+				mapLiquidiumMarket(buildPool({ id: 'b', lendingRate: 7n })),
+				mapLiquidiumMarket(buildPool({ id: 'c', lendingRate: 9n, frozen: true }))
+			];
+
+			expect(liquidiumMaxSupplyApy(markets)).toBeCloseTo(7);
+		});
+
+		it('returns 0 when there are no markets', () => {
+			expect(liquidiumMaxSupplyApy([])).toBe(0);
+		});
+	});
+
+	describe('liquidiumHealthFactorToPercent', () => {
+		it('maps a scaled health factor to a percentage', () => {
+			expect(liquidiumHealthFactorToPercent(scaledHealth(60n))).toBeCloseTo(60);
+		});
+
+		it('clamps to 100 (no-debt / over-collateralised)', () => {
+			expect(liquidiumHealthFactorToPercent(scaledHealth(500n))).toBe(100);
+		});
+
+		it('is 0 at liquidation', () => {
+			expect(liquidiumHealthFactorToPercent(ZERO)).toBe(0);
+		});
+	});
+
+	describe('liquidiumHealthLevel', () => {
+		it.each([
+			{ percent: 100, level: 'healthy' },
+			{ percent: 50, level: 'healthy' },
+			{ percent: 49.9, level: 'at-risk' },
+			{ percent: 15, level: 'at-risk' },
+			{ percent: 14.9, level: 'critical' },
+			{ percent: 0, level: 'critical' }
+		])('classifies $percent% as $level', ({ percent, level }) => {
+			expect(liquidiumHealthLevel(percent)).toBe(level);
+		});
+	});
+
+	describe('mapLiquidiumReserve', () => {
+		it('maps a reserve to oisy units (USD numbers, base-unit amounts kept)', () => {
+			const reserve: UserReserve = {
+				position: buildPosition({ borrowed: 5n, borrowedDecimals: 6n }),
+				pool: buildPool(),
+				priceUsd: 60_000,
+				suppliedUsd: 6_000_000n,
+				borrowedUsd: 30_000n,
+				usdDecimals: 2n
+			};
+
+			expect(mapLiquidiumReserve(reserve)).toEqual({
+				poolId: 'pool-btc',
+				asset: 'BTC',
+				chain: 'BTC',
+				supplyApy: expect.closeTo(5),
+				borrowApy: expect.closeTo(9),
+				deposited: 100_000_000n,
+				depositedDecimals: 8,
+				borrowed: 5n,
+				borrowedDecimals: 6,
+				suppliedUsd: 60_000,
+				borrowedUsd: 300
+			});
+		});
+	});
+
+	describe('liquidiumNetApy', () => {
+		const buildReserve = (overrides: Partial<LiquidiumReserve>): LiquidiumReserve => ({
+			poolId: 'p',
+			asset: 'BTC',
+			chain: 'BTC',
+			supplyApy: 0,
+			borrowApy: 0,
+			deposited: ZERO,
+			depositedDecimals: 8,
+			borrowed: ZERO,
+			borrowedDecimals: 8,
+			suppliedUsd: 0,
+			borrowedUsd: 0,
+			...overrides
+		});
+
+		it('equals the supply APY when there is no debt', () => {
+			expect(
+				liquidiumNetApy({
+					reserves: [buildReserve({ suppliedUsd: 1000, supplyApy: 5 })],
+					totalSuppliedUsd: 1000,
+					totalBorrowedUsd: 0,
+					netValueUsd: 1000,
+					availableBorrowsUsd: 0,
+					healthFactorPercent: 100
+				})
+			).toBeCloseTo(5);
+		});
+
+		it('is negative when borrow cost outweighs supply yield', () => {
+			expect(
+				liquidiumNetApy({
+					reserves: [
+						buildReserve({ suppliedUsd: 1000, supplyApy: 5 }),
+						buildReserve({ borrowedUsd: 800, borrowApy: 8 })
+					],
+					totalSuppliedUsd: 1000,
+					totalBorrowedUsd: 800,
+					netValueUsd: 200,
+					availableBorrowsUsd: 0,
+					healthFactorPercent: 40
+				})
+			).toBeCloseTo((1000 * 5 - 800 * 8) / 200);
+		});
+
+		it('is null when there is no net value', () => {
+			expect(
+				liquidiumNetApy({
+					reserves: [],
+					totalSuppliedUsd: 0,
+					totalBorrowedUsd: 0,
+					netValueUsd: 0,
+					availableBorrowsUsd: 0,
+					healthFactorPercent: 100
+				})
+			).toBeNull();
+		});
+	});
+
+	describe('liquidiumNetInterestUsd', () => {
+		const buildReserve = (overrides: Partial<LiquidiumReserve>): LiquidiumReserve => ({
+			poolId: 'p',
+			asset: 'BTC',
+			chain: 'BTC',
+			supplyApy: 0,
+			borrowApy: 0,
+			deposited: ZERO,
+			depositedDecimals: 8,
+			borrowed: ZERO,
+			borrowedDecimals: 8,
+			suppliedUsd: 0,
+			borrowedUsd: 0,
+			...overrides
+		});
+
+		const buildPortfolio = (reserves: LiquidiumReserve[]): LiquidiumPortfolio => ({
+			reserves,
+			totalSuppliedUsd: 0,
+			totalBorrowedUsd: 0,
+			netValueUsd: 0,
+			availableBorrowsUsd: 0,
+			healthFactorPercent: 100
+		});
+
+		it('is 0 when there is no portfolio', () => {
+			expect(liquidiumNetInterestUsd(null)).toBe(0);
+		});
+
+		it('is 0 when there are no reserves', () => {
+			expect(liquidiumNetInterestUsd(buildPortfolio([]))).toBe(0);
+		});
+
+		it('sums supply yield net of borrow cost across reserves', () => {
+			expect(
+				liquidiumNetInterestUsd(
+					buildPortfolio([
+						buildReserve({ suppliedUsd: 1000, supplyApy: 5 }),
+						buildReserve({ suppliedUsd: 2000, supplyApy: 3, borrowedUsd: 500, borrowApy: 8 })
+					])
+				)
+			).toBeCloseTo((1000 * 5 + 2000 * 3 - 500 * 8) / 100);
+		});
+	});
+
+	describe('mapLiquidiumPortfolio', () => {
+		it('maps summary aggregates and reserves', () => {
+			const summary: UserPositionSummary = {
+				totalCollateralUsd: 10_000n,
+				totalDebtUsd: 4_000n,
+				availableBorrowsUsd: 2_000n,
+				netWorthUsd: 6_000n,
+				usdDecimals: 2n,
+				currentLtvBps: 4_000n,
+				weightedMaxLtvBps: 6_000n,
+				weightedLiquidationThresholdBps: 8_000n,
+				healthFactor: scaledHealth(60n)
+			};
+
+			const portfolio = mapLiquidiumPortfolio({
+				reserves: [
+					{
+						position: buildPosition(),
+						pool: buildPool(),
+						priceUsd: 60_000,
+						suppliedUsd: 6_000_000n,
+						borrowedUsd: ZERO,
+						usdDecimals: 2n
+					}
+				],
+				summary
+			});
+
+			expect(portfolio.totalSuppliedUsd).toBe(100);
+			expect(portfolio.totalBorrowedUsd).toBe(40);
+			expect(portfolio.netValueUsd).toBe(60);
+			expect(portfolio.availableBorrowsUsd).toBe(20);
+			expect(portfolio.healthFactorPercent).toBeCloseTo(60);
+			expect(portfolio.reserves).toHaveLength(1);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

PR 2 of the Liquidium "Supply" stack. The full non-UI core: feature flags, SDK client, services, store, utils, types, derived data, and i18n — everything the feature computes, with unit tests. Nothing renders it or wires it into a loader yet, so there is zero runtime impact; the code compiles and is tested but unreachable. 

# Changes
  
  - Feature flags (env/liquidium.ts, env/lend-borrow.ts): LIQUIDIUM_ENABLED and LEND_BORROW_ENABLED, both = STAGING, plus anyLendBorrowProviderEnabled. Staging-only; hidden in BETA/PROD.
  - SDK bump (package.json, package-lock.json): @liquidium/client 0.3.3 → 0.3.4.
  - SDK client (lib/api/liquidium.api.ts): constructs LiquidiumClient for the signed-in identity, reusing oisy's Alchemy viem client as evmPublicClient (no new RPC secret), no custom headers (CORS).
  - Wallet adapter (lib/services/liquidium-wallet-adapter.services.ts): signMessage-only bridge (ETH EIP-191); profiles are ETH-owned.
  - Services: liquidium.services.ts (markets + portfolio load, transparent profile bootstrap), liquidium-supply.services.ts (supply orchestration + inflow-fee estimate + active-tx registration), liquidium-active-tx.services.ts (txid-correlated AUT poller).
  - Store + derived: liquidium.store.ts (markets/portfolio), liquidium.derived.ts (max supply APY, net value, health %, Earn-card field mapping). Earning-potential is floored at 0 so it never flashes negative during load.
  - Utils + types + constants: liquidium.utils.ts, liquidium-active-tx.utils.ts, types (liquidium, lend-borrow, liquidium-active-tx), liquidium.constants.ts (provider id, asset tokens, ck-ledger ids, health bands, poll interval), analytics.constants.ts (liquidium_submitted/success/error), config (lend-borrow.config.ts), enums (progress/wizard/steps), routes (ProvidersLiquidium + the deferred Borrow/Liabilities consts).
  - i18n: all 15 locales + i18n.d.ts (liquidium.* and earning.cards.liquidium.*). Keys land up front; consumers arrive in later PRs.

  # Production impact

None. All code is gated behind STAGING flags and not yet referenced by any rendered surface, loader, or route. The SDK version bump is the only thing that ships to the bundle.

  # Test plan
  
  - Unit specs for utils, services, store, config, wallet adapter, and derived stores.
  - npm run format && npm run lint -- --max-warnings 0 && npm run check && npm run test green.

