### PR TITLE
test(backend): run integration tests with nextest across parallel CI shards

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -60,6 +60,14 @@ jobs:
     permissions:
       contents: read
     needs: ['docker-build']
+    strategy:
+      # Don't cancel the other shards when one fails — we want the full signal.
+      fail-fast: false
+      matrix:
+        # Shards run in parallel, each on its own runner. nextest's
+        # `--partition` splits the suite across these; keep the divisor in the
+        # `NEXTEST_PARTITION` env below in sync with the number of shards.
+        partition: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -89,9 +97,15 @@ jobs:
         if: steps.changes.outputs.backend == 'true'
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
 
+      - name: Install cargo-nextest
+        if: steps.changes.outputs.backend == 'true'
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C "${CARGO_HOME:-$HOME/.cargo}/bin"
+
       - name: 'Run backend tests'
         if: steps.changes.outputs.backend == 'true'
         working-directory: .
+        env:
+          NEXTEST_PARTITION: 'count:${{ matrix.partition }}/4'
         run: ./scripts/test.backend.sh
 
   breaking-interface:

--- a/dev-tools.json
+++ b/dev-tools.json
@@ -40,6 +40,10 @@
 		"method": "cargo-binstall",
 		"version": "0.9.3"
 	},
+	"cargo-nextest": {
+		"method": "cargo-binstall",
+		"version": "0.9.138"
+	},
 	"cargo-audit": {
 		"method": "cargo-binstall",
 		"version": "0.21.2"

--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -73,56 +73,22 @@ export POCKET_IC_MUTE_SERVER=1
 
 # Run tests
 
-# Each integration test spins up a PocketIC instance holding several canisters.
-# The PocketIC server's memory grows with every instance it has ever served
-# (deleted instances are not fully reclaimed), so running the whole `it` suite
-# in a single process eventually OOM-kills the server mid-run (connection reset
-# -> SIGABRT) — and the larger the backend wasm grows, the sooner it dies.
+# Each integration test spins up a PocketIC instance holding several canisters,
+# and the PocketIC server's memory grows with every instance it has ever served
+# (deleted instances are not fully reclaimed). Running the whole `it` suite in a
+# single process therefore OOM-kills the server mid-run.
 #
-# On CI, bound that growth by running the integration suite in chunks: each
-# chunk is its own `cargo test --test it` process with a fresh PocketIC server,
-# so peak server memory is capped at one chunk's worth of instances. Explicit
-# cargo arguments (e.g. `-- --ignored candid`) and local runs keep the original
-# single-process behaviour.
-run_it_in_chunks() {
-  local chunk_size="${BACKEND_IT_TEST_CHUNK_SIZE:-40}"
-  if ! [[ "$chunk_size" =~ ^[1-9][0-9]*$ ]]; then
-    echo "BACKEND_IT_TEST_CHUNK_SIZE must be a positive integer (got '${chunk_size}')." >&2
-    return 1
-  fi
-  local tests=()
-  local line
-  while IFS= read -r line; do
-    tests+=("${line%: test}")
-  done < <(cargo test -p backend --test it -- --list 2>/dev/null | grep ': test$')
-
-  if [ "${#tests[@]}" -eq 0 ]; then
-    echo "Could not list integration tests; running them in a single process." >&2
-    cargo test -p backend --test it
-    return
-  fi
-
-  echo "Running ${#tests[@]} integration tests in chunks of ${chunk_size}."
-  local status=0 i
-  for ((i = 0; i < ${#tests[@]}; i += chunk_size)); do
-    local chunk=("${tests[@]:i:chunk_size}")
-    echo "::group::it tests $((i + 1))-$((i + ${#chunk[@]})) / ${#tests[@]}"
-    cargo test -p backend --test it -- --exact "${chunk[@]}" || status=1
-    echo "::endgroup::"
-  done
-  return "$status"
-}
-
+# On CI, run the suite with nextest, which executes each test in its own process:
+# every integration test gets a fresh PocketIC server, so its memory is released
+# when the process exits and never accumulates across the suite. NEXTEST_PARTITION
+# (e.g. "count:1/4"), set by the CI matrix, shards the suite across parallel jobs.
+# Explicit cargo arguments (e.g. `-- --ignored candid`) and local runs keep the
+# plain single-process `cargo test` behaviour.
 echo "Running backend tests."
-if [ -n "${CI:-}" ] && [ "$#" -eq 0 ]; then
-  # Chunking caps the cumulative PocketIC server memory (a fresh server per
-  # chunk), so the suite no longer needs to run single-threaded — peak memory is
-  # one chunk's instances regardless of parallelism. RUST_TEST_THREADS is still
-  # honoured if set, e.g. to pin parallelism on a smaller runner.
-  rc=0
-  cargo test -p backend --lib || rc=1
-  run_it_in_chunks || rc=1
-  exit "$rc"
+if [ "$#" -eq 0 ] && [ -n "${CI:-}" ]; then
+  nextest_args=(run -p backend)
+  [ -z "${NEXTEST_PARTITION:-}" ] || nextest_args+=(--partition "${NEXTEST_PARTITION}")
+  cargo nextest "${nextest_args[@]}"
 else
   cargo test -p backend "${@}"
 fi


### PR DESCRIPTION
# Motivation

Follow-up to #13273 (which fixed the backend `tests` OOM by running the `it` suite in sequential per-chunk processes) and [@AntonioVentilii's review suggestion](https://github.com/dfinity/oisy-wallet/pull/13273#discussion_r3506972179). Closes #13316.

`cargo-nextest` runs **each test in its own process**, so every integration test gets a fresh PocketIC server and its memory is released on process exit — memory never accumulates across the suite, so the hand-rolled chunking is no longer needed. Its `--partition` also shards the suite across **parallel CI jobs**, cutting wall-clock.

# Changes

- **`scripts/test.backend.sh`**: replaced the `run_it_in_chunks` bash workaround with `cargo nextest run -p backend`. On CI it passes `--partition "$NEXTEST_PARTITION"` (set by the matrix); explicit cargo args (e.g. the breaking-interface `-- --ignored candid`) and local runs keep the plain `cargo test` path.
- **`.github/workflows/backend-tests.yml`**: the `tests` job now fans out into a 4-way `partition` matrix (`fail-fast: false`), installs `cargo-nextest` via the official `get.nexte.st` script, and sets `NEXTEST_PARTITION=count:${matrix.partition}/4`.
- **`dev-tools.json`**: added `cargo-nextest` (cargo-binstall) for local `scripts/setup`.

# Tests

- Validated locally: `nextest list` discovers all **191** `it` tests, and `--partition count:N/4` splits them **48/48/48/47**; `shellcheck`/`shfmt`/`bash -n` clean, `dev-tools.json` valid JSON, workflow valid YAML.
- The actual test *run* (wasm + PocketIC) can't run locally (no wasm `clang`) — the chunked→nextest behaviour is validated by this PR's own `tests` matrix on CI.

# Notes

- **New dev dependency** (`cargo-nextest`) — flagging for sign-off per CLAUDE.md. It was the explicit suggestion in #13273's review and the scope of #13316.
- CI installs nextest via the official `get.nexte.st` script (fast, no `cargo-binstall` bootstrap); `dev-tools.json` covers local setup. Happy to unify on one path if preferred.
- The matrix divisor (`/4`) is coupled to the `partition: [1, 2, 3, 4]` list — both are commented; adjust together.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)
