### PR TITLE
feat(frontend): Liquidium provider page and Supply flow

### DIFF
--- a/src/frontend/src/env/earning-providers.json
+++ b/src/frontend/src/env/earning-providers.json
@@ -1,12 +1,12 @@
 [
 	{
-		"id": "sprinkles_s1e6",
-		"type": "reward",
-		"titles": ["earning.cards.sprinkles.title"],
-		"description": "earning.cards.sprinkles.description",
-		"logo": "/images/rewards/oisy-reward-logo.svg",
-		"fields": [],
-		"actionText": "earning.cards.sprinkles.action"
+		"id": "liquidium",
+		"type": "lending",
+		"titles": ["earning.cards.liquidium.title"],
+		"description": "earning.cards.liquidium.description",
+		"logo": "/images/dapps/liquidium-logo.webp",
+		"fields": ["networks", "assets", "currentEarning", "earningPotential"],
+		"actionText": "earning.cards.liquidium.action"
 	},
 	{
 		"id": "harvest-autopilot",
@@ -16,5 +16,14 @@
 		"logo": "/images/dapps/harvest-autopilot-logo.svg",
 		"fields": ["networks", "assets", "currentEarning", "earningPotential"],
 		"actionText": "earning.cards.harvest_autopilot.action"
+	},
+	{
+		"id": "sprinkles_s1e6",
+		"type": "reward",
+		"titles": ["earning.cards.sprinkles.title"],
+		"description": "earning.cards.sprinkles.description",
+		"logo": "/images/rewards/oisy-reward-logo.svg",
+		"fields": [],
+		"actionText": "earning.cards.sprinkles.action"
 	}
 ]

