### PR TITLE
fix(trade): stack "in orders" pill above amount on mobile in My positions

### DIFF
--- a/src/frontend/src/lib/components/trading/OisyTradePositionRow.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradePositionRow.svelte
@@ -61,33 +61,37 @@
 		<TokenNameAndNetwork {data} />
 	</span>
 
-	{#if hasReserved}
-		<span class="shrink-0 rounded-lg bg-secondary px-2.5 py-1 text-xs font-medium text-tertiary">
-			{#if $isPrivacyMode}
-				<span class="inline-flex items-center gap-1">
-					<IconDots variant="xs" />
-					{$i18n.trading.page.in_orders_label}
-				</span>
-			{:else}
-				{replacePlaceholders($i18n.trading.page.in_orders, { $amount: formatAmount(reserved) })}
-			{/if}
-		</span>
-	{/if}
+	<span class="flex shrink-0 flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-4">
+		{#if hasReserved}
+			<span
+				class="shrink-0 rounded-lg bg-secondary px-2.5 py-1 text-xs font-medium text-tertiary"
+			>
+				{#if $isPrivacyMode}
+					<span class="inline-flex items-center gap-1">
+						<IconDots variant="xs" />
+						{$i18n.trading.page.in_orders_label}
+					</span>
+				{:else}
+					{replacePlaceholders($i18n.trading.page.in_orders, { $amount: formatAmount(reserved) })}
+				{/if}
+			</span>
+		{/if}
 
-	<span class="flex shrink-0 flex-col text-right text-nowrap">
-		<span class="font-bold">
-			{#if $isPrivacyMode}
-				<IconDots variant="md" />
-			{:else}
-				{formatAmount(total)}
-			{/if}
-		</span>
-		<span class="text-sm text-tertiary">
-			{#if $isPrivacyMode}
-				<IconDots variant="xs" />
-			{:else if nonNullish(formattedTotalUsd)}
-				{formattedTotalUsd}
-			{/if}
+		<span class="flex flex-col text-right text-nowrap">
+			<span class="font-bold">
+				{#if $isPrivacyMode}
+					<IconDots variant="md" />
+				{:else}
+					{formatAmount(total)}
+				{/if}
+			</span>
+			<span class="text-sm text-tertiary">
+				{#if $isPrivacyMode}
+					<IconDots variant="xs" />
+				{:else if nonNullish(formattedTotalUsd)}
+					{formattedTotalUsd}
+				{/if}
+			</span>
 		</span>
 	</span>
 {/snippet}

--- a/src/frontend/src/lib/components/trading/OisyTradePositionRow.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradePositionRow.svelte
@@ -63,9 +63,7 @@
 
 	<span class="flex shrink-0 flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-4">
 		{#if hasReserved}
-			<span
-				class="shrink-0 rounded-lg bg-secondary px-2.5 py-1 text-xs font-medium text-tertiary"
-			>
+			<span class="shrink-0 rounded-lg bg-secondary px-2.5 py-1 text-xs font-medium text-tertiary">
 				{#if $isPrivacyMode}
 					<span class="inline-flex items-center gap-1">
 						<IconDots variant="xs" />


### PR DESCRIPTION
## Motivation

On the OISY TRADE provider page, the "My positions" box rendered each token row as a single horizontal flex row: token name (flex-1), the "N X in orders" pill, and the amount/USD block side by side. On narrow (mobile) viewports the pill and the amount competed for space with the token name, causing the pill to overlap the name and description.

## Changes

- Wrap the "in orders" pill and the amount/USD block in a shared flex container in `OisyTradePositionRow.svelte`.
- Below `sm`: the container is `flex-col items-end`, so the right side stacks three right-aligned elements — pill on top, amount, then USD value.
- At `sm` and up: `flex-row items-center`, preserving the existing side-by-side layout unchanged.

## Tests

- `npm run format` / `eslint --max-warnings 0` — clean.
- `npm run check:tests` — 0 errors, 0 warnings.
- `OisyTradePositionRow.svelte.spec.ts` — 7/7 passing.
- Verified both layouts visually (mobile stacked, desktop unchanged, and the no-orders case with the pill absent).

|Before|After|
|---|---|
|<img width="455" height="352" alt="image" src="https://github.com/user-attachments/assets/699ae788-c555-4de5-a8a7-6d08f65bf33c" />|<img width="455" height="352" alt="image" src="https://github.com/user-attachments/assets/4e3c8835-9234-4709-b929-e7dbd1d7c832" />|

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8 (Opus 4.8)