### PR TITLE
chore(frontend): sync package-lock.json

### DIFF
--- a/docs/ai/frontend/testing.md
+++ b/docs/ai/frontend/testing.md
@@ -193,9 +193,7 @@ import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 describe('MaxBalanceButton', () => {
 	it('renders the max action label', () => {
 		render(MaxBalanceButton, {
-			props: {
-				/* … */
-			}
+			props: {/* … */}
 		});
 		expect(screen.getByRole('button', { name: get(i18n).core.text.max })).toBeInTheDocument();
 	});

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,9 +96,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@adraffy/ens-normalize": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-			"integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+			"integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
 			"license": "MIT"
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -166,13 +166,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -264,9 +264,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+			"integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
 			"dev": true,
 			"funding": [
 				{
@@ -308,9 +308,9 @@
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
-			"integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+			"integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
 			"dev": true,
 			"funding": [
 				{
@@ -324,7 +324,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.2",
+				"@csstools/color-helpers": "^6.1.0",
 				"@csstools/css-calc": "^3.2.1"
 			},
 			"engines": {
@@ -360,9 +360,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+			"integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -471,15 +471,15 @@
 			}
 		},
 		"node_modules/@dfinity/gix-components": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-10.0.2.tgz",
-			"integrity": "sha512-NklzZyiqLBw+vy5RWn9S2J+Kbo/Wu9jZQmHM+yTGSf8yerR5ub+eVas0zxHoLJ5Rcf3c87Nw2Br4Ic883HZhnQ==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/@dfinity/gix-components/-/gix-components-10.0.3.tgz",
+			"integrity": "sha512-isjoMW79PkRwnjkfhhimUl3Y1MhWlxQZmdQfXoRT7qIcmlASM6Wu3f4PaSlmlcFMIMRTVZ9BKlK2IUUkM3A3Qg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"decimal.js": "^10.6.0",
-				"dompurify": "^3.3.1",
+				"dompurify": "^3.4.11",
 				"html5-qrcode": "^2.3.8",
-				"marked": "^9.1.0",
+				"marked": "^18.0.5",
 				"qr-creator": "^1.0.0"
 			},
 			"engines": {
@@ -489,6 +489,18 @@
 			"peerDependencies": {
 				"@dfinity/utils": "*",
 				"svelte": "^5"
+			}
+		},
+		"node_modules/@dfinity/gix-components/node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@dfinity/ic-pub-key": {
@@ -631,10 +643,35 @@
 				"zod": "^4"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1446,9 +1483,9 @@
 			}
 		},
 		"node_modules/@icp-sdk/signer": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@icp-sdk/signer/-/signer-5.3.1.tgz",
-			"integrity": "sha512-2IJOdAnAit6SLZU3FTfPK0he4kCR+mr3IunDk62PgZCQKzvJ2DyV8FPBIceDpMSOXJLuXEMwd9E4Hdc53n0nrw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@icp-sdk/signer/-/signer-5.4.0.tgz",
+			"integrity": "sha512-l7HKJ02ZszAWvBV0dSW7uNVNVwsVAlWp9zMirHk/wrtQpglMDSxh1kcXiha5R5YkIooy/d5Pt8QKHDPG4Orj6A==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"@icp-sdk/core": "^5"
@@ -1552,15 +1589,6 @@
 				"@scure/bip32": "^1.7.0",
 				"@scure/bip39": "^1.6.0",
 				"asn1js": "^3.0.7"
-			}
-		},
-		"node_modules/@liquidium/client/node_modules/@scure/base": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
-			"integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@liquidium/client/node_modules/bech32": {
@@ -1702,9 +1730,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.137.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-			"integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+			"version": "0.138.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+			"integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2047,14 +2075,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.60.0"
+				"playwright": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2071,25 +2099,25 @@
 			"license": "MIT"
 		},
 		"node_modules/@reown/walletkit": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@reown/walletkit/-/walletkit-1.5.5.tgz",
-			"integrity": "sha512-Od8XpSCuGIkckTF5Qy7qUm0vcay98D0Vqz94wEUDz581nSipWfJIsKbm0dL2Da/wme/KcyIipLtfJN5w/GtnRw==",
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/@reown/walletkit/-/walletkit-1.5.6.tgz",
+			"integrity": "sha512-pTjarXQ57ImH8s5kUWRT3V++RNCZMGp9FQKODwobyPxmOPkfre3+s7v2PwwH2fDcoNwGRi2eblqoPx3qb9+NrQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@walletconnect/core": "2.23.9",
+				"@walletconnect/core": "2.23.10",
 				"@walletconnect/jsonrpc-provider": "1.0.14",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/logger": "3.0.2",
-				"@walletconnect/pay": "1.0.8",
-				"@walletconnect/sign-client": "2.23.9",
-				"@walletconnect/types": "2.23.9",
-				"@walletconnect/utils": "2.23.9"
+				"@walletconnect/pay": "1.0.9",
+				"@walletconnect/sign-client": "2.23.10",
+				"@walletconnect/types": "2.23.10",
+				"@walletconnect/utils": "2.23.10"
 			}
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
-			"integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+			"integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2104,9 +2132,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
-			"integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+			"integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2121,9 +2149,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
-			"integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+			"integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
 			"cpu": [
 				"x64"
 			],
@@ -2138,9 +2166,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
-			"integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+			"integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2155,9 +2183,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
-			"integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+			"integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
 			"cpu": [
 				"arm"
 			],
@@ -2172,9 +2200,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
-			"integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+			"integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
 			"cpu": [
 				"arm64"
 			],
@@ -2189,9 +2217,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
-			"integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+			"integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
 			"cpu": [
 				"arm64"
 			],
@@ -2206,9 +2234,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
-			"integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+			"integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2223,9 +2251,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
-			"integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+			"integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -2240,9 +2268,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-			"integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+			"integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
 			"cpu": [
 				"x64"
 			],
@@ -2257,9 +2285,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
-			"integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+			"integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2274,9 +2302,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
-			"integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+			"integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2291,9 +2319,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
-			"integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+			"integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -2309,10 +2337,44 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
-			"integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+			"integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2327,9 +2389,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
-			"integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+			"integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2747,9 +2809,9 @@
 			]
 		},
 		"node_modules/@scure/base": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-			"integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+			"integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
@@ -2769,6 +2831,15 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/@scure/bip32/node_modules/@scure/base": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+			"integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
 		"node_modules/@scure/bip39": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
@@ -2778,6 +2849,15 @@
 				"@noble/hashes": "~1.8.0",
 				"@scure/base": "~1.2.5"
 			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@scure/bip39/node_modules/@scure/base": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+			"integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+			"license": "MIT",
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
@@ -2792,12 +2872,12 @@
 			}
 		},
 		"node_modules/@solana-program/system": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.12.0.tgz",
-			"integrity": "sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.12.2.tgz",
+			"integrity": "sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@solana/kit": "^6.1.0"
+				"@solana/kit": "^6.4.0"
 			}
 		},
 		"node_modules/@solana-program/token": {
@@ -2823,17 +2903,17 @@
 			}
 		},
 		"node_modules/@solana/accounts": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.9.0.tgz",
-			"integrity": "sha512-g36AJreJrgf9AAjOfbdFHEFUTymBgzbWHoEDElZ+fDKvqBINDiUVKzDApwc7C7kGPMFqQBaoEHnQRxf2IqfKZQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.10.0.tgz",
+			"integrity": "sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/rpc-spec": "6.9.0",
-				"@solana/rpc-types": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/rpc-spec": "6.10.0",
+				"@solana/rpc-types": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -2848,16 +2928,16 @@
 			}
 		},
 		"node_modules/@solana/addresses": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.9.0.tgz",
-			"integrity": "sha512-tWnG2L6lo/ZhcMT019F3myDsH87MM8EZbTO0cgwgvVPlEdIGblROFF3tGVrb7FVCOlbPI0ONCFyPbnrmR58LsA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.10.0.tgz",
+			"integrity": "sha512-vEoCGBTxG0HCERAn84KXkrJjl+pDaNzOpZ0qbgcPS98fYxP5yzbKB8SNOY2bzrbkRUmmw5Q3hqTRERemUN2Gcw==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/assertions": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/nominal-types": "6.9.0"
+				"@solana/assertions": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/nominal-types": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -2872,12 +2952,12 @@
 			}
 		},
 		"node_modules/@solana/assertions": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.9.0.tgz",
-			"integrity": "sha512-FjWWD6e0in+HFsHMvU2zKCbyPfKtDW6iGXZZ9+Qg1QUYpO1AEObsya3F7hb9RkZKUueK4WwWAQnIuvEUp3A1uA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.10.0.tgz",
+			"integrity": "sha512-lKSAdVo+P/6Lp4vs6shstXmFOpvxrABwn4o1462tb7sKkNapk6o9pPFVPGw4DUgPS3WqWRs1j2tmpuVjhQRntg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0"
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -2892,17 +2972,17 @@
 			}
 		},
 		"node_modules/@solana/codecs": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.9.0.tgz",
-			"integrity": "sha512-oWOybKa1PTGI1D/FyrvGKralADM1jmVZC2AtgEo+4JTKG0+i1p9ZbwNY2UcJqdYsDMDaGHAx0LMAid9LDCxXTQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.10.0.tgz",
+			"integrity": "sha512-lLVuxod4ChWp9i7OvpgIykYG8Q9OGPVXKnHM9VlzDDLylsx7Y1FoQL00sHa7PqFkJVmkBufaA6dcGbQ7FU+lAQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-data-structures": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/fixed-points": "6.9.0",
-				"@solana/options": "6.9.0"
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-data-structures": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/fixed-points": "6.10.0",
+				"@solana/options": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -2917,12 +2997,12 @@
 			}
 		},
 		"node_modules/@solana/codecs-core": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
-			"integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.10.0.tgz",
+			"integrity": "sha512-nfAl9OMGo4HanIMxGsQoVB7BxMoqBCYEUxl8oEAZZ09pDxnaXQZkTRXEwPPccag37XfW1ciPd1vWPKwB2b0HHQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0"
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -2937,14 +3017,14 @@
 			}
 		},
 		"node_modules/@solana/codecs-data-structures": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.9.0.tgz",
-			"integrity": "sha512-f7GYtiHafvJDhqiwzUUSr/6AYSK4DCw6quPmA80NZGtkNiFa+g6LoJy2wbC0wp2dxvCwNpxf6x3ILCYRutAvvg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.10.0.tgz",
+			"integrity": "sha512-CNasJW3bq5u+632Zt5aJ8rOjAjv2HyenpV8o9kAIqdmV4CBpjCCoBnKn8LkuR/sbeREZxJYfhKTXO/9ruAkw7A==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/errors": "6.9.0"
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -2959,13 +3039,13 @@
 			}
 		},
 		"node_modules/@solana/codecs-numbers": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
-			"integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.10.0.tgz",
+			"integrity": "sha512-CcM+wX4zOiA9zkh8A7t1787A0Ehgmu5+6Z2tKoHew6cNw/dkaUTPa8JnNHbvfsLC8dfHC1BhAEJl86sKmRsfkQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/codecs-core": "6.9.0",
-				"@solana/errors": "6.9.0"
+				"@solana/codecs-core": "6.10.0",
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -2980,14 +3060,14 @@
 			}
 		},
 		"node_modules/@solana/codecs-strings": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
-			"integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.10.0.tgz",
+			"integrity": "sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/errors": "6.9.0"
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3006,13 +3086,13 @@
 			}
 		},
 		"node_modules/@solana/errors": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
-			"integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.10.0.tgz",
+			"integrity": "sha512-KBLAxCtAXr357JNhCyIDQXWbuSj5vN6w+28FSfcYY6OOSiphmXLAV3V58jgV0C6iNbIzFJFi6yatFyDTdeJsNg==",
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "5.6.2",
-				"commander": "14.0.3"
+				"commander": "15.0.0"
 			},
 			"bin": {
 				"errors": "bin/cli.mjs"
@@ -3029,10 +3109,19 @@
 				}
 			}
 		},
+		"node_modules/@solana/errors/node_modules/commander": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+			"integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
 		"node_modules/@solana/fast-stable-stringify": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.9.0.tgz",
-			"integrity": "sha512-l14zGVsURbT5Aox/kLFQywqV4VaE9/j3h2EvCu9oULVPMwzQB6yezJb1/KyiDwhm/RscooPd0gFQFIKEGQbayw==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.10.0.tgz",
+			"integrity": "sha512-iCNed27wk6PKSS3QUtHovRfMWF/jbVWogs2vB4tukKUCsqG4rDfDInIwZ6ur/nY6XTrgi2gMMdZq9GAUlWsbfw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.0"
@@ -3047,13 +3136,13 @@
 			}
 		},
 		"node_modules/@solana/fixed-points": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.9.0.tgz",
