### PR TITLE
feat(frontend): implement Borrowings tab

### DIFF
--- a/src/frontend/src/lib/components/borrowings/BorrowingsList.svelte
+++ b/src/frontend/src/lib/components/borrowings/BorrowingsList.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import LiquidiumBorrowingCard from '$lib/components/liquidium/LiquidiumBorrowingCard.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	let borrowReserves = $derived(
+		($liquidiumPortfolio?.reserves ?? []).filter(({ borrowed }) => borrowed > ZERO)
+	);
+</script>
+
+<div class="flex flex-col gap-4">
+	{#if borrowReserves.length === 0}
+		<p class="py-10 text-center text-tertiary">{$i18n.borrowings.text.no_borrowings}</p>
+	{:else}
+		{#each borrowReserves as reserve (reserve.poolId)}
+			<LiquidiumBorrowingCard {reserve} variant="holdings" />
+		{/each}
+	{/if}
+</div>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumBorrowingCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumBorrowingCard.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { goto } from '$app/navigation';
+	import LiquidiumProviderTag from '$lib/components/liquidium/LiquidiumProviderTag.svelte';
 	import LiquidiumRepayModal from '$lib/components/liquidium/repay/LiquidiumRepayModal.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { AppPath } from '$lib/constants/routes.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { modalLiquidiumRepay } from '$lib/derived/modal.derived';
@@ -18,11 +21,18 @@
 
 	interface Props {
 		reserve: LiquidiumReserve;
+		// 'provider': provider-page row with a Repay action (default).
+		// 'holdings': Assets → Borrowings tab row; no action, clicks through to the provider page.
+		variant?: 'provider' | 'holdings';
 	}
 
-	let { reserve }: Props = $props();
+	let { reserve, variant = 'provider' }: Props = $props();
 
 	const modalId = Symbol();
+
+	const goToProvider = () => {
+		void goto(AppPath.ProvidersLiquidium);
+	};
 
 	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
 
@@ -40,8 +50,29 @@
 	);
 </script>
 
+{#snippet repayAction()}
+	<span class="ml-2 flex">
+		<Button
+			colorStyle="secondary-light"
+			onclick={() => modalStore.openLiquidiumRepay(modalId)}
+			paddingSmall
+		>
+			{$i18n.liquidium.text.action_repay}
+		</Button>
+	</span>
+{/snippet}
+
+{#snippet providerTag()}
+	<LiquidiumProviderTag />
+{/snippet}
+
 <div class="flex w-full flex-col">
-	<LogoButton hover={false}>
+	<LogoButton
+		action={variant === 'provider' ? repayAction : undefined}
+		hover={variant === 'holdings'}
+		onClick={variant === 'holdings' ? goToProvider : undefined}
+		subtitle={variant === 'holdings' ? providerTag : undefined}
+	>
 		{#snippet logo()}
 			<span class="mr-2 flex">
 				{#if nonNullish(token)}
@@ -77,22 +108,10 @@
 				{reserve.asset}
 			</span>
 		{/snippet}
-
-		{#snippet action()}
-			<span class="ml-2 flex">
-				<Button
-					colorStyle="secondary-light"
-					onclick={() => modalStore.openLiquidiumRepay(modalId)}
-					paddingSmall
-				>
-					{$i18n.liquidium.text.action_repay}
-				</Button>
-			</span>
-		{/snippet}
 	</LogoButton>
 
 	<!-- Outside LogoButton's <button> to keep valid HTML. -->
-	{#if $modalLiquidiumRepay && $modalStore?.id === modalId}
+	{#if variant === 'provider' && $modalLiquidiumRepay && $modalStore?.id === modalId}
 		<LiquidiumRepayModal {reserve} />
 	{/if}
 </div>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumProviderTag.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProviderTag.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
+	import { LendBorrowProvider } from '$lib/types/lend-borrow';
+
+	const { name } = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM];
+</script>
+
+<span class="hidden sm:inline-block">
+	<Badge styleClass="ml-2 mb-1" variant="transparent" width="w-fit">
+		{name}
+	</Badge>
+</span>

--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -25,6 +25,7 @@
 	import { userSelectedNetworkStore } from '$lib/stores/user-selected-network.store';
 	import {
 		isRouteActivity,
+		isRouteBorrowings,
 		isRouteDappExplorer,
 		isRouteEarn,
 		isRouteEarning,
@@ -68,6 +69,10 @@
 			return AppPath.Trading;
 		}
 
+		if ($activeAssetsTabStore === TokenTypes.BORROWINGS) {
+			return AppPath.Borrowings;
+		}
+
 		if ($activeAssetsTabStore === TokenTypes.TOKENS) {
 			return AppPath.Tokens;
 		}
@@ -76,7 +81,11 @@
 	});
 
 	let assetsSelected = $derived(
-		isRouteTokens(page) || isRouteNfts(page) || isRouteEarning(page) || isRouteTransactions(page)
+		isRouteTokens(page) ||
+			isRouteNfts(page) ||
+			isRouteEarning(page) ||
+			isRouteBorrowings(page) ||
+			isRouteTransactions(page)
 	);
 </script>
 

--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -3,7 +3,9 @@
 	import { fade } from 'svelte/transition';
 	import { page } from '$app/state';
 	import { EARNING_ENABLED } from '$env/earning';
+	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 	import { TRADING_ENABLED } from '$env/trading';
+	import BorrowingsList from '$lib/components/borrowings/BorrowingsList.svelte';
 	import EarningsList from '$lib/components/earning/EarningsList.svelte';
 	import GoToEarnButton from '$lib/components/earning/GoToEarnButton.svelte';
 	import ManageTokensModal from '$lib/components/manage/ManageTokensModal.svelte';
@@ -86,6 +88,15 @@
 													}
 												]
 											: []),
+										...(anyLendBorrowProviderEnabled
+											? [
+													{
+														label: $i18n.borrowings.text.tab_title,
+														id: TokenTypes.BORROWINGS,
+														path: `${AppPath.Borrowings}${page.url.search}`
+													}
+												]
+											: []),
 										...(TRADING_ENABLED
 											? [
 													{
@@ -131,6 +142,8 @@
 				<EarningsList />
 			{:else if activeTab === TokenTypes.TRADING}
 				<TradingList />
+			{:else if activeTab === TokenTypes.BORROWINGS}
+				<BorrowingsList />
 			{/if}
 		</StickyHeader>
 

--- a/src/frontend/src/lib/constants/routes.constants.ts
+++ b/src/frontend/src/lib/constants/routes.constants.ts
@@ -13,6 +13,7 @@ export enum AppPath {
 	EarnAutopilot = '/earn/autopilot/',
 	EarnRewards = '/earn/rewards/',
 	Borrow = '/borrow/',
+	Borrowings = '/borrowings/',
 	Liabilities = '/liabilities/',
 	ProvidersLiquidium = '/providers/liquidium/',
 	LicenseAgreement = '/license-agreement/',

--- a/src/frontend/src/lib/enums/token-types.ts
+++ b/src/frontend/src/lib/enums/token-types.ts
@@ -3,5 +3,6 @@ export enum TokenTypes {
 	TOKENS = 'tokens',
 	NFTS = 'nfts',
 	EARNING = 'earning',
-	TRADING = 'trading'
+	TRADING = 'trading',
+	BORROWINGS = 'borrowings'
 }

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "إلغاء",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Zrušit",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Abbrechen",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "Borrowings",
+			"no_borrowings": "It looks like you haven't borrowed any tokens yet."
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Cancel",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Cancelar",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Annuler",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "रद्द करें",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Annulla",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "キャンセル",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "취소",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Anuluj",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Cancelar",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Отмена",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "Hủy",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1,4 +1,10 @@
 {
+	"borrowings": {
+		"text": {
+			"tab_title": "",
+			"no_borrowings": ""
+		}
+	},
 	"core": {
 		"text": {
 			"cancel": "取消",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -2,6 +2,10 @@
  * Auto-generated definitions file ("npm run i18n")
  */
 
+interface I18nBorrowings {
+	text: { tab_title: string; no_borrowings: string };
+}
+
 interface I18nCore {
 	text: {
 		cancel: string;
@@ -2012,6 +2016,7 @@ interface I18nAi_assistant {
 
 interface I18n {
 	lang: Languages;
+	borrowings: I18nBorrowings;
 	core: I18nCore;
 	navigation: I18nNavigation;
 	auth: I18nAuth;

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -39,6 +39,8 @@ export const isNftsPath = (path: string | null) =>
 	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.Nfts}`) ?? false;
 export const isEarningPath = (path: string | null) =>
 	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.Earning}`) ?? false;
+export const isBorrowingsPath = (path: string | null) =>
+	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.Borrowings}`) ?? false;
 export const isRewardsPath = (path: string | null) =>
 	normalizePath(path) === `${ROUTE_ID_GROUP_APP}${AppPath.Rewards}`;
 export const isEarnPath = (path: string | null) =>
@@ -61,6 +63,8 @@ export const isRouteTokens = ({ route: { id } }: Page): boolean => isTokensPath(
 export const isRouteNfts = ({ route: { id } }: Page): boolean => isNftsPath(id);
 
 export const isRouteEarning = ({ route: { id } }: Page): boolean => isEarningPath(id);
+
+export const isRouteBorrowings = ({ route: { id } }: Page): boolean => isBorrowingsPath(id);
 
 export const isRouteRewards = ({ route: { id } }: Page): boolean => isRewardsPath(id);
 

--- a/src/frontend/src/routes/(app)/+layout.svelte
+++ b/src/frontend/src/routes/(app)/+layout.svelte
@@ -27,6 +27,7 @@
 	import { pageNonFungibleToken, pageToken } from '$lib/derived/page-token.derived';
 	import { token } from '$lib/stores/token.store';
 	import {
+		isRouteBorrowings,
 		isRouteEarning,
 		isRouteNfts,
 		isRouteTokens,
@@ -46,7 +47,9 @@
 
 	let earningRoute = $derived(isRouteEarning(page));
 
-	let assetsRoute = $derived(tokensRoute || nftsRoute || earningRoute);
+	let borrowingsRoute = $derived(isRouteBorrowings(page));
+
+	let assetsRoute = $derived(tokensRoute || nftsRoute || earningRoute || borrowingsRoute);
 
 	let transactionsRoute = $derived(isRouteTransactions(page));
 

--- a/src/frontend/src/routes/(app)/borrowings/+page.svelte
+++ b/src/frontend/src/routes/(app)/borrowings/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	import Assets from '$lib/components/tokens/Assets.svelte';
+	import { TokenTypes } from '$lib/enums/token-types';
+</script>
+
+<Assets tab={TokenTypes.BORROWINGS} />

--- a/src/frontend/src/tests/lib/components/borrowings/BorrowingsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/borrowings/BorrowingsList.spec.ts
@@ -1,0 +1,81 @@
+import BorrowingsList from '$lib/components/borrowings/BorrowingsList.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+describe('BorrowingsList', () => {
+	const borrowReserve: LiquidiumReserve = {
+		poolId: 'pool-usdc',
+		asset: 'USDC',
+		chain: 'ETH',
+		supplyApy: 0,
+		borrowApy: 7,
+		deposited: ZERO,
+		depositedDecimals: 6,
+		borrowed: 20_000_000_000n,
+		borrowedDecimals: 6,
+		suppliedUsd: 0,
+		borrowedUsd: 20_000
+	};
+
+	const supplyReserve: LiquidiumReserve = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 0,
+		deposited: 100_000_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 1000,
+		borrowedUsd: 0
+	};
+
+	const portfolio = (reserves: LiquidiumReserve[]): LiquidiumPortfolio => ({
+		reserves,
+		totalSuppliedUsd: 0,
+		totalBorrowedUsd: 0,
+		netValueUsd: 0,
+		availableBorrowsUsd: 0,
+		weightedLiquidationThresholdBps: 8000,
+		healthFactorPercent: 73
+	});
+
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('lists borrow positions', () => {
+		liquidiumStore.set({ markets: [], portfolio: portfolio([borrowReserve]), assetPrices: {} });
+
+		const { container } = render(BorrowingsList);
+
+		expect(container).toHaveTextContent('USDC');
+		expect(container).toHaveTextContent(en.liquidium.text.borrow_rate);
+		expect(container).not.toHaveTextContent(en.borrowings.text.no_borrowings);
+	});
+
+	it('ignores supplied-only reserves and shows the empty state', () => {
+		liquidiumStore.set({ markets: [], portfolio: portfolio([supplyReserve]), assetPrices: {} });
+
+		const { container } = render(BorrowingsList);
+
+		expect(container).toHaveTextContent(en.borrowings.text.no_borrowings);
+		expect(container).not.toHaveTextContent('BTC');
+	});
+
+	it('shows the empty state when there is no portfolio', () => {
+		liquidiumStore.set({ markets: [], portfolio: null, assetPrices: {} });
+
+		const { container } = render(BorrowingsList);
+
+		expect(container).toHaveTextContent(en.borrowings.text.no_borrowings);
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowingCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowingCard.spec.ts
@@ -1,9 +1,17 @@
+import { goto } from '$app/navigation';
 import LiquidiumBorrowingCard from '$lib/components/liquidium/LiquidiumBorrowingCard.svelte';
+import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
 import { ZERO } from '$lib/constants/app.constants';
+import { AppPath } from '$lib/constants/routes.constants';
+import { LendBorrowProvider } from '$lib/types/lend-borrow';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
 
 describe('LiquidiumBorrowingCard', () => {
 	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
@@ -42,5 +50,43 @@ describe('LiquidiumBorrowingCard', () => {
 		const { getByText } = render(LiquidiumBorrowingCard, { props: { reserve: reserve() } });
 
 		expect(getByText(en.liquidium.text.action_repay)).toBeInTheDocument();
+	});
+
+	it('does not render the provider tag in the provider variant', () => {
+		const { container } = render(LiquidiumBorrowingCard, { props: { reserve: reserve() } });
+
+		expect(container).not.toHaveTextContent(
+			lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
+		);
+	});
+
+	describe('holdings variant', () => {
+		it('does not render the Repay action button', () => {
+			const { queryByText } = render(LiquidiumBorrowingCard, {
+				props: { reserve: reserve(), variant: 'holdings' }
+			});
+
+			expect(queryByText(en.liquidium.text.action_repay)).not.toBeInTheDocument();
+		});
+
+		it('renders the Liquidium provider tag', () => {
+			const { container } = render(LiquidiumBorrowingCard, {
+				props: { reserve: reserve(), variant: 'holdings' }
+			});
+
+			expect(container).toHaveTextContent(
+				lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
+			);
+		});
+
+		it('navigates to the Liquidium provider page when clicked', async () => {
+			const { getByRole } = render(LiquidiumBorrowingCard, {
+				props: { reserve: reserve(), variant: 'holdings' }
+			});
+
+			await fireEvent.click(getByRole('button'));
+
+			expect(goto).toHaveBeenCalledWith(AppPath.ProvidersLiquidium);
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumProviderTag.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumProviderTag.spec.ts
@@ -1,0 +1,14 @@
+import LiquidiumProviderTag from '$lib/components/liquidium/LiquidiumProviderTag.svelte';
+import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
+import { LendBorrowProvider } from '$lib/types/lend-borrow';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumProviderTag', () => {
+	it('renders the Liquidium provider name', () => {
+		const { container } = render(LiquidiumProviderTag);
+
+		expect(container).toHaveTextContent(
+			lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
+		);
+	});
+});


### PR DESCRIPTION
# Motivation

This PR adds a dedicated Borrowings tab to the Assets page so users can see their outstanding debt alongside the other asset tabs. It is the first Assets-page surface for the borrow side.

# Changes

  - New /borrowings/ route (routes/(app)/borrowings/+page.svelte) rendering <Assets tab={TokenTypes.BORROWINGS} />, mirroring the Earning tab.
  - Assets tab bar: added the Borrowings tab (after Earning, gated by anyLendBorrowProviderEnabled) plus TokenTypes.BORROWINGS and AppPath.Borrowings.
  - BorrowingsList: lists the user's Liquidium borrow positions (liquidiumPortfolio.reserves filtered by borrowed > 0); empty state when there is no debt.
  - LiquidiumBorrowingCard gains a variant: 'provider' | 'holdings' prop. provider (default) is unchanged; holdings (used on the tab) drops the Repay action and makes the row navigate to /providers/liquidium/, and shows a new LiquidiumProviderTag ("Liquidium", styled like the Autopilot tag) — the tag renders only on the Borrowings tab, not the provider page.
  - Layout/nav wiring: the hero + dapps carousel now render on /borrowings/ ((app)/+layout.svelte), the Assets nav item stays highlighted on the route, and the assetsPath mapping handles the new tab (NavigationMenuMainItems, nav.utils isRouteBorrowings).
  - i18n: added borrowings.text.{tab_title, no_borrowings} and regenerated locale files + types.


# Tests

Added.
