### PR TITLE
test(frontend): raise trading deposit review/form coverage

### DIFF
--- a/src/frontend/src/tests/lib/components/trading/TradingDepositForm.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingDepositForm.svelte.spec.ts
@@ -43,6 +43,14 @@ describe('TradingDepositForm', () => {
 		expect(getByTestId(TRADING_DEPOSIT_FORM_REVIEW_BUTTON)).toBeDisabled();
 	});
 
+	it('should keep the review button disabled with consent but a zero amount', () => {
+		const { getByTestId } = render(TradingDepositForm, {
+			props: { ...baseProps, consent: true, amount: 0 }
+		});
+
+		expect(getByTestId(TRADING_DEPOSIT_FORM_REVIEW_BUTTON)).toBeDisabled();
+	});
+
 	it('should enable the review button with consent and a valid amount', () => {
 		const { getByTestId } = render(TradingDepositForm, {
 			props: { ...baseProps, consent: true, amount: 5 }

--- a/src/frontend/src/tests/lib/components/trading/TradingDepositReview.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingDepositReview.svelte.spec.ts
@@ -5,8 +5,25 @@ import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 
+const { exchangesMock } = vi.hoisted(() => {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const { writable: createWritable } = require('svelte/store');
+	return { exchangesMock: createWritable({}) };
+});
+
+vi.mock(import('$lib/derived/exchange.derived'), async (importOriginal) => ({
+	...(await importOriginal()),
+	get exchanges() {
+		return exchangesMock;
+	}
+}));
+
 describe('TradingDepositReview', () => {
 	const token: IcToken = { ...mockValidIcToken, symbol: 'ICP', decimals: 8, fee: 10000n };
+
+	beforeEach(() => {
+		exchangesMock.set({});
+	});
 
 	const baseProps = {
 		token,
@@ -22,6 +39,17 @@ describe('TradingDepositReview', () => {
 		expect(getByText(en.trading.text.provider_name)).toBeInTheDocument();
 		expect(getByText(en.trading.deposit.network)).toBeInTheDocument();
 		expect(getByText(en.trading.deposit.transaction_fee)).toBeInTheDocument();
+	});
+
+	it('should render the fee breakdown in fiat when an exchange rate is available', () => {
+		exchangesMock.set({ [token.id]: { usd: 7 } });
+
+		const { getAllByText, getByText } = render(TradingDepositReview, { props: { ...baseProps } });
+
+		expect(getByText(en.trading.deposit.transaction_fee)).toBeInTheDocument();
+		// The fiat branch formats fees through `formatCurrency` (default USD), so a
+		// "$"-prefixed value is rendered instead of the raw token amount + symbol.
+		expect(getAllByText((content) => content.includes('$')).length).toBeGreaterThan(0);
 	});
 
 	it('should call onConfirm when the confirm button is clicked', async () => {


### PR DESCRIPTION
# Motivation

Follow-up to the OISY TRADE deposit wizard (#13232). That PR landed slightly below the branch-coverage high-water mark; this raises test coverage on the new trading-deposit components.

# Changes

- `TradingDepositReview`: cover the fiat fee-breakdown path (`formatFee` with an exchange rate available), lifting the component's branch coverage from 25% to 75%.
- `TradingDepositForm`: cover the zero-amount case that keeps the review button disabled.

# Tests

- `npm run test` for the trading deposit specs (all green).
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` all pass.
