### PR TITLE
fix(frontend): render zero limit-order value difference as 0.00%

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderValueDifference.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderValueDifference.svelte
@@ -11,7 +11,10 @@
 
 	let { value, crossing }: Props = $props();
 
-	const text = $derived(`${value >= 0 ? '+' : ''}${value.toFixed(2)}%`);
+	// Round before signing so a sub-0.005 magnitude reads as a clean "0.00%"
+	// rather than "-0.00%" (or a spurious "+0.00%").
+	const rounded = $derived(Number(value.toFixed(2)));
+	const text = $derived(`${rounded > 0 ? '+' : ''}${rounded.toFixed(2)}%`);
 	const danger = $derived(value < LIMIT_ORDER_VALUE_DIFFERENCE_ERROR_PERCENT);
 </script>
 

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderValueDifference.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderValueDifference.svelte.spec.ts
@@ -18,12 +18,21 @@ describe('LimitOrderValueDifference', () => {
 		expect(container).toHaveTextContent('-2.10%');
 	});
 
-	it('formats zero with a plus sign', () => {
+	it('formats zero without a sign', () => {
 		const { container } = render(LimitOrderValueDifference, {
 			props: { value: 0, crossing: false }
 		});
 
-		expect(container).toHaveTextContent('+0.00%');
+		expect(container).toHaveTextContent('0.00%');
+	});
+
+	it('rounds a sub-threshold negative value to a clean 0.00% (no minus sign)', () => {
+		const { container } = render(LimitOrderValueDifference, {
+			props: { value: -0.001, crossing: false }
+		});
+
+		expect(container).toHaveTextContent('0.00%');
+		expect(container).not.toHaveTextContent('-0.00%');
 	});
 
 	it('does not render the warning icon when not crossing', () => {


### PR DESCRIPTION
# Motivation

In the limit-order modal, a value difference with a tiny sub-0.005 magnitude (e.g. -0.001%) rendered as `-0.00%`. A zero difference should read as a clean `0.00%`, without a misleading minus sign.

# Changes

- `LimitOrderValueDifference.svelte`: round the value to 2 decimals before choosing the sign, so a magnitude that rounds to zero renders as `0.00%` (no `-` and no spurious `+`). Positive values keep the leading `+`, negatives keep the `-`.

# Tests

- Updated the zero case to expect `0.00%` (no sign) and added a regression case for `-0.001` asserting `0.00%` and not `-0.00%`.