### PR TITLE
fix(frontend): stop an unchecked checkbox filling on hover

### DIFF
--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -166,10 +166,7 @@
 			<!-- `--checkbox-label-order: 1` puts the box before the label (leading, like
 				 the transaction-filter panels); `flex-start` top-aligns the box in case
 				 the label wraps on a narrow viewport. -->
-			<div
-				style="--checkbox-label-order: 1; --checkbox-align-items: flex-start;"
-				class="single-use-checkbox"
-			>
+			<div style="--checkbox-label-order: 1; --checkbox-align-items: flex-start;">
 				<Checkbox
 					checked={singleUse}
 					inputId="share-single-use"
@@ -251,14 +248,3 @@
 		<IconShieldCheck size="20" />
 	</div>
 {/snippet}
-
-<style lang="scss">
-	// The shared Checkbox fills the box with the solid brand-secondary colour on
-	// hover; for an unchecked box that reads as already selected and looks broken
-	// next to the label. Keep the unchecked box at its resting background on hover
-	// (only its border brightens) so hover no longer mimics the checked state.
-	.single-use-checkbox :global(.checkbox:hover input:not(:checked)) {
-		--input-background: var(--color-background-primary);
-		background: var(--color-background-primary);
-	}
-</style>

--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -166,7 +166,10 @@
 			<!-- `--checkbox-label-order: 1` puts the box before the label (leading, like
 				 the transaction-filter panels); `flex-start` top-aligns the box in case
 				 the label wraps on a narrow viewport. -->
-			<div style="--checkbox-label-order: 1; --checkbox-align-items: flex-start;">
+			<div
+				style="--checkbox-label-order: 1; --checkbox-align-items: flex-start;"
+				class="single-use-checkbox"
+			>
 				<Checkbox
 					checked={singleUse}
 					inputId="share-single-use"
@@ -248,3 +251,14 @@
 		<IconShieldCheck size="20" />
 	</div>
 {/snippet}
+
+<style lang="scss">
+	// The shared Checkbox fills the box with the solid brand-secondary colour on
+	// hover; for an unchecked box that reads as already selected and looks broken
+	// next to the label. Keep the unchecked box at its resting background on hover
+	// (only its border brightens) so hover no longer mimics the checked state.
+	.single-use-checkbox :global(.checkbox:hover input:not(:checked)) {
+		--input-background: var(--color-background-primary);
+		background: var(--color-background-primary);
+	}
+</style>

--- a/src/frontend/src/lib/components/ui/Checkbox.svelte
+++ b/src/frontend/src/lib/components/ui/Checkbox.svelte
@@ -100,21 +100,24 @@
 		--checkbox-input-size: 20px;
 
 		// Folded in from the former global gix.scss `div.checkbox, div.radio`
-		// override layer, now that OISY owns this component.
+		// override layer, now that OISY owns this component. Hover brightens the
+		// border for both states, but only a checked box also darkens its fill — an
+		// unchecked box keeps its resting background, since a solid hover fill would
+		// read as already selected.
 		&:hover input {
 			--secondary: var(--color-background-brand-secondary) !important;
 			--input-custom-border-color: var(--color-background-brand-secondary);
-			--focus-background: var(--color-background-brand-secondary);
-			--input-background: var(--color-background-brand-secondary);
+
+			// form.input-focus (border only)
+			border: var(--input-border-size) solid var(--secondary);
 		}
 
-		&:hover {
-			input {
-				// form.input-focus
-				border: var(--input-border-size) solid var(--secondary);
-				background: var(--focus-background);
-				color: var(--focus-background-contrast);
-			}
+		&:hover input:checked {
+			--focus-background: var(--color-background-brand-secondary);
+			--input-background: var(--color-background-brand-secondary);
+
+			background: var(--focus-background);
+			color: var(--focus-background-contrast);
 		}
 
 		&.disabled {


### PR DESCRIPTION
# Motivation

The shared `Checkbox` filled the box with the solid `brand-secondary` colour on hover regardless of state, so an *unchecked* box turned solid dark blue on hover — darker than a resting *checked* box — and read as already selected. It was most visible on the note-share single-use checkbox, but it affects every checkbox.

# Changes

- In `Checkbox`, hover now brightens the **border** for both states, but only a **checked** box also darkens its fill. An unchecked box keeps its resting background on hover (border emphasis only).
- The fix lives in the component, so no consumer needs a scoped override.

# Tests

- `npm run check` (svelte-check): 0 errors / 0 warnings.
- prettier + eslint (`--max-warnings 0`): clean.
- `vitest` notes component suite: 41 tests pass.
- Manual: unchecked checkbox no longer fills on hover; a checked box still darkens.
