### PR TITLE
fix(frontend): route Assets nav to Tokens from the Trading tab

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationMenuMainItems.svelte
@@ -119,23 +119,23 @@
 	const url = (path: AppPath): string =>
 		networkUrl({ path, networkId, usePreviousRoute: isTransactionsRoute, fromRoute });
 
-	// NFTs left the Assets tabs (it is now its own destination), so the Assets
-	// link never resolves to the NFTs page — a persisted NFTS tab falls back to
-	// the Tokens list.
+	// NFTs and Trading each have their own destination now, so the Assets link
+	// never resolves to them — a persisted NFTS or TRADING tab falls back to the
+	// Tokens list (Trading cannot be reinstated from the Assets link).
 	const assetsPath = $derived.by(() => {
 		if ($activeAssetsTabStore === TokenTypes.EARNING) {
 			return AppPath.Earning;
-		}
-
-		if ($activeAssetsTabStore === TokenTypes.TRADING) {
-			return AppPath.Trading;
 		}
 
 		if ($activeAssetsTabStore === TokenTypes.BORROWINGS) {
 			return AppPath.Borrowings;
 		}
 
-		if ($activeAssetsTabStore === TokenTypes.TOKENS || $activeAssetsTabStore === TokenTypes.NFTS) {
+		if (
+			$activeAssetsTabStore === TokenTypes.TOKENS ||
+			$activeAssetsTabStore === TokenTypes.NFTS ||
+			$activeAssetsTabStore === TokenTypes.TRADING
+		) {
 			return AppPath.Tokens;
 		}
 

--- a/src/frontend/src/tests/lib/components/navigation/NavigationMainMenuItems.spec.ts
+++ b/src/frontend/src/tests/lib/components/navigation/NavigationMainMenuItems.spec.ts
@@ -110,6 +110,17 @@ describe('NavigationMainMenuItems', () => {
 		expect(tokenLink.getAttribute('href')).toContain(AppPath.Tokens);
 	});
 
+	it('keeps the assets link on the Tokens list when a stale TRADING tab is persisted', () => {
+		activeAssetsTabStore.set({ key: 'active-assets-tab', value: TokenTypes.TRADING });
+
+		const { getByTestId } = render(NavigationMainMenuItems);
+
+		const tokenLink = getByTestId(NAVIGATION_ITEM_TOKENS);
+
+		expect(tokenLink.getAttribute('href')).not.toContain(AppPath.Trading);
+		expect(tokenLink.getAttribute('href')).toContain(AppPath.Tokens);
+	});
+
 	it('builds assets link with Earning path when assetsTab = EARNING', () => {
 		activeAssetsTabStore.set({ key: 'active-assets-tab', value: TokenTypes.EARNING });
 


### PR DESCRIPTION
> [!CAUTION]
> We will build a provider page for OISY Trade, so the "Trade" nav bar entry can go there, and this PR will be obsolete


## Motivation

With the new navigation, opening **Trade** shows the Assets page with the **Trading** tab selected. Clicking **Assets** in the nav bar then did nothing: the Assets link resolves its target from the persisted active-assets tab, and while Trading was active that target was `/trading/` — the route already displayed — so the click was a no-op.

Trade is its own top-level destination and cannot be reinstated from the Assets link, so when the persisted tab is Trading the Assets link should fall back to the Tokens list (just like the existing NFTS fallback).

## Changes

- `NavigationMenuMainItems.svelte`: a persisted `TRADING` tab now resolves the Assets link to `AppPath.Tokens` instead of `AppPath.Trading`, folded into the existing Tokens/NFTS fallback branch. Earning, Borrowings and Tokens behavior is unchanged.

Resulting behavior:
- On the Trading tab, clicking **Assets** now opens the **Tokens** tab (was a no-op).
- On the Earning tab (or any other), clicking **Assets** is unchanged.
- Trading → another page (e.g. Activity) → **Assets** also opens **Tokens**, since Trading can't be reinstated.

## Tests

- Added a unit test asserting the Assets link resolves to Tokens (not `/trading/`) when a `TRADING` tab is persisted, mirroring the existing NFTS-fallback test.
- `svelte-check`, `eslint`, `prettier` clean; `NavigationMainMenuItems.spec.ts` passes 12/12.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (claude-opus-4-8)