### PR TITLE
test(backend): run integration tests in chunks to bound PocketIC memory

### DIFF
--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -111,10 +111,10 @@ run_it_in_chunks() {
 
 echo "Running backend tests."
 if [ -n "${CI:-}" ] && [ "$#" -eq 0 ]; then
-  # Single-threaded within a chunk keeps peak live memory low; chunking caps the
-  # cumulative server growth that single-threading alone could not. Overridable
-  # via RUST_TEST_THREADS.
-  export RUST_TEST_THREADS="${RUST_TEST_THREADS:-1}"
+  # Chunking caps the cumulative PocketIC server memory (a fresh server per
+  # chunk), so the suite no longer needs to run single-threaded — peak memory is
+  # one chunk's instances regardless of parallelism. RUST_TEST_THREADS is still
+  # honoured if set, e.g. to pin parallelism on a smaller runner.
   rc=0
   cargo test -p backend --lib || rc=1
   run_it_in_chunks || rc=1

--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -73,5 +73,52 @@ export POCKET_IC_MUTE_SERVER=1
 
 # Run tests
 
-echo "Running backend integration tests."
-cargo test -p backend "${@}"
+# Each integration test spins up a PocketIC instance holding several canisters.
+# The PocketIC server's memory grows with every instance it has ever served
+# (deleted instances are not fully reclaimed), so running the whole `it` suite
+# in a single process eventually OOM-kills the server mid-run (connection reset
+# -> SIGABRT) — and the larger the backend wasm grows, the sooner it dies.
+#
+# On CI, bound that growth by running the integration suite in chunks: each
+# chunk is its own `cargo test --test it` process with a fresh PocketIC server,
+# so peak server memory is capped at one chunk's worth of instances. Explicit
+# cargo arguments (e.g. `-- --ignored candid`) and local runs keep the original
+# single-process behaviour.
+run_it_in_chunks() {
+  local chunk_size="${BACKEND_IT_TEST_CHUNK_SIZE:-40}"
+  local tests=()
+  local line
+  while IFS= read -r line; do
+    tests+=("${line%: test}")
+  done < <(cargo test -p backend --test it -- --list 2>/dev/null | grep ': test$')
+
+  if [ "${#tests[@]}" -eq 0 ]; then
+    echo "Could not list integration tests; running them in a single process." >&2
+    cargo test -p backend --test it
+    return
+  fi
+
+  echo "Running ${#tests[@]} integration tests in chunks of ${chunk_size}."
+  local status=0 i
+  for ((i = 0; i < ${#tests[@]}; i += chunk_size)); do
+    local chunk=("${tests[@]:i:chunk_size}")
+    echo "::group::it tests $((i + 1))-$((i + ${#chunk[@]})) / ${#tests[@]}"
+    cargo test -p backend --test it -- --exact "${chunk[@]}" || status=1
+    echo "::endgroup::"
+  done
+  return "$status"
+}
+
+echo "Running backend tests."
+if [ -n "${CI:-}" ] && [ "$#" -eq 0 ]; then
+  # Single-threaded within a chunk keeps peak live memory low; chunking caps the
+  # cumulative server growth that single-threading alone could not. Overridable
+  # via RUST_TEST_THREADS.
+  export RUST_TEST_THREADS="${RUST_TEST_THREADS:-1}"
+  rc=0
+  cargo test -p backend --lib || rc=1
+  run_it_in_chunks || rc=1
+  exit "$rc"
+else
+  cargo test -p backend "${@}"
+fi

--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -86,6 +86,10 @@ export POCKET_IC_MUTE_SERVER=1
 # single-process behaviour.
 run_it_in_chunks() {
   local chunk_size="${BACKEND_IT_TEST_CHUNK_SIZE:-40}"
+  if ! [[ "$chunk_size" =~ ^[1-9][0-9]*$ ]]; then
+    echo "BACKEND_IT_TEST_CHUNK_SIZE must be a positive integer (got '${chunk_size}')." >&2
+    return 1
+  fi
   local tests=()
   local line
   while IFS= read -r line; do


### PR DESCRIPTION
# Motivation

The backend `tests` CI job has been crashing mid-run with a PocketIC server abort (connection reset → `SIGABRT`), failing on whatever test happens to run next (recently a `signer` test, not the one at fault).

Root cause is cumulative memory, not concurrency: the PocketIC server's RSS grows with **every instance it has ever served** — deleted instances aren't fully reclaimed — so a single process running the whole `it` suite (~190 instances) eventually exhausts the 16 GB runner and the server is OOM-killed. Single-threading only slows the growth (it still dies near the end, ~instance 150 now that the `ic-vetkeys` backend wasm is larger), so it isn't a real fix.

This is shared test infrastructure; pulling it out of the personal-notes stack (#13130) so every backend PR benefits.

# Changes

- `scripts/test.backend.sh`: on CI, run the integration suite in **chunks** — each chunk is its own `cargo test --test it` process with a fresh PocketIC server, so peak server memory is capped at one chunk's worth of instances rather than the whole suite's.
  - Test names are discovered via `cargo test --test it -- --list` and partitioned, so new tests are picked up automatically (no hardcoded list).
  - Chunk size is overridable via `BACKEND_IT_TEST_CHUNK_SIZE` (default 40 → ~5 chunks today).
  - `BACKEND_IT_TEST_CHUNK_SIZE` is validated as a positive integer (fails fast on `0`/non-numeric, which would otherwise hang the loop).
  - Lib unit tests run once up front; a failure in any chunk still runs the rest and fails the job.
  - Explicit cargo args (e.g. the `breaking-interface` job's `-- --ignored candid`) and local runs keep the original single-process behaviour untouched.
  - Chunks run at full parallelism: peak memory is one chunk's instances regardless of thread count (a fresh server per chunk), so the previous single-threaded workaround is dropped. `RUST_TEST_THREADS` is still honoured if set.

# Tests

- Verified locally: `bash -n`, `shellcheck -e SC1090 -e SC1091`, and `shfmt -i 2 -d` all clean; the partition/exit-status logic simulated against 194 fake tests (full coverage, failure propagation).
- The end-to-end effect (no OOM) is validated by this PR's own `tests` job, which exercises the chunked path on CI.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)


