### PR TITLE
feat(frontend): Liquidium active-transactions integration

### DIFF
--- a/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
+++ b/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
@@ -7,12 +7,20 @@
 	import IconClose from '$lib/components/icons/lucide/IconClose.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
 	import { swapProvidersDetails } from '$lib/constants/swap.constants';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { LendBorrowProvider } from '$lib/types/lend-borrow';
+	import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
 	import { ONESEC_EXTERNAL_REF_KEYS } from '$lib/types/onesec-swap';
 	import { SwapProvider } from '$lib/types/swap';
 	import { formatNanosecondsToShortRelativeTime } from '$lib/utils/format.utils';
+	import {
+		isLiquidiumActiveUserTransaction,
+		liquidiumActionKey,
+		toLiquidiumExternalRefsMap
+	} from '$lib/utils/liquidium-active-tx.utils';
 	import {
 		isOneSecActiveUserTransaction,
 		toOneSecExternalRefsMap
@@ -28,7 +36,9 @@
 	let { tx, isUnseen, dismissing, onDismiss }: Props = $props();
 
 	const isOneSec = $derived(isOneSecActiveUserTransaction(tx));
+	const isLiquidium = $derived(isLiquidiumActiveUserTransaction(tx));
 	const refs = $derived(toOneSecExternalRefsMap(tx.external_refs));
+	const liquidiumRefs = $derived(toLiquidiumExternalRefsMap(tx.external_refs));
 
 	const isFailed = $derived('Failed' in tx.status);
 	const isSucceeded = $derived('Succeeded' in tx.status);
@@ -41,20 +51,43 @@
 				: 'bg-brand-subtle-20 text-brand-primary'
 	);
 
+	const liquidiumActionLabel = $derived(
+		'Liquidium' in tx.data
+			? {
+					supply: $i18n.liquidium.text.action_supply,
+					borrow: $i18n.liquidium.text.action_borrow,
+					repay: $i18n.liquidium.text.action_repay,
+					withdraw: $i18n.liquidium.text.action_withdraw
+				}[liquidiumActionKey(tx.data.Liquidium.action)]
+			: undefined
+	);
+
 	const providerName = $derived(
-		isOneSec ? (swapProvidersDetails[SwapProvider.ONE_SEC]?.name ?? '') : undefined
+		isLiquidium
+			? lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
+			: isOneSec
+				? (swapProvidersDetails[SwapProvider.ONE_SEC]?.name ?? '')
+				: undefined
 	);
 
 	const titleText = $derived(
-		[
-			isOneSec ? $i18n.swap.text.swap : undefined,
-			refs[ONESEC_EXTERNAL_REF_KEYS.AMOUNT],
-			refs[ONESEC_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL],
-			'→',
-			refs[ONESEC_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]
-		]
-			.filter(nonNullish)
-			.join(' ')
+		isLiquidium
+			? [
+					liquidiumActionLabel,
+					liquidiumRefs[LIQUIDIUM_EXTERNAL_REF_KEYS.AMOUNT],
+					liquidiumRefs[LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL]
+				]
+					.filter(nonNullish)
+					.join(' ')
+			: [
+					isOneSec ? $i18n.swap.text.swap : undefined,
+					refs[ONESEC_EXTERNAL_REF_KEYS.AMOUNT],
+					refs[ONESEC_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL],
+					'→',
+					refs[ONESEC_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]
+				]
+					.filter(nonNullish)
+					.join(' ')
 	);
 
 	const sourceNetwork = $derived(refs[ONESEC_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL] ?? '');
