### PR TITLE
feat(assets): add Go-to-Trade and Go-to-Borrow buttons to Assets tabs

### DIFF
--- a/src/frontend/src/lib/components/borrowings/GoToBorrowButton.svelte
+++ b/src/frontend/src/lib/components/borrowings/GoToBorrowButton.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import IconArrowRight from '$lib/components/icons/IconArrowRight.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import { AppPath } from '$lib/constants/routes.constants';
+	import { BORROWINGS_GOTO_BUTTON } from '$lib/constants/test-ids.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+</script>
+
+<Button
+	colorStyle="success"
+	onclick={() => goto(AppPath.Borrow)}
+	styleClass="gap-1 flex-none px-12 font-semibold"
+	testId={BORROWINGS_GOTO_BUTTON}
+	type="button"
+>
+	{$i18n.borrowings.text.go_to_borrow}
+	<IconArrowRight />
+</Button>

--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -6,6 +6,7 @@
 	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 	import { TRADING_ENABLED } from '$env/trading';
 	import BorrowingsList from '$lib/components/borrowings/BorrowingsList.svelte';
+	import GoToBorrowButton from '$lib/components/borrowings/GoToBorrowButton.svelte';
 	import EarningsList from '$lib/components/earning/EarningsList.svelte';
 	import GoToEarnButton from '$lib/components/earning/GoToEarnButton.svelte';
 	import ManageTokensModal from '$lib/components/manage/ManageTokensModal.svelte';
@@ -20,6 +21,7 @@
 	import TokensList from '$lib/components/tokens/TokensList.svelte';
 	import TokensMenu from '$lib/components/tokens/TokensMenu.svelte';
 	import TokensSortMenu from '$lib/components/tokens/TokensSortMenu.svelte';
+	import GoToTradeButton from '$lib/components/trading/GoToTradeButton.svelte';
 	import TradingList from '$lib/components/trading/TradingList.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import StickyHeader from '$lib/components/ui/StickyHeader.svelte';
@@ -170,6 +172,10 @@
 				</ManageTokensButton>
 			{:else if activeTab === TokenTypes.EARNING}
 				<GoToEarnButton />
+			{:else if activeTab === TokenTypes.TRADING}
+				<GoToTradeButton />
+			{:else if activeTab === TokenTypes.BORROWINGS}
+				<GoToBorrowButton />
 			{/if}
 		</div>
 	</div>

--- a/src/frontend/src/lib/components/trading/TradingList.svelte
+++ b/src/frontend/src/lib/components/trading/TradingList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { OISY_TRADE_ENABLED } from '$env/oisy-trade';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
-	import GoToTradeButton from '$lib/components/trading/GoToTradeButton.svelte';
 	import TradingAssets from '$lib/components/trading/TradingAssets.svelte';
 	import TradingListSkeleton from '$lib/components/trading/TradingListSkeleton.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
@@ -27,10 +26,7 @@
 	{:else if $oisyTradeHasAssets}
 		<TradingAssets />
 	{:else}
-		<div class="flex flex-col items-center gap-4 py-10">
-			<p class="text-center text-tertiary">{$i18n.trading.text.no_trades}</p>
-			<GoToTradeButton />
-		</div>
+		<p class="py-10 text-center text-tertiary">{$i18n.trading.text.no_trades}</p>
 	{/if}
 {:else}
 	<EmptyState

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -401,6 +401,9 @@ export const TRADING_WITHDRAW_REVIEW_BUTTON = 'trading-withdraw-review-button';
 export const TRADING_ORDER_DETAIL_CANCEL_BUTTON = 'trading-order-detail-cancel-button';
 export const TRADING_ORDER_CANCEL_CONFIRM_BUTTON = 'trading-order-cancel-confirm-button';
 
+// Borrowings
+export const BORROWINGS_GOTO_BUTTON = 'borrowings-goto-button';
+
 // PWA
 export const PWA_INFO_BANNER_TEST_ID = 'pwa-info-banner';
 export const PWA_INFO_BANNER_CLOSE_BUTTON_TEST_ID = 'pwa-info-banner-close-button';

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1683,7 +1683,7 @@
 			"intro": "Place and manage limit orders on-chain, directly from your wallet.",
 			"learn_more": "Learn more",
 			"provider_name": "OISY TRADE",
-			"no_trades": "You don't have any deposited assets or active orders",
+			"no_trades": "You don't have any deposits or active orders",
 			"go_to_trade": "Go to Trade"
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -24,7 +24,7 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "Borrowing",
-			"no_borrowings": "It looks like you haven't borrowed any tokens yet.",
+			"no_borrowings": "You don't have any active loans yet",
 			"go_to_borrow": "Go to Borrow"
 		}
 	},
@@ -1683,7 +1683,7 @@
 			"intro": "Place and manage limit orders on-chain, directly from your wallet.",
 			"learn_more": "Learn more",
 			"provider_name": "OISY TRADE",
