### PR TITLE
style(frontend): tidy note-share snapshot spacing

### DIFF
--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -128,7 +128,7 @@
 	};
 </script>
 
-<ContentWithToolbar styleClass="flex min-h-0 flex-col items-stretch gap-4 overflow-y-auto">
+<ContentWithToolbar styleClass="flex min-h-0 flex-col items-stretch gap-6 overflow-y-auto">
 	{#if createdLink === undefined}
 		<!-- State A — configure -->
 		{#if atCap}
@@ -138,17 +138,21 @@
 				})}
 			</p>
 		{/if}
-		<div class="flex flex-col gap-1 rounded-lg border border-brand-subtle-20 p-3">
-			<span style="overflow-wrap: anywhere;" class="truncate font-bold text-primary">
-				{preview.title}
-			</span>
-			{#if preview.body !== ''}
-				<span style="overflow-wrap: anywhere;" class="line-clamp-2 text-sm text-tertiary">
-					{preview.body}
+		<!-- Box + caption are one group: the caption describes the snapshot above it,
+			so it hugs the box (gap-2) and the group keeps the section rhythm (gap-6). -->
+		<div class="flex flex-col gap-2">
+			<div class="flex flex-col gap-2 rounded-lg border border-brand-subtle-20 p-4">
+				<span style="overflow-wrap: anywhere;" class="truncate font-bold text-primary">
+					{preview.title}
 				</span>
-			{/if}
+				{#if preview.body !== ''}
+					<span style="overflow-wrap: anywhere;" class="line-clamp-2 text-sm text-tertiary">
+						{preview.body}
+					</span>
+				{/if}
+			</div>
+			<span class="text-xs text-tertiary">{$i18n.notes.share.text.snapshot_caption}</span>
 		</div>
-		<span class="text-xs text-tertiary">{$i18n.notes.share.text.snapshot_caption}</span>
 
 		<div class="flex flex-col gap-2">
 			<span class="text-sm font-bold text-primary">{$i18n.notes.share.text.expires_after}</span>


### PR DESCRIPTION
# Motivation

The snapshot caption sat a full section gap (`gap-4`) below the preview box it describes, so it floated equidistant between the box and the expiry section and read as belonging to neither. The preview box was also tighter (`p-3`, inner `gap-1`) than the other note boxes on the view and recipient screens.

# Changes

- Group the preview box and its caption so the caption hugs the box.
- Align the preview box padding (`p-4`) and inner gap (`gap-2`) with the note boxes elsewhere in the feature.

# Tests

- `npm run check` (svelte-check): 0 errors / 0 warnings.
- prettier + eslint: clean.
- `vitest` notes component suite: 41 tests pass.

---

_Part of a 4-PR Notes-screen polish stack. Base: `style/frontend/notes-share-typography` — merge after it._
