### PR TITLE
fix(frontend): use Ledger balance as source of truth for ICP-standard wallet

### DIFF
--- a/src/frontend/src/icp/api/icp-ledger.api.ts
+++ b/src/frontend/src/icp/api/icp-ledger.api.ts
@@ -1,7 +1,8 @@
+import { getAccountIdentifier } from '$icp/utils/icp-account.utils';
 import { getAgent } from '$lib/actors/agents.ic';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { NullishIdentity } from '$lib/types/identity';
-import { assertNonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
+import { assertNonNullish, nowInBigIntNanoSeconds, type QueryParams } from '@dfinity/utils';
 import {
 	AccountIdentifier,
 	IcpLedgerCanister,
@@ -10,6 +11,23 @@ import {
 import { toCandidAccount, type IcrcAccount } from '@icp-sdk/canisters/ledger/icrc';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
+
+export const accountBalance = async ({
+	certified,
+	owner,
+	identity,
+	...rest
+}: {
+	owner: Principal;
+	identity: NullishIdentity;
+	ledgerCanisterId: CanisterIdText;
+} & QueryParams): Promise<bigint> => {
+	assertNonNullish(identity);
+
+	const { accountBalance } = await ledgerCanister({ identity, ...rest });
+
+	return accountBalance({ certified, accountIdentifier: getAccountIdentifier(owner) });
+};
 
 export const transfer = async ({
 	identity,

--- a/src/frontend/src/icp/schedulers/ic-wallet.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet.scheduler.ts
@@ -12,6 +12,18 @@ import { isNullish } from '@dfinity/utils';
 
 export type IcWalletMsg = 'syncIcpWallet' | 'syncIcrcWallet' | 'syncDip20Wallet';
 
+/**
+ * Resolves the message `ref` used to disambiguate wallet workers running as a singleton.
+ *
+ * ICRC and ICP tokens are keyed on their Ledger canister ID (both always provide one), while
+ * DIP-20 tokens fall back to their single canister ID. Extracted as a concrete-union helper because
+ * `in`-narrowing does not resolve cleanly on the generic `PostMessageDataRequest` type parameter.
+ */
+export const walletDataRef = (
+	data: PostMessageDataRequestIcrc | PostMessageDataRequestIcp | PostMessageDataRequestDip20
+): PostMessageCommon['ref'] =>
+	'ledgerCanisterId' in data ? data.ledgerCanisterId : data.canisterId;
+
 export abstract class IcWalletScheduler<
 	PostMessageDataRequest extends
 		| PostMessageDataRequestIcrc
@@ -27,13 +39,7 @@ export abstract class IcWalletScheduler<
 	}
 
 	protected setRef(data: PostMessageDataRequest | undefined) {
-		this.ref = isNullish(data)
-			? undefined
-			: 'ledgerCanisterId' in data
-				? data.ledgerCanisterId
-				: 'indexCanisterId' in data
-					? data.indexCanisterId
-					: data.canisterId;
+		this.ref = isNullish(data) ? undefined : walletDataRef(data);
 	}
 
 	async start(data: PostMessageDataRequest | undefined) {

--- a/src/frontend/src/icp/services/worker.icp-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icp-wallet.services.ts
@@ -24,6 +24,7 @@ export class IcpWalletWorker extends AppWorker implements WalletWorker {
 	private constructor(
 		worker: WorkerData,
 		tokenId: TokenId,
+		private readonly ledgerCanisterId: IcToken['ledgerCanisterId'],
 		private readonly indexCanisterId: IndexCanisterIdText
 	) {
 		super(worker);
@@ -42,7 +43,7 @@ export class IcpWalletWorker extends AppWorker implements WalletWorker {
 
 				// This is an additional guard because it may happen that the worker is initialised as a singleton.
 				// In this case, we need to check if we should treat the message or if the message was intended for another worker.
-				if (ref !== this.indexCanisterId) {
+				if (ref !== this.ledgerCanisterId) {
 					return;
 				}
 
@@ -70,6 +71,7 @@ export class IcpWalletWorker extends AppWorker implements WalletWorker {
 	}
 
 	static async init({
+		ledgerCanisterId,
 		indexCanisterId,
 		id: tokenId,
 		network: { id: networkId }
@@ -81,7 +83,7 @@ export class IcpWalletWorker extends AppWorker implements WalletWorker {
 		await syncWalletFromCache({ tokenId, networkId });
 
 		const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
-		return new IcpWalletWorker(worker, tokenId, indexCanisterId);
+		return new IcpWalletWorker(worker, tokenId, ledgerCanisterId, indexCanisterId);
 	}
 
 	protected override stopTimer = () => {
@@ -94,6 +96,7 @@ export class IcpWalletWorker extends AppWorker implements WalletWorker {
 		this.postMessage<PostMessage<PostMessageDataRequestIcp>>({
 			msg: 'startIcpWalletTimer',
 			data: {
+				ledgerCanisterId: this.ledgerCanisterId,
 				indexCanisterId: this.indexCanisterId
 			}
 		});
@@ -107,6 +110,7 @@ export class IcpWalletWorker extends AppWorker implements WalletWorker {
 		this.postMessage<PostMessage<PostMessageDataRequestIcp>>({
 			msg: 'triggerIcpWalletTimer',
 			data: {
+				ledgerCanisterId: this.ledgerCanisterId,
 				indexCanisterId: this.indexCanisterId
 			}
 		});

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -17,7 +17,10 @@ const getBalance = ({
 	certified,
 	data
 }: SchedulerJobParams<PostMessageDataRequestIcp>): Promise<bigint> => {
-	assertNonNullish(data, 'No data - ledgerCanisterId - provided to fetch balance.');
+	assertNonNullish(
+		data,
+		'No data provided to fetch the balance: the ledgerCanisterId is required.'
+	);
 
 	return accountBalance({
 		identity,
@@ -32,7 +35,10 @@ const getTransactionsFromIndex = ({
 	certified,
 	data
 }: SchedulerJobParams<PostMessageDataRequestIcp>): Promise<IcpIndexDid.GetAccountIdentifierTransactionsResponse> => {
-	assertNonNullish(data, 'No data - indexCanisterId - provided to fetch transactions.');
+	assertNonNullish(
+		data,
+		'No data provided to fetch the transactions: the indexCanisterId is required.'
+	);
 
 	return getTransactions({
 		identity,
@@ -47,16 +53,30 @@ const getTransactionsFromIndex = ({
 const getBalanceAndTransactions = async (
 	params: SchedulerJobParams<PostMessageDataRequestIcp>
 ): Promise<GetBalanceAndTransactions<IcpIndexDid.TransactionWithId>> => {
-	const [balance, transactions] = await Promise.all([
+	const [balanceResult, transactionsResult] = await Promise.allSettled([
 		getBalance(params),
 		getTransactionsFromIndex(params)
 	]);
 
-	// Use the Ledger balance as the source of truth and ignore the balance from the Index canister.
-	// When the Index canister is low on cycles it stops syncing new blocks without erroring, returning a
-	// stale (or zero) balance. Relying on the Ledger canister ensures the displayed balance stays correct
-	// even if the Index canister — used only for the transactions history — is lagging or frozen.
-	const { balance: _indexCanisterBalance, ...rest } = transactions;
+	// The Ledger balance is the source of truth. Without it there is nothing meaningful to display, so
+	// a Ledger failure is fatal and surfaced as a sync error.
+	if (balanceResult.status === 'rejected') {
+		throw balanceResult.reason;
+	}
+
+	const { value: balance } = balanceResult;
+
+	// A failing Index canister must not block the Ledger balance update. The Index only feeds the
+	// transactions history, so on failure we post the balance with no transaction delta and let the
+	// history catch up on the next successful tick.
+	if (transactionsResult.status === 'rejected') {
+		return { balance, transactions: [], oldest_tx_id: [] };
+	}
+
+	// Ignore the balance reported by the Index canister. When it is low on cycles it stops syncing new
+	// blocks without erroring, returning a stale (or zero) balance. Relying on the Ledger canister keeps
+	// the displayed balance correct even if the Index canister is lagging or frozen.
+	const { balance: _indexCanisterBalance, ...rest } = transactionsResult.value;
 
 	return { ...rest, balance };
 };

--- a/src/frontend/src/icp/workers/icp-wallet.worker.ts
+++ b/src/frontend/src/icp/workers/icp-wallet.worker.ts
@@ -1,5 +1,9 @@
 import { getTransactions } from '$icp/api/icp-index.api';
-import { IcWalletBalanceAndTransactionsScheduler } from '$icp/schedulers/ic-wallet-balance-and-transactions.scheduler';
+import { accountBalance } from '$icp/api/icp-ledger.api';
+import {
+	IcWalletBalanceAndTransactionsScheduler,
+	type GetBalanceAndTransactions
+} from '$icp/schedulers/ic-wallet-balance-and-transactions.scheduler';
 import type { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
 import type { IcTransactionAddOnsInfo, IcTransactionUi } from '$icp/types/ic-transaction';
 import { mapIcpTransaction, mapTransactionIcpToSelf } from '$icp/utils/icp-transactions.utils';
@@ -8,7 +12,22 @@ import type { PostMessage, PostMessageDataRequestIcp } from '$lib/types/post-mes
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 import type { IcpIndexDid } from '@icp-sdk/canisters/ledger/icp';
 
-const getBalanceAndTransactions = ({
+const getBalance = ({
+	identity,
+	certified,
+	data
+}: SchedulerJobParams<PostMessageDataRequestIcp>): Promise<bigint> => {
+	assertNonNullish(data, 'No data - ledgerCanisterId - provided to fetch balance.');
+
+	return accountBalance({
+		identity,
+		certified,
+		owner: identity.getPrincipal(),
+		ledgerCanisterId: data.ledgerCanisterId
+	});
+};
+
+const getTransactionsFromIndex = ({
 	identity,
 	certified,
 	data
@@ -21,8 +40,25 @@ const getBalanceAndTransactions = ({
 		owner: identity.getPrincipal(),
 		// We query tip to discover the new transactions
 		start: undefined,
-		...data
+		indexCanisterId: data.indexCanisterId
 	});
+};
+
+const getBalanceAndTransactions = async (
+	params: SchedulerJobParams<PostMessageDataRequestIcp>
+): Promise<GetBalanceAndTransactions<IcpIndexDid.TransactionWithId>> => {
+	const [balance, transactions] = await Promise.all([
+		getBalance(params),
+		getTransactionsFromIndex(params)
+	]);
+
+	// Use the Ledger balance as the source of truth and ignore the balance from the Index canister.
+	// When the Index canister is low on cycles it stops syncing new blocks without erroring, returning a
+	// stale (or zero) balance. Relying on the Ledger canister ensures the displayed balance stays correct
+	// even if the Index canister — used only for the transactions history — is lagging or frozen.
+	const { balance: _indexCanisterBalance, ...rest } = transactions;
+
+	return { ...rest, balance };
 };
 
 const mapTransaction = ({

--- a/src/frontend/src/lib/schema/post-message.schema.ts
+++ b/src/frontend/src/lib/schema/post-message.schema.ts
@@ -90,6 +90,7 @@ export const PostMessageDataRequestDip20Schema = z.object({
 });
 
 export const PostMessageDataRequestIcpSchema = z.object({
+	ledgerCanisterId: CanisterIdTextSchema,
 	indexCanisterId: CanisterIdTextSchema
 });
 

--- a/src/frontend/src/tests/icp/api/icp-ledger.api.spec.ts
+++ b/src/frontend/src/tests/icp/api/icp-ledger.api.spec.ts
@@ -1,4 +1,5 @@
-import { icrc1Transfer, transfer } from '$icp/api/icp-ledger.api';
+import { accountBalance, icrc1Transfer, transfer } from '$icp/api/icp-ledger.api';
+import { getAccountIdentifier } from '$icp/utils/icp-account.utils';
 import { mockLedgerCanisterId } from '$tests/mocks/ic-tokens.mock';
 import {
 	mockAccountIdentifierText,
@@ -124,6 +125,36 @@ describe('icp-ledger.api', () => {
 
 		it('throws an error if identity is undefined', async () => {
 			await expect(icrc1Transfer({ ...params, identity: undefined })).rejects.toThrow();
+		});
+	});
+
+	describe('accountBalance', () => {
+		const params = {
+			owner: mockPrincipal2,
+			identity: mockIdentity,
+			certified: true,
+			ledgerCanisterId: mockLedgerCanisterId
+		};
+
+		const mockBalance = 1_000_000n;
+
+		beforeEach(() => {
+			ledgerCanisterMock.accountBalance.mockResolvedValue(mockBalance);
+		});
+
+		it('successfully calls accountBalance endpoint with the owner account identifier', async () => {
+			const result = await accountBalance(params);
+
+			expect(result).toEqual(mockBalance);
+
+			expect(ledgerCanisterMock.accountBalance).toHaveBeenCalledExactlyOnceWith({
+				certified: true,
+				accountIdentifier: getAccountIdentifier(mockPrincipal2)
+			});
+		});
+
+		it('throws an error if identity is undefined', async () => {
+			await expect(accountBalance({ ...params, identity: undefined })).rejects.toThrow();
 		});
 	});
 });

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -540,6 +540,29 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 				);
 				expect(walletBalances).not.toContain(staleIndexBalance);
 			});
+
+			it('should still post the Ledger balance when the Index transactions call fails', async () => {
+				indexCanisterMock.getTransactions.mockRejectedValue(new Error('Index canister failure'));
+
+				await scheduler.start(startData);
+
+				await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+				const walletMessages = postMessageMock.mock.calls
+					.map(([message]) => message)
+					.filter((message) => message?.msg === msg);
+
+				expect(walletMessages.length).toBeGreaterThan(0);
+				expect(walletMessages).toSatisfy(
+					(messages: { data: { wallet: { balance: { data: bigint } } } }[]) =>
+						messages.every((message) => message.data.wallet.balance.data === ledgerBalance)
+				);
+
+				// A failing Index canister must not surface as a sync error while the Ledger balance is available.
+				expect(postMessageMock).not.toHaveBeenCalledWith(
+					expect.objectContaining({ msg: `${msg}Error` })
+				);
+			});
 		});
 
 		describe('without transactions', () => {
@@ -583,14 +606,25 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 				);
 			};
 
+			// The Ledger balance is authoritative, so only a Ledger failure is fatal for the sync.
 			const initErrorMock = (err: Error) =>
-				indexCanisterMock.getTransactions.mockRejectedValue(err);
+				ledgerCanisterMock.accountBalance.mockRejectedValue(err);
+
+			const initSuccessMock = () => {
+				ledgerCanisterMock.accountBalance.mockResolvedValue(mockBalance);
+				indexCanisterMock.getTransactions.mockResolvedValue({
+					balance: mockBalance,
+					transactions: [mockTransaction],
+					oldest_tx_id: [mockOldestTxId]
+				});
+			};
 
 			const { setup, teardown, tests } = initOtherScenarios({
 				initScheduler: initIcpWalletScheduler,
 				startData,
 				initCleanupMock,
 				initErrorMock,
+				initSuccessMock,
 				msg: 'syncIcpWallet'
 			});
 

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -1,4 +1,4 @@
-import { ICP_INDEX_CANISTER_ID } from '$env/networks/networks.icp.env';
+import { ICP_INDEX_CANISTER_ID, ICP_LEDGER_CANISTER_ID } from '$env/networks/networks.icp.env';
 import { XtcLedgerCanister } from '$icp/canisters/xtc-ledger.canister';
 import type { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
 import * as indexCanisterServices from '$icp/services/index-canister.services';
@@ -28,7 +28,11 @@ import {
 	nonNullish,
 	toNullable
 } from '@dfinity/utils';
-import { IcpIndexCanister, type IcpIndexDid } from '@icp-sdk/canisters/ledger/icp';
+import {
+	IcpIndexCanister,
+	IcpLedgerCanister,
+	type IcpIndexDid
+} from '@icp-sdk/canisters/ledger/icp';
 import {
 	IcrcIndexCanister,
 	IcrcLedgerCanister,
@@ -366,6 +370,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 	};
 
 	describe('icp-wallet.worker', () => {
+		const ledgerCanisterMock = mock<IcpLedgerCanister>();
 		const indexCanisterMock = mock<IcpIndexCanister>();
 
 		const mockTransaction: IcpIndexDid.TransactionWithId = {
@@ -393,11 +398,15 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 		});
 
 		const startData = {
+			ledgerCanisterId: ICP_LEDGER_CANISTER_ID,
 			indexCanisterId: ICP_INDEX_CANISTER_ID
 		};
 
 		beforeEach(() => {
+			vi.spyOn(IcpLedgerCanister, 'create').mockImplementation(() => ledgerCanisterMock);
 			vi.spyOn(IcpIndexCanister, 'create').mockImplementation(() => indexCanisterMock);
+
+			spyGetBalance = ledgerCanisterMock.accountBalance.mockResolvedValue(mockBalance);
 		});
 
 		describe('with transactions', () => {
@@ -409,13 +418,13 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 
 			const mockPostMessageNotCertified = mockPostMessage({
 				msg,
-				ref: startData.indexCanisterId,
+				ref: startData.ledgerCanisterId,
 				transaction,
 				certified: false
 			});
 			const mockPostMessageCertified = mockPostMessage({
 				msg,
-				ref: startData.indexCanisterId,
+				ref: startData.ledgerCanisterId,
 				transaction,
 				certified: true
 			});
@@ -489,6 +498,47 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 				await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
 
 				expect(spyGetTransactions).toHaveBeenCalledTimes(6);
+			});
+		});
+
+		describe('Ledger balance is authoritative', () => {
+			const msg = 'syncIcpWallet';
+
+			const ledgerBalance = 555n;
+			const staleIndexBalance = 100n;
+
+			let scheduler: IcWalletScheduler<PostMessageDataRequestIcp>;
+
+			beforeEach(() => {
+				scheduler = initIcpWalletScheduler(startData);
+
+				ledgerCanisterMock.accountBalance.mockResolvedValue(ledgerBalance);
+				indexCanisterMock.getTransactions.mockResolvedValue({
+					balance: staleIndexBalance,
+					transactions: [mockTransaction],
+					oldest_tx_id: [mockOldestTxId]
+				});
+			});
+
+			afterEach(() => {
+				scheduler.stop();
+			});
+
+			it('should post the Ledger balance and ignore the stale Index balance', async () => {
+				await scheduler.start(startData);
+
+				await vi.advanceTimersByTimeAsync(WALLET_TIMER_INTERVAL_MILLIS);
+
+				const walletBalances = postMessageMock.mock.calls
+					.map(([message]) => message)
+					.filter((message) => message?.msg === msg)
+					.map((message) => message.data.wallet.balance.data);
+
+				expect(walletBalances.length).toBeGreaterThan(0);
+				expect(walletBalances).toSatisfy((balances: bigint[]) =>
+					balances.every((balance) => balance === ledgerBalance)
+				);
+				expect(walletBalances).not.toContain(staleIndexBalance);
 			});
 		});
 

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
@@ -1,4 +1,4 @@
-import type { IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
+import { walletDataRef, type IcWalletScheduler } from '$icp/schedulers/ic-wallet.scheduler';
 import { initIcrcWalletScheduler } from '$icp/workers/icrc-wallet.worker';
 import { WALLET_TIMER_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import { AuthClientProvider } from '$lib/providers/auth-client.providers';
@@ -126,13 +126,7 @@ describe('ic-wallet-balance.worker', () => {
 	}): TestUtil => {
 		let scheduler: IcWalletScheduler<PostMessageDataRequest>;
 
-		const ref = isNullish(startData)
-			? undefined
-			: 'ledgerCanisterId' in startData
-				? startData.ledgerCanisterId
-				: 'indexCanisterId' in startData
-					? startData.indexCanisterId
-					: startData.canisterId;
+		const ref = isNullish(startData) ? undefined : walletDataRef(startData);
 
 		const mockPostMessageNotCertified = mockPostMessage({ msg, ref, certified: false });
 		const mockPostMessageCertified = mockPostMessage({ msg, ref, certified: true });
@@ -258,13 +252,7 @@ describe('ic-wallet-balance.worker', () => {
 	}): TestUtil => {
 		let scheduler: IcWalletScheduler<PostMessageDataRequest>;
 
-		const ref = isNullish(startData)
-			? undefined
-			: 'ledgerCanisterId' in startData
-				? startData.ledgerCanisterId
-				: 'indexCanisterId' in startData
-					? startData.indexCanisterId
-					: startData.canisterId;
+		const ref = isNullish(startData) ? undefined : walletDataRef(startData);
 
 		return {
 			setup: () => {


### PR DESCRIPTION
# Motivation

For ICP-standard tokens (ICP, TESTICP) the wallet worker derived **both** the balance and the transactions from the Index canister, via `get_account_identifier_transactions` (which returns `{ balance, transactions }`). The Ledger canister was never consulted for the balance.

When an Index canister is low on cycles it silently stops syncing new blocks from the Ledger: it keeps answering queries successfully but returns a stale (or zero) balance and a frozen transaction list, without ever erroring. The result is a wallet whose balance and history both disagree with the Ledger, with no signal that anything is wrong. This was observed on TESTICP, whose Index canister (`qcuy6-bqaaa-aaaai-aqmqq-cai`) was stuck thousands of blocks behind its Ledger (`xafvr-biaaa-aaaai-aql5q-cai`).

ICRC-standard tokens already avoid this by treating the Ledger balance as authoritative and using the Index only for the transactions history. This aligns ICP-standard tokens with that behaviour.

# Changes

- Add `accountBalance` to the ICP Ledger API (`account_balance` by account identifier).
- The ICP wallet worker now fetches the Ledger balance and the Index transactions in parallel, uses the Ledger balance as the source of truth, and ignores the Index-reported balance. The Index is still the source for the transactions history.
- Carry `ledgerCanisterId` in the ICP wallet post-message payload and key ICP wallet messages on the Ledger canister ID (as ICRC already does), so the worker can reach the Ledger.
- Extract the wallet-worker `ref` resolution into a small `walletDataRef` helper shared by `setRef`.

Note: the ICRC path additionally runs an `isIndexCanisterAwake` guard that surfaces an error and drops to a Ledger-only sync when the Index is sleepy. That guard relies on the Index's `num_blocks_synced` status, which the ICP Index SDK wrapper does not expose (and the raw declarations subpath is not a public export). Since the Ledger balance is now authoritative on every tick, the displayed balance is already correct without the guard; wiring an ICP-specific awake check is deferred as a follow-up.

# Tests

- New `accountBalance` API test.
- New worker test asserting the Ledger balance is posted while a stale Index balance is ignored.
- Updated the shared balance-and-transactions worker spec (Ledger balance mock + Ledger-keyed `ref`).
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, and the affected vitest suites all pass. No backend changes.
