### PR TITLE
refactor(frontend): own Select/SelectOption natively, detach from gix Dropdown

### DIFF
--- a/src/frontend/src/lib/components/manage/AddTokenByNetworkDropdown.svelte
+++ b/src/frontend/src/lib/components/manage/AddTokenByNetworkDropdown.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { Dropdown, DropdownItem } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
+	import Select from '$lib/components/ui/Select.svelte';
+	import SelectOption from '$lib/components/ui/SelectOption.svelte';
 	import Value from '$lib/components/ui/Value.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Network } from '$lib/types/network';
@@ -26,14 +27,14 @@
 			class="network mt-1 pt-0.5"
 			class:disabled
 		>
-			<Dropdown name="network" {disabled} bind:selectedValue={networkName}>
+			<Select name="network" {disabled} bind:selectedValue={networkName}>
 				<option class:hidden={nonNullish(networkName)} disabled selected value={undefined}
 					>{$i18n.tokens.manage.placeholder.select_network}</option
 				>
 				{#each availableNetworks as network (network.id)}
-					<DropdownItem value={network.name}>{network.name}</DropdownItem>
+					<SelectOption value={network.name}>{network.name}</SelectOption>
 				{/each}
-			</Dropdown>
+			</Select>
 		</div>
 	{/snippet}
 </Value>

--- a/src/frontend/src/lib/components/ui/Select.svelte
+++ b/src/frontend/src/lib/components/ui/Select.svelte
@@ -1,0 +1,134 @@
+<!-- Ported from @dfinity/gix-components Dropdown (a styled native <select>). -->
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
+	import IconExpandMore from '$lib/components/icons/IconExpandMore.svelte';
+
+	interface Props {
+		// Do not allow to use objects as values.
+		// Ex: in the query/update calls we do, when the object changes, the value is pointing to the old object.
+		selectedValue?: string;
+		name: string;
+		testId?: string;
+		disabled?: boolean;
+		start?: Snippet;
+		children?: Snippet;
+	}
+
+	let {
+		selectedValue = $bindable(),
+		name,
+		testId,
+		disabled = false,
+		start,
+		children
+	}: Props = $props();
+
+	let showStart = $derived(nonNullish(start));
+</script>
+
+<div class="select" data-tid="select-component">
+	{#if showStart}
+		<div class="start">
+			{@render start?.()}
+		</div>
+	{/if}
+	<select {name} class:offset={showStart} data-tid={testId} {disabled} bind:value={selectedValue}>
+		{@render children?.()}
+	</select>
+	<span class="icon">
+		<IconExpandMore />
+	</span>
+</div>
+
+<style lang="scss">
+	@use '$lib/styles/mixins/form';
+	@use '$lib/styles/mixins/text';
+
+	.select {
+		position: relative;
+		box-sizing: border-box;
+
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
+		border-radius: var(--border-radius);
+
+		width: var(--dropdown-width, auto);
+
+		overflow: hidden;
+
+		@include form.input;
+
+		// Click on <select> does not trigger "focus" on parent div.
+		// https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within
+		// Matches an element if the element or any of its descendants are focused.
+		&:focus-within {
+			@include form.input-focus;
+		}
+
+		select {
+			width: 100%;
+			background: var(--input-background);
+			border: none;
+
+			--select-padding-inner-top-bottom: var(--select-padding-top-bottom, var(--padding-2x));
+			padding: var(--select-padding-inner-top-bottom) calc(5 * var(--padding))
+				var(--select-padding-inner-top-bottom) var(--select-padding-inner-start, var(--padding-2x));
+
+			appearance: none;
+
+			font-size: inherit;
+			font-weight: inherit;
+
+			@include text.truncate;
+
+			&.offset {
+				--select-padding-inner-start: var(--select-padding-start, calc(5 * var(--padding)));
+			}
+
+			&:focus {
+				outline: none;
+			}
+		}
+
+		// Folded in from the former gix.scss `div.select` override layer (OISY-owned): the option colors
+		// need `:global` because the <option> elements are provided by the consumer (slotted content).
+		:global(option) {
+			background: var(--color-background-primary);
+			color: var(--color-foreground-primary);
+		}
+
+		.icon {
+			display: flex;
+			height: 100%;
+			align-items: center;
+
+			pointer-events: none;
+
+			margin-right: var(--padding-1_5x);
+
+			color: var(--disable-contrast);
+
+			// Folded in from the former gix.scss `div.select .icon` override layer (OISY-owned).
+			--disable-contrast: var(--color-foreground-primary);
+
+			position: absolute;
+			right: 0;
+
+			// Size to match the line-height when font-size is 16px
+			:global(svg) {
+				width: 20px;
+				height: 20px;
+			}
+		}
+	}
+
+	.start {
+		position: absolute;
+		left: 0;
+
+		pointer-events: none;
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/SelectOption.svelte
+++ b/src/frontend/src/lib/components/ui/SelectOption.svelte
@@ -1,0 +1,13 @@
+<!-- Ported from @dfinity/gix-components DropdownItem. -->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		value: string;
+		children?: Snippet;
+	}
+
+	let { value, children }: Props = $props();
+</script>
+
+<option {value}>{@render children?.()}</option>

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -312,18 +312,6 @@ div.step {
 	}
 }
 
-// Native selects
-div.select {
-	& .icon {
-		--disable-contrast: var(--color-foreground-primary);
-	}
-
-	option {
-		background: var(--color-background-primary);
-		color: var(--color-foreground-primary);
-	}
-}
-
 // Toasts
 .toast {
 	--toast-error-background: var(--color-background-error-light);

--- a/src/frontend/src/lib/styles/mixins/_form.scss
+++ b/src/frontend/src/lib/styles/mixins/_form.scss
@@ -1,0 +1,25 @@
+@mixin input {
+	background: var(--input-background);
+	color: var(--input-background-contrast);
+	border: var(--input-border-size) solid
+		var(--input-error-color, var(--input-custom-border-color, var(--input-border-color)));
+
+	transition:
+		color var(--animation-time-short) ease-out,
+		background var(--animation-time-short) ease-out,
+		border var(--animation-time-short) ease-in;
+
+	&:focus {
+		@include input-focus;
+	}
+
+	&::placeholder {
+		color: var(--disable-contrast);
+	}
+}
+
+@mixin input-focus {
+	border: var(--input-border-size) solid var(--secondary);
+	background: var(--focus-background);
+	color: var(--focus-background-contrast);
+}

--- a/src/frontend/src/tests/lib/components/ui/Select.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/Select.spec.ts
@@ -1,0 +1,61 @@
+import SelectTest from '$tests/lib/components/ui/SelectTest.svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('Select', () => {
+	const options = [
+		{ label: '1', value: '1' },
+		{ label: '2', value: '2' },
+		{ label: '3', value: '3' },
+		{ label: '4', value: '4' },
+		{ label: '5', value: '5' }
+	];
+	const props = { options };
+
+	it('should render a select', () => {
+		const { container } = render(SelectTest, { props });
+
+		expect(container.querySelector('select')).toBeInTheDocument();
+	});
+
+	it('should render an option per SelectOption', () => {
+		const { container } = render(SelectTest, { props });
+
+		const renderedOptions = container.querySelectorAll('select option');
+
+		expect(renderedOptions).toHaveLength(options.length);
+		expect(Array.from(renderedOptions).map((option) => option.textContent?.trim())).toEqual(
+			options.map(({ label }) => label)
+		);
+	});
+
+	it('should change value', () => {
+		const { container } = render(SelectTest, { props });
+
+		const selectElement = container.querySelector('select');
+
+		expect(selectElement?.value).toBe(options[0].value);
+
+		selectElement && fireEvent.change(selectElement, { target: { value: options[4].value } });
+
+		expect(selectElement?.value).toBe(options[4].value);
+	});
+
+	it('should allow setting an initial value', () => {
+		const value = options.at(2)?.value;
+		const { container } = render(SelectTest, { props: { ...props, value } });
+
+		expect(container.querySelector('select')?.value).toBe(value);
+	});
+
+	it('should reflect a bound value change', async () => {
+		const { getByTestId, container } = render(SelectTest, { props });
+
+		const selectElement = container.querySelector('select');
+
+		expect(selectElement?.value).toBe('1');
+
+		await fireEvent.click(getByTestId('test'));
+
+		expect(selectElement?.value).toBe('3');
+	});
+});

