### PR TITLE
feat(frontend): Liquidium Withdraw action

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
+	import LiquidiumWithdrawModal from '$lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { modalLiquidiumWithdraw } from '$lib/derived/modal.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
@@ -18,6 +22,8 @@
 	}
 
 	let { reserve }: Props = $props();
+
+	const modalId = Symbol();
 
 	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
 
@@ -86,5 +92,22 @@
 				{reserve.asset}
 			</span>
 		{/snippet}
+
+		{#snippet action()}
+			<span class="ml-2 flex">
+				<Button
+					colorStyle="secondary-light"
+					onclick={() => modalStore.openLiquidiumWithdraw(modalId)}
+					paddingSmall
+				>
+					{$i18n.liquidium.text.action_withdraw}
+				</Button>
+			</span>
+		{/snippet}
 	</LogoButton>
+
+	<!-- Outside LogoButton's <button> to keep valid HTML. -->
+	{#if $modalLiquidiumWithdraw && $modalStore?.id === modalId}
+		<LiquidiumWithdrawModal {reserve} />
+	{/if}
 </div>

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
+	import LiquidiumHealthFactor from '$lib/components/liquidium/LiquidiumHealthFactor.svelte';
+	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
+	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import Checkbox from '$lib/components/ui/Checkbox.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import type { LiquidiumWithdrawPreview } from '$lib/services/liquidium-withdraw.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { DisplayUnit } from '$lib/types/swap';
+	import type { Token } from '$lib/types/token';
+	import { formatToken } from '$lib/utils/format.utils';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		reserve: LiquidiumReserve;
+		withdrawToken: Token | undefined;
+		withdrawPrice: number;
+		portfolio: LiquidiumPortfolio;
+		preview: LiquidiumWithdrawPreview;
+		amount: OptionAmount;
+		confirmChecked: boolean;
+		onClose: () => void;
+		onNext: () => void;
+	}
+
+	let {
+		reserve,
+		withdrawToken,
+		withdrawPrice,
+		portfolio,
+		preview,
+		amount = $bindable(),
+		confirmChecked = $bindable(),
+		onClose,
+		onNext
+	}: Props = $props();
+
+	let exchangeValueUnit = $state<DisplayUnit>('usd');
+	let inputUnit = $derived<DisplayUnit>(exchangeValueUnit === 'token' ? 'usd' : 'token');
+	let amountSetToMax = $state(false);
+
+	$effect(() => {
+		amount;
+		confirmChecked = false;
+	});
+
+	let hasDebt = $derived(portfolio.totalBorrowedUsd > 0);
+
+	let withdrawCapFromUsd = $derived(
+		nonNullish(withdrawToken) && withdrawPrice > 0 && preview.maxWithdrawableUsd > 0
+			? parseToken({
+					value: (preview.maxWithdrawableUsd / withdrawPrice).toFixed(withdrawToken.decimals),
+					unitName: withdrawToken.decimals
+				})
+			: ZERO
+	);
+
+	let maxWithdrawBaseUnits = $derived(
+		!hasDebt
+			? reserve.deposited
+			: withdrawCapFromUsd < reserve.deposited
+				? withdrawCapFromUsd
+				: reserve.deposited
+	);
+
+	let reservedByDebtBaseUnits = $derived(reserve.deposited - maxWithdrawBaseUnits);
+
+	let parsedAmount = $derived(
+		nonNullish(amount) && !invalidAmount(amount) && nonNullish(withdrawToken)
+			? parseToken({ value: `${amount}`, unitName: withdrawToken.decimals })
+			: undefined
+	);
+
+	let hasAmount = $derived(nonNullish(parsedAmount) && parsedAmount > ZERO);
+
+	let exceedsCap = $derived(
+		hasAmount && nonNullish(parsedAmount) && parsedAmount > maxWithdrawBaseUnits
+	);
+
+	// With debt the cap needs a price to size it; without debt it doesn't.
+	let pricesUnavailable = $derived(hasDebt && withdrawPrice <= 0);
+
+	// Prices unavailable → the cap can't be computed (it collapses to 0); the dedicated
+	// MessageBox explains why, so skip the misleading "exceeds free collateral" inline.
+	const validateWithdrawAmount = (userAmount: bigint): Error | undefined => {
+		if (pricesUnavailable || userAmount <= maxWithdrawBaseUnits) {
+			return undefined;
+		}
+
+		return new Error(
+			hasDebt
+				? $i18n.liquidium.text.withdraw_exceeds_free_collateral
+				: $i18n.liquidium.text.withdraw_exceeds_supplied
+		);
+	};
+
+	let needsConfirm = $derived(hasAmount && !exceedsCap && preview.healthLevel !== 'healthy');
+
+	let canReview = $derived(
+		hasAmount && !exceedsCap && !pricesUnavailable && (!needsConfirm || confirmChecked)
+	);
+
+	let suppliedFormatted = $derived(
+		nonNullish(withdrawToken)
+			? `${formatToken({ value: reserve.deposited, unitName: reserve.depositedDecimals })} ${reserve.asset}`
+			: ''
+	);
+
+	let reservedFormatted = $derived(
+		nonNullish(withdrawToken)
+			? `${formatToken({ value: reservedByDebtBaseUnits, unitName: reserve.depositedDecimals })} ${reserve.asset}`
+			: ''
+	);
+</script>
+
+<ContentWithToolbar>
+	<div class="mb-6">
+		<TokenInput
+			displayUnit={inputUnit}
+			exchangeRate={withdrawPrice}
+			isSelectable={false}
+			onCustomErrorValidate={validateWithdrawAmount}
+			showTokenNetwork
+			token={withdrawToken}
+			bind:amount
+		>
+			{#snippet title()}{$i18n.core.text.amount}{/snippet}
+
+			{#snippet amountInfo()}
+				<div class="text-tertiary">
+					<TokenInputAmountExchange
+						{amount}
+						exchangeRate={withdrawPrice}
+						token={withdrawToken}
+						bind:displayUnit={exchangeValueUnit}
+					/>
+				</div>
+			{/snippet}
+
+			{#snippet balance()}
+				<MaxBalanceButton
+					balance={maxWithdrawBaseUnits}
+					token={withdrawToken}
+					bind:amount
+					bind:amountSetToMax
+				/>
+			{/snippet}
+		</TokenInput>
+	</div>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.supplied_label}{/snippet}
+		{#snippet mainValue()}{suppliedFormatted}{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.reserved_by_debt}{/snippet}
+		{#snippet mainValue()}{reservedFormatted}{/snippet}
+	</ModalValue>
+
+	<LiquidiumHealthFactor percent={preview.projectedHealthPercent} />
+
+	{#if pricesUnavailable}
+		<MessageBox level="warning" styleClass="mt-3">
+			{$i18n.liquidium.text.withdraw_prices_unavailable}
+		</MessageBox>
+	{/if}
+
+	{#if needsConfirm}
+		<MessageBox level={preview.healthLevel === 'critical' ? 'error' : 'warning'} styleClass="mt-3">
+			<div class="flex flex-col gap-3">
+				<span>
+					{preview.healthLevel === 'critical'
+						? $i18n.liquidium.text.withdraw_high_risk_warning
+						: $i18n.liquidium.text.withdraw_at_risk_warning}
+				</span>
+
+				<label class="flex cursor-pointer items-start gap-3">
+					<Checkbox
+						checked={confirmChecked}
+						inputId="liquidium-withdraw-confirm"
+						onChange={() => (confirmChecked = !confirmChecked)}
+					/>
+					<span class="text-sm">{$i18n.liquidium.text.withdraw_risk_confirm}</span>
+				</label>
+			</div>
+		</MessageBox>
+	{/if}
+
+	<p class="mt-4 text-sm text-tertiary">{$i18n.liquidium.text.withdraw_risk_info}</p>
+
+	{#snippet toolbar()}
+		<ButtonGroup>
+			<ButtonCancel onclick={onClose} />
+
+			<Button disabled={!canReview} onclick={onNext}>
+				{$i18n.send.text.review}
+			</Button>
+		</ButtonGroup>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import { WizardModal, type WizardStep, type WizardSteps } from '@dfinity/gix-components';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import LiquidiumWithdrawForm from '$lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte';
+	import LiquidiumWithdrawProgress from '$lib/components/liquidium/withdraw/LiquidiumWithdrawProgress.svelte';
+	import LiquidiumWithdrawReview from '$lib/components/liquidium/withdraw/LiquidiumWithdrawReview.svelte';
+	import { liquidiumWithdrawWizardSteps } from '$lib/config/lend-borrow.config';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { btcAddressMainnet, ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { liquidiumAssetPrices, liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { ProgressStepsLiquidiumWithdraw } from '$lib/enums/progress-steps';
+	import { WizardStepsLiquidiumWithdraw } from '$lib/enums/wizard-steps';
+	import {
+		computeLiquidiumWithdrawPreview,
+		executeLiquidiumWithdraw
+	} from '$lib/services/liquidium-withdraw.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import type { LiquidiumReserve } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { closeModal } from '$lib/utils/modal.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		reserve: LiquidiumReserve;
+	}
+
+	let { reserve }: Props = $props();
+
+	let modal: WizardModal<WizardStepsLiquidiumWithdraw> | undefined = $state();
+	let currentStep: WizardStep<WizardStepsLiquidiumWithdraw> | undefined = $state();
+	let amount: OptionAmount = $state();
+	let confirmChecked = $state(false);
+	let withdrawProgressStep: string = $state(ProgressStepsLiquidiumWithdraw.INITIALIZATION);
+
+	const steps: WizardSteps<WizardStepsLiquidiumWithdraw> = $derived(
+		liquidiumWithdrawWizardSteps({ i18n: $i18n })
+	);
+
+	let withdrawToken = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+	let withdrawPrice = $derived($liquidiumAssetPrices[reserve.asset] ?? 0);
+
+	let withdrawUsd = $derived((Number(amount) || 0) * withdrawPrice);
+
+	let preview = $derived(
+		nonNullish($liquidiumPortfolio)
+			? computeLiquidiumWithdrawPreview({ portfolio: $liquidiumPortfolio, reserve, withdrawUsd })
+			: undefined
+	);
+
+	let parsedAmount = $derived(
+		nonNullish(amount) && !invalidAmount(amount) && nonNullish(withdrawToken)
+			? parseToken({ value: `${amount}`, unitName: withdrawToken.decimals })
+			: undefined
+	);
+
+	let receiverAddress = $derived(reserve.chain === 'BTC' ? $btcAddressMainnet : $ethAddress);
+
+	const reset = () => {
+		amount = undefined;
+		confirmChecked = false;
+		withdrawProgressStep = ProgressStepsLiquidiumWithdraw.INITIALIZATION;
+		currentStep = undefined;
+	};
+
+	const close = () => closeModal(reset);
+
+	const withdraw = async () => {
+		const identity = $authIdentity;
+
+		if (
+			isNullish(identity) ||
+			isNullish($ethAddress) ||
+			isNullish(receiverAddress) ||
+			isNullish(parsedAmount)
+		) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed } });
+			return;
+		}
+
+		const amountBaseUnits = parsedAmount;
+		const receiver = receiverAddress;
+
+		modal?.next();
+
+		try {
+			await executeLiquidiumWithdraw({
+				identity,
+				ethAddress: $ethAddress,
+				poolId: reserve.poolId,
+				asset: reserve.asset,
+				amount: amountBaseUnits,
+				receiverAddress: receiver,
+				displayAmount: `${amount}`,
+				progress: (step) => (withdrawProgressStep = step)
+			});
+
+			withdrawProgressStep = ProgressStepsLiquidiumWithdraw.DONE;
+
+			setTimeout(close, 750);
+		} catch (err: unknown) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed }, err });
+
+			modal?.back();
+		}
+	};
+</script>
+
+<WizardModal
+	bind:this={modal}
+	disablePointerEvents={currentStep?.name === WizardStepsLiquidiumWithdraw.WITHDRAWING}
+	onClose={close}
+	{steps}
+	bind:currentStep
+>
+	{#snippet title()}{currentStep?.title ?? ''}{/snippet}
+
+	{#if nonNullish($liquidiumPortfolio) && nonNullish(preview)}
+		{#if currentStep?.name === WizardStepsLiquidiumWithdraw.REVIEW}
+			<LiquidiumWithdrawReview
+				{amount}
+				onBack={() => modal?.back()}
+				onConfirm={withdraw}
+				{preview}
+				{reserve}
+				{withdrawPrice}
+			/>
+		{:else if currentStep?.name === WizardStepsLiquidiumWithdraw.WITHDRAWING}
+			<LiquidiumWithdrawProgress {withdrawProgressStep} />
+		{:else}
+			<LiquidiumWithdrawForm
+				onClose={close}
+				onNext={() => modal?.next()}
+				portfolio={$liquidiumPortfolio}
+				{preview}
+				{reserve}
+				{withdrawPrice}
+				{withdrawToken}
+				bind:amount
+				bind:confirmChecked
+			/>
+		{/if}
+	{/if}
+</WizardModal>

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawProgress.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawProgress.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
+	import { ProgressStepsLiquidiumWithdraw } from '$lib/enums/progress-steps';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { ProgressSteps } from '$lib/types/progress-steps';
+
+	interface Props {
+		withdrawProgressStep: string;
+	}
+
+	let { withdrawProgressStep }: Props = $props();
+
+	let steps = $state<ProgressSteps>([
+		{
+			step: ProgressStepsLiquidiumWithdraw.INITIALIZATION,
+			text: $i18n.send.text.initializing,
+			state: 'in_progress'
+		},
+		{
+			step: ProgressStepsLiquidiumWithdraw.SUBMIT,
+			text: $i18n.liquidium.text.starting_to_withdraw,
+			state: 'next'
+		},
+		{
+			step: ProgressStepsLiquidiumWithdraw.REGISTER,
+			text: $i18n.liquidium.text.withdraw_started,
+			state: 'next'
+		}
+	]);
+</script>
+
+<InProgressWizard progressStep={withdrawProgressStep} {steps} />

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawReview.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawReview.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import type { LiquidiumWithdrawPreview } from '$lib/services/liquidium-withdraw.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { LendBorrowProvider } from '$lib/types/lend-borrow';
+	import type { LiquidiumReserve } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+
+	interface Props {
+		reserve: LiquidiumReserve;
+		withdrawPrice: number;
+		preview: LiquidiumWithdrawPreview;
+		amount: OptionAmount;
+		onBack: () => void;
+		onConfirm: () => void;
+	}
+
+	let { reserve, withdrawPrice, preview, amount, onBack, onConfirm }: Props = $props();
+
+	const liquidium = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM];
+
+	let withdrawToken = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+	let healthLevel = $derived(preview.healthLevel);
+</script>
+
+<ContentWithToolbar>
+	{#if nonNullish(withdrawToken)}
+		<SendTokenReview exchangeRate={withdrawPrice} sendAmount={amount} token={withdrawToken}>
+			{#snippet subtitle()}{$i18n.liquidium.text.withdraw_review_subtitle}{/snippet}
+		</SendTokenReview>
+	{/if}
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.projected_health_factor}{/snippet}
+		{#snippet mainValue()}
+			<span
+				class:text-error-primary={healthLevel === 'critical'}
+				class:text-success-primary={healthLevel === 'healthy'}
+				class:text-warning-primary={healthLevel === 'at-risk'}
+			>
+				{Math.round(preview.projectedHealthPercent)}%
+			</span>
+		{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.funds_delivered_to}{/snippet}
+		{#snippet mainValue()}{replaceOisyPlaceholders(
+				$i18n.liquidium.text.your_oisy_address
+			)}{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.provider}{/snippet}
+		{#snippet mainValue()}{liquidium.name}{/snippet}
+	</ModalValue>
+
+	{#if healthLevel === 'critical'}
+		<MessageBox level="error" styleClass="mt-4">
+			{$i18n.liquidium.text.withdraw_high_risk_warning}
+		</MessageBox>
+	{:else if healthLevel === 'at-risk'}
+		<MessageBox level="warning" styleClass="mt-4">
+			{$i18n.liquidium.text.withdraw_at_risk_warning}
+		</MessageBox>
+	{/if}
+
+	{#snippet toolbar()}
+		<ButtonGroup>
+			<ButtonBack onclick={onBack} />
+
+			<Button onclick={onConfirm}>
+				{$i18n.liquidium.text.action_withdraw}
+			</Button>
+		</ButtonGroup>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/config/lend-borrow.config.ts
+++ b/src/frontend/src/lib/config/lend-borrow.config.ts
@@ -1,4 +1,8 @@
-import { WizardStepsLiquidiumBorrow, WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import {
+	WizardStepsLiquidiumBorrow,
+	WizardStepsLiquidiumSupply,
+	WizardStepsLiquidiumWithdraw
+} from '$lib/enums/wizard-steps';
 import { LendBorrowProvider, type LendBorrowProviderConfig } from '$lib/types/lend-borrow';
 import type { WizardStepsParams } from '$lib/types/steps';
 import type { WizardSteps } from '@dfinity/gix-components';
@@ -45,5 +49,22 @@ export const liquidiumBorrowWizardSteps = ({
 	{
 		name: WizardStepsLiquidiumBorrow.BORROWING,
 		title: i18n.liquidium.text.borrowing
+	}
+];
+
+export const liquidiumWithdrawWizardSteps = ({
+	i18n
+}: WizardStepsParams): WizardSteps<WizardStepsLiquidiumWithdraw> => [
+	{
+		name: WizardStepsLiquidiumWithdraw.WITHDRAW,
+		title: i18n.liquidium.text.action_withdraw
+	},
+	{
+		name: WizardStepsLiquidiumWithdraw.REVIEW,
+		title: i18n.liquidium.text.withdraw_review
+	},
+	{
+		name: WizardStepsLiquidiumWithdraw.WITHDRAWING,
+		title: i18n.liquidium.text.withdrawing
 	}
 ];

--- a/src/frontend/src/lib/constants/liquidium.constants.ts
+++ b/src/frontend/src/lib/constants/liquidium.constants.ts
@@ -42,5 +42,8 @@ export type LiquidiumHealthLevel = 'healthy' | 'at-risk' | 'critical';
 // token's decimals) doesn't trip its own limit.
 export const LIQUIDIUM_BORROWING_POWER_TOLERANCE = 1e-6;
 
+// Withdraw free-collateral cap tolerance, so a "Max" amount doesn't flag itself.
+export const LIQUIDIUM_WITHDRAW_CAP_TOLERANCE = 1e-6;
+
 // Refresh cadence for markets + positions while the provider page is visible.
 export const LIQUIDIUM_POLL_INTERVAL_MILLIS = 30_000;

--- a/src/frontend/src/lib/derived/modal.derived.ts
+++ b/src/frontend/src/lib/derived/modal.derived.ts
@@ -75,6 +75,10 @@ export const modalLiquidiumBorrow: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'liquidium-borrow'
 );
+export const modalLiquidiumWithdraw: Readable<boolean> = derived(
+	modalStore,
+	($modalStore) => $modalStore?.type === 'liquidium-withdraw'
+);
 export const modalTradingDeposit: Readable<boolean> = derived(
 	modalStore,
 	($modalStore) => $modalStore?.type === 'trading-deposit'

--- a/src/frontend/src/lib/enums/progress-steps.ts
+++ b/src/frontend/src/lib/enums/progress-steps.ts
@@ -133,6 +133,13 @@ export enum ProgressStepsLiquidiumBorrow {
 	DONE = 'done'
 }
 
+export enum ProgressStepsLiquidiumWithdraw {
+	INITIALIZATION = 'initialization',
+	SUBMIT = 'submit',
+	REGISTER = 'register',
+	DONE = 'done'
+}
+
 export enum ProgressStepsClaimStakingReward {
 	INITIALIZATION = 'initialization',
 	CLAIM = 'claim',

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -99,6 +99,12 @@ export enum WizardStepsLiquidiumBorrow {
 	BORROWING = 'Borrowing'
 }
 
+export enum WizardStepsLiquidiumWithdraw {
+	WITHDRAW = 'Withdraw',
+	REVIEW = 'Review',
+	WITHDRAWING = 'Withdrawing'
+}
+
 export enum WizardStepsClaimStakingReward {
 	REVIEW = 'Review',
 	CLAIMING = 'Claiming'

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "This borrow puts your position close to liquidation.",
 			"borrow_risk_confirm": "I understand this borrow increases my liquidation risk.",
 			"starting_to_borrow": "Submitting your loan...",
-			"borrow_started": "The loan is now being activated."
+			"borrow_started": "The loan is now being activated.",
+			"withdraw_review": "Review withdraw",
+			"withdraw_review_subtitle": "You withdraw",
+			"withdrawing": "Withdrawing",
+			"starting_to_withdraw": "Submitting your withdrawal...",
+			"withdraw_started": "The withdrawal is now being processed.",
+			"supplied_label": "Supplied",
+			"withdrawable": "Withdrawable",
+			"reserved_by_debt": "Reserved by open debt",
+			"withdraw_exceeds_free_collateral": "Cannot withdraw more than your free collateral while debt is open.",
+			"withdraw_exceeds_supplied": "Amount exceeds your supplied balance.",
+			"withdraw_prices_unavailable": "Prices are temporarily unavailable. Withdrawing is disabled until they load.",
+			"withdraw_risk_info": "Withdrawing collateral lowers your health factor. If it falls too far your remaining collateral can be liquidated.",
+			"withdraw_at_risk_warning": "This withdrawal noticeably lowers your health factor.",
+			"withdraw_high_risk_warning": "This withdrawal puts your position close to liquidation.",
+			"withdraw_risk_confirm": "I understand this withdrawal increases my liquidation risk."
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2172,7 +2172,22 @@
 			"borrow_high_risk_warning": "",
 			"borrow_risk_confirm": "",
 			"starting_to_borrow": "",
-			"borrow_started": ""
+			"borrow_started": "",
+			"withdraw_review": "",
+			"withdraw_review_subtitle": "",
+			"withdrawing": "",
+			"starting_to_withdraw": "",
+			"withdraw_started": "",
+			"supplied_label": "",
+			"withdrawable": "",
+			"reserved_by_debt": "",
+			"withdraw_exceeds_free_collateral": "",
+			"withdraw_exceeds_supplied": "",
+			"withdraw_prices_unavailable": "",
+			"withdraw_risk_info": "",
+			"withdraw_at_risk_warning": "",
+			"withdraw_high_risk_warning": "",
+			"withdraw_risk_confirm": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/services/liquidium-withdraw.services.ts
+++ b/src/frontend/src/lib/services/liquidium-withdraw.services.ts
@@ -1,0 +1,151 @@
+import type { EthAddress } from '$eth/types/address';
+import { liquidiumClient } from '$lib/api/liquidium.api';
+import { TRACK_COUNT_LIQUIDIUM_SUBMITTED } from '$lib/constants/analytics.constants';
+import {
+	LIQUIDIUM_WITHDRAW_CAP_TOLERANCE,
+	type LiquidiumHealthLevel
+} from '$lib/constants/liquidium.constants';
+import { ProgressStepsLiquidiumWithdraw } from '$lib/enums/progress-steps';
+import { createActiveUserTransaction } from '$lib/services/active-user-transactions.services';
+import { trackEvent } from '$lib/services/analytics.services';
+import { liquidiumWalletAdapter } from '$lib/services/liquidium-wallet-adapter.services';
+import { getOrCreateLiquidiumProfile } from '$lib/services/liquidium.services';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { consoleError } from '$lib/utils/console.utils';
+import {
+	liquidiumTrackingMetadata,
+	toLiquidiumExternalRefs
+} from '$lib/utils/liquidium-active-tx.utils';
+import {
+	liquidiumAssetTokenId,
+	liquidiumFreeCollateralUsd,
+	liquidiumHealthLevel,
+	liquidiumProjectedHealthAfterWithdrawPercent
+} from '$lib/utils/liquidium.utils';
+import { nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { Chain } from '@liquidium/client';
+
+export interface LiquidiumWithdrawPreview {
+	projectedHealthPercent: number;
+	healthLevel: LiquidiumHealthLevel;
+	maxWithdrawableUsd: number;
+	reservedByDebtUsd: number;
+	valid: boolean;
+}
+
+export const computeLiquidiumWithdrawPreview = ({
+	portfolio,
+	reserve,
+	withdrawUsd
+}: {
+	portfolio: LiquidiumPortfolio;
+	reserve: LiquidiumReserve;
+	withdrawUsd: number;
+}): LiquidiumWithdrawPreview => {
+	const freeCollateralUsd = liquidiumFreeCollateralUsd({
+		totalCollateralUsd: portfolio.totalSuppliedUsd,
+		totalDebtUsd: portfolio.totalBorrowedUsd,
+		weightedLiquidationThresholdBps: portfolio.weightedLiquidationThresholdBps
+	});
+
+	const maxWithdrawableUsd = Math.min(reserve.suppliedUsd, freeCollateralUsd);
+	const reservedByDebtUsd = Math.max(0, reserve.suppliedUsd - maxWithdrawableUsd);
+
+	const projectedHealthPercent = liquidiumProjectedHealthAfterWithdrawPercent({
+		totalCollateralUsd: portfolio.totalSuppliedUsd,
+		totalDebtUsd: portfolio.totalBorrowedUsd,
+		withdrawUsd,
+		weightedLiquidationThresholdBps: portfolio.weightedLiquidationThresholdBps
+	});
+
+	const exceedsFreeCollateral =
+		withdrawUsd > maxWithdrawableUsd * (1 + LIQUIDIUM_WITHDRAW_CAP_TOLERANCE);
+
+	return {
+		projectedHealthPercent,
+		healthLevel: liquidiumHealthLevel(projectedHealthPercent),
+		maxWithdrawableUsd,
+		reservedByDebtUsd,
+		valid: !exceedsFreeCollateral
+	};
+};
+
+export const executeLiquidiumWithdraw = async ({
+	identity,
+	ethAddress,
+	poolId,
+	asset,
+	amount,
+	receiverAddress,
+	displayAmount,
+	progressStep,
+	progress
+}: {
+	identity: Identity;
+	ethAddress: EthAddress;
+	poolId: string;
+	asset: string;
+	amount: bigint;
+	receiverAddress: string;
+	displayAmount: string;
+	progressStep?: string;
+	progress?: (step: ProgressStepsLiquidiumWithdraw) => void;
+}): Promise<void> => {
+	progress?.(ProgressStepsLiquidiumWithdraw.INITIALIZATION);
+
+	const profileId = await getOrCreateLiquidiumProfile({ identity, ethAddress });
+
+	progress?.(ProgressStepsLiquidiumWithdraw.SUBMIT);
+
+	// Correlate by receipt `id`; `txid` may be assigned later.
+	const receipt = await liquidiumClient({ identity }).lending.withdraw({
+		profileId,
+		poolId,
+		amount,
+		receiverAddress,
+		signerWalletAddress: ethAddress,
+		signerChain: Chain.ETH,
+		signerWalletAdapter: liquidiumWalletAdapter({ identity })
+	});
+
+	trackEvent({
+		name: TRACK_COUNT_LIQUIDIUM_SUBMITTED,
+		metadata: liquidiumTrackingMetadata({
+			action: 'withdraw',
+			token: asset,
+			tokenAmount: displayAmount
+		})
+	});
+
+	progress?.(ProgressStepsLiquidiumWithdraw.REGISTER);
+
+	// Best-effort: withdraw is committed, so a bookkeeping failure must not fail it.
+	try {
+		await createActiveUserTransaction({
+			identity,
+			id: crypto.randomUUID(),
+			data: {
+				Liquidium: {
+					token: liquidiumAssetTokenId(asset),
+					action: { Withdraw: null },
+					pool_id: poolId,
+					amount
+				}
+			},
+			...(nonNullish(progressStep) ? { progressStep } : {}),
+			externalRefs: toLiquidiumExternalRefs({
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID]: profileId,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.OUTFLOW_ID]: receipt.id,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.AMOUNT]: displayAmount,
+				[LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL]: asset,
+				...(nonNullish(receipt.txid) ? { [LIQUIDIUM_EXTERNAL_REF_KEYS.TXID]: receipt.txid } : {})
+			})
+		});
+	} catch (err: unknown) {
+		consoleError(err);
+	}
+
+	progress?.(ProgressStepsLiquidiumWithdraw.DONE);
+};

--- a/src/frontend/src/lib/stores/modal.store.ts
+++ b/src/frontend/src/lib/stores/modal.store.ts
@@ -72,6 +72,7 @@ export interface Modal<T> {
 		| 'harvest-unstake'
 		| 'liquidium-supply'
 		| 'liquidium-borrow'
+		| 'liquidium-withdraw'
 		| 'trading-deposit'
 		| 'universal-scanner'
 		| 'pay-dialog'
@@ -146,6 +147,7 @@ export interface ModalStore<T> extends Readable<ModalData<T>> {
 	openHarvestUnstake: (id: symbol) => void;
 	openLiquidiumSupply: (id: symbol) => void;
 	openLiquidiumBorrow: (id: symbol) => void;
+	openLiquidiumWithdraw: (id: symbol) => void;
 	openTradingDeposit: (id: symbol) => void;
 	openUniversalScanner: (params: SetWithOptionalDataParams<UniversalScannerData>) => void;
 	openPayDialog: (id: symbol) => void;
@@ -258,6 +260,7 @@ const initModalStore = <T>(): ModalStore<T> => {
 		openHarvestUnstake: setType('harvest-unstake'),
 		openLiquidiumSupply: setType('liquidium-supply'),
 		openLiquidiumBorrow: setType('liquidium-borrow'),
+		openLiquidiumWithdraw: setType('liquidium-withdraw'),
 		openTradingDeposit: setType('trading-deposit'),
 		openUniversalScanner: <(params: SetWithOptionalDataParams<UniversalScannerData>) => void>(
 			setTypeWithData('universal-scanner')

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1704,6 +1704,21 @@ interface I18nLiquidium {
 		borrow_risk_confirm: string;
 		starting_to_borrow: string;
 		borrow_started: string;
+		withdraw_review: string;
+		withdraw_review_subtitle: string;
+		withdrawing: string;
+		starting_to_withdraw: string;
+		withdraw_started: string;
+		supplied_label: string;
+		withdrawable: string;
+		reserved_by_debt: string;
+		withdraw_exceeds_free_collateral: string;
+		withdraw_exceeds_supplied: string;
+		withdraw_prices_unavailable: string;
+		withdraw_risk_info: string;
+		withdraw_at_risk_warning: string;
+		withdraw_high_risk_warning: string;
+		withdraw_risk_confirm: string;
 	};
 }
 

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -91,6 +91,59 @@ export const liquidiumProjectedHealthPercent = ({
 	return Math.min(100, Math.max(0, currentHealthPercent - marginalPercent));
 };
 
+// Free collateral USD: max(0, collateral − debt / threshold); full collateral when no debt.
+// Open debt with a zero threshold (edge payload) → fully reserved.
+export const liquidiumFreeCollateralUsd = ({
+	totalCollateralUsd,
+	totalDebtUsd,
+	weightedLiquidationThresholdBps
+}: {
+	totalCollateralUsd: number;
+	totalDebtUsd: number;
+	weightedLiquidationThresholdBps: number;
+}): number => {
+	if (totalDebtUsd <= 0) {
+		return Math.max(0, totalCollateralUsd);
+	}
+
+	const thresholdRatio = weightedLiquidationThresholdBps / 10_000;
+
+	if (thresholdRatio <= 0) {
+		return 0;
+	}
+
+	return Math.max(0, totalCollateralUsd - totalDebtUsd / thresholdRatio);
+};
+
+// Projected health after removing `withdrawUsd` of collateral: (1 − ltv / threshold) × 100,
+// clamped. Threshold held constant (v1 approximation; canister is the final gate).
+export const liquidiumProjectedHealthAfterWithdrawPercent = ({
+	totalCollateralUsd,
+	totalDebtUsd,
+	withdrawUsd,
+	weightedLiquidationThresholdBps
+}: {
+	totalCollateralUsd: number;
+	totalDebtUsd: number;
+	withdrawUsd: number;
+	weightedLiquidationThresholdBps: number;
+}): number => {
+	if (totalDebtUsd <= 0) {
+		return 100;
+	}
+
+	const remainingCollateralUsd = totalCollateralUsd - withdrawUsd;
+	const thresholdRatio = weightedLiquidationThresholdBps / 10_000;
+
+	if (remainingCollateralUsd <= 0 || thresholdRatio <= 0) {
+		return 0;
+	}
+
+	const resultingLtv = totalDebtUsd / remainingCollateralUsd;
+
+	return Math.min(100, Math.max(0, (1 - resultingLtv / thresholdRatio) * 100));
+};
+
 const isUnderSupplyCap = ({ totalSupply, supplyCap }: Pool): boolean =>
 	!nonNullish(supplyCap) || totalSupply < supplyCap;
 

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
@@ -1,9 +1,12 @@
 import LiquidiumPositionCard from '$lib/components/liquidium/LiquidiumPositionCard.svelte';
 import { ZERO } from '$lib/constants/app.constants';
+import { modalLiquidiumWithdraw } from '$lib/derived/modal.derived';
+import { modalStore } from '$lib/stores/modal.store';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 
 describe('LiquidiumPositionCard', () => {
 	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
@@ -45,5 +48,17 @@ describe('LiquidiumPositionCard', () => {
 		});
 
 		expect(container).toHaveTextContent(`${formatStakeApyNumber(0)}%`);
+	});
+
+	it('opens the withdraw modal from the Withdraw button', async () => {
+		modalStore.close();
+
+		const { getByRole } = render(LiquidiumPositionCard, { props: { reserve: reserve() } });
+
+		await fireEvent.click(getByRole('button', { name: en.liquidium.text.action_withdraw }));
+
+		expect(get(modalLiquidiumWithdraw)).toBeTruthy();
+
+		modalStore.close();
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawForm.spec.ts
@@ -1,0 +1,130 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumWithdrawForm from '$lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import type { LiquidiumWithdrawPreview } from '$lib/services/liquidium-withdraw.services';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('LiquidiumWithdrawForm', () => {
+	const reserve: LiquidiumReserve = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 0,
+		// 1 BTC in satoshis.
+		deposited: 100_000_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 100_000,
+		borrowedUsd: 0
+	};
+
+	const portfolio = (overrides: Partial<LiquidiumPortfolio> = {}): LiquidiumPortfolio => ({
+		reserves: [],
+		totalSuppliedUsd: 100_000,
+		totalBorrowedUsd: 0,
+		netValueUsd: 100_000,
+		availableBorrowsUsd: 80_000,
+		weightedLiquidationThresholdBps: 8000,
+		healthFactorPercent: 100,
+		...overrides
+	});
+
+	const preview = (
+		overrides: Partial<LiquidiumWithdrawPreview> = {}
+	): LiquidiumWithdrawPreview => ({
+		projectedHealthPercent: 100,
+		healthLevel: 'healthy',
+		maxWithdrawableUsd: 100_000,
+		reservedByDebtUsd: 0,
+		valid: true,
+		...overrides
+	});
+
+	const baseProps = {
+		reserve,
+		withdrawToken: BTC_MAINNET_TOKEN,
+		withdrawPrice: 60_000,
+		portfolio: portfolio(),
+		preview: preview(),
+		amount: undefined,
+		confirmChecked: false,
+		onClose: () => {},
+		onNext: () => {}
+	};
+
+	const reviewButton = (getByRole: ReturnType<typeof render>['getByRole']) =>
+		getByRole('button', { name: en.send.text.review });
+
+	it('renders the supplied context and risk line', () => {
+		const { container } = render(LiquidiumWithdrawForm, { props: baseProps });
+
+		expect(container).toHaveTextContent(en.liquidium.text.supplied_label);
+		expect(container).toHaveTextContent(en.liquidium.text.withdraw_risk_info);
+	});
+
+	it('disables Review with no amount entered', () => {
+		const { getByRole } = render(LiquidiumWithdrawForm, { props: baseProps });
+
+		expect(reviewButton(getByRole)).toBeDisabled();
+	});
+
+	it('enables Review for a valid amount with a healthy projection', () => {
+		const { getByRole } = render(LiquidiumWithdrawForm, {
+			props: { ...baseProps, amount: 0.5 }
+		});
+
+		expect(reviewButton(getByRole)).toBeEnabled();
+	});
+
+	it('requires confirmation for a non-healthy projection before Review', async () => {
+		const { container, getByRole } = render(LiquidiumWithdrawForm, {
+			props: {
+				...baseProps,
+				amount: 0.5,
+				portfolio: portfolio({ totalBorrowedUsd: 20_000 }),
+				preview: preview({ healthLevel: 'at-risk', projectedHealthPercent: 30 })
+			}
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.withdraw_at_risk_warning);
+		expect(container).toHaveTextContent(en.liquidium.text.withdraw_risk_confirm);
+		expect(reviewButton(getByRole)).toBeDisabled();
+
+		await fireEvent.click(getByRole('checkbox'));
+
+		expect(reviewButton(getByRole)).toBeEnabled();
+	});
+
+	it('shows the reserved-by-debt line when collateral is pledged', () => {
+		const { container } = render(LiquidiumWithdrawForm, {
+			props: {
+				...baseProps,
+				portfolio: portfolio({ totalBorrowedUsd: 20_000 }),
+				preview: preview({ maxWithdrawableUsd: 30_000, reservedByDebtUsd: 70_000 })
+			}
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.reserved_by_debt);
+	});
+
+	it('blocks withdrawing and warns when the price is unavailable with open debt', () => {
+		const { container, getByRole } = render(LiquidiumWithdrawForm, {
+			props: {
+				...baseProps,
+				amount: 0.5,
+				withdrawPrice: 0,
+				portfolio: portfolio({ totalBorrowedUsd: 20_000 }),
+				preview: preview({ maxWithdrawableUsd: 30_000 })
+			}
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.withdraw_prices_unavailable);
+		expect(reviewButton(getByRole)).toBeDisabled();
+		// The dedicated warning explains the blocker; the cap-based error must not be shown.
+		expect(container).not.toHaveTextContent(en.liquidium.text.withdraw_exceeds_free_collateral);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawReview.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawReview.spec.ts
@@ -1,0 +1,82 @@
+import LiquidiumWithdrawReview from '$lib/components/liquidium/withdraw/LiquidiumWithdrawReview.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import type { LiquidiumWithdrawPreview } from '$lib/services/liquidium-withdraw.services';
+import type { LiquidiumReserve } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumWithdrawReview', () => {
+	const reserve: LiquidiumReserve = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 0,
+		deposited: 100_000_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 100_000,
+		borrowedUsd: 0
+	};
+
+	const preview = (
+		overrides: Partial<LiquidiumWithdrawPreview> = {}
+	): LiquidiumWithdrawPreview => ({
+		projectedHealthPercent: 70,
+		healthLevel: 'healthy',
+		maxWithdrawableUsd: 100_000,
+		reservedByDebtUsd: 0,
+		valid: true,
+		...overrides
+	});
+
+	const baseProps = {
+		reserve,
+		withdrawPrice: 60_000,
+		amount: 0.5,
+		onBack: () => {},
+		onConfirm: () => {}
+	};
+
+	it('renders the provider, projected health and funds destination', () => {
+		const { container } = render(LiquidiumWithdrawReview, {
+			props: { ...baseProps, preview: preview() }
+		});
+
+		expect(container).toHaveTextContent('Liquidium');
+		expect(container).toHaveTextContent(en.liquidium.text.projected_health_factor);
+		expect(container).toHaveTextContent(en.liquidium.text.funds_delivered_to);
+	});
+
+	it('shows no risk warning for a healthy projection', () => {
+		const { container } = render(LiquidiumWithdrawReview, {
+			props: { ...baseProps, preview: preview() }
+		});
+
+		expect(container).not.toHaveTextContent(en.liquidium.text.withdraw_at_risk_warning);
+		expect(container).not.toHaveTextContent(en.liquidium.text.withdraw_high_risk_warning);
+	});
+
+	it('shows the at-risk warning for an at-risk projection', () => {
+		const { container } = render(LiquidiumWithdrawReview, {
+			props: {
+				...baseProps,
+				preview: preview({ healthLevel: 'at-risk', projectedHealthPercent: 30 })
+			}
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.withdraw_at_risk_warning);
+	});
+
+	it('shows the high-risk warning for a critical projection', () => {
+		const { container } = render(LiquidiumWithdrawReview, {
+			props: {
+				...baseProps,
+				preview: preview({ healthLevel: 'critical', projectedHealthPercent: 5 })
+			}
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.withdraw_high_risk_warning);
+	});
+});

--- a/src/frontend/src/tests/lib/services/liquidium-withdraw.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-withdraw.services.spec.ts
@@ -1,0 +1,226 @@
+import type { EthAddress } from '$eth/types/address';
+import * as liquidiumApi from '$lib/api/liquidium.api';
+import { TRACK_COUNT_LIQUIDIUM_SUBMITTED } from '$lib/constants/analytics.constants';
+import { ZERO } from '$lib/constants/app.constants';
+import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
+import * as analyticsServices from '$lib/services/analytics.services';
+import {
+	computeLiquidiumWithdrawPreview,
+	executeLiquidiumWithdraw
+} from '$lib/services/liquidium-withdraw.services';
+import * as liquidiumServices from '$lib/services/liquidium.services';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+
+vi.mock('$lib/api/liquidium.api', () => ({ liquidiumClient: vi.fn() }));
+vi.mock('$lib/services/liquidium.services', () => ({ getOrCreateLiquidiumProfile: vi.fn() }));
+vi.mock('$lib/services/liquidium-wallet-adapter.services', () => ({
+	liquidiumWalletAdapter: vi.fn(() => ({ signMessage: vi.fn() }))
+}));
+vi.mock('$lib/services/active-user-transactions.services', () => ({
+	createActiveUserTransaction: vi.fn()
+}));
+vi.mock('$lib/services/analytics.services', () => ({ trackEvent: vi.fn() }));
+
+describe('liquidium-withdraw.services', () => {
+	const ethAddress = '0x1111111111111111111111111111111111111111' as EthAddress;
+	const profileId = 'profile-1';
+	const poolId = 'pool-btc';
+	const receiverAddress = 'bc1qexample';
+
+	const withdraw = vi.fn();
+	const createActiveUserTransaction = vi.mocked(
+		activeUserTransactionsServices.createActiveUserTransaction
+	);
+
+	const run = () =>
+		executeLiquidiumWithdraw({
+			identity: mockIdentity,
+			ethAddress,
+			poolId,
+			asset: 'BTC',
+			amount: 50_000_000n,
+			receiverAddress,
+			displayAmount: '0.5',
+			progressStep: 'withdrawing'
+		});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(liquidiumServices.getOrCreateLiquidiumProfile).mockResolvedValue(profileId);
+		vi.mocked(liquidiumApi.liquidiumClient).mockReturnValue({
+			lending: { withdraw }
+		} as unknown as ReturnType<typeof liquidiumApi.liquidiumClient>);
+	});
+
+	it('signs/submits the withdraw and registers the transaction, correlating by outflow id', async () => {
+		withdraw.mockResolvedValue({ id: 'outflow-1', outflowType: 'withdraw', amount: 50_000_000n });
+
+		await run();
+
+		expect(withdraw).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({
+				profileId,
+				poolId,
+				amount: 50_000_000n,
+				receiverAddress,
+				signerWalletAddress: ethAddress,
+				signerChain: 'ETH'
+			})
+		);
+
+		expect(analyticsServices.trackEvent).toHaveBeenCalledWith({
+			name: TRACK_COUNT_LIQUIDIUM_SUBMITTED,
+			metadata: { dApp: 'liquidium', action: 'withdraw', token: 'BTC', tokenAmount: '0.5' }
+		});
+
+		expect(createActiveUserTransaction).toHaveBeenCalledOnce();
+
+		const [[{ data, externalRefs }]] = createActiveUserTransaction.mock.calls;
+
+		expect(data).toEqual(
+			expect.objectContaining({
+				Liquidium: expect.objectContaining({
+					pool_id: poolId,
+					amount: 50_000_000n,
+					action: { Withdraw: null }
+				})
+			})
+		);
+		expect(externalRefs).toEqual(
+			expect.arrayContaining([
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.PROFILE_ID, value: profileId },
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.OUTFLOW_ID, value: 'outflow-1' },
+				{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.ASSET_SYMBOL, value: 'BTC' }
+			])
+		);
+		// No txid yet — must not be persisted as an empty ref.
+		expect(externalRefs).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID })])
+		);
+	});
+
+	it('persists the txid when the receipt already carries one', async () => {
+		withdraw.mockResolvedValue({
+			id: 'outflow-1',
+			outflowType: 'withdraw',
+			amount: 50_000_000n,
+			txid: '0xhash'
+		});
+
+		await run();
+
+		const [[{ externalRefs }]] = createActiveUserTransaction.mock.calls;
+
+		expect(externalRefs).toEqual(
+			expect.arrayContaining([{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID, value: '0xhash' }])
+		);
+	});
+
+	it('resolves even if AUT bookkeeping fails (withdraw already committed)', async () => {
+		withdraw.mockResolvedValue({ id: 'outflow-1', outflowType: 'withdraw', amount: 50_000_000n });
+		createActiveUserTransaction.mockRejectedValueOnce(new Error('backend unavailable'));
+
+		await expect(run()).resolves.toBeUndefined();
+
+		expect(withdraw).toHaveBeenCalledOnce();
+	});
+});
+
+describe('computeLiquidiumWithdrawPreview', () => {
+	// 1 BTC supplied (= $100k collateral), 80% liquidation threshold.
+	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 0,
+		deposited: 100_000_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 100_000,
+		borrowedUsd: 0,
+		...overrides
+	});
+
+	const portfolio = (overrides: Partial<LiquidiumPortfolio> = {}): LiquidiumPortfolio => ({
+		reserves: [],
+		totalSuppliedUsd: 100_000,
+		totalBorrowedUsd: 0,
+		netValueUsd: 100_000,
+		availableBorrowsUsd: 80_000,
+		weightedLiquidationThresholdBps: 8000,
+		healthFactorPercent: 100,
+		...overrides
+	});
+
+	it('allows the full supplied balance and stays healthy when there is no debt', () => {
+		const preview = computeLiquidiumWithdrawPreview({
+			portfolio: portfolio(),
+			reserve: reserve(),
+			withdrawUsd: 100_000
+		});
+
+		expect(preview.maxWithdrawableUsd).toBe(100_000);
+		expect(preview.reservedByDebtUsd).toBe(0);
+		expect(preview.projectedHealthPercent).toBe(100);
+		expect(preview.healthLevel).toBe('healthy');
+		expect(preview.valid).toBeTruthy();
+	});
+
+	it('caps the withdraw at the free collateral when debt is open', () => {
+		// debt $20k, threshold 0.8 → reserved = 20k / 0.8 = $25k; free = $75k.
+		const preview = computeLiquidiumWithdrawPreview({
+			portfolio: portfolio({ totalBorrowedUsd: 20_000 }),
+			reserve: reserve(),
+			withdrawUsd: 0
+		});
+
+		expect(preview.maxWithdrawableUsd).toBeCloseTo(75_000, 5);
+		expect(preview.reservedByDebtUsd).toBeCloseTo(25_000, 5);
+	});
+
+	it('lowers the projected health as collateral is removed', () => {
+		// remaining collateral = 100k − 50k = 50k; ltv = 20k/50k = 0.4; health = (1 − 0.4/0.8)×100 = 50.
+		const preview = computeLiquidiumWithdrawPreview({
+			portfolio: portfolio({ totalBorrowedUsd: 20_000 }),
+			reserve: reserve(),
+			withdrawUsd: 50_000
+		});
+
+		expect(preview.projectedHealthPercent).toBeCloseTo(50, 5);
+	});
+
+	it('is invalid when the withdraw exceeds the free collateral', () => {
+		const preview = computeLiquidiumWithdrawPreview({
+			portfolio: portfolio({ totalBorrowedUsd: 20_000 }),
+			reserve: reserve(),
+			withdrawUsd: 80_000
+		});
+
+		expect(preview.valid).toBeFalsy();
+	});
+
+	it('stays valid for a withdraw exactly at the cap (rounding tolerance)', () => {
+		const preview = computeLiquidiumWithdrawPreview({
+			portfolio: portfolio({ totalBorrowedUsd: 20_000 }),
+			reserve: reserve(),
+			withdrawUsd: 75_000
+		});
+
+		expect(preview.valid).toBeTruthy();
+	});
+
+	it('reports a critical health level near liquidation', () => {
+		// remaining = 100k − 74k = 26k; ltv = 20k/26k ≈ 0.769; health ≈ (1 − 0.961)×100 ≈ 3.8 → critical.
+		const preview = computeLiquidiumWithdrawPreview({
+			portfolio: portfolio({ totalBorrowedUsd: 20_000 }),
+			reserve: reserve(),
+			withdrawUsd: 74_000
+		});
+
+		expect(preview.healthLevel).toBe('critical');
+	});
+});

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -1,11 +1,13 @@
 import { ZERO } from '$lib/constants/app.constants';
 import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import {
+	liquidiumFreeCollateralUsd,
 	liquidiumHealthFactorPercent,
 	liquidiumHealthLevel,
 	liquidiumMaxSupplyApy,
 	liquidiumNetApy,
 	liquidiumNetInterestUsd,
+	liquidiumProjectedHealthAfterWithdrawPercent,
 	liquidiumProjectedHealthPercent,
 	liquidiumResultingLtvPercent,
 	mapLiquidiumMarket,
@@ -246,6 +248,94 @@ describe('liquidium.utils', () => {
 					newBorrowUsd: 0,
 					totalCollateralUsd: 100,
 					weightedLiquidationThresholdBps: 0
+				})
+			).toBe(0);
+		});
+	});
+
+	describe('liquidiumFreeCollateralUsd', () => {
+		it('returns the full collateral when there is no debt', () => {
+			expect(
+				liquidiumFreeCollateralUsd({
+					totalCollateralUsd: 100_000,
+					totalDebtUsd: 0,
+					weightedLiquidationThresholdBps: 8_000
+				})
+			).toBe(100_000);
+		});
+
+		it('subtracts the collateral pledged to debt at the liquidation threshold', () => {
+			// debt $20k at 0.8 → reserved 25k → free 75k.
+			expect(
+				liquidiumFreeCollateralUsd({
+					totalCollateralUsd: 100_000,
+					totalDebtUsd: 20_000,
+					weightedLiquidationThresholdBps: 8_000
+				})
+			).toBeCloseTo(75_000, 5);
+		});
+
+		it('clamps to 0 and treats debt with a zero threshold as fully reserved', () => {
+			expect(
+				liquidiumFreeCollateralUsd({
+					totalCollateralUsd: 100_000,
+					totalDebtUsd: 90_000,
+					weightedLiquidationThresholdBps: 8_000
+				})
+			).toBe(0);
+			expect(
+				liquidiumFreeCollateralUsd({
+					totalCollateralUsd: 100_000,
+					totalDebtUsd: 10_000,
+					weightedLiquidationThresholdBps: 0
+				})
+			).toBe(0);
+		});
+	});
+
+	describe('liquidiumProjectedHealthAfterWithdrawPercent', () => {
+		it('stays at 100 when there is no debt', () => {
+			expect(
+				liquidiumProjectedHealthAfterWithdrawPercent({
+					totalCollateralUsd: 100_000,
+					totalDebtUsd: 0,
+					withdrawUsd: 50_000,
+					weightedLiquidationThresholdBps: 8_000
+				})
+			).toBe(100);
+		});
+
+		it('reproduces the current health for a zero withdraw', () => {
+			// ltv 20k/100k = 0.2; health = (1 − 0.2/0.8)×100 = 75.
+			expect(
+				liquidiumProjectedHealthAfterWithdrawPercent({
+					totalCollateralUsd: 100_000,
+					totalDebtUsd: 20_000,
+					withdrawUsd: 0,
+					weightedLiquidationThresholdBps: 8_000
+				})
+			).toBeCloseTo(75, 5);
+		});
+
+		it('lowers health as collateral is removed', () => {
+			// remaining 50k; ltv 20k/50k = 0.4; health = (1 − 0.4/0.8)×100 = 50.
+			expect(
+				liquidiumProjectedHealthAfterWithdrawPercent({
+					totalCollateralUsd: 100_000,
+					totalDebtUsd: 20_000,
+					withdrawUsd: 50_000,
+					weightedLiquidationThresholdBps: 8_000
+				})
+			).toBeCloseTo(50, 5);
+		});
+
+		it('is 0 when the withdraw removes all (or more than all) collateral', () => {
+			expect(
+				liquidiumProjectedHealthAfterWithdrawPercent({
+					totalCollateralUsd: 100_000,
+					totalDebtUsd: 20_000,
+					withdrawUsd: 100_000,
+					weightedLiquidationThresholdBps: 8_000
 				})
 			).toBe(0);
 		});


### PR DESCRIPTION
# Motivation

Adds the Withdraw action to the Liquidium integration, letting users pull supplied collateral back out from a supplied-position row on the provider page. Mechanically it's a signMessage outflow — modelled on the already-merged Borrow flow rather than Supply — so it reuses the existing outflow/active-transaction machinery with no new poller code. Everything stays behind LEND_BORROW_ENABLED / LIQUIDIUM_ENABLED (= STAGING), so it's visible on staging only.

# Changes

- Action service (liquidium-withdraw.services.ts):
- executeLiquidiumWithdraw — resolve profile -> client.lending.withdraw(...) -> track -> record an AUT (correlated by outflow id) -> done. Funds return to the user's own oisy address on the pool's chain.
- computeLiquidiumWithdrawPreview — aggregate model (from getUserPositionSummary): free-collateral cap, reserved-by-debt, and projected health as collateral decreases.
- Math helpers (liquidium.utils.ts): liquidiumFreeCollateralUsd and liquidiumProjectedHealthAfterWithdrawPercent, alongside the existing borrow helpers.
- UI (components/liquidium/withdraw/): Modal, Form, Review (reuses SendTokenReview), Progress — the borrow quartet adapted for withdraw.
- Entry point: a Withdraw button on each Supplied position row (LiquidiumPositionCard), opening the modal via a per-card modal id.
- Wiring: WizardStepsLiquidiumWithdraw, ProgressStepsLiquidiumWithdraw, liquidiumWithdrawWizardSteps, modal store/derived (openLiquidiumWithdraw / modalLiquidiumWithdraw), and new withdraw_* i18n keys (locales regenerated).


# Tests

Added.
