### PR TITLE
feat(frontend): Promotion adjustments (carousel, explorer)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/src/frontend/src/env/dapp-descriptions.json
+++ b/src/frontend/src/env/dapp-descriptions.json
@@ -239,11 +239,7 @@
 		"usesInternetIdentity": true,
 		"stats": "",
 		"logo": "/images/dapps/icpindex-logo.webp",
-		"screenshots": ["/images/dapps/icpindex-screenshot.webp"],
-		"carousel": {
-			"text": "dapps.descriptions.icpindex.carousel.text",
-			"callToAction": "dapps.descriptions.icpindex.carousel.call_to_action"
-		}
+		"screenshots": ["/images/dapps/icpindex-screenshot.webp"]
 	},
 	{
 		"id": "waterneuron",

--- a/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
+++ b/src/frontend/src/lib/components/dapps/DappsCarousel.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { dAppDescriptions } from '$env/dapp-descriptions.env';
-	import { EARNING_ENABLED } from '$env/earning';
 	import { rewardCampaigns, FEATURED_REWARD_CAROUSEL_SLIDE_ID } from '$env/reward-campaigns.env';
 	import type { RewardCampaignDescription } from '$env/types/env-reward';
 	import { addUserHiddenDappId } from '$lib/api/backend.api';
 	import Carousel from '$lib/components/carousel/Carousel.svelte';
 	import DappsCarouselSlide from '$lib/components/dapps/DappsCarouselSlide.svelte';
-	import { stakeProvidersConfig } from '$lib/config/stake.config';
-	import { AppPath } from '$lib/constants/routes.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
 		userProfileLoaded,
@@ -21,7 +18,6 @@
 		CarouselSlideOisyDappDescription,
 		OisyDappDescription
 	} from '$lib/types/dapp-description';
-	import { StakeProvider } from '$lib/types/stake';
 	import { filterCarouselDapps } from '$lib/utils/dapps.utils';
 	import { emit } from '$lib/utils/events.utils';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
@@ -61,20 +57,6 @@
 			: undefined
 	);
 
