### PR TITLE
fix(frontend): remove the back arrow from the OISY TRADE hero

### DIFF
--- a/src/frontend/src/lib/components/trading/OisyTradeProviderHero.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeProviderHero.svelte
@@ -1,13 +1,8 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
-	import type { NavigationTarget } from '@sveltejs/kit';
-	import { afterNavigate } from '$app/navigation';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
-	import IconBackArrow from '$lib/components/icons/lucide/IconBackArrow.svelte';
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
 	import OisyTradeMark from '$lib/components/trading/OisyTradeMark.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import {
@@ -22,7 +17,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { back } from '$lib/utils/nav.utils';
 
 	interface Props {
 		onDeposit: () => void;
@@ -30,12 +24,6 @@
 	}
 
 	let { onDeposit, onWithdraw }: Props = $props();
-
-	let fromRoute = $state<NavigationTarget | null>(null);
-
-	afterNavigate(({ from }) => {
-		fromRoute = from;
-	});
 
 	const fiat = (value: number): string =>
 		formatCurrency({
@@ -56,19 +44,6 @@
 
 <StakeContentSection>
 	{#snippet title()}
-		<div class="absolute top-0 left-0">
-			<ButtonIcon
-				ariaLabel={$i18n.core.text.back}
-				colorStyle="tertiary"
-				link={false}
-				onclick={() => back({ pop: nonNullish(fromRoute) })}
-			>
-				{#snippet icon()}
-					<IconBackArrow />
-				{/snippet}
-			</ButtonIcon>
-		</div>
-
 		<div class="flex w-full flex-col items-center text-center">
 			<OisyTradeMark />
 


### PR DESCRIPTION
# Motivation

The OISY TRADE provider page hero had a "Back" arrow button in its top-left corner. The page already sits under the app's own navigation, so this extra button was redundant and has been removed.

# Changes

- Removed the back-arrow button (and its `absolute top-0 left-0` wrapper) from `OisyTradeProviderHero.svelte`.
- Removed the now-unused `fromRoute` state, `afterNavigate` handler, and the `nonNullish`, `NavigationTarget`, `afterNavigate`, `IconBackArrow`, `ButtonIcon`, and `back` imports that only served that button.

# Tests

- `npm run lint -- --max-warnings 0` — clean.
- `npm run check` — 0 errors, 0 warnings.
- `npx vitest run .../OisyTradeProviderHero.svelte.spec.ts` — 9/9 passing (no test referenced the back button, so no test changes were needed).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Sonnet 5)