-			"integrity": "sha512-0K7mbYC4jdAZFlXqXjpNanmEyZxk7K9NtXDLc1zuhGuxwH8J9guvohwdw2V7TQ9bfjCYsprY3Tp2kUVQpECGmA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.10.0.tgz",
+			"integrity": "sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/codecs-core": "6.9.0",
-				"@solana/errors": "6.9.0"
+				"@solana/codecs-core": "6.10.0",
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3068,9 +3157,9 @@
 			}
 		},
 		"node_modules/@solana/functional": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.9.0.tgz",
-			"integrity": "sha512-sgNHOaIjETZZuziZdlwPsU5EjBVj5M0dUbwrSQTTNZe0SxX3pQ1QFVcs5KyvdS7AQcpBVdLjx4CfQjdKXk52GA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.10.0.tgz",
+			"integrity": "sha512-P8cevu4mAqHTXC37h1TVoOh8zhWB2tlOI/R9vWjYPpcLwcyWf8p2qq4LEGHl5kY+1C+4PNX39HsmCocXOPCDkQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.0"
@@ -3085,17 +3174,17 @@
 			}
 		},
 		"node_modules/@solana/instruction-plans": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.9.0.tgz",
-			"integrity": "sha512-SxTSOetEKD+WPzvDuYRsP1+KkwUp8KqL1n7oFx9ThxjyfEY0ly0i9KdbvX5yYVDOA2TSwrltgdu14y/Pf6y3Cg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.10.0.tgz",
+			"integrity": "sha512-YG7mo4zykzdc6ZTV0BuN6pveK9qeBySzlYYerq578A4eQu3xcypMAYRGAvhMZtWTanjjmD6CKtM0M7kVp0TNxg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0",
-				"@solana/instructions": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/promises": "6.9.0",
-				"@solana/transaction-messages": "6.9.0",
-				"@solana/transactions": "6.9.0"
+				"@solana/errors": "6.10.0",
+				"@solana/instructions": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/promises": "6.10.0",
+				"@solana/transaction-messages": "6.10.0",
+				"@solana/transactions": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3110,13 +3199,13 @@
 			}
 		},
 		"node_modules/@solana/instructions": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.9.0.tgz",
-			"integrity": "sha512-LZfJx3bGdUSbGaswoOEPHygticqkCg3TusRczPJXyCmKhoQzPCcGQQ99qMzP7Wg8pEV5tWA5t7tycf8E237ydg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.10.0.tgz",
+			"integrity": "sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/codecs-core": "6.9.0",
-				"@solana/errors": "6.9.0"
+				"@solana/codecs-core": "6.10.0",
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3131,17 +3220,17 @@
 			}
 		},
 		"node_modules/@solana/keys": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.9.0.tgz",
-			"integrity": "sha512-1g2QARiqSjNqT0EIqLDLQ5vRm7hCsbqgFwFAp5GsMV/8BTYT8s1Ct2wLHDZiJ4eAX6beTHVf8LbOBfVejtn3oQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.10.0.tgz",
+			"integrity": "sha512-26IRfdm/hTUCmM7MeEeX0ULSbCM6OzkZTkfkrPircqmRM7xyNqP4hq7u0P7wjb9dl7NfgyG6K7cdvUxrj2e3mA==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/assertions": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/nominal-types": "6.9.0",
-				"@solana/promises": "6.9.0"
+				"@solana/assertions": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/nominal-types": "6.10.0",
+				"@solana/promises": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3156,37 +3245,37 @@
 			}
 		},
 		"node_modules/@solana/kit": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.9.0.tgz",
-			"integrity": "sha512-k7BRz7Akfv8wiRtlCR/xUyDLfuMfYMelMR1+AC5KgwaRRJReDF0BucMLNN1In7WoI+KuWwr1OKv4na/oKpyeAQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.10.0.tgz",
+			"integrity": "sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@solana/accounts": "6.9.0",
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/functional": "6.9.0",
-				"@solana/instruction-plans": "6.9.0",
-				"@solana/instructions": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/offchain-messages": "6.9.0",
-				"@solana/plugin-core": "6.9.0",
-				"@solana/plugin-interfaces": "6.9.0",
-				"@solana/program-client-core": "6.9.0",
-				"@solana/programs": "6.9.0",
-				"@solana/rpc": "6.9.0",
-				"@solana/rpc-api": "6.9.0",
-				"@solana/rpc-parsed-types": "6.9.0",
-				"@solana/rpc-spec-types": "6.9.0",
-				"@solana/rpc-subscriptions": "6.9.0",
-				"@solana/rpc-types": "6.9.0",
-				"@solana/signers": "6.9.0",
-				"@solana/subscribable": "6.9.0",
-				"@solana/sysvars": "6.9.0",
-				"@solana/transaction-confirmation": "6.9.0",
-				"@solana/transaction-messages": "6.9.0",
-				"@solana/transactions": "6.9.0"
+				"@solana/accounts": "6.10.0",
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/functional": "6.10.0",
+				"@solana/instruction-plans": "6.10.0",
+				"@solana/instructions": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/offchain-messages": "6.10.0",
+				"@solana/plugin-core": "6.10.0",
+				"@solana/plugin-interfaces": "6.10.0",
+				"@solana/program-client-core": "6.10.0",
+				"@solana/programs": "6.10.0",
+				"@solana/rpc": "6.10.0",
+				"@solana/rpc-api": "6.10.0",
+				"@solana/rpc-parsed-types": "6.10.0",
+				"@solana/rpc-spec-types": "6.10.0",
+				"@solana/rpc-subscriptions": "6.10.0",
+				"@solana/rpc-types": "6.10.0",
+				"@solana/signers": "6.10.0",
+				"@solana/subscribable": "6.10.0",
+				"@solana/sysvars": "6.10.0",
+				"@solana/transaction-confirmation": "6.10.0",
+				"@solana/transaction-messages": "6.10.0",
+				"@solana/transactions": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3201,17 +3290,17 @@
 			}
 		},
 		"node_modules/@solana/kit/node_modules/@solana/sysvars": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.9.0.tgz",
-			"integrity": "sha512-e0e+QKr/th9t/O2N1oUoJmcodLghzAtWKUlGb1zyYub0/WJrPImnKqJqp/gDP4tK98mJxopPMcprCeHk4B+TQg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.10.0.tgz",
+			"integrity": "sha512-cG13p1+onxz+20iWjwWQr1Z1jQwPm0fnjoW75fqZq7p4rVCie3L2sXvaJsYPjWKrUvpOzOIEHnqZGkG05rCpjg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/accounts": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-data-structures": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/rpc-types": "6.9.0"
+				"@solana/accounts": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-data-structures": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/rpc-types": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3226,9 +3315,9 @@
 			}
 		},
 		"node_modules/@solana/nominal-types": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.9.0.tgz",
-			"integrity": "sha512-ouhrnY7a6nsLXRGcariwcmHDdXroCNqOuzwtdjKt2c8e8Drwao9yxPH2VoViNgpq8IGNJeQMEI1TVnoJZRn0gw==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.10.0.tgz",
+			"integrity": "sha512-9ykyBBvnkInH7fCacjJi7zu2PJyd+OCt+VTjIISv070fHzKIMFqZqJJ/dJ0SRH2aHwfB3n86iVsmtBtuxi4KKA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.0"
@@ -3243,19 +3332,19 @@
 			}
 		},
 		"node_modules/@solana/offchain-messages": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.9.0.tgz",
-			"integrity": "sha512-qK3tqRPb+E0kmTz5qFXZbEdF4pyzfOWRZjyVESHVGemDDeGzZ1SV3zAxcA6HBCnv4wCBnlyaDPw8t+5sryNMAw==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.10.0.tgz",
+			"integrity": "sha512-RiEgAueeMkFMC1suOXBIcmCZgtXRxy24yk0DldPB37bB4zwOF1SAaRjNRPjIkGK8RhCYrEpPosnzLyavw9ueRg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-data-structures": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/nominal-types": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-data-structures": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/nominal-types": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3270,16 +3359,16 @@
 			}
 		},
 		"node_modules/@solana/options": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/options/-/options-6.9.0.tgz",
-			"integrity": "sha512-H5ZRWNzzLMwHU/fRU9aVx+3TaMN4gDNCUYxsZxq0h7mqiwxFy6mpy95xPsfdldthCHDYtYnUTxe2sBatGbNHig==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/options/-/options-6.10.0.tgz",
+			"integrity": "sha512-RO9UT3UYD8/Cu2uM6ZXbKvLeMnVD42+g9JRds7Pfs4AhiOyg4R4TJrQUAppTgavPTO3PBRlWtWOC05ZH/yAIbg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-data-structures": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0"
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-data-structures": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3294,9 +3383,9 @@
 			}
 		},
 		"node_modules/@solana/plugin-core": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.9.0.tgz",
-			"integrity": "sha512-KslLSnzY8zbGZibEBVMVUm2ZS8T2xf+cut7F65VjWPoWNAxU+p7933wsMz/az6CF7b65RI7iU3HhCr5/5QF50w==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.10.0.tgz",
+			"integrity": "sha512-JE70YTQOfFACVFGvoJon4Scc/eHUWjMu8Ovo35CcV2kHTAHYMCd4UkBd2gmlhK0vRMMomsQi1ZLPlAlTq0OoUQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.0"
@@ -3311,18 +3400,18 @@
 			}
 		},
 		"node_modules/@solana/plugin-interfaces": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.9.0.tgz",
-			"integrity": "sha512-Qj4sk9thkM1UgnFXvWIoezd/CbqpX/2jigLBDsMB5Ed/gmFlkBSTL127LFDSY3OtzBpXl4hROs+Zqv+5xqtguA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.10.0.tgz",
+			"integrity": "sha512-vr0/l9wcM4orwGr8cjkFWaJ9A4HvzuAv00jMFNMg0Spd0GZqnwnpW+D/fXa1lIJnTRaF3EeEjLh4VjKU037T0Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/instruction-plans": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/rpc-spec": "6.9.0",
-				"@solana/rpc-subscriptions-spec": "6.9.0",
-				"@solana/rpc-types": "6.9.0",
-				"@solana/signers": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/instruction-plans": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/rpc-spec": "6.10.0",
+				"@solana/rpc-subscriptions-spec": "6.10.0",
+				"@solana/rpc-types": "6.10.0",
+				"@solana/signers": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3337,20 +3426,20 @@
 			}
 		},
 		"node_modules/@solana/program-client-core": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.9.0.tgz",
-			"integrity": "sha512-+iUnsddhs72QoBJoUO+/yHUXoBvYWa1sGCBRJk35zeg8j7ZXEwRkk6eX0VOrUPxhEpQbYJsIOCrIYApNIt8RFw==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.10.0.tgz",
+			"integrity": "sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/accounts": "6.9.0",
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/instruction-plans": "6.9.0",
-				"@solana/instructions": "6.9.0",
-				"@solana/plugin-interfaces": "6.9.0",
-				"@solana/rpc-api": "6.9.0",
-				"@solana/signers": "6.9.0"
+				"@solana/accounts": "6.10.0",
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/instruction-plans": "6.10.0",
+				"@solana/instructions": "6.10.0",
+				"@solana/plugin-interfaces": "6.10.0",
+				"@solana/rpc-api": "6.10.0",
+				"@solana/signers": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3365,13 +3454,13 @@
 			}
 		},
 		"node_modules/@solana/programs": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.9.0.tgz",
-			"integrity": "sha512-L9LAnQtfFFcCDLcbbnxhUtgAmu/kS4aRmrVncdnX5CFyQshlpo0/Qhrq3UA7vnhute4gjYV4pFT+64onH5qGEQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.10.0.tgz",
+			"integrity": "sha512-qn/HeLP5KGUJXVub3fyGe69/rWaLX4jzwm6V/1pNxJDbdF+MBdgn18hP6F+VmhfdNmwK0lue3J/1HQ1UTMuQeQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/errors": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/errors": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3386,9 +3475,9 @@
 			}
 		},
 		"node_modules/@solana/promises": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.9.0.tgz",
-			"integrity": "sha512-227PlXRi6KZX4ODYTkJitr9InSa79NTquI72slay4gzxO9VmMepgvYdMAX6kawdN5pt+VzaklKhNhWXk50Pi9g==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.10.0.tgz",
+			"integrity": "sha512-oJSIn+VBBMWDo8oqw7RV3tI6Jih+Ieup6FcQLYLDUriaeo7+8l1Zdezl8zh7SIfeU4lOfAbRg6mR0huaS/Lltg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.0"
@@ -3403,20 +3492,20 @@
 			}
 		},
 		"node_modules/@solana/rpc": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.9.0.tgz",
