### PR TITLE
feat(frontend): make trading withdrawal token selectable

### DIFF
--- a/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/ModalTokensList.svelte
@@ -27,7 +27,7 @@
 		toolbar: Snippet;
 		noResults?: Snippet;
 		topBanner?: Snippet;
-		onSelectNetworkFilter: () => void;
+		onSelectNetworkFilter?: () => void;
 		onTokenButtonClick?: (token: Token) => void;
 	}
 
@@ -95,7 +95,7 @@
 		<ModalFilterButton
 			ariaLabel={$filterNetwork?.name ?? $i18n.networks.chain_fusion}
 			disabled={networkSelectorViewOnly}
-			onclick={() => !networkSelectorViewOnly && onSelectNetworkFilter()}
+			onclick={() => !networkSelectorViewOnly && onSelectNetworkFilter?.()}
 		>
 			{$filterNetwork?.name ?? $i18n.networks.chain_fusion}
 		</ModalFilterButton>

--- a/src/frontend/src/lib/components/trading/WithdrawForm.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawForm.svelte
@@ -26,8 +26,10 @@
 	interface Props {
 		amount: OptionAmount;
 		amountSetToMax?: boolean;
+		free: bigint;
 		reserved: bigint;
 		transferFee: bigint;
+		onSelectToken: () => void;
 		onClose: () => void;
 		onNext: () => void;
 	}
@@ -35,14 +37,15 @@
 	let {
 		amount = $bindable(),
 		amountSetToMax = $bindable(false),
+		free,
 		reserved,
 		transferFee,
+		onSelectToken,
 		onClose,
 		onNext
 	}: Props = $props();
 
-	const { sendToken, sendTokenExchangeRate, sendBalance } =
-		getContext<SendContext>(SEND_CONTEXT_KEY);
+	const { sendToken, sendTokenExchangeRate } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	let exchangeValueUnit = $state<DisplayUnit>('usd');
 	let inputUnit = $derived<DisplayUnit>(exchangeValueUnit === 'token' ? 'usd' : 'token');
@@ -75,7 +78,8 @@
 		<TokenInput
 			displayUnit={inputUnit}
 			exchangeRate={$sendTokenExchangeRate}
-			isSelectable={false}
+			isSelectable
+			onClick={onSelectToken}
 			showTokenNetwork
 			token={$sendToken}
 			bind:amount
