### PR TITLE
feat(frontend): extend Earnings tab with Liquidium positions

### DIFF
--- a/src/frontend/src/lib/components/earning/EarningsList.svelte
+++ b/src/frontend/src/lib/components/earning/EarningsList.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 	import { goto } from '$app/navigation';
+	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 	import { erc4626CustomTokensNotInitialized } from '$eth/derived/erc4626.derived';
 	import { allVaults } from '$eth/derived/vaults.derived';
 	import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 	import EarningsListSkeletons from '$lib/components/earning/EarningsListSkeletons.svelte';
+	import LiquidiumPositionCard from '$lib/components/liquidium/LiquidiumPositionCard.svelte';
 	import NoStakePlaceholder from '$lib/components/stake/NoStakePlaceholder.svelte';
 	import VaultCard from '$lib/components/vaults/VaultCard.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { AppPath, VAULT_PARAM } from '$lib/constants/routes.constants';
+	import { liquidiumPortfolio } from '$lib/derived/liquidium.derived';
 	import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
 	import { tokenListStore } from '$lib/stores/token-list.store';
 	import { transactionsUrl } from '$lib/utils/nav.utils';
@@ -46,24 +50,61 @@
 
 		return filteredVaults.filter(({ token }) => matchingTokenIds.has(token.id));
 	});
+
+	// Liquidium supply positions sit alongside the vault stakes (grouped by type, each card
+	// carrying its own provider tag). Gated by the lend & borrow feature flag.
+	let supplyReserves = $derived(
+		anyLendBorrowProviderEnabled
+			? ($liquidiumPortfolio?.reserves ?? []).filter(({ deposited }) => deposited > ZERO)
+			: []
+	);
+
+	let supplyReservesToDisplay = $derived(
+		filter === ''
+			? supplyReserves
+			: supplyReserves.filter(({ asset }) => asset.toLowerCase().includes(filter.toLowerCase()))
+	);
+
+	// One combined list sorted by USD value (highest first), so Autopilot stakes and Liquidium
+	// supplies interleave by size rather than sitting in separate groups.
+	let positionsToDisplay = $derived(
+		[
+			...vaultsToDisplay.map((vault) => ({
+				kind: 'vault' as const,
+				id: vault.token.id,
+				usdValue: vault.token.usdBalance ?? 0,
+				vault
+			})),
+			...supplyReservesToDisplay.map((reserve) => ({
+				kind: 'liquidium' as const,
+				id: reserve.poolId,
+				usdValue: reserve.suppliedUsd,
+				reserve
+			}))
+		].sort((a, b) => b.usdValue - a.usdValue)
+	);
 </script>
 
 <EarningsListSkeletons {loading}>
 	<div class="flex flex-col gap-3">