-			"integrity": "sha512-ny1Kt20+oq3xZErNA56+Magmb2JKYfQgHwZTsBmHKVl/9mBpv1y1+ygV+KNiiX/wWXWstLbdIo1jgPwZPbU2Vg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.10.0.tgz",
+			"integrity": "sha512-EwxsqoD+NXV+m+iobnWNtATD93gTgaNsOiQOzYB1/2e+8S6fl6obdNPB55yfXgtl4jt6GV6/ae4xuPhLv76vvg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0",
-				"@solana/fast-stable-stringify": "6.9.0",
-				"@solana/functional": "6.9.0",
-				"@solana/rpc-api": "6.9.0",
-				"@solana/rpc-spec": "6.9.0",
-				"@solana/rpc-spec-types": "6.9.0",
-				"@solana/rpc-transformers": "6.9.0",
-				"@solana/rpc-transport-http": "6.9.0",
-				"@solana/rpc-types": "6.9.0"
+				"@solana/errors": "6.10.0",
+				"@solana/fast-stable-stringify": "6.10.0",
+				"@solana/functional": "6.10.0",
+				"@solana/rpc-api": "6.10.0",
+				"@solana/rpc-spec": "6.10.0",
+				"@solana/rpc-spec-types": "6.10.0",
+				"@solana/rpc-transformers": "6.10.0",
+				"@solana/rpc-transport-http": "6.10.0",
+				"@solana/rpc-types": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3431,22 +3520,22 @@
 			}
 		},
 		"node_modules/@solana/rpc-api": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.9.0.tgz",
-			"integrity": "sha512-3KhXS6A1ie6GqTywW/KEMSXJ1VJEU66fxjhuiiqPILuJstP7kex3ycr3H6DirKydUsy6gaKaPN43rE+LfyS7OA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.10.0.tgz",
+			"integrity": "sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/rpc-parsed-types": "6.9.0",
-				"@solana/rpc-spec": "6.9.0",
-				"@solana/rpc-transformers": "6.9.0",
-				"@solana/rpc-types": "6.9.0",
-				"@solana/transaction-messages": "6.9.0",
-				"@solana/transactions": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/rpc-parsed-types": "6.10.0",
+				"@solana/rpc-spec": "6.10.0",
+				"@solana/rpc-transformers": "6.10.0",
+				"@solana/rpc-types": "6.10.0",
+				"@solana/transaction-messages": "6.10.0",
+				"@solana/transactions": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3461,9 +3550,9 @@
 			}
 		},
 		"node_modules/@solana/rpc-parsed-types": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.9.0.tgz",
-			"integrity": "sha512-6ThH8izY+DWDyrVOOlS40vTcFjwjCinjfqnId7zhRk8OxhkfHQ/iEj+OnGwD4Yhe8pGdVa7GNVYlrQgQgzQ3eQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.10.0.tgz",
+			"integrity": "sha512-5275mvSV1mxhwvrMVa+K7BU/nAetpHfcb+8Ql9rtA8RRf6DyiimFQFZUukE4Ez6XJihEpCHNy98yhkgai9wytQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.0"
@@ -3478,13 +3567,14 @@
 			}
 		},
 		"node_modules/@solana/rpc-spec": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.9.0.tgz",
-			"integrity": "sha512-3yHRoChc0IpsJbUq0/94l+ar3t9U3Ax58W0HON7eyYe7zFP10UAxpkHn7DPch9DeALyuGph8kVnvl+kXRgJlGg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.10.0.tgz",
+			"integrity": "sha512-yQdbWw5mZEWrwsunHR9NHkuhMXIB9sPOObwm18D53v5tAJnxTB0IcHvO647XqFDLTK/yQ4AdDtlYD1vsY07AMQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0",
-				"@solana/rpc-spec-types": "6.9.0"
+				"@solana/errors": "6.10.0",
+				"@solana/rpc-spec-types": "6.10.0",
+				"@solana/subscribable": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3499,9 +3589,9 @@
 			}
 		},
 		"node_modules/@solana/rpc-spec-types": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.9.0.tgz",
-			"integrity": "sha512-A4fY1JRrcKqX3EfttO4Q8L97nGPqdjfekAV0eDyxN5nu9ngf5p7GKenkl7AYDoHLNr6ZX/C96cRADxXjsRJ0iA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.10.0.tgz",
+			"integrity": "sha512-NDZrKyZrJk4HaMFhTE/lAiMB824cWAodKqDHyKi0UteHU9pyRmil3BN1jt7e+j08mwMWwfklSgyrTaq52g6DIQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.0"
@@ -3516,22 +3606,22 @@
 			}
 		},
 		"node_modules/@solana/rpc-subscriptions": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.9.0.tgz",
-			"integrity": "sha512-IMctZQaMxzvRACQ6ooW98lP+7tVoUJnRgOZtkAdzgBizldQAYPIKd3MulP0jbQPCMfdPsa2Hs0NBcUwfgonq3w==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.10.0.tgz",
+			"integrity": "sha512-6mfuHp/K7unFKCOTCCBC9ziEGnxe2tyJ74EbR51QUnBeCUdYD7Hhdpxic1WRSJ3UeNW/mG4OzFM6z8Wi64Eh9Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0",
-				"@solana/fast-stable-stringify": "6.9.0",
-				"@solana/functional": "6.9.0",
-				"@solana/promises": "6.9.0",
-				"@solana/rpc-spec-types": "6.9.0",
-				"@solana/rpc-subscriptions-api": "6.9.0",
-				"@solana/rpc-subscriptions-channel-websocket": "6.9.0",
-				"@solana/rpc-subscriptions-spec": "6.9.0",
-				"@solana/rpc-transformers": "6.9.0",
-				"@solana/rpc-types": "6.9.0",
-				"@solana/subscribable": "6.9.0"
+				"@solana/errors": "6.10.0",
+				"@solana/fast-stable-stringify": "6.10.0",
+				"@solana/functional": "6.10.0",
+				"@solana/promises": "6.10.0",
+				"@solana/rpc-spec-types": "6.10.0",
+				"@solana/rpc-subscriptions-api": "6.10.0",
+				"@solana/rpc-subscriptions-channel-websocket": "6.10.0",
+				"@solana/rpc-subscriptions-spec": "6.10.0",
+				"@solana/rpc-transformers": "6.10.0",
+				"@solana/rpc-types": "6.10.0",
+				"@solana/subscribable": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3546,18 +3636,18 @@
 			}
 		},
 		"node_modules/@solana/rpc-subscriptions-api": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.9.0.tgz",
-			"integrity": "sha512-UA/rPQeNx6zQMUFcS8PPPuB4vzUOtSzIY/igMH0DRoP020NyES2GguIb7Zo7sqDNi4n0gkQRhoW4dPVotcNKdA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.10.0.tgz",
+			"integrity": "sha512-CRPQoTtT1cOwOQUsqS7jgo7wYdAj7jB5ab/UmMPWVpecf2FNMhWhgvxP2s82M7VkDGTGl13qaQ0WySmi7Egrlg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/rpc-subscriptions-spec": "6.9.0",
-				"@solana/rpc-transformers": "6.9.0",
-				"@solana/rpc-types": "6.9.0",
-				"@solana/transaction-messages": "6.9.0",
-				"@solana/transactions": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/rpc-subscriptions-spec": "6.10.0",
+				"@solana/rpc-transformers": "6.10.0",
+				"@solana/rpc-types": "6.10.0",
+				"@solana/transaction-messages": "6.10.0",
+				"@solana/transactions": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3572,16 +3662,16 @@
 			}
 		},
 		"node_modules/@solana/rpc-subscriptions-channel-websocket": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.9.0.tgz",
-			"integrity": "sha512-kT8Yne9HjJD2gooaOFNSyKrvaIfOy2GR0Ymv8OfecBCwFStdz+SPo5eYXq8ZWoZbr5E/MMpHgqsHBanqa2Ffyg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.10.0.tgz",
+			"integrity": "sha512-KkqP1186HELPlJftA88SNAT2znR8knCVzsUipXVzY4zfW8sN3LOa0ePMzh9VZ/V+J+raTt55laR87ovAO0n+zw==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0",
-				"@solana/functional": "6.9.0",
-				"@solana/rpc-subscriptions-spec": "6.9.0",
-				"@solana/subscribable": "6.9.0",
-				"ws": "^8.19.0"
+				"@solana/errors": "6.10.0",
+				"@solana/functional": "6.10.0",
+				"@solana/rpc-subscriptions-spec": "6.10.0",
+				"@solana/subscribable": "6.10.0",
+				"ws": "^8.21.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3596,15 +3686,15 @@
 			}
 		},
 		"node_modules/@solana/rpc-subscriptions-spec": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.9.0.tgz",
-			"integrity": "sha512-DbaG67s99vRZQxFMK80UQ7DEKkRJK6JEZeYg/U5UttD6n7ax/vct7qopxGnrt4RCkaaac2fU8Sr+fcnvWQweUg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.10.0.tgz",
+			"integrity": "sha512-nWMwGaG4ulzeX2sskY5TywXF3cwEd8FDmUpLe2JBWxE8XDAOGOKcsYPYFcBgb8ee9KqfPT2PTNdcz9jOhJf34w==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0",
-				"@solana/promises": "6.9.0",
-				"@solana/rpc-spec-types": "6.9.0",
-				"@solana/subscribable": "6.9.0"
+				"@solana/errors": "6.10.0",
+				"@solana/promises": "6.10.0",
+				"@solana/rpc-spec-types": "6.10.0",
+				"@solana/subscribable": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3619,16 +3709,16 @@
 			}
 		},
 		"node_modules/@solana/rpc-transformers": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.9.0.tgz",
-			"integrity": "sha512-dg4LK2wEBpaY+KRk/SJIkYvrvjdsc1AwD4bkmGY4Fp7EwVlvwBQShAQn78Qi4IP0WQ/0n9ncFyUxgcB1Y01ZuQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.10.0.tgz",
+			"integrity": "sha512-2nFUrVTiE720pJOY4XKx3HuYmishw0of/4oScu76YGm6O8wsmvFvPNAkrEinmieWXQkfpBfRvLZmpl8PaAy+ug==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0",
-				"@solana/functional": "6.9.0",
-				"@solana/nominal-types": "6.9.0",
-				"@solana/rpc-spec-types": "6.9.0",
-				"@solana/rpc-types": "6.9.0"
+				"@solana/errors": "6.10.0",
+				"@solana/functional": "6.10.0",
+				"@solana/nominal-types": "6.10.0",
+				"@solana/rpc-spec-types": "6.10.0",
+				"@solana/rpc-types": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3643,15 +3733,15 @@
 			}
 		},
 		"node_modules/@solana/rpc-transport-http": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.9.0.tgz",
-			"integrity": "sha512-4gy30fWJcS6jrcXCoP/optFpGJ/gD9xdkE8wDbe1Ys/Y+e4XjyBt45xtTnbdmMdukvdRX+oXS3zgUIYoagpNzQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.10.0.tgz",
+			"integrity": "sha512-JrdNuYi0nBbD3X8JUtgX1dQJwIwz/WJvmigDdELysXfGB2bTJpfjqGDLhCLOz2sRl66FASIEqgG/LVa2C9VXcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0",
-				"@solana/rpc-spec": "6.9.0",
-				"@solana/rpc-spec-types": "6.9.0",
-				"undici-types": "^8.2.0"
+				"@solana/errors": "6.10.0",
+				"@solana/rpc-spec": "6.10.0",
+				"@solana/rpc-spec-types": "6.10.0",
+				"undici-types": "^8.4.1"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3666,18 +3756,18 @@
 			}
 		},
 		"node_modules/@solana/rpc-types": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.9.0.tgz",
-			"integrity": "sha512-iFhPzZK3qiQ1lhfNTNBTI7BIs5PfWZSgRLD3enKm8ZAQggzvUklfO3KPh47jVsc/Jsr1UGPH8M3o3m17qjO1Cg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.10.0.tgz",
+			"integrity": "sha512-zaSecTfCPvz/vcoAmKD6XoRstGHTr1EKJBD8T9UcpEFFB6CtF6DxerDB+wrzkamuT6msmnR2DWXMrYOGDAsgIg==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/fixed-points": "6.9.0",
-				"@solana/nominal-types": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/fixed-points": "6.10.0",
+				"@solana/nominal-types": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3692,20 +3782,20 @@
 			}
 		},
 		"node_modules/@solana/signers": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.9.0.tgz",
