### PR TITLE
feat(frontend): search the Trading tab by token, network, side, status and provider

### DIFF
--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -71,7 +71,7 @@
 					     tab row's natural width on narrow viewports (see the
 					     matching note in SlidingInput.svelte). -->
 					<div class="relative flex min-w-0 grow-1 justify-between">
-						<TokensFilter hideFilter={tab === TokenTypes.TRADING}>
+						<TokensFilter>
 							{#snippet overflowableContent()}
 								<!-- NFTs is its own nav destination now, so the standalone NFTs page
 								     shows no Tokens/Earning/Trading tab bar. -->

--- a/src/frontend/src/lib/components/tokens/TokensFilter.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensFilter.svelte
@@ -6,18 +6,22 @@
 	import { TOKEN_LIST_FILTER } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { tokenListStore } from '$lib/stores/token-list.store';
-	import { isEarningPath, isTokensPath, isTransactionsPath } from '$lib/utils/nav.utils';
+	import {
+		isEarningPath,
+		isTokensPath,
+		isTradingPath,
+		isTransactionsPath
+	} from '$lib/utils/nav.utils';
 
 	interface Props {
 		overflowableContent?: Snippet;
-		hideFilter?: boolean;
 	}
 
-	let { overflowableContent, hideFilter = false }: Props = $props();
+	let { overflowableContent }: Props = $props();
 
 	let inputValue = $derived($tokenListStore.filter);
 
-	// Persist the filter when switching between asset tabs (Tokens, Earning) or returning from transactions.
+	// Persist the filter when switching between asset tabs (Tokens, Earning, Trading) or returning from transactions.
 	// Reset it when navigating from any other page (e.g. Settings, Activity, NFTs — a standalone destination now).
 	afterNavigate(({ from }) => {
 		const previousRoute = from?.route?.id ?? null;
@@ -25,6 +29,7 @@
 		if (
 			!isTokensPath(previousRoute) &&
 			!isEarningPath(previousRoute) &&
+			!isTradingPath(previousRoute) &&
 			!isTransactionsPath(previousRoute)
 		) {
 			tokenListStore.set({ filter: '' });
@@ -37,18 +42,14 @@
 	});
 </script>
 
-{#if hideFilter}
-	{@render overflowableContent?.()}
-{:else}
-	<SlidingInput
-		ariaLabel={$i18n.tokens.alt.filter_button}
-		inputPlaceholder={$i18n.tokens.text.filter_placeholder}
-		{overflowableContent}
-		testIdPrefix={TOKEN_LIST_FILTER}
-		bind:inputValue
-	>
-		{#snippet icon()}
-			<IconSearch />
-		{/snippet}
-	</SlidingInput>
-{/if}
+<SlidingInput
+	ariaLabel={$i18n.tokens.alt.filter_button}
+	inputPlaceholder={$i18n.tokens.text.filter_placeholder}
+	{overflowableContent}
+	testIdPrefix={TOKEN_LIST_FILTER}
+	bind:inputValue
+>
+	{#snippet icon()}
+		<IconSearch />
+	{/snippet}
+</SlidingInput>

--- a/src/frontend/src/lib/components/trading/TradingAssets.svelte
+++ b/src/frontend/src/lib/components/trading/TradingAssets.svelte
@@ -5,7 +5,9 @@
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { oisyTradeAssets } from '$lib/derived/oisy-trade.derived';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { tokenListStore } from '$lib/stores/token-list.store';
 	import type { OisyTradeAsset } from '$lib/types/oisy-trade';
+	import { oisyTradeAssetMatchesFilter } from '$lib/utils/oisy-trade.utils';
 
 	interface Props {
 		onDeposit: () => void;
@@ -13,6 +15,16 @@
 	}
 
 	let { onDeposit, onWithdraw }: Props = $props();
+
+	let filteredAssets = $derived(
+		$oisyTradeAssets.filter((asset) =>
+			oisyTradeAssetMatchesFilter({
+				asset,
+				filter: $tokenListStore.filter,
+				providerLabel: $i18n.trading.text.provider_name
+			})
+		)
+	);
 </script>
 
 <!-- Mirrors the Orders section: a plain section header (title + action) over a
@@ -31,9 +43,11 @@
 
 	{#if $oisyTradeAssets.length === 0}
 		<p class="py-2 text-tertiary">{$i18n.trading.assets.empty}</p>
+	{:else if filteredAssets.length === 0}
+		<p class="py-2 text-tertiary">{$i18n.core.text.no_results}</p>
 	{:else}
 		<ul class="flex flex-col list-none">
-			{#each $oisyTradeAssets as asset (asset.token.id)}
+			{#each filteredAssets as asset (asset.token.id)}
 				<li transition:slide={SLIDE_PARAMS}>
 					<TradingAssetRow {asset} {onWithdraw} />
 				</li>

--- a/src/frontend/src/lib/components/trading/TradingOrders.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrders.svelte
@@ -65,11 +65,12 @@
 	// polled once per distinct pair, not once per order.
 	const pairKey = ({ base, quote }: OisyTradeOrderView): string => `${base.symbol}/${quote.symbol}`;
 
-	// The distinct pairs backing the current active orders, resolved to their
-	// candid pair info (needed to query the book), keyed by symbol pair.
+	// The distinct pairs backing the currently rendered active orders, resolved to
+	// their candid pair info (needed to query the book), keyed by symbol pair. Based
+	// on the filtered list so an active search doesn't poll books for hidden rows.
 	const activePairs = $derived.by((): Record<string, TradingPairInfo> => {
 		const pairs: Record<string, TradingPairInfo> = {};
-		for (const order of $oisyTradeActiveOrders) {
+		for (const order of filteredActiveOrders) {
 			const info = $oisyTradePairs.find(
 				(p) =>
 					p.base.metadata.symbol === order.base.symbol &&

--- a/src/frontend/src/lib/components/trading/TradingOrders.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrders.svelte
@@ -22,10 +22,43 @@
 	} from '$lib/derived/oisy-trade.derived';
 	import { loadOrderBook } from '$lib/services/oisy-trade.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { tokenListStore } from '$lib/stores/token-list.store';
 	import type { OisyTradeOrderBook, OisyTradeOrderView } from '$lib/types/oisy-trade';
-	import { toTradingPair } from '$lib/utils/oisy-trade.utils';
+	import {
+		oisyTradeOrderMatchesFilter,
+		toTradingPair,
+		type OisyTradeSearchLabels
+	} from '$lib/utils/oisy-trade.utils';
 
 	let activeTab = $state<'active' | 'history'>('active');
+
+	// The order rows render side, status and provider through these i18n strings;
+	// matching against the same values keeps the search in sync with any language.
+	let searchLabels = $derived<OisyTradeSearchLabels>({
+		sideSell: $i18n.trading.orders.side_sell,
+		sideBuy: $i18n.trading.orders.side_buy,
+		status: {
+			Open: $i18n.trading.orders.status_open,
+			Pending: $i18n.trading.orders.status_pending,
+			Partial: $i18n.trading.orders.status_partial,
+			Filled: $i18n.trading.orders.status_filled,
+			Canceled: $i18n.trading.orders.status_canceled,
+			Expired: $i18n.trading.orders.status_expired
+		},
+		provider: $i18n.trading.text.provider_name
+	});
+
+	let filteredActiveOrders = $derived(
+		$oisyTradeActiveOrders.filter((order) =>
+			oisyTradeOrderMatchesFilter({ order, filter: $tokenListStore.filter, labels: searchLabels })
+		)
+	);
+
+	let filteredHistoryOrders = $derived(
+		$oisyTradeHistoryOrders.filter((order) =>
+			oisyTradeOrderMatchesFilter({ order, filter: $tokenListStore.filter, labels: searchLabels })
+		)
+	);
 
 	// A row is keyed to its pair's order book by the pair's symbol pair. Multiple
 	// active orders on the same pair therefore share a single book — the book is
@@ -105,9 +138,11 @@
 		{#if activeTab === 'active'}
 			{#if $oisyTradeActiveOrders.length === 0}
 				<p class="py-2 text-tertiary">{$i18n.trading.orders.empty_active}</p>
+			{:else if filteredActiveOrders.length === 0}
+				<p class="py-2 text-tertiary">{$i18n.core.text.no_results}</p>
 			{:else}
 				<ul class="flex flex-col list-none">
-					{#each $oisyTradeActiveOrders as order (order.id)}
+					{#each filteredActiveOrders as order (order.id)}
 						<li transition:slide={SLIDE_PARAMS}>
 							<TradingOrderRow {order} orderBook={orderBooks[pairKey(order)]} />
 						</li>
@@ -117,9 +152,11 @@
 		{:else if activeTab === 'history'}
 			{#if $oisyTradeHistoryOrders.length === 0}
 				<p class="py-2 text-tertiary">{$i18n.trading.orders.empty_history}</p>
+			{:else if filteredHistoryOrders.length === 0}
+				<p class="py-2 text-tertiary">{$i18n.core.text.no_results}</p>
 			{:else}
 				<ul class="flex flex-col list-none">
-					{#each $oisyTradeHistoryOrders as order (order.id)}
+					{#each filteredHistoryOrders as order (order.id)}
 						<li transition:slide={SLIDE_PARAMS}>
 							<TradingOrderRow {order} />
 						</li>

--- a/src/frontend/src/lib/utils/oisy-trade.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade.utils.ts
@@ -22,6 +22,7 @@ import type { BadgeVariant } from '$lib/types/style';
 import { formatToken } from '$lib/utils/format.utils';
 import { parseToken } from '$lib/utils/parse.utils';
 import { calculateTokenUsdAmount } from '$lib/utils/token.utils';
+import { doesTokenMatchFilter } from '$lib/utils/tokens.utils';
 import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 
 // The distinct union of every base and quote token symbol across the trading
@@ -725,6 +726,83 @@ export const orderStatusView = (
 // True when the order is still working (Active tab): Pending or Open.
 export const isOisyTradeOrderActive = ({ status }: OisyTradeOrderView): boolean =>
 	status === 'Pending' || status === 'Open';
+
+// ---------------------------------------------------------------------------
+// Trading-tab search — free-text matching across the assets and orders lists.
+// Token identity reuses the app-wide token filter (symbol, name, canister id,
+// …); network, side, status and provider match against the very labels the
+// rows render, so the search works in whatever language the user is in (a
+// French "vendre" matches a sell order). Callers thread the localized strings
+// in, keeping the matchers pure and unit-testable.
+// ---------------------------------------------------------------------------
+
+export interface OisyTradeSearchLabels {
+	sideSell: string;
+	sideBuy: string;
+	status: Record<OisyTradeOrderDisplayStatus, string>;
+	provider: string;
+}
+
+const includesFilter = ({ value, filter }: { value: string; filter: string }): boolean =>
+	value.toLowerCase().includes(filter);
+
+// A token matches on the app's standard token filter or on its network name.
+// `filter` is expected pre-normalized (trimmed, lower-cased) by the callers below.
+const oisyTradeTokenMatchesFilter = ({
+	token,
+	filter
+}: {
+	token: IcToken;
+	filter: string;
+}): boolean =>
+	doesTokenMatchFilter({ token, filter }) || includesFilter({ value: token.network.name, filter });
+
+export const oisyTradeAssetMatchesFilter = ({
+	asset: { token },
+	filter,
+	providerLabel
+}: {
+	asset: OisyTradeAsset;
+	filter: string;
+	providerLabel: string;
+}): boolean => {
+	const normalized = filter.trim().toLowerCase();
+	if (normalized === '') {
+		return true;
+	}
+
+	return (
+		oisyTradeTokenMatchesFilter({ token, filter: normalized }) ||
+		includesFilter({ value: providerLabel, filter: normalized })
+	);
+};
+
+export const oisyTradeOrderMatchesFilter = ({
+	order,
+	filter,
+	labels
+}: {
+	order: OisyTradeOrderView;
+	filter: string;
+	labels: OisyTradeSearchLabels;
+}): boolean => {
+	const normalized = filter.trim().toLowerCase();
+	if (normalized === '') {
+		return true;
+	}
+
+	const { base, quote, side } = order;
+	const sideLabel = side === 'sell' ? labels.sideSell : labels.sideBuy;
+	const statusLabel = labels.status[oisyTradeOrderDisplayStatus(order)];
+
+	return (
+		oisyTradeTokenMatchesFilter({ token: base, filter: normalized }) ||
+		oisyTradeTokenMatchesFilter({ token: quote, filter: normalized }) ||
+		includesFilter({ value: sideLabel, filter: normalized }) ||
+		includesFilter({ value: statusLabel, filter: normalized }) ||
+		includesFilter({ value: labels.provider, filter: normalized })
+	);
+};
 
 // A `PriceLevel` price scaled to human quote-per-base.
 export const priceLevelToHuman = ({

--- a/src/frontend/src/lib/utils/oisy-trade.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade.utils.ts
@@ -21,6 +21,11 @@ import type {
 import type { BadgeVariant } from '$lib/types/style';
 import { formatToken } from '$lib/utils/format.utils';
 import { parseToken } from '$lib/utils/parse.utils';
+import {
+	normalizeTextFilter,
+	someTextMatchesFilter,
+	textMatchesFilter
+} from '$lib/utils/string.utils';
 import { calculateTokenUsdAmount } from '$lib/utils/token.utils';
 import { doesTokenMatchFilter } from '$lib/utils/tokens.utils';
 import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
@@ -743,9 +748,6 @@ export interface OisyTradeSearchLabels {
 	provider: string;
 }
 
-const includesFilter = ({ value, filter }: { value: string; filter: string }): boolean =>
-	value.toLowerCase().includes(filter);
-
 // A token matches on the app's standard token filter or on its network name.
 // `filter` is expected pre-normalized (trimmed, lower-cased) by the callers below.
 const oisyTradeTokenMatchesFilter = ({
@@ -755,7 +757,8 @@ const oisyTradeTokenMatchesFilter = ({
 	token: IcToken;
 	filter: string;
 }): boolean =>
-	doesTokenMatchFilter({ token, filter }) || includesFilter({ value: token.network.name, filter });
+	doesTokenMatchFilter({ token, filter }) ||
+	textMatchesFilter({ value: token.network.name, filter });
 
 export const oisyTradeAssetMatchesFilter = ({
 	asset: { token },
@@ -766,14 +769,14 @@ export const oisyTradeAssetMatchesFilter = ({
 	filter: string;
 	providerLabel: string;
 }): boolean => {
-	const normalized = filter.trim().toLowerCase();
+	const normalized = normalizeTextFilter(filter);
 	if (normalized === '') {
 		return true;
 	}
 
 	return (
 		oisyTradeTokenMatchesFilter({ token, filter: normalized }) ||
-		includesFilter({ value: providerLabel, filter: normalized })
+		textMatchesFilter({ value: providerLabel, filter: normalized })
 	);
 };
 
@@ -786,7 +789,7 @@ export const oisyTradeOrderMatchesFilter = ({
 	filter: string;
 	labels: OisyTradeSearchLabels;
 }): boolean => {
-	const normalized = filter.trim().toLowerCase();
+	const normalized = normalizeTextFilter(filter);
 	if (normalized === '') {
 		return true;
 	}
@@ -798,9 +801,7 @@ export const oisyTradeOrderMatchesFilter = ({
 	return (
 		oisyTradeTokenMatchesFilter({ token: base, filter: normalized }) ||
 		oisyTradeTokenMatchesFilter({ token: quote, filter: normalized }) ||
-		includesFilter({ value: sideLabel, filter: normalized }) ||
-		includesFilter({ value: statusLabel, filter: normalized }) ||
-		includesFilter({ value: labels.provider, filter: normalized })
+		someTextMatchesFilter({ values: [sideLabel, statusLabel, labels.provider], filter: normalized })
 	);
 };
 

--- a/src/frontend/src/lib/utils/string.utils.ts
+++ b/src/frontend/src/lib/utils/string.utils.ts
@@ -3,3 +3,30 @@ const naturalCollator = new Intl.Collator(undefined, { numeric: true, sensitivit
 
 // eslint-disable-next-line local-rules/prefer-object-params -- This is a sort function, so the parameters will be provided not as an object but as separate arguments.
 export const compareNatural = (a: string, b: string): number => naturalCollator.compare(a, b);
+
+// Trim and lower-case a free-text search filter once, so matchers can compare
+// against a normalized form and callers can thread the result down without
+// re-normalizing on every candidate.
+export const normalizeTextFilter = (filter: string): string => filter.trim().toLowerCase();
+
+// True when `value` contains `filter`, case-insensitively. `filter` is expected
+// pre-normalized (see `normalizeTextFilter`).
+export const textMatchesFilter = ({ value, filter }: { value: string; filter: string }): boolean =>
+	value.toLowerCase().includes(filter);
+
+// True when the filter is empty (match-all) or at least one candidate string
+// contains it. Candidates are meant to be the user-facing — typically already
+// localized — strings a row renders, so free-text search follows the user's
+// language (e.g. a French "vendre" matches a row that renders "Vendre").
+export const someTextMatchesFilter = ({
+	values,
+	filter
+}: {
+	values: string[];
+	filter: string;
+}): boolean => {
+	const normalized = normalizeTextFilter(filter);
+	return (
+		normalized === '' || values.some((value) => textMatchesFilter({ value, filter: normalized }))
+	);
+};

--- a/src/frontend/src/tests/lib/components/tokens/TokensFilter.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensFilter.spec.ts
@@ -52,12 +52,6 @@ describe('TokensFilter', () => {
 		expect(getByTestId(`${TOKEN_LIST_FILTER}-open-btn`)).toBeInTheDocument();
 	});
 
-	it('should not render the filter button when hideFilter is true', () => {
-		const { queryByTestId } = render(TokensFilter, { props: { hideFilter: true } });
-
-		expect(queryByTestId(`${TOKEN_LIST_FILTER}-open-btn`)).not.toBeInTheDocument();
-	});
-
 	// SvelteKit route IDs don't include trailing slashes (e.g. `/(app)`, `/(app)/nfts`).
 	// The is*Path helpers normalize them internally.
 	describe('filter persistence across asset tabs', () => {

--- a/src/frontend/src/tests/lib/components/tokens/TokensFilter.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokensFilter.spec.ts
@@ -58,6 +58,7 @@ describe('TokensFilter', () => {
 		it.each([
 			{ label: 'Tokens tab', routeId: `${ROUTE_ID_GROUP_APP}` },
 			{ label: 'Earning tab', routeId: `${ROUTE_ID_GROUP_APP}/earning` },
+			{ label: 'Trading tab', routeId: `${ROUTE_ID_GROUP_APP}/trading` },
 			{ label: 'Transactions page', routeId: `${ROUTE_ID_GROUP_APP}/transactions` },
 			{ label: 'WalletConnect page', routeId: `${ROUTE_ID_GROUP_APP}/wc` }
 		])('should preserve filter when navigating from $label', ({ routeId }) => {

--- a/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
@@ -7,9 +7,14 @@ import type {
 import type { IcToken } from '$icp/types/ic-token';
 import { ZERO } from '$lib/constants/app.constants';
 import type { ExchangesData } from '$lib/types/exchange';
-import type { OisyTradeOrderStatus } from '$lib/types/oisy-trade';
+import type {
+	OisyTradeAsset,
+	OisyTradeOrderStatus,
+	OisyTradeOrderView
+} from '$lib/types/oisy-trade';
 import {
 	type LimitOrderPairView,
+	type OisyTradeSearchLabels,
 	crossesBook,
 	decimalsOfStep,
 	deriveNotional,
@@ -27,8 +32,10 @@ import {
 	mapOisyTradeOrders,
 	maxSpendBaseAmount,
 	oisyTradeAssetHasReserved,
+	oisyTradeAssetMatchesFilter,
 	oisyTradeDepositableTokens,
 	oisyTradeOrderDisplayStatus,
+	oisyTradeOrderMatchesFilter,
 	oisyTradeSupportedTokenSymbols,
 	orderStatusView,
 	presetTargetPrice,
@@ -801,6 +808,143 @@ describe('oisy-trade.utils — orders', () => {
 			expect(activeFor('Filled')).toBeFalsy();
 			expect(activeFor('Canceled')).toBeFalsy();
 			expect(activeFor('Expired')).toBeFalsy();
+		});
+	});
+});
+
+describe('oisy-trade.utils — search', () => {
+	// baseToken carries the ICP network (name "Internet Computer") from the shared mock.
+	const base: IcToken = { ...mockValidIcToken, symbol: 'ICP', name: 'Internet Computer' };
+	const quote: IcToken = {
+		...mockValidIcToken,
+		id: parseTokenId('QuoteTokenId'),
+		symbol: 'ckUSDC',
+		name: 'ckUSDC'
+	};
+
+	const labels: OisyTradeSearchLabels = {
+		sideSell: 'Sell',
+		sideBuy: 'Buy',
+		status: {
+			Open: 'Open',
+			Pending: 'Pending',
+			Partial: 'Partial',
+			Filled: 'Filled',
+			Canceled: 'Canceled',
+			Expired: 'Expired'
+		},
+		provider: 'OISY TRADE'
+	};
+
+	const order: OisyTradeOrderView = {
+		id: 'order-1',
+		side: 'sell',
+		base,
+		quote,
+		quantity: 100,
+		price: 2.5,
+		filledQuantity: 0,
+		status: 'Open'
+	};
+
+	describe('oisyTradeAssetMatchesFilter', () => {
+		const asset: OisyTradeAsset = {
+			token: base,
+			free: ZERO,
+			reserved: ZERO,
+			total: ZERO,
+			totalUsd: undefined,
+			freeUsd: undefined
+		};
+
+		const matches = (filter: string): boolean =>
+			oisyTradeAssetMatchesFilter({ asset, filter, providerLabel: labels.provider });
+
+		it('matches everything on an empty or whitespace filter', () => {
+			expect(matches('')).toBeTruthy();
+			expect(matches('   ')).toBeTruthy();
+		});
+
+		it('matches on token symbol and name, case-insensitively', () => {
+			expect(matches('icp')).toBeTruthy();
+			expect(matches('ICP')).toBeTruthy();
+			expect(matches('internet')).toBeTruthy();
+		});
+
+		it('matches on the network name', () => {
+			expect(matches('Internet Computer')).toBeTruthy();
+		});
+
+		it('matches on the provider label', () => {
+			expect(matches('oisy')).toBeTruthy();
+		});
+
+		it('does not match an unrelated term', () => {
+			expect(matches('dogecoin')).toBeFalsy();
+		});
+	});
+
+	describe('oisyTradeOrderMatchesFilter', () => {
+		const matches = ({
+			order: candidate = order,
+			filter
+		}: {
+			order?: OisyTradeOrderView;
+			filter: string;
+		}): boolean => oisyTradeOrderMatchesFilter({ order: candidate, filter, labels });
+
+		it('matches everything on an empty filter', () => {
+			expect(matches({ filter: '' })).toBeTruthy();
+		});
+
+		it('matches on either the base or the quote token', () => {
+			expect(matches({ filter: 'icp' })).toBeTruthy();
+			expect(matches({ filter: 'ckusdc' })).toBeTruthy();
+		});
+
+		it('matches on the network name', () => {
+			expect(matches({ filter: 'internet' })).toBeTruthy();
+		});
+
+		it('matches a sell order on the side label but not the opposite side', () => {
+			expect(matches({ filter: 'sell' })).toBeTruthy();
+			expect(matches({ filter: 'buy' })).toBeFalsy();
+		});
+
+		it('matches a buy order on the buy side label', () => {
+			expect(matches({ order: { ...order, side: 'buy' }, filter: 'buy' })).toBeTruthy();
+		});
+
+		it('matches on the status label', () => {
+			expect(matches({ filter: 'open' })).toBeTruthy();
+			expect(matches({ filter: 'filled' })).toBeFalsy();
+		});
+
+		it('matches the derived Partial status of a partially filled open order', () => {
+			expect(matches({ order: { ...order, filledQuantity: 10 }, filter: 'partial' })).toBeTruthy();
+		});
+
+		it('matches on the provider label', () => {
+			expect(matches({ filter: 'oisy trade' })).toBeTruthy();
+		});
+
+		it('adapts side and status matching to localized labels', () => {
+			const frLabels: OisyTradeSearchLabels = {
+				...labels,
+				sideSell: 'Vendre',
+				status: { ...labels.status, Open: 'Ouvert' }
+			};
+
+			expect(
+				oisyTradeOrderMatchesFilter({ order, filter: 'vendre', labels: frLabels })
+			).toBeTruthy();
+			expect(
+				oisyTradeOrderMatchesFilter({ order, filter: 'ouvert', labels: frLabels })
+			).toBeTruthy();
+		});
+
+		it('does not match an unrelated term', () => {
+			expect(matches({ filter: 'zzz' })).toBeFalsy();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
@@ -813,8 +813,11 @@ describe('oisy-trade.utils — orders', () => {
 });
 
 describe('oisy-trade.utils — search', () => {
-	// baseToken carries the ICP network (name "Internet Computer") from the shared mock.
-	const base: IcToken = { ...mockValidIcToken, symbol: 'ICP', name: 'Internet Computer' };
+	// base carries the ICP network (name "Internet Computer") from the shared mock.
+	// Its token name is deliberately distinct from both the symbol and the network
+	// name, so the symbol / token-name / network-name facets can be tested in
+	// isolation ("icp" → symbol only, "sample" → name only, "internet" → network only).
+	const base: IcToken = { ...mockValidIcToken, symbol: 'ICP', name: 'Sample Token' };
 	const quote: IcToken = {
 		...mockValidIcToken,
 		id: parseTokenId('QuoteTokenId'),
@@ -865,14 +868,17 @@ describe('oisy-trade.utils — search', () => {
 			expect(matches('   ')).toBeTruthy();
 		});
 
-		it('matches on token symbol and name, case-insensitively', () => {
+		it('matches on the token symbol, case-insensitively', () => {
 			expect(matches('icp')).toBeTruthy();
 			expect(matches('ICP')).toBeTruthy();
-			expect(matches('internet')).toBeTruthy();
 		});
 
-		it('matches on the network name', () => {
-			expect(matches('Internet Computer')).toBeTruthy();
+		it('matches on the token name (term absent from symbol and network)', () => {
+			expect(matches('sample')).toBeTruthy();
+		});
+
+		it('matches on the network name (term absent from symbol and token name)', () => {
+			expect(matches('internet')).toBeTruthy();
 		});
 
 		it('matches on the provider label', () => {
@@ -898,11 +904,12 @@ describe('oisy-trade.utils — search', () => {
 		});
 
 		it('matches on either the base or the quote token', () => {
-			expect(matches({ filter: 'icp' })).toBeTruthy();
-			expect(matches({ filter: 'ckusdc' })).toBeTruthy();
+			expect(matches({ filter: 'icp' })).toBeTruthy(); // base symbol
+			expect(matches({ filter: 'sample' })).toBeTruthy(); // base name (name-only term)
+			expect(matches({ filter: 'ckusdc' })).toBeTruthy(); // quote symbol
 		});
 
-		it('matches on the network name', () => {
+		it('matches on the network name (term absent from symbols and token names)', () => {
 			expect(matches({ filter: 'internet' })).toBeTruthy();
 		});
 

--- a/src/frontend/src/tests/lib/utils/string.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/string.utils.spec.ts
@@ -1,6 +1,48 @@
-import { compareNatural } from '$lib/utils/string.utils';
+import {
+	compareNatural,
+	normalizeTextFilter,
+	someTextMatchesFilter,
+	textMatchesFilter
+} from '$lib/utils/string.utils';
 
 describe('string.utils', () => {
+	describe('normalizeTextFilter', () => {
+		it('trims and lower-cases', () => {
+			expect(normalizeTextFilter('  Vendre  ')).toBe('vendre');
+			expect(normalizeTextFilter('OISY')).toBe('oisy');
+			expect(normalizeTextFilter('')).toBe('');
+		});
+	});
+
+	describe('textMatchesFilter', () => {
+		it('matches a case-insensitive substring against a normalized filter', () => {
+			expect(textMatchesFilter({ value: 'Internet Computer', filter: 'internet' })).toBeTruthy();
+			expect(textMatchesFilter({ value: 'Vendre', filter: 'end' })).toBeTruthy();
+			expect(textMatchesFilter({ value: 'Sell', filter: 'buy' })).toBeFalsy();
+		});
+	});
+
+	describe('someTextMatchesFilter', () => {
+		it('matches everything on an empty or whitespace filter', () => {
+			expect(someTextMatchesFilter({ values: ['Sell', 'Open'], filter: '' })).toBeTruthy();
+			expect(someTextMatchesFilter({ values: ['Sell', 'Open'], filter: '   ' })).toBeTruthy();
+		});
+
+		it('matches when any candidate contains the filter', () => {
+			expect(someTextMatchesFilter({ values: ['Sell', 'Open'], filter: 'open' })).toBeTruthy();
+			expect(someTextMatchesFilter({ values: ['Sell', 'Open'], filter: 'sel' })).toBeTruthy();
+		});
+
+		it('normalizes the filter before matching', () => {
+			expect(someTextMatchesFilter({ values: ['Vendre'], filter: '  VEND  ' })).toBeTruthy();
+		});
+
+		it('does not match when no candidate contains the filter', () => {
+			expect(someTextMatchesFilter({ values: ['Sell', 'Open'], filter: 'filled' })).toBeFalsy();
+			expect(someTextMatchesFilter({ values: [], filter: 'x' })).toBeFalsy();
+		});
+	});
+
 	describe('compareNatural', () => {
 		it('should sort embedded numbers numerically, not lexicographically', () => {
 			const input = ['10 Address', '1 Name', '2 Age'];


### PR DESCRIPTION
# Motivation

Stacked on #13330, which hides the (currently inert) search bar on the Trading tab. This PR takes the opposite, fuller route: re-enable the search and make it actually filter the Trading tab, across both the assets and the orders lists.

The search matches free text — tokens and networks as everywhere else, plus order-specific facets: side (buy/sell), status (open/pending/partial/filled/canceled/expired) and provider (OISY TRADE). Those facets match against the same i18n labels the rows render, so the search adapts to the user's language rather than matching hard-coded English.

Draft while #13330 is in review — if the hide ships first, this cleanly supersedes it.

# Changes

- Re-enable the search bar on Trading (revert the temporary \`hideFilter\` scaffolding from the base PR).
- New pure matchers in \`oisy-trade.utils.ts\`:
  - \`oisyTradeAssetMatchesFilter\` — token (app-wide token filter) + network name + provider label.
  - \`oisyTradeOrderMatchesFilter\` — base/quote token + network name + side + status (incl. the derived \`Partial\`) + provider, all via the localized labels threaded in by the caller.
- Wire the matchers into \`TradingAssets\` and \`TradingOrders\` (both Active and History), with a \"No results\" state when a filter matches nothing.
- Persist the filter across the Trading tab like the other asset tabs (\`isTradingPath\` added to \`TokensFilter\`'s persistence allow-list).

# Tests

- New unit tests for both matchers (token/network/side/status/provider matching, the derived Partial status, i18n-aware matching, and negative cases).
- \`npm run check\` clean (0 errors, 0 warnings); lint and prettier clean on the changed files; existing Trading component specs still pass.