### PR TITLE
refactor(frontend): own 7 gix icons natively, detach from gix

### DIFF
--- a/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
+++ b/src/frontend/src/icp/components/transactions/IcTransactionsBitcoinStatusBalance.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { IconReimbursed } from '@dfinity/gix-components';
 	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
 	import { MinterAlreadyProcessingError, MinterNoNewUtxosError } from '@icp-sdk/canisters/ckbtc';
 	import { blur } from 'svelte/transition';
 	import IcTransactionsBitcoinStatus from '$icp/components/transactions/IcTransactionsBitcoinStatusProgress.svelte';
 	import { tokenAsIcToken } from '$icp/derived/ic-token.derived';
 	import { updateBalance } from '$icp/services/ckbtc.services';
+	import IconReimbursed from '$lib/components/icons/IconReimbursed.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { modalReceiveBitcoin } from '$lib/derived/modal.derived';

--- a/src/frontend/src/lib/components/carousel/Controls.svelte
+++ b/src/frontend/src/lib/components/carousel/Controls.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { IconWest, IconEast } from '@dfinity/gix-components';
+	import IconEast from '$lib/components/icons/IconEast.svelte';
+	import IconWest from '$lib/components/icons/IconWest.svelte';
 	import ButtonControl from '$lib/components/ui/ButtonControl.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 

--- a/src/frontend/src/lib/components/core/Back.svelte
+++ b/src/frontend/src/lib/components/core/Back.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { IconBack } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { afterNavigate } from '$app/navigation';
+	import IconBack from '$lib/components/icons/IconBack.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { back } from '$lib/utils/nav.utils';
 

--- a/src/frontend/src/lib/components/core/Menu.svelte
+++ b/src/frontend/src/lib/components/core/Menu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { IconUser, Popover } from '@dfinity/gix-components';
+	import { Popover } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
 	import { page } from '$app/state';
@@ -13,6 +13,7 @@
 	import IconExternalLink from '$lib/components/icons/IconExternalLink.svelte';
 	import IconHelpCircle from '$lib/components/icons/IconHelpCircle.svelte';
 	import IconPay from '$lib/components/icons/IconPay.svelte';
+	import IconUser from '$lib/components/icons/IconUser.svelte';
 	import IconVipQr from '$lib/components/icons/IconVipQr.svelte';
 	import IconWalletConnect from '$lib/components/icons/IconWalletConnect.svelte';
 	import IconEye from '$lib/components/icons/lucide/IconEye.svelte';

--- a/src/frontend/src/lib/components/icons/IconBack.svelte
+++ b/src/frontend/src/lib/components/icons/IconBack.svelte
@@ -1,0 +1,10 @@
+<!-- source: DFINITY foundation -->
+<svg fill="none" height="21" viewBox="0 0 20 21" width="20" xmlns="http://www.w3.org/2000/svg">
+	<path
+		d="M12.25 15.5L7 10.25L12.25 5"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+</svg>

--- a/src/frontend/src/lib/components/icons/IconCheckCircleFill.svelte
+++ b/src/frontend/src/lib/components/icons/IconCheckCircleFill.svelte
@@ -1,0 +1,20 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+	interface Props {
+		size?: string | number;
+	}
+
+	let { size = 20 }: Props = $props();
+</script>
+
+<svg
+	fill="currentColor"
+	height={size}
+	viewBox="0 0 20 20"
+	width={size}
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<path
+		d="M10 1.75a8.25 8.25 0 1 1 0 16.5 8.25 8.25 0 0 1 0-16.5Zm3.98 5.857a.75.75 0 0 0-1.003-.075l-.057.05-4.068 3.88L7.08 9.77l-.059-.051a.75.75 0 0 0-1.03 1.079l.052.056 2.289 2.187.116.09a.75.75 0 0 0 .92-.089l4.586-4.375.053-.056a.75.75 0 0 0-.027-1.005Z"
+	/>
+</svg>

--- a/src/frontend/src/lib/components/icons/IconEast.svelte
+++ b/src/frontend/src/lib/components/icons/IconEast.svelte
@@ -1,0 +1,12 @@
+<!-- source: DFINITY foundation -->
+<svg
+	fill="none"
+	height="24"
+	stroke="currentColor"
+	viewBox="0 0 20 20"
+	width="24"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<path d="M1 10L18 10" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+	<path d="M11 18L19 10L11 2" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+</svg>

