### PR TITLE
style(frontend): order the Trading tab after Tokens, before Earning

### DIFF
--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -74,6 +74,15 @@
 											id: TokenTypes.TOKENS,
 											path: `${AppPath.Tokens}${page.url.search}`
 										},
+										...(TRADING_ENABLED
+											? [
+													{
+														label: $i18n.trading.text.tab_title,
+														id: TokenTypes.TRADING,
+														path: `${AppPath.Trading}${page.url.search}`
+													}
+												]
+											: []),
 										{
 											label: $i18n.nfts.text.title,
 											id: TokenTypes.NFTS,
@@ -94,15 +103,6 @@
 														label: $i18n.borrowings.text.tab_title,
 														id: TokenTypes.BORROWINGS,
 														path: `${AppPath.Borrowings}${page.url.search}`
-													}
-												]
-											: []),
-										...(TRADING_ENABLED
-											? [
-													{
-														label: $i18n.trading.text.tab_title,
-														id: TokenTypes.TRADING,
-														path: `${AppPath.Trading}${page.url.search}`
 													}
 												]
 											: [])


### PR DESCRIPTION
# Motivation

The Trading asset tab currently renders **last** in the assets tab bar (after Tokens, NFTs, Earning, Borrowings). It reads more naturally right after Tokens, so trading sits next to the primary asset view and ahead of the other financial tabs.

# Changes

- In `Assets.svelte`, move the `TRADING_ENABLED` tab entry to immediately after **Tokens**, so the order is **Tokens · Trading · NFTs · Earning · Borrowings** (each still gated by its own flag).

# Tests

- No behavioural change beyond tab order; existing assets/navigation tests stay green. `format`, `lint`, `check`, `check:tests` pass.
