### PR TITLE
fix(deps): override ws to ^8.21.0 to clear ws security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6851,27 +6851,6 @@
 			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
 			"license": "MIT"
 		},
-		"node_modules/ethers/node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eventemitter3": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -10157,27 +10136,6 @@
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/viem/node_modules/ws": {
-			"version": "8.20.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
 					"optional": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
 			"@icp-sdk/core": "^5.4.0",
 			"@icp-sdk/canisters": "^3.6.0",
 			"@dfinity/utils": "^4.2.1"
-		}
+		},
+		"ws@8": "^8.21.0"
 	},
 	"engines": {
 		"node": ">=24",


### PR DESCRIPTION
# Motivation

`npm audit` reports **5 advisories**, all rooted in one transitive package — `ws` (the WebSocket lib):

| Package | Severity | Path |
| --- | --- | --- |
| `ws` 8.0.0–8.20.1 | high | GHSA-58qx-3vcg-4xpx (uninitialized memory disclosure) + GHSA-96hv-2xvq-fx4p (memory-exhaustion DoS) |
| `viem` | high | depends on vulnerable `ws` |
| `@liquidium/client` | high | depends on vulnerable `viem` |
| `@velora-dex/sdk` | high | depends on vulnerable `viem` |
| `ethers` | moderate | depends on vulnerable `ws` |

`ethers` and `viem` pin `ws` at `8.17.1` / `8.20.1`, both inside the advisory range `8.0.0 - 8.20.1`. `npm audit fix` can't resolve the highs (no upstream release bumps `ws` yet).

# Changes

- Add a scoped override `"ws@8": "^8.21.0"`. `8.21.0` is the first patched release (outside the advisory range) and is already the hoisted version, so the nested `ethers` / `viem` copies dedupe away — the lockfile change is just removing those two stale `ws` entries.
- The override is **range-scoped to `ws@8`**, so WalletConnect's `ws@7.5.11` (different major, not in the advisory range) is deliberately left untouched.
- Same-major bump (8.x → 8.x), so no API break for `ethers` / `viem`.

# Tests

- `npm audit`: **5 → 0 vulnerabilities**.
- `npm install --package-lock-only` (npm 11.5.1) confirms npm's own resolver agrees with the dedup — the only nested `ws` it keeps is WalletConnect's `7.5.11`.
- `lockfile-lint` (the repo's `lint:lockfile` gate) passes; `prettier --check` clean. Lockfile diff is exactly the two removed `ws` blocks — no unrelated churn.