### PR TITLE
fix(frontend): make splash background image cover the full viewport

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -159,7 +159,10 @@
 				pointer-events: none;
 
 				width: 100%;
+				height: 100%;
 				min-width: 1728px;
+
+				object-fit: cover;
 			}
 
 			/* Default background: landing page artwork (shown pre-hydration and on the signed-out landing screen). */


### PR DESCRIPTION
# Motivation

On the pre-hydration splash/boot screen the background image did not reach the bottom of the viewport: a darker bar showed at the bottom.

The horizon-glow background is a fixed-aspect `.webp` image (`#app-background-*`) with `width: 100%` and no height, so on viewports taller than the image's rendered aspect ratio the image stopped partway down and the container's flat fill color showed below it.

# Changes

- `src/frontend/src/app.html`: give the background images `height: 100%` + `object-fit: cover` so they scale and crop to fill the container instead of leaving a gap.

# Tests

Manual: splash background now reaches the bottom on tall/narrow viewports; image is cropped rather than gapped.