### PR TITLE
refactor(frontend): use native IconCloseThin for gix IconClose consumers

### DIFF
--- a/src/frontend/src/lib/components/agreements/AgreementsBanner.svelte
+++ b/src/frontend/src/lib/components/agreements/AgreementsBanner.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { IconClose } from '@dfinity/gix-components';
 	import { notEmptyString } from '@dfinity/utils';
+	import IconCloseThin from '$lib/components/icons/IconCloseThin.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import {
@@ -49,7 +49,7 @@
 			data-tid={AGREEMENTS_WARNING_BANNER_CLOSE_BUTTON}
 			onclick={close}
 		>
-			<IconClose />
+			<IconCloseThin />
 		</button>
 	</WarningBanner>
 {/if}

--- a/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
+++ b/src/frontend/src/lib/components/ai-assistant/AiAssistantConsole.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { IconClose } from '@dfinity/gix-components';
 	import { fade } from 'svelte/transition';
 	import AiAssistantChat from '$lib/components/ai-assistant/AiAssistantChat.svelte';
 	import AiAssistantResetButton from '$lib/components/ai-assistant/AiAssistantResetButton.svelte';
 	import IconAiAssistant from '$lib/components/icons/IconAiAssistant.svelte';
+	import IconCloseThin from '$lib/components/icons/IconCloseThin.svelte';
 	import { aiAssistantStore } from '$lib/stores/ai-assistant.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
@@ -29,7 +29,7 @@
 			aria-label={$i18n.core.text.close}
 			onclick={aiAssistantStore.close}
 		>
-			<IconClose />
+			<IconCloseThin />
 		</button>
 	</div>
 

--- a/src/frontend/src/lib/components/core/Banner.svelte
+++ b/src/frontend/src/lib/components/core/Banner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { IconClose, IconWarning } from '@dfinity/gix-components';
+	import { IconWarning } from '@dfinity/gix-components';
+	import IconCloseThin from '$lib/components/icons/IconCloseThin.svelte';
 	import WarningBanner from '$lib/components/ui/WarningBanner.svelte';
 	import { BETA, STAGING } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -17,7 +18,7 @@
 			<IconWarning size="48px" />
 			<h3 class="clamp-4">{$i18n.core.info.test_banner}</h3>
 		</span>
-		<button aria-label={$i18n.core.text.close} onclick={closeEnvBanner}><IconClose /></button>
+		<button aria-label={$i18n.core.text.close} onclick={closeEnvBanner}><IconCloseThin /></button>
 	</div>
 {:else if BETA && envBannerVisible}
 	<div
@@ -26,7 +27,7 @@
 		<WarningBanner>
 			<span class="w-full px-2">{$i18n.core.info.test_banner_beta}</span>
 			<button aria-label={$i18n.core.text.close} onclick={closeEnvBanner}>
-				<IconClose />
+				<IconCloseThin />
 			</button>
 		</WarningBanner>
 	</div>

--- a/src/frontend/src/lib/components/core/PwaBanner.svelte
+++ b/src/frontend/src/lib/components/core/PwaBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { IconClose } from '@dfinity/gix-components';
+	import IconCloseThin from '$lib/components/icons/IconCloseThin.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import InfoBanner from '$lib/components/ui/InfoBanner.svelte';
 	import {
@@ -29,7 +29,7 @@
 				data-tid={PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID}
 				onclick={closePwaBanner}
 			>
-				<IconClose />
+				<IconCloseThin />
 			</button>
 		</InfoBanner>
 	</div>

--- a/src/frontend/src/lib/components/info/InfoBox.svelte
+++ b/src/frontend/src/lib/components/info/InfoBox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { IconClose } from '@dfinity/gix-components';
 	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
+	import IconCloseThin from '$lib/components/icons/IconCloseThin.svelte';
 	import { SLIDE_EASING } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 
@@ -22,7 +22,7 @@
 		<button
 			class="absolute top-2 right-2 text-tertiary"
 			aria-label={$i18n.core.text.close}
-			onclick={onClick}><IconClose /></button
+			onclick={onClick}><IconCloseThin /></button
 		>
 		{@render children()}
 	</div>

--- a/src/frontend/src/lib/components/ui/ButtonReset.svelte
+++ b/src/frontend/src/lib/components/ui/ButtonReset.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { IconClose } from '@dfinity/gix-components';
+	import IconCloseThin from '$lib/components/icons/IconCloseThin.svelte';
 	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
@@ -18,6 +18,6 @@
 	{onclick}
 >
 	{#snippet icon()}
-		<IconClose size="24" />
+		<IconCloseThin size="24" />
 	{/snippet}
 </ButtonIcon>

--- a/src/frontend/src/lib/components/ui/InputSearch.svelte
+++ b/src/frontend/src/lib/components/ui/InputSearch.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { IconClose } from '@dfinity/gix-components';
+	import IconCloseThin from '$lib/components/icons/IconCloseThin.svelte';
 	import IconSearch from '$lib/components/icons/IconSearch.svelte';
 	import InputTextWithAction from '$lib/components/ui/InputTextWithAction.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -32,7 +32,7 @@
 	{#snippet innerEnd()}
 		{#if showResetButton}
 			<button aria-label={$i18n.core.text.clear_filter} onclick={() => (filter = '')}>
-				<IconClose />
+				<IconCloseThin />
 			</button>
 		{:else}
 			<IconSearch />


### PR DESCRIPTION
## Motivation

Part of the migration off `@dfinity/gix-components`. gix's `IconClose` (the thin close glyph) was already vendored on `main` as `IconCloseThin` (via the Modal PR), but 7 components still imported gix's `IconClose`.

## Changes

- Repoint the 7 gix-`IconClose` consumers to the existing native `$lib/components/icons/IconCloseThin.svelte` (byte-identical glyph → no rendered-output change): `ButtonReset`, `InputSearch`, `PwaBanner`, `Banner` (keeps its gix `IconWarning`), `AgreementsBanner`, `InfoBox`, `AiAssistantConsole`.

No new files. OISY's own (different) `IconClose.svelte` is unaffected — only the gix imports are removed.

## Tests

`npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` clean, and the existing PwaBanner / AgreementsBanner / AiAssistantConsole specs (12 tests) pass.