### PR TITLE
feat(frontend): extend MaxBalanceButton component

### DIFF
--- a/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
+++ b/src/frontend/src/lib/components/common/MaxBalanceButton.svelte
@@ -8,6 +8,8 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { Token } from '$lib/types/token';
 	import { preventDefault } from '$lib/utils/event-modifiers.utils';
+	import { formatToken } from '$lib/utils/format.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
 	import { getMaxTransactionAmount, getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
@@ -17,6 +19,9 @@
 		balance: OptionBalance;
 		token?: Token;
 		fee?: bigint;
+		// Optional hard cap (base units). When set, "Max" never exceeds it even if the
+		// affordable balance is higher (e.g. full debt for repay).
+		maxAmount?: bigint;
 	}
 
 	let {
@@ -25,12 +30,13 @@
 		error = false,
 		balance,
 		token,
-		fee
+		fee,
+		maxAmount
 	}: Props = $props();
 
 	let isZeroBalance = $derived(!$isIcMintingAccount && (isNullish(balance) || balance === ZERO));
 
-	let maxAmount = $derived(
+	let maxBalanceAmount = $derived(
 		nonNullish(token)
 			? getMaxTransactionAmount({
 					balance,
@@ -41,10 +47,26 @@
 			: undefined
 	);
 
+	// Clamp the affordable max to the optional base-units cap.
+	let cappedMaxAmount = $derived.by(() => {
+		if (isNullish(maxBalanceAmount) || isNullish(token) || isNullish(maxAmount)) {
+			return maxBalanceAmount;
+		}
+
+		const affordable = parseToken({ value: maxBalanceAmount, unitName: token.decimals });
+		const capped = affordable < maxAmount ? affordable : maxAmount;
+
+		return formatToken({
+			value: capped,
+			unitName: token.decimals,
+			displayDecimals: token.decimals
+		});
+	});
+
 	const setMax = () => {
-		if (!isZeroBalance && nonNullish(maxAmount)) {
+		if (!isZeroBalance && nonNullish(cappedMaxAmount)) {
 			amountSetToMax = true;
-			amount = maxAmount;
+			amount = cappedMaxAmount;
 		}
 	};
 
@@ -73,7 +95,7 @@
 	onclick={preventDefault(setMax)}
 >
 	{$i18n.core.text.max}:
-	{nonNullish(maxAmount) && nonNullish(token)
-		? `${maxAmount} ${getTokenDisplaySymbol(token)}`
+	{nonNullish(cappedMaxAmount) && nonNullish(token)
+		? `${cappedMaxAmount} ${getTokenDisplaySymbol(token)}`
 		: $i18n.core.text.not_available}
 </button>

--- a/src/frontend/src/tests/lib/components/common/MaxBalanceButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/common/MaxBalanceButton.spec.ts
@@ -1,0 +1,35 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
+import { MAX_BUTTON } from '$lib/constants/test-ids.constants';
+import { render } from '@testing-library/svelte';
+
+describe('MaxBalanceButton', () => {
+	// BTC has 8 decimals: 200_000_000 sat = 2 BTC, 100_000_000 sat = 1 BTC.
+	const baseProps = {
+		amount: undefined,
+		balance: 200_000_000n,
+		token: BTC_MAINNET_TOKEN
+	};
+
+	it('shows the affordable balance when no cap is set', () => {
+		const { getByTestId } = render(MaxBalanceButton, { props: baseProps });
+
+		expect(getByTestId(MAX_BUTTON)).toHaveTextContent('2 BTC');
+	});
+
+	it('clamps the max to maxAmount when the balance is higher', () => {
+		const { getByTestId } = render(MaxBalanceButton, {
+			props: { ...baseProps, maxAmount: 100_000_000n }
+		});
+
+		expect(getByTestId(MAX_BUTTON)).toHaveTextContent('1 BTC');
+	});
+
+	it('uses the affordable balance when it is below the cap', () => {
+		const { getByTestId } = render(MaxBalanceButton, {
+			props: { ...baseProps, maxAmount: 500_000_000n }
+		});
+
+		expect(getByTestId(MAX_BUTTON)).toHaveTextContent('2 BTC');
+	});
+});


### PR DESCRIPTION
# Motivation

The MaxBalanceButton always sets the amount to the full affordable balance. Some flows (e.g. Liquidium repay) need to cap "Max" at a hard upper bound — you should never repay more than the outstanding debt, even when the wallet balance is higher. This adds an optional ceiling so the component can be reused in those flows instead of duplicating the logic.
