### PR TITLE
fix(frontend): order same-timestamp send/receive pairs (receive above send)

### DIFF
--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -349,7 +349,11 @@ export const sortTransactions = ({
 			: sameTimestampTypeRank(typeA) - sameTimestampTypeRank(typeB);
 	}
 
-	return nonNullish(timestampA) ? -1 : 1;
+	if (nonNullish(timestampA)) {
+		return -1;
+	}
+
+	return nonNullish(timestampB) ? 1 : 0;
 };
 
 export const isTransactionsStoreInitialized = ({

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -315,18 +315,38 @@ const isMicroTransaction = ({
 	return false;
 };
 
+// Ranks transaction types for the same-timestamp tie-breaker in `sortTransactions`: the received
+// leg of a pair sorts above the sent one; any other type keeps a stable position after them.
+const sameTimestampTypeRank = (type: AnyTransactionUi['type']): number => {
+	if (type === 'receive') {
+		return 0;
+	}
+
+	if (type === 'send') {
+		return 1;
+	}
+
+	return 2;
+};
+
 export const sortTransactions = ({
-	transactionA: { timestamp: timestampA },
-	transactionB: { timestamp: timestampB }
+	transactionA: { timestamp: timestampA, type: typeA },
+	transactionB: { timestamp: timestampB, type: typeB }
 }: {
 	transactionA: AnyTransactionUi;
 	transactionB: AnyTransactionUi;
 }): number => {
 	if (nonNullish(timestampA) && nonNullish(timestampB)) {
-		return (
+		const bySeconds =
 			Number(normalizeTimestampToSeconds(timestampB)) -
-			Number(normalizeTimestampToSeconds(timestampA))
-		);
+			Number(normalizeTimestampToSeconds(timestampA));
+
+		// The two legs of one operation (a swap, or a self-transfer) share the same block timestamp
+		// and tie here. Break the tie deterministically — received leg above the sent one — so these
+		// pairs render consistently instead of in an arbitrary insertion order.
+		return bySeconds !== 0
+			? bySeconds
+			: sameTimestampTypeRank(typeA) - sameTimestampTypeRank(typeB);
 	}
 
 	return nonNullish(timestampA) ? -1 : 1;

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -784,6 +784,19 @@ describe('transactions.utils', () => {
 
 			expect(result).toEqual([transaction2, transaction1, transactionWithNullTimestamp]);
 		});
+
+		it('should place the received leg above the sent leg when timestamps tie', () => {
+			const sent = { timestamp: 5, type: 'send' } as AnyTransactionUi;
+			const received = { timestamp: 5, type: 'receive' } as AnyTransactionUi;
+
+			// Deterministic regardless of input order: the received leg always ends up above the sent one.
+			expect(
+				[sent, received].sort((a, b) => sortTransactions({ transactionA: a, transactionB: b }))
+			).toEqual([received, sent]);
+			expect(
+				[received, sent].sort((a, b) => sortTransactions({ transactionA: a, transactionB: b }))
+			).toEqual([received, sent]);
+		});
 	});
 
 	describe('isTransactionsStoreInitialized', () => {

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -797,6 +797,14 @@ describe('transactions.utils', () => {
 				[received, sent].sort((a, b) => sortTransactions({ transactionA: a, transactionB: b }))
 			).toEqual([received, sent]);
 		});
+
+		it('should return 0 when both timestamps are nullish', () => {
+			const a = { timestamp: undefined } as AnyTransactionUi;
+			const b = { timestamp: undefined } as AnyTransactionUi;
+
+			expect(sortTransactions({ transactionA: a, transactionB: b })).toBe(0);
+			expect(sortTransactions({ transactionA: b, transactionB: a })).toBe(0);
+		});
 	});
 
 	describe('isTransactionsStoreInitialized', () => {


### PR DESCRIPTION
# Motivation

In the activity list, the two legs of a single operation — a swap's send + receive, or a self-transfer — share the same block timestamp. `sortTransactions` compared only the (second-normalized) timestamp and returned `0` on ties, so these pairs fell back to `Array.sort` insertion order (driven by token/provider load order). The result looked arbitrary: sometimes the send appeared above the receive, sometimes below.

# Changes

- `sortTransactions`: when timestamps are equal, break the tie deterministically by type — the received leg sorts above the sent one. This is the single comparator the whole activity list uses, so every same-second send/receive pair (swaps, self-transfers, …) now orders consistently.
- `sortTransactions`: return `0` when both timestamps are nullish (previously `1` — and `1` again when swapped, an antisymmetry-contract violation that left such pairs in engine-dependent order). The single-nullish case still sorts nullish last. (From Copilot review.)

# Tests

- Added `sortTransactions` tests: the received leg sorts above the sent one for a same-timestamp pair (regardless of input order), and the comparator returns `0` for two nullish-timestamp transactions in both argument orders.
- `transactions.utils.spec.ts` passes in full (78).
- Manual verification on `test_fe_3`.

> Independent of #13242 — based directly on `main` and mergeable on its own. This is a standalone determinism fix for same-timestamp send/receive ordering (it also covers self-transfers). The full _visible_ swap-pair effect additionally needs #13242's dedup fix (which keeps both legs); the two can land in any order.

---

Model: Claude Opus 4.8 (`claude-opus-4-8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
