### PR TITLE
refactor(frontend): own theme store + SystemThemeListener natively, detach from gix

### DIFF
--- a/src/frontend/src/lib/components/auth/LandingPage.svelte
+++ b/src/frontend/src/lib/components/auth/LandingPage.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { themeStore } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import AuthHelpModal from '$lib/components/auth/AuthHelpModal.svelte';
 	import FeatureCards from '$lib/components/auth/FeatureCards.svelte';
@@ -8,6 +7,7 @@
 	import Img from '$lib/components/ui/Img.svelte';
 	import { modalAuthHelp, modalAuthHelpData } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { themeStore } from '$lib/stores/theme.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 
 	const ariaLabel = $derived(replaceOisyPlaceholders($i18n.auth.alt.preview));

--- a/src/frontend/src/lib/components/auth/LockPage.svelte
+++ b/src/frontend/src/lib/components/auth/LockPage.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { themeStore } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import ButtonsSignIn from '$lib/components/auth/ButtonsSignIn.svelte';
 	import OisyWalletLogoLink from '$lib/components/core/OisyWalletLogoLink.svelte';
@@ -14,6 +13,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { authLocked } from '$lib/stores/locked.store';
 	import { modalStore } from '$lib/stores/modal.store';
+	import { themeStore } from '$lib/stores/theme.store';
 	import { InternetIdentityDomain, type OpenIdProvider } from '$lib/types/auth';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
 

--- a/src/frontend/src/lib/components/core/MenuThemeSelector.svelte
+++ b/src/frontend/src/lib/components/core/MenuThemeSelector.svelte
@@ -9,11 +9,10 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { themeStore, type ThemeStoreData } from '$lib/stores/theme.store';
 	import { Theme } from '$lib/types/theme';
+	import { LOCALSTORAGE_THEME_KEY } from '$lib/utils/theme.utils';
 
 	const THEME_VALUES = [...Object.values(Theme)];
 
-	// TODO: use variable exposed from gix-components when it will be exposed.
-	const THEME_KEY = 'nnsTheme';
 	const THEME_SYSTEM = 'system';
 
 	const selectTheme = (theme: Theme | typeof THEME_SYSTEM) => {
@@ -30,7 +29,7 @@
 
 	// Here we just update the local variable above to update the selected card
 	const updateSelectedCard = (themeStore: ThemeStoreData) => {
-		selectedCard = isNullish(localStorage.getItem(THEME_KEY))
+		selectedCard = isNullish(localStorage.getItem(LOCALSTORAGE_THEME_KEY))
 			? THEME_SYSTEM
 			: (themeStore ?? THEME_SYSTEM);
 	};

--- a/src/frontend/src/lib/components/core/MenuThemeSelector.svelte
+++ b/src/frontend/src/lib/components/core/MenuThemeSelector.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Theme, themeStore, type ThemeStoreData } from '@dfinity/gix-components';
 	import { isNullish } from '@dfinity/utils';
 	import ThemeSelectorButton from '$lib/components/core/ThemeSelectorButton.svelte';
 	import IconDuoTone from '$lib/components/icons/IconDuoTone.svelte';
@@ -8,6 +7,8 @@
 	import IconSunMoon from '$lib/components/icons/IconSunMoon.svelte';
 	import { THEME_SELECTOR_CARD } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { themeStore, type ThemeStoreData } from '$lib/stores/theme.store';
+	import { Theme } from '$lib/types/theme';
 
 	const THEME_VALUES = [...Object.values(Theme)];
 

--- a/src/frontend/src/lib/components/hero/HeroContent.svelte
+++ b/src/frontend/src/lib/components/hero/HeroContent.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Theme, themeStore } from '@dfinity/gix-components';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { setContext } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
@@ -48,6 +47,8 @@
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { type HeroContext, initHeroContext, HERO_CONTEXT_KEY } from '$lib/stores/hero.store';
+	import { themeStore } from '$lib/stores/theme.store';
+	import { Theme } from '$lib/types/theme';
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { isRouteNfts, isRouteTransactions } from '$lib/utils/nav.utils';
 	import { getTokenDisplayName, mapTokenUi } from '$lib/utils/token.utils';

--- a/src/frontend/src/lib/components/icons/IconOisyEmptyState.svelte
+++ b/src/frontend/src/lib/components/icons/IconOisyEmptyState.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { Theme, themeStore } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
+	import { themeStore } from '$lib/stores/theme.store';
+	import { Theme } from '$lib/types/theme';
 
 	// soften icon for dark mode
 	let isDarkMode = $derived(nonNullish($themeStore) ? $themeStore === Theme.DARK : false);

