### PR TITLE
feat(frontend): include Liquidium net value in the hero total

### DIFF
--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -2,6 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { page } from '$app/state';
+	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 	import { anyTradingProviderEnabled } from '$env/trading';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
@@ -9,6 +10,7 @@
 	import { allBalancesZero } from '$lib/derived/balances.derived';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { liquidiumNetValueUsd } from '$lib/derived/liquidium.derived';
 	import { enabledFungibleNetworkTokensUi } from '$lib/derived/network-tokens-ui.derived';
 	import { oisyTradeUsdValue } from '$lib/derived/oisy-trade.derived';
 	import {
@@ -53,9 +55,11 @@
 	// the Trading feature/provider flags so the production hero stays unchanged.
 	const totalTradeUsd = $derived(anyTradingProviderEnabled ? $oisyTradeUsdValue : 0);
 
+	const totalLiquidiumUsd = $derived(anyLendBorrowProviderEnabled ? $liquidiumNetValueUsd : 0);
+
 	let balance = $derived(
 		formatCurrency({
-			value: $loaded ? totalUsd + totalStakeUsd + totalTradeUsd : 0,
+			value: $loaded ? totalUsd + totalStakeUsd + totalTradeUsd + totalLiquidiumUsd : 0,
 			currency: $currentCurrency,
 			exchangeRate: $currencyExchangeStore,
 			language: $currentLanguage

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeBalance.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeBalance.spec.ts
@@ -1,8 +1,10 @@
+import * as lendBorrowEnv from '$env/lend-borrow';
 import ExchangeBalance from '$lib/components/exchange/ExchangeBalance.svelte';
 import { AppPath, ROUTE_ID_GROUP_APP } from '$lib/constants/routes.constants';
 import * as balancesDerived from '$lib/derived/balances.derived';
 import * as currencyDerived from '$lib/derived/currency.derived';
 import * as i18nDerived from '$lib/derived/i18n.derived';
+import * as liquidiumDerived from '$lib/derived/liquidium.derived';
 import * as networkTokensUiDerived from '$lib/derived/network-tokens-ui.derived';
 import * as settingsDerived from '$lib/derived/settings.derived';
 import { Currency } from '$lib/enums/currency';
@@ -381,6 +383,39 @@ describe('ExchangeBalance', () => {
 			const { getByText } = renderComponent();
 
 			expect(getByText('$0.00')).toBeInTheDocument();
+		});
+	});
+
+	describe('Liquidium net value', () => {
+		beforeEach(() => {
+			mockHeroContext.loading.set(false);
+		});
+
+		it('should add supplied-minus-borrowed net value to the total when enabled', () => {
+			vi.spyOn(lendBorrowEnv, 'anyLendBorrowProviderEnabled', 'get').mockReturnValue(true);
+			vi.spyOn(liquidiumDerived, 'liquidiumNetValueUsd', 'get').mockReturnValue(staticStore(500));
+
+			const { getByText } = renderComponent();
+
+			expect(getByText('$835.00')).toBeInTheDocument();
+		});
+
+		it('should deduct a negative net value (net debt) from the total when enabled', () => {
+			vi.spyOn(lendBorrowEnv, 'anyLendBorrowProviderEnabled', 'get').mockReturnValue(true);
+			vi.spyOn(liquidiumDerived, 'liquidiumNetValueUsd', 'get').mockReturnValue(staticStore(-100));
+
+			const { getByText } = renderComponent();
+
+			expect(getByText('$235.00')).toBeInTheDocument();
+		});
+
+		it('should ignore Liquidium net value when the feature is disabled', () => {
+			vi.spyOn(lendBorrowEnv, 'anyLendBorrowProviderEnabled', 'get').mockReturnValue(false);
+			vi.spyOn(liquidiumDerived, 'liquidiumNetValueUsd', 'get').mockReturnValue(staticStore(500));
+
+			const { getByText } = renderComponent();
+
+			expect(getByText('$335.00')).toBeInTheDocument();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The assets-page hero total did not reflect Liquidium lend/borrow positions. Supplied collateral has left the wallet and borrowed debt sits in it, so net worth was overstated (borrow) / understated (supply) for users with positions.

# Changes

 - `ExchangeBalance.svelte`: add a `totalLiquidiumUsd` contribution (`liquidiumNetValueUsd` = supplied − borrowed, `0` when no portfolio), gated by `anyLendBorrowProviderEnabled`, folded into the hero `balance` sum. Mirrors the existing `totalTradeUsd`/`anyTradingProviderEnabled` pattern, so the BETA/PROD hero is unchanged until the flags broaden.


# Tests

Added.
