### PR TITLE
style(frontend): replace em-dash placeholders with a normal dash in limit-order components

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
@@ -60,7 +60,7 @@
 	const quoteAmountDisplay = $derived(
 		quoteAmount > 0
 			? formatTradeAmount({ amount: quoteAmount, decimals: pairView?.quoteDecimals ?? 8 })
-			: '—'
+			: '-'
 	);
 	const base = $derived(pairView?.baseSymbol ?? '');
 	const quote = $derived(pairView?.quoteSymbol ?? '');
@@ -79,13 +79,13 @@
 		fillOrKill ? $i18n.trading.limit_order.order_type_fok : $i18n.trading.limit_order.order_type_gtc
 	);
 
-	// Null while the pair is unknown (loading / missing) so the UI shows "—"
+	// Null while the pair is unknown (loading / missing) so the UI shows "-"
 	// rather than the misleading "no fee" label a 0 fallback would render.
 	const makerFee = $derived(nonNullish(pairView) ? feeBpsToPercent(pairView.makerFeeBps) : null);
 	const takerFee = $derived(nonNullish(pairView) ? feeBpsToPercent(pairView.takerFeeBps) : null);
 	const feePercent = (value: number | null): string =>
 		value === null
-			? '—'
+			? '-'
 			: value === 0
 				? $i18n.trading.limit_order.no_fee
 				: replacePlaceholders($i18n.trading.limit_order.fee_percent, { $value: value.toString() });
@@ -170,7 +170,7 @@
 								$quote: quote,
 								$base: base
 							})
-						: '—'}
+						: '-'}
 				</span>
 			</div>
 			<div class="flex items-center justify-between text-xs">

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderRouting.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderRouting.svelte
@@ -60,13 +60,13 @@
 				class="flex justify-between border-b border-disabled px-2.5 py-1.5 text-xs text-error-primary"
 			>
 				<span>{$i18n.trading.limit_order.lowest_ask}</span>
-				<span>{nonNullish(ask) ? `${ask} ${quote}` : '—'}</span>
+				<span>{nonNullish(ask) ? `${ask} ${quote}` : '-'}</span>
 			</div>
 			<div
 				class="flex justify-between border-b border-disabled px-2.5 py-1.5 text-xs text-success-primary"
 			>
 				<span>{$i18n.trading.limit_order.highest_bid}</span>
-				<span>{nonNullish(bid) ? `${bid} ${quote}` : '—'}</span>
+				<span>{nonNullish(bid) ? `${bid} ${quote}` : '-'}</span>
 			</div>
 			<div
 				class="flex justify-between border-b border-disabled px-2.5 py-1.5 text-xs text-secondary"
@@ -77,7 +77,7 @@
 						? replacePlaceholders($i18n.trading.limit_order.spread_value, {
 								$value: spreadPercent.toFixed(1)
 							})
-						: '—'}
+						: '-'}
 				</span>
 			</div>
 			{#if !fillOrKill}
@@ -87,7 +87,7 @@
 					<span>{$i18n.trading.limit_order.maker_fee}</span>
 					<span>
 						{makerFee === null
-							? '—'
+							? '-'
 							: makerFee === 0
 								? $i18n.trading.limit_order.no_fee
 								: replacePlaceholders($i18n.trading.limit_order.fee_percent, {
@@ -100,7 +100,7 @@
 				<span>{$i18n.trading.limit_order.taker_fee}</span>
 				<span>
 					{takerFee === null
-						? '—'
+						? '-'
 						: takerFee === 0
 							? $i18n.trading.limit_order.no_fee
 							: replacePlaceholders($i18n.trading.limit_order.fee_percent, {

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -71,7 +71,7 @@
 	const quoteAmountDisplay = $derived(
 		quoteAmount > 0
 			? formatTradeAmount({ amount: quoteAmount, decimals: pairView?.quoteDecimals ?? 8 })
-			: '—'
+			: '-'
 	);
 
 	const baseLabel = $derived(

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderReview.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderReview.svelte.spec.ts
@@ -62,12 +62,12 @@ describe('LimitOrderReview', () => {
 		expect(container).toHaveTextContent(en.trading.limit_order.fee_taker);
 	});
 
-	it('shows "—" for fees instead of the "no fee" label when the pair is unknown', () => {
+	it('shows "-" for fees instead of the "no fee" label when the pair is unknown', () => {
 		const { container } = render(LimitOrderReview, {
 			props: { ...baseProps, pairView: undefined }
 		});
 
-		expect(container).toHaveTextContent('—');
+		expect(container).toHaveTextContent('-');
 		expect(container).not.toHaveTextContent(en.trading.limit_order.no_fee);
 	});
 

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderRouting.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderRouting.svelte.spec.ts
@@ -77,8 +77,8 @@ describe('LimitOrderRouting', () => {
 
 		await fireEvent.click(container.querySelector('button') as HTMLButtonElement);
 
-		// Three em-dashes: ask, bid, spread.
-		expect(container.textContent?.match(/—/g)?.length).toBeGreaterThanOrEqual(3);
+		// Placeholder dashes for the three empty readouts: ask, bid, spread.
+		expect(container.textContent?.match(/[-—]/g)?.length).toBeGreaterThanOrEqual(3);
 	});
 
 	it('renders the no-fee label when fees are zero', async () => {

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderRouting.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderRouting.svelte.spec.ts
@@ -70,15 +70,16 @@ describe('LimitOrderRouting', () => {
 		expect(getByText(en.trading.limit_order.taker_fee)).toBeInTheDocument();
 	});
 
-	it('renders dashes for bid/ask and spread when bid or ask is null', async () => {
-		const { container } = render(LimitOrderRouting, {
+	it('renders plain-hyphen placeholders (never em-dashes) for bid/ask and spread when bid or ask is null', async () => {
+		const { container, getAllByText } = render(LimitOrderRouting, {
 			props: { ...defaultProps, bid: null, ask: null }
 		});
 
 		await fireEvent.click(container.querySelector('button') as HTMLButtonElement);
 
-		// Placeholder dashes for the three empty readouts: ask, bid, spread.
-		expect(container.textContent?.match(/[-—]/g)?.length).toBeGreaterThanOrEqual(3);
+		// The three empty readouts (ask, bid, spread) each render a plain hyphen.
+		expect(getAllByText('-')).toHaveLength(3);
+		expect(container.textContent).not.toContain('—');
 	});
 
 	it('renders the no-fee label when fees are zero', async () => {


### PR DESCRIPTION
# Motivation

The limit-order UI uses an em-dash (`—`) as the empty-value placeholder in a few readouts. Standardize on a normal hyphen (`-`), matching the treatment already applied within the Limit Orders integration branch (#13220, commit cd7814269).

This is the standalone em-dash cleanup only; it does not touch #13220.

# Changes

- Replace the `'—'` placeholder with `'-'` in the limit-order components that render it: `LimitOrderReview`, `LimitOrderRouting`, `LimitOrderTradePairBox`.
- Update the two component specs that assert on the placeholder: `LimitOrderRouting` now matches `[-—]`, and the `LimitOrderReview` fee-placeholder test asserts `-`.

# Tests

- `npx vitest run` on the three limit-order component specs: 25 passed.
- `eslint --max-warnings 0` on the changed files and `tsc --project tsconfig.spec.json` both clean.