### PR TITLE
style(frontend): move order cancel action to a destructive link in the modal body

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -307,7 +307,7 @@
 			{#if active}
 				<Hr />
 
-				<div class="flex justify-start px-3 pt-3 md:px-6">
+				<div class="flex justify-start px-3 py-3 md:px-6">
 					<Button
 						alignLeft
 						ariaLabel={$i18n.trading.order_detail.cancel_order}

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -304,7 +304,7 @@
 
 		{#snippet outerContent()}
 			{#if active}
-				<div class="flex justify-start px-3 py-3 md:px-6">
+				<div class="flex justify-start px-3 py-2 sm:px-6 sm:py-3">
 					<Button
 						alignLeft
 						ariaLabel={$i18n.trading.order_detail.cancel_order}

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -10,6 +10,7 @@
 	import LimitOrderTermsList from '$lib/components/trading/limit-order/LimitOrderTermsList.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
@@ -302,26 +303,28 @@
 			</ModalValue>
 		{/if}
 
-		{#if active}
-			<Hr />
+		{#snippet outerContent()}
+			{#if active}
+				<Hr />
 
-			<div class="flex justify-start">
-				<Button
-					alignLeft
-					ariaLabel={$i18n.trading.order_detail.cancel_order}
-					colorStyle="error"
-					onclick={() => (showCancelConfirm = true)}
-					testId={TRADING_ORDER_DETAIL_CANCEL_BUTTON}
-					transparent
-				>
-					<IconTrash />
-					{$i18n.trading.order_detail.cancel_order}
-				</Button>
-			</div>
-		{/if}
+				<div class="flex justify-start px-3 pt-3 md:px-6">
+					<Button
+						alignLeft
+						ariaLabel={$i18n.trading.order_detail.cancel_order}
+						colorStyle="error"
+						onclick={() => (showCancelConfirm = true)}
+						testId={TRADING_ORDER_DETAIL_CANCEL_BUTTON}
+						transparent
+					>
+						<IconTrash />
+						{$i18n.trading.order_detail.cancel_order}
+					</Button>
+				</div>
+			{/if}
+		{/snippet}
 
 		{#snippet toolbar()}
-			<Button colorStyle="primary" onclick={close}>{$i18n.core.text.close}</Button>
+			<ButtonCloseModal isPrimary />
 		{/snippet}
 	</ContentWithToolbar>
 </Modal>

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -3,14 +3,15 @@
 	import Decimal from 'decimal.js';
 	import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
+	import IconTrash from '$lib/components/icons/lucide/IconTrash.svelte';
 	import TradingCancelOrderConfirm from '$lib/components/trading/TradingCancelOrderConfirm.svelte';
 	import LimitOrderIntentHero from '$lib/components/trading/limit-order/LimitOrderIntentHero.svelte';
 	import LimitOrderPriceSummary from '$lib/components/trading/limit-order/LimitOrderPriceSummary.svelte';
 	import LimitOrderTermsList from '$lib/components/trading/limit-order/LimitOrderTermsList.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
-	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import Hr from '$lib/components/ui/Hr.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { OISY_TRADE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
@@ -301,19 +302,26 @@
 			</ModalValue>
 		{/if}
 
+		{#if active}
+			<Hr />
+
+			<div class="flex justify-start">
+				<Button
+					alignLeft
+					ariaLabel={$i18n.trading.order_detail.cancel_order}
+					colorStyle="error"
+					onclick={() => (showCancelConfirm = true)}
+					testId={TRADING_ORDER_DETAIL_CANCEL_BUTTON}
+					transparent
+				>
+					<IconTrash />
+					{$i18n.trading.order_detail.cancel_order}
+				</Button>
+			</div>
+		{/if}
+
 		{#snippet toolbar()}
-			<ButtonGroup>
-				<Button colorStyle="secondary-light" onclick={close}>{$i18n.core.text.close}</Button>
-				{#if active}
-					<Button
-						colorStyle="error"
-						onclick={() => (showCancelConfirm = true)}
-						testId={TRADING_ORDER_DETAIL_CANCEL_BUTTON}
-					>
-						{$i18n.trading.order_detail.cancel_order}
-					</Button>
-				{/if}
-			</ButtonGroup>
+			<Button colorStyle="primary" onclick={close}>{$i18n.core.text.close}</Button>
 		{/snippet}
 	</ContentWithToolbar>
 </Modal>

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -313,7 +313,7 @@
 						testId={TRADING_ORDER_DETAIL_CANCEL_BUTTON}
 						transparent
 					>
-						<IconTrash />
+						<span aria-hidden="true"><IconTrash /></span>
 						{$i18n.trading.order_detail.cancel_order}
 					</Button>
 				</div>

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -12,7 +12,6 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCloseModal from '$lib/components/ui/ButtonCloseModal.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Hr from '$lib/components/ui/Hr.svelte';
 	import Modal from '$lib/components/ui/Modal.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { OISY_TRADE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
@@ -305,8 +304,6 @@
 
 		{#snippet outerContent()}
 			{#if active}
-				<Hr />
-
 				<div class="flex justify-start px-3 py-3 md:px-6">
 					<Button
 						alignLeft


### PR DESCRIPTION
# Motivation

In the Order detail modal, the footer held two buttons: `Close` (secondary) and `Cancel order` (primary destructive). Cancelling an order is a destructive, secondary action and shouldn't sit as a primary footer button next to `Close`.

This aligns the modal with the pattern already used in the address book contact edit form, where the destructive "Delete contact" action is a red trash-can link at the end of the form body.

# Changes

- Footer now has a single **Close** button, styled as the primary action.
- The **Cancel order** action moves out of the footer to a red trash-can link at the end of the modal body — an `error` + `transparent` `Button` with `IconTrash` and a hover state, wrapped in `<div class="flex justify-start">` and preceded by an `<Hr />`, mirroring the delete-contact row in `EditContactStep.svelte`.
- Still rendered only for active orders; click still opens the existing `TradingCancelOrderConfirm` step. The `TRADING_ORDER_DETAIL_CANCEL_BUTTON` test id is preserved.
- Dropped the now-unused `ButtonGroup`; added `IconTrash` and `Hr` imports.

# Tests

- Existing `TradingOrderDetailModal.svelte.spec.ts` (5 tests) pass unchanged — the cancel action is still asserted by test id (present for active, absent for terminal orders).
- `format`, `eslint --max-warnings 0`, and whole-project `svelte-check` (0 errors / 0 warnings) pass.
- Not rendered in a live browser: reaching this modal requires an authenticated wallet with an active limit order. Visual confidence rests on reusing the already-shipping `EditContactStep` delete-row pattern verbatim.

|<img width="292" alt="image" src="https://github.com/user-attachments/assets/bfe0c9df-ece5-41af-b83d-f12ea0559f35" />|<img width="292" alt="image" src="https://github.com/user-attachments/assets/2c128946-a165-4046-ab8c-dab3d44a7738" />|

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.8 (claude-opus-4-8)