### PR TITLE
feat(frontend): show queue position on active order rows

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
@@ -179,7 +179,7 @@
 		// Only surface a figure when there is volume ahead; a "Front of book" (0%)
 		// order shows nothing on the compact row.
 		if (display === null || display.front) {
-			return undefined;
+			return;
 		}
 		return replacePlaceholders($i18n.trading.limit_order.are_ahead, {
 			$percentage: display.percent.toString()

--- a/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
@@ -1,16 +1,33 @@
 <script lang="ts">
+	import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+	import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
+	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TradingProviderTag from '$lib/components/trading/TradingProviderTag.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
+	import { OISY_TRADE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { oisyTradePairs } from '$lib/derived/oisy-trade.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
+	import { loadOrderBook } from '$lib/services/oisy-trade.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
-	import type { OisyTradeOrderView } from '$lib/types/oisy-trade';
+	import type { OisyTradeOrderBook, OisyTradeOrderView } from '$lib/types/oisy-trade';
 	import type { CardData } from '$lib/types/token-card';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { oisyTradeOrderDisplayStatus, orderStatusView } from '$lib/utils/oisy-trade.utils';
+	import {
+		crossesBook,
+		isOisyTradeOrderActive,
+		oisyTradeOrderDisplayStatus,
+		orderStatusView,
+		priceLevelToHuman,
+		queuePositionDisplay,
+		queuePositionFraction,
+		toPairView,
+		toTradingPair
+	} from '$lib/utils/oisy-trade.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
@@ -84,6 +101,90 @@
 					$price: formattedPrice
 				})
 	);
+
+	// Queue position — the share of same-side volume priced better than this order,
+	// shown as plain muted text under the status pill. Only for active (Pending +
+	// Open) resting orders, and only when there is volume ahead; a "Front of book"
+	// (0%) order or a crossing order that fills immediately shows nothing here.
+	const active = $derived(isOisyTradeOrderActive(order));
+
+	const pairInfo = $derived<TradingPairInfo | undefined>(
+		$oisyTradePairs.find(
+			(p) => p.base.metadata.symbol === base.symbol && p.quote.metadata.symbol === quote.symbol
+		)
+	);
+	const pairView = $derived(nonNullish(pairInfo) ? toPairView(pairInfo) : undefined);
+
+	let orderBook = $state<OisyTradeOrderBook | undefined>();
+
+	const refreshOrderBook = async (): Promise<void> => {
+		if (!active || isNullish(pairInfo)) {
+			orderBook = undefined;
+			return;
+		}
+		const next = await loadOrderBook({ identity: $authIdentity, pair: toTradingPair(pairInfo) });
+		// Keep the last good snapshot on a transient failure.
+		if (nonNullish(next)) {
+			orderBook = next;
+		}
+	};
+
+	$effect(() => {
+		pairInfo;
+		active;
+		void refreshOrderBook();
+	});
+
+	const toHuman = (level: { price: bigint; quantity: bigint }) =>
+		priceLevelToHuman({
+			level,
+			baseDecimals: pairView?.baseDecimals ?? base.decimals,
+			quoteDecimals: pairView?.quoteDecimals ?? quote.decimals
+		});
+
+	const depthLevels = $derived.by(() => {
+		if (isNullish(orderBook?.depth) || isNullish(pairView)) {
+			return { asks: [], bids: [] };
+		}
+		return {
+			asks: orderBook.depth.asks.map(toHuman),
+			bids: orderBook.depth.bids.map(toHuman)
+		};
+	});
+
+	const bid = $derived.by((): number | null => {
+		const level = nonNullish(orderBook?.ticker) ? fromNullable(orderBook.ticker.bid) : undefined;
+		return nonNullish(level) && nonNullish(pairView) ? toHuman(level).price : null;
+	});
+	const ask = $derived.by((): number | null => {
+		const level = nonNullish(orderBook?.ticker) ? fromNullable(orderBook.ticker.ask) : undefined;
+		return nonNullish(level) && nonNullish(pairView) ? toHuman(level).price : null;
+	});
+
+	const crossing = $derived(crossesBook({ side, price, bid, ask }));
+
+	const queueText = $derived.by((): string | undefined => {
+		if (!active || crossing || isNullish(pairView)) {
+			return undefined;
+		}
+		const display = queuePositionDisplay(
+			queuePositionFraction({
+				side,
+				price,
+				tickSize: pairView.tickSize,
+				asks: depthLevels.asks,
+				bids: depthLevels.bids
+			})
+		);
+		// Only surface a figure when there is volume ahead; a "Front of book" (0%)
+		// order shows nothing on the compact row.
+		if (display === null || display.front) {
+			return undefined;
+		}
+		return replacePlaceholders($i18n.trading.limit_order.are_ahead, {
+			$percentage: display.percent.toString()
+		});
+	});
 </script>
 
 <button
