### PR TITLE
chore(backend): gitignore downloaded canister-wasm test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ codes.txt
 backend.wasm.gz
 ic-btc-canister.wasm.gz
 backend-v*.wasm.gz
+internet_identity.wasm.gz
+# download-immutable.sh caches downloaded fixtures as <name>.wasm.gz.<sha>
+*.wasm.gz.*
 /test-results/
 /playwright-report/
 /blob-report/


### PR DESCRIPTION
# Motivation

`scripts/download-immutable.sh` (invoked by `scripts/test.backend.sh`) downloads the `internet_identity`, `cycles-ledger`, and `ic-btc-canister` wasms into the repo root when running the backend integration tests, caching each as `<name>.wasm.gz.<sha>`. `.gitignore` only ignored `internet_identity.wasm` (not the `.gz`) and none of the `.wasm.gz.<sha>` cache names — so a broad `git add` could commit these artifacts, as happened on #13130 (removed there in a separate commit).

# Changes

- `.gitignore`: ignore `internet_identity.wasm.gz` and `*.wasm.gz.*` (the download-cache pattern), so the fixtures can't be committed by accident again.

# Tests

- `git check-ignore` confirms all four previously-committed fixtures (`internet_identity.wasm.gz`, `internet_identity.wasm.gz.<sha>`, `cycles-ledger.wasm.gz.<sha>`, `ic-btc-canister.wasm.gz.<sha>`) are now ignored, and no currently-tracked file matches the new patterns.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)
