### PR TITLE
fix(frontend): route native EVM token swaps through Velora market

### DIFF
--- a/src/frontend/src/lib/constants/swap.constants.ts
+++ b/src/frontend/src/lib/constants/swap.constants.ts
@@ -50,6 +50,7 @@ export const NEAR_INTENTS_TOS_LINK =
 	'https://docs.near-intents.org/security-compliance/terms-of-service';
 
 export const SWAP_MODE = 'all';
+export const SWAP_MODE_MARKET = 'market';
 export const SWAP_SIDE = 'SELL';
 
 export const swapProvidersDetails: Partial<Record<SwapProvider, SwapProvidersConfig>> = {

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -7,7 +7,7 @@ import { swap } from '$eth/services/swap.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import { getCompactSignature, getSignParamsEIP712 } from '$eth/utils/eip712.utils';
 import { isTokenErc } from '$eth/utils/erc.utils';
-import { isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
+import { isDefaultEthereumToken, isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { setCustomToken as setCustomIcrcToken } from '$icp-eth/services/icrc-token.services';
 import { approve } from '$icp/api/icrc-ledger.api';
 import { sendIcp, sendIcrc } from '$icp/services/ic-send.services';
@@ -1118,6 +1118,14 @@ export const fetchVeloraDeltaSwap = async ({
 	maxPriorityFeePerGas,
 	swapDetails
 }: SwapVeloraParams): Promise<void> => {
+	// Velora Delta settles by pulling the source token via allowance/permit, which a native coin
+	// (no contract address) can't satisfy without the unimplemented DepositNativeAndPreSign flow.
+	// Native sources are routed to the Market quote upstream (fetchVeloraSwapAmount); fail fast
+	// here so a routing regression surfaces clearly instead of crashing on an undefined address.
+	if (isDefaultEthereumToken(sourceToken)) {
+		throw new Error('Velora Delta swaps do not support native source tokens.');
+	}
+
 	const parsedSwapAmount = parseToken({
 		value: `${swapAmount}`,
 		unitName: sourceToken.decimals

--- a/src/frontend/src/lib/services/velora-swap.services.ts
+++ b/src/frontend/src/lib/services/velora-swap.services.ts
@@ -1,7 +1,7 @@
 import type { Erc20Token } from '$eth/types/erc20';
 import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { OISY_URL_HOSTNAME } from '$lib/constants/oisy.constants';
-import { SWAP_MODE, SWAP_SIDE } from '$lib/constants/swap.constants';
+import { SWAP_MODE, SWAP_MODE_MARKET, SWAP_SIDE } from '$lib/constants/swap.constants';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { PLAUSIBLE_EVENTS, PLAUSIBLE_EVENT_CONTEXTS } from '$lib/enums/plausible';
 import { trackEvent } from '$lib/services/analytics.services';
@@ -53,7 +53,7 @@ export const fetchVeloraSwapAmount = async ({
 	// flow we don't implement — the Delta path would crash trying to approve a native coin.
 	// Force native sources onto the Market route, which signs a standard swap transaction
 	// carrying the native value.
-	const mode = isDefaultEthereumToken(sourceToken) ? 'market' : SWAP_MODE;
+	const mode = isDefaultEthereumToken(sourceToken) ? SWAP_MODE_MARKET : SWAP_MODE;
 
 	const baseParams: GetQuoteParams = {
 		amount: `${amount}`,

--- a/src/frontend/src/lib/services/velora-swap.services.ts
+++ b/src/frontend/src/lib/services/velora-swap.services.ts
@@ -1,4 +1,5 @@
 import type { Erc20Token } from '$eth/types/erc20';
+import { isDefaultEthereumToken } from '$eth/utils/eth.utils';
 import { OISY_URL_HOSTNAME } from '$lib/constants/oisy.constants';
 import { SWAP_MODE, SWAP_SIDE } from '$lib/constants/swap.constants';
 import { exchanges } from '$lib/derived/exchange.derived';
@@ -46,13 +47,21 @@ export const fetchVeloraSwapAmount = async ({
 		fetch: window.fetch
 	});
 
+	// Velora Delta settles by pulling the source token via allowance/permit, which is
+	// impossible for a native coin (no ERC-20 contract). Velora still returns Delta pricing
+	// for native sources, but executing it would require the on-chain DepositNativeAndPreSign
+	// flow we don't implement — the Delta path would crash trying to approve a native coin.
+	// Force native sources onto the Market route, which signs a standard swap transaction
+	// carrying the native value.
+	const mode = isDefaultEthereumToken(sourceToken) ? 'market' : SWAP_MODE;
+
 	const baseParams: GetQuoteParams = {
 		amount: `${amount}`,
 		srcToken: geSwapEthTokenAddress(sourceToken),
 		destToken: geSwapEthTokenAddress(erc20DestinationToken),
 		srcDecimals: sourceToken.decimals,
 		destDecimals: destinationToken.decimals,
-		mode: SWAP_MODE,
+		mode,
 		side: SWAP_SIDE,
 		userAddress,
 		partner: OISY_URL_HOSTNAME

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -229,7 +229,7 @@ export interface FormatSlippageParams {
 
 export type VeloraSwapDetails = DeltaPrice & BridgePrice & OptimalRate;
 
-export interface GetQuoteParams extends QuoteParams<'all'> {
+export interface GetQuoteParams extends QuoteParams<'all' | 'market'> {
 	destChainId?: number;
 }
 

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -978,7 +978,7 @@ describe('swap.services', () => {
 					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
 					swapDetails: mockSwapDetails
 				})
-			).rejects.toThrow();
+			).rejects.toThrow('Velora Delta swaps do not support native source tokens.');
 
 			expect(mockDeltaContractPostDeltaOrder).not.toHaveBeenCalled();
 		});

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -953,6 +953,36 @@ describe('swap.services', () => {
 			expect(createPermit).not.toHaveBeenCalled();
 		});
 
+		it('throws for a native (default Ethereum) source token instead of approving a contract-less coin', async () => {
+			const nativeSourceToken = {
+				...mockSourceToken,
+				standard: { code: 'ethereum' },
+				category: 'default'
+			} as unknown as Erc20Token;
+
+			await expect(
+				fetchVeloraDeltaSwap({
+					identity: mockIdentity,
+					progress: mockProgress,
+					sourceToken: nativeSourceToken,
+					destinationToken: mockDestinationToken,
+					swapAmount: mockSwapAmount,
+					sourceNetwork: mockSourceNetwork,
+					receiveAmount: mockReceiveAmount,
+					slippageValue: mockSlippageValue,
+					destinationNetwork: mockDestinationNetwork,
+					userAddress: mockUserAddress,
+					gas: BigInt(mockGas),
+					isGasless: false,
+					maxFeePerGas: BigInt(mockMaxFeePerGas),
+					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+					swapDetails: mockSwapDetails
+				})
+			).rejects.toThrow();
+
+			expect(mockDeltaContractPostDeltaOrder).not.toHaveBeenCalled();
+		});
+
 		it('should execute delta swap successfully when isGasless is true', async () => {
 			await fetchVeloraDeltaSwap({
 				identity: mockIdentity,

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -153,9 +153,14 @@ vi.mock('$eth/utils/eip712.utils', () => ({
 	getSignParamsEIP712: vi.fn(() => 'mock-hash')
 }));
 
-vi.mock('$eth/utils/eth.utils', () => ({
-	isNotDefaultEthereumToken: vi.fn(() => true)
-}));
+vi.mock('$eth/utils/eth.utils', async (importOriginal) => {
+	const actual = await importOriginal();
+
+	return {
+		...(actual as Record<string, unknown>),
+		isNotDefaultEthereumToken: vi.fn(() => true)
+	};
+});
 
 vi.mock('$lib/api/signer.api', () => ({
 	signPrehash: vi.fn(() => Promise.resolve('mock-signature'))
@@ -1672,6 +1677,44 @@ describe('swap.services', () => {
 					event_type: 'delta',
 					result_status: 'success'
 				})
+			});
+		});
+
+		describe('quote mode by source token type', () => {
+			it('requests an "all"-mode quote for an ERC-20 source token', async () => {
+				mockGetQuote.mockResolvedValue({ market: { destAmount: '456' } });
+
+				await fetchVeloraSwapAmount({
+					sourceToken,
+					destinationToken,
+					amount,
+					userAddress,
+					slippage
+				});
+
+				expect(mockGetQuote).toHaveBeenCalledWith(expect.objectContaining({ mode: 'all' }));
+			});
+
+			it('forces a "market"-mode quote for a native (default Ethereum) source token', async () => {
+				// Velora Delta cannot pull native funds and we do not implement its native deposit
+				// flow, so native sources must use the Market route to avoid the Delta approval crash.
+				const nativeSourceToken = {
+					...sourceToken,
+					standard: { code: 'ethereum' },
+					category: 'default'
+				} as unknown as Erc20Token;
+
+				mockGetQuote.mockResolvedValue({ market: { destAmount: '456' } });
+
+				await fetchVeloraSwapAmount({
+					sourceToken: nativeSourceToken,
+					destinationToken,
+					amount,
+					userAddress,
+					slippage
+				});
+
+				expect(mockGetQuote).toHaveBeenCalledWith(expect.objectContaining({ mode: 'market' }));
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

Swapping a native EVM coin (ETH, BNB, POL) to an ERC-20 token via Velora fails instantly with _"The swap could not be completed. Please check your wallet balance and try again, or choose a different provider."_ — before any request reaches Velora. ERC-20 → token swaps are unaffected.

With `mode: 'all'`, Velora returns Delta pricing whenever it is available, including for native source tokens, so a native → ERC-20 quote is typed as a Delta swap. Velora Delta settles by pulling the source token via ERC-20 allowance/permit, which is impossible for a native coin (no contract) and which we could only support through the on-chain `DepositNativeAndPreSign` flow we don't implement. The Delta execution path (`fetchVeloraDeltaSwap`) unconditionally approves the source token and throws while reading the ERC-20 allowance of a contract-less native coin; the exception is caught and surfaced as the generic failure toast. The Market path already guards this case with `isNotDefaultEthereumToken`, but the Delta path never did.

# Changes

**Primary fix — route native sources to the Market quote**

- `fetchVeloraSwapAmount`: request a `market`-mode Velora quote for native (default Ethereum) source tokens, so they execute via the Market path, which already handles native value correctly (skips the ERC-20 approval and uses the `0xEeee…` native sentinel address). ERC-20 sources keep `mode: 'all'` (Delta preferred).
- `GetQuoteParams`: widen `mode` to `'all' | 'market'` so the native override type-checks.

**Defensive guard — fail fast in the Delta path**

- `fetchVeloraDeltaSwap`: throw early when the source token is a native (default Ethereum) coin. That path approves/permits the source token and signs an order referencing `sourceToken.address` — none of which a native coin can satisfy (no contract address; it would need the unimplemented `DepositNativeAndPreSign` flow). Native sources are already routed away by the primary fix, so this is unreachable in normal use; the guard ensures a future routing regression surfaces as a clear error instead of the original undefined-address crash, and keeps the Delta path consistent with the Market path's existing `isNotDefaultEthereumToken` guard.

# Tests

- Targeted `vitest` run of `swap.services.spec.ts`: 83/83 pass, including:
  - quote mode by source token type — `all` for an ERC-20 source, `market` for a native source.
  - `fetchVeloraDeltaSwap` rejects for a native source and never posts an order.
- Audited the other EVM swap paths for the same native-handling bug class: Near Intents (`sendEvm`) does a plain native value transfer (no approval); OneSec excludes native sources at config; the Velora gasless/permit branch is unreachable for native. No further changes needed.
- Manual verification of native → ERC-20 Velora swaps to be done on `test_fe_3`.

Known limitation: a native source on a cross-chain swap relies on Velora's Delta/bridge route, which the Market path does not cover — those pairs return no Velora quote rather than crash. Native same-chain swaps (the reported bug) now route through Market and execute correctly.

---

Model: Claude Opus 4.8 (`claude-opus-4-8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
