### PR TITLE
refactor(frontend): own Input (InputBase) natively, detach from gix

### DIFF
--- a/src/frontend/src/lib/components/ui/Input.svelte
+++ b/src/frontend/src/lib/components/ui/Input.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-	import { Input as GixInput, type InputProps as GixInputProps } from '@dfinity/gix-components';
 	import { nonNullish, notEmptyString } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import ButtonPaste from '$lib/components/ui/ButtonPaste.svelte';
 	import ButtonReset from '$lib/components/ui/ButtonReset.svelte';
+	import InputBase from '$lib/components/ui/InputBase.svelte';
+	import type { InputProps as InputBaseProps } from '$lib/types/input';
 
-	export interface InputProps extends GixInputProps {
+	export interface InputProps extends InputBaseProps {
 		showResetButton?: boolean;
 		resetButtonAriaLabel?: string;
 		showPasteButton?: boolean;
@@ -29,7 +30,7 @@
 	style={`--input-padding-inner-end: calc(var(--padding-2x) + ${endWidth}px)`}
 	class="base-input"
 >
-	<GixInput {...props} bind:value>
+	<InputBase {...props} bind:value>
 		{#snippet innerEnd()}
 			<div class="flex items-center pl-2" bind:clientWidth={endWidth}>
 				{#if nonNullish(value) && notEmptyString(value.toString()) && showResetButton}
@@ -46,7 +47,7 @@
 				{@render innerEndProp?.()}
 			</div>
 		{/snippet}
-	</GixInput>
+	</InputBase>
 </div>
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/ui/InputBase.svelte
+++ b/src/frontend/src/lib/components/ui/InputBase.svelte
@@ -64,8 +64,8 @@
 	 * when dealing with currency or high-precision inputs (e.g. more than 15–17 decimal places).
 	 *
 	 * The native `Number()` can produce inaccurate results for such inputs. For example:
-	 * `Number(0.999999999999999876n)` or `(+"0.999999999999999876")` prints `0.9999999999999999`.
-	 * `Number(0.999999999999999812n)` or `(+"0.999999999999999812")` prints `0.9999999999999998`.
+	 * `Number("0.999999999999999876")` (i.e. `+"0.999999999999999876"`) prints `0.9999999999999999`.
+	 * `Number("0.999999999999999812")` (i.e. `+"0.999999999999999812"`) prints `0.9999999999999998`.
 	 * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding
 	 *
 	 * To mitigate this, we use the `decimal.js` library, which provides arbitrary-precision decimals.
@@ -90,11 +90,17 @@
 
 		// If the value is not a valid decimal, fallback to native `Number` formatting:
 		// - The input has already failed parsing via `Decimal`, which means it's either not a number or a trivial case (like an empty string).
-		// - In such edge cases, native `Number()` will return `NaN` or coerce the value into a number, and the formatting is capped via `maximumFractionDigits`,
-		//   so any inaccuracies are irrelevant or already present in the input.
-		// - The fallback ensures we don't throw or break the rendering pipeline for malformed inputs, maintaining graceful degradation.
+		// - When `Number()` cannot coerce the input to a finite number (e.g. an intermediate-but-valid entry like a lone "."), we return the raw
+		//   value unchanged rather than leaking "NaN" into the field and the bound value.
+		// - Otherwise we cap the formatting via `maximumFractionDigits`, so any inaccuracies are irrelevant or already present in the input.
 		if (isNullish(decimalValue)) {
-			return Number(value).toLocaleString('en', {
+			const asNumber = Number(value);
+
+			if (Number.isNaN(asNumber)) {
+				return value;
+			}
+
+			return asNumber.toLocaleString('en', {
 				useGrouping: false,
 				maximumFractionDigits: wrapDecimals
 			});

--- a/src/frontend/src/lib/components/ui/InputBase.svelte
+++ b/src/frontend/src/lib/components/ui/InputBase.svelte
@@ -1,0 +1,347 @@
+<!-- Ported from @dfinity/gix-components Input. -->
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import Decimal from 'decimal.js';
+	import { untrack } from 'svelte';
+	import type { InputProps } from '$lib/types/input';
+
+	let {
+		name,
+		inputType = 'number',
+		required = true,
+		spellcheck,
+		step = $bindable(),
+		disabled = false,
+		minLength,
+		max,
+		value = $bindable(),
+		placeholder,
+		testId,
+		decimals = 8,
+		ignore1Password = true,
+		inputElement = $bindable(),
+		autofocus = false,
+		autocomplete = $bindable(),
+		showInfo = true,
+		onInput,
+		onBlur,
+		onFocus,
+		start,
+		label,
+		end,
+		innerEnd,
+		bottom
+	}: InputProps = $props();
+
+	$effect(() => {
+		if (inputType === 'number') {
+			untrack(() => {
+				step = step ?? 'any';
+
+				autocomplete = undefined;
+			});
+
+			return;
+		}
+
+		untrack(() => {
+			step = undefined;
+
+			autocomplete = autocomplete ?? 'off';
+		});
+	});
+
+	// This component was developed for ICP and 8 decimals in mind. The "currency" input type was added afterwards therefore, for backwards compatibility reason, if the input type is set to icp, the number of decimals remains 8.
+	let wrapDecimals = $derived(inputType === 'icp' ? 8 : decimals);
+
+	let selectionStart: number | null = 0;
+	let selectionEnd: number | null = 0;
+
+	/**
+	 * Safely parses a value into a `Decimal` instance.
+	 *
+	 * This is used instead of JavaScript’s native `Number()` to avoid floating-point precision issues
+	 * when dealing with currency or high-precision inputs (e.g. more than 15–17 decimal places).
+	 *
+	 * The native `Number()` can produce inaccurate results for such inputs. For example:
+	 * `Number(0.999999999999999876n)` or `(+"0.999999999999999876")` prints `0.9999999999999999`.
+	 * `Number(0.999999999999999812n)` or `(+"0.999999999999999812")` prints `0.9999999999999998`.
+	 * Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding
+	 *
+	 * To mitigate this, we use the `decimal.js` library, which provides arbitrary-precision decimals.
+	 *
+	 * However, `Decimal` throws an error for invalid inputs (e.g. empty string, non-numeric strings),
+	 * whereas `Number()` simply returns `NaN`. To handle this safely, this function wraps the constructor
+	 * in a try-catch block and returns `null` on failure — allowing consumers to fallback to other logic.
+	 *
+	 * @param value - The input to parse (typically a string, but could be unknown).
+	 * @returns A `Decimal` instance if the input is valid, otherwise `null`.
+	 */
+	const safeDecimal = (value: unknown): Decimal | null => {
+		try {
+			return new Decimal(value as string);
+		} catch {
+			return null;
+		}
+	};
+
+	const toStringWrapDecimals = (value: string): string => {
+		const decimalValue = safeDecimal(value);
+
+		// If the value is not a valid decimal, fallback to native `Number` formatting:
+		// - The input has already failed parsing via `Decimal`, which means it's either not a number or a trivial case (like an empty string).
+		// - In such edge cases, native `Number()` will return `NaN` or coerce the value into a number, and the formatting is capped via `maximumFractionDigits`,
+		//   so any inaccuracies are irrelevant or already present in the input.
+		// - The fallback ensures we don't throw or break the rendering pipeline for malformed inputs, maintaining graceful degradation.
+		if (isNullish(decimalValue)) {
+			return Number(value).toLocaleString('en', {
+				useGrouping: false,
+				maximumFractionDigits: wrapDecimals
+			});
+		}
+
+		return decimalValue.toDecimalPlaces(wrapDecimals).toFixed();
+	};
+
+	// replace exponent format (1e-4) w/ plain (0.0001)
+	const exponentToPlainNumberString = (value: string): string =>
+		// number to toLocaleString doesn't support decimals for values >= ~1e16
+		value.includes('e') ? toStringWrapDecimals(value) : value;
+	// To show undefined as "" (because of the type="text")
+	const fixUndefinedValue = (value: string | number | undefined): string =>
+		isNullish(value) ? '' : `${value}`;
+
+	let currencyValue = $state(exponentToPlainNumberString(fixUndefinedValue(value)));
+	let lastValidCurrencyValue: string | number | undefined = value;
+	let internalValueChange = true;
+
+	let currency = $derived(['icp', 'currency'].includes(inputType));
+
+	$effect(() => {
+		[value];
+
+		untrack(() => {
+			if (!internalValueChange && currency) {
+				if (typeof value === 'number') {
+					currencyValue = exponentToPlainNumberString(`${value}`);
+				} else {
+					currencyValue = fixUndefinedValue(value);
+				}
+
+				lastValidCurrencyValue = currencyValue;
+			}
+
+			internalValueChange = false;
+		});
+	});
+
+	const restoreFromValidValue = (noValue = false) => {
+		if (isNullish(inputElement) || !currency) {
+			return;
+		}
+
+		if (noValue) {
+			lastValidCurrencyValue = undefined;
+		}
+
+		internalValueChange = true;
+		value = isNullish(lastValidCurrencyValue)
+			? undefined
+			: typeof lastValidCurrencyValue === 'number'
+				? lastValidCurrencyValue.toFixed(wrapDecimals)
+				: inputType === 'icp'
+					? +lastValidCurrencyValue
+					: lastValidCurrencyValue;
+		currencyValue = fixUndefinedValue(lastValidCurrencyValue);
+
+		// force dom update (because no active triggers)
+		inputElement.value = currencyValue;
+
+		// restore cursor position
+		inputElement.setSelectionRange(selectionStart, selectionEnd);
+	};
+
+	// The type declaration of the input event is neither defined in node types nor in svelte.
+	// This extends the event with the currentTarget that is provided by the browser and that can be used to retrieve the input value.
+	type InputEventHandler = Event & {
+		currentTarget: EventTarget & HTMLInputElement;
+	};
+
+	const isDecimalsFormat = (text: string): boolean => {
+		const regex = new RegExp(`^\\d*(\\.\\d{0,${wrapDecimals}})?$`);
+		return regex.test(text);
+	};
+
+	const handleInput = ({ currentTarget }: InputEventHandler) => {
+		if (currency) {
+			const currentValue = exponentToPlainNumberString(currentTarget.value);
+
+			// handle invalid input
+			if (isDecimalsFormat(currentValue) === false) {
+				// restore value (e.g. to fix invalid paste)
+				restoreFromValidValue();
+			} else if (currentValue.length === 0) {
+				// reset to undefined ("" => undefined)
+				restoreFromValidValue(true);
+			} else {
+				lastValidCurrencyValue = currentValue;
+				currencyValue = fixUndefinedValue(currentValue);
+
+				internalValueChange = true;
+				// for inputType="icp" value is a number
+				value = inputType === 'icp' ? +currentValue : toStringWrapDecimals(currentValue);
+			}
+		} else {
+			internalValueChange = true;
+			value = inputType === 'number' ? +currentTarget.value : currentTarget.value;
+		}
+
+		onInput?.();
+	};
+
+	const handleKeyDown = () => {
+		if (isNullish(inputElement)) {
+			return;
+		}
+
+		// preserve selection
+		({ selectionStart, selectionEnd } = inputElement);
+	};
+
+	let displayInnerEnd = $derived(nonNullish(innerEnd));
+
+	let displayBottom = $derived(nonNullish(bottom));
+</script>
+
+<div class="input-block" class:disabled>
+	{#if showInfo}
+		<div class="info">
+			{@render start?.()}
+			<label class="label" for={name}>{@render label?.()}</label>
+			{@render end?.()}
+		</div>
+	{/if}
+	<div class:with-bottom={displayBottom}>
+		<div class="input-field">
+			<!-- svelte-ignore a11y_autofocus -->
+			<input
+				bind:this={inputElement}
+				id={name}
+				{name}
+				class:inner-end={displayInnerEnd}
+				{autocomplete}
+				{autofocus}
+				data-1p-ignore={ignore1Password}
+				data-tid={testId}
+				{disabled}
+				{max}
+				minlength={minLength}
+				onblur={onBlur}
+				onfocus={onFocus}
+				oninput={handleInput}
+				onkeydown={handleKeyDown}
+				{placeholder}
+				{required}
+				{spellcheck}
+				{step}
+				type={currency ? 'text' : inputType}
+				value={currency ? currencyValue : value}
+			/>
+			{#if displayInnerEnd}
+				<div class="inner-end-slot">
+					{@render innerEnd?.()}
+				</div>
+			{/if}
+		</div>
+
+		{#if displayBottom}
+			<div class="bottom-slot">
+				{@render bottom?.()}
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style lang="scss">
+	@use '$lib/styles/mixins/form';
+
+	.input-block {
+		position: relative;
+
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		gap: var(--padding);
+
+		width: var(--input-width);
+
+		color: var(--background-contrast);
+		background: none;
+
+		&.disabled {
+			--disabled-color: rgba(var(--disable-contrast-rgb), 0.8);
+			color: var(--disabled-color);
+
+			input {
+				border: var(--input-border-size) solid var(--disable);
+				color: var(--disabled-color);
+			}
+		}
+	}
+
+	.info {
+		display: flex;
+		justify-content: space-between;
+		gap: var(--padding);
+
+		.label {
+			flex: 1 1 100%;
+		}
+	}
+
+	input {
+		width: 100%;
+
+		font-size: inherit;
+
+		padding: var(--padding-2x);
+		box-sizing: border-box;
+
+		border-radius: var(--border-radius);
+
+		outline: none;
+		appearance: none;
+
+		@include form.input;
+	}
+
+	input[disabled] {
+		cursor: text;
+	}
+
+	.input-field {
+		position: relative;
+	}
+
+	.inner-end {
+		padding-right: var(--input-padding-inner-end, 64px);
+	}
+
+	.inner-end-slot {
+		position: absolute;
+		top: 50%;
+		right: 0;
+		transform: translate(0, -50%);
+		padding: var(--padding) var(--padding-2x);
+	}
+
+	.with-bottom {
+		background-color: var(--input-border-color);
+		border-radius: var(--border-radius);
+
+		input {
+			padding-top: var(--padding-3x);
+			padding-bottom: var(--padding-3x);
+		}
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/InputCurrency.svelte
+++ b/src/frontend/src/lib/components/ui/InputCurrency.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Input } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { onMount, type Snippet } from 'svelte';
+	import InputBase from '$lib/components/ui/InputBase.svelte';
 
 	interface Props {
 		innerEnd?: Snippet;
@@ -43,7 +43,7 @@
 </script>
 
 <div class="input-currency-container">
-	<Input
+	<InputBase
 		{name}
 		autocomplete="off"
 		{decimals}

--- a/src/frontend/src/lib/components/ui/InputTextWithAction.svelte
+++ b/src/frontend/src/lib/components/ui/InputTextWithAction.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Input } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { onMount, type Snippet } from 'svelte';
+	import InputBase from '$lib/components/ui/InputBase.svelte';
 
 	interface Props {
 		innerEnd?: Snippet;
@@ -36,7 +36,7 @@
 	});
 </script>
 
-<Input
+<InputBase
 	{name}
 	autocomplete="off"
 	{innerEnd}

--- a/src/frontend/src/lib/styles/mixins/_form.scss
+++ b/src/frontend/src/lib/styles/mixins/_form.scss
@@ -1,0 +1,25 @@
+@mixin input {
+	background: var(--input-background);
+	color: var(--input-background-contrast);
+	border: var(--input-border-size) solid
+		var(--input-error-color, var(--input-custom-border-color, var(--input-border-color)));
+
+	transition:
+		color var(--animation-time-short) ease-out,
+		background var(--animation-time-short) ease-out,
+		border var(--animation-time-short) ease-in;
+
+	&:focus {
+		@include input-focus;
+	}
+
+	&::placeholder {
+		color: var(--disable-contrast);
+	}
+}
+
+@mixin input-focus {
+	border: var(--input-border-size) solid var(--secondary);
+	background: var(--focus-background);
+	color: var(--focus-background-contrast);
+}

--- a/src/frontend/src/lib/types/input.ts
+++ b/src/frontend/src/lib/types/input.ts
@@ -1,0 +1,36 @@
+import type { Snippet } from 'svelte';
+
+export interface InputProps {
+	name: string;
+	inputType?: 'icp' | 'number' | 'text' | 'currency';
+	required?: boolean;
+	spellcheck?: boolean;
+	step?: number | 'any';
+	disabled?: boolean;
+	minLength?: number;
+	max?: number;
+	value?: string | number;
+	placeholder: string;
+	testId?: string;
+	decimals?: number;
+	ignore1Password?: boolean;
+	inputElement?: HTMLInputElement;
+	autofocus?: boolean;
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+	autocomplete?: 'off' | 'on';
+	// When forwarding slots, they always appear as true
+	// This is a known issue in Svelte
+	// https://github.com/sveltejs/svelte/issues/6059
+	// To hack this, we pass a prop to avoid showing info element when not needed
+	// Ideally, this would be calculated
+	// showInfo = $$slots.label || $$slots.end
+	showInfo?: boolean;
+	onInput?: () => void;
+	onBlur?: () => void;
+	onFocus?: () => void;
+	start?: Snippet;
+	label?: Snippet;
+	end?: Snippet;
+	innerEnd?: Snippet;
+	bottom?: Snippet;
+}

--- a/src/frontend/src/lib/types/input.ts
+++ b/src/frontend/src/lib/types/input.ts
@@ -18,12 +18,8 @@ export interface InputProps {
 	autofocus?: boolean;
 	// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
 	autocomplete?: 'off' | 'on';
-	// When forwarding slots, they always appear as true
-	// This is a known issue in Svelte
-	// https://github.com/sveltejs/svelte/issues/6059
-	// To hack this, we pass a prop to avoid showing info element when not needed
-	// Ideally, this would be calculated
-	// showInfo = $$slots.label || $$slots.end
+	// Explicit toggle for the top info row (the `start` / `label` / `end` snippets). Retained from
+	// the original gix API so consumers can hide that row even when a label/end snippet is provided.
 	showInfo?: boolean;
 	onInput?: () => void;
 	onBlur?: () => void;

--- a/src/frontend/src/tests/lib/components/ui/InputBase.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/InputBase.spec.ts
@@ -38,7 +38,7 @@ describe('InputBase', () => {
 		expect(input(container)?.getAttribute('type')).toBe('text');
 	});
 
-	it('should be required by default and optional when disabled', () => {
+	it('should be required by default and optional when required is false', () => {
 		const { container: required } = render(InputBase, { props });
 
 		expect(input(required)?.hasAttribute('required')).toBeTruthy();

--- a/src/frontend/src/tests/lib/components/ui/InputBase.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/InputBase.spec.ts
@@ -1,0 +1,95 @@
+import InputBase from '$lib/components/ui/InputBase.svelte';
+import InputBaseTest from '$tests/lib/components/ui/InputBaseTest.svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('InputBase', () => {
+	const props = { name: 'name', placeholder: 'test.placeholder' };
+
+	const input = (container: HTMLElement): HTMLInputElement | null =>
+		container.querySelector('input');
+
+	it('should render an input', () => {
+		const { container } = render(InputBase, { props });
+
+		expect(input(container)).not.toBeNull();
+	});
+
+	it('should render the placeholder', () => {
+		const { container } = render(InputBase, { props });
+
+		expect(input(container)?.getAttribute('placeholder')).toBe('test.placeholder');
+	});
+
+	it('should default to a number input', () => {
+		const { container } = render(InputBase, { props });
+
+		expect(input(container)?.getAttribute('type')).toBe('number');
+	});
+
+	it('should render a text input', () => {
+		const { container } = render(InputBase, { props: { ...props, inputType: 'text' } });
+
+		expect(input(container)?.getAttribute('type')).toBe('text');
+	});
+
+	it('should render a currency input as text', () => {
+		const { container } = render(InputBase, { props: { ...props, inputType: 'currency' } });
+
+		expect(input(container)?.getAttribute('type')).toBe('text');
+	});
+
+	it('should be required by default and optional when disabled', () => {
+		const { container: required } = render(InputBase, { props });
+
+		expect(input(required)?.hasAttribute('required')).toBeTruthy();
+
+		const { container: optional } = render(InputBase, { props: { ...props, required: false } });
+
+		expect(input(optional)?.hasAttribute('required')).toBeFalsy();
+	});
+
+	it('should render a disabled input', () => {
+		const { container } = render(InputBase, { props: { ...props, disabled: true } });
+
+		expect(input(container)?.hasAttribute('disabled')).toBeTruthy();
+	});
+
+	it('should set the test id', () => {
+		const { container } = render(InputBase, { props: { ...props, testId: 'my-input' } });
+
+		expect(input(container)?.getAttribute('data-tid')).toBe('my-input');
+	});
+
+	it('should update the value on text input', async () => {
+		const { container } = render(InputBase, { props: { ...props, inputType: 'text' } });
+
+		const element = input(container);
+		element && (await fireEvent.input(element, { target: { value: 'hello' } }));
+
+		expect(element?.value).toBe('hello');
+	});
+
+	it('should reject a currency value with too many decimals', async () => {
+		const { container } = render(InputBase, {
+			props: { ...props, inputType: 'currency', decimals: 2, value: '1.5' }
+		});
+
+		const element = input(container);
+		// 3 decimals exceeds the 2 allowed → the invalid entry is rejected and the last valid value restored.
+		element && (await fireEvent.input(element, { target: { value: '1.999' } }));
+
+		expect(element?.value).toBe('1.5');
+	});
+
+	it('should render the label/info row via snippets', () => {
+		const { getByTestId } = render(InputBaseTest, { props });
+
+		expect(getByTestId('label-slot')).toBeInTheDocument();
+	});
+
+	it('should render the bottom slot when provided', () => {
+		const { getByTestId } = render(InputBaseTest, { props });
+
+		expect(getByTestId('bottom-slot')).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/ui/InputBaseTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/InputBaseTest.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import InputBase from '$lib/components/ui/InputBase.svelte';
+	import type { InputProps } from '$lib/types/input';
+
+	let props: InputProps = $props();
+</script>
+
+<InputBase {...props}>
+	{#snippet label()}
+		<span data-tid="label-slot">A label</span>
+	{/snippet}
+	{#snippet end()}
+		<button>End</button>
+	{/snippet}
+	{#snippet bottom()}
+		<span data-tid="bottom-slot">bottom</span>
+	{/snippet}
+</InputBase>


### PR DESCRIPTION
## Motivation

Part of the ongoing migration off `@dfinity/gix-components` (now in maintenance mode): vendor the components OISY uses as native Svelte 5 code so the wallet owns them. This PR does gix's `Input`.

## Changes

- Add native `$lib/components/ui/InputBase.svelte` (gix `Input`) — a faithful copy (gix's `Input` is already Svelte 5 runes). Named `InputBase` to avoid collision with OISY's existing enhanced `ui/Input.svelte`, which wraps it.
- Add `$lib/types/input.ts` (gix `InputProps`).
- Carry `$lib/styles/mixins/_form.scss` (the `input`/`input-focus` mixin the component needs). This is an identical copy of the mixin introduced in the Select PR (#13306); git dedupes identical files on merge.
- Rewire the 3 consumers off gix: `ui/Input.svelte` (now extends the vendored `InputProps` and renders `InputBase`), `ui/InputCurrency.svelte`, `ui/InputTextWithAction.svelte`.
- Add a unit test for `InputBase` (rendering, input types, required/disabled, value binding, currency decimal clamping, label/bottom slots). The existing `Input.spec.ts` (wrapper) keeps passing unchanged.

Faithful 1:1 port — no rendered-output change. `decimal.js` is already a direct dependency, so no new deps.

## Tests

`npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npx tsc --project tsconfig.spec.json --noEmit`, and vitest (`InputBase.spec.ts` 12 tests, plus the unchanged `Input.spec.ts`) all pass locally.