-		{#if vaultsToDisplay.length === 0}
+		{#if positionsToDisplay.length === 0}
 			<NoStakePlaceholder />
 		{:else}
-			{#each vaultsToDisplay as vault (vault.token.id)}
+			{#each positionsToDisplay as position (position.id)}
 				<div class="overflow-hidden rounded-xl" transition:fade>
-					<VaultCard
-						data={vault}
-						onClick={() =>
-							goto(
-								isTokenHarvestAutopilot(vault.token)
-									? `${AppPath.EarnAutopilot}?${VAULT_PARAM}=${vault.token.address}`
-									: transactionsUrl({ token: vault.token })
-							)}
-					/>
+					{#if position.kind === 'vault'}
+						<VaultCard
+							data={position.vault}
+							onClick={() =>
+								goto(
+									isTokenHarvestAutopilot(position.vault.token)
+										? `${AppPath.EarnAutopilot}?${VAULT_PARAM}=${position.vault.token.address}`
+										: transactionsUrl({ token: position.vault.token })
+								)}
+						/>
+					{:else}
+						<LiquidiumPositionCard reserve={position.reserve} variant="holdings" />
+					{/if}
 				</div>
 			{/each}
 		{/if}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { goto } from '$app/navigation';
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
+	import LiquidiumProviderTag from '$lib/components/liquidium/LiquidiumProviderTag.svelte';
 	import LiquidiumWithdrawModal from '$lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { AppPath } from '$lib/constants/routes.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { modalLiquidiumWithdraw } from '$lib/derived/modal.derived';
@@ -19,11 +22,18 @@
 
 	interface Props {
 		reserve: LiquidiumReserve;
+		// 'provider': provider-page row with a Withdraw action (default).
+		// 'holdings': Assets → Earning tab row; no action, clicks through to the provider page.
+		variant?: 'provider' | 'holdings';
 	}
 
-	let { reserve }: Props = $props();
+	let { reserve, variant = 'provider' }: Props = $props();
 
 	const modalId = Symbol();
+
+	const goToProvider = () => {
+		void goto(AppPath.ProvidersLiquidium);
+	};
 
 	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
 
@@ -44,8 +54,29 @@
 	);
 </script>
 
+{#snippet withdrawAction()}
+	<span class="ml-2 flex">
+		<Button
+			colorStyle="secondary-light"
+			onclick={() => modalStore.openLiquidiumWithdraw(modalId)}
+			paddingSmall
+		>
+			{$i18n.liquidium.text.action_withdraw}
+		</Button>
+	</span>
+{/snippet}
+
+{#snippet providerTag()}
+	<LiquidiumProviderTag />
+{/snippet}
+
 <div class="flex w-full flex-col">
-	<LogoButton hover={false}>
+	<LogoButton
+		action={variant === 'provider' ? withdrawAction : undefined}
+		hover={variant === 'holdings'}
+		onClick={variant === 'holdings' ? goToProvider : undefined}
+		subtitle={variant === 'holdings' ? providerTag : undefined}
+	>
 		{#snippet logo()}
 			<span class="mr-2 flex">
 				{#if nonNullish(token)}
@@ -92,22 +123,10 @@
 				{reserve.asset}
 			</span>
 		{/snippet}
-
-		{#snippet action()}
-			<span class="ml-2 flex">
-				<Button
-					colorStyle="secondary-light"
-					onclick={() => modalStore.openLiquidiumWithdraw(modalId)}
-					paddingSmall
-				>
-					{$i18n.liquidium.text.action_withdraw}
-				</Button>
-			</span>
-		{/snippet}
 	</LogoButton>
 
 	<!-- Outside LogoButton's <button> to keep valid HTML. -->
-	{#if $modalLiquidiumWithdraw && $modalStore?.id === modalId}
+	{#if variant === 'provider' && $modalLiquidiumWithdraw && $modalStore?.id === modalId}
 		<LiquidiumWithdrawModal {reserve} />
 	{/if}
 </div>

--- a/src/frontend/src/tests/lib/components/earning/EarningsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningsList.spec.ts
@@ -4,13 +4,17 @@ import * as erc4626Derived from '$eth/derived/erc4626.derived';
 import { allVaults } from '$eth/derived/vaults.derived';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import EarningsList from '$lib/components/earning/EarningsList.svelte';
+import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
 import { ZERO } from '$lib/constants/app.constants';
 import {
 	EARNING_CARD_SKELETON,
 	EARNING_NO_POSITION_PLACEHOLDER
 } from '$lib/constants/test-ids.constants';
 import * as networkDerived from '$lib/derived/network.derived';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
 import { tokenListStore } from '$lib/stores/token-list.store';
+import { LendBorrowProvider } from '$lib/types/lend-borrow';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import type { Vault } from '$lib/types/vaults';
 import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
 import { render } from '@testing-library/svelte';
@@ -22,6 +26,10 @@ vi.mock('$eth/constants/harvest-autopilots.constants', () => ({
 
 vi.mock('$app/navigation', () => ({
 	goto: vi.fn()
+}));
+
+vi.mock('$env/lend-borrow', () => ({
+	anyLendBorrowProviderEnabled: true
 }));
 
 describe('EarningsList', () => {
@@ -84,9 +92,34 @@ describe('EarningsList', () => {
 		);
 	};
 
+	const supplyReserve: LiquidiumReserve = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 0,
+		deposited: 100_000_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 1000,
+		borrowedUsd: 0
+	};
+
+	const portfolioWith = (reserves: LiquidiumReserve[]): LiquidiumPortfolio => ({
+		reserves,
+		totalSuppliedUsd: 0,
+		totalBorrowedUsd: 0,
+		netValueUsd: 0,
+		availableBorrowsUsd: 0,
+		weightedLiquidationThresholdBps: 8000,
+		healthFactorPercent: 100
+	});
+
 	beforeEach(() => {
 		vi.restoreAllMocks();
 		tokenListStore.set({ filter: '' });
+		liquidiumStore.reset();
 		mockCustomTokensInitialized();
 	});
 
@@ -261,6 +294,64 @@ describe('EarningsList', () => {
 
 		expect(getByText('Enabled Vault')).toBeInTheDocument();
 		expect(getByText('Base Vault')).toBeInTheDocument();
+	});
+
+	it('should render Liquidium supply positions with a provider tag alongside vaults', () => {
+		mockAllVaultsStore([toVault({ token: mockAutopilotToken })]);
+		liquidiumStore.set({ markets: [], portfolio: portfolioWith([supplyReserve]), assetPrices: {} });
+
+		const { getByText, queryByTestId } = render(EarningsList);
+
+		expect(queryByTestId(EARNING_NO_POSITION_PLACEHOLDER)).not.toBeInTheDocument();
+		expect(getByText('Autopilot Vault')).toBeInTheDocument();
+		expect(
+			getByText(lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name)
+		).toBeInTheDocument();
+	});
+
+	it('should render Liquidium supply positions even when there are no vaults', () => {
+		mockAllVaultsStore([]);
+		liquidiumStore.set({ markets: [], portfolio: portfolioWith([supplyReserve]), assetPrices: {} });
+
+		const { getByText, queryByTestId } = render(EarningsList);
+
+		expect(queryByTestId(EARNING_NO_POSITION_PLACEHOLDER)).not.toBeInTheDocument();
+		expect(
+			getByText(lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name)
+		).toBeInTheDocument();
+	});
+
+	it('sorts vaults and Liquidium supplies together by USD value (highest first)', () => {
+		const providerName = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name;
+
+		mockAllVaultsStore([toVault({ token: mockAutopilotToken, overrides: { usdBalance: 100 } })]);
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolioWith([{ ...supplyReserve, suppliedUsd: 5000 }]),
+			assetPrices: {}
+		});
+
+		const { container } = render(EarningsList);
+		const text = container.textContent ?? '';
+
+		// Liquidium supply ($5000) outranks the Autopilot vault ($100), so it renders first.
+		expect(text.indexOf(providerName)).toBeLessThan(text.indexOf('Autopilot Vault'));
+	});
+
+	it('sorts a higher-value vault above a lower-value Liquidium supply', () => {
+		const providerName = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name;
+
+		mockAllVaultsStore([toVault({ token: mockAutopilotToken, overrides: { usdBalance: 9000 } })]);
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolioWith([{ ...supplyReserve, suppliedUsd: 100 }]),
+			assetPrices: {}
+		});
+
+		const { container } = render(EarningsList);
+		const text = container.textContent ?? '';
+
+		expect(text.indexOf('Autopilot Vault')).toBeLessThan(text.indexOf(providerName));
 	});
 
 	it('should show skeletons when custom tokens are not initialized', () => {

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
@@ -1,12 +1,20 @@
+import { goto } from '$app/navigation';
 import LiquidiumPositionCard from '$lib/components/liquidium/LiquidiumPositionCard.svelte';
+import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
 import { ZERO } from '$lib/constants/app.constants';
+import { AppPath } from '$lib/constants/routes.constants';
 import { modalLiquidiumWithdraw } from '$lib/derived/modal.derived';
 import { modalStore } from '$lib/stores/modal.store';
+import { LendBorrowProvider } from '$lib/types/lend-borrow';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
 
 describe('LiquidiumPositionCard', () => {
 	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
@@ -60,5 +68,43 @@ describe('LiquidiumPositionCard', () => {
 		expect(get(modalLiquidiumWithdraw)).toBeTruthy();
 
 		modalStore.close();
+	});
+
+	it('does not render the provider tag in the provider variant', () => {
+		const { container } = render(LiquidiumPositionCard, { props: { reserve: reserve() } });
+
+		expect(container).not.toHaveTextContent(
+			lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
+		);
+	});
+
+	describe('holdings variant', () => {
+		it('does not render the Withdraw action button', () => {
+			const { queryByText } = render(LiquidiumPositionCard, {
+				props: { reserve: reserve(), variant: 'holdings' }
+			});
+
+			expect(queryByText(en.liquidium.text.action_withdraw)).not.toBeInTheDocument();
+		});
+
+		it('renders the Liquidium provider tag', () => {
+			const { container } = render(LiquidiumPositionCard, {
+				props: { reserve: reserve(), variant: 'holdings' }
+			});
+
+			expect(container).toHaveTextContent(
+				lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
+			);
+		});
+
+		it('navigates to the Liquidium provider page when clicked', async () => {
+			const { getByRole } = render(LiquidiumPositionCard, {
+				props: { reserve: reserve(), variant: 'holdings' }
+			});
+
+			await fireEvent.click(getByRole('button'));
+
+			expect(goto).toHaveBeenCalledWith(AppPath.ProvidersLiquidium);
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

Liquidium supply positions were only visible on the provider page (/providers/liquidium/) and, for debt, on the Borrowings tab. The Assets → Earning tab still listed only Harvest Autopilot stakes. Following the spec's holdings-view plan (2026-06-07-feat-liquidium-lend-borrow.md), this surfaces a user's Liquidium supply positions in the Earning tab alongside their vault stakes — the asset-side counterpart to the Borrowings tab — reusing the same holdings-card pattern.

# Changes

 - LiquidiumPositionCard gains a variant: 'provider' | 'holdings' prop (mirroring LiquidiumBorrowingCard). provider (default) is unchanged — the provider-page row keeps its Withdraw action + modal. holdings drops the Withdraw action, makes the row clickable through to /providers/liquidium/, and shows the LiquidiumProviderTag ("Liquidium", styled like the Autopilot tag). The tag renders only in the holdings variant, not on the provider page.
  - EarningsList now also lists Liquidium supply reserves (liquidiumPortfolio.reserves filtered by deposited > 0), gated by anyLendBorrowProviderEnabled and respecting the existing search filter. Vault stakes and Liquidium supplies are merged into one list sorted by USD value (highest first) rather than shown as separate groups; the empty-state placeholder keys off the combined list.


# Tests

Added.
