### PR TITLE
fix(frontend): resolve NFT media on-chain when Alchemy returns none

### DIFF
--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -1,11 +1,70 @@
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
+import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers';
+import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
 import type { OptionEthAddress } from '$eth/types/address';
 import type { EthNonFungibleToken } from '$eth/types/nft';
 import { createBatches } from '$lib/services/batch.services';
 import type { NetworkId } from '$lib/types/network';
 import type { Nft } from '$lib/types/nft';
 import { consoleWarn } from '$lib/utils/console.utils';
-import { isNullish } from '@dfinity/utils';
+import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+
+// Alchemy is the source for owned NFTs, but it sometimes returns no media URL
+// for a token it has not indexed yet, even when the collection's metadata (and
+// image) are reachable on-chain. For those, fall back to resolving the image
+// from the contract's tokenURI/uri so the asset still renders.
+const loadOnChainImageUrl = async ({
+	networkId,
+	nft: {
+		id: tokenId,
+		collection: { address: contractAddress, standard }
+	}
+}: {
+	networkId: NetworkId;
+	nft: Nft;
+}): Promise<string | undefined> => {
+	const { getNftMetadata } =
+		standard.code === 'erc1155'
+			? infuraErc1155Providers(networkId)
+			: infuraErc721Providers(networkId);
+
+	const { imageUrl } = await getNftMetadata({ contractAddress, tokenId });
+
+	return imageUrl;
+};
+
+const withOnChainMediaFallback = async ({
+	networkId,
+	nft
+}: {
+	networkId: NetworkId;
+	nft: Nft;
+}): Promise<Nft> => {
+	if (nonNullish(nft.imageUrl)) {
+		return nft;
+	}
+
+	try {
+		const imageUrl = await loadOnChainImageUrl({ networkId, nft });
+
+		if (isNullish(imageUrl)) {
+			return nft;
+		}
+
+		return {
+			...nft,
+			imageUrl,
+			mediaStatus: { ...nft.mediaStatus, image: await getMediaStatusOrCache(imageUrl) }
+		};
+	} catch (err: unknown) {
+		consoleWarn(
+			`Failed to resolve on-chain media for NFT ${nft.id} of token: ${nft.collection.address} on network: ${networkId.toString()}.`,
+			err
+		);
+		return nft;
+	}
+};
 
 export const loadNftsByNetwork = async ({
 	networkId,
@@ -37,5 +96,5 @@ export const loadNftsByNetwork = async ({
 		}
 	}
 
-	return nfts;
+	return await Promise.all(nfts.map((nft) => withOnChainMediaFallback({ networkId, nft })));
 };

--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -57,6 +57,8 @@ const withOnChainMediaFallback = async ({
 				token_network: nft.collection.network.name,
 				token_address: nft.collection.address,
 				token_standard: nft.collection.standard.code,
+				...(nonNullish(nft.collection.symbol) && { token_symbol: nft.collection.symbol }),
+				...(nonNullish(nft.collection.name) && { token_name: nft.collection.name }),
 				token_id: `${nft.id}`
 			}
 		});

--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -96,5 +96,16 @@ export const loadNftsByNetwork = async ({
 		}
 	}
 
-	return await Promise.all(nfts.map((nft) => withOnChainMediaFallback({ networkId, nft })));
+	// Resolve the on-chain media fallback in small batches rather than all at
+	// once, to avoid bursting Infura when many owned NFTs lack Alchemy media.
+	const fallbackBatches = createBatches<Nft>({ items: nfts, batchSize: 10 });
+
+	const withFallback: Nft[] = [];
+	for (const batch of fallbackBatches) {
+		withFallback.push(
+			...(await Promise.all(batch.map((nft) => withOnChainMediaFallback({ networkId, nft }))))
+		);
+	}
+
+	return withFallback;
 };

--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -3,6 +3,9 @@ import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers'
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
 import type { OptionEthAddress } from '$eth/types/address';
 import type { EthNonFungibleToken } from '$eth/types/nft';
