### PR TITLE
fix(frontend): restrict BTC WalletConnect signPsbt to mainnet

### DIFF
--- a/src/frontend/src/btc/services/wallet-connect.services.ts
+++ b/src/frontend/src/btc/services/wallet-connect.services.ts
@@ -411,6 +411,25 @@ export const signPsbt = ({
 				return { success: false };
 			}
 
+			// TODO(security): temporary workaround — restrict signPsbt to BTC mainnet.
+			// OISY derives a single ECDSA key for all BTC networks, so the P2WPKH script and the
+			// BIP-143 sighash are identical across mainnet/testnet/regtest; a signature obtained via a
+			// non-mainnet request is therefore valid for a mainnet spend of the same key. Until BTC keys
+			// are network-segregated (or the UTXO's network can be cryptographically proven), reject
+			// non-mainnet signPsbt. This guard is independent of the approved WC namespaces because
+			// incoming session_request chainIds are NOT validated against them.
+			const networkId = nonNullish(request.params.chainId)
+				? BIP122_CHAINS[request.params.chainId]?.networkId
+				: undefined;
+
+			if (networkId !== BTC_MAINNET_NETWORK_ID) {
+				toastsError({
+					msg: { text: get(i18n).wallet_connect.error.btc_non_mainnet_sign_not_supported }
+				});
+				await listener.rejectRequest({ topic, id, error: UNEXPECTED_ERROR });
+				return { success: false };
+			}
+
 			const network = bitcoinJsNetwork(request.params.chainId);
 
 			modalNext();

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "معلمة غير معروفة.",
 			"wallet_not_initialized": "خطأ غير متوقع. عنوان محفظتك غير مهيأ.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Neznámý parametr.",
 			"wallet_not_initialized": "Neočekávaná chyba. Vaše adresa peněženky není inicializována.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Unbekannter Parameter.",
 			"wallet_not_initialized": "Unerwarteter Fehler. Deine Wallet-Adresse ist nicht initialisiert.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Unknown parameter.",
 			"wallet_not_initialized": "Unexpected error. Your wallet address is not initialized.",
 			"btc_broadcast_not_supported": "Broadcasting the signed transaction is not supported yet. Request the transaction with \"broadcast: false\" to receive the signed PSBT and broadcast it yourself.",
+			"btc_non_mainnet_sign_not_supported": "Signing Bitcoin transactions is only supported on mainnet. For your security, this request was not signed.",
 			"btc_psbt_decode": "This transaction could not be decoded for review. For your security, it was not signed.",
 			"btc_psbt_input_not_segwit": "This transaction includes an input that is not a SegWit (P2WPKH) input, which OISY cannot sign. For your security, it was not signed.",
 			"btc_psbt_input_not_owned": "This transaction includes an input that does not belong to this wallet's address, which OISY cannot sign. For your security, it was not signed.",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Parámetro desconocido.",
 			"wallet_not_initialized": "Error inesperado. La dirección de tu billetera no está inicializada.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Paramètre inconnu.",
 			"wallet_not_initialized": "Erreur inattendue. Votre adresse de portefeuille n'est pas initialisée.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "अज्ञात पैरामीटर।",
 			"wallet_not_initialized": "अप्रत्याशित त्रुटि। आपका वॉलेट पता प्रारंभ नहीं हुआ है।",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Parametro sconosciuto.",
 			"wallet_not_initialized": "Errore inaspettato. L'indirizzo del tuo wallet non è inizializzato.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "不明なパラメータです。",
 			"wallet_not_initialized": "予期しないエラー。ウォレットアドレスが初期化されていません。",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "알 수 없는 파라미터입니다.",
 			"wallet_not_initialized": "예기치 않은 오류. 지갑 주소가 초기화되지 않았습니다.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Nieznany parametr.",
 			"wallet_not_initialized": "Nieoczekiwany błąd. Twój adres portfela nie jest zainicjowany.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Parâmetro desconhecido.",
 			"wallet_not_initialized": "Erro inesperado. Seu endereço de carteira não está inicializado.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Неизвестный параметр.",
 			"wallet_not_initialized": "Непредвиденная ошибка. Ваш адрес кошелька не инициализирован.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "Tham số không xác định.",
 			"wallet_not_initialized": "Lỗi không mong muốn. Địa chỉ ví của bạn chưa được khởi tạo.",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1641,6 +1641,7 @@
 			"unknown_parameter": "未知参数。",
 			"wallet_not_initialized": "意外错误：钱包地址尚未初始化。",
 			"btc_broadcast_not_supported": "",
+			"btc_non_mainnet_sign_not_supported": "",
 			"btc_psbt_decode": "",
 			"btc_psbt_input_not_segwit": "",
 			"btc_psbt_input_not_owned": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1312,6 +1312,7 @@ interface I18nWallet_connect {
 		unknown_parameter: string;
 		wallet_not_initialized: string;
 		btc_broadcast_not_supported: string;
+		btc_non_mainnet_sign_not_supported: string;
 		btc_psbt_decode: string;
 		btc_psbt_input_not_segwit: string;
 		btc_psbt_input_not_owned: string;

--- a/src/frontend/src/tests/btc/services/wallet-connect.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/wallet-connect.services.spec.ts
@@ -1,11 +1,14 @@
-import { decodePsbt, getAccountAddresses } from '$btc/services/wallet-connect.services';
+import { decodePsbt, getAccountAddresses, signPsbt } from '$btc/services/wallet-connect.services';
 import type { OptionBtcAddress } from '$btc/types/address';
+import * as btcWalletConnectUtils from '$btc/utils/wallet-connect.utils';
 import { BIP122_CHAINS } from '$env/bip122-chains.env';
 import { BTC_MAINNET_NETWORK_ID, BTC_TESTNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import * as signerEnv from '$env/signer.env';
+import * as signerApi from '$lib/api/signer.api';
 import { ZERO } from '$lib/constants/app.constants';
 import * as signerConstants from '$lib/constants/signer.constants';
 import { UNEXPECTED_ERROR } from '$lib/constants/wallet-connect.constants';
+import { ProgressStepsSign } from '$lib/enums/progress-steps';
 import * as toastsStore from '$lib/stores/toasts.store';
 import type { NetworkId } from '$lib/types/network';
 import type { SignerMasterPubKeys } from '$lib/types/signer';
@@ -13,6 +16,7 @@ import type { WalletConnectListener } from '$lib/types/wallet-connect';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
+import { signAsync as signSecp256k1Async } from '@noble/secp256k1';
 import type { WalletKitTypes } from '@reown/walletkit';
 import { networks, payments, Psbt } from 'bitcoinjs-lib';
 import type { MockInstance } from 'vitest';
@@ -310,5 +314,150 @@ describe('btc wallet-connect.services', () => {
 		const request = buildRequest({ psbt: 'not-a-valid-psbt', broadcast: false });
 
 		expect(() => decodePsbt({ request, address: walletAddress })).toThrow();
+	});
+
+	describe('signPsbt', () => {
+		// Private key 1 — its compressed public key is the secp256k1 generator point G. Using a known
+		// private key lets the signer mock produce a real signature bitcoinjs-lib can validate.
+		const privateKey = Uint8Array.from([...Array(31).fill(0), 1]);
+		const signerPubkey = Buffer.from(
+			'0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+			'hex'
+		);
+
+		const mainnetChainId = Object.keys(BIP122_CHAINS).find(
+			(key) => BIP122_CHAINS[key].networkId === BTC_MAINNET_NETWORK_ID
+		);
+		const testnetSignChainId = Object.keys(BIP122_CHAINS).find(
+			(key) => BIP122_CHAINS[key].networkId === BTC_TESTNET_NETWORK_ID
+		);
+
+		const buildSignRequest = ({
+			chainId,
+			params
+		}: {
+			chainId: string | undefined;
+			params: Record<string, unknown>;
+		}): WalletKitTypes.SessionRequest =>
+			({
+				id: 456,
+				topic: 'sign-topic',
+				params: {
+					chainId,
+					request: { method: 'signPsbt', params }
+				}
+			}) as unknown as WalletKitTypes.SessionRequest;
+
+		const buildOwnedPsbt = (psbtNetwork: typeof networks.bitcoin): string => {
+			const { output: ownScript } = payments.p2wpkh({ pubkey: signerPubkey, network: psbtNetwork });
+
+			const psbt = new Psbt({ network: psbtNetwork });
+			psbt.addInput({
+				hash: '0000000000000000000000000000000000000000000000000000000000000001',
+				index: 0,
+				witnessUtxo: { script: ownScript as Buffer, value: 100_000 }
+			});
+			psbt.addOutput({ script: ownScript as Buffer, value: 90_000 });
+
+			return psbt.toBase64();
+		};
+
+		const mockListener = {
+			pair: vi.fn(),
+			approveSession: vi.fn(),
+			rejectSession: vi.fn(),
+			attachHandlers: vi.fn(),
+			detachHandlers: vi.fn(),
+			rejectRequest: vi.fn(),
+			getActiveSessions: vi.fn(),
+			approveRequest: vi.fn(),
+			disconnectSession: vi.fn(),
+			disconnect: vi.fn()
+		} as WalletConnectListener;
+
+		const modalNext = vi.fn();
+		const progress = vi.fn();
+
+		let spyToastsError: MockInstance;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			spyToastsError = vi.spyOn(toastsStore, 'toastsError');
+
+			vi.spyOn(btcWalletConnectUtils, 'deriveBtcPublicKey').mockReturnValue(
+				Uint8Array.from(signerPubkey)
+			);
+
+			vi.spyOn(signerApi, 'genericSignWithEcdsa').mockImplementation(async ({ messageHash }) =>
+				(await signSecp256k1Async(Uint8Array.from(messageHash), privateKey)).toCompactRawBytes()
+			);
+		});
+
+		it('rejects a signPsbt request on a non-mainnet (testnet) chain without signing', async () => {
+			const { address: testnetAddress } = payments.p2wpkh({
+				pubkey: signerPubkey,
+				network: networks.testnet
+			});
+
+			const result = await signPsbt({
+				listener: mockListener,
+				request: buildSignRequest({
+					chainId: testnetSignChainId,
+					params: { psbt: buildOwnedPsbt(networks.testnet), broadcast: false }
+				}),
+				address: testnetAddress,
+				modalNext,
+				progress,
+				identity: mockIdentity
+			});
+
+			expect(result).toEqual({ success: false });
+
+			expect(mockListener.rejectRequest).toHaveBeenCalledExactlyOnceWith({
+				id: 456,
+				topic: 'sign-topic',
+				error: UNEXPECTED_ERROR
+			});
+
+			expect(mockListener.approveRequest).not.toHaveBeenCalled();
+			expect(signerApi.genericSignWithEcdsa).not.toHaveBeenCalled();
+			expect(modalNext).not.toHaveBeenCalled();
+
+			expect(spyToastsError).toHaveBeenCalledWith({
+				msg: { text: en.wallet_connect.error.btc_non_mainnet_sign_not_supported }
+			});
+		});
+
+		it('signs and approves an owned-input request on BTC mainnet', async () => {
+			const { address: mainnetAddress } = payments.p2wpkh({
+				pubkey: signerPubkey,
+				network: networks.bitcoin
+			});
+
+			const result = await signPsbt({
+				listener: mockListener,
+				request: buildSignRequest({
+					chainId: mainnetChainId,
+					params: { psbt: buildOwnedPsbt(networks.bitcoin), broadcast: false }
+				}),
+				address: mainnetAddress,
+				modalNext,
+				progress,
+				identity: mockIdentity
+			});
+
+			expect(result).toEqual({ success: true });
+
+			expect(mockListener.approveRequest).toHaveBeenCalledExactlyOnceWith({
+				id: 456,
+				topic: 'sign-topic',
+				message: { psbt: expect.any(String) }
+			});
+
+			expect(mockListener.rejectRequest).not.toHaveBeenCalled();
+			expect(signerApi.genericSignWithEcdsa).toHaveBeenCalledOnce();
+			expect(progress).toHaveBeenCalledWith(ProgressStepsSign.DONE);
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

The BTC WalletConnect `signPsbt` flow (unreleased — not in any release tag) can sign a mainnet BTC spend while the request claims to be testnet/regtest. OISY derives a single ECDSA key for all Bitcoin networks, so the P2WPKH scriptPubKey and the BIP-143 sighash are byte-identical across mainnet/testnet/regtest. A signature obtained on a non-mainnet request is therefore valid to spend the same key's mainnet UTXOs. The ownership check and the signature are both network-agnostic, and incoming `session_request` chainIds are not validated against the approved WC namespaces — so the only network signal is the attacker-controlled request chainId used for address display. This is cross-network signature reuse.

# Changes

- `signPsbt` now rejects any request whose resolved bip122 network is not BTC mainnet, before any signing happens. Guard placed after the existing `broadcast` rejection and before network resolution.
- Added i18n error key `wallet_connect.error.btc_non_mainnet_sign_not_supported` and regenerated i18n types/locales via `npm run i18n`.
- The guard is marked as a temporary workaround (TODO) until BTC keys are network-segregated or the UTXO's network can be cryptographically proven.

# Tests

- Added a `signPsbt` test asserting a testnet request is rejected (calls `rejectRequest`, returns `{ success: false }`, never signs, shows the new error toast) and a mainnet happy-path test that signs and approves an owned input.
- `npx vitest run src/frontend/src/tests/btc/services/wallet-connect.services.spec.ts` — 12 passed.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npx tsc --project tsconfig.spec.json` all clean except one pre-existing, unrelated error in `src/sol/utils/sol-instructions-system.utils.ts` (present on `origin/main`, not touched here).
