### PR TITLE
feat(frontend): Liquidium borrow action FE

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumHealthFactor.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumHealthFactor.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { i18n } from '$lib/stores/i18n.store';
+	import { liquidiumHealthLevel } from '$lib/utils/liquidium.utils';
+
+	interface Props {
+		percent: number;
+		label?: string;
+		showBar?: boolean;
+	}
+
+	let { percent, label, showBar = true }: Props = $props();
+
+	let level = $derived(liquidiumHealthLevel(percent));
+
+	let markerLeft = $derived(Math.min(100, Math.max(0, percent)));
+</script>
+
+<div class="flex w-full flex-col gap-2">
+	<div class="flex items-center justify-between text-sm">
+		<span class="text-tertiary">{label ?? $i18n.liquidium.text.projected_health_factor}</span>
+		<span
+			class="font-bold"
+			class:text-error-primary={level === 'critical'}
+			class:text-success-primary={level === 'healthy'}
+			class:text-warning-primary={level === 'at-risk'}
+		>
+			{Math.round(percent)}%
+		</span>
+	</div>
+
+	{#if showBar}
+		<div
+			style="background: linear-gradient(90deg, var(--color-background-error-primary), var(--color-background-warning-primary) 45%, var(--color-background-success-primary));"
+			class="relative h-2 rounded-md"
+		>
+			<div
+				style={`left: ${markerLeft}%;`}
+				class="absolute -top-0.5 h-3 w-1 rounded-sm bg-primary-inverted transition-all"
+			></div>
+		</div>
+	{/if}
+</div>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import LiquidiumBorrowModal from '$lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte';
 	import LiquidiumSupplyModal from '$lib/components/liquidium/supply/LiquidiumSupplyModal.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
-	import { modalLiquidiumSupply } from '$lib/derived/modal.derived';
+	import { liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { modalLiquidiumBorrow, modalLiquidiumSupply } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
@@ -22,6 +25,25 @@
 	const modalId = Symbol();
 
 	let token = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
+
+	// Can't borrow a token you supplied (withdraw instead).
+	let isSupplied = $derived(
+		($liquidiumPortfolio?.reserves ?? []).some(
+			({ poolId, deposited }) => poolId === market.poolId && deposited > ZERO
+		)
+	);
+
+	// Can't supply a token you borrowed (repay instead).
+	let isBorrowed = $derived(
+		($liquidiumPortfolio?.reserves ?? []).some(
+			({ poolId, borrowed }) => poolId === market.poolId && borrowed > ZERO
+		)
+	);
+
+	// Needs borrowing power and an unsupplied token; kept disabled (not hidden) otherwise.
+	let canBorrow = $derived(
+		nonNullish($liquidiumPortfolio) && $liquidiumPortfolio.availableBorrowsUsd > 0 && !isSupplied
+	);
 </script>
 
 <div class="flex w-full flex-col">
@@ -64,9 +86,24 @@
 
 		{#snippet action()}
 			{#if market.available}
-				<Button onclick={() => modalStore.openLiquidiumSupply(modalId)} paddingSmall>
-					{$i18n.liquidium.text.action_supply}
-				</Button>
+				<div class="flex gap-2">
+					<Button
+						colorStyle="secondary"
+						disabled={!canBorrow}
+						onclick={() => modalStore.openLiquidiumBorrow(modalId)}
+						paddingSmall
+					>
+						{$i18n.liquidium.text.action_borrow}
+					</Button>
+
+					<Button
+						disabled={isBorrowed}
+						onclick={() => modalStore.openLiquidiumSupply(modalId)}
+						paddingSmall
+					>
+						{$i18n.liquidium.text.action_supply}
+					</Button>
+				</div>
 			{/if}
 		{/snippet}
 	</LogoButton>
@@ -75,5 +112,9 @@
 		styles and keeps valid HTML. -->
 	{#if market.available && $modalLiquidiumSupply && $modalStore?.id === modalId}
 		<LiquidiumSupplyModal {market} />
+	{/if}
+
+	{#if market.available && $modalLiquidiumBorrow && $modalStore?.id === modalId}
+		<LiquidiumBorrowModal {market} />
 	{/if}
 </div>

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte
@@ -114,13 +114,21 @@
 		return undefined;
 	};
 
+	// No price → USD cap/risk validation silently no-ops (newBorrowUsd is always 0), so block
+	// borrowing entirely until prices load (loadLiquidium falls back to {} on a prices failure).
+	let pricesUnavailable = $derived(borrowPrice <= 0);
+
 	// Any non-healthy projection requires explicit confirmation.
 	let needsConfirm = $derived(
 		hasAmount && !belowMinimum && preview.valid && preview.healthLevel !== 'healthy'
 	);
 
 	let canReview = $derived(
-		hasAmount && !belowMinimum && preview.valid && (!needsConfirm || confirmChecked)
+		hasAmount &&
+			!belowMinimum &&
+			!pricesUnavailable &&
+			preview.valid &&
+			(!needsConfirm || confirmChecked)
 	);
 </script>
 
@@ -190,6 +198,12 @@
 	</ModalValue>
 
 	<LiquidiumHealthFactor percent={preview.projectedHealthPercent} />
+
+	{#if pricesUnavailable}
+		<MessageBox level="warning" styleClass="mt-3">
+			{$i18n.liquidium.text.borrow_prices_unavailable}
+		</MessageBox>
+	{/if}
 
 	<!-- Amount errors show inside the input; only the risk confirmation lives here. -->
 	{#if needsConfirm}

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { getMinimumBorrowAmount } from '@liquidium/client';
+	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
+	import LiquidiumHealthFactor from '$lib/components/liquidium/LiquidiumHealthFactor.svelte';
+	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
+	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import Checkbox from '$lib/components/ui/Checkbox.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { LIQUIDIUM_BORROWING_POWER_TOLERANCE } from '$lib/constants/liquidium.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import type { LiquidiumBorrowPreview } from '$lib/services/liquidium-borrow.services';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { DisplayUnit } from '$lib/types/swap';
+	import type { Token } from '$lib/types/token';
+	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		market: LiquidiumMarket;
+		borrowToken: Token | undefined;
+		borrowPrice: number;
+		portfolio: LiquidiumPortfolio;
+		preview: LiquidiumBorrowPreview;
+		amount: OptionAmount;
+		confirmChecked: boolean;
+		onClose: () => void;
+		onNext: () => void;
+	}
+
+	let {
+		market,
+		borrowToken,
+		borrowPrice,
+		portfolio,
+		preview,
+		amount = $bindable(),
+		confirmChecked = $bindable(),
+		onClose,
+		onNext
+	}: Props = $props();
+
+	let exchangeValueUnit = $state<DisplayUnit>('usd');
+	let inputUnit = $derived<DisplayUnit>(exchangeValueUnit === 'token' ? 'usd' : 'token');
+	let amountSetToMax = $state(false);
+
+	$effect(() => {
+		amount;
+		confirmChecked = false;
+	});
+
+	// Max borrowable in base units = borrowing power ÷ price (floored to token decimals).
+	let maxBorrowBaseUnits = $derived(
+		nonNullish(borrowToken) && borrowPrice > 0 && portfolio.availableBorrowsUsd > 0
+			? parseToken({
+					value: (portfolio.availableBorrowsUsd / borrowPrice).toFixed(borrowToken.decimals),
+					unitName: borrowToken.decimals
+				})
+			: ZERO
+	);
+
+	let parsedAmount = $derived(
+		nonNullish(amount) && !invalidAmount(amount) && nonNullish(borrowToken)
+			? parseToken({ value: `${amount}`, unitName: borrowToken.decimals })
+			: undefined
+	);
+
+	let hasAmount = $derived(nonNullish(parsedAmount) && parsedAmount > ZERO);
+
+	let belowMinimum = $derived(
+		hasAmount && nonNullish(parsedAmount) && parsedAmount < getMinimumBorrowAmount(market.asset)
+	);
+
+	const formatUsd = (value: number) =>
+		formatCurrency({
+			value,
+			currency: $currentCurrency,
+			exchangeRate: $currencyExchangeStore,
+			language: $currentLanguage
+		});
+
+	let minBorrowFormatted = $derived(
+		nonNullish(borrowToken)
+			? `${formatToken({
+					value: getMinimumBorrowAmount(market.asset),
+					unitName: borrowToken.decimals
+				})} ${market.asset}`
+			: ''
+	);
+
+	// Shown inside the input. Shares the service cap's tolerance so "Max" doesn't flag itself.
+	const validateBorrowAmount = (userAmount: bigint): Error | undefined => {
+		if (userAmount < getMinimumBorrowAmount(market.asset)) {
+			return new Error($i18n.liquidium.text.borrow_below_minimum);
+		}
+
+		const usd = (Number(userAmount) / 10 ** (borrowToken?.decimals ?? 0)) * borrowPrice;
+
+		if (usd > portfolio.availableBorrowsUsd * (1 + LIQUIDIUM_BORROWING_POWER_TOLERANCE)) {
+			return new Error($i18n.liquidium.text.borrow_exceeds_power);
+		}
+
+		return undefined;
+	};
+
+	// Any non-healthy projection requires explicit confirmation.
+	let needsConfirm = $derived(
+		hasAmount && !belowMinimum && preview.valid && preview.healthLevel !== 'healthy'
+	);
+
+	let canReview = $derived(
+		hasAmount && !belowMinimum && preview.valid && (!needsConfirm || confirmChecked)
+	);
+</script>
+
+<ContentWithToolbar>
+	<div class="mb-4 flex flex-col rounded-xl bg-secondary p-3">
+		<ModalValue>
+			{#snippet label()}{$i18n.liquidium.text.collateral}{/snippet}
+			{#snippet mainValue()}{formatUsd(portfolio.totalSuppliedUsd)}{/snippet}
+		</ModalValue>
+
+		<ModalValue>
+			{#snippet label()}{$i18n.liquidium.text.borrowing_power}{/snippet}
+			{#snippet mainValue()}{formatUsd(portfolio.availableBorrowsUsd)}{/snippet}
+		</ModalValue>
+	</div>
+
+	<div class="mb-6">
+		<!-- Token fixed by the market for now; a selectable step comes later. -->
+		<TokenInput
+			displayUnit={inputUnit}
+			exchangeRate={borrowPrice}
+			isSelectable={false}
+			onCustomErrorValidate={validateBorrowAmount}
+			showTokenNetwork
+			token={borrowToken}
+			bind:amount
+		>
+			{#snippet title()}{$i18n.core.text.amount}{/snippet}
+
+			{#snippet amountInfo()}
+				<div class="text-tertiary">
+					<TokenInputAmountExchange
+						{amount}
+						exchangeRate={borrowPrice}
+						token={borrowToken}
+						bind:displayUnit={exchangeValueUnit}
+					/>
+				</div>
+			{/snippet}
+
+			{#snippet balance()}
+				<MaxBalanceButton
+					balance={maxBorrowBaseUnits}
+					token={borrowToken}
+					bind:amount
+					bind:amountSetToMax
+				/>
+			{/snippet}
+		</TokenInput>
+	</div>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.minimum_borrow}{/snippet}
+		{#snippet mainValue()}{minBorrowFormatted}{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.borrow_apy}{/snippet}
+		{#snippet mainValue()}
+			<span class="text-warning-primary">{formatStakeApyNumber(market.borrowApy)}%</span>
+		{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.resulting_ltv}{/snippet}
+		{#snippet mainValue()}{preview.resultingLtvPercent.toFixed(1)}%{/snippet}
+	</ModalValue>
+
+	<LiquidiumHealthFactor percent={preview.projectedHealthPercent} />
+
+	<!-- Amount errors show inside the input; only the risk confirmation lives here. -->
+	{#if needsConfirm}
+		<MessageBox level={preview.healthLevel === 'critical' ? 'error' : 'warning'} styleClass="mt-3">
+			<div class="flex flex-col gap-3">
+				<span>
+					{preview.healthLevel === 'critical'
+						? $i18n.liquidium.text.borrow_high_risk_warning
+						: $i18n.liquidium.text.borrow_at_risk_warning}
+				</span>
+
+				<label class="flex cursor-pointer items-start gap-3">
+					<Checkbox
+						checked={confirmChecked}
+						inputId="liquidium-borrow-confirm"
+						onChange={() => (confirmChecked = !confirmChecked)}
+					/>
+					<span class="text-sm">{$i18n.liquidium.text.borrow_risk_confirm}</span>
+				</label>
+			</div>
+		</MessageBox>
+	{/if}
+
+	<p class="mt-4 text-sm text-tertiary">{$i18n.liquidium.text.borrow_risk_info}</p>
+
+	{#snippet toolbar()}
+		<ButtonGroup>
+			<ButtonCancel onclick={onClose} />
+
+			<Button disabled={!canReview} onclick={onNext}>
+				{$i18n.send.text.review}
+			</Button>
+		</ButtonGroup>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import LiquidiumBorrowForm from '$lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte';
+	import LiquidiumBorrowProgress from '$lib/components/liquidium/borrow/LiquidiumBorrowProgress.svelte';
+	import LiquidiumBorrowReview from '$lib/components/liquidium/borrow/LiquidiumBorrowReview.svelte';
+	import { liquidiumBorrowWizardSteps } from '$lib/config/lend-borrow.config';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { btcAddressMainnet, ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { liquidiumAssetPrices, liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { ProgressStepsLiquidiumBorrow } from '$lib/enums/progress-steps';
+	import { WizardStepsLiquidiumBorrow } from '$lib/enums/wizard-steps';
+	import {
+		computeLiquidiumBorrowPreview,
+		executeLiquidiumBorrow
+	} from '$lib/services/liquidium-borrow.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { closeModal } from '$lib/utils/modal.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		// Borrow market (asset/pool); collateral is the whole portfolio, none is selected.
+		market: LiquidiumMarket;
+	}
+
+	let { market }: Props = $props();
+
+	let modal: WizardModal<WizardStepsLiquidiumBorrow> | undefined = $state();
+	let currentStep: WizardStep<WizardStepsLiquidiumBorrow> | undefined = $state();
+	let amount: OptionAmount = $state();
+	let confirmChecked = $state(false);
+	let borrowProgressStep: string = $state(ProgressStepsLiquidiumBorrow.INITIALIZATION);
+
+	const steps: WizardSteps<WizardStepsLiquidiumBorrow> = $derived(
+		liquidiumBorrowWizardSteps({ i18n: $i18n })
+	);
+
+	let borrowToken = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
+	let borrowPrice = $derived($liquidiumAssetPrices[market.asset] ?? 0);
+
+	let newBorrowUsd = $derived((Number(amount) || 0) * borrowPrice);
+
+	// Single source of the aggregate preview; with no amount it reflects the current LTV / health.
+	let preview = $derived(
+		nonNullish($liquidiumPortfolio)
+			? computeLiquidiumBorrowPreview({ portfolio: $liquidiumPortfolio, newBorrowUsd })
+			: undefined
+	);
+
+	let parsedAmount = $derived(
+		nonNullish(amount) && !invalidAmount(amount) && nonNullish(borrowToken)
+			? parseToken({ value: `${amount}`, unitName: borrowToken.decimals })
+			: undefined
+	);
+
+	// Borrowed asset is delivered to the user's own oisy address on the pool's chain.
+	let receiverAddress = $derived(market.chain === 'BTC' ? $btcAddressMainnet : $ethAddress);
+
+	const reset = () => {
+		amount = undefined;
+		confirmChecked = false;
+		borrowProgressStep = ProgressStepsLiquidiumBorrow.INITIALIZATION;
+		currentStep = undefined;
+	};
+
+	const close = () => closeModal(reset);
+
+	const borrow = async () => {
+		const identity = $authIdentity;
+
+		if (
+			isNullish(identity) ||
+			isNullish($ethAddress) ||
+			isNullish(receiverAddress) ||
+			isNullish(parsedAmount)
+		) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed } });
+			return;
+		}
+
+		const amountBaseUnits = parsedAmount;
+		const receiver = receiverAddress;
+
+		modal?.next();
+
+		try {
+			await executeLiquidiumBorrow({
+				identity,
+				ethAddress: $ethAddress,
+				poolId: market.poolId,
+				asset: market.asset,
+				amount: amountBaseUnits,
+				receiverAddress: receiver,
+				displayAmount: `${amount}`,
+				progress: (step) => (borrowProgressStep = step)
+			});
+
+			borrowProgressStep = ProgressStepsLiquidiumBorrow.DONE;
+
+			setTimeout(close, 750);
+		} catch (err: unknown) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed }, err });
+
+			modal?.back();
+		}
+	};
+</script>
+
+<WizardModal
+	bind:this={modal}
+	disablePointerEvents={currentStep?.name === WizardStepsLiquidiumBorrow.BORROWING}
+	onClose={close}
+	{steps}
+	bind:currentStep
+>
+	{#snippet title()}{currentStep?.title ?? ''}{/snippet}
+
+	{#if nonNullish($liquidiumPortfolio) && nonNullish(preview)}
+		{#if currentStep?.name === WizardStepsLiquidiumBorrow.REVIEW}
+			<LiquidiumBorrowReview
+				{amount}
+				{borrowPrice}
+				{market}
+				onBack={() => modal?.back()}
+				onConfirm={borrow}
+				{preview}
+			/>
+		{:else if currentStep?.name === WizardStepsLiquidiumBorrow.BORROWING}
+			<LiquidiumBorrowProgress {borrowProgressStep} />
+		{:else}
+			<LiquidiumBorrowForm
+				{borrowPrice}
+				{borrowToken}
+				{market}
+				onClose={close}
+				onNext={() => modal?.next()}
+				portfolio={$liquidiumPortfolio}
+				{preview}
+				bind:amount
+				bind:confirmChecked
+			/>
+		{/if}
+	{/if}
+</WizardModal>

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowProgress.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowProgress.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
+	import { ProgressStepsLiquidiumBorrow } from '$lib/enums/progress-steps';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { ProgressSteps } from '$lib/types/progress-steps';
+
+	interface Props {
+		borrowProgressStep: string;
+	}
+
+	let { borrowProgressStep }: Props = $props();
+
+	let steps = $state<ProgressSteps>([
+		{
+			step: ProgressStepsLiquidiumBorrow.INITIALIZATION,
+			text: $i18n.send.text.initializing,
+			state: 'in_progress'
+		},
+		{
+			step: ProgressStepsLiquidiumBorrow.SUBMIT,
+			text: $i18n.liquidium.text.starting_to_borrow,
+			state: 'next'
+		},
+		{
+			step: ProgressStepsLiquidiumBorrow.REGISTER,
+			text: $i18n.liquidium.text.borrow_started,
+			state: 'next'
+		}
+	]);
+</script>
+
+<InProgressWizard progressStep={borrowProgressStep} {steps} />

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowReview.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowReview.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import type { LiquidiumBorrowPreview } from '$lib/services/liquidium-borrow.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { LendBorrowProvider } from '$lib/types/lend-borrow';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import { formatStakeApyNumber } from '$lib/utils/format.utils';
+	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		market: LiquidiumMarket;
+		borrowPrice: number;
+		preview: LiquidiumBorrowPreview;
+		amount: OptionAmount;
+		onBack: () => void;
+		onConfirm: () => void;
+	}
+
+	let { market, borrowPrice, preview, amount, onBack, onConfirm }: Props = $props();
+
+	const liquidium = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM];
+
+	let borrowToken = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
+	let healthLevel = $derived(preview.healthLevel);
+</script>
+
+<ContentWithToolbar>
+	{#if nonNullish(borrowToken)}
+		<SendTokenReview exchangeRate={borrowPrice} sendAmount={amount} token={borrowToken}>
+			{#snippet subtitle()}{$i18n.liquidium.text.borrow_review_subtitle}{/snippet}
+		</SendTokenReview>
+	{/if}
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.borrow_apy}{/snippet}
+		{#snippet mainValue()}
+			<span class="text-warning-primary">{formatStakeApyNumber(market.borrowApy)}%</span>
+		{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.resulting_ltv}{/snippet}
+		{#snippet mainValue()}{preview.resultingLtvPercent.toFixed(1)}%{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.projected_health_factor}{/snippet}
+		{#snippet mainValue()}
+			<span
+				class:text-error-primary={healthLevel === 'critical'}
+				class:text-success-primary={healthLevel === 'healthy'}
+				class:text-warning-primary={healthLevel === 'at-risk'}
+			>
+				{Math.round(preview.projectedHealthPercent)}%
+			</span>
+		{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.funds_delivered_to}{/snippet}
+		{#snippet mainValue()}{replaceOisyPlaceholders(
+				$i18n.liquidium.text.your_oisy_address
+			)}{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.provider}{/snippet}
+		{#snippet mainValue()}{liquidium.name}{/snippet}
+	</ModalValue>
+
+	{#if healthLevel === 'critical'}
+		<MessageBox level="error" styleClass="mt-4">
+			{$i18n.liquidium.text.borrow_high_risk_warning}
+		</MessageBox>
+	{:else if healthLevel === 'at-risk'}
+		<MessageBox level="warning" styleClass="mt-4">
+			{$i18n.liquidium.text.borrow_at_risk_warning}
+		</MessageBox>
+	{/if}
+
+	{#snippet toolbar()}
+		<ButtonGroup>
+			<ButtonBack onclick={onBack} />
+
+			<Button onclick={onConfirm}>
+				{$i18n.liquidium.text.action_borrow}
+			</Button>
+		</ButtonGroup>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/config/lend-borrow.config.ts
+++ b/src/frontend/src/lib/config/lend-borrow.config.ts
@@ -1,4 +1,4 @@
-import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import { WizardStepsLiquidiumBorrow, WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
 import { LendBorrowProvider, type LendBorrowProviderConfig } from '$lib/types/lend-borrow';
 import type { WizardStepsParams } from '$lib/types/steps';
 import type { WizardSteps } from '@dfinity/gix-components';
@@ -28,5 +28,22 @@ export const liquidiumSupplyWizardSteps = ({
 	{
 		name: WizardStepsLiquidiumSupply.SUPPLYING,
 		title: i18n.liquidium.text.supplying
+	}
+];
+
+export const liquidiumBorrowWizardSteps = ({
+	i18n
+}: WizardStepsParams): WizardSteps<WizardStepsLiquidiumBorrow> => [
+	{
+		name: WizardStepsLiquidiumBorrow.BORROW,
+		title: i18n.liquidium.text.action_borrow
+	},
+	{
+		name: WizardStepsLiquidiumBorrow.REVIEW,
+		title: i18n.liquidium.text.borrow_review
+	},
+	{
+		name: WizardStepsLiquidiumBorrow.BORROWING,
+		title: i18n.liquidium.text.borrowing
 	}
 ];

--- a/src/frontend/src/lib/constants/liquidium.constants.ts
+++ b/src/frontend/src/lib/constants/liquidium.constants.ts
@@ -38,5 +38,9 @@ export const LIQUIDIUM_HEALTH_CRITICAL_PERCENT = 15;
 
 export type LiquidiumHealthLevel = 'healthy' | 'at-risk' | 'critical';
 
+// Relative tolerance on the borrowing-power cap so a "Max" amount (rounded to the
+// token's decimals) doesn't trip its own limit.
+export const LIQUIDIUM_BORROWING_POWER_TOLERANCE = 1e-6;
+
 // Refresh cadence for markets + positions while the provider page is visible.
 export const LIQUIDIUM_POLL_INTERVAL_MILLIS = 30_000;

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -71,6 +71,10 @@ export const modalLiquidiumSupply: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'liquidium-supply'
 );
+export const modalLiquidiumBorrow: Readable<boolean> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'liquidium-borrow'
+);
 export const modalTradingDeposit: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'trading-deposit'

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -126,6 +126,13 @@ export enum ProgressStepsLiquidiumSupply {
 	DONE = 'done'
 }
 
+export enum ProgressStepsLiquidiumBorrow {
+	INITIALIZATION = 'initialization',
+	SUBMIT = 'submit',
+	REGISTER = 'register',
+	DONE = 'done'
+}
+
 export enum ProgressStepsClaimStakingReward {
 	INITIALIZATION = 'initialization',
 	CLAIM = 'claim',

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -93,6 +93,12 @@ export enum WizardStepsLiquidiumSupply {
 	SUPPLYING = 'Supplying'
 }
 
+export enum WizardStepsLiquidiumBorrow {
+	BORROW = 'Borrow',
+	REVIEW = 'Review',
+	BORROWING = 'Borrowing'
+}
+
 export enum WizardStepsClaimStakingReward {
 	REVIEW = 'Review',
 	CLAIMING = 'Claiming'

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "This borrow noticeably lowers your health factor.",
 			"borrow_exceeds_power": "Amount exceeds your borrowing power.",
 			"borrow_below_minimum": "Amount is below the minimum borrow.",
+			"borrow_prices_unavailable": "Prices are temporarily unavailable. Borrowing is disabled until they load.",
 			"borrow_high_risk_warning": "This borrow puts your position close to liquidation.",
 			"borrow_risk_confirm": "I understand this borrow increases my liquidation risk.",
 			"starting_to_borrow": "Submitting your loan...",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2168,6 +2168,7 @@
 			"borrow_at_risk_warning": "",
 			"borrow_exceeds_power": "",
 			"borrow_below_minimum": "",
+			"borrow_prices_unavailable": "",
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",

--- a/src/frontend/src/lib/services/liquidium-borrow.services.ts
+++ b/src/frontend/src/lib/services/liquidium-borrow.services.ts
@@ -1,0 +1,147 @@
+import type { EthAddress } from '$eth/types/address';
+import { liquidiumClient } from '$lib/api/liquidium.api';
+import { TRACK_COUNT_LIQUIDIUM_SUBMITTED } from '$lib/constants/analytics.constants';
+import {
+	LIQUIDIUM_BORROWING_POWER_TOLERANCE,
+	type LiquidiumHealthLevel
+} from '$lib/constants/liquidium.constants';
+import { ProgressStepsLiquidiumBorrow } from '$lib/enums/progress-steps';
+import { createActiveUserTransaction } from '$lib/services/active-user-transactions.services';
+import { trackEvent } from '$lib/services/analytics.services';
+import { liquidiumWalletAdapter } from '$lib/services/liquidium-wallet-adapter.services';
+import { getOrCreateLiquidiumProfile } from '$lib/services/liquidium.services';
+import type { LiquidiumPortfolio } from '$lib/types/liquidium';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { consoleError } from '$lib/utils/console.utils';
+import {
+	liquidiumTrackingMetadata,
+	toLiquidiumExternalRefs
+} from '$lib/utils/liquidium-active-tx.utils';
+import {
+	liquidiumAssetTokenId,
+	liquidiumHealthLevel,
+	liquidiumProjectedHealthPercent,
+	liquidiumResultingLtvPercent
+} from '$lib/utils/liquidium.utils';
+import { nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { Chain } from '@liquidium/client';
+
+export interface LiquidiumBorrowPreview {
+	resultingLtvPercent: number;
+	projectedHealthPercent: number;
+	healthLevel: LiquidiumHealthLevel;
+	valid: boolean;
+}
+
+// Aggregate preview: borrowing is backed by the whole portfolio, so the cap and
+// projected health come from the summary, not a single pool. Min-borrow lives in the form.
+export const computeLiquidiumBorrowPreview = ({
+	portfolio,
+	newBorrowUsd
+}: {
+	portfolio: LiquidiumPortfolio;
+	newBorrowUsd: number;
+}): LiquidiumBorrowPreview => {
+	const projectedHealthPercent = liquidiumProjectedHealthPercent({
+		currentHealthPercent: portfolio.healthFactorPercent,
+		newBorrowUsd,
+		totalCollateralUsd: portfolio.totalSuppliedUsd,
+		weightedLiquidationThresholdBps: portfolio.weightedLiquidationThresholdBps
+	});
+	const healthLevel = liquidiumHealthLevel(projectedHealthPercent);
+	const exceedsBorrowingPower =
+		newBorrowUsd > portfolio.availableBorrowsUsd * (1 + LIQUIDIUM_BORROWING_POWER_TOLERANCE);
+
+	return {
+		resultingLtvPercent: liquidiumResultingLtvPercent({
+			totalDebtUsd: portfolio.totalBorrowedUsd,
+			newBorrowUsd,
+			totalCollateralUsd: portfolio.totalSuppliedUsd
+		}),
+		projectedHealthPercent,
+		healthLevel,
+		valid: !exceedsBorrowingPower
+	};
+};
+
+// Borrow is a `signMessage` outflow (no oisy broadcast): resolve profile → `lending.borrow`
+// → record an AUT so the modal closes before settlement. Funds land at `receiverAddress`.
+export const executeLiquidiumBorrow = async ({
+	identity,
+	ethAddress,
+	poolId,
+	asset,
+	amount,
+	receiverAddress,
+	displayAmount,
+	progressStep,
+	progress
+}: {
+	identity: Identity;
+	ethAddress: EthAddress;
+	poolId: string;
+	asset: string;
+	amount: bigint;
+	receiverAddress: string;
+	displayAmount: string;
+	progressStep?: string;
+	progress?: (step: ProgressStepsLiquidiumBorrow) => void;
+}): Promise<void> => {
+	progress?.(ProgressStepsLiquidiumBorrow.INITIALIZATION);
+
+	const profileId = await getOrCreateLiquidiumProfile({ identity, ethAddress });
+
+	progress?.(ProgressStepsLiquidiumBorrow.SUBMIT);
+
+	// `txid` may be unset until the protocol assigns it, so the AUT correlates by receipt `id`.
+	const receipt = await liquidiumClient({ identity }).lending.borrow({
+		profileId,
+		poolId,
+		amount,
+		receiverAddress,
+		signerWalletAddress: ethAddress,
+		signerChain: Chain.ETH,
+		signerWalletAdapter: liquidiumWalletAdapter({ identity })
+	});
+
+	trackEvent({
+		name: TRACK_COUNT_LIQUIDIUM_SUBMITTED,
+		metadata: liquidiumTrackingMetadata({
+			action: 'borrow',
+			token: asset,
+			tokenAmount: displayAmount
+		})
+	});
+
+	progress?.(ProgressStepsLiquidiumBorrow.REGISTER);
+
+	// Best-effort: the borrow is already committed, so a bookkeeping failure must not
+	// fail it (positions self-heal; mirrors Supply).
+	try {
+		await createActiveUserTransaction({
+			identity,
+			id: crypto.randomUUID(),
+			data: {
+				Liquidium: {
+					token: liquidiumAssetTokenId(asset),
+					action: { Borrow: null },
+					pool_id: poolId,
+					amount
+				}
+			},
+			...(nonNullish(progressStep) ? { progressStep } : {}),
+			externalRefs: toLiquidiumExternalRefs({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.OUTFLOW_ID]: receipt.id,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.AMOUNT]: displayAmount,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL]: asset,
+				...(nonNullish(receipt.txid) ? { [LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: receipt.txid } : {})
+			})
+		});
+	} catch (err: unknown) {
+		consoleError(err);
+	}
+
+	progress?.(ProgressStepsLiquidiumBorrow.DONE);
+};

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -71,6 +71,7 @@ export interface Modal<T> {
 		| 'harvest-stake'
 		| 'harvest-unstake'
 		| 'liquidium-supply'
+		| 'liquidium-borrow'
 		| 'trading-deposit'
 		| 'universal-scanner'
 		| 'pay-dialog'
@@ -144,6 +145,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openHarvestStake: (id: symbol) => void;
 	openHarvestUnstake: (id: symbol) => void;
 	openLiquidiumSupply: (id: symbol) => void;
+	openLiquidiumBorrow: (id: symbol) => void;
 	openTradingDeposit: (id: symbol) => void;
 	openUniversalScanner: (params: SetWithOptionalDataParams<UniversalScannerData>) => void;
 	openPayDialog: (id: symbol) => void;
@@ -255,6 +257,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openHarvestStake: setType('harvest-stake'),
 		openHarvestUnstake: setType('harvest-unstake'),
 		openLiquidiumSupply: setType('liquidium-supply'),
+		openLiquidiumBorrow: setType('liquidium-borrow'),
 		openTradingDeposit: setType('trading-deposit'),
 		openUniversalScanner: <(params: SetWithOptionalDataParams<UniversalScannerData>) => void>(
 			setTypeWithData('universal-scanner')

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1699,6 +1699,7 @@ interface I18nLiquidium {
 		borrow_at_risk_warning: string;
 		borrow_exceeds_power: string;
 		borrow_below_minimum: string;
+		borrow_prices_unavailable: string;
 		borrow_high_risk_warning: string;
 		borrow_risk_confirm: string;
 		starting_to_borrow: string;

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumHealthFactor.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumHealthFactor.spec.ts
@@ -1,0 +1,40 @@
+import LiquidiumHealthFactor from '$lib/components/liquidium/LiquidiumHealthFactor.svelte';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumHealthFactor', () => {
+	it('renders the rounded percentage and the default label', () => {
+		const { container } = render(LiquidiumHealthFactor, { props: { percent: 67.4 } });
+
+		expect(container).toHaveTextContent('67%');
+		expect(container).toHaveTextContent(en.liquidium.text.projected_health_factor);
+	});
+
+	it('uses the success colour for a healthy value', () => {
+		const { container } = render(LiquidiumHealthFactor, { props: { percent: 80 } });
+
+		expect(container.querySelector('.text-success-primary')).not.toBeNull();
+	});
+
+	it('uses the warning colour for an at-risk value', () => {
+		const { container } = render(LiquidiumHealthFactor, { props: { percent: 30 } });
+
+		expect(container.querySelector('.text-warning-primary')).not.toBeNull();
+	});
+
+	it('uses the error colour for a critical value', () => {
+		const { container } = render(LiquidiumHealthFactor, { props: { percent: 5 } });
+
+		expect(container.querySelector('.text-error-primary')).not.toBeNull();
+	});
+
+	it('renders a custom label and can hide the bar', () => {
+		const { container } = render(LiquidiumHealthFactor, {
+			props: { percent: 50, label: 'Custom label', showBar: false }
+		});
+
+		expect(container).toHaveTextContent('Custom label');
+		// The gradient bar carries an inline linear-gradient background.
+		expect(container.querySelector('[style*="linear-gradient"]')).toBeNull();
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumMarketCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumMarketCard.spec.ts
@@ -1,5 +1,7 @@
 import LiquidiumMarketCard from '$lib/components/liquidium/LiquidiumMarketCard.svelte';
-import type { LiquidiumMarket } from '$lib/types/liquidium';
+import { ZERO } from '$lib/constants/app.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 
@@ -13,6 +15,54 @@ describe('LiquidiumMarketCard', () => {
 		frozen: false,
 		available: true,
 		...overrides
+	});
+
+	const suppliedReserve = (poolId: string): LiquidiumReserve => ({
+		poolId,
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		deposited: 100_000_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 1000,
+		borrowedUsd: 0
+	});
+
+	const borrowedReserve = (poolId: string): LiquidiumReserve => ({
+		poolId,
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		deposited: ZERO,
+		depositedDecimals: 8,
+		borrowed: 1_000_000n,
+		borrowedDecimals: 8,
+		suppliedUsd: 0,
+		borrowedUsd: 1000
+	});
+
+	const setPortfolio = (overrides: Partial<LiquidiumPortfolio> = {}) =>
+		liquidiumStore.set({
+			markets: [],
+			assetPrices: {},
+			portfolio: {
+				reserves: [],
+				totalSuppliedUsd: 1000,
+				totalBorrowedUsd: 0,
+				netValueUsd: 1000,
+				availableBorrowsUsd: 700,
+				weightedLiquidationThresholdBps: 8000,
+				healthFactorPercent: 100,
+				...overrides
+			}
+		});
+
+	afterEach(() => {
+		liquidiumStore.reset();
 	});
 
 	it('renders the asset and supply/borrow labels', () => {
@@ -35,5 +85,61 @@ describe('LiquidiumMarketCard', () => {
 		});
 
 		expect(container).toHaveTextContent(en.liquidium.text.coming_soon);
+	});
+
+	describe('Borrow button gating', () => {
+		it('is disabled when the user has no borrowing power', () => {
+			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeDisabled();
+		});
+
+		it('is disabled for a token the user has already supplied', () => {
+			setPortfolio({ reserves: [suppliedReserve('pool-btc')] });
+
+			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeDisabled();
+		});
+
+		it('is enabled with borrowing power on a token the user has not supplied', () => {
+			setPortfolio({ reserves: [suppliedReserve('pool-eth')] });
+
+			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeEnabled();
+		});
+
+		it('is disabled when there is borrowing power but the token is supplied', () => {
+			setPortfolio({ availableBorrowsUsd: 700, reserves: [suppliedReserve('pool-btc')] });
+
+			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeDisabled();
+		});
+	});
+
+	describe('Supply button gating', () => {
+		it('is enabled by default', () => {
+			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_supply })).toBeEnabled();
+		});
+
+		it('is disabled for a token the user has borrowed', () => {
+			setPortfolio({ totalBorrowedUsd: 1000, reserves: [borrowedReserve('pool-btc')] });
+
+			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_supply })).toBeDisabled();
+		});
+
+		it('stays enabled when only a different token is borrowed', () => {
+			setPortfolio({ totalBorrowedUsd: 1000, reserves: [borrowedReserve('pool-eth')] });
+
+			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_supply })).toBeEnabled();
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowForm.spec.ts
@@ -88,4 +88,13 @@ describe('LiquidiumBorrowForm', () => {
 
 		expect(reviewButton(getByRole)).toBeEnabled();
 	});
+
+	it('blocks borrowing and warns when the price is unavailable', () => {
+		const { container, getByRole } = render(LiquidiumBorrowForm, {
+			props: { ...baseProps, amount: 1, borrowPrice: 0 }
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_prices_unavailable);
+		expect(reviewButton(getByRole)).toBeDisabled();
+	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowForm.spec.ts
@@ -1,0 +1,91 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumBorrowForm from '$lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte';
+import type { LiquidiumBorrowPreview } from '$lib/services/liquidium-borrow.services';
+import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('LiquidiumBorrowForm', () => {
+	const market: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
+	const portfolio = (overrides: Partial<LiquidiumPortfolio> = {}): LiquidiumPortfolio => ({
+		reserves: [],
+		totalSuppliedUsd: 200_000,
+		totalBorrowedUsd: 0,
+		netValueUsd: 200_000,
+		availableBorrowsUsd: 100_000,
+		weightedLiquidationThresholdBps: 8000,
+		healthFactorPercent: 100,
+		...overrides
+	});
+
+	const preview = (overrides: Partial<LiquidiumBorrowPreview> = {}): LiquidiumBorrowPreview => ({
+		resultingLtvPercent: 40,
+		projectedHealthPercent: 70,
+		healthLevel: 'healthy',
+		valid: true,
+		...overrides
+	});
+
+	const baseProps = {
+		market,
+		borrowToken: BTC_MAINNET_TOKEN,
+		borrowPrice: 60_000,
+		portfolio: portfolio(),
+		preview: preview(),
+		amount: undefined,
+		confirmChecked: false,
+		onClose: () => {},
+		onNext: () => {}
+	};
+
+	const reviewButton = (getByRole: ReturnType<typeof render>['getByRole']) =>
+		getByRole('button', { name: en.send.text.review });
+
+	it('renders the collateral context, borrow APY, minimum borrow and risk line', () => {
+		const { container } = render(LiquidiumBorrowForm, { props: baseProps });
+
+		expect(container).toHaveTextContent(en.liquidium.text.collateral);
+		expect(container).toHaveTextContent(en.liquidium.text.borrowing_power);
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_apy);
+		expect(container).toHaveTextContent(en.liquidium.text.resulting_ltv);
+		expect(container).toHaveTextContent(en.liquidium.text.minimum_borrow);
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_risk_info);
+	});
+
+	it('disables Review with no amount entered', () => {
+		const { getByRole } = render(LiquidiumBorrowForm, { props: baseProps });
+
+		expect(reviewButton(getByRole)).toBeDisabled();
+	});
+
+	it('enables Review for a valid amount with a healthy projection', () => {
+		const { getByRole } = render(LiquidiumBorrowForm, {
+			props: { ...baseProps, amount: 1 }
+		});
+
+		expect(reviewButton(getByRole)).toBeEnabled();
+	});
+
+	it('requires confirmation for a non-healthy projection before Review', async () => {
+		const { container, getByRole } = render(LiquidiumBorrowForm, {
+			props: { ...baseProps, amount: 1, preview: preview({ healthLevel: 'at-risk' }) }
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_at_risk_warning);
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_risk_confirm);
+		expect(reviewButton(getByRole)).toBeDisabled();
+
+		await fireEvent.click(getByRole('checkbox'));
+
+		expect(reviewButton(getByRole)).toBeEnabled();
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowProgress.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowProgress.spec.ts
@@ -1,0 +1,16 @@
+import LiquidiumBorrowProgress from '$lib/components/liquidium/borrow/LiquidiumBorrowProgress.svelte';
+import { ProgressStepsLiquidiumBorrow } from '$lib/enums/progress-steps';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumBorrowProgress', () => {
+	it('renders the borrow progress steps', () => {
+		const { container } = render(LiquidiumBorrowProgress, {
+			props: { borrowProgressStep: ProgressStepsLiquidiumBorrow.INITIALIZATION }
+		});
+
+		expect(container).toHaveTextContent(en.send.text.initializing);
+		expect(container).toHaveTextContent(en.liquidium.text.starting_to_borrow);
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_started);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowReview.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowReview.spec.ts
@@ -1,0 +1,76 @@
+import LiquidiumBorrowReview from '$lib/components/liquidium/borrow/LiquidiumBorrowReview.svelte';
+import type { LiquidiumBorrowPreview } from '$lib/services/liquidium-borrow.services';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumBorrowReview', () => {
+	const market: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
+	const preview = (overrides: Partial<LiquidiumBorrowPreview> = {}): LiquidiumBorrowPreview => ({
+		resultingLtvPercent: 40,
+		projectedHealthPercent: 70,
+		healthLevel: 'healthy',
+		valid: true,
+		...overrides
+	});
+
+	const baseProps = {
+		market,
+		borrowPrice: 60_000,
+		amount: 0.01,
+		onBack: () => {},
+		onConfirm: () => {}
+	};
+
+	it('renders the provider, borrow APY, resulting LTV and projected health', () => {
+		const { container } = render(LiquidiumBorrowReview, {
+			props: { ...baseProps, preview: preview() }
+		});
+
+		expect(container).toHaveTextContent('Liquidium');
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_apy);
+		expect(container).toHaveTextContent(en.liquidium.text.resulting_ltv);
+		expect(container).toHaveTextContent(en.liquidium.text.projected_health_factor);
+		expect(container).toHaveTextContent(en.liquidium.text.funds_delivered_to);
+	});
+
+	it('shows no risk warning for a healthy projection', () => {
+		const { container } = render(LiquidiumBorrowReview, {
+			props: { ...baseProps, preview: preview() }
+		});
+
+		expect(container).not.toHaveTextContent(en.liquidium.text.borrow_at_risk_warning);
+		expect(container).not.toHaveTextContent(en.liquidium.text.borrow_high_risk_warning);
+	});
+
+	it('shows the at-risk warning for an at-risk projection', () => {
+		const { container } = render(LiquidiumBorrowReview, {
+			props: {
+				...baseProps,
+				preview: preview({ healthLevel: 'at-risk', projectedHealthPercent: 30 })
+			}
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_at_risk_warning);
+	});
+
+	it('shows the high-risk warning for a critical projection', () => {
+		const { container } = render(LiquidiumBorrowReview, {
+			props: {
+				...baseProps,
+				preview: preview({ healthLevel: 'critical', projectedHealthPercent: 5 })
+			}
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_high_risk_warning);
+	});
+});

--- a/src/frontend/src/tests/lib/services/liquidium-borrow.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-borrow.services.spec.ts
@@ -1,0 +1,182 @@
+import type { EthAddress } from '$eth/types/address';
+import * as liquidiumApi from '$lib/api/liquidium.api';
+import { TRACK_COUNT_LIQUIDIUM_SUBMITTED } from '$lib/constants/analytics.constants';
+import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
+import * as analyticsServices from '$lib/services/analytics.services';
+import {
+	computeLiquidiumBorrowPreview,
+	executeLiquidiumBorrow
+} from '$lib/services/liquidium-borrow.services';
+import * as liquidiumServices from '$lib/services/liquidium.services';
+import type { LiquidiumPortfolio } from '$lib/types/liquidium';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+
+vi.mock('$lib/api/liquidium.api', () => ({ liquidiumClient: vi.fn() }));
+vi.mock('$lib/services/liquidium.services', () => ({ getOrCreateLiquidiumProfile: vi.fn() }));
+vi.mock('$lib/services/liquidium-wallet-adapter.services', () => ({
+	liquidiumWalletAdapter: vi.fn(() => ({ signMessage: vi.fn() }))
+}));
+vi.mock('$lib/services/active-user-transactions.services', () => ({
+	createActiveUserTransaction: vi.fn()
+}));
+vi.mock('$lib/services/analytics.services', () => ({ trackEvent: vi.fn() }));
+
+describe('liquidium-borrow.services', () => {
+	const ethAddress = '0x1111111111111111111111111111111111111111' as EthAddress;
+	const profileId = 'profile-1';
+	const poolId = 'pool-btc';
+	const receiverAddress = 'bc1qexample';
+
+	const borrow = vi.fn();
+	const createActiveUserTransaction = vi.mocked(
+		activeUserTransactionsServices.createActiveUserTransaction
+	);
+
+	const run = () =>
+		executeLiquidiumBorrow({
+			identity: mockIdentity,
+			ethAddress,
+			poolId,
+			asset: 'BTC',
+			amount: 100_000_000n,
+			receiverAddress,
+			displayAmount: '1',
+			progressStep: 'borrowing'
+		});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(liquidiumServices.getOrCreateLiquidiumProfile).mockResolvedValue(profileId);
+		vi.mocked(liquidiumApi.liquidiumClient).mockReturnValue({
+			lending: { borrow }
+		} as unknown as ReturnType<typeof liquidiumApi.liquidiumClient>);
+	});
+
+	it('signs/submits the borrow and registers the transaction, correlating by outflow id', async () => {
+		borrow.mockResolvedValue({ id: 'outflow-1', outflowType: 'borrow', amount: 100_000_000n });
+
+		await run();
+
+		expect(borrow).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({
+				profileId,
+				poolId,
+				amount: 100_000_000n,
+				receiverAddress,
+				signerWalletAddress: ethAddress,
+				signerChain: 'ETH'
+			})
+		);
+
+		expect(analyticsServices.trackEvent).toHaveBeenCalledWith({
+			name: TRACK_COUNT_LIQUIDIUM_SUBMITTED,
+			metadata: { dApp: 'liquidium', action: 'borrow', token: 'BTC', tokenAmount: '1' }
+		});
+
+		expect(createActiveUserTransaction).toHaveBeenCalledOnce();
+
+		const [[{ data, externalRefs }]] = createActiveUserTransaction.mock.calls;
+
+		expect(data).toEqual(
+			expect.objectContaining({
+				Liquidium: expect.objectContaining({
+					pool_id: poolId,
+					amount: 100_000_000n,
+					action: { Borrow: null }
+				})
+			})
+		);
+		expect(externalRefs).toEqual(
+			expect.arrayContaining([
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID, value: profileId },
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.OUTFLOW_ID, value: 'outflow-1' },
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL, value: 'BTC' }
+			])
+		);
+		// No txid yet — must not be persisted as an empty ref.
+		expect(externalRefs).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID })])
+		);
+	});
+
+	it('persists the txid when the receipt already carries one', async () => {
+		borrow.mockResolvedValue({
+			id: 'outflow-1',
+			outflowType: 'borrow',
+			amount: 100_000_000n,
+			txid: '0xhash'
+		});
+
+		await run();
+
+		const [[{ externalRefs }]] = createActiveUserTransaction.mock.calls;
+
+		expect(externalRefs).toEqual(
+			expect.arrayContaining([{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID, value: '0xhash' }])
+		);
+	});
+
+	it('resolves even if AUT bookkeeping fails (borrow already committed)', async () => {
+		borrow.mockResolvedValue({ id: 'outflow-1', outflowType: 'borrow', amount: 100_000_000n });
+		createActiveUserTransaction.mockRejectedValueOnce(new Error('backend unavailable'));
+
+		await expect(run()).resolves.toBeUndefined();
+
+		expect(borrow).toHaveBeenCalledOnce();
+	});
+});
+
+describe('computeLiquidiumBorrowPreview', () => {
+	// $100k collateral, no debt, 80% liquidation threshold, $80k borrowing power left.
+	const portfolio = (overrides: Partial<LiquidiumPortfolio> = {}): LiquidiumPortfolio => ({
+		reserves: [],
+		totalSuppliedUsd: 100_000,
+		totalBorrowedUsd: 0,
+		netValueUsd: 100_000,
+		availableBorrowsUsd: 80_000,
+		weightedLiquidationThresholdBps: 8000,
+		healthFactorPercent: 100,
+		...overrides
+	});
+
+	it('reflects the current LTV / health for a zero borrow', () => {
+		const preview = computeLiquidiumBorrowPreview({ portfolio: portfolio(), newBorrowUsd: 0 });
+
+		expect(preview.resultingLtvPercent).toBe(0);
+		expect(preview.projectedHealthPercent).toBe(100);
+		expect(preview.healthLevel).toBe('healthy');
+		expect(preview.valid).toBeTruthy();
+	});
+
+	it('includes existing debt in the resulting LTV', () => {
+		const preview = computeLiquidiumBorrowPreview({
+			portfolio: portfolio({ totalBorrowedUsd: 10_000, availableBorrowsUsd: 70_000 }),
+			newBorrowUsd: 30_000
+		});
+
+		// (10k existing + 30k new) / 100k collateral.
+		expect(preview.resultingLtvPercent).toBeCloseTo(40, 5);
+	});
+
+	it('derives the health level from the projected health', () => {
+		// marginal = 76k / (100k × 0.8) = 95% → projected 5% → critical.
+		const preview = computeLiquidiumBorrowPreview({ portfolio: portfolio(), newBorrowUsd: 76_000 });
+
+		expect(preview.projectedHealthPercent).toBeCloseTo(5, 5);
+		expect(preview.healthLevel).toBe('critical');
+		expect(preview.valid).toBeTruthy();
+	});
+
+	it('is invalid when the borrow exceeds the borrowing power', () => {
+		const preview = computeLiquidiumBorrowPreview({ portfolio: portfolio(), newBorrowUsd: 90_000 });
+
+		expect(preview.valid).toBeFalsy();
+	});
+
+	it('stays valid for a borrow exactly at the cap (rounding tolerance)', () => {
+		const preview = computeLiquidiumBorrowPreview({ portfolio: portfolio(), newBorrowUsd: 80_000 });
+
+		expect(preview.valid).toBeTruthy();
+	});
+});


### PR DESCRIPTION
# Motivation

Completes the Liquidium borrow milestone by adding the borrow **action** on top of the data layer and provider-page display that already landed. After this, a user with collateral can open a borrow position from the provider page. Still flag-gated (LEND_BORROW_ENABLED / LIQUIDIUM_ENABLED = STAGING) and scoped to the borrow action only — Repay, Withdraw, the Borrow page (/borrow/), the Liabilities tab and the nav reshuffle remain deferred.

# Changes

Borrow wizard (components/liquidium/borrow/)
- LiquidiumBorrowModal — one uniform wizard (no per-chain rail split; borrow is a signMessage outflow, not an on-chain broadcast). Receiver = the user's own oisy address on the borrow pool's chain; signer is always ETH (ETH-owned profile).
- LiquidiumBorrowForm — collateral/borrowing-power context, amount + fiat with a Max shortcut, minimum-borrow row, live (debounced) LTV + projected-health preview, in-input below-minimum / exceeds-power errors, and a risk-acknowledge checkbox for non-healthy projections (reset when the amount changes).
- LiquidiumBorrowReview / LiquidiumBorrowProgress — review rows (APY, resulting LTV, projected health, provider, funds-delivered-to) and the progress steps.
- LiquidiumHealthFactor — reusable colour-banded health/LTV bar.

Service
- liquidium-borrow.services.ts — executeLiquidiumBorrow (resolve/create profile -> lending.borrow -> analytics -> best-effort AUT registration; modal closes before settlement, correlated by the outflow receipt id) and the pure computeLiquidiumBorrowPreview (resulting LTV, projected health, health level, borrowing-power validity).

Entry point & wiring
- LiquidiumMarketCard — neutral Borrow button beside Supply, pre-selecting that market's token; disabled (never hidden) unless the user has borrowing power and hasn't supplied that token. Supply is symmetrically disabled for a borrowed token.
- modal store/derived (openLiquidiumBorrow / modalLiquidiumBorrow), borrow wizard + progress step enums, liquidiumBorrowWizardSteps config, and the LIQUIDIUM_BORROWING_POWER_TOLERANCE constant (shared by the form and service).

# Tests

Added.