### PR TITLE
chore(frontend): TEST II Beta — DO NOT MERGE

### DIFF
--- a/src/frontend/src/lib/types/auth.ts
+++ b/src/frontend/src/lib/types/auth.ts
@@ -1,7 +1,7 @@
 export enum InternetIdentityDomain {
 	VERSION_1_0_LEGACY = 'identity.ic0.app',
 	VERSION_1_0 = 'identity.internetcomputer.org',
-	VERSION_2_0 = 'id.ai'
+	VERSION_2_0 = 'beta.id.ai'
 }
 
 /**


### PR DESCRIPTION
Aux/test-only PR. Points `InternetIdentityDomain.VERSION_2_0` at `beta.id.ai` so a deployed test build authenticates against Internet Identity beta instead of production `id.ai`.

**DO NOT MERGE** — for testing only.

Equivalent to Stefan's earlier test PRs (#11110, #12722).