### PR TITLE
style(frontend): slide trading orders and assets rows in and out

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingAssets.svelte
+++ b/src/frontend/src/lib/components/trading/TradingAssets.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { slide } from 'svelte/transition';
 	import TradingAssetRow from '$lib/components/trading/TradingAssetRow.svelte';
 	import { TRADING_ASSETS_DEPOSIT_BUTTON } from '$lib/constants/test-ids.constants';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { oisyTradeAssets } from '$lib/derived/oisy-trade.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OisyTradeAsset } from '$lib/types/oisy-trade';
@@ -32,7 +34,7 @@
 	{:else}
 		<ul class="flex flex-col list-none">
 			{#each $oisyTradeAssets as asset (asset.token.id)}
-				<li>
+				<li transition:slide={SLIDE_PARAMS}>
 					<TradingAssetRow {asset} {onWithdraw} />
 				</li>
 			{/each}

--- a/src/frontend/src/lib/components/trading/TradingOrders.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrders.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { untrack } from 'svelte';
+	import { slide } from 'svelte/transition';
 	import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import TradingOrderDetailModal from '$lib/components/trading/TradingOrderDetailModal.svelte';
@@ -8,6 +9,7 @@
 	import LimitOrder from '$lib/components/trading/limit-order/LimitOrder.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import { OISY_TRADE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import {
 		modalOisyTradeOrderDetail,
@@ -108,7 +110,9 @@
 			{:else}
 				<ul class="flex flex-col list-none">
 					{#each $oisyTradeActiveOrders as order (order.id)}
-						<li><TradingOrderRow {order} orderBook={orderBooks[pairKey(order)]} /></li>
+						<li transition:slide={SLIDE_PARAMS}>
+							<TradingOrderRow {order} orderBook={orderBooks[pairKey(order)]} />
+						</li>
 					{/each}
 				</ul>
 			{/if}
@@ -118,7 +122,9 @@
 			{:else}
 				<ul class="flex flex-col list-none">
 					{#each $oisyTradeHistoryOrders as order (order.id)}
-						<li><TradingOrderRow {order} /></li>
+						<li transition:slide={SLIDE_PARAMS}>
+							<TradingOrderRow {order} />
+						</li>
 					{/each}
 				</ul>
 			{/if}


### PR DESCRIPTION
# Motivation

On the Trading tab, the My-assets and Orders lists update in place as balances and orders load in from polling. Rows appeared and disappeared abruptly. Other lists in the app (e.g. tokens, token groups) animate their content with a slide transition, so aligning the trading lists with that pattern makes updates feel less jarring.

# Changes

- Add `transition:slide={SLIDE_PARAMS}` to the row `<li>` elements in `TradingAssets` (assets) and `TradingOrders` (active + history orders), so rows slide in and out as they are added or removed.
- Reuse the shared `SLIDE_PARAMS` transition constant already used across the app; no new constants or dependencies.

# Tests

Visual-only change. Verified the rows slide in/out on the Trading tab as assets and orders load and update.
