### PR TITLE
style(frontend): keep OISY TRADE badge inline with order row text

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
@@ -196,6 +196,7 @@
 	<div class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1 text-sm leading-snug text-primary">
 		{#if $isPrivacyMode}
 			<span class="inline-flex items-center gap-1"><IconDots variant="sm" /></span>
+			<TradingProviderTag />
 		{:else}
 			<span>
 				<span
@@ -205,10 +206,9 @@
 				>
 					{side === 'sell' ? $i18n.trading.orders.side_sell : $i18n.trading.orders.side_buy}
 				</span>
-				{rowText}
+				{rowText}<span class="ml-1 inline-flex align-middle"><TradingProviderTag /></span>
 			</span>
 		{/if}
-		<TradingProviderTag />
 	</div>
 
 	<span class="flex shrink-0 flex-col items-end gap-1">

--- a/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderRow.svelte
@@ -206,7 +206,7 @@
 				>
 					{side === 'sell' ? $i18n.trading.orders.side_sell : $i18n.trading.orders.side_buy}
 				</span>
-				{rowText}<span class="ml-1 inline-flex align-middle"><TradingProviderTag /></span>
+				{rowText} <span class="inline-flex align-middle"><TradingProviderTag /></span>
 			</span>
 		{/if}
 	</div>

--- a/src/frontend/src/tests/lib/components/trading/TradingOrderRow.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingOrderRow.svelte.spec.ts
@@ -77,6 +77,16 @@ describe('TradingOrderRow', () => {
 		expect(container).toHaveTextContent('Open');
 	});
 
+	it('renders the provider tag inline within the order intent text block', () => {
+		const { getByText } = render(TradingOrderRow, { props: { order } });
+
+		// The side label, order text and provider tag share one text block so the
+		// tag wraps with the text instead of dropping to its own flex line.
+		const textBlock = getByText('Sell').parentElement;
+
+		expect(textBlock).toHaveTextContent('OISY TRADE');
+	});
+
 	it('opens the order-detail modal with the order on click', async () => {
 		const openSpy = vi.spyOn(modalStore, 'openOisyTradeOrderDetail');
 


### PR DESCRIPTION
# Motivation

On mobile the "OISY TRADE" provider badge dropped onto its own line below each trading order row, because the badge was a separate flex item in a `flex-wrap` container and the order text filled the full width.

# Changes

- Move `TradingProviderTag` into the inline text flow, right after the order string, so the badge stays on the same row and wraps naturally with the text — with a small `ml-1` gap for separation.
- Keep the badge visible in privacy mode as an inline sibling next to the dots.

# Tests

Visual check on the Trading tab order rows at mobile width: the badge now sits inline after the order string with a bit of space, instead of on its own line.