-	let harvestAutopilotSlide = $derived(
-		EARNING_ENABLED
-			? ({
-					id: stakeProvidersConfig[StakeProvider.HARVEST_AUTOPILOTS].name,
-					carousel: {
-						text: $i18n.stake.text.harvest_autopilot_carousel_slide_title,
-						callToAction: $i18n.stake.text.harvest_autopilot_carousel_slide_cta
-					},
-					logo: stakeProvidersConfig[StakeProvider.HARVEST_AUTOPILOTS].logo,
-					name: stakeProvidersConfig[StakeProvider.HARVEST_AUTOPILOTS].name
-				} as CarouselSlideOisyDappDescription)
-			: undefined
-	);
-
 	/*
 	 TODO: rename and adjust DappsCarousel for different data sources (not only dApps descriptions).
 	 1. The component now displays data from difference sources - featured airdrop and dApps
@@ -86,7 +68,6 @@
 		filterCarouselDapps({
 			dAppDescriptions: [
 				...(nonNullish(featureAirdropSlide) ? [featureAirdropSlide] : []),
-				...(nonNullish(harvestAutopilotSlide) ? [harvestAutopilotSlide] : []),
 				...dAppDescriptions
 			],
 			hiddenDappsIds
@@ -144,10 +125,6 @@
 						: undefined}
 					{dappsCarouselSlide}
 					onCloseCarouselSlide={closeSlide}
-					pagePath={nonNullish(harvestAutopilotSlide) &&
-					harvestAutopilotSlide.id === dappsCarouselSlide.id
-						? AppPath.Earn
-						: undefined}
 				/>
 			{/each}
 		</Carousel>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -223,15 +223,15 @@
 			"website": "صورة $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
-			"ai": "",
+			"aa_new": "مضاف حديثًا",
+			"ab_icp": "ICP",
+			"ai": "الذكاء الاصطناعي",
 			"dex": "DEX",
 			"game": "لعبة",
-			"lending": "",
-			"nft": "",
-			"rwa": "",
-			"social": "",
+			"lending": "الإقراض",
+			"nft": "NFT",
+			"rwa": "RWA",
+			"social": "اجتماعي",
 			"staking": "التخزين",
 			"tools": "أدوات"
 		},

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "",
 			"full_history": "",
-			"recent_history": "",
-			"harvest_autopilot_carousel_slide_title": "",
-			"harvest_autopilot_carousel_slide_cta": ""
+			"recent_history": ""
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Zdá se, že jste zatím nestakovali žádné tokeny",
 			"full_history": "Zobrazit celou historii",
-			"recent_history": "Zavřít celou historii",
-			"harvest_autopilot_carousel_slide_title": "Vydělávejte v OISY s Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "Zjistit více"
+			"recent_history": "Zavřít celou historii"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Při výběru tokenů došlo k chybě.",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -223,15 +223,15 @@
 			"website": "Obrázek $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
+			"aa_new": "Nedávno přidané",
+			"ab_icp": "ICP",
 			"ai": "AI",
 			"dex": "DEX",
 			"game": "Hra",
-			"lending": "",
+			"lending": "Lending",
 			"nft": "NFT",
-			"rwa": "",
-			"social": "",
+			"rwa": "RWA",
+			"social": "Sociální",
 			"staking": "Staking",
 			"tools": "Nářadí"
 		},

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Sie haben noch keine Token gestakt",
 			"full_history": "Vollständige Historie anzeigen",
-			"recent_history": "Vollständige Historie schließen",
-			"harvest_autopilot_carousel_slide_title": "Mit Harvest Autopilot Yield Farming in OISY verdienen",
-			"harvest_autopilot_carousel_slide_cta": "Mehr erfahren"
+			"recent_history": "Vollständige Historie schließen"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Beim Abheben der Token ist ein Fehler aufgetreten.",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -223,16 +223,16 @@
 			"website": "Bild von $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
+			"aa_new": "Neu hinzugefügt",
+			"ab_icp": "ICP",
 			"ai": "KI",
 			"dex": "DEX",
 			"game": "Spiele",
-			"lending": "",
+			"lending": "Lending",
 			"nft": "NFT",
-			"rwa": "",
-			"social": "",
-			"staking": "Beteiligungen",
+			"rwa": "RWA",
+			"social": "Soziales",
+			"staking": "Staking",
 			"tools": "Tools"
 		},
 		"descriptions": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "It looks like you haven't staked any tokens yet",
 			"full_history": "Show full history",
-			"recent_history": "Close full history",
-			"harvest_autopilot_carousel_slide_title": "Earn in OISY with Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "Learn more"
+			"recent_history": "Close full history"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Something went wrong while withdrawing tokens.",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -223,15 +223,15 @@
 			"website": "Imagen de $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
+			"aa_new": "Añadido recientemente",
+			"ab_icp": "ICP",
 			"ai": "IA",
 			"dex": "DEX",
 			"game": "Juego",
-			"lending": "",
-			"nft": "",
-			"rwa": "",
-			"social": "",
+			"lending": "Lending",
+			"nft": "NFT",
+			"rwa": "RWA",
+			"social": "Social",
 			"staking": "Staking",
 			"tools": "Herramientas"
 		},

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Parece que aún no has hecho staking de ningún token",
 			"full_history": "Mostrar historial completo",
-			"recent_history": "Cerrar historial completo",
-			"harvest_autopilot_carousel_slide_title": "Gana en OISY con Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "Saber más"
+			"recent_history": "Cerrar historial completo"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Algo salió mal al retirar los tokens.",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -223,15 +223,15 @@
 			"website": "Image de $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
+			"aa_new": "Récemment ajoutés",
+			"ab_icp": "ICP",
 			"ai": "IA",
 			"dex": "DEX",
 			"game": "Jeu",
-			"lending": "",
+			"lending": "Lending",
 			"nft": "NFT",
-			"rwa": "",
-			"social": "",
+			"rwa": "RWA",
+			"social": "Social",
 			"staking": "Staking",
 			"tools": "Outils"
 		},

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Il semble que vous n'ayez encore staké aucun token",
 			"full_history": "Afficher l'historique complet",
-			"recent_history": "Fermer l'historique complet",
-			"harvest_autopilot_carousel_slide_title": "Gagnez dans OISY avec Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "En savoir plus"
+			"recent_history": "Fermer l'historique complet"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Une erreur s'est produite lors du retrait des tokens.",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -223,15 +223,15 @@
 			"website": "$dAppName की छवि"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
-			"ai": "",
+			"aa_new": "हाल ही में जोड़ा गया",
+			"ab_icp": "ICP",
+			"ai": "एआई",
 			"dex": "DEX",
 			"game": "गेम",
-			"lending": "",
-			"nft": "",
-			"rwa": "",
-			"social": "",
+			"lending": "लेंडिंग",
+			"nft": "NFT",
+			"rwa": "RWA",
+			"social": "सोशल",
 			"staking": "स्टेकिंग",
 			"tools": "टूल्स"
 		},

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "ऐसा लगता है कि आपने अभी तक कोई टोकन स्टेक नहीं किया है",
 			"full_history": "पूरा इतिहास दिखाएं",
-			"recent_history": "पूरा इतिहास बंद करें",
-			"harvest_autopilot_carousel_slide_title": "Harvest Autopilot Yield Farming के साथ OISY में कमाएं",
-			"harvest_autopilot_carousel_slide_cta": "और जानें"
+			"recent_history": "पूरा इतिहास बंद करें"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "टोकन निकालते समय कुछ गलत हो गया।",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -223,15 +223,15 @@
 			"website": "Immagine di $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
-			"ai": "",
+			"aa_new": "Aggiunti di recente",
+			"ab_icp": "ICP",
+			"ai": "IA",
 			"dex": "DEX",
 			"game": "Gioco",
-			"lending": "",
-			"nft": "",
-			"rwa": "",
-			"social": "",
+			"lending": "Lending",
+			"nft": "NFT",
+			"rwa": "RWA",
+			"social": "Social",
 			"staking": "Staking",
 			"tools": "Strumenti"
 		},

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Sembra che tu non abbia ancora messo in staking nessun token",
 			"full_history": "Mostra cronologia completa",
-			"recent_history": "Chiudi cronologia completa",
-			"harvest_autopilot_carousel_slide_title": "Guadagna in OISY con Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "Scopri di più"
+			"recent_history": "Chiudi cronologia completa"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Si è verificato un errore durante il prelievo dei token.",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -223,15 +223,15 @@
 			"website": "$dAppNameの画像"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
+			"aa_new": "最近追加",
+			"ab_icp": "ICP",
 			"ai": "AI",
 			"dex": "DEX",
 			"game": "ゲーム",
-			"lending": "",
+			"lending": "レンディング",
 			"nft": "NFT",
-			"rwa": "",
-			"social": "",
+			"rwa": "RWA",
+			"social": "ソーシャル",
 			"staking": "ステーキング",
 			"tools": "ツール"
 		},

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "まだトークンをステークしていないようです",
 			"full_history": "全履歴を表示",
-			"recent_history": "全履歴を閉じる",
-			"harvest_autopilot_carousel_slide_title": "Harvest Autopilot Yield FarmingでOISYを稼ぐ",
-			"harvest_autopilot_carousel_slide_cta": "詳しく見る"
+			"recent_history": "全履歴を閉じる"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "トークンの引き出し中にエラーが発生しました。",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "아직 스테이킹한 토큰이 없는 것 같습니다",
 			"full_history": "전체 내역 보기",
-			"recent_history": "전체 내역 닫기",
-			"harvest_autopilot_carousel_slide_title": "Harvest Autopilot Yield Farming으로 OISY에서 수익 창출",
-			"harvest_autopilot_carousel_slide_cta": "자세히 알아보기"
+			"recent_history": "전체 내역 닫기"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "토큰 출금 중 오류가 발생했습니다.",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -228,10 +228,10 @@
 			"ai": "AI",
 			"dex": "DEX",
 			"game": "게임",
-			"lending": "",
+			"lending": "렌딩",
 			"nft": "NFT",
 			"rwa": "RWA",
-			"social": "",
+			"social": "소셜",
 			"staking": "스테이킹",
 			"tools": "도구"
 		},

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -223,15 +223,15 @@
 			"website": "Obraz $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
-			"ai": "",
+			"aa_new": "Ostatnio dodane",
+			"ab_icp": "ICP",
+			"ai": "AI",
 			"dex": "DEX",
 			"game": "Gra",
-			"lending": "",
-			"nft": "",
-			"rwa": "",
-			"social": "",
+			"lending": "Lending",
+			"nft": "NFT",
+			"rwa": "RWA",
+			"social": "Społecznościowe",
 			"staking": "Staking",
 			"tools": "Narzędzia"
 		},

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Wygląda na to, że nie stakowano jeszcze żadnych tokenów",
 			"full_history": "Pokaż pełną historię",
-			"recent_history": "Zamknij pełną historię",
-			"harvest_autopilot_carousel_slide_title": "Zarabiaj w OISY z Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "Dowiedz się więcej"
+			"recent_history": "Zamknij pełną historię"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Coś poszło nie tak podczas wypłacania tokenów.",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Parece que você ainda não fez staking de nenhum token",
 			"full_history": "Exibir histórico completo",
-			"recent_history": "Fechar histórico completo",
-			"harvest_autopilot_carousel_slide_title": "Ganhe no OISY com Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "Saiba mais"
+			"recent_history": "Fechar histórico completo"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Algo deu errado ao retirar os tokens.",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -223,15 +223,15 @@
 			"website": "Imagem de $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
-			"ai": "",
+			"aa_new": "Adicionado recentemente",
+			"ab_icp": "ICP",
+			"ai": "IA",
 			"dex": "DEX",
 			"game": "Jogo",
-			"lending": "",
-			"nft": "",
-			"rwa": "",
-			"social": "",
+			"lending": "Lending",
+			"nft": "NFT",
+			"rwa": "RWA",
+			"social": "Social",
 			"staking": "Staking",
 			"tools": "Ferramentas"
 		},

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -223,15 +223,15 @@
 			"website": "Изображение $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
+			"aa_new": "Недавно добавленные",
+			"ab_icp": "ICP",
 			"ai": "ИИ",
 			"dex": "DEX",
 			"game": "Игра",
-			"lending": "",
+			"lending": "Лендинг",
 			"nft": "NFT",
-			"rwa": "",
-			"social": "",
+			"rwa": "RWA",
+			"social": "Социальные",
 			"staking": "Стейкинг",
 			"tools": "Инструменты"
 		},

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Похоже, вы ещё не стейкировали ни одного токена",
 			"full_history": "Показать полную историю",
-			"recent_history": "Закрыть полную историю",
-			"harvest_autopilot_carousel_slide_title": "Зарабатывайте в OISY с Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "Узнать больше"
+			"recent_history": "Закрыть полную историю"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "При выводе токенов произошла ошибка.",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "Có vẻ như bạn chưa staking token nào",
 			"full_history": "Xem toàn bộ lịch sử",
-			"recent_history": "Đóng toàn bộ lịch sử",
-			"harvest_autopilot_carousel_slide_title": "Kiếm tiền trong OISY với Harvest Autopilot Yield Farming",
-			"harvest_autopilot_carousel_slide_cta": "Tìm hiểu thêm"
+			"recent_history": "Đóng toàn bộ lịch sử"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "Đã xảy ra lỗi khi rút token.",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -223,15 +223,15 @@
 			"website": "Hình ảnh của $dAppName"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
+			"aa_new": "Mới thêm",
+			"ab_icp": "ICP",
 			"ai": "AI",
 			"dex": "DEX",
 			"game": "Trò chơi",
-			"lending": "",
-			"nft": "",
-			"rwa": "",
-			"social": "",
+			"lending": "Lending",
+			"nft": "NFT",
+			"rwa": "RWA",
+			"social": "Mạng xã hội",
 			"staking": "Staking",
 			"tools": "Công cụ"
 		},

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2254,9 +2254,7 @@
 			"title_empty_3": "",
 			"description_empty": "您似乎还没有质押任何代币",
 			"full_history": "显示完整历史记录",
-			"recent_history": "关闭完整历史记录",
-			"harvest_autopilot_carousel_slide_title": "通过Harvest Autopilot Yield Farming在OISY中赚取",
-			"harvest_autopilot_carousel_slide_cta": "了解更多"
+			"recent_history": "关闭完整历史记录"
 		},
 		"error": {
 			"unexpected_error_on_withdraw": "提取代币时出现错误。",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -223,15 +223,15 @@
 			"website": "$dAppName 的图像"
 		},
 		"categories": {
-			"aa_new": "",
-			"ab_icp": "",
+			"aa_new": "最近添加",
+			"ab_icp": "ICP",
 			"ai": "人工智能",
 			"dex": "DEX",
 			"game": "游戏",
-			"lending": "",
+			"lending": "借贷",
 			"nft": "NFT",
-			"rwa": "",
-			"social": "",
+			"rwa": "RWA",
+			"social": "社交",
 			"staking": "质押",
 			"tools": "工具包"
 		},

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1785,8 +1785,6 @@ interface I18nStake {
 		description_empty: string;
 		full_history: string;
 		recent_history: string;
-		harvest_autopilot_carousel_slide_title: string;
-		harvest_autopilot_carousel_slide_cta: string;
 	};
 	error: {
 		unexpected_error_on_withdraw: string;

--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -3,10 +3,8 @@ import * as dapps from '$env/dapp-descriptions.env';
 import * as rewards from '$env/reward-campaigns.env';
 import { FEATURED_REWARD_CAROUSEL_SLIDE_ID } from '$env/reward-campaigns.env';
 import DappsCarousel from '$lib/components/dapps/DappsCarousel.svelte';
-import { stakeProvidersConfig } from '$lib/config/stake.config';
 import { CAROUSEL_CONTAINER } from '$lib/constants/test-ids.constants';
 import { userProfileStore } from '$lib/stores/user-profile.store';
-import { StakeProvider } from '$lib/types/stake';
 import { mockDappsDescriptions } from '$tests/mocks/dapps.mock';
 import { mockUserProfile, mockUserSettings } from '$tests/mocks/user-profile.mock';
 import { toNullable } from '@dfinity/utils';
@@ -20,7 +18,7 @@ describe('DappsCarousel', () => {
 		userProfileStore.set({ profile: mockUserProfile, certified: false });
 	});
 
-	it('should render nothing if there is no dApps, no rewards and earning is not enabled', () => {
+	it('should render nothing if there is no dApps and no rewards', () => {
 		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue([]);
 		vi.spyOn(rewards, 'rewardCampaigns', 'get').mockReturnValue([]);
 
@@ -29,7 +27,7 @@ describe('DappsCarousel', () => {
 		expect(container.textContent).toBe('');
 	});
 
-	it('should render nothing if no dApps has the carousel prop, no rewards and earning is not enabled', () => {
+	it('should render nothing if no dApps has the carousel prop and no rewards', () => {
 		vi.spyOn(rewards, 'rewardCampaigns', 'get').mockReturnValue([]);
 		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue(
 			mockDappsDescriptions.map((dapp) => ({ ...dapp, carousel: undefined }))
@@ -40,7 +38,7 @@ describe('DappsCarousel', () => {
 		expect(container.textContent).toBe('');
 	});
 
-	it('should render nothing if no dApps, featured reward is unknown and earning is not enabled', () => {
+	it('should render nothing if no dApps and featured reward is unknown', () => {
 		vi.spyOn(rewards, 'FEATURED_REWARD_CAROUSEL_SLIDE_ID', 'get').mockReturnValue(
 			'test' as typeof FEATURED_REWARD_CAROUSEL_SLIDE_ID
 		);
@@ -60,7 +58,6 @@ describe('DappsCarousel', () => {
 					...mockUserSettings.dapp.dapp_carousel,
 					hidden_dapp_ids: [
 						FEATURED_REWARD_CAROUSEL_SLIDE_ID,
-						stakeProvidersConfig[StakeProvider.HARVEST_AUTOPILOTS].name,
 						...mockDappsDescriptions.map(({ id }) => id)
 					]
 				}

--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -38,7 +38,7 @@ describe('DappsCarousel', () => {
 		expect(container.textContent).toBe('');
 	});
 
-	it('should render nothing if no dApps and featured reward is unknown', () => {
+	it('should render nothing if there are no dApps and the featured reward is unknown', () => {
 		vi.spyOn(rewards, 'FEATURED_REWARD_CAROUSEL_SLIDE_ID', 'get').mockReturnValue(
 			'test' as typeof FEATURED_REWARD_CAROUSEL_SLIDE_ID
 		);

--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -18,7 +18,7 @@ describe('DappsCarousel', () => {
 		userProfileStore.set({ profile: mockUserProfile, certified: false });
 	});
 
-	it('should render nothing if there is no dApps and no rewards', () => {
+	it('should render nothing if there are no dApps and no rewards', () => {
 		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue([]);
 		vi.spyOn(rewards, 'rewardCampaigns', 'get').mockReturnValue([]);
 

--- a/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
+++ b/src/frontend/src/tests/lib/components/dapps/DappsCarousel.spec.ts
@@ -27,7 +27,7 @@ describe('DappsCarousel', () => {
 		expect(container.textContent).toBe('');
 	});
 
-	it('should render nothing if no dApps has the carousel prop and no rewards', () => {
+	it('should render nothing if no dApps have the carousel prop and no rewards', () => {
 		vi.spyOn(rewards, 'rewardCampaigns', 'get').mockReturnValue([]);
 		vi.spyOn(dapps, 'dAppDescriptions', 'get').mockReturnValue(
 			mockDappsDescriptions.map((dapp) => ({ ...dapp, carousel: undefined }))


### PR DESCRIPTION
# Motivation

The dApps carousel had grown too many promotional cards, and the explorer's category filter chips were only partially translated (many rendered blank). This trims the carousel and fills in the missing category labels across all supported languages.

# Changes

- Remove the **ICP Index** carousel card (dropped from `dapp-descriptions.json`).
- Remove the **Harvest Autopilot** carousel card:
  - Drop the `harvestAutopilotSlide` derived slide, its entry in the carousel slide list, and the `pagePath`/`AppPath.Earn` wiring in `DappsCarousel.svelte`, along with the now-unused `EARNING_ENABLED`, `stakeProvidersConfig`, `StakeProvider` and `AppPath` imports.
  - Remove the orphaned `harvest_autopilot_carousel_slide_title` / `harvest_autopilot_carousel_slide_cta` i18n keys from all locales and the i18n type definition.
- Translate the dApp explorer **category filter labels** across all supported languages. Many were empty strings and rendered as blank filter chips. Conventions applied: acronyms and proper nouns (`ICP`, `DEX`, `NFT`, `RWA`) kept as-is everywhere; `Lending` kept in English for Latin-script locales and localized for non-Latin scripts; clear common terms (Recently added, Social, AI) localized per language. German `staking` also changed from "Beteiligungen" to the more common "Staking".

# Tests

- Updated `DappsCarousel.spec.ts`: removed the Harvest Autopilot id from the hidden-ids case, dropped the unused stake imports, and refreshed the now-stale test titles. All 7 tests pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (claude-opus-4-8)
