### PR TITLE
refactor(frontend): use native Html in LiquidiumProviderHero, detach from gix

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumProviderHero.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProviderHero.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Html } from '@dfinity/gix-components';
 	import { nonNullish } from '@dfinity/utils';
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { afterNavigate } from '$app/navigation';
@@ -8,6 +7,7 @@
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
+	import Html from '$lib/components/ui/Html.svelte';
 	import Logo from '$lib/components/ui/Logo.svelte';
 	import { STAKE_PROVIDER_LOGO } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';


### PR DESCRIPTION
## Motivation

Cleanup straggler for the migration off `@dfinity/gix-components`: the `Html` component was already vendored natively (`$lib/components/ui/Html.svelte`), but `LiquidiumProviderHero` still imported gix's `Html`.

## Changes

- Repoint `LiquidiumProviderHero.svelte` from gix `Html` to the native `$lib/components/ui/Html.svelte` (same `text` prop / sanitized `{@html}` behavior). No other change.

## Tests

`npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, and the existing `LiquidiumProviderHero.spec.ts` (2 tests) all pass locally.