### PR TITLE
fix(frontend): base Trading order-detail current value on the cross-pair exchange rate

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -48,6 +48,7 @@
 		priceLevelToHuman,
 		queuePositionDisplay,
 		queuePositionFraction,
+		referenceRate,
 		toPairView,
 		toTradingPair,
 		valueDifferencePercent
@@ -120,12 +121,13 @@
 		return nonNullish(level) && nonNullish(pairView) ? toHuman(level).price : null;
 	});
 
-	const currentValue = $derived.by((): number => {
-		if (nonNullish(bid) && nonNullish(ask)) {
-			return (bid + ask) / 2;
-		}
-		return bid ?? ask ?? 0;
-	});
+	// "Current value" anchors on the cross of the two legs' USD exchange-rate
+	// prices (base ÷ quote), NOT the DEX order-book mid — mirroring the reference
+	// the limit-order creation flow uses (see `referenceRate`). The book bid/ask
+	// still drive the crossing check below.
+	const baseUsdPrice = $derived($exchanges?.[base.id]?.usd);
+	const quoteUsdPrice = $derived($exchanges?.[quote.id]?.usd);
+	const currentValue = $derived(referenceRate({ baseUsd: baseUsdPrice, quoteUsd: quoteUsdPrice }));
 
 	const crossing = $derived(crossesBook({ side, price, bid, ask }));
 	const valueDiff = $derived(valueDifferencePercent({ side, price, currentValue }));


### PR DESCRIPTION
# Motivation

In the Trading order-detail modal, the "current value" was derived from the DEX order-book bid/ask mid. The limit-order creation flow instead anchors its "current value" (and the percentage presets / value-difference indicator) on the *cross of the two legs' USD exchange-rate prices* (base ÷ quote), which is a more stable reference than a possibly thin or one-sided book. The two surfaces disagreed for the same order.

# Changes

- `TradingOrderDetailModal.svelte`: compute `currentValue` from the existing `referenceRate({ baseUsd, quoteUsd })` util (the same one the creation flow uses) instead of the order-book bid/ask mid.
- The book bid/ask are still derived and still drive the crossing check; only the displayed current value / value-difference anchor changed.
- No new util — reused `referenceRate` from `oisy-trade.utils.ts`.

# Tests

- `npm run test` for `TradingOrderDetailModal.svelte.spec.ts`: 5/5 pass.
- `svelte-check`: no new errors introduced by this change.
- Prettier + ESLint clean on the changed file.