### PR TITLE
chore(frontend): drop @rollup/plugin-inject devDependency (canary, based on #13297)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
 				"@dfinity/internet-identity-playwright": "^3.0.0",
 				"@icp-sdk/bindgen": "^0.2.0",
 				"@playwright/test": "^1.60.0",
-				"@rollup/plugin-inject": "^5.0.5",
 				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/kit": "^2.65.1",
 				"@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -1933,52 +1932,6 @@
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@rollup/plugin-inject": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
-			"integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rollup/pluginutils": "^5.0.1",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.3"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@rollup/pluginutils": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
-			"integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^2.0.2",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/@scure/base": {
 			"version": "1.2.6",
@@ -6759,13 +6712,6 @@
 			"engines": {
 				"node": ">=4.0"
 			}
-		},
-		"node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
 		"@dfinity/internet-identity-playwright": "^3.0.0",
 		"@icp-sdk/bindgen": "^0.2.0",
 		"@playwright/test": "^1.60.0",
-		"@rollup/plugin-inject": "^5.0.5",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.65.1",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",


### PR DESCRIPTION
# Motivation

Canary / integration check — do not merge directly.

`main` was reverted to Vite 7 (#13296), so it still uses `@rollup/plugin-inject` and is not a coherent base for dropping the dependency. This PR is therefore based on #13297 (`av/fix-vite8-rolldown-build-oom`), which restores Vite 8 / Rolldown — the line where the Buffer-polyfill migration off `@rollup/plugin-inject` (native `build.rollupOptions.inject`) actually applies.

This PR carries only the dependency removal. Its base (#13297) still imports `@rollup/plugin-inject` in `vite.config.ts`, so the build is expected to be RED until the native-`inject` migration reaches this base. When the base gains the migration and CI turns green, that green is the manual confirmation the dependency is genuinely unused.

# Changes

- Remove the unused `@rollup/plugin-inject` devDependency from `package.json`.
- Prune it from `package-lock.json` along with `@rollup/pluginutils` and the hoisted `estree-walker@2.0.2` (the `estree-walker@3.x` copies used by vitest/ast-v8-to-istanbul stay).

# Tests

- Expected RED against the current base: `vite.config.ts` imports `@rollup/plugin-inject`, which this PR removes.
- Expected GREEN once the base contains the native-`inject` migration.
- The same two-file diff already builds green on top of the migration branch (`npx vite build` ✓).
