### PR TITLE
chore(frontend): rebrand OISY TRADE to OISY Trade and refresh the trade hero

### DIFF
--- a/src/frontend/src/lib/components/trading/OisyTradeActiveOrders.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeActiveOrders.svelte
@@ -4,7 +4,6 @@
 	import { slide } from 'svelte/transition';
 	import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
-	import IconPlus from '$lib/components/icons/lucide/IconPlus.svelte';
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
 	import OisyTradeOrderRow from '$lib/components/trading/OisyTradeOrderRow.svelte';
 	import LimitOrder from '$lib/components/trading/limit-order/LimitOrder.svelte';
@@ -87,7 +86,6 @@
 			{#snippet trigger(open)}
 				{#if $oisyTradeHasAssets}
 					<Button colorStyle="primary" onclick={open} paddingSmall type="button">
-						<IconPlus size="16" />
 						{$i18n.trading.page.new_order}
 					</Button>
 				{:else}
@@ -97,7 +95,6 @@
 						empty state below already tells the user to deposit, so no tooltip.
 					-->
 					<Button colorStyle="primary" disabled paddingSmall type="button">
-						<IconPlus size="16" />
 						{$i18n.trading.page.new_order}
 					</Button>
 				{/if}

--- a/src/frontend/src/lib/components/trading/OisyTradeInfoBox.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeInfoBox.svelte
@@ -22,18 +22,18 @@
 				<h4 class="flex flex-1">{$i18n.trading.info.title}</h4>
 
 				<ExternalLink
-					ariaLabel={$i18n.trading.info.visit_website}
+					ariaLabel={$i18n.trading.text.learn_more}
 					href={OISY_TRADE_LEARN_MORE_URL}
 					iconAsLast
 					iconSize="15"
 					styleClass="text-sm"
 					trackEvent={buildLearnMoreEvent({
 						sourceLocation: PLAUSIBLE_EVENT_SOURCE_LOCATIONS.OISY_TRADE,
-						labelKey: 'trading.info.visit_website',
+						labelKey: 'trading.text.learn_more',
 						url: OISY_TRADE_LEARN_MORE_URL
 					})}
 				>
-					{$i18n.trading.info.visit_website}
+					{$i18n.trading.text.learn_more}
 				</ExternalLink>
 			</div>
 		{/snippet}

--- a/src/frontend/src/lib/components/trading/OisyTradeMark.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeMark.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <svg
-	aria-label="OISY TRADE"
+	aria-label="OISY Trade"
 	fill="none"
 	height={size}
 	role="img"

--- a/src/frontend/src/lib/components/trading/OisyTradeProviderHero.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeProviderHero.svelte
@@ -58,7 +58,6 @@
 
 			<div class="max-w-lg text-sm text-tertiary sm:text-base">
 				{$i18n.trading.page.tagline}
-				<span class="hidden sm:inline">{$i18n.trading.page.tagline_desktop}</span>
 			</div>
 
 			<Button

--- a/src/frontend/src/lib/constants/oisy-trade.constants.ts
+++ b/src/frontend/src/lib/constants/oisy-trade.constants.ts
@@ -1,6 +1,11 @@
-// Display name for the OISY TRADE provider, shown on the Trading tab venue tag,
+// Display name for the OISY Trade provider, shown on the Trading tab venue tag,
 // order rows, and deposit/withdraw flows.
-export const OISY_TRADE_PROVIDER_NAME = 'OISY TRADE';
+export const OISY_TRADE_PROVIDER_NAME = 'OISY Trade';
+
+// Frozen analytics identifier for the OISY Trade provider (`dApp` property).
+// Kept as the original casing so trading events remain comparable across the
+// display rename — do NOT sync this to OISY_TRADE_PROVIDER_NAME.
+export const OISY_TRADE_ANALYTICS_DAPP_NAME = 'OISY TRADE';
 
 // How often the Trading tab refreshes balances / pairs while visible.
 // Mirrors the Liquidium polling cadence.

--- a/src/frontend/src/lib/constants/oisy-trade.constants.ts
+++ b/src/frontend/src/lib/constants/oisy-trade.constants.ts
@@ -20,9 +20,9 @@ export const OISY_TRADE_ORDERS_PAGE_SIZE = 100;
 // need an explicit "load more").
 export const OISY_TRADE_MAX_ORDER_PAGES = 5;
 
-// "Learn more" destination for the Trading tab and deposit flow.
-// TODO: point at the public OISY TRADE docs page once it exists.
-export const OISY_TRADE_LEARN_MORE_URL = 'https://github.com/dfinity/oisy-trade';
+// "Learn more" destination for the Trading tab and deposit flow: the public
+// OISY Trade docs page.
+export const OISY_TRADE_LEARN_MORE_URL = 'https://docs.oisy.com/using-oisy-wallet/oisy-trade';
 
 // Value-difference (%) of a crossing limit order at/below which the give-up is
 // "severe" — rendered red rather than amber (a >5% give-up vs current value).

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1683,7 +1683,7 @@
 			"tab_title": "Trading",
 			"intro": "Place and manage limit orders on-chain, directly from your wallet.",
 			"learn_more": "Learn more",
-			"provider_name": "OISY TRADE",
+			"provider_name": "OISY Trade",
 			"no_trades": "You don't have any deposits or active orders",
 			"go_to_trade": "Go to Trade"
 		},
@@ -1702,7 +1702,7 @@
 			"deposit": "Deposit",
 			"withdraw": "Withdraw",
 			"active_orders": "Active orders",
-			"active_orders_empty_deposit": "Deposit tokens from your wallet to start placing limit orders on OISY TRADE.",
+			"active_orders_empty_deposit": "Deposit tokens from your wallet to start placing limit orders on OISY Trade.",
 			"active_orders_empty_place": "Your open and pending limit orders will appear here once you place one.",
 			"new_order": "New order",
 			"order_history": "Order history"
@@ -1712,8 +1712,8 @@
 			"description": "No trading provider is available right now. Your balances are safe and will be actionable again once a provider is back online."
 		},
 		"onboarding": {
-			"title": "Trade on-chain with OISY TRADE",
-			"description": "OISY TRADE is an on-chain order-book exchange. Place limit orders right from your wallet, with your funds held in smart contracts you control, never with a central party.",
+			"title": "Trade on-chain with OISY Trade",
+			"description": "OISY Trade is an on-chain order-book exchange. Place limit orders right from your wallet, with your funds held in smart contracts you control, never with a central party.",
 			"step_deposit": "Deposit a supported token",
 			"step_order": "Place a limit order",
 			"step_withdraw": "Withdraw anytime",
@@ -1735,16 +1735,16 @@
 			"transaction_fee": "Total estimated fee",
 			"approval_fee": "Approval fee",
 			"transfer_fee": "Network fee",
-			"consent": "I understand my tokens will be held by the OISY TRADE canister and are subject to on-chain smart contract risk.",
-			"info_title": "OISY TRADE: on-chain order book",
-			"info_description": "Deposited funds are held by the OISY TRADE canister and used to place limit orders, secured by on-chain smart contracts.",
+			"consent": "I understand my tokens will be held by the OISY Trade canister and are subject to on-chain smart contract risk.",
+			"info_title": "OISY Trade: on-chain order book",
+			"info_description": "Deposited funds are held by the OISY Trade canister and used to place limit orders, secured by on-chain smart contracts.",
 			"empty_title": "Nothing to deposit yet",
-			"empty_description": "OISY TRADE lets you create orders for these tokens. Add any of them to your wallet, then deposit it here to start trading.",
+			"empty_description": "OISY Trade lets you create orders for these tokens. Add any of them to your wallet, then deposit it here to start trading.",
 			"approving": "Approving",
 			"approved": "Approved",
-			"approve_description": "OISY TRADE authorised to transfer $symbol",
+			"approve_description": "OISY Trade authorised to transfer $symbol",
 			"depositing": "Depositing",
-			"deposit_description": "Transferring $symbol to OISY TRADE",
+			"deposit_description": "Transferring $symbol to OISY Trade",
 			"done": "Done",
 			"error": {
 				"unknown_fee": "The ledger fee for this token couldn't be determined. Your funds stayed in your wallet. Try again in a moment.",
@@ -1767,7 +1767,7 @@
 			"open": "Withdraw",
 			"progress_withdraw": "Sending $symbol to your wallet",
 			"progress_done": "Done",
-			"error": "Your withdrawal didn't complete. Your funds stayed on OISY TRADE. Try again in a moment."
+			"error": "Your withdrawal didn't complete. Your funds stayed on OISY Trade. Try again in a moment."
 		},
 		"orders": {
 			"title": "Orders",
@@ -1794,8 +1794,8 @@
 			"count_canceled": "$count canceled"
 		},
 		"info": {
-			"title": "What is OISY TRADE",
-			"description": "OISY TRADE is a fully onchain order-book exchange, integrated right into your wallet. Set a price to buy or sell at, and your order settles onchain the moment the market meets it, even while you're signed out.",
+			"title": "What is OISY Trade",
+			"description": "OISY Trade is a fully onchain order-book exchange, integrated right into your wallet. Set a price to buy or sell at, and your order settles onchain the moment the market meets it, even while you're signed out.",
 			"visit_website": "Visit website",
 			"fact_1_title": "Buy or sell at your price",
 			"fact_1_description": "Set the exact price you want to buy or sell a token at. Your limit order rests on the book until the market reaches it.",
@@ -1905,7 +1905,7 @@
 			"market_moved_sell": "Market moved: best bid is now $price. At this price your fill-or-kill order would be canceled. Go back and lower your price.",
 			"market_moved_buy": "Market moved: best ask is now $price. At this price your fill-or-kill order would be canceled. Go back and raise your price.",
 			"placing_initializing": "Submitting order",
-			"placing_sub": "Sending limit order to OISY TRADE",
+			"placing_sub": "Sending limit order to OISY Trade",
 			"placing_done": "Order placed",
 			"place_error": "Could not place the order. Please try again."
 		}

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1798,7 +1798,7 @@
 			"visit_website": "Visit website",
 			"fact_1_title": "Buy or sell at your price",
 			"fact_1_description": "Set the exact price you want to buy or sell a token at. Your limit order rests on the book until the market reaches it.",
-			"fact_2_title": "Fills even while you're away",
+			"fact_2_title": "Fills even while away",
 			"fact_2_description": "Your order lives onchain once placed. The exchange fills it as soon as a matching order appears, whether or not you're signed in.",
 			"fact_3_title": "Fully onchain",
 			"fact_3_description": "Orders are matched and settled inside a canister on the Internet Computer, governed by the NNS, with no centralized exchange in the middle."

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "What is OISY Trade",
 			"description": "OISY Trade is a fully onchain order-book exchange, integrated right into your wallet. Set a price to buy or sell at, and your order settles onchain the moment the market meets it, even while you're signed out.",
-			"visit_website": "Visit website",
 			"fact_1_title": "Buy or sell at your price",
 			"fact_1_description": "Set the exact price you want to buy or sell a token at. Your limit order rests on the book until the market reaches it.",
 			"fact_2_title": "Fills even while away",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1688,8 +1688,7 @@
 			"go_to_trade": "Go to Trade"
 		},
 		"page": {
-			"tagline": "A fully onchain order-book exchange, built into your wallet.",
-			"tagline_desktop": "Set your price, place a limit order, and let it settle onchain.",
+			"tagline": "Place limit orders right from your wallet. Your funds stay in smart contracts you control, never with a central party.",
 			"trading_potential": "Trading potential",
 			"trading_potential_hint": "In your wallet, not on the exchange",
 			"deposited_assets": "Deposited assets",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1689,7 +1689,6 @@
 		},
 		"page": {
 			"tagline": "",
-			"tagline_desktop": "",
 			"trading_potential": "",
 			"trading_potential_hint": "",
 			"deposited_assets": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1795,7 +1795,6 @@
 		"info": {
 			"title": "",
 			"description": "",
-			"visit_website": "",
 			"fact_1_title": "",
 			"fact_1_description": "",
 			"fact_2_title": "",

--- a/src/frontend/src/lib/services/trading-analytics.services.ts
+++ b/src/frontend/src/lib/services/trading-analytics.services.ts
@@ -1,4 +1,4 @@
-import { OISY_TRADE_PROVIDER_NAME } from '$lib/constants/oisy-trade.constants';
+import { OISY_TRADE_ANALYTICS_DAPP_NAME } from '$lib/constants/oisy-trade.constants';
 import {
 	PLAUSIBLE_EVENTS,
 	PLAUSIBLE_EVENT_CONTEXTS,
@@ -53,7 +53,7 @@ export const trackTrading = ({
 	trackEvent({
 		name: PLAUSIBLE_EVENTS.TRADING,
 		metadata: {
-			dApp: OISY_TRADE_PROVIDER_NAME,
+			dApp: OISY_TRADE_ANALYTICS_DAPP_NAME,
 			event_context: PLAUSIBLE_EVENT_CONTEXTS.TRADING,
 			event_subcontext: subContext,
 			result_status: resultStatus,

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1463,7 +1463,6 @@ interface I18nTrading {
 	info: {
 		title: string;
 		description: string;
-		visit_website: string;
 		fact_1_title: string;
 		fact_1_description: string;
 		fact_2_title: string;

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1366,7 +1366,6 @@ interface I18nTrading {
 	};
 	page: {
 		tagline: string;
-		tagline_desktop: string;
 		trading_potential: string;
 		trading_potential_hint: string;
 		deposited_assets: string;

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeInfoBox.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeInfoBox.svelte.spec.ts
@@ -14,10 +14,10 @@ describe('OisyTradeInfoBox', () => {
 		expect(getByText(en.trading.info.fact_3_title)).toBeInTheDocument();
 	});
 
-	it('links "Visit website" to the OISY Trade docs URL', () => {
+	it('links "Learn more" to the OISY Trade docs URL', () => {
 		const { getByText } = render(OisyTradeInfoBox);
 
-		expect(getByText(en.trading.info.visit_website).closest('a')).toHaveAttribute(
+		expect(getByText(en.trading.text.learn_more).closest('a')).toHaveAttribute(
 			'href',
 			OISY_TRADE_LEARN_MORE_URL
 		);

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeInfoBox.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeInfoBox.svelte.spec.ts
@@ -14,7 +14,7 @@ describe('OisyTradeInfoBox', () => {
 		expect(getByText(en.trading.info.fact_3_title)).toBeInTheDocument();
 	});
 
-	it('links "Visit website" to the OISY TRADE docs URL', () => {
+	it('links "Visit website" to the OISY Trade docs URL', () => {
 		const { getByText } = render(OisyTradeInfoBox);
 
 		expect(getByText(en.trading.info.visit_website).closest('a')).toHaveAttribute(

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeMark.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeMark.svelte.spec.ts
@@ -5,21 +5,21 @@ describe('OisyTradeMark', () => {
 	it('renders the round mark with an accessible label', () => {
 		const { getByLabelText } = render(OisyTradeMark);
 
-		expect(getByLabelText('OISY TRADE')).toBeInTheDocument();
+		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
 	});
 
 	it('renders at the default size', () => {
 		const { getByLabelText } = render(OisyTradeMark);
 
-		expect(getByLabelText('OISY TRADE')).toHaveAttribute('width', '64');
-		expect(getByLabelText('OISY TRADE')).toHaveAttribute('height', '64');
+		expect(getByLabelText('OISY Trade')).toHaveAttribute('width', '64');
+		expect(getByLabelText('OISY Trade')).toHaveAttribute('height', '64');
 	});
 
 	it('renders at a custom size', () => {
 		const { getByLabelText } = render(OisyTradeMark, { props: { size: '42' } });
 
-		expect(getByLabelText('OISY TRADE')).toHaveAttribute('width', '42');
-		expect(getByLabelText('OISY TRADE')).toHaveAttribute('height', '42');
+		expect(getByLabelText('OISY Trade')).toHaveAttribute('width', '42');
+		expect(getByLabelText('OISY Trade')).toHaveAttribute('height', '42');
 	});
 
 	it('gives each instance unique clipPath / filter ids', () => {

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeOrderRow.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeOrderRow.svelte.spec.ts
@@ -110,7 +110,7 @@ describe('OisyTradeOrderRow', () => {
 	it('does not render the provider tag (it is the venue’s own page)', () => {
 		const { queryByText } = render(OisyTradeOrderRow, { props: { order } });
 
-		expect(queryByText('OISY TRADE')).toBeNull();
+		expect(queryByText('OISY Trade')).toBeNull();
 	});
 
 	it('opens the order-detail modal with the order on click', async () => {

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeProviderHero.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeProviderHero.svelte.spec.ts
@@ -59,14 +59,6 @@ describe('OisyTradeProviderHero', () => {
 		expect(getByText(en.trading.page.deposited_assets)).toBeInTheDocument();
 	});
 
-	it('separates the two tagline sentences with a space', () => {
-		const { container } = render(OisyTradeProviderHero);
-
-		expect(container).toHaveTextContent(
-			`${en.trading.page.tagline} ${en.trading.page.tagline_desktop}`
-		);
-	});
-
 	it('shows the "nothing deposited" sub-line when there are no deposits', () => {
 		const { getByText } = render(OisyTradeProviderHero);
 

--- a/src/frontend/src/tests/lib/components/trading/TradingOrderRow.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingOrderRow.svelte.spec.ts
@@ -86,7 +86,7 @@ describe('TradingOrderRow', () => {
 		// tag wraps with the text instead of dropping to its own flex line.
 		const textBlock = getByText('Sell').parentElement;
 
-		expect(textBlock).toHaveTextContent('OISY TRADE');
+		expect(textBlock).toHaveTextContent('OISY Trade');
 	});
 
 	it('opens the order-detail modal with the order on click', async () => {

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTermsList.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTermsList.svelte.spec.ts
@@ -7,7 +7,7 @@ describe('LimitOrderTermsList', () => {
 			props: { orderTypeLabel: 'Good until canceled', makerFee: 0, takerFee: 0.2 }
 		});
 
-		expect(container).toHaveTextContent('OISY TRADE');
+		expect(container).toHaveTextContent('OISY Trade');
 		expect(container).toHaveTextContent('Good until canceled');
 		// maker 0 → "no fee" copy, taker 0.2 → percentage
 		expect(container).toHaveTextContent('0.2');

--- a/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
@@ -896,7 +896,7 @@ describe('oisy-trade.utils — search', () => {
 			Canceled: 'Canceled',
 			Expired: 'Expired'
 		},
-		provider: 'OISY TRADE'
+		provider: 'OISY Trade'
 	};
 
 	const order: OisyTradeOrderView = {


### PR DESCRIPTION
# Motivation

On the OISY Trade page (and everywhere the venue is named), the provider was written in all-caps "OISY TRADE". We want the branded title case "OISY Trade" across all visual surfaces. Separately, the hero tagline is being refreshed, and its old copy was split into two i18n keys where the second sentence was hidden on mobile (`hidden sm:inline`) — the new copy should read in full on every screen size.

# Changes

**Rename "OISY TRADE" → "OISY Trade" (visual only)**
- Provider display-name constant (`OISY_TRADE_PROVIDER_NAME`), used for the venue tag, order rows and deposit/withdraw flows.
- All user-facing strings in `en.json`: trading tab, onboarding, deposit/withdraw, info box, order placing.
- `OisyTradeMark` `aria-label`.
- **Analytics untouched:** the `dApp` property is decoupled into a new frozen `OISY_TRADE_ANALYTICS_DAPP_NAME` (`'OISY TRADE'`) so trading-event data isn't split by the rename. Code comments / `.did` / internal identifiers are left as-is.

**Hero tagline**
- New copy: _"Place limit orders right from your wallet. Your funds stay in smart contracts you control, never with a central party."_
- Removed the `tagline_desktop` key and its `hidden sm:inline` wrapper so the full message shows on mobile and desktop alike; regenerated the i18n types and pruned the now-empty key from all locale files.

# Tests

- `npm run format`, `check`, `check:tests`, and `lint --max-warnings 0` all clean.
- Updated and passing component/util specs (mark, terms list, order rows, hero, utils); analytics-value assertions kept at `'OISY TRADE'`. Removed the obsolete "two tagline sentences" hero test.
- Not visually verified in a running browser (the OISY Trade page sits behind II auth + trading enablement); can deploy to `test_fe_3` for a live look on request.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (claude-opus-4-8)