### PR TITLE
refactor(frontend): dedupe signPsbt network resolution + harden tests

### DIFF
--- a/src/frontend/src/btc/services/wallet-connect.services.ts
+++ b/src/frontend/src/btc/services/wallet-connect.services.ts
@@ -418,19 +418,17 @@ export const signPsbt = ({
 			// are network-segregated (or the UTXO's network can be cryptographically proven), reject
 			// non-mainnet signPsbt. This guard is independent of the approved WC namespaces because
 			// incoming session_request chainIds are NOT validated against them.
-			const networkId = nonNullish(request.params.chainId)
-				? BIP122_CHAINS[request.params.chainId]?.networkId
-				: undefined;
+			// `bitcoinJsNetwork` is the single chainId→network mapping; unknown/non-mainnet chains
+			// resolve to a non-`networks.bitcoin` value, so this also covers unknown chain ids.
+			const network = bitcoinJsNetwork(request.params.chainId);
 
-			if (networkId !== BTC_MAINNET_NETWORK_ID) {
+			if (network !== networks.bitcoin) {
 				toastsError({
 					msg: { text: get(i18n).wallet_connect.error.btc_non_mainnet_sign_not_supported }
 				});
 				await listener.rejectRequest({ topic, id, error: UNEXPECTED_ERROR });
 				return { success: false };
 			}
-
-			const network = bitcoinJsNetwork(request.params.chainId);
 
 			modalNext();
 

--- a/src/frontend/src/tests/btc/services/wallet-connect.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/wallet-connect.services.spec.ts
@@ -16,6 +16,7 @@ import type { WalletConnectListener } from '$lib/types/wallet-connect';
 import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
+import { assertNonNullish } from '@dfinity/utils';
 import { signAsync as signSecp256k1Async } from '@noble/secp256k1';
 import type { WalletKitTypes } from '@reown/walletkit';
 import { networks, payments, Psbt } from 'bitcoinjs-lib';
@@ -209,6 +210,8 @@ describe('btc wallet-connect.services', () => {
 	const testnetChainId = Object.keys(BIP122_CHAINS).find(
 		(key) => BIP122_CHAINS[key].networkId === BTC_TESTNET_NETWORK_ID
 	);
+	// Fail loudly here rather than silently testing the "missing chainId" path if BIP122_CHAINS changes.
+	assertNonNullish(testnetChainId);
 
 	const buildPsbt = (): string => {
 		const psbt = new Psbt({ network });
@@ -331,6 +334,9 @@ describe('btc wallet-connect.services', () => {
 		const testnetSignChainId = Object.keys(BIP122_CHAINS).find(
 			(key) => BIP122_CHAINS[key].networkId === BTC_TESTNET_NETWORK_ID
 		);
+		// Fail loudly here rather than silently testing the "missing chainId" path if BIP122_CHAINS changes.
+		assertNonNullish(mainnetChainId);
+		assertNonNullish(testnetSignChainId);
 
 		const buildSignRequest = ({
 			chainId,


### PR DESCRIPTION
# Motivation

Follow-up to #13223, addressing two Copilot review comments that landed late on that PR (after it merged):

- The `signPsbt` mainnet guard re-derived the chain → network mapping from `BIP122_CHAINS` directly, duplicating the resolution already encapsulated by `bitcoinJsNetwork()`. Two parallel mappings are easy to drift apart.
- A few test chain ids were derived via `Object.keys(BIP122_CHAINS).find(...)`, which can silently return `undefined`; if `BIP122_CHAINS` changes the tests would quietly start exercising the "missing chainId" path instead of failing clearly.

No behavior change — the guard still rejects every non-mainnet (and unknown) chain.

# Changes

- `signPsbt`: resolve `network` once via `bitcoinJsNetwork()` and reject when it is not `networks.bitcoin`, removing the duplicate `BIP122_CHAINS` lookup. Unknown/non-mainnet chains resolve to a non-`networks.bitcoin` value, so unknown chain ids stay rejected.
- Tests: assert `assertNonNullish` on the `mainnetChainId` / `testnetChainId` / `testnetSignChainId` fixtures so a future `BIP122_CHAINS` change fails loudly instead of silently testing the missing-chainId path.

# Tests

- `npx eslint --max-warnings 0` — clean
- `npx tsc --project tsconfig.spec.json --noEmit` — clean
- `npx vitest run src/frontend/src/tests/btc/services/wallet-connect.services.spec.ts` — 12/12 passing