### PR TITLE
feat(frontend): no-fee warning on Liquidium Supply

### DIFF
--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
@@ -34,6 +34,7 @@
 		amount: OptionAmount;
 		supplyProgressStep: string;
 		inflowFee?: bigint;
+		inflowFeeUnavailable?: boolean;
 		currentStep?: WizardStep;
 		onClose: () => void;
 		onNext: () => void;
@@ -45,6 +46,7 @@
 		amount = $bindable(),
 		supplyProgressStep = $bindable(),
 		inflowFee,
+		inflowFeeUnavailable,
 		currentStep,
 		onClose,
 		onNext,
@@ -164,6 +166,7 @@
 		<LiquidiumSupplyForm
 			{feeDisplay}
 			{inflowFee}
+			{inflowFeeUnavailable}
 			{market}
 			{onClose}
 			onCustomErrorValidate={validateSupplyAmount}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte
@@ -42,6 +42,7 @@
 		amount: OptionAmount;
 		supplyProgressStep: string;
 		inflowFee?: bigint;
+		inflowFeeUnavailable?: boolean;
 		currentStep?: WizardStep;
 		onClose: () => void;
 		onNext: () => void;
@@ -53,6 +54,7 @@
 		amount = $bindable(),
 		supplyProgressStep = $bindable(),
 		inflowFee,
+		inflowFeeUnavailable,
 		currentStep,
 		onClose,
 		onNext,
@@ -243,6 +245,7 @@
 			<LiquidiumSupplyForm
 				{feeDisplay}
 				{inflowFee}
+				{inflowFeeUnavailable}
 				{market}
 				{onClose}
 				onCustomErrorValidate={validateSupplyAmount}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyForm.svelte
@@ -20,6 +20,9 @@
 		totalFee?: bigint;
 		// Provider fee (base units); shown as a row and reserved from Max.
 		inflowFee?: bigint;
+		// The provider-fee estimate failed (e.g. stale oracle price). Unlike repay, supply does not
+		// guess a fee — it surfaces a retry message and stays disabled until prices refresh.
+		inflowFeeUnavailable?: boolean;
 		// Rail-specific balance check (gas/provider-fee coverage); owned by the wizard,
 		// which holds the per-chain fee context.
 		onCustomErrorValidate?: (userAmount: bigint) => Error | undefined;
@@ -34,6 +37,7 @@
 		amount = $bindable(),
 		totalFee,
 		inflowFee,
+		inflowFeeUnavailable = false,
 		onCustomErrorValidate,
 		feeDisplay,
 		onClose,
@@ -67,7 +71,7 @@
 </script>
 
 <StakeForm
-	disabled={!agreementChecked || feeMissing}
+	disabled={!agreementChecked || feeMissing || inflowFeeUnavailable}
 	{onClose}
 	{onCustomErrorValidate}
 	{onNext}
@@ -91,6 +95,12 @@
 		<LiquidiumProviderFee {inflowFee} />
 
 		{@render feeDisplay()}
