### PR TITLE
fix(frontend): format limit-order prices and balances through shared token formatter

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
@@ -6,6 +6,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import {
 		crossesBook,
+		formatTradeAmount,
 		type LimitOrderPairView,
 		type LimitOrderSide,
 		isPresetSelected,
@@ -160,7 +161,9 @@
 			return {
 				text: replacePlaceholders(
 					side === 'sell' ? t.warning_fok_blocked_sell : t.warning_fok_blocked_buy,
-					{ $price: refPrice.toString() }
+					{
+						$price: formatTradeAmount({ amount: refPrice, decimals: pairView?.quoteDecimals ?? 8 })
+					}
 				),
 				danger: true
 			};

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
@@ -156,7 +156,7 @@
 			<span class="text-sm text-secondary">{$i18n.trading.limit_order.limit_price}</span>
 			<span class="text-lg font-semibold text-primary">
 				{replacePlaceholders($i18n.trading.limit_order.limit_price_value, {
-					$price: price.toString(),
+					$price: formatTradeAmount({ amount: price, decimals: pairView?.quoteDecimals ?? 8 }),
 					$quote: quote,
 					$base: base
 				})}
@@ -168,7 +168,10 @@
 				<span class="font-medium text-secondary">
 					{currentValue > 0
 						? replacePlaceholders($i18n.trading.limit_order.current_value_feed, {
-								$price: currentValue.toString(),
+								$price: formatTradeAmount({
+									amount: currentValue,
+									decimals: pairView?.quoteDecimals ?? 8
+								}),
 								$quote: quote,
 								$base: base
 							})

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -191,14 +191,14 @@
 							type="button"
 						>
 							{replacePlaceholders($i18n.trading.limit_order.max_with_amount, {
-								$amount: freeBase.toString(),
+								$amount: fmtBase(freeBase),
 								$symbol: baseSymbol
 							})}
 						</button>
 					{:else}
 						<span class="text-tertiary">
 							{replacePlaceholders($i18n.trading.limit_order.balance, {
-								$amount: freeBase.toString(),
+								$amount: fmtBase(freeBase),
 								$symbol: baseSymbol
 							})}
 						</span>
@@ -244,14 +244,14 @@
 						type="button"
 					>
 						{replacePlaceholders($i18n.trading.limit_order.max_with_amount, {
-							$amount: freeQuote.toString(),
+							$amount: fmtQuote(freeQuote),
 							$symbol: quoteSymbol
 						})}
 					</button>
 				{:else}
 					<span class="text-tertiary">
 						{replacePlaceholders($i18n.trading.limit_order.balance, {
-							$amount: freeQuote.toString(),
+							$amount: fmtQuote(freeQuote),
 							$symbol: quoteSymbol
 						})}
 					</span>


### PR DESCRIPTION
# Motivation

In the "Review limit order" modal the **Current value** row rendered a raw JavaScript number, so a clean-looking rate leaked float artifacts, e.g. `1.7999999999999998 ckSepoliaUSDC / TESTICP` instead of `1.8`. The value comes from `(bid + ask) / 2`, and it was displayed with `.toString()`.

Auditing the rest of the trading feature turned up the same `.toString()` pattern on other price/amount readouts. The fix reuses the formatting helpers that already exist for exactly this reason — no new utils.

# Changes

Route displayed prices/amounts through the shared `formatTradeAmount` (and the local `fmtBase` / `fmtQuote` wrappers), so they round to the pair's decimals like the rest of the trading UI:

- `LimitOrderReview.svelte` — Current value and Limit price (previously `currentValue.toString()` / `price.toString()`).
- `LimitOrderTradePairBox.svelte` — Max / Balance readouts (previously `freeBase.toString()` / `freeQuote.toString()`); now use the `fmtBase` / `fmtQuote` helpers already used by this component's error strings.
- `LimitOrderPriceSection.svelte` — the FOK-blocked warning's reference price (previously `refPrice.toString()`).

Left untouched after audit, as they are not float-prone: fee percentages (single `bps / 100` division), queue-position percentages (already rounded), tick-size in error messages (clean config value by contract), and the Max/preset input setters (already snapped via `floorToStep` / `snapToTick`, which `toFixed`). The order detail modal and order rows already used the shared formatters.

# Tests

- `npm run check` — 0 errors / 0 warnings.
- ESLint + Prettier on the changed files — clean.
- Component specs pass: `LimitOrderReview`, `LimitOrderTradePairBox`, `LimitOrderPriceSection` (26 tests).
