### PR TITLE
fix(frontend): keep personal-notes cache on a failed same-owner reload

### DIFF
--- a/src/frontend/src/lib/services/personal-notes.services.ts
+++ b/src/frontend/src/lib/services/personal-notes.services.ts
@@ -57,7 +57,12 @@ const refreshCount = async ({
  */
 export const loadPersonalNotes = async (identity: Identity): Promise<void> => {
 	const owner = ownerPrincipal(identity);
-	personalNotesStore.beginLoad({ ownerPrincipal: owner });
+	// Only blank the cache when the owner changes; a same-owner refresh keeps the
+	// last-known-good list so a failed reload (e.g. the decryption-failure Retry)
+	// doesn't drop the notes already on screen.
+	if (get(personalNotesStore).ownerPrincipal !== owner) {
+		personalNotesStore.beginLoad({ ownerPrincipal: owner });
+	}
 
 	const [entries, count] = await Promise.all([
 		getPersonalNotes({ identity }),

--- a/src/frontend/src/tests/lib/services/personal-notes.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/personal-notes.services.spec.ts
@@ -69,7 +69,8 @@ describe('personal-notes.services', () => {
 
 		it('does not repopulate the store when an old load resolves after reset', async () => {
 			let resolveEntries:
-				((value: Awaited<ReturnType<typeof backendApi.getPersonalNotes>>) => void) | undefined;
+				| ((value: Awaited<ReturnType<typeof backendApi.getPersonalNotes>>) => void)
+				| undefined;
 
 			vi.spyOn(backendApi, 'getPersonalNotes').mockReturnValue(
 				new Promise((resolve) => {
@@ -100,6 +101,32 @@ describe('personal-notes.services', () => {
 				count: 0,
 				loaded: false
 			});
+		});
+
+		it('keeps the cached notes when a same-owner reload fails', async () => {
+			const cached = {
+				id: 'cached',
+				note: 'keep me',
+				created_at_ns: '100',
+				updated_at_ns: '100'
+			};
+			personalNotesStore.beginLoad({ ownerPrincipal: mockPrincipalText });
+			personalNotesStore.setLoaded({
+				ownerPrincipal: mockPrincipalText,
+				entries: [cached],
+				count: 1
+			});
+
+			// A same-owner refresh (e.g. the decryption-failure Retry) that fails must
+			// not blank the last-known-good list.
+			vi.spyOn(backendApi, 'getPersonalNotes').mockRejectedValue(new Error('network down'));
+			vi.spyOn(backendApi, 'getPersonalNotesCount').mockResolvedValue(1n);
+
+			await expect(loadPersonalNotes(mockIdentity)).rejects.toThrow('network down');
+
+			expect((get(personalNotesList) ?? []).map(({ id }) => id)).toEqual(['cached']);
+			expect(get(personalNotesStore).ownerPrincipal).toBe(mockPrincipalText);
+			expect(get(personalNotesStore).loaded).toBeTruthy();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/personal-notes.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/personal-notes.services.spec.ts
@@ -69,8 +69,7 @@ describe('personal-notes.services', () => {
 
 		it('does not repopulate the store when an old load resolves after reset', async () => {
 			let resolveEntries:
-				| ((value: Awaited<ReturnType<typeof backendApi.getPersonalNotes>>) => void)
-				| undefined;
+				((value: Awaited<ReturnType<typeof backendApi.getPersonalNotes>>) => void) | undefined;
 
 			vi.spyOn(backendApi, 'getPersonalNotes').mockReturnValue(
 				new Promise((resolve) => {


### PR DESCRIPTION
# Motivation

Follow-up to a Copilot review comment on #13361 (already merged). `loadPersonalNotes` called `personalNotesStore.beginLoad` unconditionally, which blanks the decrypted cache before the network/vetKD round-trip. On a **same-owner refresh** — notably the decryption-failure **Retry** in `NotesModal` — a reload that then throws left the modal showing the empty state instead of falling back to the notes already on screen. No data loss (the notes are still on-chain); it's a display regression introduced by the cache-scoping change.

# Changes

- Guard `beginLoad` on an **owner change** in `loadPersonalNotes`: only blank the cache when the principal actually changes, so a same-owner refresh keeps the last-known-good list. The principal-scoping from #13361 is fully preserved — `beginLoad` still runs and clears whenever the owner differs, so stale cross-principal load completions are still ignored.

# Tests

- `personal-notes.services.spec.ts`: new case — a same-owner reload that fails keeps the cached notes (owner, entries, and `loaded` intact).
- Existing personal-notes service / store / modal specs pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.8 (claude-opus-4-8)