+import { TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL } from '$lib/constants/analytics.constants';
+import { PLAUSIBLE_EVENT_CONTEXTS, PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
+import { trackEvent } from '$lib/services/analytics.services';
 import { createBatches } from '$lib/services/batch.services';
 import type { NetworkId } from '$lib/types/network';
 import type { Nft } from '$lib/types/nft';
@@ -45,8 +48,29 @@ const withOnChainMediaFallback = async ({
 		return nft;
 	}
 
+	const trackLoad = (resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES) =>
+		trackEvent({
+			name: TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL,
+			metadata: {
+				event_context: PLAUSIBLE_EVENT_CONTEXTS.NFT,
+				result_status: resultStatus,
+				token_network: nft.collection.network.name,
+				token_address: nft.collection.address,
+				token_standard: nft.collection.standard.code,
+				token_id: `${nft.id}`
+			}
+		});
+
 	try {
 		const imageUrl = await loadOnChainImageUrl({ networkId, nft });
+
+		// `success` means we recovered an image URL; `error` covers both a load
+		// that returned no image and one that threw (handled below).
+		trackLoad(
+			nonNullish(imageUrl)
+				? PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+				: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR
+		);
 
 		if (isNullish(imageUrl)) {
 			return nft;
@@ -58,6 +82,7 @@ const withOnChainMediaFallback = async ({
 			mediaStatus: { ...nft.mediaStatus, image: await getMediaStatusOrCache(imageUrl) }
 		};
 	} catch (err: unknown) {
+		trackLoad(PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR);
 		consoleWarn(
 			`Failed to resolve on-chain media for NFT ${nft.id} of token: ${nft.collection.address} on network: ${networkId.toString()}.`,
 			err

--- a/src/frontend/src/lib/constants/analytics.constants.ts
+++ b/src/frontend/src/lib/constants/analytics.constants.ts
@@ -184,3 +184,4 @@ export const TRACK_NFT_CONSENT_GIVEN = 'nft_consent_given';
 export const TRACK_NFT_OPEN = 'nft_open';
 export const TRACK_NFT_OPEN_CONSENT_MODAL = 'nft_open_consent_modal';
 export const TRACK_NFT_SPAM_HIDE_ACTION = 'nft_spam_hide_action';
+export const TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL = 'nft_load_onchain_image_url';

--- a/src/frontend/src/tests/eth/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/nft.services.spec.ts
@@ -235,6 +235,8 @@ describe('nft.services', () => {
 						token_network: mockErc721NftWithoutImage.collection.network.name,
 						token_address: mockErc721NftWithoutImage.collection.address,
 						token_standard: mockErc721NftWithoutImage.collection.standard.code,
+						token_symbol: mockErc721NftWithoutImage.collection.symbol,
+						token_name: mockErc721NftWithoutImage.collection.name,
 						token_id: `${mockErc721NftWithoutImage.id}`
 					}
 				});
@@ -301,6 +303,8 @@ describe('nft.services', () => {
 						token_network: mockErc721NftWithoutImage.collection.network.name,
 						token_address: mockErc721NftWithoutImage.collection.address,
 						token_standard: mockErc721NftWithoutImage.collection.standard.code,
+						token_symbol: mockErc721NftWithoutImage.collection.symbol,
+						token_name: mockErc721NftWithoutImage.collection.name,
 						token_id: `${mockErc721NftWithoutImage.id}`
 					}
 				});
@@ -333,6 +337,8 @@ describe('nft.services', () => {
 						token_network: mockErc721NftWithoutImage.collection.network.name,
 						token_address: mockErc721NftWithoutImage.collection.address,
 						token_standard: mockErc721NftWithoutImage.collection.standard.code,
+						token_symbol: mockErc721NftWithoutImage.collection.symbol,
+						token_name: mockErc721NftWithoutImage.collection.name,
 						token_id: `${mockErc721NftWithoutImage.id}`
 					}
 				});

--- a/src/frontend/src/tests/eth/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/nft.services.spec.ts
@@ -1,6 +1,11 @@
 import { alchemyProviders, type AlchemyProvider } from '$eth/providers/alchemy.providers';
+import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers';
+import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
 import { loadNftsByNetwork } from '$eth/services/nft.services';
 import type { EthNonFungibleToken } from '$eth/types/nft';
+import { MediaStatusEnum } from '$lib/enums/media-status';
+import type { Nft } from '$lib/types/nft';
+import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
 import { NYAN_CAT_TOKEN } from '$tests/mocks/erc1155-tokens.mock';
 import { AZUKI_ELEMENTAL_BEANS_TOKEN } from '$tests/mocks/erc721-tokens.mock';
@@ -13,12 +18,33 @@ vi.mock('$eth/providers/alchemy.providers', () => ({
 	AlchemyProvider: vi.fn()
 }));
 
+vi.mock('$eth/providers/infura-erc721.providers', () => ({
+	infuraErc721Providers: vi.fn()
+}));
+
+vi.mock('$eth/providers/infura-erc1155.providers', () => ({
+	infuraErc1155Providers: vi.fn()
+}));
+
+vi.mock(import('$lib/utils/nfts.utils'), async (importOriginal) => ({
+	...(await importOriginal()),
+	getMediaStatusOrCache: vi.fn()
+}));
+
 describe('nft.services', () => {
 	const mockAlchemyProvider = {
 		network: new Network('ethereum', 1),
 		provider: {},
 		getNftsByOwner: vi.fn()
 	} as unknown as AlchemyProvider;
+
+	const mockInfuraErc721Provider = {
+		getNftMetadata: vi.fn()
+	} as unknown as ReturnType<typeof infuraErc721Providers>;
+
+	const mockInfuraErc1155Provider = {
+		getNftMetadata: vi.fn()
+	} as unknown as ReturnType<typeof infuraErc1155Providers>;
 
 	describe('loadNftsByNetwork', () => {
 		const mockNft1 = {
@@ -49,6 +75,17 @@ describe('nft.services', () => {
 			}
 		};
 
+		const mockErc721NftWithoutImage: Nft = {
+			...mockNft1,
+			imageUrl: undefined,
+			mediaStatus: { image: MediaStatusEnum.INVALID_DATA, thumbnail: MediaStatusEnum.INVALID_DATA }
+		};
+		const mockErc1155NftWithoutImage: Nft = {
+			...mockNft3,
+			imageUrl: undefined,
+			mediaStatus: { image: MediaStatusEnum.INVALID_DATA, thumbnail: MediaStatusEnum.INVALID_DATA }
+		};
+
 		const erc721AzukiToken = { ...AZUKI_ELEMENTAL_BEANS_TOKEN, version: BigInt(1), enabled: true };
 		const erc1155NyanCatToken = { ...NYAN_CAT_TOKEN, version: BigInt(1), enabled: true };
 		const mockWalletAddress = mockEthAddress;
@@ -63,6 +100,9 @@ describe('nft.services', () => {
 			vi.clearAllMocks();
 
 			vi.mocked(alchemyProviders).mockReturnValue(mockAlchemyProvider);
+			vi.mocked(infuraErc721Providers).mockReturnValue(mockInfuraErc721Provider);
+			vi.mocked(infuraErc1155Providers).mockReturnValue(mockInfuraErc1155Provider);
+			vi.mocked(getMediaStatusOrCache).mockResolvedValue(MediaStatusEnum.OK);
 		});
 
 		it('should not load NFTs if no tokens were provided', async () => {
@@ -147,6 +187,114 @@ describe('nft.services', () => {
 				`Failed to load NFTs for tokens: ${erc1155NyanCatToken.address} on network: ${mockParams.networkId.toString()}.`,
 				mockError
 			);
+		});
+
+		describe('on-chain media fallback', () => {
+			it('resolves the image from the contract when Alchemy returns no media (ERC721)', async () => {
+				vi.mocked(mockAlchemyProvider.getNftsByOwner).mockResolvedValueOnce([
+					mockErc721NftWithoutImage
+				]);
+				vi.mocked(mockInfuraErc721Provider.getNftMetadata).mockResolvedValueOnce({
+					id: mockErc721NftWithoutImage.id,
+					imageUrl: 'https://arweave.net/on-chain-image'
+				});
+
+				const result = await loadNftsByNetwork({
+					...mockParams,
+					tokens: [erc721AzukiToken],
+					networkId: erc721AzukiToken.network.id
+				});
+
+				expect(mockInfuraErc721Provider.getNftMetadata).toHaveBeenCalledExactlyOnceWith({
+					contractAddress: mockErc721NftWithoutImage.collection.address,
+					tokenId: mockErc721NftWithoutImage.id
+				});
+				expect(result).toStrictEqual([
+					{
+						...mockErc721NftWithoutImage,
+						imageUrl: 'https://arweave.net/on-chain-image',
+						mediaStatus: {
+							image: MediaStatusEnum.OK,
+							thumbnail: MediaStatusEnum.INVALID_DATA
+						}
+					}
+				]);
+			});
+
+			it('resolves the image from the contract when Alchemy returns no media (ERC1155)', async () => {
+				vi.mocked(mockAlchemyProvider.getNftsByOwner).mockResolvedValueOnce([
+					mockErc1155NftWithoutImage
+				]);
+				vi.mocked(mockInfuraErc1155Provider.getNftMetadata).mockResolvedValueOnce({
+					id: mockErc1155NftWithoutImage.id,
+					imageUrl: 'https://arweave.net/on-chain-1155'
+				});
+
+				const result = await loadNftsByNetwork({
+					...mockParams,
+					tokens: [erc1155NyanCatToken],
+					networkId: erc1155NyanCatToken.network.id
+				});
+
+				expect(mockInfuraErc1155Provider.getNftMetadata).toHaveBeenCalledExactlyOnceWith({
+					contractAddress: mockErc1155NftWithoutImage.collection.address,
+					tokenId: mockErc1155NftWithoutImage.id
+				});
+				expect(mockInfuraErc721Provider.getNftMetadata).not.toHaveBeenCalled();
+				expect(result[0].imageUrl).toBe('https://arweave.net/on-chain-1155');
+			});
+
+			it('does not query the contract when Alchemy already returns media', async () => {
+				vi.mocked(mockAlchemyProvider.getNftsByOwner).mockResolvedValueOnce([mockNft1]);
+
+				const result = await loadNftsByNetwork({
+					...mockParams,
+					tokens: [erc721AzukiToken],
+					networkId: erc721AzukiToken.network.id
+				});
+
+				expect(mockInfuraErc721Provider.getNftMetadata).not.toHaveBeenCalled();
+				expect(result).toStrictEqual([mockNft1]);
+			});
+
+			it('leaves the NFT without media when the contract has none either', async () => {
+				vi.mocked(mockAlchemyProvider.getNftsByOwner).mockResolvedValueOnce([
+					mockErc721NftWithoutImage
+				]);
+				vi.mocked(mockInfuraErc721Provider.getNftMetadata).mockResolvedValueOnce({
+					id: mockErc721NftWithoutImage.id
+				});
+
+				const result = await loadNftsByNetwork({
+					...mockParams,
+					tokens: [erc721AzukiToken],
+					networkId: erc721AzukiToken.network.id
+				});
+
+				expect(result).toStrictEqual([mockErc721NftWithoutImage]);
+				expect(getMediaStatusOrCache).not.toHaveBeenCalled();
+			});
+
+			it('keeps the NFT and warns when the contract lookup fails', async () => {
+				const mockError = new Error('tokenURI failed');
+
+				vi.mocked(mockAlchemyProvider.getNftsByOwner).mockResolvedValueOnce([
+					mockErc721NftWithoutImage
+				]);
+				vi.mocked(mockInfuraErc721Provider.getNftMetadata).mockRejectedValueOnce(mockError);
+
+				const result = await loadNftsByNetwork({
+					...mockParams,
+					tokens: [erc721AzukiToken],
+					networkId: erc721AzukiToken.network.id
+				});
+
+				expect(result).toStrictEqual([mockErc721NftWithoutImage]);
+				expect(console.warn).toHaveBeenCalledExactlyOnceWith(
+					`Failed to resolve on-chain media for NFT ${mockErc721NftWithoutImage.id} of token: ${mockErc721NftWithoutImage.collection.address} on network: ${erc721AzukiToken.network.id.toString()}.`,
+					mockError
+				);
+			});
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/nft.services.spec.ts
@@ -3,7 +3,10 @@ import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers'
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
 import { loadNftsByNetwork } from '$eth/services/nft.services';
 import type { EthNonFungibleToken } from '$eth/types/nft';
+import { TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL } from '$lib/constants/analytics.constants';
 import { MediaStatusEnum } from '$lib/enums/media-status';
+import { PLAUSIBLE_EVENT_CONTEXTS, PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
+import { trackEvent } from '$lib/services/analytics.services';
 import type { Nft } from '$lib/types/nft';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { parseNftId } from '$lib/validation/nft.validation';
@@ -29,6 +32,11 @@ vi.mock('$eth/providers/infura-erc1155.providers', () => ({
 vi.mock(import('$lib/utils/nfts.utils'), async (importOriginal) => ({
 	...(await importOriginal()),
 	getMediaStatusOrCache: vi.fn()
+}));
+
+vi.mock(import('$lib/services/analytics.services'), async (importOriginal) => ({
+	...(await importOriginal()),
+	trackEvent: vi.fn()
 }));
 
 describe('nft.services', () => {
@@ -219,6 +227,17 @@ describe('nft.services', () => {
 						}
 					}
 				]);
+				expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+					name: TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL,
+					metadata: {
+						event_context: PLAUSIBLE_EVENT_CONTEXTS.NFT,
+						result_status: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
+						token_network: mockErc721NftWithoutImage.collection.network.name,
+						token_address: mockErc721NftWithoutImage.collection.address,
+						token_standard: mockErc721NftWithoutImage.collection.standard.code,
+						token_id: `${mockErc721NftWithoutImage.id}`
+					}
+				});
 			});
 
 			it('resolves the image from the contract when Alchemy returns no media (ERC1155)', async () => {
@@ -255,6 +274,7 @@ describe('nft.services', () => {
 
 				expect(mockInfuraErc721Provider.getNftMetadata).not.toHaveBeenCalled();
 				expect(result).toStrictEqual([mockNft1]);
+				expect(trackEvent).not.toHaveBeenCalled();
 			});
 
 			it('leaves the NFT without media when the contract has none either', async () => {
@@ -273,6 +293,17 @@ describe('nft.services', () => {
 
 				expect(result).toStrictEqual([mockErc721NftWithoutImage]);
 				expect(getMediaStatusOrCache).not.toHaveBeenCalled();
+				expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+					name: TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL,
+					metadata: {
+						event_context: PLAUSIBLE_EVENT_CONTEXTS.NFT,
+						result_status: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+						token_network: mockErc721NftWithoutImage.collection.network.name,
+						token_address: mockErc721NftWithoutImage.collection.address,
+						token_standard: mockErc721NftWithoutImage.collection.standard.code,
+						token_id: `${mockErc721NftWithoutImage.id}`
+					}
+				});
 			});
 
 			it('keeps the NFT and warns when the contract lookup fails', async () => {
@@ -294,6 +325,17 @@ describe('nft.services', () => {
 					`Failed to resolve on-chain media for NFT ${mockErc721NftWithoutImage.id} of token: ${mockErc721NftWithoutImage.collection.address} on network: ${erc721AzukiToken.network.id.toString()}.`,
 					mockError
 				);
+				expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
+					name: TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL,
+					metadata: {
+						event_context: PLAUSIBLE_EVENT_CONTEXTS.NFT,
+						result_status: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+						token_network: mockErc721NftWithoutImage.collection.network.name,
+						token_address: mockErc721NftWithoutImage.collection.address,
+						token_standard: mockErc721NftWithoutImage.collection.standard.code,
+						token_id: `${mockErc721NftWithoutImage.id}`
+					}
+				});
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

For owned NFTs on EVM chains, OISY takes the media URL from Alchemy's `getNFTsForOwner` (`image.originalUrl`). When Alchemy has not indexed a token's media, it returns no URL — so the NFT renders without an image and the "Media URL" field shows an empty skeleton, even though the token's metadata and image are perfectly reachable on-chain.

This was hit by a real support case (a MANDARADAN token on Base whose Arweave image is live, but which Alchemy does not return media for). OISY already has code to read an NFT's image straight from the contract (`tokenURI`/`uri` → metadata → image) in the Infura ERC721/ERC1155 providers, but `getNftMetadata` there was unused — nothing fell back to it.

# Changes

- `eth/services/nft.services.ts`: after the Alchemy owner-load, for any NFT that came back **without** an `imageUrl`, resolve the image directly from the contract via the existing `infuraErc721Providers` / `infuraErc1155Providers` `getNftMetadata` (picked by collection standard), then recompute `mediaStatus.image`.
- The fallback only fires for NFTs missing media (no extra work for NFTs Alchemy already resolved), and degrades gracefully — on error it keeps the NFT as-is and logs a warning.
- The fallback is resolved in batches of 10 (via the existing `createBatches` helper) rather than one unbounded `Promise.all`, to avoid bursting Infura when many owned NFTs lack Alchemy media (Copilot review).
- Added a Plausible event `nft_load_onchain_image_url`, fired once per on-chain Infura load attempt, with `event_context` (`nft`), `result_status` (`success` when an image url is recovered, `error` otherwise), `token_network`, `token_address`, `token_standard`, `token_symbol` and `token_name` (when the collection exposes them), and `token_id`.

# Tests

- Extended `tests/eth/services/nft.services.spec.ts` (11 cases total):
  - resolves the image from the contract when Alchemy returns no media (ERC721 and ERC1155),
  - does **not** query the contract when Alchemy already returned media,
  - leaves the NFT without media when the contract has none either (and skips the media-status recompute),
  - keeps the NFT and warns when the contract lookup throws,
  - asserts the `nft_load_onchain_image_url` event fires with the right metadata (incl. `token_symbol` / `token_name`) on success/error and not at all when Alchemy already returned media.
- Gates: `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` (0 errors / 0 warnings).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)