@@ -113,7 +214,14 @@
 		</span>
 	</div>
 
-	<span class="shrink-0">
+	<span class="flex shrink-0 flex-col items-end gap-1">
 		<Badge variant={pillVariant} width="w-fit">{statusLabels[labelKey]}</Badge>
+		{#if nonNullish(queueText)}
+			<span class="text-xs text-tertiary">{queueText}</span>
+		{/if}
 	</span>
 </button>
+
+{#if active}
+	<IntervalLoader interval={OISY_TRADE_POLL_INTERVAL_MILLIS} onLoad={refreshOrderBook} />
+{/if}

--- a/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
 	import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 	import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
-	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TradingProviderTag from '$lib/components/trading/TradingProviderTag.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
-	import { OISY_TRADE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
-	import { authIdentity } from '$lib/derived/auth.derived';
 	import { oisyTradePairs } from '$lib/derived/oisy-trade.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
-	import { loadOrderBook } from '$lib/services/oisy-trade.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { OisyTradeOrderBook, OisyTradeOrderView } from '$lib/types/oisy-trade';
@@ -25,18 +21,20 @@
 		priceLevelToHuman,
 		queuePositionDisplay,
 		queuePositionFraction,
-		toPairView,
-		toTradingPair
+		toPairView
 	} from '$lib/utils/oisy-trade.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
 		order: OisyTradeOrderView;
+		// Live order-book snapshot for this order's pair, polled once per pair by the
+		// parent list. Undefined for history rows or before the first load.
+		orderBook?: OisyTradeOrderBook;
 	}
 
 	// Tapping the row opens the read-only order-detail modal (Review-styled), which
 	// also hosts the Cancel action for active orders — there is no inline cancel.
-	let { order }: Props = $props();
+	let { order, orderBook }: Props = $props();
 
 	const openDetail = () => modalStore.openOisyTradeOrderDetail({ id: Symbol(), data: order });
 
@@ -105,7 +103,8 @@
 	// Queue position — the share of same-side volume priced better than this order,
 	// shown as plain muted text under the status pill. Only for active (Pending +
 	// Open) resting orders, and only when there is volume ahead; a "Front of book"
-	// (0%) order or a crossing order that fills immediately shows nothing here.
+	// (0%) order or a crossing order that fills immediately shows nothing here. The
+	// order book itself is polled once per pair by the parent list and passed in.
 	const active = $derived(isOisyTradeOrderActive(order));
 
 	const pairInfo = $derived<TradingPairInfo | undefined>(
@@ -114,26 +113,6 @@
 		)
 	);
 	const pairView = $derived(nonNullish(pairInfo) ? toPairView(pairInfo) : undefined);