--- a/src/frontend/src/lib/components/ui/SystemThemeListener.svelte
+++ b/src/frontend/src/lib/components/ui/SystemThemeListener.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-	import { onDestroy, onMount } from 'svelte';
+	import { onMount } from 'svelte';
 	import { themeStore } from '$lib/stores/theme.store';
 	import { isThemeSelected } from '$lib/utils/theme.utils';
-
-	// Set up our MediaQueryList
-	const matchMediaDark = window.matchMedia('(prefers-color-scheme: dark)');
 
 	// Update the store if OS preference changes
 	const updateThemeOnChange = () => {
@@ -16,9 +13,12 @@
 		themeStore.resetToSystemSettings();
 	};
 
-	// Register change event on mount
-	onMount(() => matchMediaDark.addEventListener('change', updateThemeOnChange));
+	// Set up the MediaQueryList and register the listener on mount only:
+	// `window` is undefined during SSR/prerender (adapter-static).
+	onMount(() => {
+		const matchMediaDark = window.matchMedia('(prefers-color-scheme: dark)');
+		matchMediaDark.addEventListener('change', updateThemeOnChange);
 
-	// Clean up if this component is destroyed
-	onDestroy(() => matchMediaDark.removeEventListener('change', updateThemeOnChange));
+		return () => matchMediaDark.removeEventListener('change', updateThemeOnChange);
+	});
 </script>

--- a/src/frontend/src/lib/components/ui/SystemThemeListener.svelte
+++ b/src/frontend/src/lib/components/ui/SystemThemeListener.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
+	import { themeStore } from '$lib/stores/theme.store';
+	import { isThemeSelected } from '$lib/utils/theme.utils';
+
+	// Set up our MediaQueryList
+	const matchMediaDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+	// Update the store if OS preference changes
+	const updateThemeOnChange = () => {
+		// Only reset to system theme if no specific preference has been selected
+		if (isThemeSelected()) {
+			return;
+		}
+
+		themeStore.resetToSystemSettings();
+	};
+
+	// Register change event on mount
+	onMount(() => matchMediaDark.addEventListener('change', updateThemeOnChange));
+
+	// Clean up if this component is destroyed
+	onDestroy(() => matchMediaDark.removeEventListener('change', updateThemeOnChange));
+</script>

--- a/src/frontend/src/lib/components/ui/ThemeSwitchButton.svelte
+++ b/src/frontend/src/lib/components/ui/ThemeSwitchButton.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { themeStore, Theme } from '@dfinity/gix-components';
 	import IconMoon from '$lib/components/icons/IconMoon.svelte';
 	import IconSun from '$lib/components/icons/IconSun.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { themeStore } from '$lib/stores/theme.store';
