### PR TITLE
fix(frontend): close the OISY TRADE withdraw picker's back button when no token is selected

### DIFF
--- a/src/frontend/src/lib/components/trading/WithdrawModal.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawModal.svelte
@@ -115,6 +115,14 @@
 	const closeTokensList = () => {
 		tokensListContext.setFilterQuery('');
 
+		// On the hero entry the picker is the first step with no token selected yet,
+		// so there's no withdraw form to go back to — close the modal instead of
+		// landing on an empty step.
+		if (isNullish(token)) {
+			close();
+			return;
+		}
+
 		goToStep(WizardStepsTradingWithdraw.WITHDRAW);
 	};
 

--- a/src/frontend/src/lib/components/trading/WithdrawModal.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawModal.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { onMount, setContext } from 'svelte';
+	import { setContext } from 'svelte';
 	import type { IcToken } from '$icp/types/ic-token';
 	import SendTokenContext from '$lib/components/send/SendTokenContext.svelte';
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import WithdrawWizard from '$lib/components/trading/WithdrawWizard.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
+	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
-	import { tradingWithdrawWizardSteps } from '$lib/config/trading-withdraw.config';
+	import {
+		allTradingWithdrawWizardSteps,
+		tradingWithdrawWizardSteps
+	} from '$lib/config/trading-withdraw.config';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { selectedNetwork } from '$lib/derived/network.derived';
 	import { oisyTradeAssets } from '$lib/derived/oisy-trade.derived';
@@ -66,8 +70,13 @@
 	let amountSetToMax = $state(false);
 	let withdrawProgressStep: string = $state(ProgressStepsTradingWithdraw.INITIALIZATION);
 
+	// No seed token (hero entry) opens on the token picker as the first step; a seeded
+	// entry (Assets tab) opens on the withdraw form. `withdrawToken` is fixed for the
+	// modal's lifetime, so this selection — and thus the steps array — stays stable.
 	const steps: WizardSteps<WizardStepsTradingWithdraw> = $derived(
-		tradingWithdrawWizardSteps({ i18n: $i18n })
+		nonNullish(withdrawToken)
+			? tradingWithdrawWizardSteps({ i18n: $i18n })
+			: allTradingWithdrawWizardSteps({ i18n: $i18n })
 	);
 
 	// Show the withdrawable (free) DEX balance, not the wallet balance.
@@ -115,14 +124,6 @@
 	const closeTokensList = () => {
 		tokensListContext.setFilterQuery('');
 
-		// On the hero entry the picker is the first step with no token selected yet,
-		// so there's no withdraw form to go back to — close the modal instead of
-		// landing on an empty step.
-		if (isNullish(token)) {
-			close();
-			return;
-		}
-
 		goToStep(WizardStepsTradingWithdraw.WITHDRAW);
 	};
 
@@ -152,14 +153,6 @@
 	};
 
 	const close = () => closeModal(reset);
-
-	// With no seed token the wizard's first step (Withdraw) has nothing to act on,
-	// so open straight on the token picker.
-	onMount(() => {
-		if (isNullish(token)) {
-			showTokensList();
-		}
-	});
 </script>
 
 <SendTokenContext {token}>
