### PR TITLE
refactor(frontend): reusable GoToButton component

### DIFF
--- a/docs/ai/frontend/reusability.md
+++ b/docs/ai/frontend/reusability.md
@@ -52,15 +52,16 @@
 
 ### Common building blocks
 
-| Component                            | Where                      | Use it for                                     |
-| ------------------------------------ | -------------------------- | ---------------------------------------------- |
-| `List`, `ListItem`, `ListItemButton` | `$lib/components/common/`  | Vertical lists of items.                       |
-| `Divider`                            | `$lib/components/common/`  | Section separator. Don't roll your own border. |
-| `MaxBalanceButton`                   | `$lib/components/common/`  | "Max" button on amount inputs.                 |
-| `ModalHero`, `ModalListItem`         | `$lib/components/common/`  | Modal headers and modal list items.            |
-| `QrButton`                           | `$lib/components/common/`  | "Scan QR" entry-point button.                  |
-| `Loader*` and `loaders/`             | `$lib/components/loaders/` | Loaders, suspense boundaries, skeletons.       |
-| `icons/`                             | `$lib/components/icons/`   | Project's icon set.                            |
+| Component                            | Where                      | Use it for                                                                                                        |
+| ------------------------------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `List`, `ListItem`, `ListItemButton` | `$lib/components/common/`  | Vertical lists of items.                                                                                          |
+| `Divider`                            | `$lib/components/common/`  | Section separator. Don't roll your own border.                                                                    |
+| `MaxBalanceButton`                   | `$lib/components/common/`  | "Max" button on amount inputs.                                                                                    |
+| `ModalHero`, `ModalListItem`         | `$lib/components/common/`  | Modal headers and modal list items.                                                                               |
+| `QrButton`                           | `$lib/components/common/`  | "Scan QR" entry-point button.                                                                                     |
+| `GoToButton`                         | `$lib/components/common/`  | "Go to X" success CTA (label + testId + onclick); base for `GoToTradeButton`/`GoToEarnButton`/`GoToBorrowButton`. |
+| `Loader*` and `loaders/`             | `$lib/components/loaders/` | Loaders, suspense boundaries, skeletons.                                                                          |
+| `icons/`                             | `$lib/components/icons/`   | Project's icon set.                                                                                               |
 
 ### Cross-chain feature folders
 

--- a/src/frontend/src/lib/components/borrowings/GoToBorrowButton.svelte
+++ b/src/frontend/src/lib/components/borrowings/GoToBorrowButton.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import IconArrowRight from '$lib/components/icons/IconArrowRight.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
+	import GoToButton from '$lib/components/common/GoToButton.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { BORROWINGS_GOTO_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>
 
-<Button
-	colorStyle="success"
+<GoToButton
+	label={$i18n.borrowings.text.go_to_borrow}
 	onclick={() => goto(AppPath.Borrow)}
-	styleClass="gap-1 flex-none px-12 font-semibold"
 	testId={BORROWINGS_GOTO_BUTTON}
-	type="button"
->
-	{$i18n.borrowings.text.go_to_borrow}
-	<IconArrowRight />
-</Button>
+/>

--- a/src/frontend/src/lib/components/common/GoToButton.svelte
+++ b/src/frontend/src/lib/components/common/GoToButton.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { MouseEventHandler } from 'svelte/elements';
+	import IconArrowRight from '$lib/components/icons/IconArrowRight.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+
+	interface Props {
+		label: string;
+		testId: string;
+		onclick: MouseEventHandler<HTMLButtonElement>;
+	}
+
+	let { label, testId, onclick }: Props = $props();
+</script>
+
+<Button
+	colorStyle="success"
+	{onclick}
+	styleClass="gap-1 flex-none px-12 font-semibold"
+	{testId}
+	type="button"
+>
+	{label}
+	<IconArrowRight />
+</Button>

--- a/src/frontend/src/lib/components/earning/GoToEarnButton.svelte
+++ b/src/frontend/src/lib/components/earning/GoToEarnButton.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { NavigationTarget } from '@sveltejs/kit';
 	import { afterNavigate, goto } from '$app/navigation';
-	import IconArrowRight from '$lib/components/icons/IconArrowRight.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
+	import GoToButton from '$lib/components/common/GoToButton.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { EARNING_GOTO_BUTTON } from '$lib/constants/test-ids.constants';
 	import { networkId } from '$lib/derived/network.derived';
@@ -25,13 +24,8 @@
 	);
 </script>
 
-<Button
-	colorStyle="success"
+<GoToButton
+	label={$i18n.earning.text.go_to_earn}
 	onclick={() => goto(path)}
-	styleClass="gap-1 flex-none px-12 font-semibold"
 	testId={EARNING_GOTO_BUTTON}
-	type="button"
->
-	{$i18n.earning.text.go_to_earn}
-	<IconArrowRight />
-</Button>
+/>

--- a/src/frontend/src/lib/components/trading/GoToTradeButton.svelte
+++ b/src/frontend/src/lib/components/trading/GoToTradeButton.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import IconArrowRight from '$lib/components/icons/IconArrowRight.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
+	import GoToButton from '$lib/components/common/GoToButton.svelte';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { TRADING_GOTO_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 </script>
 
-<Button
-	colorStyle="success"
+<GoToButton
+	label={$i18n.trading.text.go_to_trade}
 	onclick={() => goto(AppPath.ProvidersOisyTrade)}
-	styleClass="gap-1 flex-none px-12 font-semibold"
 	testId={TRADING_GOTO_BUTTON}
-	type="button"
->
-	{$i18n.trading.text.go_to_trade}
-	<IconArrowRight />
-</Button>
+/>

--- a/src/frontend/src/tests/lib/components/common/GoToButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/common/GoToButton.spec.ts
@@ -1,0 +1,27 @@
+import GoToButton from '$lib/components/common/GoToButton.svelte';
+import { render } from '@testing-library/svelte';
+
+describe('GoToButton', () => {
+	const props = { label: 'Go to X', testId: 'go-to-x', onclick: vi.fn() };
+
+	it('should render the label', () => {
+		const { getByText } = render(GoToButton, props);
+
+		expect(getByText(props.label)).toBeInTheDocument();
+	});
+
+	it('should render the icon', () => {
+		const { container } = render(GoToButton, props);
+
+		expect(container.querySelector('svg')).toBeInTheDocument();
+	});
+
+	it('should call onclick when clicked', () => {
+		const onclick = vi.fn();
+		const { getByTestId } = render(GoToButton, { ...props, onclick });
+
+		(getByTestId(props.testId) as HTMLButtonElement).click();
+
+		expect(onclick).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
# Motivation

We need to align all Go-to buttons across Earn, Borrow and Trade pages.
