### PR TITLE
fix(frontend): only emit bip122_addressesChanged to subscribed WalletConnect sessions

### DIFF
--- a/src/frontend/src/btc/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/btc/constants/wallet-connect.constants.ts
@@ -8,11 +8,6 @@ export const SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES = 'getAccountAddresses';
 export const SESSION_REQUEST_BTC_SIGN_MESSAGE = 'signMessage';
 export const SESSION_REQUEST_BTC_SIGN_PSBT = 'signPsbt';
 
-// Bitcoin (bip122) event advertised in the approved namespace and emitted to deliver the account
-// address set. The same value MUST be used when advertising, emitting and guarding the emit: the
-// SDK's `isValidEmit` rejects any event name absent from the session's approved namespace events.
-export const SESSION_EVENT_BTC_ADDRESSES_CHANGED = 'bip122_addressesChanged';
-
 export const BTC_ECDSA_KEY_ID: EcdsaKeyId = {
 	curve: { secp256k1: null },
 	name: SIGNER_ROOT_KEY_NAME

--- a/src/frontend/src/btc/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/btc/constants/wallet-connect.constants.ts
@@ -7,6 +7,7 @@ import type { NetworkId } from '$lib/types/network';
 export const SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES = 'getAccountAddresses';
 export const SESSION_REQUEST_BTC_SIGN_MESSAGE = 'signMessage';
 export const SESSION_REQUEST_BTC_SIGN_PSBT = 'signPsbt';
+export const SESSION_REQUEST_BTC_ADDRESSES_CHANGED = 'bip122_addressesChanged';
 
 export const BTC_ECDSA_KEY_ID: EcdsaKeyId = {
 	curve: { secp256k1: null },

--- a/src/frontend/src/btc/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/btc/constants/wallet-connect.constants.ts
@@ -8,6 +8,11 @@ export const SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES = 'getAccountAddresses';
 export const SESSION_REQUEST_BTC_SIGN_MESSAGE = 'signMessage';
 export const SESSION_REQUEST_BTC_SIGN_PSBT = 'signPsbt';
 
+// Bitcoin (bip122) event advertised in the approved namespace and emitted to deliver the account
+// address set. The same value MUST be used when advertising, emitting and guarding the emit: the
+// SDK's `isValidEmit` rejects any event name absent from the session's approved namespace events.
+export const SESSION_EVENT_BTC_ADDRESSES_CHANGED = 'bip122_addressesChanged';
+
 export const BTC_ECDSA_KEY_ID: EcdsaKeyId = {
 	curve: { secp256k1: null },
 	name: SIGNER_ROOT_KEY_NAME

--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -1,5 +1,4 @@
 import {
-	SESSION_EVENT_BTC_ADDRESSES_CHANGED,
 	SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
 	SESSION_REQUEST_BTC_SIGN_MESSAGE,
 	SESSION_REQUEST_BTC_SIGN_PSBT
@@ -323,7 +322,7 @@ export class WalletConnectClient extends WalletConnectListener {
 									SESSION_REQUEST_BTC_SIGN_MESSAGE,
 									SESSION_REQUEST_BTC_SIGN_PSBT
 								],
-								events: [SESSION_EVENT_BTC_ADDRESSES_CHANGED],
+								events: ['bip122_addressesChanged'],
 								accounts: [
 									...(nonNullish(this.#btcAddressMainnet)
 										? BIP122_MAINNET_CHAINS_KEYS.map(
@@ -374,9 +373,7 @@ export class WalletConnectClient extends WalletConnectListener {
 				// so a dApp that never lists `bip122_addressesChanged` ends up with an empty event set and
 				// the SDK's `isValidEmit` rejects the emit — which would otherwise surface as a spurious
 				// "Unexpected error" toast on an otherwise successful connection.
-				if (
-					!(session.namespaces.bip122?.events ?? []).includes(SESSION_EVENT_BTC_ADDRESSES_CHANGED)
-				) {
+				if (!(session.namespaces.bip122?.events ?? []).includes('bip122_addressesChanged')) {
 					return [];
 				}
 
@@ -385,7 +382,7 @@ export class WalletConnectClient extends WalletConnectListener {
 						topic: session.topic,
 						chainId,
 						event: {
-							name: SESSION_EVENT_BTC_ADDRESSES_CHANGED,
+							name: 'bip122_addressesChanged',
 							data: btcAccountAddresses
 						}
 					})

--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -1,4 +1,5 @@
 import {
+	SESSION_REQUEST_BTC_ADDRESSES_CHANGED,
 	SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
 	SESSION_REQUEST_BTC_SIGN_MESSAGE,
 	SESSION_REQUEST_BTC_SIGN_PSBT
@@ -322,7 +323,7 @@ export class WalletConnectClient extends WalletConnectListener {
 									SESSION_REQUEST_BTC_SIGN_MESSAGE,
 									SESSION_REQUEST_BTC_SIGN_PSBT
 								],
-								events: ['bip122_addressesChanged'],
+								events: [SESSION_REQUEST_BTC_ADDRESSES_CHANGED],
 								accounts: [
 									...(nonNullish(this.#btcAddressMainnet)
 										? BIP122_MAINNET_CHAINS_KEYS.map(
@@ -373,7 +374,9 @@ export class WalletConnectClient extends WalletConnectListener {
 				// so a dApp that never lists `bip122_addressesChanged` ends up with an empty event set and
 				// the SDK's `isValidEmit` rejects the emit — which would otherwise surface as a spurious
 				// "Unexpected error" toast on an otherwise successful connection.
-				if (!(session.namespaces.bip122?.events ?? []).includes('bip122_addressesChanged')) {
+				if (
+					!(session.namespaces.bip122?.events ?? []).includes(SESSION_REQUEST_BTC_ADDRESSES_CHANGED)
+				) {
 					return [];
 				}
 
@@ -382,7 +385,7 @@ export class WalletConnectClient extends WalletConnectListener {
 						topic: session.topic,
 						chainId,
 						event: {
-							name: 'bip122_addressesChanged',
+							name: SESSION_REQUEST_BTC_ADDRESSES_CHANGED,
 							data: btcAccountAddresses
 						}
 					})

--- a/src/frontend/src/lib/providers/wallet-connect.providers.ts
+++ b/src/frontend/src/lib/providers/wallet-connect.providers.ts
@@ -1,4 +1,5 @@
 import {
+	SESSION_EVENT_BTC_ADDRESSES_CHANGED,
 	SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
 	SESSION_REQUEST_BTC_SIGN_MESSAGE,
 	SESSION_REQUEST_BTC_SIGN_PSBT
@@ -322,7 +323,7 @@ export class WalletConnectClient extends WalletConnectListener {
 									SESSION_REQUEST_BTC_SIGN_MESSAGE,
 									SESSION_REQUEST_BTC_SIGN_PSBT
 								],
-								events: ['bip122_addressesChanged'],
+								events: [SESSION_EVENT_BTC_ADDRESSES_CHANGED],
 								accounts: [
 									...(nonNullish(this.#btcAddressMainnet)
 										? BIP122_MAINNET_CHAINS_KEYS.map(
@@ -367,18 +368,29 @@ export class WalletConnectClient extends WalletConnectListener {
 		const sessions = Object.values(this.#walletKit.getActiveSessions());
 
 		await Promise.all(
-			sessions.flatMap((session) =>
-				(session.namespaces.bip122?.chains ?? []).map((chainId) =>
+			sessions.flatMap((session) => {
+				// Only emit to sessions whose approved bip122 namespace actually subscribed to the event.
+				// `buildApprovedNamespaces` intersects the events we offer with the ones the dApp requested,
+				// so a dApp that never lists `bip122_addressesChanged` ends up with an empty event set and
+				// the SDK's `isValidEmit` rejects the emit — which would otherwise surface as a spurious
+				// "Unexpected error" toast on an otherwise successful connection.
+				if (
+					!(session.namespaces.bip122?.events ?? []).includes(SESSION_EVENT_BTC_ADDRESSES_CHANGED)
+				) {
+					return [];
+				}
+
+				return (session.namespaces.bip122?.chains ?? []).map((chainId) =>
 					this.#walletKit.emitSessionEvent({
 						topic: session.topic,
 						chainId,
 						event: {
-							name: 'bip122_addressesChanged',
+							name: SESSION_EVENT_BTC_ADDRESSES_CHANGED,
 							data: btcAccountAddresses
 						}
 					})
-				)
-			)
+				);
+			})
 		);
 	};
 

--- a/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
+++ b/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
@@ -1,4 +1,5 @@
 import {
+	SESSION_EVENT_BTC_ADDRESSES_CHANGED,
 	SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
 	SESSION_REQUEST_BTC_SIGN_MESSAGE,
 	SESSION_REQUEST_BTC_SIGN_PSBT
@@ -63,6 +64,7 @@ describe('wallet-connect.providers', () => {
 		const mockDisconnectSession = vi.fn();
 		const mockRejectSession = vi.fn();
 		const mockApproveSession = vi.fn();
+		const mockEmitSessionEvent = vi.fn();
 		const mockRespondSessionRequest = vi.fn();
 		const mockPair = vi.fn();
 		const mockOn = vi.fn();
@@ -74,6 +76,7 @@ describe('wallet-connect.providers', () => {
 			disconnectSession: mockDisconnectSession,
 			rejectSession: mockRejectSession,
 			approveSession: mockApproveSession,
+			emitSessionEvent: mockEmitSessionEvent,
 			respondSessionRequest: mockRespondSessionRequest,
 			core: {
 				pairing: { pair: mockPair }
@@ -291,6 +294,53 @@ describe('wallet-connect.providers', () => {
 				// Mainnet-only: with no mainnet address the account addresses are empty, so the session
 				// property is omitted entirely.
 				expect(sessionProperties?.bip122_getAccountAddresses).toBeUndefined();
+			});
+		});
+
+		describe('emit bip122_addressesChanged on approval', () => {
+			const sessionWith = (events: string[]) => ({
+				topic: 'mock-topic',
+				namespaces: {
+					bip122: {
+						chains: BIP122_MAINNET_CHAINS_KEYS,
+						events
+					}
+				}
+			});
+
+			it('should emit to sessions whose approved namespace subscribed to the event', async () => {
+				mockGetActiveSessions.mockReturnValue({
+					session1: sessionWith([SESSION_EVENT_BTC_ADDRESSES_CHANGED])
+				});
+
+				const listener = await WalletConnectClient.init(mockParams);
+
+				await listener.approveSession(mockProposal);
+
+				expect(mockEmitSessionEvent).toHaveBeenCalledTimes(BIP122_MAINNET_CHAINS_KEYS.length);
+				expect(mockEmitSessionEvent).toHaveBeenCalledWith({
+					topic: 'mock-topic',
+					chainId: BIP122_MAINNET_CHAINS_KEYS[0],
+					event: {
+						name: SESSION_EVENT_BTC_ADDRESSES_CHANGED,
+						data: [expect.objectContaining({ address: mockBtcAddress, intention: 'payment' })]
+					}
+				});
+			});
+
+			it('should not emit to sessions whose approved namespace did not subscribe to the event', async () => {
+				// `buildApprovedNamespaces` intersects offered events with the dApp's requested events, so a
+				// dApp that never lists the event ends up with an empty event set; emitting anyway is the
+				// `isValidEmit` rejection that surfaced as a spurious connection error.
+				mockGetActiveSessions.mockReturnValue({
+					session1: sessionWith([])
+				});
+
+				const listener = await WalletConnectClient.init(mockParams);
+
+				await listener.approveSession(mockProposal);
+
+				expect(mockEmitSessionEvent).not.toHaveBeenCalled();
 			});
 		});
 

--- a/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
+++ b/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
@@ -1,4 +1,5 @@
 import {
+	SESSION_REQUEST_BTC_ADDRESSES_CHANGED,
 	SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
 	SESSION_REQUEST_BTC_SIGN_MESSAGE,
 	SESSION_REQUEST_BTC_SIGN_PSBT
@@ -309,7 +310,7 @@ describe('wallet-connect.providers', () => {
 
 			it('should emit to sessions whose approved namespace subscribed to the event', async () => {
 				mockGetActiveSessions.mockReturnValue({
-					session1: sessionWith(['bip122_addressesChanged'])
+					session1: sessionWith([SESSION_REQUEST_BTC_ADDRESSES_CHANGED])
 				});
 
 				const listener = await WalletConnectClient.init(mockParams);
@@ -321,7 +322,7 @@ describe('wallet-connect.providers', () => {
 					topic: 'mock-topic',
 					chainId: BIP122_MAINNET_CHAINS_KEYS[0],
 					event: {
-						name: 'bip122_addressesChanged',
+						name: SESSION_REQUEST_BTC_ADDRESSES_CHANGED,
 						data: [expect.objectContaining({ address: mockBtcAddress, intention: 'payment' })]
 					}
 				});

--- a/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
+++ b/src/frontend/src/tests/lib/providers/wallet-connect.providers.spec.ts
@@ -1,5 +1,4 @@
 import {
-	SESSION_EVENT_BTC_ADDRESSES_CHANGED,
 	SESSION_REQUEST_BTC_GET_ACCOUNT_ADDRESSES,
 	SESSION_REQUEST_BTC_SIGN_MESSAGE,
 	SESSION_REQUEST_BTC_SIGN_PSBT
@@ -310,7 +309,7 @@ describe('wallet-connect.providers', () => {
 
 			it('should emit to sessions whose approved namespace subscribed to the event', async () => {
 				mockGetActiveSessions.mockReturnValue({
-					session1: sessionWith([SESSION_EVENT_BTC_ADDRESSES_CHANGED])
+					session1: sessionWith(['bip122_addressesChanged'])
 				});
 
 				const listener = await WalletConnectClient.init(mockParams);
@@ -322,7 +321,7 @@ describe('wallet-connect.providers', () => {
 					topic: 'mock-topic',
 					chainId: BIP122_MAINNET_CHAINS_KEYS[0],
 					event: {
-						name: SESSION_EVENT_BTC_ADDRESSES_CHANGED,
+						name: 'bip122_addressesChanged',
 						data: [expect.objectContaining({ address: mockBtcAddress, intention: 'payment' })]
 					}
 				});


### PR DESCRIPTION
# Motivation

Connecting a Bitcoin dApp over WalletConnect surfaced a spurious "Unexpected error while communicating with WalletConnect" toast, even though the session connected fine.

On approval, OISY emits `bip122_addressesChanged` to deliver the BTC account address set. The WalletConnect SDK validates emits against the **approved** session namespace, and `buildApprovedNamespaces` intersects the events we offer with the events the dApp requested. A dApp that never lists `bip122_addressesChanged` (e.g. the Reown lab dApp) ends up with an empty approved event set, so the SDK's `isValidEmit` rejects the emit and the rejection bubbles up as a user-facing error.

The address set is already delivered on connect via the `bip122_getAccountAddresses` session property, so this emit is purely an extra notification — it should never break a successful connection.

# Changes

- Guard the initial emit in `#emitInitialBtcAddresses` to only sessions whose approved bip122 namespace actually subscribed to `bip122_addressesChanged`.
- Hoist the event name into a shared `SESSION_EVENT_BTC_ADDRESSES_CHANGED` constant so the advertised, emitted and guarded name cannot drift.

# Tests

- Added two cases: emits to a session whose approved namespace includes the event; does not emit when the event is absent.
- `npm run test` (this spec), prettier, eslint `--max-warnings 0` and tsc spec all pass.