### PR TITLE
fix(frontend): BTC supply issue

### DIFF
--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
@@ -62,6 +62,16 @@
 			: undefined
 	);
 
+	// UTXO selection and the network fee must cover the gross transfer that is actually
+	// broadcast (net supply + Liquidium inflow fee), not just the net amount the user typed.
+	// Selecting UTXOs for the net amount alone under-funds the transaction, so the signer
+	// rejects it with NotEnoughFunds once the inflow fee is added on broadcast.
+	let feeEstimationAmount = $derived(
+		nonNullish(parsedAmount) && nonNullish(inflowFee)
+			? convertSatoshisToBtc(parsedAmount + inflowFee)
+			: amount
+	);
+
 	const { store: utxosFeeStore } = setContext<UtxosFeeContext>(UTXOS_FEE_CONTEXT_KEY, {
 		store: initUtxosFeeStore()
 	});
@@ -145,7 +155,7 @@
 	</BtcUtxosFeeDisplay>
 {/snippet}
 
-<UtxosFeeLoader {amount} {networkId} source={$btcAddressMainnet ?? ''}>
+<UtxosFeeLoader amount={feeEstimationAmount} {networkId} source={$btcAddressMainnet ?? ''}>
 	{#if currentStep?.name === WizardStepsLiquidiumSupply.REVIEW}
 		<LiquidiumSupplyReview {amount} {feeDisplay} {inflowFee} {market} {onBack} onConfirm={supply} />
 	{:else if currentStep?.name === WizardStepsLiquidiumSupply.SUPPLYING}

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.spec.ts
@@ -4,6 +4,7 @@ import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
+import { convertSatoshisToBtc } from '$btc/utils/btc-send.utils';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import * as bitcoinApi from '$icp/api/bitcoin.api';
 import LiquidiumSupplyBtcWizard from '$lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte';
@@ -11,12 +12,12 @@ import * as addressesStore from '$lib/derived/address.derived';
 import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
 import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
-import { mockBtcAddress, mockUtxosFee } from '$tests/mocks/btc.mock';
+import { mockBtcAddress, mockUtxo, mockUtxosFee } from '$tests/mocks/btc.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockContextMap } from '$tests/utils/context.test-utils';
 import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
 import type { WizardStep } from '@dfinity/gix-components';
-import { render } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
 describe('LiquidiumSupplyBtcWizard', () => {
@@ -101,5 +102,30 @@ describe('LiquidiumSupplyBtcWizard', () => {
 		});
 
 		expect(container).toHaveTextContent(en.liquidium.text.starting_to_supply);
+	});
+
+	it('selects UTXOs for the gross transfer (supply amount + inflow fee)', async () => {
+		// The broadcast sends `amount + inflowFee`, so UTXO selection must cover the gross
+		// amount — selecting for the net amount alone under-funds the signer (NotEnoughFunds).
+		allUtxosStore.setAllUtxos({ allUtxos: [mockUtxo] });
+		feeRatePercentilesStore.setFeeRateFromPercentiles({ feeRateFromPercentiles: 1000n });
+		btcPendingSentTransactionsStore.setPendingTransactions({
+			address: mockBtcAddress,
+			pendingTransactions: []
+		});
+
+		// 0.001 BTC = 100_000 sat; + 50 sat inflow fee = 100_050 sat → 0.0010005 BTC.
+		const grossAmount = Number(convertSatoshisToBtc(100_050n));
+
+		render(LiquidiumSupplyBtcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.SUPPLY) },
+			context: context()
+		});
+
+		await waitFor(() => {
+			expect(btcUtxosService.prepareBtcSend).toHaveBeenCalledWith(
+				expect.objectContaining({ amount: grossAmount })
+			);
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

Submitting a Liquidium BTC supply failed with NotEnoughFunds (e.g. available 700, required 1194) even when the wallet held enough balance to cover the amount and all fees.

The supply broadcasts a gross transfer — amount + inflowFee (the protocol deducts its per-inflow fee on arrival) — but the UTXO selection and network-fee estimation ran against only the net amount the user typed. Because the selection uses a smallest-sufficient greedy algorithm, the chosen UTXOs just barely covered net + networkFee, leaving nothing for the inflow fee. The signer then needed net + inflowFee + networkFee and rejected the transaction. The regular send-BTC flow is unaffected because it feeds the same amount to both selection and broadcast.

# Changes

- LiquidiumSupplyBtcWizard.svelte: pass the gross amount (net + inflowFee) to UtxosFeeLoader, so UTXO selection and the displayed network fee cover what is actually broadcast. Reuses the existing parsedAmount (satoshis) and convertSatoshisToBtc — bigint math, no new parsing and no float drift.


# Tests

Added a regression test asserting prepareBtcSend is invoked with the gross amount (0.0010005 for 0.001 BTC + 50 sat inflow fee); it fails against the previous net-amount wiring.
