### PR TITLE
fix(frontend): align confirmation bottom-sheet title and close button on one row

### DIFF
--- a/src/frontend/src/lib/components/address-book/DeleteAddressConfirmBottomSheet.svelte
+++ b/src/frontend/src/lib/components/address-book/DeleteAddressConfirmBottomSheet.svelte
@@ -15,7 +15,7 @@
 	let { onCancel, onDelete, address, contact, disabled = false }: Props = $props();
 </script>
 
-<BottomSheetConfirmationPopup {disabled} {onCancel}>
+<BottomSheetConfirmationPopup {disabled} {onCancel} showCloseButton={false}>
 	{#snippet title()}
 		{$i18n.address.delete.title}
 	{/snippet}

--- a/src/frontend/src/lib/components/address-book/DeleteContactConfirmBottomSheet.svelte
+++ b/src/frontend/src/lib/components/address-book/DeleteContactConfirmBottomSheet.svelte
@@ -15,7 +15,7 @@
 	let { onCancel, onDelete, contact, disabled = false }: Props = $props();
 </script>
 
-<BottomSheetConfirmationPopup {disabled} {onCancel}>
+<BottomSheetConfirmationPopup {disabled} {onCancel} showCloseButton={false}>
 	{#snippet title()}
 		{replacePlaceholders($i18n.contact.delete.title, {
 			$contact: contact.name

--- a/src/frontend/src/lib/components/tokens/TokenModal.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenModal.svelte
@@ -511,7 +511,11 @@
 </WizardModal>
 
 {#if currentStepName === TokenModalSteps.CONTENT && showBottomSheetDeleteConfirmation}
-	<BottomSheetConfirmationPopup disabled={loading} onCancel={() => onTokenDeleteCancel(token)}>
+	<BottomSheetConfirmationPopup
+		disabled={loading}
+		onCancel={() => onTokenDeleteCancel(token)}
+		showCloseButton={false}
+	>
 		{#snippet title()}
 			{$i18n.tokens.text.delete_token}
 		{/snippet}

--- a/src/frontend/src/lib/components/trading/TradingCancelOrderConfirm.svelte
+++ b/src/frontend/src/lib/components/trading/TradingCancelOrderConfirm.svelte
@@ -40,7 +40,7 @@
 	);
 </script>
 
-<BottomSheetConfirmationPopup {disabled} {onCancel}>
+<BottomSheetConfirmationPopup {disabled} {onCancel} showCloseButton={false}>
 	{#snippet title()}{$i18n.trading.order_detail.confirm_title}{/snippet}
 
 	{#snippet content()}

--- a/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
+++ b/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
@@ -11,9 +11,10 @@
 		title: Snippet;
 		content: Snippet;
 		disabled?: boolean;
+		showCloseButton?: boolean;
 	}
 
-	let { onCancel, title, content, disabled = false }: Props = $props();
+	let { onCancel, title, content, disabled = false, showCloseButton = true }: Props = $props();
 </script>
 
 <div class="fixed inset-0 z-50">
@@ -22,16 +23,18 @@
 			<div class="flex w-full items-center justify-between gap-4 p-4">
 				<h3 class="m-0">{@render title()}</h3>
 
-				<ButtonIcon
-					ariaLabel={$i18n.core.alt.close_details}
-					{disabled}
-					onclick={onCancel}
-					styleClass="text-disabled"
-				>
-					{#snippet icon()}
-						<IconClose size="24" />
-					{/snippet}
-				</ButtonIcon>
+				{#if showCloseButton}
+					<ButtonIcon
+						ariaLabel={$i18n.core.alt.close_details}
+						{disabled}
+						onclick={onCancel}
+						styleClass="text-disabled"
+					>
+						{#snippet icon()}
+							<IconClose size="24" />
+						{/snippet}
+					</ButtonIcon>
+				{/if}
 			</div>
 		{/snippet}
 

--- a/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
+++ b/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
@@ -21,7 +21,13 @@
 	<BottomSheet transition>
 		{#snippet header()}
 			<div class="flex w-full items-center justify-between gap-4 p-4">
-				<h3 class="m-0 min-w-0 break-words">{@render title()}</h3>
+				<h3
+					class="m-0 min-w-0 break-words"
+					class:text-center={!showCloseButton}
+					class:w-full={!showCloseButton}
+				>
+					{@render title()}
+				</h3>
 
 				{#if showCloseButton}
 					<ButtonIcon

--- a/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
+++ b/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
@@ -21,7 +21,7 @@
 	<BottomSheet transition>
 		{#snippet header()}
 			<div class="flex w-full items-center justify-between gap-4 p-4">
-				<h3 class="m-0">{@render title()}</h3>
+				<h3 class="m-0 min-w-0 break-words">{@render title()}</h3>
 
 				{#if showCloseButton}
 					<ButtonIcon

--- a/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
+++ b/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
@@ -18,22 +18,24 @@
 
 <div class="fixed inset-0 z-50">
 	<BottomSheet transition>
-		<div class="flex w-full flex-col">
-			<div class="w-full p-4">
+		{#snippet header()}
+			<div class="flex w-full items-center justify-between gap-4 p-4">
+				<h3 class="m-0">{@render title()}</h3>
+
 				<ButtonIcon
 					ariaLabel={$i18n.core.alt.close_details}
 					{disabled}
 					onclick={onCancel}
-					styleClass="text-disabled float-right"
+					styleClass="text-disabled"
 				>
 					{#snippet icon()}
 						<IconClose size="24" />
 					{/snippet}
 				</ButtonIcon>
 			</div>
+		{/snippet}
 
-			<h3 class="mt-4 mb-2 text-center">{@render title()}</h3>
-
+		<div class="flex w-full flex-col">
 			{@render content()}
 		</div>
 	</BottomSheet>


### PR DESCRIPTION
# Motivation

`BottomSheetConfirmationPopup` rendered the close (X) button in its own full-width `p-4` row (floated right), with the title centered *below* it. The X floated high above the title instead of sitting on the same line, which didn't match how the rest of the app presents a titled sheet/modal header.

On top of that, every confirmation sheet built on this component already has explicit action buttons that dismiss it (e.g. "Keep"/"Cancel order", "Cancel"/"Delete"), which makes a separate close button redundant.

# Changes

- Moved the header into the gix `BottomSheet` `header` snippet, matching the convention used by `BottomSheet.svelte` and `CollapsibleBottomSheet.svelte`, and laid the title (`h3`) and close button out on a single row (`flex ... items-center justify-between`), dropping the `float-right` hack and the title's stray margins.
- Added an optional `showCloseButton` prop (default `true`) so each usage can choose whether to render the X — mirroring how gix `Modal` conditionally renders its close button. The default keeps the affordance for any future popup whose content lacks its own dismiss button.
- Swept all current usages: since each already exposes an explicit dismiss/cancel button in its content, set `showCloseButton={false}` on all of them — `TradingCancelOrderConfirm`, `DeleteContactConfirmBottomSheet`, `DeleteAddressConfirmBottomSheet`, and the `TokenModal` delete confirmation.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` all pass.
- `TradingOrderDetailModal` unit tests pass (5/5).
- Verified each consumer still lays out and dismisses correctly; backdrop click still cancels.