+	import { Theme } from '$lib/types/theme';
 
 	const handleClick = () => {
 		themeStore.select($themeStore === Theme.LIGHT ? Theme.DARK : Theme.LIGHT);

--- a/src/frontend/src/lib/stores/theme.store.ts
+++ b/src/frontend/src/lib/stores/theme.store.ts
@@ -1,0 +1,38 @@
+import type { Theme } from '$lib/types/theme';
+import {
+	applyTheme,
+	getThemeFromSystemSettings,
+	initTheme,
+	resetTheme
+} from '$lib/utils/theme.utils';
+import { writable, type Readable } from 'svelte/store';
+
+export type ThemeStoreData = Theme | undefined;
+
+export interface ThemeStore extends Readable<ThemeStoreData> {
+	select: (theme: Theme) => void;
+	resetToSystemSettings: () => void;
+}
+
+export const initThemeStore = (): ThemeStore => {
+	const initialTheme: ThemeStoreData = initTheme();
+
+	const { subscribe, set } = writable<ThemeStoreData>(initialTheme);
+
+	return {
+		subscribe,
+
+		select: (theme: Theme) => {
+			applyTheme({ theme, preserve: true });
+			set(theme);
+		},
+
+		resetToSystemSettings: () => {
+			const theme = getThemeFromSystemSettings();
+			resetTheme(theme);
+			set(theme);
+		}
+	};
+};
+
+export const themeStore = initThemeStore();

--- a/src/frontend/src/lib/types/theme.ts
+++ b/src/frontend/src/lib/types/theme.ts
@@ -1,0 +1,4 @@
+export enum Theme {
+	DARK = 'dark',
+	LIGHT = 'light'
+}

--- a/src/frontend/src/lib/utils/enum.utils.ts
+++ b/src/frontend/src/lib/utils/enum.utils.ts
@@ -1,0 +1,7 @@
+export const enumFromStringExists = <T extends object>({
+	obj,
+	value
+}: {
+	obj: T;
+	value: string | null;
+}): boolean => Object.values(obj).includes(value);

--- a/src/frontend/src/lib/utils/theme.utils.ts
+++ b/src/frontend/src/lib/utils/theme.utils.ts
@@ -1,0 +1,58 @@
+import { Theme } from '$lib/types/theme';
+import { enumFromStringExists } from '$lib/utils/enum.utils';
+import { isNode } from '$lib/utils/env.utils';
+import { notEmptyString } from '@dfinity/utils';
+
+export const THEME_ATTRIBUTE = 'theme';
+export const LOCALSTORAGE_THEME_KEY = 'nnsTheme';
+
+export const initTheme = (): Theme | undefined => {
+	// No DOM therefore cannot guess the theme
+	if (isNode()) {
+		return undefined;
+	}
+
+	const theme: string | null = document.documentElement.getAttribute(THEME_ATTRIBUTE);
+
+	const initialTheme: Theme = enumFromStringExists({
+		obj: Theme,
+		value: theme
+	})
+		? (theme as Theme)
+		: Theme.DARK;
+
+	applyTheme({ theme: initialTheme, preserve: false });
+
+	return initialTheme;
+};
+
+export const applyTheme = ({ theme, preserve = true }: { theme: Theme; preserve?: boolean }) => {
+	const { documentElement, head } = document;
+
+	documentElement.setAttribute(THEME_ATTRIBUTE, theme);
+
+	const color: string = getComputedStyle(documentElement).getPropertyValue('--theme-color');
+
+	// Update theme-color for mobile devices to customize the display of the page or of the surrounding user interface
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color
+	head?.children?.namedItem('theme-color')?.setAttribute('content', color.trim());
+
+	if (preserve) {
+		localStorage.setItem(LOCALSTORAGE_THEME_KEY, JSON.stringify(theme));
+	}
+};
+
+export const getThemeFromSystemSettings = (): Theme => {
+	const isDarkPreferred = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+	return isDarkPreferred ? Theme.DARK : Theme.LIGHT;
+};
+
+export const resetTheme = (theme: Theme) => {
+	localStorage.removeItem(LOCALSTORAGE_THEME_KEY);
+
+	applyTheme({ theme, preserve: false });
+};
+
+export const isThemeSelected = (): boolean =>
+	notEmptyString(localStorage.getItem(LOCALSTORAGE_THEME_KEY));

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { SystemThemeListener, Toasts } from '@dfinity/gix-components';
+	import { Toasts } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { onDestroy, onMount, type Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -9,6 +9,7 @@
 	import LoaderSpinner from '$lib/components/ui/LoaderSpinner.svelte';
 	import ModalExitHandler from '$lib/components/ui/ModalExitHandler.svelte';
 	import ResponsiveListener from '$lib/components/ui/ResponsiveListener.svelte';
+	import SystemThemeListener from '$lib/components/ui/SystemThemeListener.svelte';
 	import {
 		TRACK_SYNC_AUTH_AUTHENTICATED_COUNT,
 		TRACK_SYNC_AUTH_ERROR_COUNT,

--- a/src/frontend/src/tests/lib/components/settings/MenuThemeSelector.spec.ts
+++ b/src/frontend/src/tests/lib/components/settings/MenuThemeSelector.spec.ts
@@ -1,6 +1,7 @@
 import MenuThemeSelector from '$lib/components/core/MenuThemeSelector.svelte';
 import { THEME_SELECTOR_CARD } from '$lib/constants/test-ids.constants';
-import { Theme, themeStore } from '@dfinity/gix-components';
+import { themeStore } from '$lib/stores/theme.store';
+import { Theme } from '$lib/types/theme';
 import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 


### PR DESCRIPTION
# Motivation

Detaching OISY from `@dfinity/gix-components` (now maintenance-mode). The theme system (`themeStore`, `SystemThemeListener`, theme utils/types) brought in-house. `themeStore` is a singleton, so it's migrated **atomically with all its readers** to avoid state desync.

# Changes

- Vendor `types/theme.ts` (`Theme`), `utils/enum.utils.ts`, `utils/theme.utils.ts`, `stores/theme.store.ts` (`themeStore` + `ThemeStoreData`). The `localStorage` key stays `nnsTheme` for parity with existing users' saved preference.
- New `$lib/components/ui/SystemThemeListener.svelte` (Svelte 5). gix's `nnsSystemThemeChange` event and `<slot>` are dropped — neither is used by OISY (`+layout` renders it self-closing).
- Rewire all 8 consumers off gix (`themeStore` / `Theme` / `ThemeStoreData` / `SystemThemeListener`).
- No new deps, no behavioral change.

# Tests

- `lint --max-warnings 0` clean; `check` clean
- MenuThemeSelector spec passes (8)