@@ -123,8 +156,12 @@
 		{/snippet}
 
 		{#snippet description()}
-			{sourceNetwork} → {destinationNetwork}{#if nonNullish(providerName)}<Divider
-				/>{providerName}{/if}
+			{#if isLiquidium}
+				{providerName}
+			{:else}
+				{sourceNetwork} → {destinationNetwork}{#if nonNullish(providerName)}<Divider
+					/>{providerName}{/if}
+			{/if}
 		{/snippet}
 
 		{#snippet descriptionEnd()}

--- a/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
@@ -2,18 +2,27 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { onDestroy } from 'svelte';
 	import {
+		TRACK_COUNT_LIQUIDIUM_ERROR,
+		TRACK_COUNT_LIQUIDIUM_SUCCESS,
 		TRACK_COUNT_SWAP_ERROR,
 		TRACK_COUNT_SWAP_SUCCESS
 	} from '$lib/constants/analytics.constants';
 	import { ACTIVE_USER_TRANSACTIONS_POLL_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 	import { activeUserTransactionsPending } from '$lib/derived/active-user-transactions.derived';
+	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { loadActiveUserTransactions } from '$lib/services/active-user-transactions.services';
 	import { trackEvent } from '$lib/services/analytics.services';
+	import { pollLiquidiumActiveUserTransactions } from '$lib/services/liquidium-active-tx.services';
+	import { loadLiquidium } from '$lib/services/liquidium.services';
 	import { pollOneSecActiveUserTransactions } from '$lib/services/onesec-swap.services';
 	import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
 	import { isTerminalActiveUserTransaction } from '$lib/utils/active-user-transactions.utils';
 	import { consoleError } from '$lib/utils/console.utils';
+	import {
+		buildLiquidiumTrackingMetadata,
+		isLiquidiumActiveUserTransaction
+	} from '$lib/utils/liquidium-active-tx.utils';
 	import {
 		buildOneSecSwapTrackingMetadata,
 		isOneSecActiveUserTransaction
@@ -49,6 +58,12 @@
 
 			if (oneSec.length > 0) {
 				await pollOneSecActiveUserTransactions({ identity, transactions: oneSec });
+			}
+
+			const liquidium = $activeUserTransactionsPending.filter(isLiquidiumActiveUserTransaction);
+
+			if (liquidium.length > 0) {
+				await pollLiquidiumActiveUserTransactions({ identity, transactions: liquidium });
 			}
 		} catch (err: unknown) {
 			consoleError(err);
@@ -95,18 +110,19 @@
 
 		const newlyAppliedIds: string[] = [];
 		let shouldRefresh = false;
+		let shouldRefreshLiquidium = false;
 
 		for (const tx of Object.values($activeUserTransactionsStore.data)) {
 			const alreadyApplied =
 				$activeUserTransactionsStore.terminalSideEffectsApplied[tx.id] === true;
+
+			const isSucceeded = 'Succeeded' in tx.status;
 
 			if (
 				isTerminalActiveUserTransaction(tx) &&
 				!alreadyApplied &&
 				isOneSecActiveUserTransaction(tx)
 			) {
-				const isSucceeded = 'Succeeded' in tx.status;
-
 				newlyAppliedIds.push(tx.id);
 
 				trackEvent({
@@ -117,6 +133,22 @@
 				if (isSucceeded) {
 					shouldRefresh = true;
 				}
+			} else if (
+				isTerminalActiveUserTransaction(tx) &&
+				!alreadyApplied &&
+				isLiquidiumActiveUserTransaction(tx)
+			) {
+				newlyAppliedIds.push(tx.id);
+
+				trackEvent({
+					name: isSucceeded ? TRACK_COUNT_LIQUIDIUM_SUCCESS : TRACK_COUNT_LIQUIDIUM_ERROR,
+					metadata: buildLiquidiumTrackingMetadata({ tx })
+				});
+
+				if (isSucceeded) {
+					shouldRefresh = true;
+					shouldRefreshLiquidium = true;
+				}
 			}
 		}
 
@@ -126,6 +158,11 @@
 
 		if (shouldRefresh) {
 			waitAndTriggerWallet().catch(consoleError);
+		}
+
+		// Refresh Liquidium positions/health once when a Liquidium action settles.
+		if (shouldRefreshLiquidium) {
+			loadLiquidium({ identity: $authIdentity, ethAddress: $ethAddress }).catch(consoleError);
 		}
 	});
 </script>


### PR DESCRIPTION
# Motivation

PR 3 of the Liquidium "Supply" stack. Wires the (already-merged) Liquidium active-transactions poller and row rendering into oisy's shared active-user-transactions machinery. Dormant until a Liquidium action can create an AUT row (Supply, PR 5), but reviewable and gated. Stacked on PR 2.

# Changes
  - LoaderActiveUserTransactions.svelte: each poll tick, poll Liquidium AUT rows via pollLiquidiumActiveUserTransactions. On a terminal row, fire liquidium_success / liquidium_error analytics (metadata rebuilt from external_refs so it survives refresh/resume), and refresh wallet + Liquidium positions once on success.
  - ActiveUserTransactionItem.svelte: render the Liquidium branch — action + amount + asset title, provider name only (no step subtitle / confirmation count), so BTC and ERC-20 rows render identically.

# Tests

  - The poller and metadata builders are unit-tested in merged PR 2; this PR is the wiring layer.
  - eslint clean on both files. Run format / lint / check / test on the branch before merge.
