### PR TITLE
style(frontend): secondary style for close button in order detail modal

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingCancelOrderConfirm.svelte
+++ b/src/frontend/src/lib/components/trading/TradingCancelOrderConfirm.svelte
@@ -65,7 +65,7 @@
 
 			<div class="mt-5">
 				<ButtonGroup>
-					<Button colorStyle="secondary" {disabled} onclick={onCancel}>
+					<Button colorStyle="secondary-light" {disabled} onclick={onCancel}>
 						{$i18n.trading.order_detail.confirm_keep}
 					</Button>
 					<Button

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -293,7 +293,7 @@
 
 		{#snippet toolbar()}
 			<ButtonGroup>
-				<Button onclick={close}>{$i18n.core.text.close}</Button>
+				<Button colorStyle="secondary" onclick={close}>{$i18n.core.text.close}</Button>
 				{#if active}
 					<Button
 						colorStyle="error"

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -293,7 +293,7 @@
 
 		{#snippet toolbar()}
 			<ButtonGroup>
-				<Button colorStyle="secondary" onclick={close}>{$i18n.core.text.close}</Button>
+				<Button colorStyle="secondary-light" onclick={close}>{$i18n.core.text.close}</Button>
 				{#if active}
 					<Button
 						colorStyle="error"


### PR DESCRIPTION
# Motivation

In the order detail modal the close button was rendered in primary style. As a secondary/neutral action it should use the secondary style, consistent with the "keep order" button in the cancel confirmation modal.

# Changes

- Set `colorStyle="secondary"` on the close button in `TradingOrderDetailModal`.

The "keep order" button in `TradingCancelOrderConfirm` was already secondary, so no change was needed there.

# Tests

Visual change only.