### PR TITLE
feat(frontend): slide late-loaded values in trading asset & order rows

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingAssetRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingAssetRow.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import { slide } from 'svelte/transition';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
 	import TradingProviderTag from '$lib/components/trading/TradingProviderTag.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { TRADING_ASSET_WITHDRAW_BUTTON } from '$lib/constants/test-ids.constants';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
@@ -82,7 +84,7 @@
 			{#snippet descriptionEnd()}
 				<span class="flex flex-col items-end text-nowrap">
 					{#if hasReserved}
-						<span>
+						<span transition:slide={SLIDE_PARAMS}>
 							{#if $isPrivacyMode}
 								<span class="inline-flex items-center gap-1"
 									>{$i18n.trading.assets.available_label} <IconDots variant="xs" /></span
@@ -97,7 +99,7 @@
 					{#if $isPrivacyMode}
 						<IconDots variant="xs" />
 					{:else if nonNullish(formattedTotalUsd)}
-						<span>{formattedTotalUsd}</span>
+						<span transition:slide={SLIDE_PARAMS}>{formattedTotalUsd}</span>
 					{/if}
 				</span>
 			{/snippet}

--- a/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+	import { slide } from 'svelte/transition';
 	import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 	import IconCheck from '$lib/components/icons/IconCheck.svelte';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
@@ -8,6 +9,7 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TradingProviderTag from '$lib/components/trading/TradingProviderTag.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { oisyTradePairs } from '$lib/derived/oisy-trade.derived';
 	import { isPrivacyMode } from '$lib/derived/settings.derived';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -219,7 +221,7 @@
 			</span>
 		</Badge>
 		{#if nonNullish(queueText)}
-			<span class="text-xs text-tertiary">{queueText}</span>
+			<span class="text-xs text-tertiary" transition:slide={SLIDE_PARAMS}>{queueText}</span>
 		{/if}
 	</span>
 </button>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
@@ -2,6 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import ValueDifference from '$lib/components/ui/ValueDifference.svelte';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import {
@@ -271,11 +272,11 @@
 	</div>
 
 	{#if nonNullish(tickError)}
-		<p class="mt-1 text-xs text-error-primary" transition:slide>{tickError}</p>
+		<p class="mt-1 text-xs text-error-primary" transition:slide={SLIDE_PARAMS}>{tickError}</p>
 	{/if}
 
 	{#if nonNullish(queueText)}
-		<p class="mt-1.5 text-xs text-tertiary" transition:slide>{queueText}</p>
+		<p class="mt-1.5 text-xs text-tertiary" transition:slide={SLIDE_PARAMS}>{queueText}</p>
 	{/if}
 
 	{#if nonNullish(warningText)}
@@ -285,7 +286,7 @@
 			class:bg-warning-subtle={!warningText.danger}
 			class:text-error-primary={warningText.danger}
 			class:text-warning-primary={!warningText.danger}
-			transition:slide
+			transition:slide={SLIDE_PARAMS}
 		>
 			{warningText.text}
 		</p>


### PR DESCRIPTION
# Motivation

In the trading asset and order lists, some data is fetched after the row itself renders (queue position, fiat total, reserved/available amount). Until now these values just popped into place. Everything else in the app that appears conditionally slides in/out — this makes the late-loaded values behave the same way.

# Changes

- `TradingOrderRow`: the "% are ahead" queue text now slides in/out (`transition:slide` with the shared `SLIDE_PARAMS`), matching the identical text in `LimitOrderPriceSection`.
- `TradingAssetRow`: the fiat total and the "Available:" reserved line now slide in/out on the same `SLIDE_PARAMS`.

# Tests

- `npm run check` (svelte-check): 0 errors
- eslint (scoped): clean
- `TradingOrderRow.svelte.spec.ts` + `TradingAssetRow.svelte.spec.ts`: 15 passed