-
-	let orderBook = $state<OisyTradeOrderBook | undefined>();
-
-	const refreshOrderBook = async (): Promise<void> => {
-		if (!active || isNullish(pairInfo)) {
-			orderBook = undefined;
-			return;
-		}
-		const next = await loadOrderBook({ identity: $authIdentity, pair: toTradingPair(pairInfo) });
-		// Keep the last good snapshot on a transient failure.
-		if (nonNullish(next)) {
-			orderBook = next;
-		}
-	};
-
-	$effect(() => {
-		pairInfo;
-		active;
-		void refreshOrderBook();
-	});
 
 	const toHuman = (level: { price: bigint; quantity: bigint }) =>
 		priceLevelToHuman({
@@ -221,7 +200,3 @@
 		{/if}
 	</span>
 </button>
-
-{#if active}
-	<IntervalLoader interval={OISY_TRADE_POLL_INTERVAL_MILLIS} onLoad={refreshOrderBook} />
-{/if}

--- a/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
@@ -144,7 +144,7 @@
 
 	const queueText = $derived.by((): string | undefined => {
 		if (!active || crossing || isNullish(pairView)) {
-			return undefined;
+			return;
 		}
 		const display = queuePositionDisplay(
 			queuePositionFraction({
@@ -158,7 +158,7 @@
 		// Only surface a figure when there is volume ahead; a "Front of book" (0%)
 		// order shows nothing on the compact row.
 		if (display === null || display.front) {
-			return undefined;
+			return;
 		}
 		return replacePlaceholders($i18n.trading.limit_order.are_ahead, {
 			$percentage: display.percent.toString()

--- a/src/frontend/src/lib/components/trading/TradingOrders.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrders.svelte
@@ -1,17 +1,86 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { untrack } from 'svelte';
+	import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
+	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import TradingOrderDetailModal from '$lib/components/trading/TradingOrderDetailModal.svelte';
 	import TradingOrderRow from '$lib/components/trading/TradingOrderRow.svelte';
 	import LimitOrder from '$lib/components/trading/limit-order/LimitOrder.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
+	import { OISY_TRADE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
+	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
 		modalOisyTradeOrderDetail,
 		modalOisyTradeOrderDetailData
 	} from '$lib/derived/modal.derived';
-	import { oisyTradeActiveOrders, oisyTradeHistoryOrders } from '$lib/derived/oisy-trade.derived';
+	import {
+		oisyTradeActiveOrders,
+		oisyTradeHistoryOrders,
+		oisyTradePairs
+	} from '$lib/derived/oisy-trade.derived';
+	import { loadOrderBook } from '$lib/services/oisy-trade.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { OisyTradeOrderBook, OisyTradeOrderView } from '$lib/types/oisy-trade';
+	import { toTradingPair } from '$lib/utils/oisy-trade.utils';
 
 	let activeTab = $state<'active' | 'history'>('active');
+
+	// A row is keyed to its pair's order book by the pair's symbol pair. Multiple
+	// active orders on the same pair therefore share a single book — the book is
+	// polled once per distinct pair, not once per order.
+	const pairKey = ({ base, quote }: OisyTradeOrderView): string => `${base.symbol}/${quote.symbol}`;
+
+	// The distinct pairs backing the current active orders, resolved to their
+	// candid pair info (needed to query the book), keyed by symbol pair.
+	const activePairs = $derived.by((): Record<string, TradingPairInfo> => {
+		const pairs: Record<string, TradingPairInfo> = {};
+		for (const order of $oisyTradeActiveOrders) {
+			const info = $oisyTradePairs.find(
+				(p) =>
+					p.base.metadata.symbol === order.base.symbol &&
+					p.quote.metadata.symbol === order.quote.symbol
+			);
+			if (nonNullish(info)) {
+				pairs[pairKey(order)] = info;
+			}
+		}
+		return pairs;
+	});
+
+	// Only re-run the initial/reactive load when the SET of pairs changes, not on
+	// every orders-store refresh.
+	const activePairsKey = $derived(Object.keys(activePairs).sort().join(','));
+
+	let orderBooks = $state<Record<string, OisyTradeOrderBook>>({});
+
+	const refreshOrderBooks = async (): Promise<void> => {
+		const pairs = untrack(() => activePairs);
+		const keys = Object.keys(pairs);
+		if (keys.length === 0) {
+			return;
+		}
+		const entries = await Promise.all(
+			keys.map(
+				async (key): Promise<[string, OisyTradeOrderBook | undefined]> => [
+					key,
+					await loadOrderBook({ identity: $authIdentity, pair: toTradingPair(pairs[key]) })
+				]
+			)
+		);
+		// Keep the last good snapshot per pair on a transient failure.
+		const next = { ...untrack(() => orderBooks) };
+		for (const [key, book] of entries) {
+			if (nonNullish(book)) {
+				next[key] = book;
+			}
+		}
+		orderBooks = next;
+	};
+
+	$effect(() => {
+		activePairsKey;
+		void refreshOrderBooks();
+	});
 </script>
 
 <div class="mt-4 flex flex-col gap-2">
@@ -39,7 +108,7 @@
 			{:else}
 				<ul class="flex flex-col list-none">
 					{#each $oisyTradeActiveOrders as order (order.id)}
-						<li><TradingOrderRow {order} /></li>
+						<li><TradingOrderRow {order} orderBook={orderBooks[pairKey(order)]} /></li>
 					{/each}
 				</ul>
 			{/if}
@@ -56,6 +125,14 @@
 		{/if}
 	</Tabs>
 </div>
+
+{#if Object.keys(activePairs).length > 0}
+	<IntervalLoader
+		interval={OISY_TRADE_POLL_INTERVAL_MILLIS}
+		onLoad={refreshOrderBooks}
+		skipInitialLoad
+	/>
+{/if}
 
 {#if $modalOisyTradeOrderDetail && nonNullish($modalOisyTradeOrderDetailData)}
 	<TradingOrderDetailModal order={$modalOisyTradeOrderDetailData} />

--- a/src/frontend/src/tests/lib/components/trading/TradingOrderRow.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingOrderRow.svelte.spec.ts
@@ -1,17 +1,12 @@
 import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 import type { IcToken } from '$icp/types/ic-token';
 import TradingOrderRow from '$lib/components/trading/TradingOrderRow.svelte';
-import { loadOrderBook } from '$lib/services/oisy-trade.services';
 import { modalStore } from '$lib/stores/modal.store';
-import type { OisyTradeOrderView } from '$lib/types/oisy-trade';
+import type { OisyTradeOrderBook, OisyTradeOrderView } from '$lib/types/oisy-trade';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
-import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 
-vi.mock('$lib/services/oisy-trade.services', () => ({
-	loadOrderBook: vi.fn(() => Promise.resolve(undefined))
-}));
-
-// A single ICP/ckUSDC pair so the row can resolve the order book for its order.
+// A single ICP/ckUSDC pair so the row can resolve tick size / decimals for its order.
 vi.mock('$lib/derived/oisy-trade.derived', async () => {
 	const { writable } = await import('svelte/store');
 	const { Principal } = await import('@dfinity/principal');
@@ -50,7 +45,7 @@ const order: OisyTradeOrderView = {
 };
 
 // Half the ask volume (the 2.4 level) is priced better than the 2.5 sell price.
-const bookWithVolumeAhead = {
+const bookWithVolumeAhead: OisyTradeOrderBook = {
 	ticker: { ask: [], bid: [] },
 	depth: {
 		asks: [
@@ -59,7 +54,13 @@ const bookWithVolumeAhead = {
 		],
 		bids: []
 	}
-} as const;
+};
+
+// No ask volume priced better than the order → front of book (0%).
+const bookFrontOfBook: OisyTradeOrderBook = {
+	ticker: { ask: [], bid: [] },
+	depth: { asks: [{ price: 2_600_000n, quantity: 500_000_000n }], bids: [] }
+};
 
 describe('TradingOrderRow', () => {
 	beforeEach(() => {
@@ -86,37 +87,27 @@ describe('TradingOrderRow', () => {
 		expect(openSpy).toHaveBeenCalledWith(expect.objectContaining({ data: order }));
 	});
 
-	it('shows the queue position under the status for an active order with volume ahead', async () => {
-		vi.mocked(loadOrderBook).mockResolvedValue(bookWithVolumeAhead);
-
-		const { container } = render(TradingOrderRow, { props: { order } });
-
-		await waitFor(() => expect(container).toHaveTextContent('50% are ahead'));
-	});
-
-	it('shows no queue position for a front-of-book active order', async () => {
-		// No ask volume priced better than the order → front of book (0%).
-		vi.mocked(loadOrderBook).mockResolvedValue({
-			ticker: { ask: [], bid: [] },
-			depth: { asks: [{ price: 2_600_000n, quantity: 500_000_000n }], bids: [] }
+	it('shows the queue position under the status when there is volume ahead', () => {
+		const { container } = render(TradingOrderRow, {
+			props: { order, orderBook: bookWithVolumeAhead }
 		});
 
-		const { container } = render(TradingOrderRow, { props: { order } });
+		expect(container).toHaveTextContent('50% are ahead');
+	});
 
-		await waitFor(() => expect(loadOrderBook).toHaveBeenCalled());
+	it('shows no queue position for a front-of-book active order', () => {
+		const { container } = render(TradingOrderRow, {
+			props: { order, orderBook: bookFrontOfBook }
+		});
 
 		expect(container).not.toHaveTextContent('are ahead');
 	});
 
 	it('shows no queue position for a terminal (history) order', () => {
-		vi.mocked(loadOrderBook).mockResolvedValue(bookWithVolumeAhead);
-
 		const { container } = render(TradingOrderRow, {
-			props: { order: { ...order, status: 'Filled' } }
+			props: { order: { ...order, status: 'Filled' }, orderBook: bookWithVolumeAhead }
 		});
 
-		// Terminal rows never load or show queue position.
-		expect(loadOrderBook).not.toHaveBeenCalled();
 		expect(container).not.toHaveTextContent('are ahead');
 	});
 });

--- a/src/frontend/src/tests/lib/components/trading/TradingOrderRow.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingOrderRow.svelte.spec.ts
@@ -1,9 +1,39 @@
+import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 import type { IcToken } from '$icp/types/ic-token';
 import TradingOrderRow from '$lib/components/trading/TradingOrderRow.svelte';
+import { loadOrderBook } from '$lib/services/oisy-trade.services';
 import { modalStore } from '$lib/stores/modal.store';
 import type { OisyTradeOrderView } from '$lib/types/oisy-trade';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+
+vi.mock('$lib/services/oisy-trade.services', () => ({
+	loadOrderBook: vi.fn(() => Promise.resolve(undefined))
+}));
+
+// A single ICP/ckUSDC pair so the row can resolve the order book for its order.
+vi.mock('$lib/derived/oisy-trade.derived', async () => {
+	const { writable } = await import('svelte/store');
+	const { Principal } = await import('@dfinity/principal');
+	const pair: TradingPairInfo = {
+		status: { Trading: null },
+		base: {
+			id: { ledger_id: Principal.fromText('aaaaa-aa') },
+			metadata: { symbol: 'ICP', decimals: 8 }
+		},
+		quote: {
+			id: { ledger_id: Principal.fromText('aaaaa-aa') },
+			metadata: { symbol: 'ckUSDC', decimals: 6 }
+		},
+		min_notional: 1_000_000n,
+		lot_size: 100_000_000n,
+		taker_fee_bps: 0,
+		maker_fee_bps: 0,
+		tick_size: 10_000n,
+		max_notional: []
+	};
+	return { oisyTradePairs: writable([pair]) };
+});
 
 const base: IcToken = { ...mockValidIcToken, symbol: 'ICP', decimals: 8 };
 const quote: IcToken = { ...mockValidIcToken, symbol: 'ckUSDC', decimals: 6 };
@@ -18,6 +48,18 @@ const order: OisyTradeOrderView = {
 	filledQuantity: 0,
 	status: 'Open'
 };
+
+// Half the ask volume (the 2.4 level) is priced better than the 2.5 sell price.
+const bookWithVolumeAhead = {
+	ticker: { ask: [], bid: [] },
+	depth: {
+		asks: [
+			{ price: 2_400_000n, quantity: 500_000_000n },
+			{ price: 2_600_000n, quantity: 500_000_000n }
+		],
+		bids: []
+	}
+} as const;
 
 describe('TradingOrderRow', () => {
 	beforeEach(() => {
@@ -42,5 +84,39 @@ describe('TradingOrderRow', () => {
 		await fireEvent.click(container.querySelector('button') as HTMLButtonElement);
 
 		expect(openSpy).toHaveBeenCalledWith(expect.objectContaining({ data: order }));
+	});
+
+	it('shows the queue position under the status for an active order with volume ahead', async () => {
+		vi.mocked(loadOrderBook).mockResolvedValue(bookWithVolumeAhead);
+
+		const { container } = render(TradingOrderRow, { props: { order } });
+
+		await waitFor(() => expect(container).toHaveTextContent('50% are ahead'));
+	});
+
+	it('shows no queue position for a front-of-book active order', async () => {
+		// No ask volume priced better than the order → front of book (0%).
+		vi.mocked(loadOrderBook).mockResolvedValue({
+			ticker: { ask: [], bid: [] },
+			depth: { asks: [{ price: 2_600_000n, quantity: 500_000_000n }], bids: [] }
+		});
+
+		const { container } = render(TradingOrderRow, { props: { order } });
+
+		await waitFor(() => expect(loadOrderBook).toHaveBeenCalled());
+
+		expect(container).not.toHaveTextContent('are ahead');
+	});
+
+	it('shows no queue position for a terminal (history) order', () => {
+		vi.mocked(loadOrderBook).mockResolvedValue(bookWithVolumeAhead);
+
+		const { container } = render(TradingOrderRow, {
+			props: { order: { ...order, status: 'Filled' } }
+		});
+
+		// Terminal rows never load or show queue position.
+		expect(loadOrderBook).not.toHaveBeenCalled();
+		expect(container).not.toHaveTextContent('are ahead');
 	});
 });


### PR DESCRIPTION
# Motivation

The limit-orders spec wireframe shows each active Orders row surfacing its queue position ("share of same-side volume priced better") under the status pill, so users get an at-a-glance sense of how soon an order might fill. The active rows were not yet rendering it.

# Changes

- `TradingOrderRow`: load the pair's live order book (`loadOrderBook` + `IntervalLoader`, same plumbing as the order-detail modal) and render "X% are ahead" under the status pill.
- Shown only for active (Pending/Open) resting orders with volume ahead; hidden for front-of-book (0%), crossing orders that fill immediately, and terminal (History) rows. Non-active rows skip loading/polling entirely.
- Stays visible under privacy mode (only the amount is masked).

# Tests

- Added row tests: renders "50% are ahead" with volume ahead, hides it for a front-of-book order, and never loads/shows it for a terminal order.
- Gates: prettier, eslint (--max-warnings 0), svelte-check (0 errors/warnings), vitest (5/5).
