### PR TITLE
fix(frontend): format limit-order quote amounts via shared formatToken

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
@@ -15,6 +15,7 @@
 		crossesBook,
 		deriveQuoteAmount,
 		feeBpsToPercent,
+		formatTradeAmount,
 		type LimitOrderPairView,
 		type LimitOrderSide,
 		queuePositionDisplay,
@@ -56,6 +57,11 @@
 	}: Props = $props();
 
 	const quoteAmount = $derived(deriveQuoteAmount({ baseAmount, price }));
+	const quoteAmountDisplay = $derived(
+		quoteAmount > 0
+			? formatTradeAmount({ amount: quoteAmount, decimals: pairView?.quoteDecimals ?? 8 })
+			: '—'
+	);
 	const base = $derived(pairView?.baseSymbol ?? '');
 	const quote = $derived(pairView?.quoteSymbol ?? '');
 
@@ -127,7 +133,7 @@
 		<div class="border-t border-disabled px-3.5 py-3">
 			<div class="mb-1 text-xs text-secondary">{quoteLabel}</div>
 			<div class="text-xl font-medium text-primary">
-				{quoteAmount > 0 ? quoteAmount : '—'}
+				{quoteAmountDisplay}
 				{quote}
 			</div>
 		</div>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -11,6 +11,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import {
 		deriveQuoteAmount,
+		formatTradeAmount,
 		type LimitOrderPairView,
 		type LimitOrderSide,
 		validateAmount
@@ -65,10 +66,12 @@
 
 	const quoteAmount = $derived(deriveQuoteAmount({ baseAmount: baseNum, price: priceNum }));
 
-	// Round the read-only readout to the quote token's decimals so JS float
-	// multiplication artifacts (e.g. 0.1 * 3 = 0.30000000000000004) never surface.
+	// Format through the shared token formatter (rounds to the quote decimals,
+	// no raw float artifacts).
 	const quoteAmountDisplay = $derived(
-		quoteAmount > 0 ? parseFloat(quoteAmount.toFixed(pairView?.quoteDecimals ?? 8)) : '—'
+		quoteAmount > 0
+			? formatTradeAmount({ amount: quoteAmount, decimals: pairView?.quoteDecimals ?? 8 })
+			: '—'
 	);
 
 	const baseLabel = $derived(

--- a/src/frontend/src/lib/utils/oisy-trade.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade.utils.ts
@@ -11,6 +11,7 @@ import { ZERO } from '$lib/constants/app.constants';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { OisyTradeAsset } from '$lib/types/oisy-trade';
 import { formatToken } from '$lib/utils/format.utils';
+import { parseToken } from '$lib/utils/parse.utils';
 import { calculateTokenUsdAmount } from '$lib/utils/token.utils';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 
@@ -121,6 +122,8 @@ export const deriveQuoteAmount = ({
 // Format a human-unit trade amount for display through the shared token
 // formatter, so it rounds to the token's decimals and matches the rest of the
 // app instead of leaking raw JS float artifacts (e.g. 0.1 * 3 = 0.30000000000000004).
+// Rounds to a fixed-decimals string first, then parses to base units with
+// `parseToken` (string-based, no float scaling) so large decimals/amounts stay exact.
 export const formatTradeAmount = ({
 	amount,
 	decimals
@@ -129,7 +132,7 @@ export const formatTradeAmount = ({
 	decimals: number;
 }): string =>
 	formatToken({
-		value: BigInt((amount * pow10(decimals)).toFixed(0)),
+		value: parseToken({ value: amount.toFixed(decimals), unitName: decimals }),
 		unitName: decimals,
 		displayDecimals: decimals
 	});

--- a/src/frontend/src/lib/utils/oisy-trade.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade.utils.ts
@@ -10,6 +10,7 @@ import type { IcToken } from '$icp/types/ic-token';
 import { ZERO } from '$lib/constants/app.constants';
 import type { ExchangesData } from '$lib/types/exchange';
 import type { OisyTradeAsset } from '$lib/types/oisy-trade';
+import { formatToken } from '$lib/utils/format.utils';
 import { calculateTokenUsdAmount } from '$lib/utils/token.utils';
 import { fromNullable, nonNullish } from '@dfinity/utils';
 
@@ -116,6 +117,22 @@ export const deriveQuoteAmount = ({
 	}
 	return baseAmount * price;
 };
+
+// Format a human-unit trade amount for display through the shared token
+// formatter, so it rounds to the token's decimals and matches the rest of the
+// app instead of leaking raw JS float artifacts (e.g. 0.1 * 3 = 0.30000000000000004).
+export const formatTradeAmount = ({
+	amount,
+	decimals
+}: {
+	amount: number;
+	decimals: number;
+}): string =>
+	formatToken({
+		value: BigInt((amount * pow10(decimals)).toFixed(0)),
+		unitName: decimals,
+		displayDecimals: decimals
+	});
 
 // Order value in human quote units (= base × price). NaN when not derivable.
 export const deriveNotional = ({

--- a/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
@@ -17,6 +17,7 @@ import {
 	deriveQuoteAmount,
 	feeBpsToPercent,
 	floorToStep,
+	formatTradeAmount,
 	isMultipleOfStep,
 	isOrderValid,
 	isPresetSelected,
@@ -143,6 +144,13 @@ describe('oisy-trade.utils', () => {
 			expect(deriveNotional({ baseAmount: 10, price: 2.5 })).toBe(25);
 			expect(deriveQuoteAmount({ baseAmount: 0, price: 2.5 })).toBeNaN();
 			expect(deriveQuoteAmount({ baseAmount: 10, price: 0 })).toBeNaN();
+		});
+
+		it('formatTradeAmount rounds to the token decimals without float artifacts', () => {
+			// 0.1 * 3 = 0.30000000000000004 as a raw JS float.
+			expect(formatTradeAmount({ amount: 0.1 * 3, decimals: 6 })).toBe('0.3');
+			expect(formatTradeAmount({ amount: 25, decimals: 6 })).toBe('25');
+			expect(formatTradeAmount({ amount: 1.23456789, decimals: 2 })).toBe('1.23');
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The limit-order form's derived quote readout (`base × price`) was rendered as a raw JS float, so precision artifacts (e.g. `0.1 * 3 = 0.30000000000000004`) surfaced in the UI. Unlike the balance/order rows, it did not go through the shared token formatter.

# Changes

- Add `formatTradeAmount({ amount, decimals })` to `oisy-trade.utils` — routes a human-unit amount through the shared `formatToken` so it rounds to the token's decimals and matches the rest of the app.
- `LimitOrderTradePairBox` and `LimitOrderReview`: render the quote readout via `formatTradeAmount` (with the pair's `quoteDecimals`) instead of the raw number / ad-hoc `toFixed`.

# Tests

- Added a `formatTradeAmount` unit test asserting the float artifact is gone (`0.1 * 3` → `0.3`).
- `npm run format`, `lint --max-warnings 0`, `check`, and the affected vitest suites pass.