@@ -96,7 +100,7 @@
 
 			{#snippet balance()}
 				<MaxBalanceButton
-					balance={$sendBalance}
+					balance={free}
 					fee={ZERO}
 					token={$sendToken}
 					bind:amountSetToMax

--- a/src/frontend/src/lib/components/trading/WithdrawModal.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawModal.svelte
@@ -151,11 +151,7 @@
 
 		{#if currentStep?.name === WizardStepsTradingWithdraw.TOKENS_LIST}
 			<!-- Network filter is view-only: OISY TRADE holds IC-network tokens only. -->
-			<ModalTokensList
-				networkSelectorViewOnly
-				onSelectNetworkFilter={() => {}}
-				onTokenButtonClick={onSelectToken}
-			>
+			<ModalTokensList networkSelectorViewOnly onTokenButtonClick={onSelectToken}>
 				{#snippet tokenListItem(listToken, onClick)}
 					<ModalTokensListItem {onClick} token={listToken} />
 				{/snippet}

--- a/src/frontend/src/lib/components/trading/WithdrawModal.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawModal.svelte
@@ -1,23 +1,58 @@
 <script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { setContext } from 'svelte';
+	import type { IcToken } from '$icp/types/ic-token';
 	import SendTokenContext from '$lib/components/send/SendTokenContext.svelte';
+	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
+	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import WithdrawWizard from '$lib/components/trading/WithdrawWizard.svelte';
+	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { tradingWithdrawWizardSteps } from '$lib/config/trading-withdraw.config';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { selectedNetwork } from '$lib/derived/network.derived';
+	import { oisyTradeAssets } from '$lib/derived/oisy-trade.derived';
 	import { ProgressStepsTradingWithdraw } from '$lib/enums/progress-steps';
 	import { WizardStepsTradingWithdraw } from '$lib/enums/wizard-steps';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		initModalTokensListContext,
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
 	import type { OisyTradeWithdrawToken } from '$lib/types/oisy-trade';
 	import type { OptionAmount } from '$lib/types/send';
+	import type { Token } from '$lib/types/token';
 	import type { WizardStep, WizardSteps } from '$lib/types/wizard';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	interface Props {
+		// A preselection only — the user can switch to any other DEX holding in-modal.
 		withdrawToken: OisyTradeWithdrawToken;
 	}
 
 	let { withdrawToken }: Props = $props();
 
-	let { token, free, reserved } = $derived(withdrawToken);
+	// eslint-disable-next-line svelte/no-unused-svelte-ignore
+	// svelte-ignore state_referenced_locally -- the prop only seeds the initial selection; afterwards the token is driven by the in-modal picker.
+	let token = $state<IcToken>(withdrawToken.token);
+
+	// free/reserved follow the selected token, read live from the polled DEX
+	// balances. The prop snapshot only covers the preselected token while the
+	// store has no data (e.g. right after opening).
+	let { free, reserved } = $derived.by(() => {
+		const asset = $oisyTradeAssets.find(({ token: { id } }) => id === token.id);
+
+		if (nonNullish(asset)) {
+			return { free: asset.free, reserved: asset.reserved };
+		}
+
+		return token.id === withdrawToken.token.id
+			? { free: withdrawToken.free, reserved: withdrawToken.reserved }
+			: { free: ZERO, reserved: ZERO };
+	});
 
 	let modal: WizardModal<WizardStepsTradingWithdraw> | undefined = $state();
 	let currentStep: WizardStep<WizardStepsTradingWithdraw> | undefined = $state();
@@ -29,36 +64,132 @@
 		tradingWithdrawWizardSteps({ i18n: $i18n })
 	);
 
+	// The picker lists the user's DEX holdings with the withdrawable (free)
+	// balance instead of the wallet balance — same trick as the limit-order
+	// tokens list. `sortByBalance: false` below keeps these preset balances from
+	// being re-mapped to the wallet balances store.
+	const withdrawableTokens = $derived(
+		$oisyTradeAssets.map(({ token: assetToken, free: assetFree, freeUsd }) => ({
+			...assetToken,
+			balance: assetFree,
+			usdBalance: freeUsd
+		}))
+	);
+
+	// Reuse the shared token-picker pipeline (search box + filters) the deposit
+	// modal uses. The page's selected network is honored for the same reason: a
+	// testnet DEX (staging) must not have its own tokens stripped by the default
+	// pseudo-chain-fusion (mainnet-only) view.
+	const tokensListContext = initModalTokensListContext({
+		// eslint-disable-next-line svelte/no-unused-svelte-ignore
+		// svelte-ignore state_referenced_locally -- the context is initialized once at mount; the reactive token list is kept in sync below via `setTokens`.
+		tokens: withdrawableTokens,
+		// eslint-disable-next-line svelte/no-unused-svelte-ignore
+		// svelte-ignore state_referenced_locally -- initialized once at mount; the page network is fixed for the modal's lifetime and locks the in-modal selector below.
+		filterNetwork: $selectedNetwork,
+		sortByBalance: false
+	});
+	setContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY, tokensListContext);
+
+	$effect(() => {
+		tokensListContext.setTokens(withdrawableTokens);
+	});
+
+	const goToStep = (stepName: WizardStepsTradingWithdraw) => {
+		if (isNullish(modal)) {
+			return;
+		}
+
+		goToWizardStep({ modal, steps, stepName });
+	};
+
+	const showTokensList = () => {
+		tokensListContext.setFilterQuery('');
+
+		goToStep(WizardStepsTradingWithdraw.TOKENS_LIST);
+	};
+
+	const closeTokensList = () => {
+		tokensListContext.setFilterQuery('');
+
+		goToStep(WizardStepsTradingWithdraw.WITHDRAW);
+	};
+
+	// The picker only ever lists DEX holdings; resolve the selection back to the
+	// matching asset the withdraw flow needs.
+	const onSelectToken = (selected: Token) => {
+		const matched = $oisyTradeAssets.find(({ token: { id } }) => id === selected.id);
+
+		if (isNullish(matched)) {
+			return;
+		}
+
+		if (token.id !== matched.token.id) {
+			amount = undefined;
+			amountSetToMax = false;
+		}
+		({ token } = matched);
+
+		closeTokensList();
+	};
+
 	const reset = () => {
+		({ token } = withdrawToken);
 		amount = undefined;
 		amountSetToMax = false;
 		withdrawProgressStep = ProgressStepsTradingWithdraw.INITIALIZATION;
 		currentStep = undefined;
+		tokensListContext.resetFilters();
 	};
 
 	const close = () => closeModal(reset);
 </script>
 
-<SendTokenContext customSendBalance={free} {token}>
+<SendTokenContext {token}>
 	<WizardModal
 		bind:this={modal}
-		disablePointerEvents={currentStep?.name === WizardStepsTradingWithdraw.WITHDRAWING}
+		disablePointerEvents={currentStep?.name === WizardStepsTradingWithdraw.WITHDRAWING ||
+			currentStep?.name === WizardStepsTradingWithdraw.TOKENS_LIST}
 		onClose={close}
 		{steps}
 		bind:currentStep
 	>
 		{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-		<WithdrawWizard
-			{currentStep}
-			onBack={modal.back}
-			onClose={close}
-			onNext={modal.next}
-			{reserved}
-			{token}
-			bind:amount
-			bind:amountSetToMax
-			bind:withdrawProgressStep
-		/>
+		{#if currentStep?.name === WizardStepsTradingWithdraw.TOKENS_LIST}
+			<!-- OISY TRADE holds IC-network tokens only, so the network filter stays
+				view-only — the shared picker still renders search and category filters. -->
+			<ModalTokensList
+				networkSelectorViewOnly
+				onSelectNetworkFilter={() => {}}
+				onTokenButtonClick={onSelectToken}
+			>
+				{#snippet tokenListItem(listToken, onClick)}
+					<ModalTokensListItem {onClick} token={listToken} />
+				{/snippet}
+				{#snippet noResults()}
+					<p class="text-primary">{$i18n.core.text.no_results}</p>
+				{/snippet}
+				{#snippet toolbar()}
+					<ButtonGroup>
+						<ButtonBack onclick={closeTokensList} />
+					</ButtonGroup>
+				{/snippet}
+			</ModalTokensList>
+		{:else}
+			<WithdrawWizard
+				{currentStep}
+				{free}
+				onBack={modal.back}
+				onClose={close}
+				onNext={modal.next}
+				onSelectToken={showTokensList}
+				{reserved}
+				{token}
+				bind:amount
+				bind:amountSetToMax
+				bind:withdrawProgressStep
+			/>
+		{/if}
 	</WizardModal>
 </SendTokenContext>

--- a/src/frontend/src/lib/components/trading/WithdrawModal.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawModal.svelte
@@ -29,19 +29,17 @@
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	interface Props {
-		// A preselection only — the user can switch to any other DEX holding in-modal.
+		// Seeds the initial selection only; the user can switch token in-modal.
 		withdrawToken: OisyTradeWithdrawToken;
 	}
 
 	let { withdrawToken }: Props = $props();
 
 	// eslint-disable-next-line svelte/no-unused-svelte-ignore
-	// svelte-ignore state_referenced_locally -- the prop only seeds the initial selection; afterwards the token is driven by the in-modal picker.
+	// svelte-ignore state_referenced_locally -- prop seeds the initial selection only
 	let token = $state<IcToken>(withdrawToken.token);
 
-	// free/reserved follow the selected token, read live from the polled DEX
-	// balances. The prop snapshot only covers the preselected token while the
-	// store has no data (e.g. right after opening).
+	// Falls back to the prop snapshot until the DEX balances store has loaded.
 	let { free, reserved } = $derived.by(() => {
 		const asset = $oisyTradeAssets.find(({ token: { id } }) => id === token.id);
 
@@ -64,10 +62,7 @@
 		tradingWithdrawWizardSteps({ i18n: $i18n })
 	);
 
-	// The picker lists the user's DEX holdings with the withdrawable (free)
-	// balance instead of the wallet balance — same trick as the limit-order
-	// tokens list. `sortByBalance: false` below keeps these preset balances from
-	// being re-mapped to the wallet balances store.
+	// Show the withdrawable (free) DEX balance, not the wallet balance.
 	const withdrawableTokens = $derived(
 		$oisyTradeAssets.map(({ token: assetToken, free: assetFree, freeUsd }) => ({
 			...assetToken,
@@ -76,17 +71,17 @@
 		}))
 	);
 
-	// Reuse the shared token-picker pipeline (search box + filters) the deposit
-	// modal uses. The page's selected network is honored for the same reason: a
-	// testnet DEX (staging) must not have its own tokens stripped by the default
-	// pseudo-chain-fusion (mainnet-only) view.
 	const tokensListContext = initModalTokensListContext({
 		// eslint-disable-next-line svelte/no-unused-svelte-ignore
-		// svelte-ignore state_referenced_locally -- the context is initialized once at mount; the reactive token list is kept in sync below via `setTokens`.
+		// svelte-ignore state_referenced_locally -- kept in sync below via setTokens
 		tokens: withdrawableTokens,
+		// Honor the page network so a testnet DEX (staging) isn't stripped by the
+		// default mainnet-only view.
 		// eslint-disable-next-line svelte/no-unused-svelte-ignore
-		// svelte-ignore state_referenced_locally -- initialized once at mount; the page network is fixed for the modal's lifetime and locks the in-modal selector below.
+		// svelte-ignore state_referenced_locally -- page network is fixed for the modal's lifetime
 		filterNetwork: $selectedNetwork,
+		// Keep the free balances above from being re-sorted against the wallet
+		// balances store.
 		sortByBalance: false
 	});
 	setContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY, tokensListContext);
@@ -115,8 +110,6 @@
 		goToStep(WizardStepsTradingWithdraw.WITHDRAW);
 	};
 
-	// The picker only ever lists DEX holdings; resolve the selection back to the
-	// matching asset the withdraw flow needs.
 	const onSelectToken = (selected: Token) => {
 		const matched = $oisyTradeAssets.find(({ token: { id } }) => id === selected.id);
 
@@ -157,8 +150,7 @@
 		{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
 		{#if currentStep?.name === WizardStepsTradingWithdraw.TOKENS_LIST}
-			<!-- OISY TRADE holds IC-network tokens only, so the network filter stays
-				view-only — the shared picker still renders search and category filters. -->
+			<!-- Network filter is view-only: OISY TRADE holds IC-network tokens only. -->
 			<ModalTokensList
 				networkSelectorViewOnly
 				onSelectNetworkFilter={() => {}}

--- a/src/frontend/src/lib/components/trading/WithdrawWizard.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawWizard.svelte
@@ -24,9 +24,11 @@
 		token: IcToken;
 		amount: OptionAmount;
 		amountSetToMax?: boolean;
+		free: bigint;
 		reserved: bigint;
 		withdrawProgressStep: string;
 		currentStep?: WizardStep<WizardStepsTradingWithdraw>;
+		onSelectToken: () => void;
 		onClose: () => void;
 		onNext: () => void;
 		onBack: () => void;
@@ -36,9 +38,11 @@
 		token,
 		amount = $bindable(),
 		amountSetToMax = $bindable(false),
+		free,
 		reserved,
 		withdrawProgressStep = $bindable(),
 		currentStep,
+		onSelectToken,
 		onClose,
 		onNext,
 		onBack
@@ -110,5 +114,14 @@
 {:else if currentStep?.name === WizardStepsTradingWithdraw.WITHDRAWING}
 	<WithdrawProgress symbol={token.symbol} {withdrawProgressStep} />
 {:else}
-	<WithdrawForm {onClose} {onNext} {reserved} {transferFee} bind:amount bind:amountSetToMax />
+	<WithdrawForm
+		{free}
+		{onClose}
+		{onNext}
+		{onSelectToken}
+		{reserved}
+		{transferFee}
+		bind:amount
+		bind:amountSetToMax
+	/>
 {/if}

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTokensList.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTokensList.svelte
@@ -89,16 +89,11 @@
 	$effect(() => {
 		setTokens(tokens);
 	});
-
-	// OISY TRADE lists IC-network tokens only (mainnet or the testnet ledgers a
-	// staging DEX trades), so the network filter stays view-only — the shared
-	// picker still renders search and category filters.
-	const onSelectNetworkFilter = () => {};
 </script>
 
+<!-- Network filter is view-only: OISY TRADE lists IC-network tokens only. -->
 <ModalTokensList
 	networkSelectorViewOnly={true}
-	{onSelectNetworkFilter}
 	onTokenButtonClick={(token) => onSelect(token.symbol)}
 >
 	{#snippet tokenListItem(token, onClick)}

--- a/src/frontend/src/lib/config/trading-withdraw.config.ts
+++ b/src/frontend/src/lib/config/trading-withdraw.config.ts
@@ -17,9 +17,7 @@ export const tradingWithdrawWizardSteps = ({
 		name: WizardStepsTradingWithdraw.WITHDRAWING,
 		title: i18n.trading.withdraw.progress_title
 	},
-	// Appended after the linear Withdraw → Review → Withdrawing flow so that
-	// `modal.next`/`modal.back` keep stepping through it untouched; the tokens
-	// list is only ever reached via an explicit jump.
+	// Last so it stays off the linear next/back path; reached only via an explicit jump.
 	{
 		name: WizardStepsTradingWithdraw.TOKENS_LIST,
 		title: i18n.send.text.select_token

--- a/src/frontend/src/lib/config/trading-withdraw.config.ts
+++ b/src/frontend/src/lib/config/trading-withdraw.config.ts
@@ -16,5 +16,12 @@ export const tradingWithdrawWizardSteps = ({
 	{
 		name: WizardStepsTradingWithdraw.WITHDRAWING,
 		title: i18n.trading.withdraw.progress_title
+	},
+	// Appended after the linear Withdraw → Review → Withdrawing flow so that
+	// `modal.next`/`modal.back` keep stepping through it untouched; the tokens
+	// list is only ever reached via an explicit jump.
+	{
+		name: WizardStepsTradingWithdraw.TOKENS_LIST,
+		title: i18n.send.text.select_token
 	}
 ];

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -90,7 +90,8 @@ export enum WizardStepsUnstake {
 export enum WizardStepsTradingWithdraw {
 	WITHDRAW = 'Withdraw',
 	REVIEW = 'Review',
-	WITHDRAWING = 'Withdrawing'
+	WITHDRAWING = 'Withdrawing',
+	TOKENS_LIST = 'Tokens List'
 }
 
 export enum WizardStepsLiquidiumSupply {

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -9,7 +9,8 @@ import type {
 	WizardStepsScanner,
 	WizardStepsSend,
 	WizardStepsSwap,
-	WizardStepsTradingDeposit
+	WizardStepsTradingDeposit,
+	WizardStepsTradingWithdraw
 } from '$lib/enums/wizard-steps';
 import type { WizardStepsGetTokenType } from '$lib/types/get-token';
 import type { WizardModal, WizardSteps } from '$lib/types/wizard';
@@ -26,6 +27,7 @@ type StepName =
 	| WizardStepsGetTokenType
 	| WizardStepsScanner
 	| WizardStepsTradingDeposit
+	| WizardStepsTradingWithdraw
 	| WizardStepsLimitOrder;
 
 export const goToWizardStep = <T extends StepName>({

--- a/src/frontend/src/tests/lib/components/trading/WithdrawForm.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawForm.svelte.spec.ts
@@ -8,21 +8,24 @@ import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { getMaxTransactionAmount } from '$lib/utils/token.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 
 describe('WithdrawForm', () => {
 	const free = 5_000_000n;
 
-	const mockContext = (customSendBalance = free) =>
+	const mockContext = () =>
 		new Map<symbol, SendContext>([
-			[SEND_CONTEXT_KEY, initSendContext({ token: mockValidIcToken, customSendBalance })]
+			[SEND_CONTEXT_KEY, initSendContext({ token: mockValidIcToken })]
 		]);
 
 	const baseProps = {
 		amount: undefined,
 		amountSetToMax: false,
+		free,
 		reserved: ZERO,
 		transferFee: mockValidIcToken.fee,
+		onSelectToken: () => {},
 		onClose: () => {},
 		onNext: () => {}
 	};
@@ -102,6 +105,27 @@ describe('WithdrawForm', () => {
 			})
 		);
 		expect(testProps.amountSetToMax).toBeTruthy();
+	});
+
+	it('calls onSelectToken when the token selector is clicked', async () => {
+		const onSelectToken = vi.fn();
+
+		const { getAllByText } = render(WithdrawForm, {
+			props: { ...baseProps, onSelectToken },
+			context: mockContext()
+		});
+
+		// The token pill is the only element whose text is exactly the symbol and
+		// that sits inside a button (the fee lines render "<amount> <symbol>").
+		const tokenPill = getAllByText(mockValidIcToken.symbol).find(
+			(element) => element.closest('button') !== null
+		);
+
+		assertNonNullish(tokenPill);
+
+		await fireEvent.click(tokenPill);
+
+		expect(onSelectToken).toHaveBeenCalledOnce();
 	});
 
 	it('calls onNext when the review button is clicked', async () => {

--- a/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
@@ -1,15 +1,111 @@
+import type { UserTokenBalance } from '$declarations/oisy_trade/oisy_trade.did';
+import type { IcToken } from '$icp/types/ic-token';
 import WithdrawModal from '$lib/components/trading/WithdrawModal.svelte';
 import { ZERO } from '$lib/constants/app.constants';
+import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
+import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
 import type { OisyTradeWithdrawToken } from '$lib/types/oisy-trade';
+import { parseTokenId } from '$lib/validation/token.validation';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
-import { render } from '@testing-library/svelte';
+import { assertNonNullish } from '@dfinity/utils';
+import { Principal } from '@icp-sdk/core/principal';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+
+const { enabledIcTokensMock, exchangesMock } = vi.hoisted(() => {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const { writable: createWritable } = require('svelte/store');
+	return {
+		enabledIcTokensMock: createWritable([]),
+		exchangesMock: createWritable({})
+	};
+});
+
+vi.mock(import('$lib/derived/tokens.derived'), async (importOriginal) => ({
+	...(await importOriginal()),
+	get enabledIcTokens() {
+		return enabledIcTokensMock;
+	}
+}));
+
+vi.mock(import('$lib/derived/exchange.derived'), async (importOriginal) => ({
+	...(await importOriginal()),
+	get exchanges() {
+		return exchangesMock;
+	}
+}));
+
+const LEDGER_ICP = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
+const LEDGER_CKBTC = 'mxzaz-hqaaa-aaaar-qaada-cai';
+
+const buildBalance = ({
+	ledgerId,
+	free,
+	reserved
+}: {
+	ledgerId: string;
+	free: bigint;
+	reserved: bigint;
+}): UserTokenBalance =>
+	({
+		token: { id: { ledger_id: Principal.fromText(ledgerId) } },
+		balance: { free, reserved }
+	}) as unknown as UserTokenBalance;
 
 describe('WithdrawModal', () => {
+	const icp: IcToken = {
+		...mockValidIcToken,
+		id: parseTokenId('WithdrawIcpTokenId'),
+		ledgerCanisterId: LEDGER_ICP,
+		symbol: 'ICP'
+	};
+
+	const ckBtc: IcToken = {
+		...mockValidIcToken,
+		id: parseTokenId('WithdrawCkBtcTokenId'),
+		ledgerCanisterId: LEDGER_CKBTC,
+		symbol: 'ckBTC'
+	};
+
 	const withdrawToken: OisyTradeWithdrawToken = {
-		token: mockValidIcToken,
+		token: icp,
 		free: 5_000_000n,
 		reserved: ZERO
+	};
+
+	beforeEach(() => {
+		oisyTradeStore.reset();
+		enabledIcTokensMock.set([]);
+		exchangesMock.set({});
+	});
+
+	const setDexBalances = () => {
+		enabledIcTokensMock.set([icp, ckBtc]);
+		oisyTradeStore.set({
+			pairs: undefined,
+			supportedTokens: undefined,
+			balances: [
+				buildBalance({ ledgerId: LEDGER_ICP, free: 5_000_000n, reserved: ZERO }),
+				buildBalance({ ledgerId: LEDGER_CKBTC, free: 7_000_000n, reserved: 250_000n })
+			],
+			orders: undefined
+		});
+	};
+
+	// The token pill is the only element whose text is exactly the symbol and
+	// that sits inside a button (the fee lines render "<amount> <symbol>").
+	const getTokenPill = ({
+		getAllByText,
+		symbol
+	}: {
+		getAllByText: (text: string) => HTMLElement[];
+		symbol: string;
+	}) => {
+		const pill = getAllByText(symbol).find((element) => element.closest('button') !== null);
+
+		assertNonNullish(pill);
+
+		return pill;
 	};
 
 	it('opens on the withdraw form step with the title and amount label', () => {
@@ -29,5 +125,45 @@ describe('WithdrawModal', () => {
 		});
 
 		expect(container).toHaveTextContent('reserved · locked by open orders');
+	});
+
+	it('opens the tokens list with the DEX holdings when the token selector is clicked', async () => {
+		setDexBalances();
+
+		const { getAllByText, getByTestId, container } = render(WithdrawModal, {
+			props: { withdrawToken }
+		});
+
+		await fireEvent.click(getTokenPill({ getAllByText, symbol: 'ICP' }));
+
+		await waitFor(() => {
+			expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
+			expect(container).toHaveTextContent('ckBTC');
+		});
+	});
+
+	it('switches the withdraw flow to the selected token', async () => {
+		setDexBalances();
+
+		const { getAllByText, getByText, container } = render(WithdrawModal, {
+			props: { withdrawToken }
+		});
+
+		// The preselected ICP holding has nothing reserved.
+		expect(container).not.toHaveTextContent('reserved · locked by open orders');
+
+		await fireEvent.click(getTokenPill({ getAllByText, symbol: 'ICP' }));
+
+		await waitFor(() => expect(getByText('ckBTC')).toBeInTheDocument());
+
+		await fireEvent.click(getByText('ckBTC'));
+
+		// Back on the form, with the token — and its free/reserved DEX balance —
+		// switched to the selected holding.
+		await waitFor(() => {
+			expect(container).toHaveTextContent(en.trading.withdraw.amount_label);
+			expect(getTokenPill({ getAllByText, symbol: 'ckBTC' })).toBeInTheDocument();
+			expect(container).toHaveTextContent('reserved · locked by open orders');
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
@@ -149,7 +149,6 @@ describe('WithdrawModal', () => {
 			props: { withdrawToken }
 		});
 
-		// The preselected ICP holding has nothing reserved.
 		expect(container).not.toHaveTextContent('reserved · locked by open orders');
 
 		await fireEvent.click(getTokenPill({ getAllByText, symbol: 'ICP' }));
@@ -158,8 +157,7 @@ describe('WithdrawModal', () => {
 
 		await fireEvent.click(getByText('ckBTC'));
 
-		// Back on the form, with the token — and its free/reserved DEX balance —
-		// switched to the selected holding.
+		// Back on the form, with free/reserved now following the selected token.
 		await waitFor(() => {
 			expect(container).toHaveTextContent(en.trading.withdraw.amount_label);
 			expect(getTokenPill({ getAllByText, symbol: 'ckBTC' })).toBeInTheDocument();

--- a/src/frontend/src/tests/lib/components/trading/WithdrawWizard.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawWizard.svelte.spec.ts
@@ -26,8 +26,10 @@ describe('WithdrawWizard', () => {
 		token: mockValidIcToken,
 		amount: 0.01,
 		amountSetToMax: false,
+		free: 5_000_000n,
 		reserved: ZERO,
 		withdrawProgressStep: ProgressStepsTradingWithdraw.INITIALIZATION,
+		onSelectToken: () => {},
 		onClose: () => {},
 		onNext: () => {},
 		onBack: () => {}

--- a/src/frontend/src/tests/lib/config/trading-withdraw.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/trading-withdraw.config.spec.ts
@@ -8,7 +8,8 @@ describe('trading-withdraw.config', () => {
 			expect(tradingWithdrawWizardSteps({ i18n: en })).toStrictEqual([
 				{ name: WizardStepsTradingWithdraw.WITHDRAW, title: en.trading.withdraw.title },
 				{ name: WizardStepsTradingWithdraw.REVIEW, title: en.trading.withdraw.review_title },
-				{ name: WizardStepsTradingWithdraw.WITHDRAWING, title: en.trading.withdraw.progress_title }
+				{ name: WizardStepsTradingWithdraw.WITHDRAWING, title: en.trading.withdraw.progress_title },
+				{ name: WizardStepsTradingWithdraw.TOKENS_LIST, title: en.send.text.select_token }
 			]);
 		});
 	});


### PR DESCRIPTION
# Motivation

On the Trading page, the Withdraw modal was bound to the asset row it was opened from — the token was fixed for the whole flow. This makes the opened token a preselection only: the user can switch to any of their other DEX holdings from inside the modal, matching the token-picker UX the Deposit and Limit-order flows already have.

# Changes

- `WithdrawModal.svelte`: the withdraw token is now local state seeded by the `withdrawToken` prop (preselection). Added a `Tokens List` step reusing the shared `ModalTokensList` picker (search + category filters, network filter view-only since OISY TRADE is IC-only). The list shows each holding's free (withdrawable) balance rather than the wallet balance. `free`/`reserved` are derived live from `$oisyTradeAssets` for the selected token.
- `WithdrawForm.svelte` / `WithdrawWizard.svelte`: token input made selectable and wired to open the picker; the free balance is now passed in as a prop instead of the send-context `customSendBalance` (captured once at mount, so it wouldn't update on a token switch).
- `wizard-steps.ts`, `trading-withdraw.config.ts`, `wizard-modal.utils.ts`: new `TOKENS_LIST` step appended after the linear Withdraw → Review → Withdrawing sequence so `modal.next`/`back` semantics stay untouched; it is only reached via an explicit jump.

# Tests

- Updated `WithdrawForm` / `WithdrawWizard` specs for the new props and the token-selector click.
- Added `WithdrawModal` tests covering opening the picker with the DEX holdings and switching the flow to another token (asserting `free`/`reserved` follow the selection).
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, and the trading test suite (161 tests) pass.