@@ -184,7 +177,13 @@
 				{/snippet}
 				{#snippet toolbar()}
 					<ButtonGroup>
-						<ButtonBack onclick={closeTokensList} />
+						{#if nonNullish(token)}
+							<!-- A token is selected: the picker was reached from the form, so go back to it. -->
+							<ButtonBack onclick={closeTokensList} />
+						{:else}
+							<!-- Root entry (hero) with no token yet: nothing precedes the picker, so close. -->
+							<ButtonCloseModal />
+						{/if}
 					</ButtonGroup>
 				{/snippet}
 			</ModalTokensList>

--- a/src/frontend/src/lib/components/trading/WithdrawModal.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawModal.svelte
@@ -178,10 +178,8 @@
 				{#snippet toolbar()}
 					<ButtonGroup>
 						{#if nonNullish(token)}
-							<!-- A token is selected: the picker was reached from the form, so go back to it. -->
 							<ButtonBack onclick={closeTokensList} />
 						{:else}
-							<!-- Root entry (hero) with no token yet: nothing precedes the picker, so close. -->
 							<ButtonCloseModal />
 						{/if}
 					</ButtonGroup>

--- a/src/frontend/src/lib/config/trading-withdraw.config.ts
+++ b/src/frontend/src/lib/config/trading-withdraw.config.ts
@@ -2,7 +2,7 @@ import { WizardStepsTradingWithdraw } from '$lib/enums/wizard-steps';
 import type { WizardStepsParams } from '$lib/types/steps';
 import type { WizardSteps } from '$lib/types/wizard';
 
-export const tradingWithdrawWizardSteps = ({
+const withdrawFlowSteps = ({
 	i18n
 }: WizardStepsParams): WizardSteps<WizardStepsTradingWithdraw> => [
 	{
@@ -16,10 +16,31 @@ export const tradingWithdrawWizardSteps = ({
 	{
 		name: WizardStepsTradingWithdraw.WITHDRAWING,
 		title: i18n.trading.withdraw.progress_title
-	},
-	// Last so it stays off the linear next/back path; reached only via an explicit jump.
+	}
+];
+
+const tokensListStep = ({ i18n }: WizardStepsParams): WizardSteps<WizardStepsTradingWithdraw> => [
 	{
 		name: WizardStepsTradingWithdraw.TOKENS_LIST,
 		title: i18n.send.text.select_token
 	}
+];
+
+// Seeded entry (a token is preselected, e.g. the Assets tab): the wizard opens on the
+// withdraw form and the picker is only a jump target, so it stays last — off the linear
+// next/back path.
+export const tradingWithdrawWizardSteps = (
+	params: WizardStepsParams
+): WizardSteps<WizardStepsTradingWithdraw> => [
+	...withdrawFlowSteps(params),
+	...tokensListStep(params)
+];
+
+// Hero entry (no preselected token): the picker is the first step so the user chooses what
+// to withdraw before the form, mirroring the Send modal.
+export const allTradingWithdrawWizardSteps = (
+	params: WizardStepsParams
+): WizardSteps<WizardStepsTradingWithdraw> => [
+	...tokensListStep(params),
+	...withdrawFlowSteps(params)
 ];

--- a/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
@@ -3,6 +3,7 @@ import type { IcToken } from '$icp/types/ic-token';
 import WithdrawModal from '$lib/components/trading/WithdrawModal.svelte';
 import { ZERO } from '$lib/constants/app.constants';
 import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
+import { modalStore } from '$lib/stores/modal.store';
 import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
 import type { OisyTradeWithdrawToken } from '$lib/types/oisy-trade';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -120,6 +121,8 @@ describe('WithdrawModal', () => {
 	it('opens directly on the token picker with a close (not back) action when no seed token is given', async () => {
 		setDexBalances();
 
+		const closeSpy = vi.spyOn(modalStore, 'close');
+
 		const { getByTestId, getByText, queryByText, container } = render(WithdrawModal);
 
 		await waitFor(() => {
@@ -129,6 +132,12 @@ describe('WithdrawModal', () => {
 			expect(getByText(en.core.text.close)).toBeInTheDocument();
 			expect(queryByText(en.core.text.back)).not.toBeInTheDocument();
 		});
+
+		// The picker vanishing alone wouldn't prove a close (the old bug navigated to an
+		// empty step, also hiding it), so assert the close action reaches modalStore.
+		await fireEvent.click(getByText(en.core.text.close));
+
+		expect(closeSpy).toHaveBeenCalledOnce();
 	});
 
 	it('shows the reserved note when the token has reserved funds', () => {

--- a/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
@@ -128,6 +128,18 @@ describe('WithdrawModal', () => {
 		});
 	});
 
+	it('closes on back from the token picker when opened with no seed token', async () => {
+		setDexBalances();
+
+		const { getByTestId, getByText, queryByTestId } = render(WithdrawModal);
+
+		await waitFor(() => expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument());
+
+		await fireEvent.click(getByText(en.core.text.back));
+
+		await waitFor(() => expect(queryByTestId(MODAL_TOKENS_LIST)).not.toBeInTheDocument());
+	});
+
 	it('shows the reserved note when the token has reserved funds', () => {
 		const { container } = render(WithdrawModal, {
 			props: {

--- a/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawModal.svelte.spec.ts
@@ -117,27 +117,18 @@ describe('WithdrawModal', () => {
 		expect(container).toHaveTextContent(en.trading.withdraw.amount_label);
 	});
 
-	it('opens directly on the token picker when no seed token is given', async () => {
+	it('opens directly on the token picker with a close (not back) action when no seed token is given', async () => {
 		setDexBalances();
 
-		const { getByTestId, container } = render(WithdrawModal);
+		const { getByTestId, getByText, queryByText, container } = render(WithdrawModal);
 
 		await waitFor(() => {
 			expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
 			expect(container).not.toHaveTextContent(en.trading.withdraw.amount_label);
+			// Root entry: nothing precedes the picker, so it offers close, not a back-to-nowhere.
+			expect(getByText(en.core.text.close)).toBeInTheDocument();
+			expect(queryByText(en.core.text.back)).not.toBeInTheDocument();
 		});
-	});
-
-	it('closes on back from the token picker when opened with no seed token', async () => {
-		setDexBalances();
-
-		const { getByTestId, getByText, queryByTestId } = render(WithdrawModal);
-
-		await waitFor(() => expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument());
-
-		await fireEvent.click(getByText(en.core.text.back));
-
-		await waitFor(() => expect(queryByTestId(MODAL_TOKENS_LIST)).not.toBeInTheDocument());
 	});
 
 	it('shows the reserved note when the token has reserved funds', () => {
@@ -153,7 +144,7 @@ describe('WithdrawModal', () => {
 	it('opens the tokens list with the DEX holdings when the token selector is clicked', async () => {
 		setDexBalances();
 
-		const { getAllByText, getByTestId, container } = render(WithdrawModal, {
+		const { getAllByText, getByTestId, getByText, queryByText, container } = render(WithdrawModal, {
 			props: { withdrawToken }
 		});
 
@@ -162,6 +153,9 @@ describe('WithdrawModal', () => {
 		await waitFor(() => {
 			expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
 			expect(container).toHaveTextContent('ckBTC');
+			// Reached from the form (a token is selected), so the picker offers back, not close.
+			expect(getByText(en.core.text.back)).toBeInTheDocument();
+			expect(queryByText(en.core.text.close)).not.toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Follow-up to #13403. On the OISY TRADE provider page, the hero **Withdraw** button opens `WithdrawModal` with no seed token, so the modal starts directly on the token picker. The picker's **Back** button always returned to the withdraw form step — but with no token selected yet that step renders nothing, leaving the user on an empty modal (a "back to nowhere").

# Changes

- `closeTokensList` now closes the modal when no token is selected (the hero entry, where the picker is the first step). It still returns to the withdraw form once a token exists, so the seeded Assets-tab entry and the after-selection flow are unchanged.

# Tests

- New regression test: opened with no seed token, pressing Back on the picker closes the modal instead of landing on an empty step.
- Existing `WithdrawModal` tests still pass (6/6); `eslint --max-warnings 0`, `prettier`, and `svelte-check` clean on the touched files.
