### PR TITLE
feat(frontend): update Liquidium hero boxes placeholders

### DIFF
--- a/src/frontend/src/lib/components/borrow/ActiveLoansCard.svelte
+++ b/src/frontend/src/lib/components/borrow/ActiveLoansCard.svelte
@@ -49,12 +49,16 @@
 		</div>
 
 		<div class="text-sm text-tertiary sm:text-base">
-			{$i18n.borrow.text.apr}
-			<EarningYearlyAmount
-				showMinusSign
-				{showWithShortenedLabel}
-				value={$liquidiumBorrowInterestUsd}
-			/>
+			{#if hasDebt}
+				{$i18n.borrow.text.apr}
+				<EarningYearlyAmount
+					showMinusSign
+					{showWithShortenedLabel}
+					value={$liquidiumBorrowInterestUsd}
+				/>
+			{:else}
+				{$i18n.borrow.text.no_active_loans}
+			{/if}
 		</div>
 
 		{#if showHealthFactor && hasDebt && nonNullish($liquidiumHealthFactorPercent)}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumSummary.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSummary.svelte
@@ -78,8 +78,12 @@
 			</div>
 
 			<div class="text-sm text-tertiary sm:text-base">
-				{$i18n.liquidium.text.apy_suffix}
-				<EarningYearlyAmount showPlusSign showWithShortenedLabel value={supplyInterestUsd} />
+				{#if totalSuppliedUsd > 0}
+					{$i18n.liquidium.text.apy_suffix}
+					<EarningYearlyAmount showPlusSign showWithShortenedLabel value={supplyInterestUsd} />
+				{:else}
+					{$i18n.liquidium.text.no_assets_supplied}
+				{/if}
 			</div>
 		{/snippet}
 	</StakeContentCard>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "available · best provider",
 			"remaining_best_provider": "remaining · best provider",
 			"active_loans": "Active loans",
+			"no_active_loans": "no active loans",
 			"amount_borrowed": "$amount borrowed",
 			"apr": "APR",
 			"borrow_apr_from": "Borrow APR from"
@@ -2373,6 +2374,7 @@
 			"net_value": "Net value",
 			"markets": "Markets",
 			"total_supplied": "Total supplied",
+			"no_assets_supplied": "no assets supplied",
 			"supplied": "Supplied",
 			"borrowed": "Borrowed",
 			"borrow_rate": "Borrow rate",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -9,6 +9,7 @@
 			"available_best_provider": "",
 			"remaining_best_provider": "",
 			"active_loans": "",
+			"no_active_loans": "",
 			"amount_borrowed": "",
 			"apr": "",
 			"borrow_apr_from": ""
@@ -2373,6 +2374,7 @@
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",
+			"no_assets_supplied": "",
 			"supplied": "",
 			"borrowed": "",
 			"borrow_rate": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -12,6 +12,7 @@ interface I18nBorrow {
 		available_best_provider: string;
 		remaining_best_provider: string;
 		active_loans: string;
+		no_active_loans: string;
 		amount_borrowed: string;
 		apr: string;
 		borrow_apr_from: string;
@@ -1912,6 +1913,7 @@ interface I18nLiquidium {
 		net_value: string;
 		markets: string;
 		total_supplied: string;
+		no_assets_supplied: string;
 		supplied: string;
 		borrowed: string;
 		borrow_rate: string;

--- a/src/frontend/src/tests/lib/components/borrow/ActiveLoansCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/borrow/ActiveLoansCard.spec.ts
@@ -34,11 +34,11 @@ describe('ActiveLoansCard', () => {
 		liquidiumStore.reset();
 	});
 
-	it('shows the APR line and no health factor when there is no debt', () => {
+	it('shows the empty state and no health factor when there is no debt', () => {
 		const { container } = render(ActiveLoansCard);
 
 		expect(container).toHaveTextContent(en.borrow.text.active_loans);
-		expect(container).toHaveTextContent(en.borrow.text.apr);
+		expect(container).toHaveTextContent(en.borrow.text.no_active_loans);
 		expect(container).not.toHaveTextContent(en.liquidium.text.health_factor);
 	});
 
@@ -48,6 +48,7 @@ describe('ActiveLoansCard', () => {
 		const { container } = render(ActiveLoansCard);
 
 		expect(container).toHaveTextContent(en.liquidium.text.health_factor);
+		expect(container).not.toHaveTextContent(en.borrow.text.no_active_loans);
 		expect(container).toHaveTextContent(en.borrow.text.apr);
 	});
 

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
@@ -50,6 +50,12 @@ describe('LiquidiumSummary', () => {
 		expect(container).toHaveTextContent(en.liquidium.text.net_value);
 	});
 
+	it('shows the empty supplied text instead of the APY line when nothing is supplied', () => {
+		const { container } = render(LiquidiumSummary, { props: { portfolio: null } });
+
+		expect(container).toHaveTextContent(en.liquidium.text.no_assets_supplied);
+	});
+
 	it('signs the net interest from net interest, not net value', () => {
 		const netNegative: LiquidiumPortfolio = {
 			...portfolio,


### PR DESCRIPTION
# Motivation

Insteadl of "$0.00/yr" as a placeholder, we'd like to display a short text - "no assets supplied"/"no active loans".
