### PR TITLE
chore(frontend): Revert version from 2.1.0 to 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet",
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/gix-components": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"private": true,
 	"license": "Apache-2.0",
 	"repository": {


### PR DESCRIPTION
# Motivation

OISY version was accidentally set back to 2.1.0 in this commit: https://github.com/dfinity/oisy-wallet/commit/c25126c27369bdb7beb3bb0416b68bebd93d0ee1

# Changes

- revert it to 2.1.1

# Tests

