### PR TITLE
fix(frontend): hide asset search bar on the Trading tab

### DIFF
--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -63,7 +63,7 @@
 			{#snippet header()}
 				<div class="flex w-full justify-between">
 					<div class="relative flex grow-1 justify-between">
-						<TokensFilter>
+						<TokensFilter hideFilter={tab === TokenTypes.TRADING}>
 							{#snippet overflowableContent()}
 								<Tabs
 									styleClass="mt-2 mb-6"

--- a/src/frontend/src/lib/components/tokens/TokensFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensFilter.svelte
@@ -15,9 +15,10 @@
 
 	interface Props {
 		overflowableContent?: Snippet;
+		hideFilter?: boolean;
 	}
 
-	let { overflowableContent }: Props = $props();
+	let { overflowableContent, hideFilter = false }: Props = $props();
 
 	let inputValue = $derived($tokenListStore.filter);
 
@@ -42,14 +43,18 @@
 	});
 </script>
 
-<SlidingInput
-	ariaLabel={$i18n.tokens.alt.filter_button}
-	inputPlaceholder={$i18n.tokens.text.filter_placeholder}
-	{overflowableContent}
-	testIdPrefix={TOKEN_LIST_FILTER}
-	bind:inputValue
->
-	{#snippet icon()}
-		<IconSearch />
-	{/snippet}
-</SlidingInput>
+{#if hideFilter}
+	{@render overflowableContent?.()}
+{:else}
+	<SlidingInput
+		ariaLabel={$i18n.tokens.alt.filter_button}
+		inputPlaceholder={$i18n.tokens.text.filter_placeholder}
+		{overflowableContent}
+		testIdPrefix={TOKEN_LIST_FILTER}
+		bind:inputValue
+	>
+		{#snippet icon()}
+			<IconSearch />
+		{/snippet}
+	</SlidingInput>
+{/if}

--- a/src/frontend/src/tests/lib/components/tokens/TokensFilter.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensFilter.spec.ts
@@ -52,6 +52,12 @@ describe('TokensFilter', () => {
 		expect(getByTestId(`${TOKEN_LIST_FILTER}-open-btn`)).toBeInTheDocument();
 	});
 
+	it('should not render the filter button when hideFilter is true', () => {
+		const { queryByTestId } = render(TokensFilter, { props: { hideFilter: true } });
+
+		expect(queryByTestId(`${TOKEN_LIST_FILTER}-open-btn`)).not.toBeInTheDocument();
+	});
+
 	// SvelteKit route IDs don't include trailing slashes (e.g. `/(app)`, `/(app)/nfts`).
 	// The is*Path helpers normalize them internally.
 	describe('filter persistence across asset tabs', () => {


### PR DESCRIPTION
# Motivation

The Trading tab renders the shared asset search bar (from `TokensFilter`), but none of the Trading components consume `$tokenListStore.filter`. Typing into the search box on Trading did nothing — a visible control with no effect, which is worse than no control.

# Changes

- Add an optional `hideFilter` prop to `TokensFilter`. When set, only the tabs (`overflowableContent`) render; the search `SlidingInput` is skipped.
- Pass `hideFilter={tab === TokenTypes.TRADING}` from `Assets.svelte`, so the search bar is hidden on the Trading tab while the tab navigation stays intact.

# Tests

- New unit test asserting the filter button is not rendered when `hideFilter` is true.
- `TokensFilter.spec.ts` passes (11 tests). `npm run check` clean (0 errors, 0 warnings); lint and prettier clean on the changed files.