### PR TITLE
fix(frontend): borrow page hero copy fixes

### DIFF
--- a/src/frontend/src/env/oisy.metadata.json
+++ b/src/frontend/src/env/oisy.metadata.json
@@ -12,7 +12,7 @@
 	"OISY_REFERRAL_URL": "https://docs.oisy.com/rewards",
 	"OISY_EARN_URL": "https://docs.oisy.com/using-oisy-wallet/earn",
 	"OISY_EARN_HARVEST_AUTOPILOT_URL": "https://docs.oisy.com/using-oisy-wallet/earn/harvest-autopilot",
-	"OISY_BORROW_URL": "https://docs.oisy.com/using-oisy-wallet/earn",
+	"OISY_BORROW_URL": "https://docs.oisy.com/using-oisy-wallet/borrow",
 	"OISY_WELCOME_TWITTER_URL": "https://x.com/intent/post?text=Just%20set%20up%20my%20%40OISY%20wallet%20and%20am%20now%20eligible%20for%20Sprinkles.%0AUp%20to%20%24200%20is%20on%20the%20table%20from%20the%20most%20rewarding%20wallet%20in%20web3.%0AOISY.com",
 	"OISY_INTERNET_IDENTITY_URL": "https://docs.oisy.com/introduction/internet-identity",
 	"OISY_FIND_INTERNET_IDENTITY_URL": "https://docs.oisy.com/using-oisy-wallet/how-tos/find-your-internet-identity",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2,7 +2,7 @@
 	"borrow": {
 		"text": {
 			"header_title": "Welcome to Borrow!",
-			"header_description": "Access liquidity without selling — borrow stablecoins or BTC against your crypto.",
+			"header_description": "Access liquidity without selling. Borrow stablecoins or BTC against your crypto.",
 			"borrowing_options": "Borrowing options",
 			"borrowing_potential": "Borrowing potential",
 			"borrowing_power_hint": "An estimate of how much you could borrow if you supplied your assets as collateral, at the best available rate.",


### PR DESCRIPTION
# Motivation

Two small copy issues on the new `/borrow` page:

- The hero's "Learn more" link pointed to the earn docs (`OISY_BORROW_URL` was copy-pasted from `OISY_EARN_URL`) instead of the borrow docs.
- The hero description used an em dash, which reads awkwardly.

# Changes

- Point `OISY_BORROW_URL` to `https://docs.oisy.com/using-oisy-wallet/borrow`.
- Replace the em dash in `borrow.text.header_description` with a period, splitting it into two sentences.

# Tests

- `npx prettier --write` on the two changed files reports no changes needed.
- Verified both JSON files remain valid.
- Local UI verification via the browser preview wasn't possible in this session (dev-server port was held by an unrelated session); changes are non-logic (a URL constant and a copy string), so risk is minimal.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 5, claude-sonnet-5)