--- a/src/frontend/src/lib/components/icons/IconQrCodeScanner.svelte
+++ b/src/frontend/src/lib/components/icons/IconQrCodeScanner.svelte
@@ -1,0 +1,67 @@
+<!-- source: https://fonts.google.com/icons?selected=Material%20Symbols%20Outlined%3Aqr_code_scanner%3AFILL%400%3Bwght%40400%3BGRAD%400%3Bopsz%4048 -->
+<script lang="ts">
+	interface Props {
+		size?: string | number;
+	}
+
+	let { size = '20px' }: Props = $props();
+</script>
+
+<svg
+	fill="none"
+	height={size}
+	stroke="currentColor"
+	viewBox="0 0 20 20"
+	width={size}
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<path
+		d="M8.125 3.75H4.375C4.02982 3.75 3.75 4.02982 3.75 4.375V8.125C3.75 8.47018 4.02982 8.75 4.375 8.75H8.125C8.47018 8.75 8.75 8.47018 8.75 8.125V4.375C8.75 4.02982 8.47018 3.75 8.125 3.75Z"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+	<path
+		d="M8.125 11.25H4.375C4.02982 11.25 3.75 11.5298 3.75 11.875V15.625C3.75 15.9702 4.02982 16.25 4.375 16.25H8.125C8.47018 16.25 8.75 15.9702 8.75 15.625V11.875C8.75 11.5298 8.47018 11.25 8.125 11.25Z"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+	<path
+		d="M15.625 3.75H11.875C11.5298 3.75 11.25 4.02982 11.25 4.375V8.125C11.25 8.47018 11.5298 8.75 11.875 8.75H15.625C15.9702 8.75 16.25 8.47018 16.25 8.125V4.375C16.25 4.02982 15.9702 3.75 15.625 3.75Z"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+	<path
+		d="M11.25 11.25V13.75"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+	<path
+		d="M11.25 16.25H13.75V11.25"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+	<path
+		d="M13.75 12.5H16.25"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+	<path
+		d="M16.25 15V16.25"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+</svg>

--- a/src/frontend/src/lib/components/icons/IconReimbursed.svelte
+++ b/src/frontend/src/lib/components/icons/IconReimbursed.svelte
@@ -1,0 +1,25 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+	interface Props {
+		size?: string | number;
+	}
+
+	let { size = '20px' }: Props = $props();
+</script>
+
+<svg
+	data-tid="icon-reimbursed"
+	fill="none"
+	height={size}
+	stroke="currentColor"
+	viewBox="0 0 20 20"
+	width={size}
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<path
+		d="M8.33342 12.9191H4.16675V17.0858M12.0147 7.50004H16.1814V3.33337M4.16721 8.33621C4.63445 7.17976 5.41674 6.17757 6.42517 5.44356C7.43359 4.70955 8.62875 4.27297 9.87284 4.1838C11.1169 4.09462 12.3603 4.35621 13.4631 4.93888C14.5659 5.52156 15.4824 6.40216 16.1098 7.48014M16.1814 12.0834C15.7141 13.2398 14.9318 14.242 13.9234 14.976C12.915 15.71 11.7211 16.1461 10.477 16.2352C9.23289 16.3244 7.98847 16.0629 6.88566 15.4802C5.78285 14.8975 4.86577 14.0171 4.23836 12.9391"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="1.5"
+	/>
+</svg>

--- a/src/frontend/src/lib/components/icons/IconUser.svelte
+++ b/src/frontend/src/lib/components/icons/IconUser.svelte
@@ -1,0 +1,17 @@
+<!-- source: DFINITY foundation -->
+<script lang="ts">
+	interface Props {
+		size?: string | number;
+	}
+
+	let { size = '20px' }: Props = $props();
+</script>
+
+<svg fill="none" height={size} viewBox="0 0 20 20" width={size} xmlns="http://www.w3.org/2000/svg">
+	<circle cx="10" cy="5.83333" r="3.33333" stroke="currentColor" stroke-width="1.5" />
+	<path
+		d="M12.5 11.667H7.50004C5.19886 11.667 3.13762 13.7919 4.65211 15.5244C5.68203 16.7026 7.38522 17.5003 10 17.5003C12.6149 17.5003 14.3181 16.7026 15.348 15.5244C16.8625 13.7919 14.8012 11.667 12.5 11.667Z"
+		stroke="currentColor"
+		stroke-width="1.5"
+	/>
+</svg>

