### PR TITLE
fix(frontend): open Receive modal on ICP testnet network

### DIFF
--- a/src/frontend/src/lib/derived/token.derived.ts
+++ b/src/frontend/src/lib/derived/token.derived.ts
@@ -1,3 +1,4 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import {
 	DEFAULT_ARBITRUM_TOKEN,
 	DEFAULT_BASE_TOKEN,
@@ -13,6 +14,7 @@ import {
 	networkBitcoin,
 	networkBsc,
 	networkEthereum,
+	networkICP,
 	networkPolygon,
 	networkSolana
 } from '$lib/derived/network.derived';
@@ -28,7 +30,8 @@ export const defaultFallbackToken: Readable<RequiredToken> = derived(
 		networkBsc,
 		networkPolygon,
 		networkSolana,
-		networkArbitrum
+		networkArbitrum,
+		networkICP
 	],
 	([
 		$networkBitcoin,
@@ -37,13 +40,17 @@ export const defaultFallbackToken: Readable<RequiredToken> = derived(
 		$networkBsc,
 		$networkPolygon,
 		$networkSolana,
-		$networkArbitrum
+		$networkArbitrum,
+		$networkICP
 	]) => {
 		if ($networkBitcoin) {
 			return DEFAULT_BITCOIN_TOKEN;
 		}
 		if ($networkSolana) {
 			return DEFAULT_SOLANA_TOKEN;
+		}
+		if ($networkICP) {
+			return ICP_TOKEN;
 		}
 		if ($networkEthereum) {
 			return DEFAULT_ETHEREUM_TOKEN;

--- a/src/frontend/src/tests/lib/derived/token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/token.derived.spec.ts
@@ -17,6 +17,7 @@ import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { DEFAULT_ARBITRUM_TOKEN } from '$lib/constants/tokens.constants';
 import { defaultFallbackToken } from '$lib/derived/token.derived';
 import { token } from '$lib/stores/token.store';
+import { isNetworkIdICP } from '$lib/utils/network.utils';
 import { mockPage } from '$tests/mocks/page.store.mock';
 import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
@@ -130,7 +131,10 @@ describe('token.derived', () => {
 				(networkId) => {
 					mockPage.mockNetwork(networkId.description);
 
-					expect(get(defaultFallbackToken)).toEqual(ETHEREUM_TOKEN);
+					// ICP (incl. its testnet pseudo-network) is always available, so it keeps resolving to the ICP token.
+					expect(get(defaultFallbackToken)).toEqual(
+						isNetworkIdICP(networkId) ? ICP_TOKEN : ETHEREUM_TOKEN
+					);
 				}
 			);
 		});
@@ -144,7 +148,10 @@ describe('token.derived', () => {
 			it.each(SUPPORTED_NETWORK_IDS)(`should return default token for network %s`, (networkId) => {
 				mockPage.mockNetwork(networkId.description);
 
-				expect(get(defaultFallbackToken)).toEqual(ETHEREUM_TOKEN);
+				// ICP (incl. its testnet pseudo-network) is always available, so it keeps resolving to the ICP token.
+				expect(get(defaultFallbackToken)).toEqual(
+					isNetworkIdICP(networkId) ? ICP_TOKEN : ETHEREUM_TOKEN
+				);
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/derived/token.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/token.derived.spec.ts
@@ -5,13 +5,14 @@ import { SUPPORTED_POLYGON_NETWORK_IDS } from '$env/networks/networks-evm/networ
 import { SUPPORTED_BITCOIN_NETWORK_IDS } from '$env/networks/networks.btc.env';
 import { SUPPORTED_NETWORK_IDS, SUPPORTED_TESTNET_NETWORK_IDS } from '$env/networks/networks.env';
 import { SUPPORTED_ETHEREUM_NETWORK_IDS } from '$env/networks/networks.eth.env';
-import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
+import { ICP_NETWORK_ID, ICP_PSEUDO_TESTNET_NETWORK_ID } from '$env/networks/networks.icp.env';
 import { SUPPORTED_SOLANA_NETWORK_IDS } from '$env/networks/networks.sol.env';
 import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { BNB_MAINNET_TOKEN } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
 import { POL_MAINNET_TOKEN } from '$env/tokens/tokens-evm/tokens-polygon/tokens.pol.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { DEFAULT_ARBITRUM_TOKEN } from '$lib/constants/tokens.constants';
 import { defaultFallbackToken } from '$lib/derived/token.derived';
@@ -101,10 +102,16 @@ describe('token.derived', () => {
 			}
 		);
 
-		it('should return ETH for ICP network', () => {
+		it('should return ICP for ICP network', () => {
 			mockPage.mockNetwork(ICP_NETWORK_ID.description);
 
-			expect(get(defaultFallbackToken)).toEqual(ETHEREUM_TOKEN);
+			expect(get(defaultFallbackToken)).toEqual(ICP_TOKEN);
+		});
+
+		it('should return ICP for ICP testnet pseudo-network', () => {
+			mockPage.mockNetwork(ICP_PSEUDO_TESTNET_NETWORK_ID.description);
+
+			expect(get(defaultFallbackToken)).toEqual(ICP_TOKEN);
 		});
 
 		it('should return ETH for any other network', () => {


### PR DESCRIPTION
# Motivation

With an ICP network selected in the hero — notably the IC **testnet** pseudo-network — clicking **Receive** did nothing on routes that don't carry a token in the URL (trading / earning / borrowings). The modal never opened.

Root cause: `defaultFallbackToken` had a branch for every network family *except* ICP, so on an ICP network with no page token it fell through to an Ethereum token. `IcReceiveIcp` then saw a non-ICP token, routed the click to `openEthReceive`, but only renders the `icp-receive` modal — so nothing appeared.

# Changes

- Add an ICP branch to `defaultFallbackToken` returning `ICP_TOKEN` (covers ICP mainnet and the testnet pseudo-network), matching the per-network-family pattern used for every other network.

# Tests

- Updated `token.derived.spec.ts`: the ICP case now expects `ICP_TOKEN`, and added a case for the ICP testnet pseudo-network.
- `token.derived`, `page-token.derived`, and hero `Actions` specs pass; lint clean.