--- a/src/frontend/src/env/schema/env-earning-providers.schema.ts
+++ b/src/frontend/src/env/schema/env-earning-providers.schema.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 
 export const EarningProviderConfigSchema = z.object({
 	id: z.string(),
-	type: z.enum(['stake', 'reward']),
+	type: z.enum(['stake', 'reward', 'lending']),
 	titles: z.array(z.string()),
 	description: z.string(),
 	logo: z.string(),

--- a/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import LiquidiumSupplyModal from '$lib/components/liquidium/supply/LiquidiumSupplyModal.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { modalLiquidiumSupply } from '$lib/derived/modal.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import { isMobile } from '$lib/utils/device.utils';
+	import { formatStakeApyNumber } from '$lib/utils/format.utils';
+
+	interface Props {
+		market: LiquidiumMarket;
+	}
+
+	let { market }: Props = $props();
+
+	// Per-card id so only the clicked card's modal opens.
+	const modalId = Symbol();
+
+	let token = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
+</script>
+
+<div class="flex w-full flex-col">
+	<LogoButton hover={false}>
+		{#snippet logo()}
+			<span class="mr-2 flex">
+				{#if nonNullish(token)}
+					<TokenLogo
+						badge={{ type: 'network' }}
+						color="white"
+						data={token}
+						logoSize={isMobile() ? 'sm' : 'lg'}
+					/>
+				{/if}
+			</span>
+		{/snippet}
+
+		{#snippet title()}
+			<span class="text-sm sm:text-lg">{market.asset}</span>
+		{/snippet}
+
+		{#snippet subtitle()}
+			{#if !market.available}
+				<span
+					class="ml-2 rounded-full bg-warning-subtle-20 px-2 py-0.5 text-xs text-warning-primary"
+				>
+					{$i18n.liquidium.text.coming_soon}
+				</span>
+			{/if}
+		{/snippet}
+
+		{#snippet description()}
+			<span>
+				{$i18n.liquidium.text.supply_label}
+				<span class="text-success-primary">{formatStakeApyNumber(market.supplyApy)}%</span>
+				· {$i18n.liquidium.text.borrow_label}
+				<span class="text-warning-primary">{formatStakeApyNumber(market.borrowApy)}%</span>
+			</span>
+		{/snippet}
+
+		{#snippet action()}
+			{#if market.available}
+				<Button onclick={() => modalStore.openLiquidiumSupply(modalId)} paddingSmall>
+					{$i18n.liquidium.text.action_supply}
+				</Button>
+			{/if}
+		{/snippet}
+	</LogoButton>
+
+	<!-- Sibling of LogoButton, not inside its <button> — avoids inheriting button
+		styles and keeps valid HTML. -->
+	{#if market.available && $modalLiquidiumSupply && $modalStore?.id === modalId}
+		<LiquidiumSupplyModal {market} />
+	{/if}
+</div>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumReserve } from '$lib/types/liquidium';
+	import { isMobile } from '$lib/utils/device.utils';
+	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+
+	interface Props {
+		reserve: LiquidiumReserve;
+	}
+
+	let { reserve }: Props = $props();
+
+	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+
+	let suppliedAmount = $derived(
+		formatToken({ value: reserve.deposited, unitName: reserve.depositedDecimals })
+	);
+
+	// Yearly interest at the current supply APY.
+	let currentlyEarning = $derived((reserve.suppliedUsd * reserve.supplyApy) / 100);
+
+	let suppliedValue = $derived(
+		formatCurrency({
+			value: reserve.suppliedUsd,
+			currency: $currentCurrency,
+			exchangeRate: $currencyExchangeStore,
+			language: $currentLanguage
+		})
+	);
+</script>
+
+<div class="flex w-full flex-col">
+	<LogoButton hover={false}>
+		{#snippet logo()}
+			<span class="mr-2 flex">
+				{#if nonNullish(token)}
+					<TokenLogo
+						badge={{ type: 'network' }}
+						color="white"
+						data={token}
+						logoSize={isMobile() ? 'sm' : 'lg'}
+					/>
+				{/if}
+			</span>
+		{/snippet}
+
+		{#snippet title()}
+			<span class="text-sm sm:text-lg">{$i18n.liquidium.text.supplied} {reserve.asset}</span>
+		{/snippet}
+
+		{#snippet description()}
+			<Badge variant={reserve.supplyApy > 0 ? 'success' : 'default'} width="w-fit">
+				{`${formatStakeApyNumber(reserve.supplyApy)}% ${$i18n.liquidium.text.apy_suffix}`}
+			</Badge>
+		{/snippet}
+
+		{#snippet titleEnd()}
+			<span
+				class="flex min-w-12 items-center justify-end gap-1 text-sm text-nowrap sm:gap-2 sm:text-base"
+			>
+				{#if currentlyEarning > 0}
+					<EarningYearlyAmount
+						showAsSuccess
+						showPlusSign
+						showWithShortenedLabel
+						value={currentlyEarning}
+					/>
+				{/if}
+
+				<span>{suppliedValue}</span>
+			</span>
+		{/snippet}
+
+		{#snippet descriptionEnd()}
+			<span class="block min-w-12 text-nowrap">
+				{suppliedAmount}
+				{reserve.asset}
+			</span>
+		{/snippet}
+	</LogoButton>
+</div>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { LEND_BORROW_ENABLED } from '$env/lend-borrow';
+	import { LIQUIDIUM_ENABLED } from '$env/liquidium';
+	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
+	import LiquidiumMarketCard from '$lib/components/liquidium/LiquidiumMarketCard.svelte';
+	import LiquidiumPositionCard from '$lib/components/liquidium/LiquidiumPositionCard.svelte';
+	import LiquidiumProviderHero from '$lib/components/liquidium/LiquidiumProviderHero.svelte';
+	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
+	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
+	import { LIQUIDIUM_POLL_INTERVAL_MILLIS } from '$lib/constants/liquidium.constants';
+	import { AppPath } from '$lib/constants/routes.constants';
+	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { liquidiumMarkets, liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { loadLiquidium } from '$lib/services/liquidium.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { LendBorrowProvider } from '$lib/types/lend-borrow';
+	import { replaceOisyPlaceholders, resolveText } from '$lib/utils/i18n.utils';
+
+	const liquidium = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM];
+
+	let reserves = $derived($liquidiumPortfolio?.reserves ?? []);
+
+	const load = (): Promise<void> =>
+		loadLiquidium({ identity: $authIdentity, ethAddress: $ethAddress });
+
+	onMount(() => {
+		if (!LEND_BORROW_ENABLED) {
+			goto(AppPath.Earn);
+		}
+	});
+</script>
+
+{#if LEND_BORROW_ENABLED}
+	{#if LIQUIDIUM_ENABLED}
+		<IntervalLoader interval={LIQUIDIUM_POLL_INTERVAL_MILLIS} onLoad={load} />
+	{/if}
+
+	<div class="flex flex-col gap-6 pb-6">
+		<LiquidiumProviderHero
+			logo={liquidium.logo}
+			pageDescription={replaceOisyPlaceholders(
+				resolveText({ i18n: $i18n, path: liquidium.descriptionKey })
+			)}
+			pageTitle={liquidium.name}
+			portfolio={$liquidiumPortfolio}
+			showSummary={LIQUIDIUM_ENABLED}
+			url={liquidium.url}
+		/>
+
+		{#if LIQUIDIUM_ENABLED && reserves.length > 0}
+			<StakeContentSection>
+				{#snippet title()}
+					<h4>{$i18n.liquidium.text.my_positions}</h4>
+				{/snippet}
+
+				{#snippet content()}
+					<div class="flex w-full flex-col gap-4">
+						{#each reserves as reserve (reserve.poolId)}
+							<LiquidiumPositionCard {reserve} />
+						{/each}
+					</div>
+				{/snippet}
+			</StakeContentSection>
+		{/if}
+
+		{#if LIQUIDIUM_ENABLED && $liquidiumMarkets.length > 0}
+			<StakeContentSection>
+				{#snippet title()}
+					<h4>{$i18n.liquidium.text.markets}</h4>
+				{/snippet}
+
+				{#snippet content()}
+					<div class="flex w-full flex-col">
+						{#each $liquidiumMarkets as market (market.poolId)}
+							<LiquidiumMarketCard {market} />
+						{/each}
+					</div>
+				{/snippet}
+			</StakeContentSection>
+		{/if}
+	</div>
+{/if}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumProviderHero.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProviderHero.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { Html } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+	import { afterNavigate } from '$app/navigation';
+	import IconBackArrow from '$lib/components/icons/lucide/IconBackArrow.svelte';
+	import LiquidiumSummary from '$lib/components/liquidium/LiquidiumSummary.svelte';
+	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
+	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import { STAKE_PROVIDER_LOGO } from '$lib/constants/test-ids.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumPortfolio } from '$lib/types/liquidium';
+	import { back } from '$lib/utils/nav.utils';
+
+	interface Props {
+		logo: string;
+		pageTitle: string;
+		pageDescription: string;
+		url: string;
+		portfolio: LiquidiumPortfolio | null;
+		showSummary?: boolean;
+	}
+
+	let { logo, pageTitle, pageDescription, url, portfolio, showSummary = true }: Props = $props();
+
+	let fromRoute = $state<NavigationTarget | null>(null);
+
+	afterNavigate(({ from }) => {
+		fromRoute = from;
+	});
+</script>
+
+<StakeContentSection>
+	{#snippet title()}
+		<div class="absolute top-0 left-0">
+			<ButtonIcon
+				ariaLabel={$i18n.core.text.back}
+				colorStyle="tertiary"
+				link={false}
+				onclick={() => back({ pop: nonNullish(fromRoute) })}
+			>
+				{#snippet icon()}
+					<IconBackArrow />
+				{/snippet}
+			</ButtonIcon>
+		</div>
+
+		<div class="flex w-full flex-col items-center text-center">
+			<Logo alt={pageTitle} size="xl" src={logo} testId={STAKE_PROVIDER_LOGO} />
+
+			<h2 class="my-2 text-xl font-bold sm:text-2xl">
+				{pageTitle}
+			</h2>
+
+			<div class="text-sm sm:text-base">
+				<Html text={pageDescription} />
+			</div>
+		</div>
+
+		{#if showSummary}
+			<div class="absolute top-0 right-0">
+				<ExternalLink
+					ariaLabel={$i18n.core.text.learn_more}
+					color="blue"
+					href={url}
+					iconAsLast
+					styleClass="text-sm"
+				>
+					{$i18n.core.text.learn_more}
+				</ExternalLink>
+			</div>
+		{/if}
+	{/snippet}
+
+	{#snippet content()}
+		{#if showSummary}
+			<LiquidiumSummary {portfolio} />
+		{/if}
+	{/snippet}
+</StakeContentSection>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumSummary.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSummary.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumPortfolio } from '$lib/types/liquidium';
+	import { formatCurrency, formatStakeApyNumber } from '$lib/utils/format.utils';
+	import { liquidiumHealthLevel, liquidiumNetApy } from '$lib/utils/liquidium.utils';
+
+	interface Props {
+		portfolio: LiquidiumPortfolio | null;
+	}
+
+	let { portfolio }: Props = $props();
+
+	// No positions ⇒ no debt ⇒ 100% healthy.
+	let healthPercent = $derived(portfolio?.healthFactorPercent ?? 100);
+	let healthLevel = $derived(liquidiumHealthLevel(healthPercent));
+
+	// Net APY (supply earnings − borrow cost); null when there's nothing to annualise.
+	let netApy = $derived(nonNullish(portfolio) ? liquidiumNetApy(portfolio) : null);
+
+	let netValueUsd = $derived(portfolio?.netValueUsd ?? 0);
+	let formattedNetValue = $derived(
+		formatCurrency({
+			value: netValueUsd,
+			currency: $currentCurrency,
+			exchangeRate: $currencyExchangeStore,
+			language: $currentLanguage
+		})
+	);
+
+	let netApyLabel = $derived(
+		nonNullish(netApy)
+			? `${netApy >= 0 ? '+' : '−'}${formatStakeApyNumber(Math.abs(netApy))}%`
+			: '0.00%'
+	);
+</script>
+
+<div class="mt-6 flex w-full flex-col gap-3 sm:flex-row">
+	<StakeContentCard widthClass="sm:w-1/3">
+		{#snippet content()}
+			<div class="text-sm font-bold">{$i18n.liquidium.text.health_factor}</div>
+
+			<div
+				class="my-1 text-lg font-bold sm:text-xl"
+				class:text-error-primary={healthLevel === 'critical'}
+				class:text-success-primary={healthLevel === 'healthy'}
+				class:text-warning-primary={healthLevel === 'at-risk'}
+			>
+				{Math.round(healthPercent)}%
+			</div>
+		{/snippet}
+	</StakeContentCard>
+
+	<StakeContentCard widthClass="sm:w-1/3">
+		{#snippet content()}
+			<div class="text-sm font-bold">{$i18n.liquidium.text.net_value}</div>
+
+			<div class="my-1 text-lg font-bold sm:text-xl">{formattedNetValue}</div>
+		{/snippet}
+	</StakeContentCard>
+
+	<StakeContentCard widthClass="sm:w-1/3">
+		{#snippet content()}
+			<div class="text-sm font-bold">{$i18n.liquidium.text.net_apy}</div>
+
+			<div
+				class="my-1 text-lg font-bold sm:text-xl"
+				class:text-error-primary={nonNullish(netApy) && netApy < 0}
+				class:text-success-primary={nonNullish(netApy) && netApy > 0}
+				class:text-tertiary={!nonNullish(netApy)}
+			>
+				{netApyLabel}
+			</div>
+		{/snippet}
+	</StakeContentCard>
+</div>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumProviderFee.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumProviderFee.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+
+	interface Props {
+		// Provider fee, base units of the supplied token.
+		inflowFee?: bigint;
+	}
+
+	let { inflowFee }: Props = $props();
+
+	const { sendToken, sendTokenSymbol, sendTokenExchangeRate } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
+</script>
+
+{#if nonNullish(inflowFee)}
+	<FeeDisplay
+		decimals={$sendToken.decimals}
+		exchangeRate={$sendTokenExchangeRate}
+		feeAmount={inflowFee}
+		symbol={$sendTokenSymbol}
+	>
+		{#snippet label()}{$i18n.liquidium.text.provider_fee}{/snippet}
+	</FeeDisplay>
+{/if}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import Checkbox from '$lib/components/ui/Checkbox.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	interface Props {
+		checked: boolean;
+	}
+
+	let { checked = $bindable() }: Props = $props();
+
+	const handleCheckboxChange = () => {
+		checked = !checked;
+	};
+</script>
+
+<div class="my-6 flex gap-4 rounded-xl bg-secondary p-2">
+	<Checkbox {checked} inputId="liquidium-supply-agreement" onChange={handleCheckboxChange} />
+
+	<span class="text-sm text-tertiary">
+		{$i18n.liquidium.text.supply_agreement}
+	</span>
+</div>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+	import type { WizardStep } from '@dfinity/gix-components';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { getContext, setContext } from 'svelte';
+	import UtxosFeeLoader from '$btc/components/fee/UtxosFeeLoader.svelte';
+	import BtcUtxosFeeDisplay from '$btc/components/send/BtcUtxosFeeDisplay.svelte';
+	import { sendBtc } from '$btc/services/btc-send.services';
+	import {
+		initUtxosFeeStore,
+		UTXOS_FEE_CONTEXT_KEY,
+		type UtxosFeeContext
+	} from '$btc/stores/utxos-fee.store';
+	import { convertSatoshisToBtc } from '$btc/utils/btc-send.utils';
+	import LiquidiumSupplyForm from '$lib/components/liquidium/supply/LiquidiumSupplyForm.svelte';
+	import LiquidiumSupplyProgress from '$lib/components/liquidium/supply/LiquidiumSupplyProgress.svelte';
+	import LiquidiumSupplyReview from '$lib/components/liquidium/supply/LiquidiumSupplyReview.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { btcAddressMainnet, ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+	import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+	import { executeLiquidiumSupply } from '$lib/services/liquidium-supply.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { mapNetworkIdToBitcoinNetwork } from '$lib/utils/network.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		market: LiquidiumMarket;
+		amount: OptionAmount;
+		supplyProgressStep: string;
+		inflowFee?: bigint;
+		currentStep?: WizardStep;
+		onClose: () => void;
+		onNext: () => void;
+		onBack: () => void;
+	}
+
+	let {
+		market,
+		amount = $bindable(),
+		supplyProgressStep = $bindable(),
+		inflowFee,
+		currentStep,
+		onClose,
+		onNext,
+		onBack
+	}: Props = $props();
+
+	const { sendToken, sendTokenDecimals, sendBalance } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	let networkId = $derived($sendToken.network.id);
+	let network = $derived(mapNetworkIdToBitcoinNetwork(networkId));
+
+	let parsedAmount = $derived(
+		nonNullish(amount) && !invalidAmount(amount)
+			? parseToken({ value: `${amount}`, unitName: $sendTokenDecimals })
+			: undefined
+	);
+
+	const { store: utxosFeeStore } = setContext<UtxosFeeContext>(UTXOS_FEE_CONTEXT_KEY, {
+		store: initUtxosFeeStore()
+	});
+
+	let utxosFee = $derived($utxosFeeStore?.utxosFee);
+
+	let validateSupplyAmount = $derived.by(() => {
+		const balance = $sendBalance;
+		const inflow = inflowFee;
+		const networkFee = utxosFee?.feeSatoshis;
+
+		return (userAmount: bigint): Error | undefined =>
+			nonNullish(inflow) &&
+			nonNullish(balance) &&
+			userAmount + inflow + (networkFee ?? ZERO) > balance
+				? new Error($i18n.liquidium.text.insufficient_funds_for_fee)
+				: undefined;
+	});
+
+	const supply = async () => {
+		if (
+			isNullish($authIdentity) ||
+			isNullish($ethAddress) ||
+			isNullish($btcAddressMainnet) ||
+			isNullish(network) ||
+			isNullish(utxosFee) ||
+			isNullish(inflowFee)
+		) {
+			toastsError({ msg: { text: $i18n.send.assertion.utxos_fee_missing } });
+			return;
+		}
+
+		if (isNullish(parsedAmount)) {
+			toastsError({ msg: { text: $i18n.send.assertion.amount_invalid } });
+			return;
+		}
+
+		// BTC sent from the BTC address, but the profile is ETH-owned → look it up by ETH address.
+		const source = $btcAddressMainnet;
+		const btcNetwork = network;
+		const preparedUtxosFee = utxosFee;
+		const amountBaseUnits = parsedAmount;
+
+		onNext();
+
+		try {
+			await executeLiquidiumSupply({
+				identity: $authIdentity,
+				ethAddress: $ethAddress,
+				poolId: market.poolId,
+				asset: market.asset,
+				amount: amountBaseUnits,
+				inflowFee,
+				displayAmount: `${amount}`,
+				progress: (step) => (supplyProgressStep = step),
+				broadcast: async ({ target, amount: transferAmount }) =>
+					await sendBtc({
+						identity: $authIdentity,
+						network: btcNetwork,
+						utxosFee: preparedUtxosFee,
+						destination: target.address,
+						amount: convertSatoshisToBtc(transferAmount),
+						source
+					})
+			});
+
+			supplyProgressStep = ProgressStepsLiquidiumSupply.DONE;
+
+			setTimeout(onClose, 750);
+		} catch (err: unknown) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed }, err });
+
+			onBack();
+		}
+	};
+</script>
+
+{#snippet feeDisplay()}
+	<BtcUtxosFeeDisplay>
+		{#snippet label()}{$i18n.fee.text.network_fee}{/snippet}
+	</BtcUtxosFeeDisplay>
+{/snippet}
+
+<UtxosFeeLoader {amount} {networkId} source={$btcAddressMainnet ?? ''}>
+	{#if currentStep?.name === WizardStepsLiquidiumSupply.REVIEW}
+		<LiquidiumSupplyReview {amount} {feeDisplay} {inflowFee} {market} {onBack} onConfirm={supply} />
+	{:else if currentStep?.name === WizardStepsLiquidiumSupply.SUPPLYING}
+		<LiquidiumSupplyProgress {supplyProgressStep} />
+	{:else}
+		<LiquidiumSupplyForm
+			{feeDisplay}
+			{inflowFee}
+			{market}
+			{onClose}
+			onCustomErrorValidate={validateSupplyAmount}
+			{onNext}
+			totalFee={utxosFee?.feeSatoshis}
+			bind:amount
+		/>
+	{/if}
+</UtxosFeeLoader>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte
@@ -1,0 +1,255 @@
+<script lang="ts">
+	import type { WizardStep } from '@dfinity/gix-components';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { getContext, setContext, untrack } from 'svelte';
+	import { writable } from 'svelte/store';
+	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
+	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
+	import { enabledEthereumTokens } from '$eth/derived/tokens.derived';
+	import { send } from '$eth/services/send.services';
+	import {
+		ETH_FEE_CONTEXT_KEY,
+		type EthFeeContext as FeeContextType,
+		initEthFeeContext,
+		initEthFeeStore
+	} from '$eth/stores/eth-fee.store';
+	import type { EthereumNetwork } from '$eth/types/network';
+	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
+	import { enabledEvmTokens } from '$evm/derived/tokens.derived';
+	import { isSupportedEvmNativeTokenId } from '$evm/utils/native-token.utils';
+	import LiquidiumSupplyForm from '$lib/components/liquidium/supply/LiquidiumSupplyForm.svelte';
+	import LiquidiumSupplyProgress from '$lib/components/liquidium/supply/LiquidiumSupplyProgress.svelte';
+	import LiquidiumSupplyReview from '$lib/components/liquidium/supply/LiquidiumSupplyReview.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+	import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+	import { executeLiquidiumSupply } from '$lib/services/liquidium-supply.services';
+	import { balancesStore } from '$lib/stores/balances.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { TokenId } from '$lib/types/token';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		market: LiquidiumMarket;
+		amount: OptionAmount;
+		supplyProgressStep: string;
+		inflowFee?: bigint;
+		currentStep?: WizardStep;
+		onClose: () => void;
+		onNext: () => void;
+		onBack: () => void;
+	}
+
+	let {
+		market,
+		amount = $bindable(),
+		supplyProgressStep = $bindable(),
+		inflowFee,
+		currentStep,
+		onClose,
+		onNext,
+		onBack
+	}: Props = $props();
+
+	const { sendToken, sendTokenDecimals, sendTokenId, sendBalance } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	let sourceNetwork = $derived($sendToken.network as EthereumNetwork);
+
+	let parsedAmount = $derived(
+		nonNullish(amount) && !invalidAmount(amount)
+			? parseToken({ value: `${amount}`, unitName: $sendTokenDecimals })
+			: undefined
+	);
+
+	const feeStore = initEthFeeStore();
+	const feeSymbolStore = writable<string | undefined>(undefined);
+	const feeTokenIdStore = writable<TokenId | undefined>(undefined);
+	const feeDecimalsStore = writable<number | undefined>(undefined);
+	const feeExchangeRateStore = writable<number | undefined>(undefined);
+
+	let nativeEthereumToken = $derived(
+		[...$enabledEvmTokens, ...$enabledEthereumTokens].find(
+			({ network: { id: networkId } }) => $sendToken.network.id === networkId
+		)
+	);
+
+	let isNativeSend = $derived(
+		isSupportedEthTokenId($sendTokenId) || isSupportedEvmNativeTokenId($sendTokenId)
+	);
+
+	let nativeFeeBalance = $derived(
+		nonNullish(nativeEthereumToken) ? $balancesStore?.[nativeEthereumToken.id]?.data : undefined
+	);
+
+	$effect(() => {
+		if (nonNullish(nativeEthereumToken)) {
+			feeSymbolStore.set(nativeEthereumToken.symbol);
+			feeTokenIdStore.set(nativeEthereumToken.id);
+			feeDecimalsStore.set(nativeEthereumToken.decimals);
+			feeExchangeRateStore.set($exchanges?.[nativeEthereumToken.id]?.usd);
+		}
+	});
+
+	let feeContext = $state<EthFeeContext | undefined>();
+	const evaluateFee = () => feeContext?.triggerUpdateFee();
+
+	const ethFeeContext = initEthFeeContext({
+		feeStore,
+		feeSymbolStore,
+		feeTokenIdStore,
+		feeDecimalsStore,
+		feeExchangeRateStore,
+		evaluateFee
+	});
+
+	setContext<FeeContextType>(ETH_FEE_CONTEXT_KEY, ethFeeContext);
+
+	const { maxGasFee } = ethFeeContext;
+
+	let validateSupplyAmount = $derived.by(() => {
+		const balance = $sendBalance;
+		const inflow = inflowFee;
+		const gasFee = $maxGasFee;
+		const nativeBalance = nativeFeeBalance;
+		const native = isNativeSend;
+
+		return (userAmount: bigint): Error | undefined => {
+			if (isNullish(inflow) || isNullish(balance)) {
+				return undefined;
+			}
+
+			if (userAmount + inflow + (native ? (gasFee ?? ZERO) : ZERO) > balance) {
+				return new Error($i18n.liquidium.text.insufficient_funds_for_fee);
+			}
+
+			if (!native && nonNullish(gasFee) && nonNullish(nativeBalance) && nativeBalance < gasFee) {
+				return new Error($i18n.send.assertion.insufficient_ethereum_funds_to_cover_the_fees);
+			}
+
+			return undefined;
+		};
+	});
+
+	// Re-evaluate the gas fee whenever the amount changes (mirrors the stake wizard).
+	$effect(() => {
+		amount;
+
+		untrack(() => evaluateFee());
+	});
+
+	const supply = async () => {
+		if (
+			isNullish($authIdentity) ||
+			isNullish($ethAddress) ||
+			isNullish($feeStore) ||
+			isNullish(inflowFee)
+		) {
+			toastsError({ msg: { text: $i18n.send.assertion.gas_fees_not_defined } });
+			return;
+		}
+
+		if (isNullish(parsedAmount)) {
+			toastsError({ msg: { text: $i18n.send.assertion.amount_invalid } });
+			return;
+		}
+
+		const { maxFeePerGas, maxPriorityFeePerGas, gas } = $feeStore;
+
+		if (isNullish(maxFeePerGas) || isNullish(maxPriorityFeePerGas)) {
+			toastsError({ msg: { text: $i18n.send.assertion.max_gas_fee_per_gas_undefined } });
+			return;
+		}
+
+		const amountBaseUnits = parsedAmount;
+
+		onNext();
+
+		try {
+			await executeLiquidiumSupply({
+				identity: $authIdentity,
+				ethAddress: $ethAddress,
+				poolId: market.poolId,
+				asset: market.asset,
+				amount: amountBaseUnits,
+				inflowFee,
+				displayAmount: `${amount}`,
+				progress: (step) => (supplyProgressStep = step),
+				broadcast: async ({ target, amount: transferAmount }) => {
+					const { hash } = await send({
+						identity: $authIdentity,
+						from: $ethAddress,
+						to: target.address,
+						amount: transferAmount,
+						token: $sendToken,
+						sourceNetwork,
+						maxFeePerGas,
+						maxPriorityFeePerGas,
+						gas
+					});
+
+					return hash;
+				}
+			});
+
+			supplyProgressStep = ProgressStepsLiquidiumSupply.DONE;
+
+			setTimeout(onClose, 750);
+		} catch (err: unknown) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed }, err });
+
+			onBack();
+		}
+	};
+</script>
+
+{#snippet feeDisplay()}
+	<EthFeeDisplay>
+		{#snippet label()}{$i18n.fee.text.network_fee}{/snippet}
+	</EthFeeDisplay>
+{/snippet}
+
+{#if nonNullish(nativeEthereumToken)}
+	<EthFeeContext
+		bind:this={feeContext}
+		{amount}
+		destination={$ethAddress ?? ''}
+		{nativeEthereumToken}
+		observe={currentStep?.name !== WizardStepsLiquidiumSupply.SUPPLYING}
+		sendToken={$sendToken}
+		sendTokenId={$sendTokenId}
+		{sourceNetwork}
+	>
+		{#if currentStep?.name === WizardStepsLiquidiumSupply.REVIEW}
+			<LiquidiumSupplyReview
+				{amount}
+				{feeDisplay}
+				{inflowFee}
+				{market}
+				{onBack}
+				onConfirm={supply}
+			/>
+		{:else if currentStep?.name === WizardStepsLiquidiumSupply.SUPPLYING}
+			<LiquidiumSupplyProgress {supplyProgressStep} />
+		{:else}
+			<LiquidiumSupplyForm
+				{feeDisplay}
+				{inflowFee}
+				{market}
+				{onClose}
+				onCustomErrorValidate={validateSupplyAmount}
+				{onNext}
+				totalFee={$maxGasFee}
+				bind:amount
+			/>
+		{/if}
+	</EthFeeContext>
+{/if}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyForm.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import { getContext, type Snippet } from 'svelte';
+	import LiquidiumProviderFee from '$lib/components/liquidium/supply/LiquidiumProviderFee.svelte';
+	import LiquidiumSupplyAgreement from '$lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte';
+	import StakeForm from '$lib/components/stake/StakeForm.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		market: LiquidiumMarket;
+		amount: OptionAmount;
+		// Network (gas/UTXO) fee, for the Max shortcut + disabled gate.
+		totalFee?: bigint;
+		// Provider fee (base units); shown as a row and reserved from Max.
+		inflowFee?: bigint;
+		// Rail-specific balance check (gas/provider-fee coverage); owned by the wizard,
+		// which holds the per-chain fee context.
+		onCustomErrorValidate?: (userAmount: bigint) => Error | undefined;
+		// Per-rail fee row (EthFeeDisplay / BtcUtxosFeeDisplay).
+		feeDisplay: Snippet;
+		onClose: () => void;
+		onNext: () => void;
+	}
+
+	let {
+		market,
+		amount = $bindable(),
+		totalFee,
+		inflowFee,
+		onCustomErrorValidate,
+		feeDisplay,
+		onClose,
+		onNext
+	}: Props = $props();
+
+	const { sendTokenDecimals } = getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	let agreementChecked = $state(false);
+	let amountError = $state<Error | undefined>();
+
+	// Both fees must be resolved before the form can submit.
+	let feeMissing = $derived(isNullish(totalFee) || isNullish(inflowFee));
+
+	// TokenInput only re-validates on amount/token change, missing the async fee/
+	// balance. Re-run synchronously so the error appears once they settle (mirrors
+	// the stake form); clearing on an emptied amount stays with TokenInput.
+	$effect(() => {
+		if (invalidAmount(amount)) {
+			return;
+		}
+
+		const next = onCustomErrorValidate?.(
+			parseToken({ value: `${amount}`, unitName: $sendTokenDecimals })
+		);
+
+		if (next?.message !== amountError?.message) {
+			amountError = next;
+		}
+	});
+</script>
+
+<StakeForm
+	disabled={!agreementChecked || feeMissing}
+	{onClose}
+	{onCustomErrorValidate}
+	{onNext}
+	providerFee={inflowFee}
+	{totalFee}
+	bind:amount
+	bind:error={amountError}
+>
+	{#snippet content()}
+		<MessageBox styleClass="sm:text-sm mb-6 !items-center">
+			{$i18n.liquidium.text.supply_collateral_info}
+		</MessageBox>
+
+		<ModalValue>
+			{#snippet label()}{$i18n.liquidium.text.supply_apy}{/snippet}
+			{#snippet mainValue()}
+				<span class="text-success-primary">{market.supplyApy.toFixed(2)}%</span>
+			{/snippet}
+		</ModalValue>
+
+		<LiquidiumProviderFee {inflowFee} />
+
+		{@render feeDisplay()}
+
+		<LiquidiumSupplyAgreement bind:checked={agreementChecked} />
+	{/snippet}
+</StakeForm>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { nonNullish } from '@dfinity/utils';
+	import type { Asset, Chain } from '@liquidium/client';
+	import LiquidiumSupplyBtcWizard from '$lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte';
+	import LiquidiumSupplyEthWizard from '$lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte';
+	import SendTokenContext from '$lib/components/send/SendTokenContext.svelte';
+	import { liquidiumSupplyWizardSteps } from '$lib/config/lend-borrow.config';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+	import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+	import { estimateLiquidiumInflowFee } from '$lib/services/liquidium-supply.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import { consoleError } from '$lib/utils/console.utils';
+	import { closeModal } from '$lib/utils/modal.utils';
+
+	interface Props {
+		market: LiquidiumMarket;
+	}
+
+	let { market }: Props = $props();
+
+	let token = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
+
+	// Provider inflow fee for this asset, passed to the wizard.
+	let inflowFee = $state<bigint | undefined>();
+
+	$effect(() => {
+		const identity = $authIdentity;
+
+		if (nonNullish(identity)) {
+			// Market data widens asset/chain to open strings (future assets); narrow to
+			// the SDK's strict mutating-flow types at this boundary.
+			estimateLiquidiumInflowFee({
+				identity,
+				asset: market.asset as Asset,
+				chain: market.chain as Chain
+			})
+				.then((fee) => (inflowFee = fee))
+				.catch(consoleError);
+		}
+	});
+
+	let modal: WizardModal<WizardStepsLiquidiumSupply> | undefined = $state();
+	let currentStep: WizardStep<WizardStepsLiquidiumSupply> | undefined = $state();
+	let amount: OptionAmount = $state();
+	let supplyProgressStep: string = $state(ProgressStepsLiquidiumSupply.INITIALIZATION);
+
+	const steps: WizardSteps<WizardStepsLiquidiumSupply> = $derived(
+		liquidiumSupplyWizardSteps({ i18n: $i18n })
+	);
+
+	const reset = () => {
+		amount = undefined;
+		supplyProgressStep = ProgressStepsLiquidiumSupply.INITIALIZATION;
+		currentStep = undefined;
+	};
+
+	const close = () => closeModal(reset);
+</script>
+
+{#if nonNullish(token)}
+	<SendTokenContext {token}>
+		<WizardModal
+			bind:this={modal}
+			disablePointerEvents={currentStep?.name === WizardStepsLiquidiumSupply.SUPPLYING}
+			onClose={close}
+			{steps}
+			bind:currentStep
+		>
+			{#snippet title()}{currentStep?.title ?? ''}{/snippet}
+
+			{#if market.chain === 'BTC'}
+				<LiquidiumSupplyBtcWizard
+					{currentStep}
+					{inflowFee}
+					{market}
+					onBack={modal.back}
+					onClose={close}
+					onNext={modal.next}
+					bind:amount
+					bind:supplyProgressStep
+				/>
+			{:else}
+				<LiquidiumSupplyEthWizard
+					{currentStep}
+					{inflowFee}
+					{market}
+					onBack={modal.back}
+					onClose={close}
+					onNext={modal.next}
+					bind:amount
+					bind:supplyProgressStep
+				/>
+			{/if}
+		</WizardModal>
+	</SendTokenContext>
+{/if}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyProgress.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyProgress.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
+	import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { ProgressSteps } from '$lib/types/progress-steps';
+
+	interface Props {
+		supplyProgressStep: string;
+	}
+
+	let { supplyProgressStep }: Props = $props();
+
+	let steps = $state<ProgressSteps>([
+		{
+			step: ProgressStepsLiquidiumSupply.INITIALIZATION,
+			text: $i18n.send.text.initializing,
+			state: 'in_progress'
+		},
+		{
+			step: ProgressStepsLiquidiumSupply.TRANSFER,
+			text: $i18n.liquidium.text.starting_to_supply,
+			state: 'next'
+		},
+		{
+			step: ProgressStepsLiquidiumSupply.REGISTER,
+			text: $i18n.liquidium.text.supply_started,
+			state: 'next'
+		}
+	]);
+</script>
+
+<InProgressWizard progressStep={supplyProgressStep} {steps} />

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyReview.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyReview.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import LiquidiumProviderFee from '$lib/components/liquidium/supply/LiquidiumProviderFee.svelte';
+	import StakeReview from '$lib/components/stake/StakeReview.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { LendBorrowProvider } from '$lib/types/lend-borrow';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+
+	const liquidium = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM];
+
+	interface Props {
+		market: LiquidiumMarket;
+		amount: OptionAmount;
+		// Provider fee (base units of the supplied token).
+		inflowFee?: bigint;
+		// Per-rail fee row (EthFeeDisplay / BtcUtxosFeeDisplay).
+		feeDisplay: Snippet;
+		onBack: () => void;
+		onConfirm: () => void;
+	}
+
+	let { market, amount, inflowFee, feeDisplay, onBack, onConfirm }: Props = $props();
+</script>
+
+<StakeReview actionButtonLabel={$i18n.liquidium.text.action_supply} {amount} {onBack} {onConfirm}>
+	{#snippet subtitle()}
+		{$i18n.liquidium.text.supply_review_subtitle}
+	{/snippet}
+
+	{#snippet content()}
+		<ModalValue>
+			{#snippet label()}{$i18n.core.text.to}{/snippet}
+			{#snippet mainValue()}{liquidium.name}{/snippet}
+		</ModalValue>
+
+		<ModalValue>
+			{#snippet label()}{$i18n.liquidium.text.supply_apy}{/snippet}
+			{#snippet mainValue()}
+				<span class="text-success-primary">{market.supplyApy.toFixed(2)}%</span>
+			{/snippet}
+		</ModalValue>
+
+		<LiquidiumProviderFee {inflowFee} />
+
+		{@render feeDisplay()}
+	{/snippet}
+</StakeReview>

--- a/src/frontend/src/lib/components/loaders/LoaderLiquidium.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderLiquidium.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
+	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { loadLiquidium } from '$lib/services/liquidium.services';
+
+	// Loads Liquidium markets + portfolio app-wide (e.g. the Earn-page card) without
+	// visiting the provider page first. Reactive on identity / ETH address.
+	$effect(() => {
+		if (!anyLendBorrowProviderEnabled) {
+			return;
+		}
+
+		loadLiquidium({ identity: $authIdentity, ethAddress: $ethAddress });
+	});
+</script>

--- a/src/frontend/src/lib/components/loaders/Loaders.svelte
+++ b/src/frontend/src/lib/components/loaders/Loaders.svelte
@@ -12,6 +12,7 @@
 	import LoaderActiveUserTransactions from '$lib/components/loaders/LoaderActiveUserTransactions.svelte';
 	import LoaderContacts from '$lib/components/loaders/LoaderContacts.svelte';
 	import LoaderHarvest from '$lib/components/loaders/LoaderHarvest.svelte';
+	import LoaderLiquidium from '$lib/components/loaders/LoaderLiquidium.svelte';
 	import LoaderMetamask from '$lib/components/loaders/LoaderMetamask.svelte';
 	import LoaderSwapTokens from '$lib/components/loaders/LoaderSwapTokens.svelte';
 	import LoaderTokens from '$lib/components/loaders/LoaderTokens.svelte';
@@ -58,6 +59,8 @@
 		<BalancesIdbSetter />
 
 		<LoaderHarvest />
+
+		<LoaderLiquidium />
 
 		<LoaderSwapTokens />
 

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -67,6 +67,10 @@ export const modalHarvestUnstake: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'harvest-unstake'
 );
+export const modalLiquidiumSupply: Readable<boolean> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'liquidium-supply'
+);
 export const modalSwap: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'swap'

--- a/src/frontend/src/lib/providers/earning.providers.ts
+++ b/src/frontend/src/lib/providers/earning.providers.ts
@@ -1,11 +1,14 @@
 import { goto } from '$app/navigation';
 import { earningProviderConfigs } from '$env/earning-providers.env';
+import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 import { rewardCampaigns } from '$env/reward-campaigns.env';
+import { LIQUIDIUM_PROVIDER_ID } from '$lib/constants/liquidium.constants';
 import { AppPath } from '$lib/constants/routes.constants';
 import {
 	HARVEST_AUTOPILOT_PROVIDER_ID,
 	harvestAutopilotEarningData
 } from '$lib/derived/harvest-autopilot-earning.derived';
+import { liquidiumEarningData } from '$lib/derived/liquidium.derived';
 import type { EarningProvider, EarningProviderData } from '$lib/types/earning-provider';
 import { nonNullish } from '@dfinity/utils';
 import { readable, type Readable } from 'svelte/store';
@@ -14,6 +17,7 @@ const currentReward = rewardCampaigns[rewardCampaigns.length - 1];
 
 const earningDataStores: Record<string, Readable<EarningProviderData> | undefined> = {
 	[HARVEST_AUTOPILOT_PROVIDER_ID]: harvestAutopilotEarningData,
+	...(anyLendBorrowProviderEnabled ? { [LIQUIDIUM_PROVIDER_ID]: liquidiumEarningData } : {}),
 	...(nonNullish(currentReward)
 		? {
 				[currentReward.id]: readable<EarningProviderData>({

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -70,6 +70,7 @@ export interface Modal<T> {
 		| 'get-token'
 		| 'harvest-stake'
 		| 'harvest-unstake'
+		| 'liquidium-supply'
 		| 'universal-scanner'
 		| 'pay-dialog'
 		| 'wallet-connect-sessions';
@@ -141,6 +142,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openNftFullscreenDisplay: (params: SetWithDataParams<Nft>) => void;
 	openHarvestStake: (id: symbol) => void;
 	openHarvestUnstake: (id: symbol) => void;
+	openLiquidiumSupply: (id: symbol) => void;
 	openUniversalScanner: (params: SetWithOptionalDataParams<UniversalScannerData>) => void;
 	openPayDialog: (id: symbol) => void;
 	openGetToken: (id: symbol) => void;
@@ -250,6 +252,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 		),
 		openHarvestStake: setType('harvest-stake'),
 		openHarvestUnstake: setType('harvest-unstake'),
+		openLiquidiumSupply: setType('liquidium-supply'),
 		openUniversalScanner: <(params: SetWithOptionalDataParams<UniversalScannerData>) => void>(
 			setTypeWithData('universal-scanner')
 		),

--- a/src/frontend/src/lib/types/earning-provider.ts
+++ b/src/frontend/src/lib/types/earning-provider.ts
@@ -1,7 +1,7 @@
 import type { EarningCardFields } from '$env/types/env.earning-cards';
 import type { Readable } from 'svelte/store';
 
-export type EarningType = 'stake' | 'reward';
+export type EarningType = 'stake' | 'reward' | 'lending';
 
 export interface EarningProviderCardConfig {
 	id: string;

--- a/src/frontend/src/routes/(app)/providers/liquidium/+page.svelte
+++ b/src/frontend/src/routes/(app)/providers/liquidium/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import LiquidiumProvider from '$lib/components/liquidium/LiquidiumProvider.svelte';
+</script>
+
+<LiquidiumProvider />

--- a/src/frontend/src/routes/(app)/providers/liquidium/+page.ts
+++ b/src/frontend/src/routes/(app)/providers/liquidium/+page.ts
@@ -1,0 +1,6 @@
+import { loadRouteParams, type RouteParams } from '$lib/utils/nav.utils';
+import type { LoadEvent } from '@sveltejs/kit';
+// eslint-disable-next-line local-rules/no-relative-imports
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ($event: LoadEvent): RouteParams => loadRouteParams($event);

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumMarketCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumMarketCard.spec.ts
@@ -1,0 +1,39 @@
+import LiquidiumMarketCard from '$lib/components/liquidium/LiquidiumMarketCard.svelte';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumMarketCard', () => {
+	const market = (overrides: Partial<LiquidiumMarket> = {}): LiquidiumMarket => ({
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true,
+		...overrides
+	});
+
+	it('renders the asset and supply/borrow labels', () => {
+		const { container } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+		expect(container).toHaveTextContent('BTC');
+		expect(container).toHaveTextContent(en.liquidium.text.supply_label);
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_label);
+	});
+
+	it('does not show "Coming soon" for an available market', () => {
+		const { container } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+		expect(container).not.toHaveTextContent(en.liquidium.text.coming_soon);
+	});
+
+	it('shows "Coming soon" for an unavailable market', () => {
+		const { container } = render(LiquidiumMarketCard, {
+			props: { market: market({ available: false }) }
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.coming_soon);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
@@ -1,0 +1,49 @@
+import LiquidiumPositionCard from '$lib/components/liquidium/LiquidiumPositionCard.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import type { LiquidiumReserve } from '$lib/types/liquidium';
+import { formatStakeApyNumber } from '$lib/utils/format.utils';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumPositionCard', () => {
+	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 0,
+		// 1 BTC in satoshis.
+		deposited: 100_000_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 1000,
+		borrowedUsd: 0,
+		...overrides
+	});
+
+	it('renders the supplied asset, APY and amount', () => {
+		const { container } = render(LiquidiumPositionCard, { props: { reserve: reserve() } });
+
+		expect(container).toHaveTextContent(en.liquidium.text.supplied);
+		expect(container).toHaveTextContent('BTC');
+		expect(container).toHaveTextContent(en.liquidium.text.apy_suffix);
+		expect(container).toHaveTextContent(`${formatStakeApyNumber(5)}%`);
+	});
+
+	it('does not show the yearly earning when the supplied value is zero', () => {
+		const { container } = render(LiquidiumPositionCard, {
+			props: { reserve: reserve({ suppliedUsd: 0 }) }
+		});
+
+		expect(container).not.toHaveTextContent('/year');
+	});
+
+	it('renders a zero APY position (default badge variant)', () => {
+		const { container } = render(LiquidiumPositionCard, {
+			props: { reserve: reserve({ supplyApy: 0 }) }
+		});
+
+		expect(container).toHaveTextContent(`${formatStakeApyNumber(0)}%`);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumProvider.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumProvider.spec.ts
@@ -1,0 +1,82 @@
+import LiquidiumProvider from '$lib/components/liquidium/LiquidiumProvider.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(),
+	afterNavigate: vi.fn()
+}));
+
+// Force the feature flags on (off by default outside staging) so the page renders.
+vi.mock('$env/lend-borrow', () => ({
+	LEND_BORROW_ENABLED: true,
+	anyLendBorrowProviderEnabled: true
+}));
+vi.mock('$env/liquidium', () => ({ LIQUIDIUM_ENABLED: true }));
+
+// Keep the IntervalLoader's onLoad a no-op so it doesn't reset the store we seed.
+vi.mock('$lib/services/liquidium.services', () => ({
+	loadLiquidium: vi.fn().mockResolvedValue(undefined)
+}));
+
+describe('LiquidiumProvider', () => {
+	const market: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
+	const portfolio: LiquidiumPortfolio = {
+		reserves: [
+			{
+				poolId: 'pool-btc',
+				asset: 'BTC',
+				chain: 'BTC',
+				supplyApy: 5,
+				borrowApy: 0,
+				deposited: 100_000_000n,
+				depositedDecimals: 8,
+				borrowed: ZERO,
+				borrowedDecimals: 8,
+				suppliedUsd: 1000,
+				borrowedUsd: 0
+			}
+		],
+		totalSuppliedUsd: 1000,
+		totalBorrowedUsd: 0,
+		netValueUsd: 1000,
+		availableBorrowsUsd: 0,
+		healthFactorPercent: 73
+	};
+
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('renders the markets and the positions section when data is present', () => {
+		liquidiumStore.set({ markets: [market], portfolio });
+
+		const { container } = render(LiquidiumProvider);
+
+		expect(container).toHaveTextContent(en.liquidium.text.health_factor);
+		expect(container).toHaveTextContent(en.liquidium.text.my_positions);
+		expect(container).toHaveTextContent(en.liquidium.text.markets);
+		expect(container).toHaveTextContent('BTC');
+	});
+
+	it('hides the positions section when there are no reserves', () => {
+		liquidiumStore.set({ markets: [market], portfolio: null });
+
+		const { container } = render(LiquidiumProvider);
+
+		expect(container).toHaveTextContent(en.liquidium.text.markets);
+		expect(container).not.toHaveTextContent(en.liquidium.text.my_positions);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumProviderHero.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumProviderHero.spec.ts
@@ -1,0 +1,35 @@
+import LiquidiumProviderHero from '$lib/components/liquidium/LiquidiumProviderHero.svelte';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+vi.mock('$app/navigation', () => ({
+	afterNavigate: vi.fn(),
+	goto: vi.fn()
+}));
+
+describe('LiquidiumProviderHero', () => {
+	const props = {
+		logo: '/images/dapps/liquidium-logo.webp',
+		pageTitle: 'Liquidium',
+		pageDescription: 'Lend & borrow native assets.',
+		url: 'https://liquidium.fi',
+		portfolio: null
+	};
+
+	it('renders the title, description and learn-more link', () => {
+		const { container } = render(LiquidiumProviderHero, { props });
+
+		expect(container).toHaveTextContent('Liquidium');
+		expect(container).toHaveTextContent('Lend & borrow native assets.');
+		expect(container).toHaveTextContent(en.core.text.learn_more);
+	});
+
+	it('hides the summary and learn-more link when showSummary is false', () => {
+		const { container } = render(LiquidiumProviderHero, {
+			props: { ...props, showSummary: false }
+		});
+
+		expect(container).not.toHaveTextContent(en.core.text.learn_more);
+		expect(container).not.toHaveTextContent(en.liquidium.text.health_factor);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
@@ -1,0 +1,87 @@
+import LiquidiumSummary from '$lib/components/liquidium/LiquidiumSummary.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import type { LiquidiumPortfolio } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumSummary', () => {
+	const portfolio: LiquidiumPortfolio = {
+		reserves: [
+			{
+				poolId: 'pool-btc',
+				asset: 'BTC',
+				chain: 'BTC',
+				supplyApy: 5,
+				borrowApy: 0,
+				deposited: ZERO,
+				depositedDecimals: 8,
+				borrowed: ZERO,
+				borrowedDecimals: 8,
+				suppliedUsd: 1000,
+				borrowedUsd: 0
+			}
+		],
+		totalSuppliedUsd: 1000,
+		totalBorrowedUsd: 0,
+		netValueUsd: 1000,
+		availableBorrowsUsd: 0,
+		healthFactorPercent: 73
+	};
+
+	it('renders the health factor, net value and net APY labels', () => {
+		const { container } = render(LiquidiumSummary, { props: { portfolio } });
+
+		expect(container).toHaveTextContent(en.liquidium.text.health_factor);
+		expect(container).toHaveTextContent(en.liquidium.text.net_value);
+		expect(container).toHaveTextContent(en.liquidium.text.net_apy);
+	});
+
+	it('renders the portfolio health factor percentage', () => {
+		const { container } = render(LiquidiumSummary, { props: { portfolio } });
+
+		expect(container).toHaveTextContent('73%');
+	});
+
+	it('defaults to 100% health when there is no portfolio', () => {
+		const { container } = render(LiquidiumSummary, { props: { portfolio: null } });
+
+		expect(container).toHaveTextContent('100%');
+	});
+
+	it('renders a negative net APY with a minus sign', () => {
+		const negativeApy: LiquidiumPortfolio = {
+			...portfolio,
+			reserves: [
+				{
+					...portfolio.reserves[0],
+					supplyApy: 1,
+					borrowApy: 20,
+					borrowedUsd: 900
+				}
+			],
+			totalBorrowedUsd: 900,
+			netValueUsd: 100
+		};
+
+		const { container } = render(LiquidiumSummary, { props: { portfolio: negativeApy } });
+
+		// Weighted (1000·1 − 900·20) / 100 < 0 → shown with a minus sign.
+		expect(container).toHaveTextContent('−');
+	});
+
+	it('renders an at-risk health factor (amber band)', () => {
+		const { container } = render(LiquidiumSummary, {
+			props: { portfolio: { ...portfolio, healthFactorPercent: 30 } }
+		});
+
+		expect(container).toHaveTextContent('30%');
+	});
+
+	it('renders a critical health factor (red band)', () => {
+		const { container } = render(LiquidiumSummary, {
+			props: { portfolio: { ...portfolio, healthFactorPercent: 8 } }
+		});
+
+		expect(container).toHaveTextContent('8%');
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumProviderFee.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumProviderFee.spec.ts
@@ -1,0 +1,47 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumProviderFee from '$lib/components/liquidium/supply/LiquidiumProviderFee.svelte';
+import { SEND_CONTEXT_KEY } from '$lib/stores/send.store';
+import { formatToken } from '$lib/utils/format.utils';
+import en from '$tests/mocks/i18n.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { render } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+
+describe('LiquidiumProviderFee', () => {
+	const context = mockContextMap([
+		[
+			SEND_CONTEXT_KEY,
+			{
+				sendToken: readable(BTC_MAINNET_TOKEN),
+				sendTokenDecimals: readable(BTC_MAINNET_TOKEN.decimals),
+				sendTokenId: readable(BTC_MAINNET_TOKEN.id),
+				sendTokenStandard: readable(BTC_MAINNET_TOKEN.standard),
+				sendTokenSymbol: readable(BTC_MAINNET_TOKEN.symbol),
+				sendTokenNetworkId: readable(BTC_MAINNET_TOKEN.network.id),
+				sendTokenExchangeRate: readable(undefined)
+			}
+		]
+	]);
+
+	it('renders the provider fee label, amount and symbol', () => {
+		const inflowFee = 1500n;
+
+		const { container } = render(LiquidiumProviderFee, { props: { inflowFee }, context });
+
+		expect(container).toHaveTextContent(en.liquidium.text.provider_fee);
+		expect(container).toHaveTextContent(
+			formatToken({
+				value: inflowFee,
+				unitName: BTC_MAINNET_TOKEN.decimals,
+				displayDecimals: BTC_MAINNET_TOKEN.decimals
+			})
+		);
+		expect(container).toHaveTextContent(BTC_MAINNET_TOKEN.symbol);
+	});
+
+	it('renders nothing when no fee is provided', () => {
+		const { container } = render(LiquidiumProviderFee, { props: {}, context });
+
+		expect(container).not.toHaveTextContent(en.liquidium.text.provider_fee);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyAgreement.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyAgreement.spec.ts
@@ -1,0 +1,26 @@
+import LiquidiumSupplyAgreement from '$lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte';
+import en from '$tests/mocks/i18n.mock';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('LiquidiumSupplyAgreement', () => {
+	it('renders the agreement text and an unchecked checkbox', () => {
+		const { container } = render(LiquidiumSupplyAgreement, { props: { checked: false } });
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_agreement);
+
+		const checkbox = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+
+		expect(checkbox).not.toBeNull();
+		expect(checkbox?.checked).toBeFalsy();
+	});
+
+	it('toggles the checkbox on click', async () => {
+		const { container } = render(LiquidiumSupplyAgreement, { props: { checked: false } });
+
+		const checkbox = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+
+		await fireEvent.click(checkbox as HTMLInputElement);
+
+		expect(checkbox?.checked).toBeTruthy();
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.spec.ts
@@ -1,0 +1,105 @@
+import * as btcPendingSentTransactionsServices from '$btc/services/btc-pending-sent-transactions.services';
+import * as btcSendServices from '$btc/services/btc-send.services';
+import * as btcUtxosService from '$btc/services/btc-utxos.service';
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import * as bitcoinApi from '$icp/api/bitcoin.api';
+import LiquidiumSupplyBtcWizard from '$lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte';
+import * as addressesStore from '$lib/derived/address.derived';
+import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockBtcAddress, mockUtxosFee } from '$tests/mocks/btc.mock';
+import en from '$tests/mocks/i18n.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
+import type { WizardStep } from '@dfinity/gix-components';
+import { render } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+
+describe('LiquidiumSupplyBtcWizard', () => {
+	const market = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
+	const context = () => mockContextMap([mockSendContextEntry({ token: BTC_MAINNET_TOKEN })]);
+
+	const step = (name: WizardStepsLiquidiumSupply): WizardStep => ({ name, title: name });
+
+	const baseProps = {
+		market,
+		amount: 0.001,
+		supplyProgressStep: ProgressStepsLiquidiumSupply.INITIALIZATION,
+		inflowFee: 50n,
+		onClose: () => {},
+		onNext: () => {},
+		onBack: () => {}
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		allUtxosStore.reset();
+		feeRatePercentilesStore.reset();
+		btcPendingSentTransactionsStore.reset();
+
+		mockAuthStore();
+		vi.spyOn(addressesStore, 'btcAddressMainnet', 'get').mockImplementation(() =>
+			readable(mockBtcAddress)
+		);
+		vi.spyOn(addressesStore, 'ethAddress', 'get').mockImplementation(() => readable(undefined));
+
+		// Stub the UTXO/fee loaders' data sources so they resolve without network calls.
+		vi.spyOn(bitcoinApi, 'getUtxosQuery').mockResolvedValue({
+			utxos: [],
+			tip_block_hash: new Uint8Array(),
+			tip_height: 100,
+			next_page: []
+		});
+		vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
+			feeSatoshis: mockUtxosFee.feeSatoshis,
+			utxos: mockUtxosFee.utxos
+		});
+		vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
+		vi.spyOn(btcSendServices, 'validateBtcSend').mockResolvedValue(undefined);
+		vi.spyOn(
+			btcPendingSentTransactionsServices,
+			'loadBtcPendingSentTransactions'
+		).mockResolvedValue({ success: true });
+	});
+
+	it('renders the form step', () => {
+		const { container } = render(LiquidiumSupplyBtcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.SUPPLY) },
+			context: context()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_apy);
+	});
+
+	it('renders the review step', () => {
+		const { container } = render(LiquidiumSupplyBtcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.REVIEW) },
+			context: context()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_apy);
+	});
+
+	it('renders the progress step', () => {
+		const { container } = render(LiquidiumSupplyBtcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.SUPPLYING) },
+			context: context()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.starting_to_supply);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.spec.ts
@@ -1,0 +1,56 @@
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import LiquidiumSupplyEthWizard from '$lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte';
+import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import type { WizardStep } from '@dfinity/gix-components';
+import { render } from '@testing-library/svelte';
+
+// No matching enabled native token in the test, so the EthFeeContext (and its fee
+// estimation) never mounts — rendering exercises the wizard's setup/deriveds only,
+// without triggering network calls.
+describe('LiquidiumSupplyEthWizard', () => {
+	const market: LiquidiumMarket = {
+		poolId: 'pool-eth',
+		asset: 'ETH',
+		chain: 'ETH',
+		supplyApy: 4,
+		borrowApy: 7,
+		frozen: false,
+		available: true
+	};
+
+	const context = () =>
+		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ETHEREUM_TOKEN })]]);
+
+	const step = (name: WizardStepsLiquidiumSupply): WizardStep => ({ name, title: name });
+
+	const baseProps = {
+		market,
+		amount: 0.01,
+		supplyProgressStep: ProgressStepsLiquidiumSupply.INITIALIZATION,
+		inflowFee: 50n,
+		onClose: () => {},
+		onNext: () => {},
+		onBack: () => {}
+	};
+
+	it('mounts the form step without triggering fee estimation', () => {
+		const { container } = render(LiquidiumSupplyEthWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.SUPPLY) },
+			context: context()
+		});
+
+		expect(container).toBeTruthy();
+	});
+
+	it('mounts the progress step', () => {
+		const { container } = render(LiquidiumSupplyEthWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.SUPPLYING) },
+			context: context()
+		});
+
+		expect(container).toBeTruthy();
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyForm.spec.ts
@@ -1,0 +1,88 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumSupplyForm from '$lib/components/liquidium/supply/LiquidiumSupplyForm.svelte';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+
+describe('LiquidiumSupplyForm', () => {
+	const market: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
+	const mockContext = () =>
+		new Map<symbol, SendContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: BTC_MAINNET_TOKEN })]
+		]);
+
+	const feeDisplay = createRawSnippet(() => ({ render: () => '<span>network fee</span>' }));
+
+	const baseProps = {
+		market,
+		amount: undefined,
+		totalFee: 100n,
+		inflowFee: 50n,
+		feeDisplay,
+		onClose: () => {},
+		onNext: () => {}
+	};
+
+	it('renders the supply APY, provider fee, collateral info and agreement', () => {
+		const { container } = render(LiquidiumSupplyForm, {
+			props: baseProps,
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_apy);
+		expect(container).toHaveTextContent(en.liquidium.text.provider_fee);
+		expect(container).toHaveTextContent(en.liquidium.text.supply_collateral_info);
+		expect(container).toHaveTextContent(en.liquidium.text.supply_agreement);
+	});
+
+	it('still renders while the provider fee is unresolved (fee-missing branch)', () => {
+		const { container } = render(LiquidiumSupplyForm, {
+			props: { ...baseProps, inflowFee: undefined },
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_apy);
+	});
+
+	it('surfaces an amount error from the custom validator', () => {
+		const { container } = render(LiquidiumSupplyForm, {
+			props: {
+				...baseProps,
+				amount: 1,
+				onCustomErrorValidate: () => new Error(en.liquidium.text.insufficient_funds_for_fee)
+			},
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.insufficient_funds_for_fee);
+	});
+
+	it('renders a valid amount with no custom validator', () => {
+		const { container } = render(LiquidiumSupplyForm, {
+			props: { ...baseProps, amount: 1 },
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_apy);
+	});
+
+	it('keeps the form valid when the custom validator returns no error', () => {
+		const { container } = render(LiquidiumSupplyForm, {
+			props: { ...baseProps, amount: 1, onCustomErrorValidate: () => undefined },
+			context: mockContext()
+		});
+
+		expect(container).not.toHaveTextContent(en.liquidium.text.insufficient_funds_for_fee);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyProgress.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyProgress.spec.ts
@@ -1,0 +1,16 @@
+import LiquidiumSupplyProgress from '$lib/components/liquidium/supply/LiquidiumSupplyProgress.svelte';
+import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumSupplyProgress', () => {
+	it('renders the supply progress steps', () => {
+		const { container } = render(LiquidiumSupplyProgress, {
+			props: { supplyProgressStep: ProgressStepsLiquidiumSupply.INITIALIZATION }
+		});
+
+		expect(container).toHaveTextContent(en.send.text.initializing);
+		expect(container).toHaveTextContent(en.liquidium.text.starting_to_supply);
+		expect(container).toHaveTextContent(en.liquidium.text.supply_started);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyReview.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyReview.spec.ts
@@ -1,0 +1,44 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumSupplyReview from '$lib/components/liquidium/supply/LiquidiumSupplyReview.svelte';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+
+describe('LiquidiumSupplyReview', () => {
+	const market: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
+	const mockContext = () =>
+		new Map<symbol, SendContext>([
+			[SEND_CONTEXT_KEY, initSendContext({ token: BTC_MAINNET_TOKEN })]
+		]);
+
+	const feeDisplay = createRawSnippet(() => ({ render: () => '<span>network fee</span>' }));
+
+	it('renders the provider name, supply APY and provider fee', () => {
+		const { container } = render(LiquidiumSupplyReview, {
+			props: {
+				market,
+				amount: 0.01,
+				inflowFee: 50n,
+				feeDisplay,
+				onBack: () => {},
+				onConfirm: () => {}
+			},
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent('Liquidium');
+		expect(container).toHaveTextContent(en.liquidium.text.supply_apy);
+		expect(container).toHaveTextContent(en.liquidium.text.provider_fee);
+	});
+});


### PR DESCRIPTION
# Motivation

Combines the former PR 4 + PR 5 of the Liquidium "Supply" stack: the read-only Liquidium provider page AND the full Supply wizard, in one cohesive PR. Reached at /providers/liquidium/, gated by LEND_BORROW_ENABLED / LIQUIDIUM_ENABLED (STAGING) — hidden in BETA/PROD. Stacked on the merged data + active-transactions layers.

# Changes

  - Route (routes/(app)/providers/liquidium/+page.{svelte,ts}): renders LiquidiumProvider; redirects to Earn when the feature flag is off.
  - Provider page (LiquidiumProvider, LiquidiumProviderHero, LiquidiumSummary, LiquidiumPositionCard, LiquidiumMarketCard): header (health factor / net value / net APY, colour-coded), "My positions" rows, and a "Markets" list with per-pool supply/borrow APY, a "Coming soon" pill for frozen/capped pools, and a working Supply CTA. Polls via the shared IntervalLoader while mounted; app-wide load owned by LoaderLiquidium.
  - Supply wizard (supply/*): Form -> Review -> Progress, dispatched by chain to per-rail BTC/ETH wizards sharing LiquidiumSupplyForm / Review / Progress. Form/Review show supply APY, a Provider fee row, the per-rail network fee, the collateral-info line and an agreement checkbox. Closes before settlement; the action is tracked via the active-transactions mechanism.
  - Modal wiring (modal.store.ts, modal.derived.ts): the liquidium-supply modal type.
  - Loaders (LoaderLiquidium, Loaders.svelte): reactive app-wide markets/positions load, gated by anyLendBorrowProviderEnabled.
  - Component tests for LiquidiumSummary, LiquidiumMarketCard, and LiquidiumProviderFee.

# Tests

  - prettier, eslint, npm run check (0 errors / 0 warnings), and the new component specs all green.
