### PR TITLE
feat(frontend): track OISY TRADE provider page opens

### DIFF
--- a/src/frontend/src/lib/components/trading/OisyTradeProvider.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeProvider.svelte
@@ -24,6 +24,12 @@
 		modalOisyTradeWithdrawData,
 		modalTradingDeposit
 	} from '$lib/derived/modal.derived';
+	import {
+		PLAUSIBLE_EVENT_CONTEXTS,
+		PLAUSIBLE_EVENT_VALUES,
+		PLAUSIBLE_EVENTS
+	} from '$lib/enums/plausible';
+	import { trackEvent } from '$lib/services/analytics.services';
 	import { loadOisyTrade } from '$lib/services/oisy-trade.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
@@ -43,7 +49,16 @@
 	onMount(() => {
 		if (!TRADING_ENABLED) {
 			goto(AppPath.Tokens);
+			return;
 		}
+
+		trackEvent({
+			name: PLAUSIBLE_EVENTS.PAGE_OPEN,
+			metadata: {
+				event_context: PLAUSIBLE_EVENT_CONTEXTS.TRADING,
+				event_value: PLAUSIBLE_EVENT_VALUES.OISY_TRADE_PAGE
+			}
+		});
 	});
 </script>
 

--- a/src/frontend/src/lib/enums/plausible.ts
+++ b/src/frontend/src/lib/enums/plausible.ts
@@ -99,6 +99,7 @@ export enum PLAUSIBLE_EVENT_VALUES {
 	NFT_PAGE = 'nft-page',
 	EARN_PAGE = 'earn-page',
 	BORROW_PAGE = 'borrow-page',
+	OISY_TRADE_PAGE = 'oisy-trade-page',
 	HARVEST_AUTOPILOTS_PAGE = 'harvest-autopilots-page',
 	HARVEST_AUTOPILOT_DETAIL_PAGE = 'harvest-autopilot-detail-page',
 	TOKENS_BASIC = 'tokens_basic',

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeProvider.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeProvider.svelte.spec.ts
@@ -94,10 +94,12 @@ describe('OisyTradeProvider', () => {
 		});
 	});
 
-	it('does not track a page_open event when the Trading feature flag is off', () => {
+	it('does not track a page_open event when the Trading feature flag is off', async () => {
 		mockTradingEnabled.value = false;
 
 		render(OisyTradeProvider);
+
+		await tick();
 
 		expect(mockTrackEvent).not.toHaveBeenCalled();
 	});

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeProvider.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeProvider.svelte.spec.ts
@@ -4,12 +4,14 @@ import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 
-const { mockTradingEnabled, mockProviderEnabled, mockLoadOisyTrade, mockGoto } = vi.hoisted(() => ({
-	mockTradingEnabled: { value: true },
-	mockProviderEnabled: { value: true },
-	mockLoadOisyTrade: vi.fn(() => Promise.resolve(undefined)),
-	mockGoto: vi.fn()
-}));
+const { mockTradingEnabled, mockProviderEnabled, mockLoadOisyTrade, mockGoto, mockTrackEvent } =
+	vi.hoisted(() => ({
+		mockTradingEnabled: { value: true },
+		mockProviderEnabled: { value: true },
+		mockLoadOisyTrade: vi.fn(() => Promise.resolve(undefined)),
+		mockGoto: vi.fn(),
+		mockTrackEvent: vi.fn()
+	}));
 
 vi.mock('$env/trading', () => ({
 	get TRADING_ENABLED() {
@@ -30,6 +32,10 @@ vi.mock('$lib/services/oisy-trade.services', () => ({
 vi.mock('$app/navigation', () => ({
 	goto: mockGoto,
 	afterNavigate: vi.fn()
+}));
+
+vi.mock('$lib/services/analytics.services', () => ({
+	trackEvent: mockTrackEvent
 }));
 
 describe('OisyTradeProvider', () => {
@@ -72,5 +78,25 @@ describe('OisyTradeProvider', () => {
 
 		expect(mockGoto).toHaveBeenCalled();
 		expect(queryByText(en.trading.text.provider_name)).toBeNull();
+	});
+
+	it('tracks a page_open event on mount when trading is enabled', () => {
+		render(OisyTradeProvider);
+
+		expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith({
+			name: 'page_open',
+			metadata: {
+				event_context: 'trading',
+				event_value: 'oisy-trade-page'
+			}
+		});
+	});
+
+	it('does not track a page_open event when the Trading feature flag is off', () => {
+		mockTradingEnabled.value = false;
+
+		render(OisyTradeProvider);
+
+		expect(mockTrackEvent).not.toHaveBeenCalled();
 	});
 });

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeProvider.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeProvider.svelte.spec.ts
@@ -80,8 +80,10 @@ describe('OisyTradeProvider', () => {
 		expect(queryByText(en.trading.text.provider_name)).toBeNull();
 	});
 
-	it('tracks a page_open event on mount when trading is enabled', () => {
+	it('tracks a page_open event on mount when trading is enabled', async () => {
 		render(OisyTradeProvider);
+
+		await tick();
 
 		expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith({
 			name: 'page_open',


### PR DESCRIPTION
## Motivation

We want to know when users access the OISY TRADE provider page (`/providers/oisy-trade/`). This reuses the existing `page_open` Plausible event, exactly as the sibling Borrow and Earn pages already do — no new event type.

## Changes

- Fire `PLAUSIBLE_EVENTS.PAGE_OPEN` in the provider component's `onMount`, with `event_context: trading` and a new `event_value: oisy-trade-page`.
- Add `OISY_TRADE_PAGE` to `PLAUSIBLE_EVENT_VALUES`.
- The event fires only after the `TRADING_ENABLED` gate passes — not on the redirect path taken when the flag is off.

## Tests

- Extended `OisyTradeProvider.svelte.spec.ts`: asserts the exact `page_open` payload on mount (awaiting `tick()` so both the positive and flag-off assertions cover the real post-mount state), and that nothing is tracked when the Trading flag is off (6 tests, passing).
- `npm run format`, `eslint --max-warnings 0`, `npm run check` (0 errors), `npm run check:tests` (0 errors) all green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)