--- a/src/frontend/src/tests/lib/components/ui/SelectTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/SelectTest.svelte
@@ -16,7 +16,7 @@
 
 <button data-tid="test" onclick={changeValue}>change</button>
 
-<Select name="test" selectedValue={value}>
+<Select name="test" bind:selectedValue={value}>
 	{#each options as { label, value } (value)}
 		<SelectOption {value}>{label}</SelectOption>
 	{/each}

--- a/src/frontend/src/tests/lib/components/ui/SelectTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/SelectTest.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import Select from '$lib/components/ui/Select.svelte';
+	import SelectOption from '$lib/components/ui/SelectOption.svelte';
+
+	interface Props {
+		options: { label: string; value: string }[];
+		value?: string;
+	}
+
+	let { options, value = $bindable() }: Props = $props();
+
+	const changeValue = () => {
+		value = options.at(2)?.value;
+	};
+</script>
+
+<button data-tid="test" onclick={changeValue}>change</button>
+
+<Select name="test" selectedValue={value}>
+	{#each options as { label, value } (value)}
+		<SelectOption {value}>{label}</SelectOption>
+	{/each}
+</Select>


### PR DESCRIPTION
## Motivation

Part of the ongoing migration off `@dfinity/gix-components` (now in maintenance mode): vendor the components OISY uses as native Svelte 5 code so the wallet owns them. This PR does gix's `Dropdown` (a styled native `<select>`) and `DropdownItem`.

## Changes

- Add native `$lib/components/ui/Select.svelte` (gix `Dropdown`) and `$lib/components/ui/SelectOption.svelte` (gix `DropdownItem`), ported to Svelte 5 runes. Named `Select`/`SelectOption` to avoid collision with OISY's existing menu-style `ui/Dropdown.svelte`; the `.select` CSS class and public API are unchanged.
- Vendor the `form` scss mixin as `$lib/styles/mixins/_form.scss` (faithful copy of gix's `input`/`input-focus`; will also be reused by the future `Input` migration). Reuses the already-vendored `IconExpandMore` and `text` mixin.
- Fold the former `div.select` override from `gix.scss` into `Select.svelte` and remove that block.
- Rewire the sole consumer, `AddTokenByNetworkDropdown`, to `Select`/`SelectOption`.
- Add a unit test covering rendering, option projection, value change, initial value and binding (adapted from gix's Dropdown spec).

Faithful 1:1 port — no rendered-output change.

## Tests

`npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npx tsc --project tsconfig.spec.json --noEmit`, and vitest (`Select.spec.ts`, 5 tests) all pass locally.