### PR TITLE
style(frontend): center and tighten NEW badge in desktop navigation

### DIFF
--- a/src/frontend/src/lib/components/navigation/NavigationItem.svelte
+++ b/src/frontend/src/lib/components/navigation/NavigationItem.svelte
@@ -35,11 +35,13 @@
 		{@render label?.()}
 	</span>
 	{#if nonNullish(tag)}
-		<!-- Desktop: scaled to 80% and lifted (-translate-y-1.5) instead of sitting
-		     inline at the label's own baseline, so it reads as a raised badge
-		     rather than a same-size continuation of the label text. -->
+		<!-- Desktop: scaled to 80% from its left edge (origin-left) so the shrink
+		     hugs the label instead of drifting right. md:ml-0 resets the mobile
+		     ml-10, leaving the label-to-badge gap to the row's own gap-3
+		     (0.75rem/12px) — the same token spacing the icon and label use. No
+		     vertical offset — the row's items-center keeps the badge centred. -->
 		<div
-			class="absolute -mt-1.5 ml-10 scale-75 text-xs/4.5 font-bold uppercase md:relative md:ml-1 md:mt-0 md:-translate-y-1.5 md:scale-[0.8]"
+			class="absolute -mt-1.5 ml-10 scale-75 text-xs/4.5 font-bold uppercase md:relative md:mt-0 md:ml-0 md:origin-left md:scale-[0.8]"
 		>
 			<Tag size="sm" variant={tagVariant}>{tag}</Tag>
 		</div>


### PR DESCRIPTION
# Motivation

On desktop, the NEW badge next to Finance nav items (Trade, Borrow) sat too
far from its label and above the label's vertical centre, so it read as
detached rather than a badge on the label.

# Changes

- In `NavigationItem.svelte`, adjust the desktop badge positioning:
  - Drop `md:-translate-y-1.5` — the row is already `items-center`, so removing the manual lift centres the badge on the label (was ~6px high).
  - Replace `md:ml-1` with `md:ml-0` and add `md:origin-left`, so the label-to-badge gap comes solely from the row's existing `gap-3` token (`0.75rem` / 12px — the same spacing between the icon and label) and the 0.8 scale hugs the label's edge instead of drifting right (gap was ~20px, now 12px).
- Mobile styling is unchanged (only `md:` classes are touched; grouped Trade/Borrow render via a separate card path on mobile).

<img width="494" height="629" alt="image" src="https://github.com/user-attachments/assets/e9932019-459a-40e3-9ed6-07d920084631" />