### PR TITLE
refactor(frontend): remove duplicated OISY trade type declarations

### DIFF
--- a/src/frontend/src/lib/types/oisy-trade.ts
+++ b/src/frontend/src/lib/types/oisy-trade.ts
@@ -72,36 +72,3 @@ export interface OisyTradeOrderBook {
 	ticker: OrderBookTicker | undefined;
 	depth: OrderBookDepth | undefined;
 }
-
-// Live, per-pair order-book snapshot kept fresh while the limit-order form is
-// open. Keyed by the pair's symbol pair (e.g. "ICP/ckUSDC"). `undefined` = not
-// loaded yet for that pair.
-export interface OisyTradeOrderBook {
-	ticker: OrderBookTicker | undefined;
-	depth: OrderBookDepth | undefined;
-}
-
-// A DEX balance entry resolved to the matching OISY token, ready for display in
-// the Trading tab "My assets" section.
-export interface OisyTradeAsset {
-	token: IcToken;
-	// Funds available for new orders or withdrawal.
-	free: bigint;
-	// Funds locked by open orders.
-	reserved: bigint;
-	// `free + reserved` — the total deposited on the DEX.
-	total: bigint;
-	// Fiat value of `total`, or undefined when no exchange rate is available.
-	totalUsd: number | undefined;
-	// Fiat value of `free`, or undefined when no exchange rate is available.
-	freeUsd: number | undefined;
-}
-
-// A DEX balance entry paired with the resolved OISY token (for the logo,
-// network, decimals and exchange rate the wallet already knows about). Used to
-// open the Withdraw flow with the token pre-selected.
-export interface OisyTradeWithdrawToken {
-	token: IcToken;
-	free: bigint;
-	reserved: bigint;
-}


### PR DESCRIPTION
# Motivation

`src/frontend/src/lib/types/oisy-trade.ts` declared `OisyTradeAsset`, `OisyTradeWithdrawToken`, and `OisyTradeOrderBook` twice, each with an identical body and comment block — the result of a bad merge. TypeScript declaration merging let this compile, but it's dead duplicated code that misleads readers and invites drift between the copies.

# Changes

- Removed the second copy of each of the three interfaces (and their duplicated comment blocks), leaving a single declaration per interface. Net 33-line deletion, no behavioral change.

# Tests

- `prettier --check`: passes.
- ESLint on the file: passes (zero warnings).
- `svelte-check`: no new type errors introduced. The one remaining error is in an unrelated file (`liquidium-active-tx.utils.ts`) and is pre-existing — it reproduces on `main` without this change.