### PR TITLE
feat(frontend): anchor limit-order presets on the exchange-rate cross, latch to market until review

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
@@ -10,7 +10,6 @@
 		formatTradeAmount,
 		type LimitOrderPairView,
 		type LimitOrderSide,
-		isPresetSelected,
 		presetTargetPrice,
 		type PricePreset,
 		queuePositionDisplay,
@@ -91,18 +90,6 @@
 			{ $base: base }
 		);
 	});
-
-	const presetSelected = (preset: PricePreset): boolean =>
-		active &&
-		isPresetSelected({
-			preset,
-			price: priceNum,
-			side,
-			currentValue,
-			bid,
-			ask,
-			tickSize: pairView?.tickSize ?? 0
-		});
 
 	const setPreset = (preset: PricePreset) => {
 		if (!nonNullish(pairView)) {
@@ -197,6 +184,12 @@
 	const bidAskLabel = $derived(
 		side === 'sell' ? $i18n.trading.limit_order.preset_bid : $i18n.trading.limit_order.preset_ask
 	);
+	const presets = $derived<{ preset: PricePreset; label: string }[]>([
+		{ preset: 'book', label: bidAskLabel },
+		{ preset: 0, label: $i18n.trading.limit_order.preset_market },
+		{ preset: 1, label: presetLabel1 },
+		{ preset: 5, label: presetLabel5 }
+	]);
 </script>
 
 <div
@@ -208,41 +201,24 @@
 	<div class="flex items-center justify-between gap-2">
 		<span class="text-xs text-secondary">{label}</span>
 		<div class="flex items-center gap-1.5 text-xs">
-			<button
-				class="underline"
-				class:font-semibold={presetSelected('book')}
-				class:text-brand-primary={!presetSelected('book')}
-				class:text-primary={presetSelected('book')}
-				onclick={() => setPreset('book')}
-				type="button">{bidAskLabel}</button
-			>
-			<span class="text-tertiary">·</span>
-			<button
-				class="underline"
-				class:font-semibold={presetSelected(0)}
-				class:text-brand-primary={!presetSelected(0)}
-				class:text-primary={presetSelected(0)}
-				onclick={() => setPreset(0)}
-				type="button">{$i18n.trading.limit_order.preset_market}</button
-			>
-			<span class="text-tertiary">·</span>
-			<button
-				class="underline"
-				class:font-semibold={presetSelected(1)}
-				class:text-brand-primary={!presetSelected(1)}
-				class:text-primary={presetSelected(1)}
-				onclick={() => setPreset(1)}
-				type="button">{presetLabel1}</button
-			>
-			<span class="text-tertiary">·</span>
-			<button
-				class="underline"
-				class:font-semibold={presetSelected(5)}
-				class:text-brand-primary={!presetSelected(5)}
-				class:text-primary={presetSelected(5)}
-				onclick={() => setPreset(5)}
-				type="button">{presetLabel5}</button
-			>
+			{#each presets as { preset, label }, i (preset)}
+				{#if i > 0}
+					<span class="text-tertiary">·</span>
+				{/if}
+				<!-- Border marks the latched preset; it clears on a manual price edit
+					 (which nulls `activePreset`) and follows the market while latched. -->
+				<button
+					class="rounded border px-1 py-0.5 transition-colors"
+					class:border-brand-primary={activePreset === preset}
+					class:border-transparent={activePreset !== preset}
+					class:font-semibold={activePreset === preset}
+					class:text-brand-primary={activePreset !== preset}
+					class:text-primary={activePreset === preset}
+					class:underline={activePreset !== preset}
+					onclick={() => setPreset(preset)}
+					type="button">{label}</button
+				>
+			{/each}
 		</div>
 	</div>
 

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
@@ -8,7 +8,8 @@
 	import LimitOrderTokensList from '$lib/components/trading/limit-order/LimitOrderTokensList.svelte';
 	import { OISY_TRADE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { oisyTradePairs } from '$lib/derived/oisy-trade.derived';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { oisyTradeIcTokenBySymbol, oisyTradePairs } from '$lib/derived/oisy-trade.derived';
 	import {
 		PLAUSIBLE_EVENT_RESULT_STATUSES,
 		PLAUSIBLE_EVENT_SUBCONTEXT_TRADING
@@ -24,6 +25,7 @@
 	import { replaceIcErrorFields } from '$lib/utils/error.utils';
 	import {
 		type LimitOrderSide,
+		presetTargetPrice,
 		priceLevelToHuman,
 		toCandidSide,
 		toPairView,
@@ -98,14 +100,60 @@
 			: null;
 	});
 
-	// "Current value" reference: order-book mid-price (best on-chain reference
-	// available without the full USD feed integration; see PR notes). Falls back
-	// to whichever side exists, else 0 (presets/value-difference then inert).
+	// USD exchange-rate price of each leg, from the app-wide price feed.
+	const baseToken = $derived(
+		nonNullish(baseSymbol) ? $oisyTradeIcTokenBySymbol[baseSymbol] : undefined
+	);
+	const quoteToken = $derived(
+		nonNullish(quoteSymbol) ? $oisyTradeIcTokenBySymbol[quoteSymbol] : undefined
+	);
+	const baseUsdPrice = $derived(
+		nonNullish(baseToken) ? $exchanges?.[baseToken.id]?.usd : undefined
+	);
+	const quoteUsdPrice = $derived(
+		nonNullish(quoteToken) ? $exchanges?.[quoteToken.id]?.usd : undefined
+	);
+
+	// "Current value" reference the percentage presets (Market / ±%) and the
+	// value-difference indicator anchor on. Deliberately the *cross* of the two
+	// legs' USD exchange-rate prices (base ÷ quote), NOT the DEX order-book mid.
+	// Unusual for an order-book UI, but intentional: the book mid can be stale or
+	// one-sided on a thin book, whereas the USD feed gives a stable fair-value
+	// reference independent of current on-chain liquidity. The book bid/ask/mid
+	// still drives the Bid/Ask preset and the crossing / fill-or-kill checks.
+	// 0 when either price is missing, so the percentage presets and the
+	// value-difference stay inert until the feed loads.
 	const currentValue = $derived.by((): number => {
-		if (nonNullish(bid) && nonNullish(ask)) {
-			return (bid + ask) / 2;
+		if (nonNullish(baseUsdPrice) && nonNullish(quoteUsdPrice) && quoteUsdPrice > 0) {
+			return baseUsdPrice / quoteUsdPrice;
 		}
-		return bid ?? ask ?? 0;
+		return 0;
+	});
+
+	// While a preset is latched, keep the price tracking its live target as the
+	// reference rate (or book) moves — but only on the Form step. Opening Review
+	// freezes the price: this effect stops running there, mirroring how the swap
+	// flow freezes its quote at review. A manual price edit clears `activePreset`
+	// (see LimitOrderForm), so typing detaches the price from the market.
+	$effect(() => {
+		if (
+			currentStep?.name !== WizardStepsLimitOrder.FORM ||
+			isNullish(activePreset) ||
+			isNullish(pairView)
+		) {
+			return;
+		}
+		const target = presetTargetPrice({
+			preset: activePreset,
+			side,
+			currentValue,
+			bid,
+			ask,
+			tickSize: pairView.tickSize
+		});
+		if (nonNullish(target)) {
+			price = target.toString();
+		}
 	});
 
 	// Aggregated depth in human units, for the queue-position projection.
@@ -150,6 +198,24 @@
 	});
 
 	const goTo = (stepName: WizardStepsLimitOrder) => goToWizardStep({ modal, steps, stepName });
+
+	// Frozen market snapshot captured the moment Review opens, so the confirmation
+	// screen stays put while the ticker / price feed keep polling underneath.
+	let reviewCurrentValue = $state(0);
+	let reviewBid = $state<number | null>(null);
+	let reviewAsk = $state<number | null>(null);
+	let reviewDepthLevels = $state<{
+		asks: { price: number; quantity: number }[];
+		bids: { price: number; quantity: number }[];
+	}>({ asks: [], bids: [] });
+
+	const openReview = () => {
+		reviewCurrentValue = currentValue;
+		reviewBid = bid;
+		reviewAsk = ask;
+		reviewDepthLevels = depthLevels;
+		goTo(WizardStepsLimitOrder.REVIEW);
+	};
 
 	// Parsed Review inputs, guarded against NaN from empty/partial fields so the
 	// Review step never renders NaN (nor feeds NaN% into ValueDifference).
@@ -261,11 +327,11 @@
 	/>
 {:else if currentStep?.name === WizardStepsLimitOrder.REVIEW}
 	<LimitOrderReview
-		{ask}
+		ask={reviewAsk}
 		baseAmount={reviewBaseAmount}
-		{bid}
-		{currentValue}
-		{depthLevels}
+		bid={reviewBid}
+		currentValue={reviewCurrentValue}
+		depthLevels={reviewDepthLevels}
 		{fillOrKill}
 		onBack={() => goTo(WizardStepsLimitOrder.FORM)}
 		onPlace={place}
@@ -283,7 +349,7 @@
 		{currentValue}
 		{depthLevels}
 		{onClose}
-		onReview={() => goTo(WizardStepsLimitOrder.REVIEW)}
+		onReview={openReview}
 		onSelectBase={() => goTo(WizardStepsLimitOrder.BASE_TOKEN)}
 		onSelectQuote={() => goTo(WizardStepsLimitOrder.QUOTE_TOKEN)}
 		{pairView}

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderWizard.svelte
@@ -27,6 +27,7 @@
 		type LimitOrderSide,
 		presetTargetPrice,
 		priceLevelToHuman,
+		referenceRate,
 		toCandidSide,
 		toPairView,
 		toPriceUnits,
@@ -115,20 +116,11 @@
 	);
 
 	// "Current value" reference the percentage presets (Market / ±%) and the
-	// value-difference indicator anchor on. Deliberately the *cross* of the two
-	// legs' USD exchange-rate prices (base ÷ quote), NOT the DEX order-book mid.
-	// Unusual for an order-book UI, but intentional: the book mid can be stale or
-	// one-sided on a thin book, whereas the USD feed gives a stable fair-value
-	// reference independent of current on-chain liquidity. The book bid/ask/mid
-	// still drives the Bid/Ask preset and the crossing / fill-or-kill checks.
-	// 0 when either price is missing, so the percentage presets and the
-	// value-difference stay inert until the feed loads.
-	const currentValue = $derived.by((): number => {
-		if (nonNullish(baseUsdPrice) && nonNullish(quoteUsdPrice) && quoteUsdPrice > 0) {
-			return baseUsdPrice / quoteUsdPrice;
-		}
-		return 0;
-	});
+	// value-difference indicator anchor on: the cross of the two legs' USD
+	// exchange-rate prices, NOT the DEX order-book mid (see `referenceRate`). The
+	// book bid/ask/mid still drives the Bid/Ask preset and the crossing /
+	// fill-or-kill checks.
+	const currentValue = $derived(referenceRate({ baseUsd: baseUsdPrice, quoteUsd: quoteUsdPrice }));
 
 	// While a preset is latched, keep the price tracking its live target as the
 	// reference rate (or book) moves — but only on the Form step. Opening Review

--- a/src/frontend/src/lib/utils/oisy-trade.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade.utils.ts
@@ -459,6 +459,20 @@ export const maxSpendBaseAmount = ({
 
 export type PricePreset = 'book' | 0 | 1 | 5;
 
+// The presets' fair-value anchor: the cross of the two legs' USD exchange-rate
+// prices (base ÷ quote). Deliberately independent of the DEX order-book mid — the
+// book can be stale or one-sided on a thin market, whereas the USD feed is a
+// stable reference. Returns 0 when either price is missing or the quote price is
+// non-positive, which leaves the percentage presets inert until the feed loads.
+export const referenceRate = ({
+	baseUsd,
+	quoteUsd
+}: {
+	baseUsd: number | undefined;
+	quoteUsd: number | undefined;
+}): number =>
+	nonNullish(baseUsd) && nonNullish(quoteUsd) && quoteUsd > 0 ? baseUsd / quoteUsd : 0;
+
 const snapToTick = ({ price, tickSize }: { price: number; tickSize: number }): number =>
 	parseFloat((Math.round(price / tickSize) * tickSize).toFixed(decimalsOfStep(tickSize)));
 

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderPriceSection.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderPriceSection.svelte.spec.ts
@@ -113,6 +113,24 @@ describe('LimitOrderPriceSection', () => {
 		expect(parseFloat(props.price)).toBeGreaterThan(0);
 	});
 
+	it('borders the latched preset and no other', () => {
+		const { getByText } = render(LimitOrderPriceSection, {
+			props: { ...baseProps, activePreset: 1 as PricePreset | null }
+		});
+
+		expect(getByText(en.trading.limit_order.preset_sell_1)).toHaveClass('border-brand-primary');
+		expect(getByText(en.trading.limit_order.preset_market)).not.toHaveClass('border-brand-primary');
+	});
+
+	it('borders no preset when none is latched', () => {
+		const { getByText } = render(LimitOrderPriceSection, {
+			props: { ...baseProps, activePreset: null as PricePreset | null }
+		});
+
+		expect(getByText(en.trading.limit_order.preset_market)).not.toHaveClass('border-brand-primary');
+		expect(getByText(en.trading.limit_order.preset_sell_1)).not.toHaveClass('border-brand-primary');
+	});
+
 	it('renders the value difference when price and current value are positive', () => {
 		const { container } = render(LimitOrderPriceSection, {
 			props: { ...baseProps, price: '12', currentValue: 10 }

--- a/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
@@ -41,6 +41,7 @@ import {
 	presetTargetPrice,
 	queuePositionDisplay,
 	queuePositionFraction,
+	referenceRate,
 	spendAmount,
 	sumOisyTradeAssetsUsd,
 	toOisyTradeWithdrawTokens,
@@ -441,6 +442,19 @@ describe('oisy-trade.utils — limit order', () => {
 			expect(
 				maxSpendBaseAmount({ side: 'buy', freeBase: 0, freeQuote: 30, price: 0, pair })
 			).toBeNull();
+		});
+	});
+
+	describe('referenceRate', () => {
+		it('is the cross of the two USD prices (base ÷ quote)', () => {
+			expect(referenceRate({ baseUsd: 6.6, quoteUsd: 1 })).toBeCloseTo(6.6, 6);
+			expect(referenceRate({ baseUsd: 2, quoteUsd: 0.5 })).toBeCloseTo(4, 6);
+		});
+
+		it('is 0 when either price is missing or the quote price is non-positive', () => {
+			expect(referenceRate({ baseUsd: undefined, quoteUsd: 1 })).toBe(0);
+			expect(referenceRate({ baseUsd: 6.6, quoteUsd: undefined })).toBe(0);
+			expect(referenceRate({ baseUsd: 6.6, quoteUsd: 0 })).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The limit-order price presets read their anchor from the DEX order-book mid (`(bid+ask)/2`), which can be stale or one-sided on a thin book. They should instead reference a stable fair-value: the cross of the two tokens' USD exchange-rate prices. They should also stay live with the market while a preset is latched, and freeze once the user reaches Review — the same way the swap flow freezes its quote.

# Changes

- The percentage presets (Market / ±1% / ±5%) and the value-difference indicator now anchor on the exchange-rate cross (base USD ÷ quote USD), not the order-book mid. The Bid/Ask preset and the crossing / fill-or-kill checks still use the live book.
- While a preset is latched, the price now tracks its live target reactively as the reference moves — but only on the Form step. Opening Review freezes the price and snapshots the market reference (currentValue/bid/ask/depth), so the confirmation screen no longer moves under the user.
- The selected preset now shows a small border driven by the latch; it clears on a manual price edit.

# Tests

- Added component tests asserting the selection border tracks `activePreset`.
- `npm run format`, `lint`, `check`, and the limit-order / oisy-trade suites pass (157 tests).
