### PR TITLE
chore(signer): bump legacy signer version to 2.1.2

### DIFF
--- a/signer-versions.json
+++ b/signer-versions.json
@@ -1,3 +1,3 @@
 {
-	"legacy_signer_frontend": "2.0.2"
+	"legacy_signer_frontend": "2.1.2"
 }


### PR DESCRIPTION
# Motivation

The legacy signer frontend (`beta.legacy-signer.oisy.com`) still displays `v2.0.2` even after redeploying from `main`. Its version label is intentionally decoupled from `package.json` (introduced in #12392) and pinned in `signer-versions.json`, which was still set to `2.0.2` while the rest of the app is at `2.1.2`.

# Changes

- Bump `legacy_signer_frontend` in `signer-versions.json` from `2.0.2` to `2.1.2` to align it with the current `package.json` version.

# Tests

- Version is sourced by `svelte.config.js` from `signer-versions.json` when `OISY_SIGNER_TARGET=legacy_signer`; after this change a legacy-signer build reports `2.1.2`.