+
+		{#if inflowFeeUnavailable}
+			<MessageBox level="warning" styleClass="mt-3">
+				{$i18n.liquidium.text.supply_prices_unavailable}
+			</MessageBox>
+		{/if}
 
 		<LiquidiumSupplyAgreement bind:checked={agreementChecked} />
 	{/snippet}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
@@ -27,11 +27,15 @@
 
 	// Provider inflow fee for this asset, passed to the wizard.
 	let inflowFee = $state<bigint | undefined>();
+	// The estimate failed (e.g. stale oracle price): surface a retry message and block submit.
+	let inflowFeeUnavailable = $state(false);
 
 	$effect(() => {
 		const identity = $authIdentity;
 
 		if (nonNullish(identity)) {
+			inflowFeeUnavailable = false;
+
 			// Market data widens asset/chain to open strings (future assets); narrow to
 			// the SDK's strict mutating-flow types at this boundary.
 			estimateLiquidiumInflowFee({
@@ -40,7 +44,10 @@
 				chain: market.chain as Chain
 			})
 				.then((fee) => (inflowFee = fee))
-				.catch(consoleError);
+				.catch((err: unknown) => {
+					consoleError(err);
+					inflowFeeUnavailable = true;
+				});
 		}
 	});
 
@@ -77,6 +84,7 @@
 				<LiquidiumSupplyBtcWizard
 					{currentStep}
 					{inflowFee}
+					{inflowFeeUnavailable}
 					{market}
 					onBack={modal.back}
 					onClose={close}
@@ -88,6 +96,7 @@
 				<LiquidiumSupplyEthWizard
 					{currentStep}
 					{inflowFee}
+					{inflowFeeUnavailable}
 					{market}
 					onBack={modal.back}
 					onClose={close}

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "I understand my assets will be supplied to the Liquidium protocol and are subject to on-chain smart-contract risk.",
 			"provider_fee": "Provider fee",
 			"insufficient_funds_for_fee": "Insufficient balance to cover the amount and the provider fee.",
+			"supply_prices_unavailable": "Prices are temporarily unavailable. Supplying is disabled until they load.",
 			"borrow_review": "Review borrow",
 			"borrow_review_subtitle": "You borrow",
 			"borrowing": "Borrowing",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "Withdrawing collateral lowers your health factor. If it falls too far your remaining collateral can be liquidated.",
 			"withdraw_at_risk_warning": "This withdrawal noticeably lowers your health factor.",
 			"withdraw_high_risk_warning": "This withdrawal puts your position close to liquidation.",
-			"withdraw_risk_confirm": "I understand this withdrawal increases my liquidation risk."
+			"withdraw_risk_confirm": "I understand this withdrawal increases my liquidation risk.",
+			"repay_review": "Review repay",
+			"repay_review_subtitle": "You repay",
+			"repaying": "Repaying",
+			"starting_to_repay": "Submitting your repayment...",
+			"repay_started": "The repayment is now being processed.",
+			"current_debt": "Current debt",
+			"interest_accrued": "Interest accrued",
+			"debt_after_repay": "Debt after repay",
+			"repay_exceeds_debt": "Amount exceeds your outstanding debt.",
+			"repay_prices_unavailable": "Prices are temporarily unavailable. Repaying is disabled until they load."
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2261,6 +2261,7 @@
 			"supply_agreement": "",
 			"provider_fee": "",
 			"insufficient_funds_for_fee": "",
+			"supply_prices_unavailable": "",
 			"borrow_review": "",
 			"borrow_review_subtitle": "",
 			"borrowing": "",
@@ -2296,7 +2297,17 @@
 			"withdraw_risk_info": "",
 			"withdraw_at_risk_warning": "",
 			"withdraw_high_risk_warning": "",
-			"withdraw_risk_confirm": ""
+			"withdraw_risk_confirm": "",
+			"repay_review": "",
+			"repay_review_subtitle": "",
+			"repaying": "",
+			"starting_to_repay": "",
+			"repay_started": "",
+			"current_debt": "",
+			"interest_accrued": "",
+			"debt_after_repay": "",
+			"repay_exceeds_debt": "",
+			"repay_prices_unavailable": ""
 		}
 	},
 	"vaults": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1793,6 +1793,7 @@ interface I18nLiquidium {
 		supply_agreement: string;
 		provider_fee: string;
 		insufficient_funds_for_fee: string;
+		supply_prices_unavailable: string;
 		borrow_review: string;
 		borrow_review_subtitle: string;
 		borrowing: string;
@@ -1829,6 +1830,16 @@ interface I18nLiquidium {
 		withdraw_at_risk_warning: string;
 		withdraw_high_risk_warning: string;
 		withdraw_risk_confirm: string;
+		repay_review: string;
+		repay_review_subtitle: string;
+		repaying: string;
+		starting_to_repay: string;
+		repay_started: string;
+		current_debt: string;
+		interest_accrued: string;
+		debt_after_repay: string;
+		repay_exceeds_debt: string;
+		repay_prices_unavailable: string;
 	};
 }
 

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyForm.spec.ts
@@ -85,4 +85,22 @@ describe('LiquidiumSupplyForm', () => {
 
 		expect(container).not.toHaveTextContent(en.liquidium.text.insufficient_funds_for_fee);
 	});
+
+	it('surfaces a retry message when the provider-fee estimate is unavailable', () => {
+		const { container } = render(LiquidiumSupplyForm, {
+			props: { ...baseProps, inflowFeeUnavailable: true },
+			context: mockContext()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_prices_unavailable);
+	});
+
+	it('does not show the retry message when the fee is available', () => {
+		const { container } = render(LiquidiumSupplyForm, {
+			props: baseProps,
+			context: mockContext()
+		});
+
+		expect(container).not.toHaveTextContent(en.liquidium.text.supply_prices_unavailable);
+	});
 });


### PR DESCRIPTION
# Motivation

The Liquidium Supply flow estimates a provider inflow fee before letting the user submit. When that estimate fails (e.g. a stale oracle price), the previous behaviour only logged the error — the user was left with no fee row and an enabled submit button, allowing them to proceed without a valid fee. Unlike repay, supply does not guess a fallback fee, so the flow needs to surface the failure and block submission until prices refresh.

