### PR TITLE
fix(frontend): keep the native value leg of swaps in the activity list

### DIFF
--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -97,7 +97,11 @@ const findDuplicateEthNativeTransactions = (
 
 				if (hasNonNative) {
 					for (const tx of group) {
-						if (isTokenEthereumNative(tx.token)) {
+						// Only the zero-value native entry is a duplicate: the gas/fee companion that
+						// block explorers return alongside an ERC-20 transfer. A native entry that moved
+						// value is a real leg — e.g. the native input of a native→token swap — and must
+						// stay next to the token leg instead of being collapsed into it.
+						if (isTokenEthereumNative(tx.token) && tx.transaction.value === ZERO) {
 							duplicates.add(tx);
 						}
 					}

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -471,8 +471,9 @@ describe('transactions.utils', () => {
 			};
 
 			it('should keep the ERC-20 transaction when native and ERC-20 share the same hash on the same network', () => {
+				// A real ERC-20 transfer's native companion moved no value (it is only the gas/fee entry).
 				const nativeTx: EthCertifiedTransaction = {
-					data: { ...mockEthTransaction, hash: duplicateHash },
+					data: { ...mockEthTransaction, hash: duplicateHash, value: ZERO },
 					certified: false
 				};
 				const erc20Tx: EthCertifiedTransaction = {
@@ -491,6 +492,31 @@ describe('transactions.utils', () => {
 
 				expect(result).toHaveLength(1);
 				expect(result[0].token).toBe(PEPE_TOKEN);
+			});
+
+			it('should keep the native leg when it moved value (e.g. a native→ERC-20 swap) sharing the hash', () => {
+				// The native input of a swap shares its hash with the received-token transfer, but it is
+				// a real transfer (non-zero value), so both legs must remain in the activity list.
+				const nativeSwapLeg: EthCertifiedTransaction = {
+					data: { ...mockEthTransaction, hash: duplicateHash },
+					certified: false
+				};
+				const erc20ReceiveLeg: EthCertifiedTransaction = {
+					data: { ...mockEthTransaction, hash: duplicateHash, value: ZERO },
+					certified: false
+				};
+
+				const result = mapAllTransactionsUi({
+					tokens: [ETHEREUM_TOKEN, USDC_TOKEN],
+					$ethTransactions: {
+						[ETHEREUM_TOKEN_ID]: [nativeSwapLeg],
+						[USDC_TOKEN_ID]: [erc20ReceiveLeg]
+					},
+					...rest
+				});
+
+				expect(result).toHaveLength(2);
+				expect(result.map(({ token }) => token)).toEqual([ETHEREUM_TOKEN, USDC_TOKEN]);
 			});
 
 			it('should keep both transactions when they have different hashes', () => {
@@ -570,7 +596,7 @@ describe('transactions.utils', () => {
 			it('should keep all non-native transactions and only remove the native one when multiple ERC-20 transfers share the same hash', () => {
 				const sharedHash = duplicateHash;
 				const nativeTx: EthCertifiedTransaction = {
-					data: { ...mockEthTransaction, hash: sharedHash },
+					data: { ...mockEthTransaction, hash: sharedHash, value: ZERO },
 					certified: false
 				};
 				const pepeTx: EthCertifiedTransaction = {

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -502,7 +502,7 @@ describe('transactions.utils', () => {
 					certified: false
 				};
 				const erc20ReceiveLeg: EthCertifiedTransaction = {
-					data: { ...mockEthTransaction, hash: duplicateHash, value: ZERO },
+					data: { ...mockEthTransaction, hash: duplicateHash },
 					certified: false
 				};
 


### PR DESCRIPTION
# Motivation

A native → ERC-20 swap (e.g. ETH → USDC, BNB → USDC) is a single on-chain transaction with two real legs: the native input that leaves the wallet and the token that arrives. On the per-token pages both legs render correctly, but the global Activity page collapsed each swap into a single row — showing only the received token and hiding the native send.

The cause is the all-transactions dedup, `findDuplicateEthNativeTransactions`. It groups ETH/EVM transactions by `(networkId, hash)` and, whenever a group also contains a non-native (ERC-20) transfer, drops every native entry. That rule exists to remove the gas/fee companion entry block explorers return alongside an ERC-20 transfer — but that companion has `value === 0`. For a swap, the native entry is a genuine value transfer (the swap input, `value > 0`) that shares the hash with the received-token transfer, so it was wrongly discarded. The per-token pages are unaffected because they render from the per-token store, not this cross-token dedup.

# Changes

- `findDuplicateEthNativeTransactions`: only treat a native entry as a duplicate when it moved no value (`value === ZERO`). Native entries that actually transferred value (the input/output leg of a swap) are kept, so both legs of a swap appear in the Activity list. This is direction-agnostic — it also covers ERC-20 → native swaps, whose received-native leg was dropped the same way.

# Tests

- Updated the two existing dedup tests so the native companion carries `value: ZERO` (the realistic gas/fee entry); they still assert it is removed.
- Added a regression test: a native entry that moved value, sharing a hash with an ERC-20 transfer, keeps both legs in the activity list.
- `transactions.utils.spec.ts` passes in full.
- Manual verification on `test_fe_3` against existing swap history.

---

Model: Claude Opus 4.8 (`claude-opus-4-8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
