### PR TITLE
fix(frontend): make button loading spinner actually rotate

### DIFF
--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -51,7 +51,7 @@
 
 <button
 	class={`${colorStyle} flex text-center ${styleClass}`}
-	class:animate-pulse={loading || initialising}
+	class:animate-pulse={initialising}
 	class:cursor-not-allowed={loading || initialising || disabled}
 	class:duration-500={loading || initialising}
 	class:ease-in-out={loading || initialising}

--- a/src/frontend/src/lib/components/ui/Spinner.svelte
+++ b/src/frontend/src/lib/components/ui/Spinner.svelte
@@ -26,30 +26,25 @@
 		width: var(--spinner-size);
 		height: var(--spinner-size);
 
-		animation: app-spinner-linear-rotate 2000ms linear infinite;
+		animation: app-spinner-rotate 800ms linear infinite;
 
 		position: absolute;
 		top: calc(50% - (var(--spinner-size) / 2));
 		left: calc(50% - (var(--spinner-size) / 2));
 
-		--radius: 45px;
-		--circumference: calc(3.14159265359 * var(--radius) * 2);
-
-		--start: calc((1 - 0.05) * var(--circumference));
-		--end: calc((1 - 0.8) * var(--circumference));
-
 		circle {
-			stroke-dasharray: var(--circumference);
+			// r=45 in a 100x100 viewBox → circumference ≈ 283; show a ~25% arc, hide the rest.
+			stroke-dasharray: 70 213;
 			stroke-width: 10%;
-			transform-origin: 50% 50% 0;
-			transition-property: stroke;
-			animation-name: app-spinner-stroke-rotate-100;
-			animation-duration: 4000ms;
-			animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1);
-			animation-iteration-count: infinite;
+			stroke-linecap: round;
 			fill: transparent;
 			stroke: currentColor;
-			transition: stroke-dashoffset 225ms linear;
+		}
+	}
+
+	@keyframes app-spinner-rotate {
+		to {
+			transform: rotate(360deg);
 		}
 	}
 </style>


### PR DESCRIPTION
# Motivation

The loading spinner shown inside `Button` never actually rotated. It referenced two keyframes — `app-spinner-linear-rotate` and `app-spinner-stroke-rotate-100` — that no longer exist anywhere in the repo (they were global CSS from gix-components, lost when the component was vendored in-house). On top of that, the button applied Tailwind's `animate-pulse` to the loading state, so the button pulsed while the spinner sat frozen — two loading affordances at once, one of them broken.

# Changes

- `Spinner.svelte`: replace the two missing keyframes with a self-contained `app-spinner-rotate` animation that rotates the SVG 360° on a loop, drawing a ~25% arc with round line caps. No external CSS dependency.
- `Button.svelte`: apply `animate-pulse` only to the `initialising` (skeleton) state, not to `loading`. The spinner state now spins cleanly with no competing pulse; the skeleton state keeps its pulse.

# Tests

- `prettier --check`, `eslint --max-warnings 0`, `npm run check` (svelte-check: 0 errors, 0 warnings) all pass.
- Spinner + ButtonIcon unit tests pass (14/14); Spinner spec asserts structure/size/a11y, unaffected by the CSS change.
