### PR TITLE
fix(frontend): title OISY TRADE deposit/withdraw token pickers correctly

### DIFF
--- a/src/frontend/src/lib/config/trading-withdraw.config.ts
+++ b/src/frontend/src/lib/config/trading-withdraw.config.ts
@@ -20,6 +20,6 @@ export const tradingWithdrawWizardSteps = ({
 	// Last so it stays off the linear next/back path; reached only via an explicit jump.
 	{
 		name: WizardStepsTradingWithdraw.TOKENS_LIST,
-		title: i18n.send.text.select_token
+		title: i18n.trading.withdraw.title
 	}
 ];

--- a/src/frontend/src/lib/config/trading.config.ts
+++ b/src/frontend/src/lib/config/trading.config.ts
@@ -11,7 +11,7 @@ export const tradingDepositWizardSteps = ({
 	},
 	{
 		name: WizardStepsTradingDeposit.TOKENS_LIST,
-		title: i18n.send.text.select_token
+		title: i18n.trading.deposit.title
 	},
 	{
 		name: WizardStepsTradingDeposit.FILTER_NETWORKS,

--- a/src/frontend/src/tests/lib/config/trading-withdraw.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/trading-withdraw.config.spec.ts
@@ -9,7 +9,7 @@ describe('trading-withdraw.config', () => {
 				{ name: WizardStepsTradingWithdraw.WITHDRAW, title: en.trading.withdraw.title },
 				{ name: WizardStepsTradingWithdraw.REVIEW, title: en.trading.withdraw.review_title },
 				{ name: WizardStepsTradingWithdraw.WITHDRAWING, title: en.trading.withdraw.progress_title },
-				{ name: WizardStepsTradingWithdraw.TOKENS_LIST, title: en.send.text.select_token }
+				{ name: WizardStepsTradingWithdraw.TOKENS_LIST, title: en.trading.withdraw.title }
 			]);
 		});
 	});

--- a/src/frontend/src/tests/lib/config/trading.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/trading.config.spec.ts
@@ -19,7 +19,7 @@ describe('trading.config', () => {
 		it('uses the matching i18n titles', () => {
 			expect(steps.map(({ title }) => title)).toEqual([
 				en.trading.deposit.title,
-				en.send.text.select_token,
+				en.trading.deposit.title,
 				en.send.text.select_network_filter,
 				en.trading.deposit.review_title,
 				en.trading.deposit.progress_title


### PR DESCRIPTION
# Motivation

In the OISY TRADE deposit and withdraw flows, the token-picker step showed the generic header "Select token to send" (reused from the send flow). That is the wrong label here — the user is choosing a token to deposit or withdraw, not to send.

# Changes

- Withdraw wizard `TOKENS_LIST` step now uses `i18n.trading.withdraw.title` ("Withdraw").
- Deposit wizard `TOKENS_LIST` step now uses `i18n.trading.deposit.title` ("Deposit").

Each keeps the header consistent across every step of its respective flow.

# Tests

- `prettier --check` passes on both changed config files.