--- a/src/frontend/src/lib/components/icons/IconWest.svelte
+++ b/src/frontend/src/lib/components/icons/IconWest.svelte
@@ -1,0 +1,12 @@
+<!-- source: DFINITY foundation -->
+<svg
+	fill="none"
+	height="24"
+	stroke="currentColor"
+	viewBox="0 0 20 20"
+	width="24"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<path d="M19 10L2 10" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+	<path d="M9 2L1 10L9 18" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" />
+</svg>

--- a/src/frontend/src/lib/components/nfts/NftCollectionHero.svelte
+++ b/src/frontend/src/lib/components/nfts/NftCollectionHero.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { IconBack } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import { goto } from '$app/navigation';
+	import IconBack from '$lib/components/icons/IconBack.svelte';
 	import IconClose from '$lib/components/icons/IconClose.svelte';
 	import NftBadge from '$lib/components/nfts/NftBadge.svelte';
 	import NftCollectionActionButtons from '$lib/components/nfts/NftCollectionActionButtons.svelte';

--- a/src/frontend/src/lib/components/nfts/NftHero.svelte
+++ b/src/frontend/src/lib/components/nfts/NftHero.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { IconBack } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { fade } from 'svelte/transition';
 	import { afterNavigate, goto } from '$app/navigation';
+	import IconBack from '$lib/components/icons/IconBack.svelte';
 	import IconClose from '$lib/components/icons/IconClose.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import NftActionButtons from '$lib/components/nfts/NftActionButtons.svelte';

--- a/src/frontend/src/lib/components/receive/ReceiveActions.svelte
+++ b/src/frontend/src/lib/components/receive/ReceiveActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { IconQRCodeScanner } from '@dfinity/gix-components';
+	import IconQrCodeScanner from '$lib/components/icons/IconQrCodeScanner.svelte';
 	import ReceiveCopy from '$lib/components/receive/ReceiveCopy.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import type { ReceiveQRCodeAction } from '$lib/types/receive';
@@ -28,7 +28,7 @@
 			testId={qrCodeAction.testId}
 		>
 			{#snippet icon()}
-				<IconQRCodeScanner size="24" />
+				<IconQrCodeScanner size="24" />
 			{/snippet}
 		</ButtonIcon>
 	{/if}

--- a/src/frontend/src/lib/components/rewards/RewardRequirement.svelte
+++ b/src/frontend/src/lib/components/rewards/RewardRequirement.svelte
@@ -11,8 +11,8 @@
 </script>
 
 <script generics="T extends CampaignCriterion = CampaignCriterion" lang="ts">
-	import { IconCheckCircleFill } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
+	import IconCheckCircleFill from '$lib/components/icons/IconCheckCircleFill.svelte';
 	import { RewardCriterionType } from '$lib/enums/reward-criterion-type';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';


### PR DESCRIPTION
## Motivation

Part of the ongoing migration off `@dfinity/gix-components` (now in maintenance mode): vendor the icons OISY uses as native Svelte 5 components. This PR does the gix icons that have **no existing OISY equivalent** (so it's a clean, decoupled batch).

## Changes

Vendor 7 gix icons natively under `$lib/components/icons/` (faithful SVG copies; `DEFAULT_ICON_SIZE` inlined as `20` since OISY has no such constant):

- `IconReimbursed`, `IconEast`, `IconWest`, `IconBack`, `IconUser`, `IconCheckCircleFill`, and `IconQrCodeScanner` (renamed from gix's `IconQRCodeScanner` to satisfy OISY's `.ls-lint` no-consecutive-caps rule).

Rewire all 8 consumers off gix: `IcTransactionsBitcoinStatusBalance`, carousel `Controls`, core `Back`, `NftCollectionHero`, `NftHero`, core `Menu` (keeps its gix `Popover` import, migrated separately), `ReceiveActions`, `RewardRequirement`.

Faithful 1:1 port — no rendered-output change.

### Scope note

The remaining gix icons (`IconClose`, `IconInfo`, `IconWarning`, `IconGitHub`, `IconWallet`, `IconCheck`, `IconCheckCircle`) already have native OISY equivalents on `main`, so detaching those is a per-icon glyph-equivalence decision (and `IconClose` is tied to the Modal PR's `IconCloseThin`); those are deferred to a focused follow-up.

## Tests

`npm run format`, `npm run lint -- --max-warnings 0`, `@ls-lint/ls-lint`, `npm run check`, and `npx tsc --project tsconfig.spec.json --noEmit` all pass locally. Icons are pure SVG (no logic) and are exercised transitively by their consumers' tests.