-			"integrity": "sha512-x7WyoRm9IORMqeSqNivZgyY+RERPkmqWxpINPD13kUH+oaZzonORIgxk2Lz+u5iPRXiJPkdRPrQ4FoFWv8i6kQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.10.0.tgz",
+			"integrity": "sha512-+vtCc+mT1FpGxrA5oL2aaMxSHiMJ2hH5PcDIfjo2XJkHz2klZiCZyT5F9+zpltc9vdi1QTElQq59Sfplmtd33A==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/instructions": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/nominal-types": "6.9.0",
-				"@solana/offchain-messages": "6.9.0",
-				"@solana/transaction-messages": "6.9.0",
-				"@solana/transactions": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/instructions": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/nominal-types": "6.10.0",
+				"@solana/offchain-messages": "6.10.0",
+				"@solana/transaction-messages": "6.10.0",
+				"@solana/transactions": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -3720,12 +3810,13 @@
 			}
 		},
 		"node_modules/@solana/subscribable": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.9.0.tgz",
-			"integrity": "sha512-YV0/BrJNfepf10CTfLwD7kRY1kkELDHd+BbHJZhBeiuiXTY3xQTvvx1RFs3NtfFCcTHG25Uh8NpRacQJnxSSIQ==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.10.0.tgz",
+			"integrity": "sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/errors": "6.9.0"
+				"@solana/errors": "6.10.0",
+				"@solana/promises": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -4082,21 +4173,21 @@
 			}
 		},
 		"node_modules/@solana/transaction-confirmation": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.9.0.tgz",
-			"integrity": "sha512-fzYCOih7hhtBzzNSkAnxMjeFeQ8U7e27k9i0RsgQc3/e3OCynF5HoIVNhhqZbwfIBKiaD4ginJR6slRnfqO32Q==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.10.0.tgz",
+			"integrity": "sha512-ULvtg65qfenh4T/GYcIlKSUv5EqDcng9UN0dxbHU4kuZdR2e0B8HN2xDC4WhcFQVeFJSbTZmaYFkeTY/Y4gfGQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/promises": "6.9.0",
-				"@solana/rpc": "6.9.0",
-				"@solana/rpc-subscriptions": "6.9.0",
-				"@solana/rpc-types": "6.9.0",
-				"@solana/transaction-messages": "6.9.0",
-				"@solana/transactions": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/promises": "6.10.0",
+				"@solana/rpc": "6.10.0",
+				"@solana/rpc-subscriptions": "6.10.0",
+				"@solana/rpc-types": "6.10.0",
+				"@solana/transaction-messages": "6.10.0",
+				"@solana/transactions": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -4111,20 +4202,20 @@
 			}
 		},
 		"node_modules/@solana/transaction-messages": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.9.0.tgz",
-			"integrity": "sha512-OWpryt0w6SHlwHx12Vd1wvx2QwSGBXAIUEHTCtkctcM3AaZRy5cIl7CAq9iD5PgahUsaOyRLBV0zlCJcC2JrJA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.10.0.tgz",
+			"integrity": "sha512-s7v8G3BTxGlKYIj3eWCG0g1296v+1LBt16mVnlRH5FuyaJ5AdhlhtRho5HUDpdwE8EXun+y1c48V6uhcZ8wdbQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-data-structures": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/functional": "6.9.0",
-				"@solana/instructions": "6.9.0",
-				"@solana/nominal-types": "6.9.0",
-				"@solana/rpc-types": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-data-structures": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/functional": "6.10.0",
+				"@solana/instructions": "6.10.0",
+				"@solana/nominal-types": "6.10.0",
+				"@solana/rpc-types": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -4139,23 +4230,23 @@
 			}
 		},
 		"node_modules/@solana/transactions": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.9.0.tgz",
-			"integrity": "sha512-uKPzLwHbjwChfVl82he17ntkh02PfgnMMhN7uOAC+VbkIt1O+EEw8sX87gi6kdG/EV+QBDQXm9PLAo5W0tYylw==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.10.0.tgz",
+			"integrity": "sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA==",
 			"license": "MIT",
 			"dependencies": {
-				"@solana/addresses": "6.9.0",
-				"@solana/codecs-core": "6.9.0",
-				"@solana/codecs-data-structures": "6.9.0",
-				"@solana/codecs-numbers": "6.9.0",
-				"@solana/codecs-strings": "6.9.0",
-				"@solana/errors": "6.9.0",
-				"@solana/functional": "6.9.0",
-				"@solana/instructions": "6.9.0",
-				"@solana/keys": "6.9.0",
-				"@solana/nominal-types": "6.9.0",
-				"@solana/rpc-types": "6.9.0",
-				"@solana/transaction-messages": "6.9.0"
+				"@solana/addresses": "6.10.0",
+				"@solana/codecs-core": "6.10.0",
+				"@solana/codecs-data-structures": "6.10.0",
+				"@solana/codecs-numbers": "6.10.0",
+				"@solana/codecs-strings": "6.10.0",
+				"@solana/errors": "6.10.0",
+				"@solana/functional": "6.10.0",
+				"@solana/instructions": "6.10.0",
+				"@solana/keys": "6.10.0",
+				"@solana/nominal-types": "6.10.0",
+				"@solana/rpc-types": "6.10.0",
+				"@solana/transaction-messages": "6.10.0"
 			},
 			"engines": {
 				"node": ">=20.18.0"
@@ -4196,9 +4287,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.65.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.65.1.tgz",
-			"integrity": "sha512-Sa1rFYYqBB+zv3rIxAg/CsFskR/x4aj5BY/hvLxBd9r/mqbipxM945As1K3PqsDicJAyekPR0BlWoVIiw2OHYg==",
+			"version": "2.69.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.1.tgz",
+			"integrity": "sha512-+nz8Fx/cElzb2ZPHC+6Ll3y3NEVIe4Na75PeplLlyTmd1dBXAjz2KR14y1ZgNjb2ThfAYzulu+PFy1UE3RCUzA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -4239,9 +4330,9 @@
 			}
 		},
 		"node_modules/@sveltejs/load-config": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.1.1.tgz",
-			"integrity": "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+			"integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4511,51 +4602,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Brooooooklyn"
-			},
-			"peerDependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "0BSD",
-			"optional": true
-		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
@@ -4662,14 +4708,14 @@
 			}
 		},
 		"node_modules/@testing-library/svelte": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
-			"integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.4.2.tgz",
+			"integrity": "sha512-4o31E4HGo5BU5KwPkulNRocEden+7Tt9JYm9uhln5ajF7DULeyFA46BBWVfKJ8Ms9B3JmOFPTIiVamH7n3KpuQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@testing-library/dom": "9.x.x || 10.x.x",
-				"@testing-library/svelte-core": "1.0.0"
+				"@testing-library/svelte-core": "1.1.3"
 			},
 			"engines": {
 				"node": ">= 10"
@@ -4689,9 +4735,9 @@
 			}
 		},
 		"node_modules/@testing-library/svelte-core": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
-			"integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.1.3.tgz",
+			"integrity": "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4778,9 +4824,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.19.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-			"integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+			"version": "22.20.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+			"integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -5356,40 +5402,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
 		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
@@ -5433,9 +5445,9 @@
 			]
 		},
 		"node_modules/@velora-dex/sdk": {
-			"version": "9.5.3",
-			"resolved": "https://registry.npmjs.org/@velora-dex/sdk/-/sdk-9.5.3.tgz",
-			"integrity": "sha512-yTPbxdQxN8D2R6BY8sydHNDEIS8UaF5b6f++fNvDD3rpSYdYT0E+qaIcQ4qLpFctS7ZBMgUH2O/J1Ta6yTgh7Q==",
+			"version": "9.5.4",
+			"resolved": "https://registry.npmjs.org/@velora-dex/sdk/-/sdk-9.5.4.tgz",
+			"integrity": "sha512-nQw039K6PO+Yvq88CHgK6q2uiu6cugTGnX/6Q0fbAFDvrWa+xRMhja7kvRfFMFMccAcOTeJWB/NCCZNr3HjWvg==",
 			"license": "MIT",
 			"dependencies": {
 				"@paraswap/core": "2.4.3",
@@ -5654,9 +5666,9 @@
 			}
 		},
 		"node_modules/@walletconnect/core": {
-			"version": "2.23.9",
-			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.9.tgz",
-			"integrity": "sha512-ws4WG8LeagUo2ERRo02HryXRcpwIRmCQ3pHLW5gWbVReLXXIpgk6ZAfID3fEGHevIwwnHSGww+nNhNpdXyiq0g==",
+			"version": "2.23.10",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.10.tgz",
+			"integrity": "sha512-Qq2btHEoCgruvkZCWLSrVsvg/dYbM9Z045qeClwhJR4meL32jbIRT0mKWjf0HkRc2LA82MsnszVnfuZl3yWl5A==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/heartbeat": "1.2.2",
@@ -5670,10 +5682,10 @@
 				"@walletconnect/relay-auth": "1.1.0",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.23.9",
-				"@walletconnect/utils": "2.23.9",
+				"@walletconnect/types": "2.23.10",
+				"@walletconnect/utils": "2.23.10",
 				"@walletconnect/window-getters": "1.0.1",
-				"es-toolkit": "1.44.0",
+				"es-toolkit": "1.45.1",
 				"events": "3.3.0",
 				"uint8arrays": "3.1.1"
 			},
@@ -5824,15 +5836,15 @@
 			}
 		},
 		"node_modules/@walletconnect/pay": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@walletconnect/pay/-/pay-1.0.8.tgz",
-			"integrity": "sha512-0LaCIlt0XIST8CpwuUHH9z485PEX+1J869tAq04zgPIxMA6gNZJ0j7vff2smFNCeKmKjFU4RpOdbw4zDAHcJwg==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@walletconnect/pay/-/pay-1.0.9.tgz",
+			"integrity": "sha512-09L6KhM6IeWKNdYefuuWwVxWpAsTdjCPETl1TQT5bWzyO9TiDSov70Y6knaZD19R173sTqKTyNfego/Y+iscDg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/logger": "3.0.2",
-				"@walletconnect/types": "2.23.9",
-				"@walletconnect/utils": "2.23.9",
-				"brotli": "^1.3.3"
+				"@walletconnect/types": "2.23.10",
+				"@walletconnect/utils": "2.23.10",
+				"brotli": "1.3.3"
 			},
 			"peerDependencies": {
 				"react-native": ">=0.64.0"
@@ -5908,19 +5920,17 @@
 			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/sign-client": {
-			"version": "2.23.9",
-			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.9.tgz",
-			"integrity": "sha512-Xj+hw4E6mGRyhCdVOT/RMgnG+up/Y3v0ho5PlkVozvXWeVSqHNh9DmjLuU97a7OACoGd/oHBF6g3NVqD7MgCMQ==",
+			"version": "2.23.10",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.10.tgz",
+			"integrity": "sha512-vO7DGRRmKo+rykmjVyQR1aM4I2nbk9kJ6olbxgjFRR6Jdhy+Kz+zgN7Ce5xVhPfWYVu4bV/XhOQxhvnQw7S5ng==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@walletconnect/core": "2.23.9",
-				"@walletconnect/events": "1.0.1",
-				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/core": "2.23.10",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.23.9",
-				"@walletconnect/utils": "2.23.9",
+				"@walletconnect/types": "2.23.10",
+				"@walletconnect/utils": "2.23.10",
 				"events": "3.3.0"
 			}
 		},