-			"no_trades": "It looks like you haven't traded any tokens yet.",
+			"no_trades": "You don't have any deposited assets or active orders",
 			"go_to_trade": "Go to Trade"
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "Borrowing",
-			"no_borrowings": "It looks like you haven't borrowed any tokens yet."
+			"no_borrowings": "It looks like you haven't borrowed any tokens yet.",
+			"go_to_borrow": "Go to Borrow"
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -24,7 +24,8 @@
 	"borrowings": {
 		"text": {
 			"tab_title": "",
-			"no_borrowings": ""
+			"no_borrowings": "",
+			"go_to_borrow": ""
 		}
 	},
 	"core": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -20,7 +20,7 @@ interface I18nBorrow {
 }
 
 interface I18nBorrowings {
-	text: { tab_title: string; no_borrowings: string };
+	text: { tab_title: string; no_borrowings: string; go_to_borrow: string };
 }
 
 interface I18nCore {

--- a/src/frontend/src/tests/lib/components/borrowings/GoToBorrowButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/borrowings/GoToBorrowButton.spec.ts
@@ -1,0 +1,38 @@
+import { goto } from '$app/navigation';
+import GoToBorrowButton from '$lib/components/borrowings/GoToBorrowButton.svelte';
+import { AppPath } from '$lib/constants/routes.constants';
+import { BORROWINGS_GOTO_BUTTON } from '$lib/constants/test-ids.constants';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+vi.mock(import('$app/navigation'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		goto: vi.fn()
+	};
+});
+
+describe('GoToBorrowButton', () => {
+	it('should render the label', () => {
+		const { getByText } = render(GoToBorrowButton);
+
+		expect(getByText(en.borrowings.text.go_to_borrow)).toBeInTheDocument();
+	});
+
+	it('should render the icon', () => {
+		const { container } = render(GoToBorrowButton);
+
+		expect(container.querySelector('svg')).toBeInTheDocument();
+	});
+
+	it('should redirect to the borrow page when clicked', () => {
+		const { getByTestId } = render(GoToBorrowButton);
+
+		const button = getByTestId(BORROWINGS_GOTO_BUTTON) as HTMLButtonElement;
+
+		button.click();
+
+		expect(goto).toHaveBeenCalledExactlyOnceWith(AppPath.Borrow);
+	});
+});

--- a/src/frontend/src/tests/lib/components/trading/TradingList.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingList.svelte.spec.ts
@@ -81,7 +81,7 @@ describe('TradingList', () => {
 		setPrivacyMode({ enabled: false });
 	});
 
-	it('should render the empty placeholder with the go-to-trade button when the user has no assets', () => {
+	it('should render the empty placeholder when the user has no assets', () => {
 		// Loaded (balances non-null) but empty → the empty placeholder rather than the skeleton.
 		oisyTradeStore.set({
 			pairs: undefined,
@@ -90,10 +90,11 @@ describe('TradingList', () => {
 			orders: undefined
 		});
 
-		const { getByText, getByTestId } = render(TradingList);
+		const { getByText, queryByTestId } = render(TradingList);
 
 		expect(getByText(en.trading.text.no_trades)).toBeInTheDocument();
-		expect(getByTestId(TRADING_GOTO_BUTTON)).toBeInTheDocument();
+		// The go-to-trade button now lives in the Assets footer, not the list itself.
+		expect(queryByTestId(TRADING_GOTO_BUTTON)).toBeNull();
 	});
 
 	it('renders only the assets section once the user has assets', () => {


### PR DESCRIPTION
## Motivation

The Earning tab on the Assets page shows a green "Go to Earn" button below the positions list, taking the user to the standalone Earn page. The Trading and Borrowing tabs had no equivalent: the Trading tab only surfaced a "Go to Trade" button inside its empty state, and the Borrowing tab had no button at all. This makes the three earning-related tabs consistent.

## Changes

- New `GoToBorrowButton` component, mirroring `GoToTradeButton` (green success `Button` with an arrow icon), navigating to `AppPath.Borrow` (`/borrow/`).
- `Assets.svelte` footer now renders `GoToTradeButton` on the Trading tab and `GoToBorrowButton` on the Borrowing tab, alongside the existing `GoToEarnButton` — all shown below the positions list regardless of whether positions exist, matching the earn button.
- Moved `GoToTradeButton` out of `TradingList`'s empty state (it would otherwise render twice now that it lives in the footer); the empty state keeps just the "no trades" placeholder text, styled like the Borrowing empty state.
- Added the `borrowings.text.go_to_borrow` i18n key ("Go to Borrow") and the `BORROWINGS_GOTO_BUTTON` test id.
- Reworded the two empty-state placeholders to be more descriptive: Trading `no_trades` → "You don't have any deposited assets or active orders", Borrowing `no_borrowings` → "You don't have any active loans yet" (English only; the other locales carry no translation for these keys yet).

Both buttons navigate to the same destinations as the corresponding navigation-bar entries: Trade → `/providers/oisy-trade/`, Borrow → `/borrow/`.

## Tests

- New `GoToBorrowButton.spec.ts` covering label, icon and navigation.
- Updated `TradingList.svelte.spec.ts` since the go-to-trade button moved out of the empty state.
- `npm run check:tests` passes with 0 errors / 0 warnings; targeted vitest specs pass; eslint and prettier clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8 (Opus 4.8)