### PR TITLE
fix(frontend): restore Popover wrapper padding regressed by native port

### DIFF
--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -221,8 +221,11 @@
 		color: var(--background-contrast);
 
 		// Folded in from the former gix.scss `div.popover .wrapper` override layer (OISY-owned):
-		// tighter padding, a 16px radius, and a matching first-paint width cap.
-		padding: var(--padding-0_5x);
+		// a 16px radius, a matching first-paint width cap, and `--padding` scaled to 0.5x so the
+		// placement calcs and inner content inherit the tighter unit. The wrapper's own box padding
+		// stays at `--padding-2x`: in gix the override's `padding` declaration lost specificity to
+		// gix's base `.wrapper { padding: var(--padding-2x) }`, so 2x is what actually rendered.
+		padding: var(--padding-2x);
 		--padding: var(--padding-0_5x);
 		--border-radius: 16px;
 


### PR DESCRIPTION
# Motivation

The account menu (and every other) popover lost padding on `main` vs prod. Measured on the live deployments (account menu open, computed styles of `.wrapper`):

| | oisy.com (prod, correct) | main / staging (regressed) |
| --- | --- | --- |
| `padding` | **14px** | **4px** |
| `--padding` | 0.5x | 0.5x (same) |
| border-radius | 16px | 16px |
| width | 312 | 292 |

Only the wrapper's own box `padding` changed (14px -> 4px); the 20px width drop is a consequence.

Root cause is in #13305 (native Popover port). It folded the former `gix.scss` `div.popover .wrapper` override assuming its `padding: var(--padding-0_5x)` line was live. In gix it never was: that declaration lost specificity to gix's own base `.wrapper { padding: var(--padding-2x) }`, so 14px is what actually rendered in prod. Only the override's `--padding: var(--padding-0_5x)` custom property took effect. Porting it into a scoped rule with no competing base made the previously-dead 0.5x line win, collapsing the padding to 4px.

# Changes

- `Popover.svelte`: set the wrapper box `padding` back to `var(--padding-2x)` (what prod renders) while keeping `--padding: var(--padding-0_5x)` for the placement calcs and inherited unit.
- Corrected the folded-comment, which wrongly claimed the override produced "tighter padding".

# Tests

- Confirmed prod's live computed `padding` is `14px` = `var(--padding-2x)`; the fix restores exactly that. `--padding`, radius, min-width, nav-item padding already matched.
- Existing `Popover.spec.ts` / `popover.utils.spec.ts` assert no wrapper padding value, so they are unaffected.
