### PR TITLE
fix(frontend): cache on-chain NFT image resolution to load once per token

### DIFF
--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -12,6 +12,7 @@ import type { Nft } from '$lib/types/nft';
 import { consoleWarn } from '$lib/utils/console.utils';
 import { getMediaStatusOrCache } from '$lib/utils/nfts.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import { SvelteMap } from 'svelte/reactivity';
 
 // Alchemy is the source for owned NFTs, but it sometimes returns no media URL
 // for a token it has not indexed yet, even when the collection's metadata (and
@@ -37,6 +38,13 @@ const loadOnChainImageUrl = async ({
 	return imageUrl;
 };
 
+// Caches the on-chain image URL resolved per (network, contract, token id) so
+// the NFT polling loop reuses it instead of re-resolving — and re-reporting —
+// the same media on every refresh. A `null` entry records a token that resolved
+// to no media (so we don't re-report that either). Transient failures are not
+// cached, so they keep retrying on the next poll. Exposed so tests can reset it.
+export const onChainImageUrlCache = new SvelteMap<string, string | null>();
+
 const withOnChainMediaFallback = async ({
 	networkId,
 	nft
@@ -46,6 +54,19 @@ const withOnChainMediaFallback = async ({
 }): Promise<Nft> => {
 	if (nonNullish(nft.imageUrl)) {
 		return nft;
+	}
+
+	const withImageUrl = async (imageUrl: string): Promise<Nft> => ({
+		...nft,
+		imageUrl,
+		mediaStatus: { ...nft.mediaStatus, image: await getMediaStatusOrCache(imageUrl) }
+	});
+
+	const cacheKey = `${networkId.toString()}#${nft.collection.address}#${nft.id}`;
+
+	if (onChainImageUrlCache.has(cacheKey)) {
+		const cached = onChainImageUrlCache.get(cacheKey);
+		return nonNullish(cached) ? await withImageUrl(cached) : nft;
 	}
 
 	const trackLoad = (resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES) =>
@@ -66,24 +87,21 @@ const withOnChainMediaFallback = async ({
 	try {
 		const imageUrl = await loadOnChainImageUrl({ networkId, nft });
 
-		// `success` means we recovered an image URL; `error` covers both a load
-		// that returned no image and one that threw (handled below).
+		// Cache the resolved outcome (the URL, or `null` for "no media on chain")
+		// so later polls reuse it without re-resolving or re-reporting.
+		onChainImageUrlCache.set(cacheKey, imageUrl ?? null);
+
+		// `success` means we recovered an image URL; `error` means the contract
+		// metadata exposed no usable image.
 		trackLoad(
 			nonNullish(imageUrl)
 				? PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
 				: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR
 		);
 
-		if (isNullish(imageUrl)) {
-			return nft;
-		}
-
-		return {
-			...nft,
-			imageUrl,
-			mediaStatus: { ...nft.mediaStatus, image: await getMediaStatusOrCache(imageUrl) }
-		};
+		return nonNullish(imageUrl) ? await withImageUrl(imageUrl) : nft;
 	} catch (err: unknown) {
+		// Not cached: a transient failure should be retried on the next poll.
 		trackLoad(PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR);
 		consoleWarn(
 			`Failed to resolve on-chain media for NFT ${nft.id} of token: ${nft.collection.address} on network: ${networkId.toString()}.`,

--- a/src/frontend/src/eth/services/nft.services.ts
+++ b/src/frontend/src/eth/services/nft.services.ts
@@ -42,8 +42,12 @@ const loadOnChainImageUrl = async ({
 // the NFT polling loop reuses it instead of re-resolving — and re-reporting —
 // the same media on every refresh. A `null` entry records a token that resolved
 // to no media (so we don't re-report that either). Transient failures are not
-// cached, so they keep retrying on the next poll. Exposed so tests can reset it.
-export const onChainImageUrlCache = new SvelteMap<string, string | null>();
+// cached, so they keep retrying on the next poll.
+const onChainImageUrlCache = new SvelteMap<string, string | null>();
+
+export const __test__only__clear_on_chain_image_url_cache__ = (): void => {
+	onChainImageUrlCache.clear();
+};
 
 const withOnChainMediaFallback = async ({
 	networkId,

--- a/src/frontend/src/tests/eth/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/nft.services.spec.ts
@@ -1,7 +1,7 @@
 import { alchemyProviders, type AlchemyProvider } from '$eth/providers/alchemy.providers';
 import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers';
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
-import { loadNftsByNetwork } from '$eth/services/nft.services';
+import { loadNftsByNetwork, onChainImageUrlCache } from '$eth/services/nft.services';
 import type { EthNonFungibleToken } from '$eth/types/nft';
 import { TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL } from '$lib/constants/analytics.constants';
 import { MediaStatusEnum } from '$lib/enums/media-status';
@@ -106,6 +106,7 @@ describe('nft.services', () => {
 
 		beforeEach(() => {
 			vi.clearAllMocks();
+			onChainImageUrlCache.clear();
 
 			vi.mocked(alchemyProviders).mockReturnValue(mockAlchemyProvider);
 			vi.mocked(infuraErc721Providers).mockReturnValue(mockInfuraErc721Provider);
@@ -342,6 +343,31 @@ describe('nft.services', () => {
 						token_id: `${mockErc721NftWithoutImage.id}`
 					}
 				});
+			});
+
+			it('resolves on-chain media only once across repeated polls', async () => {
+				vi.mocked(mockAlchemyProvider.getNftsByOwner)
+					.mockResolvedValueOnce([mockErc721NftWithoutImage])
+					.mockResolvedValueOnce([mockErc721NftWithoutImage]);
+				vi.mocked(mockInfuraErc721Provider.getNftMetadata).mockResolvedValueOnce({
+					id: mockErc721NftWithoutImage.id,
+					imageUrl: 'https://arweave.net/on-chain-image'
+				});
+
+				const params = {
+					...mockParams,
+					tokens: [erc721AzukiToken],
+					networkId: erc721AzukiToken.network.id
+				};
+
+				const first = await loadNftsByNetwork(params);
+				const second = await loadNftsByNetwork(params);
+
+				// On-chain resolution and the event happen once; the second poll reuses the cache.
+				expect(mockInfuraErc721Provider.getNftMetadata).toHaveBeenCalledOnce();
+				expect(trackEvent).toHaveBeenCalledOnce();
+				expect(first[0].imageUrl).toBe('https://arweave.net/on-chain-image');
+				expect(second[0].imageUrl).toBe('https://arweave.net/on-chain-image');
 			});
 		});
 	});

--- a/src/frontend/src/tests/eth/services/nft.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/nft.services.spec.ts
@@ -1,7 +1,10 @@
 import { alchemyProviders, type AlchemyProvider } from '$eth/providers/alchemy.providers';
 import { infuraErc1155Providers } from '$eth/providers/infura-erc1155.providers';
 import { infuraErc721Providers } from '$eth/providers/infura-erc721.providers';
-import { loadNftsByNetwork, onChainImageUrlCache } from '$eth/services/nft.services';
+import {
+	__test__only__clear_on_chain_image_url_cache__,
+	loadNftsByNetwork
+} from '$eth/services/nft.services';
 import type { EthNonFungibleToken } from '$eth/types/nft';
 import { TRACK_NFT_LOAD_ONCHAIN_IMAGE_URL } from '$lib/constants/analytics.constants';
 import { MediaStatusEnum } from '$lib/enums/media-status';
@@ -106,7 +109,7 @@ describe('nft.services', () => {
 
 		beforeEach(() => {
 			vi.clearAllMocks();
-			onChainImageUrlCache.clear();
+			__test__only__clear_on_chain_image_url_cache__();
 
 			vi.mocked(alchemyProviders).mockReturnValue(mockAlchemyProvider);
 			vi.mocked(infuraErc721Providers).mockReturnValue(mockInfuraErc721Provider);


### PR DESCRIPTION
# Motivation

The NFT list polls every ~20s (`NFT_TIMER_INTERVAL_MILLIS`). On each tick, `loadNftsByNetwork` re-runs, and for any NFT that Alchemy never returns media for (the case the on-chain fallback exists for), `withOnChainMediaFallback` ran again — firing the `nft_load_onchain_image_url` analytics event every poll. The actual on-chain fetch is already cached in the Infura provider, so this over-reported a single load as ~3 events/min per token.

# Changes

- `eth/services/nft.services.ts`: cache the resolved on-chain image URL per `(network, contract, token id)`. On later polls the cached value is reused (the image still renders) without re-invoking the fallback or re-firing the event.
  - A `null` entry records a token that resolved to "no media on chain", so that outcome isn't re-reported either.
  - Transient failures (the contract lookup throwing) are **not** cached, so they keep retrying — and reporting — on the next poll, which is the signal worth watching.
- Net effect: `nft_load_onchain_image_url` now fires once per token per session — a true "load" count.
- The on-chain image cache is module-private; a `__test__only__clear_on_chain_image_url_cache__()` reset hook (per the repo's `__test__only__…` convention) lets the spec reset it between cases instead of an exported mutable cache (Copilot review).

# Tests

- Extended `tests/eth/services/nft.services.spec.ts` (12 cases): added a case asserting that two consecutive loads of the same media-less NFT resolve on-chain (and fire the event) exactly once, with the image still applied on both, while the existing success/error/no-media cases are unchanged (the cache is reset per test via the test-only hook).
- Gates: `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` (0 errors / 0 warnings).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)

