### PR TITLE
refactor(frontend): extract shared ProviderTag and fix order-row alignment

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumProviderTag.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProviderTag.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Badge from '$lib/components/ui/Badge.svelte';
+	import ProviderTag from '$lib/components/ui/ProviderTag.svelte';
 	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
 	import { LendBorrowProvider } from '$lib/types/lend-borrow';
 
@@ -7,7 +7,5 @@
 </script>
 
 <span class="hidden sm:inline-block">
-	<Badge styleClass="ml-2 mb-1" variant="transparent" width="w-fit">
-		{name}
-	</Badge>
+	<ProviderTag {name} styleClass="ml-2 mb-1" />
 </span>

--- a/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
@@ -95,22 +95,22 @@
 		<TokenLogo badge={{ type: 'network' }} color="white" data={baseData} logoSize="xs" />
 	</span>
 
-	<div class="min-w-0 flex-1 text-sm leading-snug text-primary">
+	<div class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1 text-sm leading-snug text-primary">
 		{#if $isPrivacyMode}
 			<span class="inline-flex items-center gap-1"><IconDots variant="sm" /></span>
 		{:else}
-			<span
-				class="font-semibold"
-				class:text-error-primary={side === 'sell'}
-				class:text-success-primary={side === 'buy'}
-			>
-				{side === 'sell' ? $i18n.trading.orders.side_sell : $i18n.trading.orders.side_buy}
+			<span>
+				<span
+					class="font-semibold"
+					class:text-error-primary={side === 'sell'}
+					class:text-success-primary={side === 'buy'}
+				>
+					{side === 'sell' ? $i18n.trading.orders.side_sell : $i18n.trading.orders.side_buy}
+				</span>
+				{rowText}
 			</span>
-			{rowText}
 		{/if}
-		<span class="ml-1 inline-flex align-middle">
-			<TradingProviderTag />
-		</span>
+		<TradingProviderTag />
 	</div>
 
 	<span class="shrink-0">

--- a/src/frontend/src/lib/components/trading/TradingProviderTag.svelte
+++ b/src/frontend/src/lib/components/trading/TradingProviderTag.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
+	import ProviderTag from '$lib/components/ui/ProviderTag.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>
 
-<span
-	class="flex min-h-0 flex-0 grow-0 rounded-full border-1 border-tertiary bg-primary px-2 py-0.5 text-xs whitespace-nowrap text-tertiary"
->
-	{$i18n.trading.text.provider_name}
-</span>
+<ProviderTag name={$i18n.trading.text.provider_name} />

--- a/src/frontend/src/lib/components/ui/ProviderTag.svelte
+++ b/src/frontend/src/lib/components/ui/ProviderTag.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import Badge from '$lib/components/ui/Badge.svelte';
+
+	interface Props {
+		name: string;
+		styleClass?: string;
+		testId?: string;
+	}
+
+	let { name, styleClass = undefined, testId = undefined }: Props = $props();
+</script>
+
+<Badge {styleClass} {testId} variant="transparent" width="w-fit">
+	{name}
+</Badge>

--- a/src/frontend/src/tests/lib/components/ui/ProviderTag.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/ProviderTag.spec.ts
@@ -1,0 +1,18 @@
+import ProviderTag from '$lib/components/ui/ProviderTag.svelte';
+import { render } from '@testing-library/svelte';
+
+describe('ProviderTag', () => {
+	it('renders the provider name', () => {
+		const { getByText } = render(ProviderTag, { props: { name: 'OISY TRADE' } });
+
+		expect(getByText('OISY TRADE')).toBeInTheDocument();
+	});
+
+	it('forwards the test id', () => {
+		const { getByTestId } = render(ProviderTag, {
+			props: { name: 'Liquidium', testId: 'provider-tag' }
+		});
+
+		expect(getByTestId('provider-tag')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

The "OISY TRADE" tag in the Trading orders list was a bespoke `<span>`, visually and structurally different from the "Liquidium" provider tag used in the Earnings tab (which is the shared `Badge` with `variant="transparent"`). On top of that, the order row looked vertically misaligned.

Investigating with a geometry harness confirmed the three columns (logo / text / status) are correctly centered by `items-center`, but the running sentence text sat ~1.5px above the badge, logo and status pill — the tall inline badge inflated the line box, pushing the text baseline up.

# Changes

- Extract a generic `ui/ProviderTag.svelte` (thin wrapper over `Badge variant="transparent"`, takes a `name` prop).
- `LiquidiumProviderTag` now renders `ProviderTag` (Earnings output unchanged).
- `TradingProviderTag` now renders `ProviderTag`, so the OISY TRADE badge matches the Earnings badge exactly.
- `TradingOrderRow` middle block is now `flex flex-wrap items-center`, co-centering text, tag, logo and status (measured offset drops from ~1.5px to ~0).

# Tests

- New `ProviderTag.spec.ts` (renders name, forwards test id).
- Existing `TradingProviderTag`, `LiquidiumProviderTag`, `TradingOrderRow` and `TradingOrderDetailModal` specs pass.
- `prettier --check`, `eslint --max-warnings 0`, and `svelte-check --fail-on-warnings` all clean on the changed files.