### PR TITLE
fix(frontend): anchor landing background to top so light-mode glow is not squashed

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -163,6 +163,11 @@
 				min-width: 1728px;
 
 				object-fit: cover;
+				/* Anchor to the top: the portrait light artwork keeps its meaningful
+				   region (horizon glow) in the upper part, so cropping must happen from
+				   the bottom. Without this, cover centers and squashes the glow into a
+				   thin band at the top edge in light mode. */
+				object-position: top;
 			}
 
 			/* Default background: landing page artwork (shown pre-hydration and on the signed-out landing screen). */

--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -163,6 +163,9 @@
 				min-width: 1728px;
 
 				object-fit: cover;
+			}
+
+			#app-background-landing-light {
 				object-position: top;
 			}
 

--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -163,10 +163,6 @@
 				min-width: 1728px;
 
 				object-fit: cover;
-				/* Anchor to the top: the portrait light artwork keeps its meaningful
-				   region (horizon glow) in the upper part, so cropping must happen from
-				   the bottom. Without this, cover centers and squashes the glow into a
-				   thin band at the top edge in light mode. */
 				object-position: top;
 			}
 


### PR DESCRIPTION
# Motivation

#13336 gave the fixed background images `object-fit: cover` (+ `height: 100%`) to make the splash/landing background fill the full viewport. But `object-fit: cover` defaults to center anchoring, and the light landing artwork (`landing_bg_light.webp`) is a tall portrait image (1304×1947) with its horizon glow in the upper part. On a wide viewport, cover scales it up and center-crops it, squashing the glow into a thin band at the top edge — the light-mode background looked "shrunk up". Dark mode was unaffected because `landing_bg_dark.webp` is landscape (1536×1024) and barely gets cropped.

# Changes

- `src/frontend/src/app.html`: add `object-position: top` to the background images so `cover` crops from the bottom instead of centering. This preserves the glow region and restores the pre-#13336 look, while keeping the full-viewport fill.

# Tests

Manual (isolated CSS harness with the real `.webp` assets, at multiple viewports and both themes):
- Light mode at 1728×900: glow now rises from the bottom (matches pre-#13336) instead of being squashed at the top.
- Dark mode: unchanged.
- Tall/narrow viewport (700×1000): background still fills to the bottom with no gap — #13336's original goal is preserved.
