### PR TITLE
fix(frontend): increase font size of share-note expiry pill options

### DIFF
--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -136,7 +136,7 @@
 
 		<div class="flex flex-col gap-2">
 			<span class="text-sm font-bold text-primary">{$i18n.notes.share.text.expires_after}</span>
-			<div class="flex flex-wrap gap-2">
+			<div class="flex flex-wrap gap-2 [&_button]:text-sm">
 				{#each EXPIRY_OPTIONS as option (option.ms)}
 					<PillButton onClick={() => (durationMs = option.ms)} selected={durationMs === option.ms}>
 						{$i18n.notes.share.text[option.labelKey]}


### PR DESCRIPTION
# Motivation

The "Link expires after" pill options in the Share note modal (`ShareNoteContent.svelte`) rendered at `text-xs` (12px), noticeably smaller than the surrounding label (`text-sm`) and other body text in the same modal.

# Changes

- Bumped the expiry-pill text size from `text-xs` (12px) to `text-sm` (14px) via a wrapper-level arbitrary-variant selector (`[&_button]:text-sm`), matching the existing pattern used elsewhere in the codebase for consumer-side style overrides.
- `PillButton.svelte` itself is untouched since it's shared with `TokenTypeFilterBar`.

# Tests

- `npm run check` — 0 errors, 0 warnings.
- `eslint --fix` — clean.
- `ShareNoteContent.spec.ts` — 3/3 passing.
- Verified visually in a running dev server: computed font-size confirmed 12px → 14px on the pill buttons before/after.

---
Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 5, claude-sonnet-5)