### PR TITLE
fix(frontend): let clicking anywhere in the Liquidium supply agreement box toggle the checkbox

### DIFF
--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte
@@ -13,15 +13,10 @@
 	};
 </script>
 
-<div class="my-6 flex gap-4 rounded-xl bg-secondary p-2">
-	<Checkbox
-		{checked}
-		inputId="liquidium-supply-agreement"
-		onChange={handleCheckboxChange}
-		text="block"
-	>
-		<span class="text-sm text-tertiary">
-			{$i18n.liquidium.text.supply_agreement}
-		</span>
-	</Checkbox>
-</div>
+<label class="my-6 flex gap-4 rounded-xl bg-secondary p-2" for="liquidium-supply-agreement">
+	<Checkbox {checked} inputId="liquidium-supply-agreement" onChange={handleCheckboxChange} />
+
+	<span class="text-sm text-tertiary">
+		{$i18n.liquidium.text.supply_agreement}
+	</span>
+</label>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte
@@ -8,13 +8,15 @@
 
 	let { checked = $bindable() }: Props = $props();
 
+	const inputId = 'liquidium-supply-agreement';
+
 	const handleCheckboxChange = () => {
 		checked = !checked;
 	};
 </script>
 
-<label class="my-6 flex gap-4 rounded-xl bg-secondary p-2" for="liquidium-supply-agreement">
-	<Checkbox {checked} inputId="liquidium-supply-agreement" onChange={handleCheckboxChange} />
+<label class="my-6 flex gap-4 rounded-xl bg-secondary p-2" for={inputId}>
+	<Checkbox {checked} {inputId} onChange={handleCheckboxChange} />
 
 	<span class="text-sm text-tertiary">
 		{$i18n.liquidium.text.supply_agreement}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte
@@ -14,9 +14,14 @@
 </script>
 
 <div class="my-6 flex gap-4 rounded-xl bg-secondary p-2">
-	<Checkbox {checked} inputId="liquidium-supply-agreement" onChange={handleCheckboxChange} />
-
-	<span class="text-sm text-tertiary">
-		{$i18n.liquidium.text.supply_agreement}
-	</span>
+	<Checkbox
+		{checked}
+		inputId="liquidium-supply-agreement"
+		onChange={handleCheckboxChange}
+		text="block"
+	>
+		<span class="text-sm text-tertiary">
+			{$i18n.liquidium.text.supply_agreement}
+		</span>
+	</Checkbox>
 </div>

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyAgreement.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyAgreement.spec.ts
@@ -23,4 +23,16 @@ describe('LiquidiumSupplyAgreement', () => {
 
 		expect(checkbox?.checked).toBeTruthy();
 	});
+
+	it('toggles the checkbox when clicking the agreement text', async () => {
+		const { container, getByText } = render(LiquidiumSupplyAgreement, {
+			props: { checked: false }
+		});
+
+		const checkbox = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+
+		await fireEvent.click(getByText(en.liquidium.text.supply_agreement));
+
+		expect(checkbox?.checked).toBeTruthy();
+	});
 });


### PR DESCRIPTION
# Motivation

In the Liquidium "Supply" modal, the confirmation checkbox required clicking the small checkbox input itself; clicking the adjacent agreement text did nothing. This is a small, easy-to-miss hit target on a required confirmation step.

# Changes

- Wrap the checkbox + agreement text in a native `<label for="liquidium-supply-agreement">` instead of a plain `<div>`. Clicking anywhere in a `<label>` forwards a real click event to its associated input, so the whole row becomes clickable/tappable natively, with zero change to layout, spacing, or element order.
- Added a test asserting the checkbox toggles when clicking the agreement text.
- Hoisted the `liquidium-supply-agreement` input id into a local constant, reused by both the `for` attribute and the `Checkbox` `inputId` prop, so the two can't drift apart (addresses Copilot review feedback).

# Tests

- Added `LiquidiumSupplyAgreement.spec.ts` case: clicking the agreement text toggles the checkbox. All 3 tests in the file pass.
- `eslint --fix`, `prettier --check`, and `svelte-check` (spec tsconfig) run clean on the changed file.
- Manually verified in a local preview: checkbox stays on the left, text on the right (unchanged from before), and clicking the text toggles the checkbox both on and off.

---
Generated with Claude Sonnet 5