### PR TITLE
refactor(frontend): own Popover natively, detach from gix

### DIFF
--- a/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionsButton.svelte
+++ b/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionsButton.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { Popover } from '@dfinity/gix-components';
 	import ActiveUserTransactionsList from '$lib/components/active-user-transactions/ActiveUserTransactionsList.svelte';
 	import AnimatedIconLoader from '$lib/components/icons/animated/AnimatedIconLoader.svelte';
 	import IconBell from '$lib/components/icons/lucide/IconBell.svelte';
 	import IconBellDot from '$lib/components/icons/lucide/IconBellDot.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
+	import Popover from '$lib/components/ui/Popover.svelte';
 	import {
 		activeUserTransactionsHasUnseen,
 		activeUserTransactionsList,

--- a/src/frontend/src/lib/components/contact/EditAvatar.svelte
+++ b/src/frontend/src/lib/components/contact/EditAvatar.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { Popover } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import IconImage from '$lib/components/icons/lucide/IconImage.svelte';
 	import IconPencil from '$lib/components/icons/lucide/IconPencil.svelte';
 	import IconTrash from '$lib/components/icons/lucide/IconTrash.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import Popover from '$lib/components/ui/Popover.svelte';
 	import {
 		CONTACT_POPOVER_TRIGGER,
 		CONTACT_POPOVER_MENU,

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { IconUser, Popover } from '@dfinity/gix-components';
+	import { IconUser } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
@@ -29,6 +29,7 @@
 	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
+	import Popover from '$lib/components/ui/Popover.svelte';
 	import { USER_MENU_ROUTE } from '$lib/constants/analytics.constants';
 	import { OISY_SUPPORT_URL } from '$lib/constants/oisy.constants';
 	import {

--- a/src/frontend/src/lib/components/tokens/TokenCategoryFilterDropdown.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCategoryFilterDropdown.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { Popover } from '@dfinity/gix-components';
 	import { isNullish } from '@dfinity/utils';
 	import List from '$lib/components/common/List.svelte';
 	import ListItem from '$lib/components/common/ListItem.svelte';
 	import IconCheck from '$lib/components/icons/IconCheck.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ModalFilterButton from '$lib/components/ui/ModalFilterButton.svelte';
+	import Popover from '$lib/components/ui/Popover.svelte';
 	import { tokenCategoryFilter } from '$lib/derived/settings.derived';
 	import { TokenCategoryTagValue } from '$lib/enums/token-tag';
 	import { i18n } from '$lib/stores/i18n.store';

--- a/src/frontend/src/lib/components/tokens/TokenMenu.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenMenu.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { Popover } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import type { Snippet } from 'svelte';
 	import { afterNavigate } from '$app/navigation';
 	import IconMoreVertical from '$lib/components/icons/lucide/IconMoreVertical.svelte';
 	import ButtonMenu from '$lib/components/ui/ButtonMenu.svelte';
+	import Popover from '$lib/components/ui/Popover.svelte';
 	import {
 		networkBitcoin,
 		networkEthereum,

--- a/src/frontend/src/lib/components/ui/Dropdown.svelte
+++ b/src/frontend/src/lib/components/ui/Dropdown.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { Modal, Popover } from '@dfinity/gix-components';
+	import { Modal } from '@dfinity/gix-components';
 	import type { Snippet } from 'svelte';
 	import DropdownButton from '$lib/components/ui/DropdownButton.svelte';
+	import Popover from '$lib/components/ui/Popover.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 
 	interface Props {

--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -1,0 +1,260 @@
+<!-- Ported from @dfinity/gix-components Popover; originally based on
+	 https://github.com/papyrs/papyrs/blob/main/src/lib/components/ui/Popover.svelte -->
+<script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
+	import { quintOut } from 'svelte/easing';
+	import { fade, scale } from 'svelte/transition';
+	import IconClose from '$lib/components/icons/IconClose.svelte';
+	import Backdrop from '$lib/components/ui/Backdrop.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { PopoverDirection } from '$lib/types/popover';
+	import { stopPropagation } from '$lib/utils/event-modifiers.utils';
+	import { computePopoverPlacement } from '$lib/utils/popover.utils';
+
+	interface Props {
+		anchor?: HTMLElement;
+		visible?: boolean;
+		direction?: PopoverDirection;
+		closeButton?: boolean;
+		invisibleBackdrop?: boolean;
+		testId?: string;
+		children?: Snippet;
+	}
+
+	let {
+		anchor,
+		visible = $bindable(false),
+		direction = 'ltr',
+		closeButton = false,
+		invisibleBackdrop = false,
+		testId = 'popover-component',
+		children
+	}: Props = $props();
+
+	// Fallback used when `--padding` cannot be read (e.g. before the CSS
+	// variables are applied). Matches the default declared in
+	// `src/lib/styles/global/variables.scss`.
+	const DEFAULT_VIEWPORT_PADDING = 8;
+
+	let popoverTop = $state(0);
+	let popoverLeft = $state(0);
+	let popoverRight = $state(0);
+	let panelWidth = $state(0);
+	let placementResolved = $state(false);
+	// svelte-ignore state_referenced_locally
+	let effectiveDirection = $state<PopoverDirection>(direction);
+
+	const readViewportPadding = (): number => {
+		if (typeof window === 'undefined') {
+			return DEFAULT_VIEWPORT_PADDING;
+		}
+
+		const raw = getComputedStyle(document.documentElement).getPropertyValue('--padding');
+
+		const parsed = parseFloat(raw);
+
+		return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_VIEWPORT_PADDING;
+	};
+
+	const initPosition = () => {
+		if (typeof window === 'undefined') {
+			return;
+		}
+
+		if (isNullish(anchor)) {
+			popoverTop = 0;
+			popoverLeft = 0;
+			popoverRight = 0;
+			effectiveDirection = direction;
+
+			return;
+		}
+
+		const { bottom, left, right } = anchor.getBoundingClientRect();
+
+		const viewportWidth = document.documentElement.clientWidth;
+
+		const placement = computePopoverPlacement({
+			anchorLeft: left,
+			anchorRight: right,
+			panelWidth,
+			viewportWidth,
+			viewportPadding: readViewportPadding(),
+			preferredDirection: direction
+		});
+
+		popoverTop = bottom;
+		popoverLeft = placement.left;
+		popoverRight = placement.right;
+		effectiveDirection = placement.direction;
+	};
+
+	$effect(() => {
+		// Recompute the placement whenever the anchor, visibility or preferred direction changes.
+		[anchor, visible, direction];
+		initPosition();
+	});
+
+	const observePanelWidth = (node: HTMLElement) => {
+		placementResolved = false;
+
+		const measure = () => {
+			const next = node.offsetWidth;
+
+			if (next === panelWidth) {
+				return;
+			}
+
+			panelWidth = next;
+
+			initPosition();
+
+			if (next > 0) {
+				placementResolved = true;
+			}
+		};
+
+		measure();
+
+		if (typeof ResizeObserver === 'undefined') {
+			return {};
+		}
+
+		const ro = new ResizeObserver(measure);
+
+		ro.observe(node);
+
+		return {
+			destroy: () => {
+				ro.disconnect();
+
+				placementResolved = false;
+				panelWidth = 0;
+			}
+		};
+	};
+
+	const close = () => {
+		visible = false;
+	};
+</script>
+
+<svelte:window onresize={initPosition} />
+
+{#if visible}
+	<div
+		style="--popover-top: {popoverTop}px; --popover-left: {popoverLeft}px; --popover-right: {popoverRight}px"
+		class="popover"
+		aria-orientation="vertical"
+		data-tid={testId}
+		role="menu"
+		tabindex="-1"
+		transition:fade|global
+	>
+		<Backdrop invisible={invisibleBackdrop} onClose={close} />
+		<div
+			class="wrapper"
+			class:placed={placementResolved}
+			class:rtl={effectiveDirection === 'rtl'}
+			class:with-border={invisibleBackdrop}
+			use:observePanelWidth
+			transition:scale|global={{ delay: 25, duration: 150, easing: quintOut }}
+		>
+			{#if closeButton}
+				<button
+					class="close icon-only"
+					aria-label={$i18n.core.text.close}
+					onclick={stopPropagation(close)}><IconClose /></button
+				>
+			{/if}
+
+			<div class="popover-content" data-tid="popover-content">
+				{@render children?.()}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style lang="scss">
+	@use '$lib/styles/mixins/display';
+
+	.popover {
+		position: fixed;
+		@include display.inset;
+
+		z-index: var(--overlay-z-index);
+
+		// Folded in from the former gix.scss `div.popover` override layer (OISY-owned).
+		--background-contrast: var(--overlay-background-contrast);
+	}
+
+	.wrapper {
+		cursor: initial;
+
+		// position
+		position: absolute;
+		top: calc(var(--popover-top) + var(--padding));
+		left: var(--popover-left);
+
+		// size
+		--size: min(calc(20 * var(--padding)), calc(100vw - var(--padding)));
+
+		min-width: var(--size);
+
+		max-height: calc(var(--full-vh, 100vh) - var(--popover-top) - calc(6 * var(--padding)));
+
+		width: fit-content;
+		height: auto;
+
+		display: flex;
+		flex-direction: column;
+
+		background-color: var(--dropdown-background);
+		color: var(--background-contrast);
+
+		// Folded in from the former gix.scss `div.popover .wrapper` override layer (OISY-owned):
+		// tighter padding, a 16px radius, and a matching first-paint width cap.
+		padding: var(--padding-0_5x);
+		--padding: var(--padding-0_5x);
+		--border-radius: 16px;
+
+		border-radius: var(--border-radius);
+
+		// Loose cap used during the first paint so we can measure the panel's
+		// natural width. `.placed` swaps this for a side-aware cap that keeps the
+		// panel inside the viewport on whichever side was chosen.
+		max-width: calc(100vw - (2 * var(--padding)));
+
+		@supports (height: 100dvh) {
+			--full-vh: 100dvh;
+		}
+
+		&.rtl {
+			left: auto;
+			right: var(--popover-right);
+		}
+
+		// After the initial measurement, clamp the panel to the available room on
+		// the chosen side so it never extends past the viewport edge.
+		&.placed {
+			max-width: calc(100vw - var(--popover-left) - var(--padding));
+		}
+
+		&.placed.rtl {
+			max-width: calc(100vw - var(--popover-right) - var(--padding));
+		}
+
+		&.with-border {
+			border: var(--dropdown-border-size) solid var(--dropdown-border-color);
+		}
+	}
+
+	.close {
+		align-self: flex-end;
+	}
+
+	.popover-content {
+		overflow-y: auto;
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -32,9 +32,10 @@
 		children
 	}: Props = $props();
 
-	// Fallback used when `--padding` cannot be read (e.g. before the CSS
-	// variables are applied). Matches the default declared in
-	// `src/lib/styles/global/variables.scss`.
+	// Conservative fallback used only when `--padding` cannot be read (e.g. during SSR or
+	// before the CSS variables are applied). The live value from
+	// `src/lib/styles/global/variables.scss` (`round(0.45rem, 1px)`) is read at runtime and
+	// takes precedence; this constant just guards that pre-paint edge case.
 	const DEFAULT_VIEWPORT_PADDING = 8;
 
 	let popoverTop = $state(0);
@@ -117,8 +118,14 @@
 
 		measure();
 
+		const reset = () => {
+			placementResolved = false;
+			panelWidth = 0;
+		};
+
 		if (typeof ResizeObserver === 'undefined') {
-			return {};
+			// Still reset state on unmount so a later re-mount re-measures from scratch.
+			return { destroy: reset };
 		}
 
 		const ro = new ResizeObserver(measure);
@@ -129,8 +136,7 @@
 			destroy: () => {
 				ro.disconnect();
 
-				placementResolved = false;
-				panelWidth = 0;
+				reset();
 			}
 		};
 	};
@@ -165,7 +171,8 @@
 				<button
 					class="close icon-only"
 					aria-label={$i18n.core.text.close}
-					onclick={stopPropagation(close)}><IconClose /></button
+					onclick={stopPropagation(close)}
+					type="button"><IconClose /></button
 				>
 			{/if}
 

--- a/src/frontend/src/lib/components/ui/ResponsivePopover.svelte
+++ b/src/frontend/src/lib/components/ui/ResponsivePopover.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { Popover } from '@dfinity/gix-components';
 	import type { Snippet } from 'svelte';
 	import BottomSheet from '$lib/components/ui/BottomSheet.svelte';
 	import ButtonDone from '$lib/components/ui/ButtonDone.svelte';
+	import Popover from '$lib/components/ui/Popover.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
 
 	interface Props {

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -257,19 +257,6 @@ div.modal {
 	}
 }
 
-div.popover {
-	--background-contrast: var(--overlay-background-contrast);
-
-	.wrapper {
-		padding: var(--padding-0_5x);
-		--padding: var(--padding-0_5x);
-
-		--border-radius: 16px;
-
-		max-width: calc(100vw - (2 * var(--padding)));
-	}
-}
-
 div.segment-button {
 	button.selected {
 		color: var(--color-foreground-primary-inverted);

--- a/src/frontend/src/lib/types/popover.ts
+++ b/src/frontend/src/lib/types/popover.ts
@@ -1,0 +1,1 @@
+export type PopoverDirection = 'ltr' | 'rtl';

--- a/src/frontend/src/lib/utils/popover.utils.ts
+++ b/src/frontend/src/lib/utils/popover.utils.ts
@@ -1,0 +1,144 @@
+import type { PopoverDirection } from '$lib/types/popover';
+
+export interface PickPopoverPlacementParams {
+	/** Anchor's left edge relative to the viewport (e.g. `getBoundingClientRect().left`). */
+	anchorLeft: number;
+	/** Anchor's right edge relative to the viewport (e.g. `getBoundingClientRect().right`). */
+	anchorRight: number;
+	/** Measured width of the popover panel. Pass `0` when not yet measured. */
+	panelWidth: number;
+	/** Viewport width excluding the vertical scrollbar (`document.documentElement.clientWidth`). */
+	viewportWidth: number;
+	/** Minimum margin (in px) we want to keep between the panel and the viewport edge. */
+	viewportPadding: number;
+	/** Consumer-requested side; treated as a preference and honored when it fits. */
+	preferredDirection: PopoverDirection;
+}
+
+export interface PopoverPlacement {
+	/** The side the panel grows toward. */
+	direction: PopoverDirection;
+	/** Distance (px) from the viewport's left edge to the panel's left edge. */
+	left: number;
+	/** Distance (px) from the viewport's right edge to the panel's right edge. */
+	right: number;
+}
+
+/**
+ * Picks the side the popover panel should grow toward.
+ *
+ * The `preferredDirection` is honored when the panel fits within the viewport
+ * on that side. If it would overflow, we flip to the opposite side when that
+ * one fits. When neither side can contain the panel in full at the anchor's
+ * edge, we fall back to the side that leaves the most room.
+ *
+ * When `panelWidth` is `0` (not measured yet) we return the preferred side
+ * unchanged so that the first paint matches today's behavior.
+ */
+export const pickPopoverDirection = ({
+	anchorLeft,
+	anchorRight,
+	panelWidth,
+	viewportWidth,
+	viewportPadding,
+	preferredDirection
+}: PickPopoverPlacementParams): PopoverDirection => {
+	if (panelWidth <= 0) {
+		return preferredDirection;
+	}
+
+	const ltrFits = anchorLeft + panelWidth <= viewportWidth - viewportPadding;
+	const rtlFits = anchorRight - panelWidth >= viewportPadding;
+
+	if (preferredDirection === 'ltr') {
+		if (ltrFits) {
+			return 'ltr';
+		}
+
+		if (rtlFits) {
+			return 'rtl';
+		}
+	} else {
+		if (rtlFits) {
+			return 'rtl';
+		}
+
+		if (ltrFits) {
+			return 'ltr';
+		}
+	}
+
+	const ltrRoom = viewportWidth - viewportPadding - anchorLeft;
+	const rtlRoom = anchorRight - viewportPadding;
+
+	return rtlRoom > ltrRoom ? 'rtl' : 'ltr';
+};
+
+/**
+ * Computes a viewport offset for one edge of the panel. When the anchor offset
+ * would push the panel past the opposite viewport edge, we "shift" the panel
+ * toward the viewport's interior so it stays inside at its natural width.
+ * If the panel is wider than the viewport's usable room, we pin the offset to
+ * `viewportPadding`; the caller is then expected to clamp the panel's width
+ * via CSS as a last resort.
+ */
+const shiftEdgeOffset = ({
+	anchorOffset,
+	panelWidth,
+	viewportWidth,
+	viewportPadding
+}: {
+	anchorOffset: number;
+	panelWidth: number;
+	viewportWidth: number;
+	viewportPadding: number;
+}): number => {
+	const maxOffsetThatFits = viewportWidth - viewportPadding - panelWidth;
+
+	if (anchorOffset <= maxOffsetThatFits) {
+		return anchorOffset;
+	}
+
+	return Math.max(viewportPadding, maxOffsetThatFits);
+};
+
+/**
+ * Returns the panel's effective left/right offsets relative to the viewport
+ * edges, after running:
+ *
+ *   1. `pickPopoverDirection` to choose the side.
+ *   2. A "shift" step: when the natural-width panel would overflow the chosen
+ *      side, translate the panel along the cross-axis so it stays inside the
+ *      viewport (with a `viewportPadding` margin) at its full natural width.
+ *
+ * If even after shifting the panel is wider than the viewport's usable room,
+ * the offsets are pinned to `viewportPadding`. The caller is then expected to
+ * clamp the panel's width via CSS as a last resort.
+ */
+export const computePopoverPlacement = (params: PickPopoverPlacementParams): PopoverPlacement => {
+	const direction = pickPopoverDirection(params);
+
+	const { anchorLeft, anchorRight, panelWidth, viewportWidth, viewportPadding } = params;
+
+	const anchorFromRight = viewportWidth - anchorRight;
+
+	if (panelWidth <= 0) {
+		return { direction, left: anchorLeft, right: anchorFromRight };
+	}
+
+	return {
+		direction,
+		left: shiftEdgeOffset({
+			anchorOffset: anchorLeft,
+			panelWidth,
+			viewportWidth,
+			viewportPadding
+		}),
+		right: shiftEdgeOffset({
+			anchorOffset: anchorFromRight,
+			panelWidth,
+			viewportWidth,
+			viewportPadding
+		})
+	};
+};

--- a/src/frontend/src/tests/lib/components/ui/Popover.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/Popover.spec.ts
@@ -1,0 +1,67 @@
+import Popover from '$lib/components/ui/Popover.svelte';
+import PopoverTest from '$tests/lib/components/ui/PopoverTest.svelte';
+import { render, waitFor } from '@testing-library/svelte';
+
+describe('Popover', () => {
+	it('should be closed by default', () => {
+		const { getByRole } = render(Popover);
+
+		expect(() => getByRole('menu')).toThrow();
+	});
+
+	it('should be visible', async () => {
+		const { getByRole } = render(Popover, { props: { visible: true } });
+
+		await waitFor(() => expect(getByRole('menu')).not.toBeNull());
+	});
+
+	it('should render a backdrop', () => {
+		const { container } = render(Popover, { props: { visible: true } });
+
+		const backdrop = container.querySelector('div.backdrop');
+
+		expect(backdrop).not.toBeNull();
+		expect(backdrop?.classList).toContain('visible');
+	});
+
+	it('should render a backdrop invisible', () => {
+		const { container } = render(Popover, {
+			props: { visible: true, invisibleBackdrop: true }
+		});
+
+		const backdrop = container.querySelector('div.backdrop');
+
+		expect(backdrop).not.toBeNull();
+		expect(backdrop?.classList).not.toContain('visible');
+	});
+
+	it('should render slotted content', () => {
+		const { getByTestId } = render(PopoverTest);
+
+		expect(getByTestId('popover-slot')).not.toBeNull();
+	});
+
+	it('should render direction classes', () => {
+		const { container } = render(Popover, {
+			props: { visible: true, direction: 'rtl' }
+		});
+
+		expect(container.querySelector('.rtl')).not.toBeNull();
+	});
+
+	it('should render the content container', () => {
+		const { container } = render(Popover, { props: { visible: true } });
+
+		expect(container.querySelector('.popover-content')).not.toBeNull();
+	});
+
+	it('should render the close button only when requested', async () => {
+		const { rerender, container } = render(Popover, { props: { visible: true } });
+
+		expect(container.querySelector('button.close')).toBeNull();
+
+		await rerender({ visible: true, closeButton: true });
+
+		expect(container.querySelector('button.close')).not.toBeNull();
+	});
+});

--- a/src/frontend/src/tests/lib/components/ui/PopoverTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/PopoverTest.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import Popover from '$lib/components/ui/Popover.svelte';
+</script>
+
+<Popover visible={true}>
+	<div data-tid="popover-slot"></div>
+</Popover>

--- a/src/frontend/src/tests/lib/utils/popover.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/popover.utils.spec.ts
@@ -1,0 +1,229 @@
+import { computePopoverPlacement, pickPopoverDirection } from '$lib/utils/popover.utils';
+
+describe('pickPopoverDirection', () => {
+	const viewportWidth = 1000;
+	const viewportPadding = 8;
+
+	it('returns the preferred direction when the panel has not been measured yet', () => {
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 900,
+				anchorRight: 950,
+				panelWidth: 0,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'ltr'
+			})
+		).toBe('ltr');
+
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 10,
+				anchorRight: 60,
+				panelWidth: 0,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'rtl'
+			})
+		).toBe('rtl');
+	});
+
+	it('keeps the preferred ltr direction when there is enough room on the right', () => {
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 100,
+				anchorRight: 150,
+				panelWidth: 300,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'ltr'
+			})
+		).toBe('ltr');
+	});
+
+	it('keeps the preferred rtl direction when there is enough room on the left', () => {
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 800,
+				anchorRight: 850,
+				panelWidth: 300,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'rtl'
+			})
+		).toBe('rtl');
+	});
+
+	it('flips from ltr to rtl when the preferred side overflows the viewport', () => {
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 900,
+				anchorRight: 950,
+				panelWidth: 300,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'ltr'
+			})
+		).toBe('rtl');
+	});
+
+	it('flips from rtl to ltr when the preferred side overflows the viewport', () => {
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 10,
+				anchorRight: 60,
+				panelWidth: 300,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'rtl'
+			})
+		).toBe('ltr');
+	});
+
+	it('falls back to the side with the most room when the panel fits on neither side', () => {
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 200,
+				anchorRight: 300,
+				panelWidth: 950,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'ltr'
+			})
+		).toBe('ltr');
+
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 700,
+				anchorRight: 800,
+				panelWidth: 950,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'rtl'
+			})
+		).toBe('rtl');
+	});
+
+	it('respects the viewport padding when checking fit', () => {
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 700,
+				anchorRight: 750,
+				panelWidth: 200,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'ltr'
+			})
+		).toBe('ltr');
+
+		expect(
+			pickPopoverDirection({
+				anchorLeft: 700,
+				anchorRight: 750,
+				panelWidth: 200,
+				viewportWidth,
+				viewportPadding: 150,
+				preferredDirection: 'ltr'
+			})
+		).toBe('rtl');
+	});
+});
+
+describe('computePopoverPlacement', () => {
+	const viewportWidth = 1000;
+	const viewportPadding = 8;
+
+	it('aligns offsets to the raw anchor edges before the panel is measured', () => {
+		expect(
+			computePopoverPlacement({
+				anchorLeft: 700,
+				anchorRight: 750,
+				panelWidth: 0,
+				viewportWidth,
+				viewportPadding,
+				preferredDirection: 'ltr'
+			})
+		).toEqual({ direction: 'ltr', left: 700, right: 250 });
+	});
+
+	it('does not shift the panel when it naturally fits on the chosen side', () => {
+		const ltrPlacement = computePopoverPlacement({
+			anchorLeft: 100,
+			anchorRight: 150,
+			panelWidth: 300,
+			viewportWidth,
+			viewportPadding,
+			preferredDirection: 'ltr'
+		});
+
+		expect(ltrPlacement.direction).toBe('ltr');
+		expect(ltrPlacement.left).toBe(100);
+
+		const rtlPlacement = computePopoverPlacement({
+			anchorLeft: 800,
+			anchorRight: 850,
+			panelWidth: 300,
+			viewportWidth,
+			viewportPadding,
+			preferredDirection: 'rtl'
+		});
+
+		expect(rtlPlacement.direction).toBe('rtl');
+		expect(rtlPlacement.right).toBe(viewportWidth - 850);
+	});
+
+	it('shifts the ltr panel away from the right edge so it stays inside the viewport', () => {
+		const placement = computePopoverPlacement({
+			anchorLeft: 700,
+			anchorRight: 750,
+			panelWidth: 900,
+			viewportWidth,
+			viewportPadding,
+			preferredDirection: 'ltr'
+		});
+
+		expect(placement.left).toBe(viewportWidth - viewportPadding - 900);
+		expect(placement.left + 900).toBe(viewportWidth - viewportPadding);
+	});
+
+	it('shifts the rtl panel away from the left edge so it stays inside the viewport', () => {
+		const placement = computePopoverPlacement({
+			anchorLeft: 50,
+			anchorRight: 100,
+			panelWidth: 900,
+			viewportWidth,
+			viewportPadding,
+			preferredDirection: 'rtl'
+		});
+
+		expect(placement.right).toBe(viewportWidth - viewportPadding - 900);
+		expect(viewportWidth - placement.right - 900).toBe(viewportPadding);
+	});
+
+	it('pins the offset to viewportPadding when the panel is wider than the usable viewport', () => {
+		const placement = computePopoverPlacement({
+			anchorLeft: 700,
+			anchorRight: 750,
+			panelWidth: 1500,
+			viewportWidth,
+			viewportPadding,
+			preferredDirection: 'ltr'
+		});
+
+		expect(placement.left).toBe(viewportPadding);
+		expect(placement.right).toBe(viewportPadding);
+	});
+
+	it('respects the chosen direction returned by pickPopoverDirection', () => {
+		const placement = computePopoverPlacement({
+			anchorLeft: 900,
+			anchorRight: 950,
+			panelWidth: 300,
+			viewportWidth,
+			viewportPadding,
+			preferredDirection: 'ltr'
+		});
+
+		expect(placement.direction).toBe('rtl');
+	});
+});


