### PR TITLE
feat(frontend): route the Borrow nav item to the /borrow/ page

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -54,12 +54,12 @@
 	} from '$lib/types/navigation';
 	import {
 		isRouteActivity,
+		isRouteBorrow,
 		isRouteBorrowings,
 		isRouteDappExplorer,
 		isRouteEarn,
 		isRouteEarning,
 		isRouteNfts,
-		isRouteProvidersLiquidium,
 		isRouteRewards,
 		isRouteSettings,
 		isRouteTokens,
@@ -179,7 +179,7 @@
 			},
 			// Trade and Borrow are NEW Finance destinations. Trade is gated behind
 			// TRADING_ENABLED like the Assets Trading tab; Borrow routes to the
-			// Liquidium provider page (no dedicated /borrow/ route exists yet).
+			// dedicated /borrow/ page.
 			...(TRADING_ENABLED
 				? {
 						trade: {
@@ -199,8 +199,8 @@
 				ariaLabel: $i18n.navigation.alt.borrow,
 				testId: prefixedTestId(NAVIGATION_ITEM_BORROW),
 				icon: IconCoins,
-				href: url(AppPath.ProvidersLiquidium),
-				selected: isRouteProvidersLiquidium(page),
+				href: url(AppPath.Borrow),
+				selected: isRouteBorrow(page),
 				tag: $i18n.core.text.new,
 				tagVariant: 'emphasis'
 			},

--- a/src/frontend/src/lib/utils/nav.utils.ts
+++ b/src/frontend/src/lib/utils/nav.utils.ts
@@ -41,14 +41,14 @@ export const isEarningPath = (path: string | null) =>
 	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.Earning}`) ?? false;
 export const isTradingPath = (path: string | null) =>
 	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.Trading}`) ?? false;
+export const isBorrowPath = (path: string | null) =>
+	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.Borrow}`) ?? false;
 export const isBorrowingsPath = (path: string | null) =>
 	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.Borrowings}`) ?? false;
 export const isRewardsPath = (path: string | null) =>
 	normalizePath(path) === `${ROUTE_ID_GROUP_APP}${AppPath.Rewards}`;
 export const isEarnPath = (path: string | null) =>
 	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.Earn}`) ?? false;
-export const isProvidersLiquidiumPath = (path: string | null) =>
-	normalizePath(path)?.startsWith(`${ROUTE_ID_GROUP_APP}${AppPath.ProvidersLiquidium}`) ?? false;
 
 export const transactionsUrl = ({ token }: { token: Token }): string =>
 	tokenUrl({ path: AppPath.Transactions, token });
@@ -69,14 +69,12 @@ export const isRouteNfts = ({ route: { id } }: Page): boolean => isNftsPath(id);
 export const isRouteEarning = ({ route: { id } }: Page): boolean => isEarningPath(id);
 
 export const isRouteTrading = ({ route: { id } }: Page): boolean => isTradingPath(id);
+export const isRouteBorrow = ({ route: { id } }: Page): boolean => isBorrowPath(id);
 export const isRouteBorrowings = ({ route: { id } }: Page): boolean => isBorrowingsPath(id);
 
 export const isRouteRewards = ({ route: { id } }: Page): boolean => isRewardsPath(id);
 
 export const isRouteEarn = ({ route: { id } }: Page): boolean => isEarnPath(id);
-
-export const isRouteProvidersLiquidium = ({ route: { id } }: Page): boolean =>
-	isProvidersLiquidiumPath(id);
 
 const tokenUrl = ({
 	token,

--- a/src/frontend/src/tests/lib/components/navigation/NavigationMainMenuItems.spec.ts
+++ b/src/frontend/src/tests/lib/components/navigation/NavigationMainMenuItems.spec.ts
@@ -83,12 +83,12 @@ describe('NavigationMainMenuItems', () => {
 		expect(get(bottomSheetOpenStore)).toBeFalsy();
 	});
 
-	it('surfaces Borrow in Finance linking to the Liquidium provider page', () => {
+	it('surfaces Borrow in Finance linking to the Borrow page', () => {
 		const { getByTestId } = render(NavigationMainMenuItems);
 
 		const borrowLink = getByTestId(NAVIGATION_ITEM_BORROW);
 
-		expect(borrowLink.getAttribute('href')).toContain(AppPath.ProvidersLiquidium);
+		expect(borrowLink.getAttribute('href')).toContain(AppPath.Borrow);
 	});
 
 	it('surfaces NFTs as its own nav item linking to the NFTs page', () => {


### PR DESCRIPTION
# Motivation

The **Borrow** item in the Finance navigation group was interim-wired to the Liquidium provider page (`/providers/liquidium/`) because a dedicated Borrow route did not exist yet. Now that the `/borrow/` page is in place, the nav item should point at it.

# Changes

- Point the Borrow nav item's `href` at `AppPath.Borrow` (`/borrow/`) instead of `AppPath.ProvidersLiquidium`.
- Add `isBorrowPath` / `isRouteBorrow` helpers so the item gets the active-page highlight on `/borrow/`.
- Remove the now-orphaned `isProvidersLiquidiumPath` / `isRouteProvidersLiquidium` helpers (the Borrow nav item was their only consumer).
- Update the nav component comment and the corresponding unit test.

# Tests

- `npm run check` and `npm run check:tests` pass.
- `npm run lint -- --max-warnings 0` passes for the changed files.
- Nav unit tests pass, including the updated assertion that the Borrow item links to `/borrow/`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (claude-opus-4-8)