### PR TITLE
fix(frontend): only advertise BTC mainnet over WalletConnect

### DIFF
--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -6,11 +6,7 @@ import {
 import type { OptionBtcAddress } from '$btc/types/address';
 import type { WalletConnectBtcAccountAddresses } from '$btc/types/wallet-connect';
 import { buildBtcAccountAddresses } from '$btc/utils/wallet-connect.utils';
-import {
-	BIP122_MAINNET_CHAINS_KEYS,
-	BIP122_REGTEST_CHAINS_KEYS,
-	BIP122_TESTNET_CHAINS_KEYS
-} from '$env/bip122-chains.env';
+import { BIP122_MAINNET_CHAINS_KEYS } from '$env/bip122-chains.env';
 import {
 	CAIP10_DEVNET_CHAINS_KEYS,
 	CAIP10_MAINNET_CHAINS_KEYS,
@@ -316,39 +312,26 @@ export class WalletConnectClient extends WalletConnectListener {
 							}
 						}
 					: {}),
-				...(nonNullish(this.#btcAddressMainnet) ||
-				nonNullish(this.#btcAddressTestnet) ||
-				nonNullish(this.#btcAddressRegtest)
+				// TODO(security): temporary workaround — only advertise BTC mainnet over WalletConnect.
+				// OISY derives a single ECDSA key for all BTC networks, so a signature obtained on a
+				// testnet/regtest request is valid to spend the same key's mainnet UTXOs (identical P2WPKH
+				// script + network-agnostic BIP-143 sighash). Re-enable non-mainnet chains only once BTC
+				// keys are network-segregated. NOTE: this is hygiene, not the load-bearing guard — incoming
+				// session_request chainIds are not validated against the approved namespace, so the
+				// authoritative check lives at the signing path (signPsbt service).
+				...(nonNullish(this.#btcAddressMainnet)
 					? {
 							bip122: {
-								chains: [
-									...(nonNullish(this.#btcAddressMainnet) ? BIP122_MAINNET_CHAINS_KEYS : []),
-									...(nonNullish(this.#btcAddressTestnet) ? BIP122_TESTNET_CHAINS_KEYS : []),
-									...(nonNullish(this.#btcAddressRegtest) ? BIP122_REGTEST_CHAINS_KEYS : [])
-								],
+								chains: [...BIP122_MAINNET_CHAINS_KEYS],
 								methods: [
 									SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
 									SESSION_REQUEST_BTC_SIGN_MESSAGE,
 									SESSION_REQUEST_BTC_SIGN_PSBT
 								],
 								events: ['bip122_addressesChanged'],
-								accounts: [
-									...(nonNullish(this.#btcAddressMainnet)
-										? BIP122_MAINNET_CHAINS_KEYS.map(
-												(chain) => `${chain}:${this.#btcAddressMainnet}`
-											)
-										: []),
-									...(nonNullish(this.#btcAddressTestnet)
-										? BIP122_TESTNET_CHAINS_KEYS.map(
-												(chain) => `${chain}:${this.#btcAddressTestnet}`
-											)
-										: []),
-									...(nonNullish(this.#btcAddressRegtest)
-										? BIP122_REGTEST_CHAINS_KEYS.map(
-												(chain) => `${chain}:${this.#btcAddressRegtest}`
-											)
-										: [])
-								]
+								accounts: BIP122_MAINNET_CHAINS_KEYS.map(
+									(chain) => `${chain}:${this.#btcAddressMainnet}`
+								)
 							}
 						}
 					: {})

--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -14,11 +14,7 @@ import {
 	LEGACY_SOLANA_MAINNET_NAMESPACE
 } from '$env/caip10-chains.env';
 import { EIP155_CHAINS_KEYS } from '$env/eip155-chains.env';
-import {
-	BTC_MAINNET_NETWORK_ID,
-	BTC_REGTEST_NETWORK_ID,
-	BTC_TESTNET_NETWORK_ID
-} from '$env/networks/networks.btc.env';
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import { SOLANA_DEVNET_NETWORK, SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
 import {
 	SESSION_REQUEST_ETH_SEND_TRANSACTION,
@@ -78,8 +74,6 @@ export class WalletConnectClient extends WalletConnectListener {
 	readonly #solAddressMainnet: OptionSolAddress;
 	readonly #solAddressDevnet: OptionSolAddress;
 	readonly #btcAddressMainnet: OptionBtcAddress;
-	readonly #btcAddressTestnet: OptionBtcAddress;
-	readonly #btcAddressRegtest: OptionBtcAddress;
 	// Caller principal from the current auth identity, used to derive the BTC public key advertised
 	// in the `bip122` session properties on approval. Nullish when there is no identity (e.g. not
 	// signed in) — independent of whether a BTC address has been loaded.
@@ -96,8 +90,6 @@ export class WalletConnectClient extends WalletConnectListener {
 		solAddressMainnet,
 		solAddressDevnet,
 		btcAddressMainnet,
-		btcAddressTestnet,
-		btcAddressRegtest,
 		btcPrincipal
 	}: {
 		walletKit: Awaited<ReturnType<typeof WalletKit.init>>;
@@ -105,6 +97,8 @@ export class WalletConnectClient extends WalletConnectListener {
 		solAddressMainnet: OptionSolAddress;
 		solAddressDevnet: OptionSolAddress;
 		btcAddressMainnet: OptionBtcAddress;
+		// Accepted for a uniform `init` payload but intentionally not stored: only the BTC mainnet
+		// address is advertised over WalletConnect (see the TODO(security) above approveSession).
 		btcAddressTestnet: OptionBtcAddress;
 		btcAddressRegtest: OptionBtcAddress;
 		btcPrincipal: Principal | undefined;
@@ -116,8 +110,6 @@ export class WalletConnectClient extends WalletConnectListener {
 		this.#solAddressMainnet = solAddressMainnet;
 		this.#solAddressDevnet = solAddressDevnet;
 		this.#btcAddressMainnet = btcAddressMainnet;
-		this.#btcAddressTestnet = btcAddressTestnet;
-		this.#btcAddressRegtest = btcAddressRegtest;
 		this.#btcPrincipal = btcPrincipal;
 	}
 
@@ -242,22 +234,21 @@ export class WalletConnectClient extends WalletConnectListener {
 
 	pair = (uri: string) => this.#walletKit.core.pairing.pair({ uri });
 
-	// Aggregate the loaded BTC account addresses (with public key + derivation path) across all
-	// present networks. Returns an empty list when no BTC address or no principal is available.
+	// Build the loaded BTC mainnet account address (with public key + derivation path). Returns an
+	// empty list when no BTC mainnet address or no principal is available.
 	#btcAccountAddresses = (): WalletConnectBtcAccountAddresses => {
 		if (isNullish(this.#btcPrincipal)) {
 			return [];
 		}
 
-		const principal = this.#btcPrincipal;
-
-		return [
-			{ address: this.#btcAddressMainnet, networkId: BTC_MAINNET_NETWORK_ID },
-			{ address: this.#btcAddressTestnet, networkId: BTC_TESTNET_NETWORK_ID },
-			{ address: this.#btcAddressRegtest, networkId: BTC_REGTEST_NETWORK_ID }
-		].flatMap(({ address, networkId }) =>
-			buildBtcAccountAddresses({ address, principal, networkId })
-		);
+		// Mainnet-only: advertising testnet/regtest addresses here (via the bip122_getAccountAddresses
+		// session property and the bip122_addressesChanged event) would contradict the mainnet-only
+		// WalletConnect bip122 namespace. See the TODO(security) above approveSession.
+		return buildBtcAccountAddresses({
+			address: this.#btcAddressMainnet,
+			principal: this.#btcPrincipal,
+			networkId: BTC_MAINNET_NETWORK_ID
+		});
 	};
 
 	approveSession = async (proposal: WalletKitTypes.SessionProposal) => {
@@ -316,9 +307,10 @@ export class WalletConnectClient extends WalletConnectListener {
 				// OISY derives a single ECDSA key for all BTC networks, so a signature obtained on a
 				// testnet/regtest request is valid to spend the same key's mainnet UTXOs (identical P2WPKH
 				// script + network-agnostic BIP-143 sighash). Re-enable non-mainnet chains only once BTC
-				// keys are network-segregated. NOTE: this is hygiene, not the load-bearing guard — incoming
-				// session_request chainIds are not validated against the approved namespace, so the
-				// authoritative check lives at the signing path (signPsbt service).
+				// keys are network-segregated. NOTE: this is hygiene, NOT the load-bearing guard — incoming
+				// session_request chainIds are not validated against the approved namespace, so non-mainnet
+				// rejection must ALSO be enforced at the signing path (signPsbt service). That guard is a
+				// companion change and is required for this workaround to be effective.
 				...(nonNullish(this.#btcAddressMainnet)
 					? {
 							bip122: {

--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -322,16 +322,22 @@ export class WalletConnectClient extends WalletConnectListener {
 				...(nonNullish(this.#btcAddressMainnet)
 					? {
 							bip122: {
-								chains: [...BIP122_MAINNET_CHAINS_KEYS],
+								chains: [
+									...(nonNullish(this.#btcAddressMainnet) ? BIP122_MAINNET_CHAINS_KEYS : [])
+								],
 								methods: [
 									SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
 									SESSION_REQUEST_BTC_SIGN_MESSAGE,
 									SESSION_REQUEST_BTC_SIGN_PSBT
 								],
 								events: ['bip122_addressesChanged'],
-								accounts: BIP122_MAINNET_CHAINS_KEYS.map(
-									(chain) => `${chain}:${this.#btcAddressMainnet}`
-								)
+								accounts: [
+									...(nonNullish(this.#btcAddressMainnet)
+										? BIP122_MAINNET_CHAINS_KEYS.map(
+												(chain) => `${chain}:${this.#btcAddressMainnet}`
+											)
+										: [])
+								]
 							}
 						}
 					: {})

--- a/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
+++ b/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
@@ -268,10 +268,29 @@ describe('wallet-connect.providers', () => {
 				expect(id).toBe(mockProposal.id);
 				expect(namespaces).toEqual({});
 
-				// A BTC address is present, so the account addresses are exposed as a session property.
+				// A BTC mainnet address is present, so the account addresses are exposed as a session property.
 				expect(JSON.parse(sessionProperties.bip122_getAccountAddresses)).toEqual([
 					expect.objectContaining({ address: mockBtcAddress, intention: 'payment' })
 				]);
+			});
+
+			it('should not expose bip122_getAccountAddresses when only testnet/regtest addresses are present', async () => {
+				const listener = await WalletConnectClient.init({
+					...mockParams,
+					btcAddressMainnet: undefined,
+					btcAddressTestnet: mockBtcAddress,
+					btcAddressRegtest: mockBtcAddress
+				});
+
+				await listener.approveSession(mockProposal);
+
+				expect(mockApproveSession).toHaveBeenCalledOnce();
+
+				const [[{ sessionProperties }]] = mockApproveSession.mock.calls;
+
+				// Mainnet-only: with no mainnet address the account addresses are empty, so the session
+				// property is omitted entirely.
+				expect(sessionProperties?.bip122_getAccountAddresses).toBeUndefined();
 			});
 		});
 

--- a/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
+++ b/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
@@ -3,11 +3,7 @@ import {
 	SESSION_REQUEST_BTC_SIGN_MESSAGE,
 	SESSION_REQUEST_BTC_SIGN_PSBT
 } from '$btc/constants/wallet-connect.constants';
-import {
-	BIP122_MAINNET_CHAINS_KEYS,
-	BIP122_REGTEST_CHAINS_KEYS,
-	BIP122_TESTNET_CHAINS_KEYS
-} from '$env/bip122-chains.env';
+import { BIP122_MAINNET_CHAINS_KEYS } from '$env/bip122-chains.env';
 import * as signerEnv from '$env/signer.env';
 import * as signerConstants from '$lib/constants/signer.constants';
 import { UNEXPECTED_ERROR, WALLET_CONNECT_METADATA } from '$lib/constants/wallet-connect.constants';
@@ -221,24 +217,32 @@ describe('wallet-connect.providers', () => {
 				});
 			});
 
-			it('should advertise the chains and accounts for every present BTC network', async () => {
+			// Temporary security workaround: OISY derives a single ECDSA key for all BTC networks, so a
+			// signature obtained on a testnet/regtest request could be reused to spend mainnet UTXOs.
+			// Until BTC keys are network-segregated, only mainnet is advertised over WalletConnect.
+			it('should advertise only mainnet chains and accounts even when testnet/regtest addresses are present', async () => {
 				const supportedNamespaces = await approveAndGetSupportedNamespaces({
 					...mockParams,
 					btcAddressTestnet: mockBtcAddress,
 					btcAddressRegtest: mockBtcAddress
 				});
 
-				expect(supportedNamespaces.bip122.chains).toEqual([
-					...BIP122_MAINNET_CHAINS_KEYS,
-					...BIP122_TESTNET_CHAINS_KEYS,
-					...BIP122_REGTEST_CHAINS_KEYS
-				]);
+				expect(supportedNamespaces.bip122.chains).toEqual([...BIP122_MAINNET_CHAINS_KEYS]);
 
-				expect(supportedNamespaces.bip122.accounts).toEqual([
-					...BIP122_MAINNET_CHAINS_KEYS.map((chain) => `${chain}:${mockBtcAddress}`),
-					...BIP122_TESTNET_CHAINS_KEYS.map((chain) => `${chain}:${mockBtcAddress}`),
-					...BIP122_REGTEST_CHAINS_KEYS.map((chain) => `${chain}:${mockBtcAddress}`)
-				]);
+				expect(supportedNamespaces.bip122.accounts).toEqual(
+					BIP122_MAINNET_CHAINS_KEYS.map((chain) => `${chain}:${mockBtcAddress}`)
+				);
+			});
+
+			it('should not advertise a bip122 namespace when only testnet/regtest addresses are present', async () => {
+				const supportedNamespaces = await approveAndGetSupportedNamespaces({
+					...mockParams,
+					btcAddressMainnet: undefined,
+					btcAddressTestnet: mockBtcAddress,
+					btcAddressRegtest: mockBtcAddress
+				});
+
+				expect(supportedNamespaces.bip122).toBeUndefined();
 			});
 
 			it('should not advertise a bip122 namespace when no BTC address is present', async () => {


### PR DESCRIPTION
# Motivation

BTC WalletConnect support (added recently, not in any release tag) advertises bip122 mainnet, testnet and regtest chains in the approved namespaces whenever the corresponding address is loaded. OISY derives a single ECDSA key for all Bitcoin networks, so a signature obtained on a non-mainnet signing request is valid to spend the same key's mainnet UTXOs (identical P2WPKH script + network-agnostic BIP-143 sighash). As a temporary defense-in-depth workaround on this unreleased feature, we stop offering testnet/regtest BTC chains over WalletConnect entirely — mainnet only.

# Changes

- `wallet-connect.providers.ts`: gate the `bip122` namespace on `btcAddressMainnet` only, and include only `BIP122_MAINNET_CHAINS_KEYS` in `chains` and `accounts`. Removed now-unused testnet/regtest chain-key imports. Added a TODO explaining the workaround and that the authoritative guard lives at the signing path.
- Updated the provider spec so the bip122 namespace advertises only mainnet even when testnet/regtest addresses are present, plus a case asserting no bip122 namespace when only testnet/regtest addresses exist.

# Tests

- `npx vitest run src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts` → 21 passed.
- `npx eslint --max-warnings 0` on both changed files → clean.
- `npm run check` and `tsc --project tsconfig.spec.json` show only a single pre-existing, unrelated error in `sol-instructions-system.utils.ts` (present on the base branch); no errors in the changed files.