### PR DESCRIPTION
## Motivation

Part of the ongoing migration off `@dfinity/gix-components` (now in maintenance mode): we vendor the components OISY uses as native Svelte 5 code so the wallet owns them. This PR does the `Popover` primitive.

## Changes

- Add native `$lib/components/ui/Popover.svelte`, ported from gix v10.0.2 to Svelte 5 runes. It wires to OISY's own `Backdrop` (via the `onClose` callback), uses `$i18n.core.text.close`, and reuses the existing native `IconClose`.
- Add `$lib/utils/popover.utils.ts` and `$lib/types/popover.ts` (the viewport-aware placement math, copied from gix).
- Fold the former `div.popover` override from `gix.scss` into the component's scoped styles and remove that block.
- Rewire all 7 `Popover` consumers to the native component (Dropdown, ResponsivePopover, EditAvatar, core Menu, ActiveUserTransactionsButton, TokenMenu, TokenCategoryFilterDropdown).
- Add unit tests for the component and the placement utils (adapted from gix's specs).

Faithful 1:1 port — no rendered-output change. gix `Dropdown`/`DropdownItem` (1 consumer, still served by gix's own internal Popover) follow in the next PR.

## Tests

`npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npx tsc --project tsconfig.spec.json --noEmit`, and vitest (`Popover.spec.ts` + `popover.utils.spec.ts`, 21 tests) all pass locally.