### PR TITLE
feat(frontend): show loading skeletons on the Trading tab before positions resolve

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingList.svelte
+++ b/src/frontend/src/lib/components/trading/TradingList.svelte
@@ -12,7 +12,7 @@
 		OISY_TRADE_LEARN_MORE_URL,
 		OISY_TRADE_POLL_INTERVAL_MILLIS
 	} from '$lib/constants/oisy-trade.constants';
-	import { authIdentity } from '$lib/derived/auth.derived';
+	import { authIdentity, authSignedIn } from '$lib/derived/auth.derived';
 	import { modalTradingDeposit } from '$lib/derived/modal.derived';
 	import { oisyTradeHasAssets, oisyTradeLoaded } from '$lib/derived/oisy-trade.derived';
 	import { loadOisyTrade } from '$lib/services/oisy-trade.services';
@@ -28,7 +28,12 @@
 {#if OISY_TRADE_ENABLED}
 	<IntervalLoader interval={OISY_TRADE_POLL_INTERVAL_MILLIS} onLoad={load} />
 
-	{#if !$oisyTradeLoaded}
+	<!--
+		Only skeleton while a signed-in load is actually in flight. Signed out,
+		`loadOisyTrade` resets the store (balances stay unresolved) and never
+		populates it, so gate on the identity to settle on onboarding instead.
+	-->
+	{#if $authSignedIn && !$oisyTradeLoaded}
 		<TradingListSkeleton />
 	{:else if $oisyTradeHasAssets}
 		<div class="flex flex-col gap-4">

--- a/src/frontend/src/lib/components/trading/TradingList.svelte
+++ b/src/frontend/src/lib/components/trading/TradingList.svelte
@@ -3,6 +3,7 @@
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import TradingAssets from '$lib/components/trading/TradingAssets.svelte';
 	import TradingDepositModal from '$lib/components/trading/TradingDepositModal.svelte';
+	import TradingListSkeleton from '$lib/components/trading/TradingListSkeleton.svelte';
 	import TradingOnboarding from '$lib/components/trading/TradingOnboarding.svelte';
 	import LimitOrder from '$lib/components/trading/limit-order/LimitOrder.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
@@ -13,7 +14,7 @@
 	} from '$lib/constants/oisy-trade.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalTradingDeposit } from '$lib/derived/modal.derived';
-	import { oisyTradeHasAssets } from '$lib/derived/oisy-trade.derived';
+	import { oisyTradeHasAssets, oisyTradeLoaded } from '$lib/derived/oisy-trade.derived';
 	import { loadOisyTrade } from '$lib/services/oisy-trade.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -27,7 +28,9 @@
 {#if OISY_TRADE_ENABLED}
 	<IntervalLoader interval={OISY_TRADE_POLL_INTERVAL_MILLIS} onLoad={load} />
 
-	{#if $oisyTradeHasAssets}
+	{#if !$oisyTradeLoaded}
+		<TradingListSkeleton />
+	{:else if $oisyTradeHasAssets}
 		<div class="flex flex-col gap-4">
 			<p class="text-sm text-tertiary">
 				{$i18n.trading.text.intro}

--- a/src/frontend/src/lib/components/trading/TradingListSkeleton.svelte
+++ b/src/frontend/src/lib/components/trading/TradingListSkeleton.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import SkeletonCard from '$lib/components/ui/SkeletonCard.svelte';
+	import { TRADING_LIST_SKELETON } from '$lib/constants/test-ids.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+</script>
+
+<!--
+	Shown while the first OISY TRADE load is in flight, so the Trading tab settles
+	into My-assets/Orders or the onboarding placeholder instead of flashing the
+	placeholder first. Mirrors the My-assets + Orders section layout with the shared
+	`SkeletonCard` rows.
+-->
+<div class="flex flex-col gap-4" data-tid={TRADING_LIST_SKELETON}>
+	<section class="flex flex-col gap-2">
+		<h3 class="text-base font-bold text-primary">{$i18n.trading.assets.title}</h3>
+		<SkeletonCard />
+		<SkeletonCard />
+	</section>
+
+	<section class="flex flex-col gap-2">
+		<h3 class="text-base font-bold text-primary">{$i18n.trading.orders.title}</h3>
+		<SkeletonCard />
+	</section>
+</div>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -345,6 +345,7 @@ export const STAKE_PROVIDER_EXTERNAL_URL = 'stake-provider-external-url';
 export const STAKE_DISSOLVE_EVENTS_WITHDRAW_BUTTON = 'stake-dissolve-events-withdraw-button';
 
 // Trading
+export const TRADING_LIST_SKELETON = 'trading-list-skeleton';
 export const TRADING_ASSETS_DEPOSIT_BUTTON = 'trading-assets-deposit-button';
 export const TRADING_ASSET_WITHDRAW_BUTTON = 'trading-asset-withdraw-button';
 export const TRADING_ONBOARDING_DEPOSIT_BUTTON = 'trading-onboarding-deposit-button';

--- a/src/frontend/src/lib/derived/oisy-trade.derived.ts
+++ b/src/frontend/src/lib/derived/oisy-trade.derived.ts
@@ -34,6 +34,13 @@ export const oisyTradeBalances: Readable<UserTokenBalance[]> = derived(
 	({ balances }) => balances ?? []
 );
 
+// True once the first load has resolved (balances populated). Distinguishes the
+// initial loading state from a genuinely empty wallet, so the Trading tab can show
+// skeletons first instead of flashing the onboarding placeholder.
+export const oisyTradeLoaded: Readable<boolean> = derived(oisyTradeStore, ({ balances }) =>
+	nonNullish(balances)
+);
+
 // The supported trade tokens resolved to their matching app `IcToken` (by ledger
 // canister id), keyed by symbol. The trade canister exposes only symbol/decimals,
 // so the form joins against the enabled IC tokens (which include testnets when a

--- a/src/frontend/src/tests/lib/components/trading/TradingList.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingList.svelte.spec.ts
@@ -2,6 +2,7 @@ import type { UserTokenBalance } from '$declarations/oisy_trade/oisy_trade.did';
 import type { IcToken } from '$icp/types/ic-token';
 import TradingList from '$lib/components/trading/TradingList.svelte';
 import { ZERO } from '$lib/constants/app.constants';
+import { TRADING_LIST_SKELETON } from '$lib/constants/test-ids.constants';
 import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
 import { setPrivacyMode } from '$lib/utils/privacy.utils';
 import en from '$tests/mocks/i18n.mock';
@@ -70,6 +71,16 @@ describe('TradingList', () => {
 		});
 	};
 
+	// Loaded (balances resolved) but empty, so the tab settles on the onboarding
+	// placeholder rather than the initial-load skeleton.
+	const seedLoadedEmpty = () => {
+		oisyTradeStore.set({
+			pairs: undefined,
+			supportedTokens: undefined,
+			balances: []
+		});
+	};
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockEnabled.value = true;
@@ -79,10 +90,20 @@ describe('TradingList', () => {
 		setPrivacyMode({ enabled: false });
 	});
 
+	it('renders the loading skeleton before the first load resolves', () => {
+		const { getByTestId, queryByText } = render(TradingList);
+
+		expect(getByTestId(TRADING_LIST_SKELETON)).toBeInTheDocument();
+		expect(queryByText(en.trading.onboarding.title)).toBeNull();
+	});
+
 	it('should render the onboarding when the user has no assets', () => {
-		const { getByText } = render(TradingList);
+		seedLoadedEmpty();
+
+		const { getByText, queryByTestId } = render(TradingList);
 
 		expect(getByText(en.trading.onboarding.title)).toBeInTheDocument();
+		expect(queryByTestId(TRADING_LIST_SKELETON)).toBeNull();
 	});
 
 	it('renders the assets section, intro, learn-more and orders header once the user has assets', () => {

--- a/src/frontend/src/tests/lib/components/trading/TradingList.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingList.svelte.spec.ts
@@ -5,6 +5,7 @@ import { ZERO } from '$lib/constants/app.constants';
 import { TRADING_LIST_SKELETON } from '$lib/constants/test-ids.constants';
 import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
 import { setPrivacyMode } from '$lib/utils/privacy.utils';
+import { mockAuthSignedIn } from '$tests/mocks/auth.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { Principal } from '@icp-sdk/core/principal';
@@ -84,17 +85,27 @@ describe('TradingList', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockEnabled.value = true;
+		mockAuthSignedIn(false);
 		oisyTradeStore.reset();
 		enabledIcTokensMock.set([]);
 		exchangesMock.set({});
 		setPrivacyMode({ enabled: false });
 	});
 
-	it('renders the loading skeleton before the first load resolves', () => {
+	it('renders the loading skeleton before the first load resolves when signed in', () => {
+		mockAuthSignedIn(true);
+
 		const { getByTestId, queryByText } = render(TradingList);
 
 		expect(getByTestId(TRADING_LIST_SKELETON)).toBeInTheDocument();
 		expect(queryByText(en.trading.onboarding.title)).toBeNull();
+	});
+
+	it('renders the onboarding (not the skeleton) when signed out, since no load populates the store', () => {
+		const { getByText, queryByTestId } = render(TradingList);
+
+		expect(getByText(en.trading.onboarding.title)).toBeInTheDocument();
+		expect(queryByTestId(TRADING_LIST_SKELETON)).toBeNull();
 	});
 
 	it('should render the onboarding when the user has no assets', () => {

--- a/src/frontend/src/tests/lib/derived/oisy-trade.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/oisy-trade.derived.spec.ts
@@ -30,6 +30,7 @@ const {
 	oisyTradePairs,
 	oisyTradeSupportedTokens,
 	oisyTradeBalances,
+	oisyTradeLoaded,
 	oisyTradeSupportedTokenSymbols,
 	oisyTradeIcTokenBySymbol,
 	oisyTradeFreeBalanceBySymbol,
@@ -125,6 +126,18 @@ describe('oisy-trade.derived', () => {
 			oisyTradeStore.set({ pairs: undefined, supportedTokens: undefined, balances });
 
 			expect(get(oisyTradeBalances)).toBe(balances);
+		});
+	});
+
+	describe('oisyTradeLoaded', () => {
+		it('is false while balances are unset', () => {
+			expect(get(oisyTradeLoaded)).toBeFalsy();
+		});
+
+		it('is true once balances resolve, even when empty', () => {
+			oisyTradeStore.set({ pairs: undefined, supportedTokens: undefined, balances: [] });
+
+			expect(get(oisyTradeLoaded)).toBeTruthy();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

On first load, the Trading tab flashes the onboarding placeholder before positions resolve, because `balances` is briefly `undefined`. Show loading skeletons during that window so the tab settles into My assets / Orders or the onboarding placeholder without a flash. Ports the skeleton work from the Limit Orders integration branch (#13220, commit cc5b237f90).

# Changes

- Add `oisyTradeLoaded` derived: true once `balances` resolve (populated), distinguishing the initial-load state from a genuinely empty wallet.
- Add `TradingListSkeleton` (mirrors the My assets + Orders layout with the shared `SkeletonCard`) and render it in `TradingList` while `!$oisyTradeLoaded`, before the has-assets / onboarding branch.
- Add the `TRADING_LIST_SKELETON` test id.

# Tests

- `TradingList` spec: new test for the skeleton before first load; the existing no-assets test now seeds a loaded-but-empty store so it asserts onboarding (not the skeleton) — 6 passed.
- `oisy-trade.derived` spec: covers `oisyTradeLoaded` false while unset and true once balances resolve (even empty) — 20 passed.
- `eslint --max-warnings 0` on the changed files and `tsc --project tsconfig.spec.json` both clean.