@@ -5940,9 +5950,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/@walletconnect/types": {
-			"version": "2.23.9",
-			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.9.tgz",
-			"integrity": "sha512-IUl1PpD/Dig8IE2OZ9XtjbPohEyOZJ73xs92EDUzoIyzRtfm36g2D340pY3iu3AAdLv1yFiaZafB8Hf8RFze8A==",
+			"version": "2.23.10",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.10.tgz",
+			"integrity": "sha512-XP8d41979anTrc1OJF3ISF+g81cvp1wim+ObdNnbcaT/jhwLwv+0T7rRe9VwRv+h8EaRgLyeb5YGy7oJ49vxVg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/events": "1.0.1",
@@ -5954,9 +5964,9 @@
 			}
 		},
 		"node_modules/@walletconnect/utils": {
-			"version": "2.23.9",
-			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.9.tgz",
-			"integrity": "sha512-C5TltCs8UPypNiteYnKSv8+ZDK2EjVDyXCxN6kA9bkA+j6KGsNIV7l9MUA8WBAvE5Gi5EcBdhD3R9Hpo/1HHqQ==",
+			"version": "2.23.10",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.10.tgz",
+			"integrity": "sha512-b1c9FRF2g7vNnz66oLW5WZD2VCMrbu9xhpmwJJwqGarBiGW7cY8NbUtS9/w2/qc0vsBVKJ/bzDn4TGjpELU6aQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@msgpack/msgpack": "3.1.3",
@@ -5971,13 +5981,22 @@
 				"@walletconnect/relay-auth": "1.1.0",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.23.9",
+				"@walletconnect/types": "2.23.10",
 				"@walletconnect/window-getters": "1.0.1",
 				"@walletconnect/window-metadata": "1.0.1",
 				"blakejs": "1.2.1",
 				"detect-browser": "5.3.0",
 				"ox": "0.9.3",
 				"uint8arrays": "3.1.1"
+			}
+		},
+		"node_modules/@walletconnect/utils/node_modules/@scure/base": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+			"integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@walletconnect/window-getters": {
@@ -6071,9 +6090,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"license": "MIT",
 			"peer": true,
 			"bin": {
@@ -6260,12 +6279,12 @@
 			"license": "MIT"
 		},
 		"node_modules/barcode-detector": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.1.3.tgz",
-			"integrity": "sha512-omL3/x26oU9jlR0gUQcGdXIjQtMlrUGKF7xRFO1RwrQkRkRU7WLz0mgQEsdUtYBm2uX3JH+HQLrKlyTS/BxZRw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.2.0.tgz",
+			"integrity": "sha512-MrT5TT058ptG5YB157pHLfXKVpp0BKEfQBOb8QvzTbatzmLDu85JJ0Gd/sCYwbwdwStJvxsYflrSN6D6E4Ndyw==",
 			"license": "MIT",
 			"dependencies": {
-				"zxing-wasm": "3.0.3"
+				"zxing-wasm": "3.1.0"
 			}
 		},
 		"node_modules/base-x": {
@@ -6503,16 +6522,15 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-			"dev": true,
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
 			"license": "MIT",
 			"dependencies": {
-				"readdirp": "^4.0.1"
+				"readdirp": "^5.0.0"
 			},
 			"engines": {
-				"node": ">= 14.16.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
@@ -6612,9 +6630,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+			"integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6832,9 +6850,9 @@
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.23.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
-			"integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
+			"version": "5.24.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+			"integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6879,16 +6897,16 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+			"integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/es-toolkit": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
-			"integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+			"integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
 			"license": "MIT",
 			"workspaces": [
 				"docs",
@@ -7502,9 +7520,9 @@
 			}
 		},
 		"node_modules/esrap": {
-			"version": "2.2.11",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.11.tgz",
-			"integrity": "sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==",
+			"version": "2.2.13",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
+			"integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -7559,9 +7577,9 @@
 			}
 		},
 		"node_modules/ethers": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-			"integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+			"integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
 			"funding": [
 				{
 					"type": "individual",
@@ -7574,13 +7592,13 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@adraffy/ens-normalize": "1.10.1",
+				"@adraffy/ens-normalize": "1.11.1",
 				"@noble/curves": "1.2.0",
 				"@noble/hashes": "1.3.2",
 				"@types/node": "22.7.5",
 				"aes-js": "4.0.0-beta.5",
 				"tslib": "2.7.0",
-				"ws": "8.17.1"
+				"ws": "8.21.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -7631,27 +7649,6 @@
 			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
 			"license": "MIT"
 		},
-		"node_modules/ethers/node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eventemitter3": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -7668,9 +7665,9 @@
 			}
 		},
 		"node_modules/expect-type": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -7985,8 +7982,7 @@
 			"version": "6.2.4",
 			"resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.4.tgz",
 			"integrity": "sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q==",
-			"license": "Apache-2.0",
-			"peer": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
@@ -8879,9 +8875,9 @@
 			"license": "(Apache-2.0 AND MIT)"
 		},
 		"node_modules/nanoid": {
-			"version": "5.1.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.15.tgz",
-			"integrity": "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw==",
+			"version": "5.1.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+			"integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -8959,15 +8955,18 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/ofetch": {
 			"version": "1.5.1",
@@ -9054,12 +9053,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/ox/node_modules/@adraffy/ens-normalize": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-			"integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-			"license": "MIT"
 		},
 		"node_modules/ox/node_modules/@noble/curves": {
 			"version": "1.9.1",
@@ -9195,9 +9188,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9245,13 +9238,13 @@
 			"license": "MIT"
 		},
 		"node_modules/playwright": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.60.0"
+				"playwright-core": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -9264,9 +9257,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -9277,9 +9270,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.16",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
 			"dev": true,
 			"funding": [
 				{
@@ -9444,9 +9437,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"version": "3.9.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+			"integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -9701,13 +9694,12 @@
 			"license": "MIT"
 		},
 		"node_modules/readdirp": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-			"dev": true,
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 14.18.0"
+				"node": ">= 20.19.0"
 			},
 			"funding": {
 				"type": "individual",
@@ -9789,13 +9781,13 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
-			"integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+			"integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.137.0",
+				"@oxc-project/types": "=0.138.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -9805,21 +9797,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.1.3",
-				"@rolldown/binding-darwin-arm64": "1.1.3",
-				"@rolldown/binding-darwin-x64": "1.1.3",
-				"@rolldown/binding-freebsd-x64": "1.1.3",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
-				"@rolldown/binding-linux-arm64-gnu": "1.1.3",
-				"@rolldown/binding-linux-arm64-musl": "1.1.3",
-				"@rolldown/binding-linux-ppc64-gnu": "1.1.3",
-				"@rolldown/binding-linux-s390x-gnu": "1.1.3",
-				"@rolldown/binding-linux-x64-gnu": "1.1.3",
-				"@rolldown/binding-linux-x64-musl": "1.1.3",
-				"@rolldown/binding-openharmony-arm64": "1.1.3",
-				"@rolldown/binding-wasm32-wasi": "1.1.3",
-				"@rolldown/binding-win32-arm64-msvc": "1.1.3",
-				"@rolldown/binding-win32-x64-msvc": "1.1.3"
+				"@rolldown/binding-android-arm64": "1.1.4",
+				"@rolldown/binding-darwin-arm64": "1.1.4",
+				"@rolldown/binding-darwin-x64": "1.1.4",
+				"@rolldown/binding-freebsd-x64": "1.1.4",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+				"@rolldown/binding-linux-arm64-gnu": "1.1.4",
+				"@rolldown/binding-linux-arm64-musl": "1.1.4",
+				"@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+				"@rolldown/binding-linux-s390x-gnu": "1.1.4",
+				"@rolldown/binding-linux-x64-gnu": "1.1.4",
+				"@rolldown/binding-linux-x64-musl": "1.1.4",
+				"@rolldown/binding-openharmony-arm64": "1.1.4",
+				"@rolldown/binding-wasm32-wasi": "1.1.4",
+				"@rolldown/binding-win32-arm64-msvc": "1.1.4",
+				"@rolldown/binding-win32-x64-msvc": "1.1.4"
 			}
 		},
 		"node_modules/rollup": {
@@ -9935,14 +9927,14 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.99.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
-			"integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
+			"version": "1.101.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
+			"integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"chokidar": "^4.0.0",
+				"chokidar": "^5.0.0",
 				"immutable": "^5.1.5",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
@@ -9950,7 +9942,7 @@
 				"sass": "sass.js"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=20.19.0"
 			},
 			"optionalDependencies": {
 				"@parcel/watcher": "^2.4.1"
@@ -9983,9 +9975,9 @@
 			}
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-			"integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
+			"integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10173,9 +10165,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.56.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
-			"integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
+			"version": "5.56.4",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+			"integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -10190,7 +10182,7 @@
 				"clsx": "^2.1.1",
 				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.11",
+				"esrap": "^2.2.12",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -10201,14 +10193,14 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.6.0.tgz",
-			"integrity": "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
+			"integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
-				"@sveltejs/load-config": "0.1.1",
+				"@sveltejs/load-config": "^0.2.0",
 				"chokidar": "^4.0.1",
 				"fdir": "^6.2.0",
 				"picocolors": "^1.0.0",
@@ -10223,6 +10215,36 @@
 			"peerDependencies": {
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
 				"typescript": ">=5.0.0"
+			}
+		},
+		"node_modules/svelte-check/node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/svelte-check/node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/svelte-confetti": {
@@ -10414,22 +10436,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-			"integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.6.tgz",
+			"integrity": "sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.4.2"
+				"tldts-core": "^7.4.6"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-			"integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.6.tgz",
+			"integrity": "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10519,9 +10541,9 @@
 			}
 		},
 		"node_modules/ts-essentials": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.2.0.tgz",
-			"integrity": "sha512-z9FlLywg0XEV46Ws1FwYN4NZDMr9qAe38lTTtgVBqzhhyEgwrnCUkFe4MEqnvar1kY1kFEnlkp56bxn2g0V+UA==",
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.2.1.tgz",
+			"integrity": "sha512-+Id1fRkuir+CsgK2x04/icS2b4V1hQmq7ObzIrDjhN0ozfRYivnP7aaKMVJfLApQm0trjR39A6NIMVchiB9Erw==",
 			"license": "MIT",
 			"peerDependencies": {
 				"typescript": ">=4.5.0"
@@ -10644,9 +10666,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.6.0.tgz",
+			"integrity": "sha512-PNaUHMvBDydpZd0N0J30w9m5p3a2zvCD5bxaLLnlwZkNKAlWhg8QeIJUaiPUI5lXh2M/m26gp75ah+Kbmpm13Q==",
 			"license": "MIT"
 		},
 		"node_modules/unrs-resolver": {
@@ -10784,34 +10806,6 @@
 				}
 			}
 		},
-		"node_modules/unstorage/node_modules/chokidar": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-			"license": "MIT",
-			"dependencies": {
-				"readdirp": "^5.0.0"
-			},
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/unstorage/node_modules/readdirp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.19.0"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -10845,9 +10839,9 @@
 			}
 		},
 		"node_modules/viem": {
-			"version": "2.52.2",
-			"resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
-			"integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
+			"version": "2.54.2",
+			"resolved": "https://registry.npmjs.org/viem/-/viem-2.54.2.tgz",
+			"integrity": "sha512-o0+5dEAUekBMTbixXy2mKbSDPnwsCJ+8+mOeMBDjkuS9iM4fcr3yKUWb2zlOy2NKInkg3anl1W11sxYspLiXig==",
 			"funding": [
 				{
 					"type": "github",
@@ -10863,7 +10857,7 @@
 				"abitype": "1.2.3",
 				"isows": "1.0.7",
 				"ox": "0.14.29",
-				"ws": "8.20.1"
+				"ws": "8.21.0"
 			},
 			"peerDependencies": {
 				"typescript": ">=5.0.4"
@@ -10873,12 +10867,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/viem/node_modules/@adraffy/ens-normalize": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-			"integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-			"license": "MIT"
 		},
 		"node_modules/viem/node_modules/@noble/curves": {
 			"version": "1.9.1",
@@ -10942,27 +10930,6 @@
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/viem/node_modules/ws": {
-			"version": "8.20.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
 					"optional": true
 				}
 			}
@@ -11081,58 +11048,10 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
-		"node_modules/vite-node/node_modules/nanoid": {
-			"version": "3.3.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
-		},
-		"node_modules/vite-node/node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/postcss"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"nanoid": "^3.3.12",
-				"picocolors": "^1.1.1",
-				"source-map-js": "^1.2.1"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
-			}
-		},
 		"node_modules/vite-node/node_modules/vite": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.1.tgz",
-			"integrity": "sha512-X/05/cT+VITy2AeDc1der6smvGWWREtL4hPbPTaVbjSBuuWkmNOjR6HP3NzqcQA2nF6VHGUPaFRJyft/2AE9Kg==",
+			"version": "8.1.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+			"integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11521,10 +11440,28 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
 		"node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11580,13 +11517,13 @@
 			}
 		},
 		"node_modules/zxing-wasm": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.0.3.tgz",
