### PR TITLE
fix(frontend): normalize signed-zero to a clean 0.00% in ValueDifference

### DIFF
--- a/src/frontend/src/lib/components/ui/ValueDifference.svelte
+++ b/src/frontend/src/lib/components/ui/ValueDifference.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 
 	interface Props {
 		// The signed value difference, in percent (already computed by the caller).
@@ -42,7 +42,7 @@
 	// rather than "-0.00%" (or a spurious "+0.00%"): toFixed keeps the sign of a
 	// negative rounding-to-zero, so we must snap through Number() first.
 	let text = $derived.by((): string => {
-		if (!nonNullish(value)) {
+		if (isNullish(value)) {
 			return '';
 		}
 		const rounded = Number(value.toFixed(2));

--- a/src/frontend/src/lib/components/ui/ValueDifference.svelte
+++ b/src/frontend/src/lib/components/ui/ValueDifference.svelte
@@ -37,6 +37,17 @@
 	let isSuccess = $derived(!muted && nonNullish(value) && value > warningLevel);
 
 	let showWarningIcon = $derived(isWarning || isError);
+
+	// Round before signing so a sub-0.005 magnitude reads as a clean "0.00%"
+	// rather than "-0.00%" (or a spurious "+0.00%"): toFixed keeps the sign of a
+	// negative rounding-to-zero, so we must snap through Number() first.
+	let text = $derived.by((): string => {
+		if (!nonNullish(value)) {
+			return '';
+		}
+		const rounded = Number(value.toFixed(2));
+		return `${rounded > 0 ? '+' : ''}${rounded.toFixed(2)}%`;
+	});
 </script>
 
 {#snippet valueDifferenceWarningIcon()}
@@ -57,7 +68,7 @@
 			{@render valueDifferenceWarningIcon()}
 		{/if}
 		<span>
-			{`${value > 0 ? '+' : ''}${value.toFixed(2)}`}%
+			{text}
 		</span>
 		{#if showWarningIcon && iconPosition === 'right'}
 			{@render valueDifferenceWarningIcon()}

--- a/src/frontend/src/tests/lib/components/ui/ValueDifference.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/ValueDifference.spec.ts
@@ -1,0 +1,48 @@
+import ValueDifference from '$lib/components/ui/ValueDifference.svelte';
+import { render } from '@testing-library/svelte';
+
+describe('ValueDifference', () => {
+	it('formats a positive value with a leading plus sign', () => {
+		const { container } = render(ValueDifference, { props: { value: 3.456 } });
+
+		expect(container).toHaveTextContent('+3.46%');
+	});
+
+	it('formats a negative value without an extra plus sign', () => {
+		const { container } = render(ValueDifference, { props: { value: -2.1 } });
+
+		expect(container).toHaveTextContent('-2.10%');
+	});
+
+	it('formats zero without a sign', () => {
+		const { container } = render(ValueDifference, { props: { value: 0 } });
+
+		expect(container).toHaveTextContent('0.00%');
+	});
+
+	it('rounds a sub-threshold negative value to a clean 0.00% (no minus sign)', () => {
+		const { container } = render(ValueDifference, { props: { value: -0.001 } });
+
+		expect(container).toHaveTextContent('0.00%');
+		expect(container).not.toHaveTextContent('-0.00%');
+	});
+
+	it('rounds a sub-threshold positive value to a clean 0.00% (no plus sign)', () => {
+		const { container } = render(ValueDifference, { props: { value: 0.004 } });
+
+		expect(container).toHaveTextContent('0.00%');
+		expect(container).not.toHaveTextContent('+0.00%');
+	});
+
+	it('renders nothing when the value is undefined', () => {
+		const { container } = render(ValueDifference, { props: { value: undefined } });
+
+		expect(container).toHaveTextContent('');
+	});
+
+	it('renders nothing when the value is not finite', () => {
+		const { container } = render(ValueDifference, { props: { value: Number.NaN } });
+
+		expect(container).toHaveTextContent('');
+	});
+});

--- a/src/frontend/src/tests/lib/components/ui/ValueDifference.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/ValueDifference.spec.ts
@@ -37,12 +37,14 @@ describe('ValueDifference', () => {
 	it('renders nothing when the value is undefined', () => {
 		const { container } = render(ValueDifference, { props: { value: undefined } });
 
+		expect(container.querySelectorAll('*')).toHaveLength(0);
 		expect(container).toHaveTextContent('');
 	});
 
 	it('renders nothing when the value is not finite', () => {
 		const { container } = render(ValueDifference, { props: { value: Number.NaN } });
 
+		expect(container.querySelectorAll('*')).toHaveLength(0);
 		expect(container).toHaveTextContent('');
 	});
 });


### PR DESCRIPTION
# Motivation

The value-difference figure on the OISY TRADE limit-order price section could render as `-0.00%` (and, symmetrically, a spurious `+0.00%`). A sub-0.005 negative magnitude like `-0.001` passed straight to `toFixed(2)` keeps its sign — `(-0.001).toFixed(2) === "-0.00"` — so the UI showed a minus sign on what is effectively zero.

The sibling `LimitOrderValueDifference` already guards against this; the shared generic `ui/ValueDifference` (used by swap and limit-order) did not.

# Changes

- `ValueDifference.svelte`: round the value through `Number(value.toFixed(2))` before choosing the sign and formatting, so a rounding-to-zero magnitude snaps to a clean `0.00%`. `(-0).toFixed(2)` yields `"0.00"`, dropping the sign. Output is identical for every non-zero value; only signed zero changes.

# Tests

- New `ValueDifference.spec.ts` covering positive/negative/zero signs plus the `-0.00%` and `+0.00%` regressions, and the undefined/non-finite no-render cases.