### PR TITLE
chore(frontend): forbid `!nonNullish` / `!isNullish` double negatives

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,19 @@ const ZERO_BIGINT_RESTRICTION = {
 	message: 'Use the shared constant `ZERO` instead of `0n`.'
 };
 
+// `!nonNullish(x)` and `!isNullish(x)` are double negatives that read backwards;
+// each has a direct, positive counterpart in `@dfinity/utils`.
+const NULLISH_NEGATION_RESTRICTIONS = [
+	{
+		selector: "UnaryExpression[operator='!'] > CallExpression[callee.name='nonNullish']",
+		message: 'Use `isNullish(x)` instead of `!nonNullish(x)`.'
+	},
+	{
+		selector: "UnaryExpression[operator='!'] > CallExpression[callee.name='isNullish']",
+		message: 'Use `nonNullish(x)` instead of `!isNullish(x)`.'
+	}
+];
+
 export default [
 	...vitestConfig,
 	...svelteConfig,
@@ -41,7 +54,7 @@ export default [
 
 	{
 		rules: {
-			'no-restricted-syntax': ['error', ZERO_BIGINT_RESTRICTION]
+			'no-restricted-syntax': ['error', ZERO_BIGINT_RESTRICTION, ...NULLISH_NEGATION_RESTRICTIONS]
 		}
 	},
 
@@ -52,6 +65,7 @@ export default [
 			'no-restricted-syntax': [
 				'error',
 				ZERO_BIGINT_RESTRICTION,
+				...NULLISH_NEGATION_RESTRICTIONS,
 				{
 					selector: "MemberExpression[object.name='console'][property.name='error']",
 					message:

--- a/src/frontend/src/btc/components/wallet-connect/BtcWalletConnectSignPsbtReview.svelte
+++ b/src/frontend/src/btc/components/wallet-connect/BtcWalletConnectSignPsbtReview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { WalletConnectBtcDecodedPsbt } from '$btc/types/wallet-connect';
 	import { BTC_DECIMALS } from '$env/tokens/tokens.btc.env';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
@@ -29,7 +29,7 @@
 	<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.signing_address}</p>
 	<p class="mb-4 font-normal"><output class="break-all">{source}</output></p>
 
-	{#if decodeError || !nonNullish(decoded)}
+	{#if decodeError || isNullish(decoded)}
 		<p class="mb-4 font-normal text-error-primary">
 			{$i18n.wallet_connect.error.btc_psbt_decode}
 		</p>

--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -128,13 +128,13 @@ export const validateBtcSend = async ({
 	}
 	for (const utxo of utxos) {
 		if (
-			!nonNullish(utxo.outpoint) ||
-			!nonNullish(utxo.outpoint.txid) ||
+			isNullish(utxo.outpoint) ||
+			isNullish(utxo.outpoint.txid) ||
 			utxo.outpoint.txid.length === 0 ||
 			utxo.outpoint.vout === undefined ||
-			!nonNullish(utxo.value) ||
+			isNullish(utxo.value) ||
 			BigInt(utxo.value) <= ZERO ||
-			!nonNullish(utxo.height) ||
+			isNullish(utxo.height) ||
 			utxo.height < 0
 		) {
 			throw new BtcValidationError(BtcSendValidationError.InvalidUtxoData);

--- a/src/frontend/src/icp/api/bitcoin.api.ts
+++ b/src/frontend/src/icp/api/bitcoin.api.ts
@@ -1,7 +1,7 @@
 import { getAgent } from '$lib/actors/agents.ic';
 import type { CanisterIdText } from '$lib/types/canister';
 import type { NullishIdentity } from '$lib/types/identity';
-import { assertNonNullish, isNullish } from '@dfinity/utils';
+import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { BitcoinCanister, type BitcoinDid, type BitcoinNetwork } from '@icp-sdk/canisters/ckbtc';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
@@ -28,7 +28,7 @@ export const getUtxosQuery = async ({
 	return getUtxosQuery({
 		address,
 		network,
-		...(!isNullish(minConfirmations) && { filter: { minConfirmations } })
+		...(nonNullish(minConfirmations) && { filter: { minConfirmations } })
 	});
 };
 

--- a/src/frontend/src/lib/canisters/backend.canister.ts
+++ b/src/frontend/src/lib/canisters/backend.canister.ts
@@ -62,7 +62,7 @@ import {
 	Canister,
 	createServices,
 	fromNullable,
-	nonNullish,
+	isNullish,
 	toNullable,
 	type QueryParams
 } from '@dfinity/utils';
@@ -444,7 +444,7 @@ export class BackendCanister extends Canister<BackendService> {
 	};
 
 	private mapExchangeRate = (rate: ExchangeRate | undefined): BackendExchangeRate | undefined => {
-		if (!nonNullish(rate)) {
+		if (isNullish(rate)) {
 			return;
 		}
 

--- a/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
+++ b/src/frontend/src/lib/components/onramper/OnramperWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 	import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 	import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
@@ -106,7 +106,7 @@
 	// guard against late resolutions overwriting newer state via a cancellation token.
 	$effect(() => {
 		const currentIdentity = $authIdentity;
-		if (!nonNullish(currentIdentity)) {
+		if (isNullish(currentIdentity)) {
 			src = undefined;
 			signingFailed = false;
 			return;
@@ -201,7 +201,7 @@
 		class="absolute top-0 right-0 bottom-0 left-0 bg-surface text-brand-primary transition-all duration-500 ease-in-out"
 		class:invisible={themeLoaded && nonNullish(src)}
 		class:opacity-0={themeLoaded && nonNullish(src)}
-		class:opacity-100={!themeLoaded || !nonNullish(src)}
+		class:opacity-100={!themeLoaded || isNullish(src)}
 	>
 		<LoaderSpinner inline />
 	</div>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import ValueDifference from '$lib/components/ui/ValueDifference.svelte';
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
@@ -92,7 +92,7 @@
 	});
 
 	const setPreset = (preset: PricePreset) => {
-		if (!nonNullish(pairView)) {
+		if (isNullish(pairView)) {
 			return;
 		}
 		const target = presetTargetPrice({
@@ -194,7 +194,7 @@
 
 <div
 	class="rounded-lg border bg-secondary px-3 py-2.5"
-	class:border-disabled={!nonNullish(warningText)}
+	class:border-disabled={isNullish(warningText)}
 	class:border-error-primary={nonNullish(warningText) && warningText.danger}
 	class:border-warning-primary={nonNullish(warningText) && !warningText.danger}
 >

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderRouting.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderRouting.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import IconChevronRight from '$lib/components/icons/lucide/IconChevronRight.svelte';
 	import { OISY_TRADE_PROVIDER_NAME } from '$lib/constants/oisy-trade.constants';
@@ -20,7 +20,7 @@
 
 	// Relative spread only: (ask − bid) / mid × 100.
 	const spreadPercent = $derived.by((): number | null => {
-		if (!nonNullish(bid) || !nonNullish(ask)) {
+		if (isNullish(bid) || isNullish(ask)) {
 			return null;
 		}
 		const mid = (ask + bid) / 2;

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTokenPill.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTokenPill.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import IconChevronRight from '$lib/components/icons/lucide/IconChevronRight.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 
@@ -14,10 +14,10 @@
 
 <button
 	class="flex flex-shrink-0 items-center gap-1.5 rounded-full border px-2 py-1"
-	class:border-dashed={!nonNullish(symbol)}
+	class:border-dashed={isNullish(symbol)}
 	class:border-secondary={nonNullish(symbol)}
 	class:opacity-40={disabled}
-	class:text-brand-primary={!nonNullish(symbol) && !disabled}
+	class:text-brand-primary={isNullish(symbol) && !disabled}
 	{disabled}
 	{onclick}
 	type="button"

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { IcToken } from '$icp/types/ic-token';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
@@ -99,7 +99,7 @@
 	const maxEnabled = $derived(side === 'sell' || priceNum > 0);
 
 	const amountErrorKind = $derived.by((): string | undefined => {
-		if (!nonNullish(pairView) || !(baseNum > 0)) {
+		if (isNullish(pairView) || !(baseNum > 0)) {
 			return undefined;
 		}
 		return validateAmount({
@@ -229,7 +229,7 @@
 				{quoteAmountDisplay}
 			</span>
 			<LimitOrderTokenPill
-				disabled={!nonNullish(baseSymbol)}
+				disabled={isNullish(baseSymbol)}
 				onclick={onSelectQuote}
 				symbol={quoteSymbol}
 			/>

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -7,7 +7,7 @@ import {
 	type LiquidiumHealthLevel
 } from '$lib/constants/liquidium.constants';
 import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
-import { assertNonNullish, nonNullish } from '@dfinity/utils';
+import { assertNonNullish, isNullish } from '@dfinity/utils';
 import { Principal } from '@icp-sdk/core/principal';
 import type { Pool, UserPositionSummary, UserReserve } from '@liquidium/client';
 
@@ -176,7 +176,7 @@ export const liquidiumProjectedHealthAfterRepayPercent = ({
 };
 
 const isUnderSupplyCap = ({ totalSupply, supplyCap }: Pool): boolean =>
-	!nonNullish(supplyCap) || totalSupply < supplyCap;
+	isNullish(supplyCap) || totalSupply < supplyCap;
 
 export const mapLiquidiumMarket = (pool: Pool): LiquidiumMarket => ({
 	poolId: pool.id,


### PR DESCRIPTION
# Motivation

`!nonNullish(x)` and `!isNullish(x)` are double negatives that read backwards: each already has a direct, positive counterpart in `@dfinity/utils` (`isNullish` / `nonNullish`). This originated from spotting a `-0.00%`-style guard using `!nonNullish`; a lint rule prevents the pattern from creeping back in across the codebase.

# Changes

- Add an ESLint `no-restricted-syntax` rule (`NULLISH_NEGATION_RESTRICTIONS`) that flags `!nonNullish(x)` → use `isNullish(x)`, and `!isNullish(x)` → use `nonNullish(x)`, wired into both the global and frontend rule sets.
- Rewrite all existing call sites (btc send/psbt, bitcoin api, backend canister, liquidium utils, onramper widget, limit-order components) to the positive form, adjusting imports where the old symbol became unused.

# Tests

- Confirmed the rule fires on both patterns and that every rewritten file lints clean (no unused-import regressions).
- Pure syntactic swap; no behavioural change.