-			"integrity": "sha512-DdOn/G5F+qvZELWeO5ZFFwcN611TfMybxPV0LUUoutUmiH2t47MZSB7gLV9O9YLhvudBdnzQNAoFOu4Xz8eOrQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.0.tgz",
+			"integrity": "sha512-5+3V1wPRx4gvbeLH2jB7n2cKrYJ1q4i3QgjnBUtrDPeqxJSi6BdzKJg4y6aF6bgW8zfntnYJyrkqFMevDhL2NA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/emscripten": "^1.41.5",
-				"type-fest": "^5.6.0"
+				"type-fest": "^5.7.0"
 			},
 			"peerDependencies": {
 				"@types/emscripten": ">=1.39.6"

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -82,8 +82,7 @@ export interface ActiveUserTransactionRef {
  * dedupe twin variants anyway.
  */
 export type ActiveUserTransactionResult =
-	| { Ok: ActiveUserTransaction }
-	| { Err: ActiveUserTransactionError };
+	{ Ok: ActiveUserTransaction } | { Err: ActiveUserTransactionError };
 /**
  * Lifecycle status of an active user transaction.
  *
@@ -93,10 +92,7 @@ export type ActiveUserTransactionResult =
  * terminal states are immutable (idempotent no-op).
  */
 export type ActiveUserTransactionStatus =
-	| { Failed: null }
-	| { Executing: null }
-	| { Succeeded: null }
-	| { Pending: null };
+	{ Failed: null } | { Executing: null } | { Succeeded: null } | { Pending: null };
 export type AddDappSettingsError =
 	| { MaxHiddenDappIds: null }
 	| { VersionMismatch: null }
@@ -116,8 +112,7 @@ export interface AddHiddenDappIdRequest {
 	dapp_id: string;
 }
 export type AddUserDismissedNotificationResult =
-	| { Ok: null }
-	| { Err: AddDismissedNotificationError };
+	{ Ok: null } | { Err: AddDismissedNotificationError };
 export type AddUserHiddenDappIdResult =
 	| {
 			/**
@@ -941,8 +936,7 @@ export interface GetUserTransactionsResponse {
 	transactions: Array<UserTransaction>;
 }
 export type GetUserTransactionsResult =
-	| { Ok: GetUserTransactionsResponse }
-	| { Err: UserTransactionError };
+	{ Ok: GetUserTransactionsResponse } | { Err: UserTransactionError };
 export interface HasUserProfileResponse {
 	has_user_profile: boolean;
 }
@@ -1036,10 +1030,7 @@ export interface IcrcTransactionData {
  * The kind of ICRC ledger operation.
  */
 export type IcrcTransactionType =
-	| { Approve: { spender: string } }
-	| { Burn: null }
-	| { Mint: null }
-	| { Transfer: null };
+	{ Approve: { spender: string } } | { Burn: null } | { Mint: null } | { Transfer: null };
 /**
  * An account identifier for Internet Computer tokens.
  */
@@ -1065,10 +1056,7 @@ export type Icrcv2AccountId =
  * Represents the MIME type of image.
  */
 export type ImageMimeType =
-	| { 'image/gif': null }
-	| { 'image/png': null }
-	| { 'image/jpeg': null }
-	| { 'image/webp': null };
+	{ 'image/gif': null } | { 'image/png': null } | { 'image/jpeg': null } | { 'image/webp': null };
 export interface InitArg {
 	/**
 	 * The derivation origin used for II authentication, ensuring users get a
@@ -1109,10 +1097,7 @@ export interface InitArg {
  * Which Liquidium lend/borrow action an active transaction tracks.
  */
 export type LiquidiumAction =
-	| { Withdraw: null }
-	| { Repay: null }
-	| { Borrow: null }
-	| { Supply: null };
+	{ Withdraw: null } | { Repay: null } | { Borrow: null } | { Supply: null };
 export interface LiquidiumData {
 	/**
 	 * The asset moved by this action (supplied, borrowed, repaid, withdrawn).
@@ -1319,8 +1304,7 @@ export interface ProviderAgreementType {
 	scope: ProviderAgreementScope;
 }
 export type QualifiedNotificationKind =
-	| { NoIndexCanister: null }
-	| { UnavailableIndexCanister: null };
+	{ NoIndexCanister: null } | { UnavailableIndexCanister: null };
 /**
  * Error returned when a caller exceeds the allowed call rate.
  */
@@ -1529,10 +1513,7 @@ export type Token =
 	| { Erc4626: ErcToken }
 	| { Dip721: ExtV2Token };
 export type TokenAccountId =
-	| { Btc: BtcAddress }
-	| { Eth: EthAddress }
-	| { Sol: string }
-	| { Icrcv2: Icrcv2AccountId };
+	{ Btc: BtcAddress } | { Eth: EthAddress } | { Sol: string } | { Icrcv2: Icrcv2AccountId };
 /**
  * A unified token identifier covering both native and custom tokens for the main supported chains.
  * Unlike `CustomTokenId` (which only covers user-added tokens), this enum also includes

--- a/src/declarations/ext_v2_token/ext_v2_token.did.d.ts
+++ b/src/declarations/ext_v2_token/ext_v2_token.did.d.ts
@@ -15,9 +15,7 @@ export type AccountIdentifier__1 = string;
 export type AssetHandle = string;
 export type AssetId = number;
 export type AssetType =
-	| { other: string }
-	| { canister: { id: AssetId; canister: string } }
-	| { direct: Uint32Array };
+	{ other: string } | { canister: { id: AssetId; canister: string } } | { direct: Uint32Array };
 export type Balance = bigint;
 export interface BalanceRequest {
 	token: TokenIdentifier;
@@ -201,9 +199,7 @@ export type Metadata =
 			};
 	  };
 export type MetadataContainer =
-	| { blob: Uint8Array }
-	| { data: Array<MetadataValue> }
-	| { json: string };
+	{ blob: Uint8Array } | { data: Array<MetadataValue> } | { json: string };
 export type MetadataLegacy =
 	| {
 			fungible: {

--- a/src/declarations/icp_swap_pool/icp_swap_pool.did.d.ts
+++ b/src/declarations/icp_swap_pool/icp_swap_pool.did.d.ts
@@ -115,10 +115,7 @@ export interface DepositInfo {
 	transfer: Transfer;
 }
 export type DepositStatus =
-	| { Failed: null }
-	| { TransferCompleted: null }
-	| { Created: null }
-	| { Completed: null };
+	{ Failed: null } | { TransferCompleted: null } | { Created: null } | { Completed: null };
 export type Error =
 	| { CommonError: null }
 	| { InternalError: string }
@@ -321,10 +318,7 @@ export interface RefundInfo {
 	transfer: Transfer;
 }
 export type RefundStatus =
-	| { Failed: null }
-	| { CreditCompleted: null }
-	| { Created: null }
-	| { Completed: null };
+	{ Failed: null } | { CreditCompleted: null } | { Created: null } | { Completed: null };
 export interface RemoveLimitOrderInfo {
 	err: [] | [Error__1];
 	status: RemoveLimitOrderStatus;
@@ -338,10 +332,7 @@ export interface RemoveLimitOrderInfo {
 	tickLimit: bigint;
 }
 export type RemoveLimitOrderStatus =
-	| { Failed: null }
-	| { LimitOrderDeleted: null }
-	| { Created: null }
-	| { Completed: null };
+	{ Failed: null } | { LimitOrderDeleted: null } | { Created: null } | { Completed: null };
 export type Result = { ok: bigint } | { err: Error };
 export type Result_1 = { ok: string } | { err: Error };
 export type Result_10 = { ok: Page } | { err: Error };
@@ -646,10 +637,7 @@ export interface WithdrawInfo {
 	transfer: Transfer;
 }
 export type WithdrawStatus =
-	| { Failed: null }
-	| { CreditCompleted: null }
-	| { Created: null }
-	| { Completed: null };
+	{ Failed: null } | { CreditCompleted: null } | { Created: null } | { Completed: null };
 export interface WithdrawToSubaccountArgs {
 	fee: bigint;
 	token: string;

--- a/src/declarations/llm/llm.did.d.ts
+++ b/src/declarations/llm/llm.did.d.ts
@@ -18,9 +18,7 @@ export interface assistant_message {
 	}>;
 }
 export type backend_config =
-	| { worker: null }
-	| { ollama: null }
-	| { openrouter: { api_key: string } };
+	{ worker: null } | { ollama: null } | { openrouter: { api_key: string } };
 export interface chat_message_v0 {
 	content: string;
 	role: { user: null } | { assistant: null } | { system: null };

--- a/src/declarations/signer/signer.did.d.ts
+++ b/src/declarations/signer/signer.did.d.ts
@@ -71,8 +71,7 @@ export interface EcdsaPublicKeyResponse {
 	chain_code: Uint8Array;
 }
 export type EthAddressError =
-	| { SigningError: [RejectionCode_1, string] }
-	| { PaymentError: PaymentError };
+	{ SigningError: [RejectionCode_1, string] } | { PaymentError: PaymentError };
 export interface EthAddressRequest {
 	principal: [] | [Principal];
 }

--- a/src/declarations/sol_rpc/sol_rpc.did.d.ts
+++ b/src/declarations/sol_rpc/sol_rpc.did.d.ts
@@ -185,8 +185,7 @@ export interface ConfirmedTransactionStatusWithSignature {
  * Defines a consensus strategy for combining responses from different providers.
  */
 export type ConsensusStrategy =
-	| { Equality: null }
-	| { Threshold: { min: number; total: [] | [number] } };
+	{ Equality: null } | { Threshold: { min: number; total: [] | [number] } };
 /**
  * Represents a slice of the return value of the `getAccountInfo` Solana RPC method.
  * NOTE: Data slicing is only available for base58, base64, or base64+zstd encodings.
@@ -217,8 +216,7 @@ export interface EncodedConfirmedTransactionWithStatusMeta {
  * Encoding of a Solana transaction.
  */
 export type EncodedTransaction =
-	| { legacyBinary: string }
-	| { binary: [string, { base58: null } | { base64: null }] };
+	{ legacyBinary: string } | { binary: [string, { base58: null } | { base64: null }] };
 /**
  * Represents an encoded Solana transaction with status metadata object.
  */
@@ -646,10 +644,7 @@ export interface LoadedAddresses {
  * A filter for log entries.
  */
 export type LogFilter =
-	| { ShowAll: null }
-	| { HideAll: null }
-	| { ShowPattern: Regex }
-	| { HidePattern: Regex };
+	{ ShowAll: null } | { HideAll: null } | { ShowPattern: Regex } | { HidePattern: Regex };
 /**
  * Micro-lamports are used for the calculation of prioritization fees.
  * 1_000_000 MicroLamport == 1 Lamport
@@ -683,14 +678,12 @@ export type MultiGetAccountInfoResult =
  * Represents an aggregated result from multiple RPC calls to the `getBalance` Solana RPC method.
  */
 export type MultiGetBalanceResult =
-	| { Consistent: GetBalanceResult }
-	| { Inconsistent: Array<[RpcSource, GetBalanceResult]> };
+	{ Consistent: GetBalanceResult } | { Inconsistent: Array<[RpcSource, GetBalanceResult]> };
 /**
  * Represents an aggregated result from multiple RPC calls to the `getBlock` Solana RPC method.
  */
 export type MultiGetBlockResult =
-	| { Consistent: GetBlockResult }
-	| { Inconsistent: Array<[RpcSource, GetBlockResult]> };
+	{ Consistent: GetBlockResult } | { Inconsistent: Array<[RpcSource, GetBlockResult]> };
 /**
  * Represents an aggregated result from multiple RPC calls to the `getRecentPrioritizationFeesResult` Solana RPC method.
  */
@@ -719,8 +712,7 @@ export type MultiGetSignaturesForAddressResult =
  * Represents an aggregated result from multiple RPC calls to the `getSlot` Solana RPC method.
  */
 export type MultiGetSlotResult =
-	| { Consistent: GetSlotResult }
-	| { Inconsistent: Array<[RpcSource, GetSlotResult]> };
+	{ Consistent: GetSlotResult } | { Inconsistent: Array<[RpcSource, GetSlotResult]> };
 /**
  * Represents an aggregated result from multiple RPC calls to the `getTokenAccountBalance` Solana RPC method.
  */
@@ -741,8 +733,7 @@ export type MultiGetTransactionResult =
  * Represents an aggregated result from multiple RPC calls for a raw JSON-RPC request.
  */
 export type MultiRequestResult =
-	| { Consistent: RequestResult }
-	| { Inconsistent: Array<[RpcSource, RequestResult]> };
+	{ Consistent: RequestResult } | { Inconsistent: Array<[RpcSource, RequestResult]> };
 /**
  * Represents an aggregated result from multiple RPC calls to the `sendTransaction` Solana RPC method.
  */
@@ -1051,9 +1042,7 @@ export interface TokenAmount {
  * A Solana transaction confirmation status.
  */
 export type TransactionConfirmationStatus =
-	| { finalized: null }
-	| { confirmed: null }
-	| { processed: null };
+	{ finalized: null } | { confirmed: null } | { processed: null };
 /**
  * Determines whether and how transactions are included in a `getBlock` response.
  */

--- a/src/declarations/xtc_ledger/xtc_ledger.did.d.ts
+++ b/src/declarations/xtc_ledger/xtc_ledger.did.d.ts
@@ -11,9 +11,7 @@ import type { IDL } from '@icp-sdk/core/candid';
 import type { Principal } from '@icp-sdk/core/principal';
 
 export type BurnError =
-	| { InsufficientBalance: null }
-	| { InvalidTokenContract: null }
-	| { NotSufficientLiquidity: null };
+	{ InsufficientBalance: null } | { InvalidTokenContract: null } | { NotSufficientLiquidity: null };
 export type BurnResult = { Ok: TransactionId } | { Err: BurnError };
 export type CreateResult = { Ok: { canister_id: Principal } } | { Err: string };
 export interface Event {

--- a/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.ck.btc.env.ts
+++ b/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.ck.btc.env.ts
@@ -33,9 +33,7 @@ export const LOCAL_CKBTC_LEDGER_CANISTER_ID = import.meta.env
 	.VITE_LOCAL_CKBTC_LEDGER_CANISTER_ID as OptionCanisterIdText;
 
 export const LOCAL_CKBTC_INDEX_CANISTER_ID = import.meta.env.VITE_LOCAL_CKBTC_INDEX_CANISTER_ID as
-	| CanisterIdText
-	| null
-	| undefined;
+	CanisterIdText | null | undefined;
 
 export const LOCAL_CKBTC_MINTER_CANISTER_ID = import.meta.env
 	.VITE_LOCAL_CKBTC_MINTER_CANISTER_ID as OptionCanisterIdText;

--- a/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.ck.eth.env.ts
+++ b/src/frontend/src/env/tokens/tokens-icrc/tokens.icrc.ck.eth.env.ts
@@ -32,9 +32,7 @@ export const LOCAL_CKETH_LEDGER_CANISTER_ID = import.meta.env
 	.VITE_LOCAL_CKETH_LEDGER_CANISTER_ID as OptionCanisterIdText;
 
 export const LOCAL_CKETH_INDEX_CANISTER_ID = import.meta.env.VITE_LOCAL_CKETH_INDEX_CANISTER_ID as
-	| CanisterIdText
-	| null
-	| undefined;
+	CanisterIdText | null | undefined;
 
 export const LOCAL_CKETH_MINTER_CANISTER_ID = import.meta.env
 	.VITE_LOCAL_CKETH_MINTER_CANISTER_ID as OptionCanisterIdText;

--- a/src/frontend/src/eth/providers/alchemy.providers.ts
+++ b/src/frontend/src/eth/providers/alchemy.providers.ts
@@ -82,9 +82,7 @@ interface MinedTxEvent {
 }
 
 type PendingTxEvent =
-	| string
-	| { removed?: boolean; transaction: { hash: string } }
-	| { hash: string };
+	string | { removed?: boolean; transaction: { hash: string } } | { hash: string };
 
 /**
  * Generic eth_subscribe wrapper for Alchemy (and other WS JSON-RPC providers).

--- a/src/frontend/src/eth/services/erc20.services.ts
+++ b/src/frontend/src/eth/services/erc20.services.ts
@@ -57,14 +57,12 @@ export const loadDefaultErc20Tokens = async (): Promise<ResultSuccess> => {
 			Partial<Pick<Erc20Token, 'id'>>;
 
 		const loadKnownContracts = (): Promise<ContractData>[] =>
-			ERC20_CONTRACTS.map(
-				async ({ network, ...contract }): Promise<ContractData> => ({
-					...contract,
-					network,
-					category: 'default',
-					...(await infuraErc20Providers(network.id).metadata(contract))
-				})
-			);
+			ERC20_CONTRACTS.map(async ({ network, ...contract }): Promise<ContractData> => ({
+				...contract,
+				network,
+				category: 'default',
+				...(await infuraErc20Providers(network.id).metadata(contract))
+			}));
 
 		const contracts = await Promise.all(loadKnownContracts());
 		erc20DefaultTokensStore.set([...ALL_DEFAULT_ERC20_TOKENS, ...contracts.map(mapErc20Token)]);

--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -266,13 +266,11 @@
 				});
 			}
 
-			if (
-				!(
-					isSwapError(err) &&
-					(err.code === SwapErrorCodes.ICP_SWAP_WITHDRAW_SUCCESS ||
-						err.code === SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED)
-				)
-			) {
+			if (!(
+				isSwapError(err) &&
+				(err.code === SwapErrorCodes.ICP_SWAP_WITHDRAW_SUCCESS ||
+					err.code === SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED)
+			)) {
 				trackEvent({
 					name: TRACK_COUNT_SWAP_ERROR,
 					metadata: {

--- a/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance-and-transactions.scheduler.ts
@@ -28,21 +28,15 @@ interface IcWalletStore<T> {
 
 export type GetBalanceAndTransactions<
 	TWithId extends
-		| IcrcIndexDid.TransactionWithId
-		| IcpIndexDid.TransactionWithId
-		| Dip20TransactionWithId
+		IcrcIndexDid.TransactionWithId | IcpIndexDid.TransactionWithId | Dip20TransactionWithId
 > = GetTransactions & { transactions: TWithId[] };
 
 export class IcWalletBalanceAndTransactionsScheduler<
 	T extends IcrcIndexDid.Transaction | IcpIndexDid.Transaction | Event,
 	TWithId extends
-		| IcrcIndexDid.TransactionWithId
-		| IcpIndexDid.TransactionWithId
-		| Dip20TransactionWithId,
+		IcrcIndexDid.TransactionWithId | IcpIndexDid.TransactionWithId | Dip20TransactionWithId,
 	PostMessageDataRequest extends
-		| PostMessageDataRequestIcrcStrict
-		| PostMessageDataRequestIcp
-		| PostMessageDataRequestDip20
+		PostMessageDataRequestIcrcStrict | PostMessageDataRequestIcp | PostMessageDataRequestDip20
 > extends IcWalletScheduler<PostMessageDataRequest> {
 	private _queryAndUpdateWithWarmup?: ReturnType<typeof createQueryAndUpdateWithWarmup>;
 

--- a/src/frontend/src/icp/schedulers/ic-wallet-balance.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet-balance.scheduler.ts
@@ -16,9 +16,7 @@ interface IcrcBalanceStore {
 
 export class IcWalletBalanceScheduler<
 	PostMessageDataRequest extends
-		| PostMessageDataRequestIcrc
-		| PostMessageDataRequestIcp
-		| PostMessageDataRequestDip20
+		PostMessageDataRequestIcrc | PostMessageDataRequestIcp | PostMessageDataRequestDip20
 > extends IcWalletScheduler<PostMessageDataRequest> {
 	private _queryAndUpdateWithWarmup?: ReturnType<typeof createQueryAndUpdateWithWarmup>;
 

--- a/src/frontend/src/icp/schedulers/ic-wallet.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet.scheduler.ts
@@ -26,9 +26,7 @@ export const walletDataRef = (
 
 export abstract class IcWalletScheduler<
 	PostMessageDataRequest extends
-		| PostMessageDataRequestIcrc
-		| PostMessageDataRequestIcp
-		| PostMessageDataRequestDip20
+		PostMessageDataRequestIcrc | PostMessageDataRequestIcp | PostMessageDataRequestDip20
 > implements Scheduler<PostMessageDataRequest> {
 	protected ref: PostMessageCommon['ref'] | undefined;
 

--- a/src/frontend/src/lib/components/qr/QrCodeScanner.svelte
+++ b/src/frontend/src/lib/components/qr/QrCodeScanner.svelte
@@ -18,8 +18,8 @@
 	let { onScan, onBack, universalScanner = false }: Props = $props();
 
 	let resolveQrCodePromise:
-		| (({ status, code }: { status: QrStatus; code?: string }) => void)
-		| undefined = $state(undefined);
+		(({ status, code }: { status: QrStatus; code?: string }) => void) | undefined =
+		$state(undefined);
 
 	let cameraPermissionDenied = $state(false);
 

--- a/src/frontend/src/lib/components/trading/TradingOrders.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrders.svelte
@@ -62,12 +62,10 @@
 			return;
 		}
 		const entries = await Promise.all(
-			keys.map(
-				async (key): Promise<[string, OisyTradeOrderBook | undefined]> => [
-					key,
-					await loadOrderBook({ identity: $authIdentity, pair: toTradingPair(pairs[key]) })
-				]
-			)
+			keys.map(async (key): Promise<[string, OisyTradeOrderBook | undefined]> => [
+				key,
+				await loadOrderBook({ identity: $authIdentity, pair: toTradingPair(pairs[key]) })
+			])
 		);
 		// Keep the last good snapshot per pair on a transient failure.
 		const next = { ...untrack(() => orderBooks) };

--- a/src/frontend/src/lib/config/convert.config.ts
+++ b/src/frontend/src/lib/config/convert.config.ts
@@ -9,8 +9,7 @@ export interface ConvertWizardStepsParams extends WizardStepsParams {
 }
 
 export type WizardStepsConvertComplete =
-	| Exclude<WizardStepsConvert, 'QR_CODE_SCAN'>
-	| WizardStepsSend.QR_CODE_SCAN;
+	Exclude<WizardStepsConvert, 'QR_CODE_SCAN'> | WizardStepsSend.QR_CODE_SCAN;
 
 export const convertWizardSteps = ({
 	i18n,

--- a/src/frontend/src/lib/services/token-manage-analytics.services.ts
+++ b/src/frontend/src/lib/services/token-manage-analytics.services.ts
@@ -11,8 +11,7 @@ export type TokenManageEventModifier = 'import' | 'delete' | 'enable' | 'disable
 export type TokenManageEventKey = 'index_canister';
 
 export type TokenManageSourceLocation =
-	| PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS
-	| PLAUSIBLE_EVENT_SOURCE_LOCATIONS.TOKEN_DETAILS;
+	PLAUSIBLE_EVENT_SOURCE_LOCATIONS.MANAGE_TOKENS | PLAUSIBLE_EVENT_SOURCE_LOCATIONS.TOKEN_DETAILS;
 
 export interface TokenManageEventToken {
 	network: string;

--- a/src/frontend/src/lib/stores/transactions.store.ts
+++ b/src/frontend/src/lib/stores/transactions.store.ts
@@ -30,8 +30,7 @@ export type TransactionsStoreIdParams<T extends TransactionTypes> = Omit<
 export type NullableCertifiedTransactions = null;
 
 export type TransactionsData<T extends TransactionTypes> =
-	| CertifiedTransaction<T>[]
-	| NullableCertifiedTransactions;
+	CertifiedTransaction<T>[] | NullableCertifiedTransactions;
 
 export interface TransactionsStore<T extends TransactionTypes> extends CertifiedStore<
 	TransactionsData<T>

--- a/src/frontend/src/lib/types/coingecko.ts
+++ b/src/frontend/src/lib/types/coingecko.ts
@@ -56,9 +56,9 @@ export type CoingeckoSimplePrice = {
 	usd_24h_change?: number;
 	last_updated_at?: number;
 } & {
-	[K in
-		| Exclude<`${Currency}`, Currency.USD>
-		| `${Exclude<Currency, Currency.USD>}_24h_change`]?: number;
+	[
+		K in Exclude<`${Currency}`, Currency.USD> | `${Exclude<Currency, Currency.USD>}_24h_change`
+	]?: number;
 };
 
 export type CoingeckoSimpleTokenPrice = Omit<CoingeckoSimplePrice, 'usd_market_cap'> &

--- a/src/frontend/src/lib/types/nft.ts
+++ b/src/frontend/src/lib/types/nft.ts
@@ -38,6 +38,4 @@ export type NonFungibleTokensByNetwork = Map<NetworkId, NonFungibleToken[]>;
 export type NonFungibleToken = EthNonFungibleToken | IcNonFungibleToken;
 
 export type NonFungibleTokenIdentifier =
-	| Erc721Token['address']
-	| Erc1155Token['address']
-	| ExtToken['canisterId'];
+	Erc721Token['address'] | Erc1155Token['address'] | ExtToken['canisterId'];

--- a/src/frontend/src/lib/types/receive.ts
+++ b/src/frontend/src/lib/types/receive.ts
@@ -9,5 +9,4 @@ export interface ReceiveQRCode {
 }
 
 export type ReceiveQRCodeAction =
-	| { enabled: true; ariaLabel: string; testId?: string; onClick: () => void }
-	| { enabled: false };
+	{ enabled: true; ariaLabel: string; testId?: string; onClick: () => void } | { enabled: false };

--- a/src/frontend/src/lib/types/style.ts
+++ b/src/frontend/src/lib/types/style.ts
@@ -24,13 +24,7 @@ export type BadgeVariant =
 	| 'transparent';
 
 export type TagVariant =
-	| 'default'
-	| 'emphasis'
-	| 'info'
-	| 'error'
-	| 'warning'
-	| 'success'
-	| 'outline';
+	'default' | 'emphasis' | 'info' | 'error' | 'warning' | 'success' | 'outline';
 
 export type AvatarVariants = 'xl' | 'lg' | 'md' | 'sm' | 'xs' | 'xxs';
 

--- a/src/frontend/src/lib/types/transaction-ui.ts
+++ b/src/frontend/src/lib/types/transaction-ui.ts
@@ -10,10 +10,7 @@ import type { SolTransactionUi } from '$sol/types/sol-transaction';
 export type AnyTransaction = BtcTransactionUi | Transaction | IcTransactionUi | SolTransactionUi;
 
 export type AnyTransactionUi =
-	| BtcTransactionUi
-	| EthTransactionUi
-	| IcTransactionUi
-	| SolTransactionUi;
+	BtcTransactionUi | EthTransactionUi | IcTransactionUi | SolTransactionUi;
 
 export type AnyTransactionUiWithToken = AnyTransactionUi & {
 	token: Token;

--- a/src/frontend/src/lib/types/transaction.ts
+++ b/src/frontend/src/lib/types/transaction.ts
@@ -42,10 +42,9 @@ export type TransactionFeeData = Pick<FeeData, 'maxFeePerGas' | 'maxPriorityFeeP
 };
 
 export type RequiredTransactionFeeData = {
-	[K in keyof Pick<
-		TransactionFeeData,
-		'gas' | 'maxFeePerGas' | 'maxPriorityFeePerGas'
-	>]: NonNullable<TransactionFeeData[K]>;
+	[
+		K in keyof Pick<TransactionFeeData, 'gas' | 'maxFeePerGas' | 'maxPriorityFeePerGas'>
+	]: NonNullable<TransactionFeeData[K]>;
 };
 
 export type TransactionType = z.infer<typeof TransactionTypeSchema>;

--- a/src/frontend/src/lib/utils/address.utils.ts
+++ b/src/frontend/src/lib/utils/address.utils.ts
@@ -53,8 +53,7 @@ export const areAddressesEqual = <T extends Address>({
 	address2,
 	...rest
 }: { address1: OptionAddress<T>; address2: OptionAddress<T> } & (
-	| { networkId: NetworkId }
-	| { addressType: TokenAccountIdTypes }
+	{ networkId: NetworkId } | { addressType: TokenAccountIdTypes }
 )): boolean => {
 	if (isNullish(address1) || isNullish(address2)) {
 		return false;

--- a/src/frontend/src/lib/utils/auth.utils.ts
+++ b/src/frontend/src/lib/utils/auth.utils.ts
@@ -14,8 +14,7 @@ const isAlternativeOrigin = (): boolean => {
 };
 
 export const getOptionalDerivationOrigin = ():
-	| { derivationOrigin: string }
-	| Record<string, never> =>
+	{ derivationOrigin: string } | Record<string, never> =>
 	isAlternativeOrigin() && !isNullishOrEmpty(AUTH_DERIVATION_ORIGIN)
 		? {
 				derivationOrigin: AUTH_DERIVATION_ORIGIN

--- a/src/frontend/src/lib/utils/derived-memo.utils.ts
+++ b/src/frontend/src/lib/utils/derived-memo.utils.ts
@@ -1,9 +1,7 @@
 import { derived, type Readable, type Subscriber, type Unsubscriber } from 'svelte/store';
 
 type Stores =
-	| Readable<unknown>
-	| [Readable<unknown>, ...Array<Readable<unknown>>]
-	| Array<Readable<unknown>>;
+	Readable<unknown> | [Readable<unknown>, ...Array<Readable<unknown>>] | Array<Readable<unknown>>;
 type StoresValues<T> =
 	T extends Readable<infer U> ? U : { [K in keyof T]: T[K] extends Readable<infer U> ? U : never };
 

--- a/src/frontend/src/sol/utils/sol-instructions-system.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-system.utils.ts
@@ -9,6 +9,7 @@ import {
 	parseAssignInstruction,
 	parseAssignWithSeedInstruction,
 	parseAuthorizeNonceAccountInstruction,
+	parseCreateAccountAllowPrefundInstruction,
 	parseCreateAccountInstruction,
 	parseCreateAccountWithSeedInstruction,
 	parseInitializeNonceAccountInstruction,
@@ -46,6 +47,11 @@ export const parseSolSystemInstruction = (
 			return {
 				...parseCreateAccountWithSeedInstruction(instruction),
 				instructionType: SystemInstruction.CreateAccountWithSeed
+			};
+		case SystemInstruction.CreateAccountAllowPrefund:
+			return {
+				...parseCreateAccountAllowPrefundInstruction(instruction),
+				instructionType: SystemInstruction.CreateAccountAllowPrefund
 			};
 		case SystemInstruction.AdvanceNonceAccount:
 			return {

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -161,9 +161,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 
 	const initWithoutTransactions = <
 		PostMessageDataRequest extends
-			| PostMessageDataRequestIcrc
-			| PostMessageDataRequestIcp
-			| PostMessageDataRequestDip20
+			PostMessageDataRequestIcrc | PostMessageDataRequestIcp | PostMessageDataRequestDip20
 	>({
 		msg,
 		initScheduler,
@@ -250,9 +248,7 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 
 	const initOtherScenarios = <
 		PostMessageDataRequest extends
-			| PostMessageDataRequestIcrc
-			| PostMessageDataRequestIcp
-			| PostMessageDataRequestDip20
+			PostMessageDataRequestIcrc | PostMessageDataRequestIcp | PostMessageDataRequestDip20
 	>({
 		initScheduler,
 		startData = undefined,

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance.worker.spec.ts
@@ -110,9 +110,7 @@ describe('ic-wallet-balance.worker', () => {
 
 	const initWithBalance = <
 		PostMessageDataRequest extends
-			| PostMessageDataRequestIcrc
-			| PostMessageDataRequestIcp
-			| PostMessageDataRequestDip20
+			PostMessageDataRequestIcrc | PostMessageDataRequestIcp | PostMessageDataRequestDip20
 	>({
 		initScheduler,
 		msg,
@@ -232,9 +230,7 @@ describe('ic-wallet-balance.worker', () => {
 
 	const initOtherScenarios = <
 		PostMessageDataRequest extends
-			| PostMessageDataRequestIcrc
-			| PostMessageDataRequestIcp
-			| PostMessageDataRequestDip20
+			PostMessageDataRequestIcrc | PostMessageDataRequestIcp | PostMessageDataRequestDip20
 	>({
 		initScheduler,
 		startData = undefined,

--- a/src/frontend/src/tests/sol/utils/sol-instructions-system.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-system.utils.spec.ts
@@ -11,6 +11,7 @@ import {
 	parseAssignInstruction,
 	parseAssignWithSeedInstruction,
 	parseAuthorizeNonceAccountInstruction,
+	parseCreateAccountAllowPrefundInstruction,
 	parseCreateAccountInstruction,
 	parseCreateAccountWithSeedInstruction,
 	parseInitializeNonceAccountInstruction,
@@ -32,6 +33,7 @@ vi.mock(import('@solana-program/system'), async (importOriginal) => {
 		parseAssignInstruction: vi.fn(),
 		parseAssignWithSeedInstruction: vi.fn(),
 		parseAuthorizeNonceAccountInstruction: vi.fn(),
+		parseCreateAccountAllowPrefundInstruction: vi.fn(),
 		parseCreateAccountInstruction: vi.fn(),
 		parseCreateAccountWithSeedInstruction: vi.fn(),
 		parseInitializeNonceAccountInstruction: vi.fn(),
@@ -108,6 +110,20 @@ describe('sol-instructions-system.utils', () => {
 			});
 
 			expect(parseCreateAccountWithSeedInstruction).toHaveBeenCalledExactlyOnceWith(
+				mockInstruction
+			);
+		});
+
+		it('should parse a CreateAccountAllowPrefund instruction', () => {
+			vi.mocked(identifySystemInstruction).mockReturnValue(
+				SystemInstruction.CreateAccountAllowPrefund
+			);
+
+			expect(parseSolSystemInstruction(mockInstruction)).toStrictEqual({
+				instructionType: SystemInstruction.CreateAccountAllowPrefund
+			});
+
+			expect(parseCreateAccountAllowPrefundInstruction).toHaveBeenCalledExactlyOnceWith(
 				mockInstruction
 			);
 		});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,87 +10,85 @@ process.env = {
 	...readCanisterIds({ prefix: 'VITE_' })
 };
 
-export default defineConfig(
-	(): UserConfig => ({
-		plugins: [sveltekit(), svelteTesting()],
-		resolve: {
-			alias: [
-				{
-					find: '$lib',
-					replacement: resolve(__dirname, 'src/frontend/src/lib')
-				},
-				{
-					find: '$routes',
-					replacement: resolve(__dirname, 'src/frontend/src/routes')
-				},
-				{
-					find: '$btc',
-					replacement: resolve(__dirname, 'src/frontend/src/btc')
-				},
-				{
-					find: '$eth',
-					replacement: resolve(__dirname, 'src/frontend/src/eth')
-				},
-				{
-					find: '$evm',
-					replacement: resolve(__dirname, 'src/frontend/src/evm')
-				},
-				{
-					find: '$icp',
-					replacement: resolve(__dirname, 'src/frontend/src/icp')
-				},
-				{
-					find: '$sol',
-					replacement: resolve(__dirname, 'src/frontend/src/sol')
-				},
-				{
-					find: '$icp-eth',
-					replacement: resolve(__dirname, 'src/frontend/src/icp-eth')
-				},
-				{
-					find: '$tests',
-					replacement: resolve(__dirname, 'src/frontend/src/tests')
-				},
-				{
-					find: '$env',
-					replacement: resolve(__dirname, 'src/frontend/src/env')
-				},
-				{
-					find: '$declarations',
-					replacement: resolve(__dirname, 'src/declarations')
-				},
-				{
-					find: '@plausible-analytics/tracker',
-					replacement: resolve(__dirname, 'src/frontend/src/tests/mocks/plausible-tracker.mock')
-				}
-			]
-		},
-		define: {
-			...defineViteReplacements()
-		},
-		test: {
-			environment: 'jsdom',
-			globals: true,
-			watch: false,
-			silent: false,
-			setupFiles: ['./vitest.setup.ts'],
-			include: ['src/frontend/src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-			coverage: {
-				include: ['src/frontend/src/**/*.{ts,svelte}'],
-				exclude: [
-					'src/frontend/src/routes/**/+page.ts',
-					'src/frontend/src/tests/**/*',
-					'src/frontend/src/**/*.d.ts'
-				],
-				// TODO: increase the thresholds slowly up to an acceptable 90% at least
-				thresholds: {
-					autoUpdate: true,
-					statements: 80.2,
-					branches: 73.4,
-					functions: 77.8,
-					lines: 81.3
-				}
+export default defineConfig((): UserConfig => ({
+	plugins: [sveltekit(), svelteTesting()],
+	resolve: {
+		alias: [
+			{
+				find: '$lib',
+				replacement: resolve(__dirname, 'src/frontend/src/lib')
+			},
+			{
+				find: '$routes',
+				replacement: resolve(__dirname, 'src/frontend/src/routes')
+			},
+			{
+				find: '$btc',
+				replacement: resolve(__dirname, 'src/frontend/src/btc')
+			},
+			{
+				find: '$eth',
+				replacement: resolve(__dirname, 'src/frontend/src/eth')
+			},
+			{
+				find: '$evm',
+				replacement: resolve(__dirname, 'src/frontend/src/evm')
+			},
+			{
+				find: '$icp',
+				replacement: resolve(__dirname, 'src/frontend/src/icp')
+			},
+			{
+				find: '$sol',
+				replacement: resolve(__dirname, 'src/frontend/src/sol')
+			},
+			{
+				find: '$icp-eth',
+				replacement: resolve(__dirname, 'src/frontend/src/icp-eth')
+			},
+			{
+				find: '$tests',
+				replacement: resolve(__dirname, 'src/frontend/src/tests')
+			},
+			{
+				find: '$env',
+				replacement: resolve(__dirname, 'src/frontend/src/env')
+			},
+			{
+				find: '$declarations',
+				replacement: resolve(__dirname, 'src/declarations')
+			},
+			{
+				find: '@plausible-analytics/tracker',
+				replacement: resolve(__dirname, 'src/frontend/src/tests/mocks/plausible-tracker.mock')
+			}
+		]
+	},
+	define: {
+		...defineViteReplacements()
+	},
+	test: {
+		environment: 'jsdom',
+		globals: true,
+		watch: false,
+		silent: false,
+		setupFiles: ['./vitest.setup.ts'],
+		include: ['src/frontend/src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+		coverage: {
+			include: ['src/frontend/src/**/*.{ts,svelte}'],
+			exclude: [
+				'src/frontend/src/routes/**/+page.ts',
+				'src/frontend/src/tests/**/*',
+				'src/frontend/src/**/*.d.ts'
+			],
+			// TODO: increase the thresholds slowly up to an acceptable 90% at least
+			thresholds: {
+				autoUpdate: true,
+				statements: 80.2,
+				branches: 73.4,
+				functions: 77.8,
+				lines: 81.3
 			}
 		}
-	})
-);
+	}
+}));


### PR DESCRIPTION
# Motivation

The committed `package-lock.json` on `main` is out of sync with `package.json` — `npm ci` fails (`Missing: @emnapi/core / @emnapi/runtime from lock file`). This syncs the lockfile.

# Changes

- Sync `package-lock.json` (`npm install`). This refreshes transitive dependencies within their existing `package.json` ranges, including `@solana-program/system` 0.12.0 → 0.12.2, which adds a new `CreateAccountAllowPrefund` system instruction.
- Handle the new `SystemInstruction.CreateAccountAllowPrefund` variant in `parseSolSystemInstruction` (the exhaustive switch otherwise fails to compile), plus a matching unit test.

# Tests

- `npm run test` for the affected spec (17 passing).
- Type-check and lint clean.