### PR TITLE
feat(frontend): simulate NFT possession for local support reproduction

### DIFF
--- a/src/frontend/src/eth/services/nft-mock.services.ts
+++ b/src/frontend/src/eth/services/nft-mock.services.ts
@@ -1,0 +1,52 @@
+import { ARBITRUM_MAINNET_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.base.env';
+import { POLYGON_MAINNET_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.polygon.env';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import type { EthNonFungibleToken } from '$eth/types/nft';
+import type { NetworkId } from '$lib/types/network';
+import type { NftId } from '$lib/types/nft';
+import { areAddressesEqual } from '$lib/utils/address.utils';
+import { parseNftId } from '$lib/validation/nft.validation';
+
+// LOCAL SIMULATION ONLY — do not merge.
+//
+// Fakes possession of a hard-coded list of token ids per contract so NFT-related
+// support cases can be reproduced after importing the contract through the UI.
+// Only ownership is faked: metadata and media still resolve through Alchemy, so
+// the result matches exactly what the affected user sees (e.g. a token whose
+// image Alchemy does not index shows no media).
+//
+// Add contracts / ids here as needed.
+const FAKE_OWNED_NFTS: { address: string; networkId: NetworkId; tokenIds: number[] }[] = [
+	{
+		// MANDARADAN
+		address: '0x40ff3db9d64432aB4a91F134e344e79Ea074f7DA',
+		networkId: BASE_NETWORK_ID,
+		tokenIds: [1, 4, 7, 8, 11]
+	},
+	{
+		// Pudgy Penguins
+		address: '0xBd3531dA5CF5857e7CfAA92426877b022e612cf8',
+		networkId: ETHEREUM_NETWORK_ID,
+		tokenIds: [1, 2, 3]
+	},
+	{
+		// GMX Blueberry Club
+		address: '0x17f4BAa9D35Ee54fFbCb2608e20786473c7aa49f',
+		networkId: ARBITRUM_MAINNET_NETWORK_ID,
+		tokenIds: [1, 4, 5]
+	},
+	{
+		// Lens Protocol Profiles
+		address: '0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d',
+		networkId: POLYGON_MAINNET_NETWORK_ID,
+		tokenIds: [1, 2, 3]
+	}
+];
+
+export const getFakeOwnedTokenIds = (token: EthNonFungibleToken): NftId[] =>
+	FAKE_OWNED_NFTS.filter(
+		({ address, networkId }) =>
+			token.network.id === networkId &&
+			areAddressesEqual({ address1: token.address, address2: address, networkId: token.network.id })
+	).flatMap(({ tokenIds }) => tokenIds.map((id) => parseNftId(`${id}`)));

--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -12,6 +12,7 @@ import type { Nft } from '$lib/types/nft';
 import { consoleWarn } from '$lib/utils/console.utils';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import { SvelteMap } from 'svelte/reactivity';
 
 // Alchemy is the source for owned NFTs, but it sometimes returns no media URL
 // for a token it has not indexed yet, even when the collection's metadata (and
@@ -37,6 +38,13 @@ const loadOnChainImageUrl = async ({
 	return imageUrl;
 };
 
+// Caches the on-chain image URL resolved per (network, contract, token id) so
+// the NFT polling loop reuses it instead of re-resolving — and re-reporting —
+// the same media on every refresh. A `null` entry records a token that resolved
+// to no media (so we don't re-report that either). Transient failures are not
+// cached, so they keep retrying on the next poll. Exposed so tests can reset it.
+export const onChainImageUrlCache = new SvelteMap<string, string | null>();
+
 const withOnChainMediaFallback = async ({
 	networkId,
 	nft
@@ -46,6 +54,19 @@ const withOnChainMediaFallback = async ({
 }): Promise<Nft> => {
 	if (nonNullish(nft.imageUrl)) {
 		return nft;
+	}
+
+	const withImageUrl = async (imageUrl: string): Promise<Nft> => ({
+		...nft,
+		imageUrl,
+		mediaStatus: { ...nft.mediaStatus, image: await getMediaStatusOrCache(imageUrl) }
+	});
+
+	const cacheKey = `${networkId.toString()}#${nft.collection.address}#${nft.id}`;
+
+	if (onChainImageUrlCache.has(cacheKey)) {
+		const cached = onChainImageUrlCache.get(cacheKey);
+		return nonNullish(cached) ? await withImageUrl(cached) : nft;
 	}
 
 	const trackLoad = (resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES) =>
@@ -66,24 +87,21 @@ const withOnChainMediaFallback = async ({
 	try {
 		const imageUrl = await loadOnChainImageUrl({ networkId, nft });
 
-		// `success` means we recovered an image URL; `error` covers both a load
-		// that returned no image and one that threw (handled below).
+		// Cache the resolved outcome (the URL, or `null` for "no media on chain")
+		// so later polls reuse it without re-resolving or re-reporting.
+		onChainImageUrlCache.set(cacheKey, imageUrl ?? null);
+
+		// `success` means we recovered an image URL; `error` means the contract
+		// metadata exposed no usable image.
 		trackLoad(
 			nonNullish(imageUrl)
 				? PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 				: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR
 		);
 
-		if (isNullish(imageUrl)) {
-			return nft;
-		}
-
-		return {
-			...nft,
-			imageUrl,
-			mediaStatus: { ...nft.mediaStatus, image: await getMediaStatusOrCache(imageUrl) }
-		};
+		return nonNullish(imageUrl) ? await withImageUrl(imageUrl) : nft;
 	} catch (err: unknown) {
+		// Not cached: a transient failure should be retried on the next poll.
 		trackLoad(PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR);
 		consoleWarn(
 			`Failed to resolve on-chain media for NFT ${nft.id} of token: ${nft.collection.address} on network: ${networkId.toString()}.`,

--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -42,8 +42,12 @@ const loadOnChainImageUrl = async ({
 // the NFT polling loop reuses it instead of re-resolving — and re-reporting —
 // the same media on every refresh. A `null` entry records a token that resolved
 // to no media (so we don't re-report that either). Transient failures are not
-// cached, so they keep retrying on the next poll. Exposed so tests can reset it.
-export const onChainImageUrlCache = new SvelteMap<string, string | null>();
+// cached, so they keep retrying on the next poll.
+const onChainImageUrlCache = new SvelteMap<string, string | null>();
+
+export const __test__only__clear_on_chain_image_url_cache__ = (): void => {
+	onChainImageUrlCache.clear();
+};
 
 const withOnChainMediaFallback = async ({
 	networkId,

--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -1,6 +1,7 @@
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
 import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers';
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
+import { getFakeOwnedTokenIds } from '$eth/services/nft-mock.services';
 import type { OptionEthAddress } from '$eth/types/address';
 import type { EthNonFungibleToken } from '$eth/types/nft';
 import { TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL } from '$lib/constants/analytics.constants';
@@ -128,7 +129,7 @@ export const loadNftsByNetwork = async ({
 		return [];
 	}
 
-	const { getNftsByOwner } = alchemyProviders(networkId);
+	const { getNftsByOwner, getNftMetadata } = alchemyProviders(networkId);
 
 	const batches = createBatches<EthNonFungibleToken>({ items: tokens, batchSize: 40 });
 
@@ -142,6 +143,22 @@ export const loadNftsByNetwork = async ({
 				`Failed to load NFTs for tokens: ${tokenAddresses} on network: ${networkId.toString()}.`,
 				err
 			);
+		}
+	}
+
+	// LOCAL SIMULATION ONLY — do not merge.
+	// Fake possession of a hard-coded list of token ids, still resolving their
+	// metadata/media through Alchemy so the result matches what the user sees.
+	for (const token of tokens) {
+		for (const tokenId of getFakeOwnedTokenIds(token)) {
+			try {
+				nfts.push(await getNftMetadata({ token, tokenId }));
+			} catch (err: unknown) {
+				consoleWarn(
+					`Failed to load faked NFT ${tokenId} for token: ${token.address} on network: ${networkId.toString()}.`,
+					err
+				);
+			}
 		}
 	}
 

--- a/src/frontend/src/tests/eth/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/nft.services.spec.ts
@@ -1,7 +1,7 @@
 import { alchemyProviders, type AlchemyProvider } from '$eth/providers/alchemy.providers';
 import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers';
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
-import { loadNftsByNetwork } from '$eth/services/nft.services';
+import { loadNftsByNetwork, onChainImageUrlCache } from '$eth/services/nft.services';
 import type { EthNonFungibleToken } from '$eth/types/nft';
 import { TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL } from '$lib/constants/analytics.constants';
 import { MediaStatusEnum } from '$lib/enums/media-status';
@@ -106,6 +106,7 @@ describe('nft.services', () => {
 
 		beforeEach(() => {
 			vi.clearAllMocks();
+			onChainImageUrlCache.clear();
 
 			vi.mocked(alchemyProviders).mockReturnValue(mockAlchemyProvider);
 			vi.mocked(infuraErc721Providers).mockReturnValue(mockInfuraErc721Provider);
@@ -342,6 +343,31 @@ describe('nft.services', () => {
 						token_id: `${mockErc721NftWithoutImage.id}`
 					}
 				});
+			});
+
+			it('resolves on-chain media only once across repeated polls', async () => {
+				vi.mocked(mockAlchemyProvider.getNftsByOwner)
+					.mockResolvedValueOnce([mockErc721NftWithoutImage])
+					.mockResolvedValueOnce([mockErc721NftWithoutImage]);
+				vi.mocked(mockInfuraErc721Provider.getNftMetadata).mockResolvedValueOnce({
+					id: mockErc721NftWithoutImage.id,
+					imageUrl: 'https://arweave.net/on-chain-image'
+				});
+
+				const params = {
+					...mockParams,
+					tokens: [erc721AzukiToken],
+					networkId: erc721AzukiToken.network.id
+				};
+
+				const first = await loadNftsByNetwork(params);
+				const second = await loadNftsByNetwork(params);
+
+				// On-chain resolution and the event happen once; the second poll reuses the cache.
+				expect(mockInfuraErc721Provider.getNftMetadata).toHaveBeenCalledOnce();
+				expect(trackEvent).toHaveBeenCalledOnce();
+				expect(first[0].imageUrl).toBe('https://arweave.net/on-chain-image');
+				expect(second[0].imageUrl).toBe('https://arweave.net/on-chain-image');
 			});
 		});
 	});

--- a/src/frontend/src/tests/eth/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/nft.services.spec.ts
@@ -1,7 +1,10 @@
 import { alchemyProviders, type AlchemyProvider } from '$eth/providers/alchemy.providers';
 import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers';
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
-import { loadNftsByNetwork, onChainImageUrlCache } from '$eth/services/nft.services';
+import {
+	__test__only__clear_on_chain_image_url_cache__,
+	loadNftsByNetwork
+} from '$eth/services/nft.services';
 import type { EthNonFungibleToken } from '$eth/types/nft';
 import { TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL } from '$lib/constants/analytics.constants';
 import { MediaStatusEnum } from '$lib/enums/media-status';
@@ -106,7 +109,7 @@ describe('nft.services', () => {
 
 		beforeEach(() => {
 			vi.clearAllMocks();
-			onChainImageUrlCache.clear();
+			__test__only__clear_on_chain_image_url_cache__();
 
 			vi.mocked(alchemyProviders).mockReturnValue(mockAlchemyProvider);
 			vi.mocked(infuraErc721Providers).mockReturnValue(mockInfuraErc721Provider);


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE** — local-only debugging branch for reproducing NFT support cases. Not intended for `main`.

> **Rebased on #13271** (`fix(frontend)/nft-onchain-media-load-once`) — the on-chain media fix: the load-once cache (module-private behind a `__test__only__…` reset hook), the batched fallback, and the `nft_load_onchain_image_url` event (with `token_symbol` / `token_name`). The diff shown here is only the simulation layer on top of that fix.

# Motivation

Reproduce NFT support cases locally without holding the assets — fake possession of a fixed set of token ids while letting metadata/media resolve through the real provider path.

# Changes

This branch = the #13271 fix + a simulation layer on top:

- `eth/services/nft-mock.services.ts` (new): a hard-coded list of `{ contract → token ids }` to fake-own, keyed by contract address + network — MANDARADAN (Base), Pudgy Penguins (Ethereum), GMX Blueberry Club (Arbitrum), Lens Protocol Profiles (Polygon) — plus a `getFakeOwnedTokenIds(token)` lookup. Extend the list to reproduce other cases. Each collection must still be imported in the UI for it to load.
- `eth/services/nft.services.ts`: after the normal owner query, append the faked token ids by fetching each one's metadata via Alchemy's `getNftMetadata`. Only ownership is faked — metadata/media resolve exactly as in production.

The simulation touch points are flagged `LOCAL SIMULATION ONLY — do not merge`.

# Tests

Local simulation branch, not for merge — no automated tests added for the simulation layer (the #13271 fix carries its own tests, which pass on this branch: 12/12).

Manual end-to-end check:
1. Open the environment and log in.
2. Import the four contracts on their networks: MANDARADAN / Base (`0x40ff3db9d64432aB4a91F134e344e79Ea074f7DA`), Pudgy Penguins / Ethereum (`0xBd3531dA5CF5857e7CfAA92426877b022e612cf8`), GMX Blueberry Club / Arbitrum (`0x17f4BAa9D35Ee54fFbCb2608e20786473c7aa49f`), Lens Protocol Profiles / Polygon (`0xDb46d1Dc155634FbC732f92E853b10B288AD5a1d`).
3. The faked token ids appear as owned and render their media.
4. MANDARADAN #8 (Alchemy returns no media) resolves on-chain and — with #13271 — logs the `nft_load_onchain_image_url` event **once per session** instead of on every ~20s poll.

Gates: `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` (0 errors / 0 warnings), `nft.services` spec (12/12).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)

