### PR TITLE
feat(frontend): add per-token volume to trading Plausible events

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Modal } from '@dfinity/gix-components';
 	import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+	import Decimal from 'decimal.js';
 	import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import TradingCancelOrderConfirm from '$lib/components/trading/TradingCancelOrderConfirm.svelte';
@@ -218,12 +219,13 @@
 
 	const confirmCancel = async () => {
 		canceling = true;
-		// Order volume is the base-token (`token`) quantity.
+		// Order volume is the base-token (`token`) quantity. `quantity` is a JS number, so
+		// stringify it via Decimal to get a plain decimal string (no `1e-7`/float artifacts).
 		const orderFields = {
 			token: baseSymbol,
 			token2: quoteSymbol,
 			side,
-			volume: `${quantity}`
+			volume: new Decimal(quantity).toFixed()
 		};
 		trackTrading({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.CANCEL_ORDER,

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -218,7 +218,8 @@
 
 	const confirmCancel = async () => {
 		canceling = true;
-		const orderFields = { base: baseSymbol, quote: quoteSymbol, side };
+		// Order volume is the base-token quantity.
+		const orderFields = { base: baseSymbol, quote: quoteSymbol, side, volume: `${quantity}` };
 		trackTrading({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.CANCEL_ORDER,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.EXECUTING,

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -218,8 +218,13 @@
 
 	const confirmCancel = async () => {
 		canceling = true;
-		// Order volume is the base-token quantity.
-		const orderFields = { base: baseSymbol, quote: quoteSymbol, side, volume: `${quantity}` };
+		// Order volume is the base-token (`token`) quantity.
+		const orderFields = {
+			token: baseSymbol,
+			token2: quoteSymbol,
+			side,
+			volume: `${quantity}`
+		};
 		trackTrading({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.CANCEL_ORDER,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.EXECUTING,

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -219,11 +219,11 @@
 
 	const confirmCancel = async () => {
 		canceling = true;
-		// Order volume is the base-token (`token`) quantity. `quantity` is a JS number, so
-		// stringify it via Decimal to get a plain decimal string (no `1e-7`/float artifacts).
+		// Order volume is the base-token quantity. `quantity` is a JS number, so stringify it
+		// via Decimal to get a plain decimal string (no `1e-7`/float artifacts).
 		const orderFields = {
-			token: baseSymbol,
-			token2: quoteSymbol,
+			base: baseSymbol,
+			quote: quoteSymbol,
 			side,
 			volume: new Decimal(quantity).toFixed()
 		};

--- a/src/frontend/src/lib/components/trading/WithdrawWizard.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawWizard.svelte
@@ -61,10 +61,14 @@
 
 		onNext();
 
+		// The entered amount is already in human token units — carry it as volume.
+		const volume = `${amount}`;
+
 		trackTrading({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.WITHDRAW,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.EXECUTING,
-			token: token.symbol
+			token: token.symbol,
+			volume
 		});
 
 		try {
@@ -81,7 +85,8 @@
 			trackTrading({
 				subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.WITHDRAW,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
-				token: token.symbol
+				token: token.symbol,
+				volume
 			});
 
 			setTimeout(onClose, 750);
@@ -90,6 +95,7 @@
 				subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.WITHDRAW,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 				token: token.symbol,
+				volume,
 				error: replaceIcErrorFields(err)
 			});
 			toastsError({ msg: { text: $i18n.trading.withdraw.error }, err });

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
@@ -172,11 +172,16 @@
 		goTo(WizardStepsLimitOrder.PLACING);
 		progressStep = ProgressStepsLimitOrder.PLACE;
 
-		const orderFields: Pick<TrackTradingParams, 'base' | 'quote' | 'side' | 'orderType'> = {
+		const orderFields: Pick<
+			TrackTradingParams,
+			'base' | 'quote' | 'side' | 'orderType' | 'volume'
+		> = {
 			base: baseSymbol,
 			quote: quoteSymbol,
 			side,
-			orderType: fillOrKill ? 'FOK' : 'GTC'
+			orderType: fillOrKill ? 'FOK' : 'GTC',
+			// Order volume is the base-token quantity.
+			volume: `${baseNum}`
 		};
 		trackTrading({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.LIMIT_ORDER,

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
@@ -174,13 +174,13 @@
 
 		const orderFields: Pick<
 			TrackTradingParams,
-			'base' | 'quote' | 'side' | 'orderType' | 'volume'
+			'token' | 'token2' | 'side' | 'orderType' | 'volume'
 		> = {
-			base: baseSymbol,
-			quote: quoteSymbol,
+			token: baseSymbol,
+			token2: quoteSymbol,
 			side,
 			orderType: fillOrKill ? 'FOK' : 'GTC',
-			// Order volume is the base-token quantity.
+			// Order volume is the base-token (`token`) quantity.
 			volume: `${baseNum}`
 		};
 		trackTrading({

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
@@ -174,14 +174,14 @@
 
 		const orderFields: Pick<
 			TrackTradingParams,
-			'token' | 'token2' | 'side' | 'orderType' | 'volume'
+			'base' | 'quote' | 'side' | 'orderType' | 'volume'
 		> = {
-			token: baseSymbol,
-			token2: quoteSymbol,
+			base: baseSymbol,
+			quote: quoteSymbol,
 			side,
 			orderType: fillOrKill ? 'FOK' : 'GTC',
-			// Order volume is the base-token (`token`) quantity. Use the raw entered string
-			// rather than the parsed number so full precision is preserved (no `1e-7`).
+			// Order volume is the base-token quantity. Use the raw entered string rather than
+			// the parsed number so full precision is preserved (no `1e-7`).
 			volume: baseAmount
 		};
 		trackTrading({

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
@@ -180,8 +180,9 @@
 			token2: quoteSymbol,
 			side,
 			orderType: fillOrKill ? 'FOK' : 'GTC',
-			// Order volume is the base-token (`token`) quantity.
-			volume: `${baseNum}`
+			// Order volume is the base-token (`token`) quantity. Use the raw entered string
+			// rather than the parsed number so full precision is preserved (no `1e-7`).
+			volume: baseAmount
 		};
 		trackTrading({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.LIMIT_ORDER,

--- a/src/frontend/src/lib/services/oisy-trade.deposit.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade.deposit.services.ts
@@ -17,6 +17,7 @@ import { replaceIcErrorFields } from '$lib/utils/error.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import { assertNonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
 import { Principal } from '@icp-sdk/core/principal';
+import { formatUnits } from 'ethers/utils';
 import { get } from 'svelte/store';
 
 const APPROVE_EXPIRATION_MINUTES = 5n;
@@ -45,6 +46,9 @@ export const depositOisyTrade = async ({
 }: DepositOisyTradeParams): Promise<boolean> => {
 	const { auth, trading } = get(i18n);
 
+	// Full-precision human amount (smallest units → token units) for volume analytics.
+	const volume = formatUnits(amount, token.decimals);
+
 	try {
 		assertNonNullish(identity, auth.error.no_internet_identity);
 		assertNonNullish(OISY_TRADE_CANISTER_ID);
@@ -57,7 +61,8 @@ export const depositOisyTrade = async ({
 		trackTrading({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.DEPOSIT,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.EXECUTING,
-			token: token.symbol
+			token: token.symbol,
+			volume
 		});
 
 		progress?.(ProgressStepsTradingDeposit.APPROVE);
@@ -87,7 +92,8 @@ export const depositOisyTrade = async ({
 		trackTrading({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.DEPOSIT,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
-			token: token.symbol
+			token: token.symbol,
+			volume
 		});
 
 		return true;
@@ -96,6 +102,7 @@ export const depositOisyTrade = async ({
 			subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.DEPOSIT,
 			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
 			token: token.symbol,
+			volume,
 			error: replaceIcErrorFields(err)
 		});
 		toastsError({ msg: { text: trading.deposit.error.deposit_failed }, err });

--- a/src/frontend/src/lib/services/trading-analytics.services.ts
+++ b/src/frontend/src/lib/services/trading-analytics.services.ts
@@ -18,15 +18,16 @@ export interface TrackTradingParams {
 	subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING;
 	// Lifecycle: `executing` when the flow starts, then `success` / `error`.
 	resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
-	// Primary token symbol — the single token for deposit/withdraw, or the base leg of an
-	// order pair. `token`/`token2` mirror the two-token shape used by the swap events.
-	token?: string;
-	// Second leg (the quote token) of an order pair; absent for deposit/withdraw.
-	token2?: string;
+	// Order pair leg symbols — free-form token symbols (no closed set), so kept as strings.
+	// Emitted as the swap-style `token`/`token2` metadata keys (base → token, quote → token2).
+	base?: string;
+	quote?: string;
 	side?: LimitOrderSide;
 	orderType?: OisyTradeOrderType;
-	// Traded amount in `token`'s own units (the deposited/withdrawn token, or the order's
-	// base token), as a full-precision decimal string so volume can be aggregated per token.
+	// Single-token flows (deposit/withdraw). Emitted as the `token` metadata key.
+	token?: string;
+	// Traded amount in the primary token's own units (the deposited/withdrawn token, or the
+	// order's base token), as a full-precision decimal string so volume aggregates per token.
 	volume?: string;
 	// Sanitized (IC-request-id-stripped) error string; omitted when empty.
 	error?: string;
@@ -39,13 +40,16 @@ export interface TrackTradingParams {
 export const trackTrading = ({
 	subContext,
 	resultStatus,
-	token,
-	token2,
+	base,
+	quote,
 	side,
 	orderType,
+	token,
 	volume,
 	error
 }: TrackTradingParams) => {
+	// The primary token key is sourced from `token` (deposit/withdraw) or the order's `base`.
+	const primaryToken = token ?? base;
 	trackEvent({
 		name: PLAUSIBLE_EVENTS.TRADING,
 		metadata: {
@@ -53,8 +57,8 @@ export const trackTrading = ({
 			event_context: PLAUSIBLE_EVENT_CONTEXTS.TRADING,
 			event_subcontext: subContext,
 			result_status: resultStatus,
-			...(nonNullish(token) && { token }),
-			...(nonNullish(token2) && { token2 }),
+			...(nonNullish(primaryToken) && { token: primaryToken }),
+			...(nonNullish(quote) && { token2: quote }),
 			...(nonNullish(side) && { side }),
 			...(nonNullish(orderType) && { orderType }),
 			...(notEmptyString(volume) && { volume }),

--- a/src/frontend/src/lib/services/trading-analytics.services.ts
+++ b/src/frontend/src/lib/services/trading-analytics.services.ts
@@ -18,16 +18,15 @@ export interface TrackTradingParams {
 	subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING;
 	// Lifecycle: `executing` when the flow starts, then `success` / `error`.
 	resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES;
-	// Pair leg symbols — free-form token symbols (no closed set), so kept as strings.
-	base?: string;
-	quote?: string;
+	// Primary token symbol — the single token for deposit/withdraw, or the base leg of an
+	// order pair. `token`/`token2` mirror the two-token shape used by the swap events.
+	token?: string;
+	// Second leg (the quote token) of an order pair; absent for deposit/withdraw.
+	token2?: string;
 	side?: LimitOrderSide;
 	orderType?: OisyTradeOrderType;
-	// Token symbol; open-ended like `base`/`quote`, so a plain symbol string.
-	token?: string;
-	// Traded amount in the relevant token's own units (the deposited/withdrawn token,
-	// or the order's base token), as a full-precision decimal string so volume can be
-	// aggregated per token in analytics.
+	// Traded amount in `token`'s own units (the deposited/withdrawn token, or the order's
+	// base token), as a full-precision decimal string so volume can be aggregated per token.
 	volume?: string;
 	// Sanitized (IC-request-id-stripped) error string; omitted when empty.
 	error?: string;
@@ -40,11 +39,10 @@ export interface TrackTradingParams {
 export const trackTrading = ({
 	subContext,
 	resultStatus,
-	base,
-	quote,
+	token,
+	token2,
 	side,
 	orderType,
-	token,
 	volume,
 	error
 }: TrackTradingParams) => {
@@ -55,11 +53,10 @@ export const trackTrading = ({
 			event_context: PLAUSIBLE_EVENT_CONTEXTS.TRADING,
 			event_subcontext: subContext,
 			result_status: resultStatus,
-			...(nonNullish(base) && { base }),
-			...(nonNullish(quote) && { quote }),
+			...(nonNullish(token) && { token }),
+			...(nonNullish(token2) && { token2 }),
 			...(nonNullish(side) && { side }),
 			...(nonNullish(orderType) && { orderType }),
-			...(nonNullish(token) && { token }),
 			...(notEmptyString(volume) && { volume }),
 			...(notEmptyString(error) && { result_error: error })
 		}

--- a/src/frontend/src/lib/services/trading-analytics.services.ts
+++ b/src/frontend/src/lib/services/trading-analytics.services.ts
@@ -25,6 +25,10 @@ export interface TrackTradingParams {
 	orderType?: OisyTradeOrderType;
 	// Token symbol; open-ended like `base`/`quote`, so a plain symbol string.
 	token?: string;
+	// Traded amount in the relevant token's own units (the deposited/withdrawn token,
+	// or the order's base token), as a full-precision decimal string so volume can be
+	// aggregated per token in analytics.
+	volume?: string;
 	// Sanitized (IC-request-id-stripped) error string; omitted when empty.
 	error?: string;
 }
@@ -41,6 +45,7 @@ export const trackTrading = ({
 	side,
 	orderType,
 	token,
+	volume,
 	error
 }: TrackTradingParams) => {
 	trackEvent({
@@ -55,6 +60,7 @@ export const trackTrading = ({
 			...(nonNullish(side) && { side }),
 			...(nonNullish(orderType) && { orderType }),
 			...(nonNullish(token) && { token }),
+			...(notEmptyString(volume) && { volume }),
 			...(notEmptyString(error) && { result_error: error })
 		}
 	});

--- a/src/frontend/src/tests/lib/services/trading-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/trading-analytics.services.spec.ts
@@ -19,8 +19,8 @@ describe('trading-analytics.services', () => {
 			trackTrading({
 				subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.LIMIT_ORDER,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.EXECUTING,
-				base: 'ICP',
-				quote: 'ckUSDC',
+				token: 'ICP',
+				token2: 'ckUSDC',
 				side: 'sell',
 				orderType: 'GTC',
 				volume: '12.5'
@@ -33,8 +33,8 @@ describe('trading-analytics.services', () => {
 					event_context: 'trading',
 					event_subcontext: 'limit_order',
 					result_status: 'executing',
-					base: 'ICP',
-					quote: 'ckUSDC',
+					token: 'ICP',
+					token2: 'ckUSDC',
 					side: 'sell',
 					orderType: 'GTC',
 					volume: '12.5'

--- a/src/frontend/src/tests/lib/services/trading-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/trading-analytics.services.spec.ts
@@ -19,13 +19,14 @@ describe('trading-analytics.services', () => {
 			trackTrading({
 				subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.LIMIT_ORDER,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.EXECUTING,
-				token: 'ICP',
-				token2: 'ckUSDC',
+				base: 'ICP',
+				quote: 'ckUSDC',
 				side: 'sell',
 				orderType: 'GTC',
 				volume: '12.5'
 			});
 
+			// `base`/`quote` params map onto the swap-style `token`/`token2` metadata keys.
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
 				name: 'trading',
 				metadata: {

--- a/src/frontend/src/tests/lib/services/trading-analytics.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/trading-analytics.services.spec.ts
@@ -22,7 +22,8 @@ describe('trading-analytics.services', () => {
 				base: 'ICP',
 				quote: 'ckUSDC',
 				side: 'sell',
-				orderType: 'GTC'
+				orderType: 'GTC',
+				volume: '12.5'
 			});
 
 			expect(trackEvent).toHaveBeenCalledExactlyOnceWith({
@@ -35,7 +36,8 @@ describe('trading-analytics.services', () => {
 					base: 'ICP',
 					quote: 'ckUSDC',
 					side: 'sell',
-					orderType: 'GTC'
+					orderType: 'GTC',
+					volume: '12.5'
 				}
 			});
 		});
@@ -61,11 +63,12 @@ describe('trading-analytics.services', () => {
 			});
 		});
 
-		it('omits absent optional fields and an empty error', () => {
+		it('omits absent optional fields, an empty volume and an empty error', () => {
 			trackTrading({
 				subContext: PLAUSIBLE_EVENT_SUBCONTEXT_TRADING.WITHDRAW,
 				resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
 				token: 'ckUSDC',
+				volume: '',
 				error: ''
 			});
 


### PR DESCRIPTION
# Motivation

The trading Plausible events (deposit, withdraw, limit order, cancel order) already carry the token(s) involved, but not how much was traded. Without an amount we can't measure volume per token in analytics.

# Changes

- Add an optional `volume` field to `TrackTradingParams`/`trackTrading`, emitted as a full-precision decimal string in the primary token's own units (omitted when empty).
- Represent order pairs with a `token` / `token2` shape (base = `token`, quote = `token2`), matching the two-token convention already used by the swap events, instead of the previous `base` / `quote` keys. Deposit/withdraw keep their single `token`.
- Wire volume at every trading flow:
  - Deposit: converts the smallest-unit `amount` to human units via `formatUnits(amount, token.decimals)`.
  - Withdraw: uses the entered (already human-unit) amount.
  - Limit order: base-token quantity.
  - Cancel order: the order's base quantity.
- Volume is always expressed in `token`'s own units (the base token for orders), so it can be aggregated per token.

# Tests

- Updated `trading-analytics.services.spec.ts` to assert `volume` and the `token`/`token2` pair are forwarded, and that an empty `volume` is omitted.
- `eslint` (changed files), `tsc --project tsconfig.spec.json`, `svelte-check` (0 errors), and the affected vitest specs (10 passed) all green.
