### PR TITLE
style(frontend): use a soft grey (secondary) for the note privacy boxes

### DIFF
--- a/src/frontend/src/lib/components/notes/NotesPrivacyInfoBox.svelte
+++ b/src/frontend/src/lib/components/notes/NotesPrivacyInfoBox.svelte
@@ -12,10 +12,9 @@
 	</div>
 {/snippet}
 
-<!-- A neutral-grey box (the modal surface is white, so the plain level's white
-	background would be invisible). Grey, not a blue tint, since there's already
-	blue above (the Note panel) and below (Cancel/Save). -->
-<MessageBox icon={shieldIcon} level="plain" styleClass="w-full bg-tertiary! text-left">
+<!-- A soft grey callout (secondary surface) so the privacy note reads as a
+	distinct reassurance box on the white modal. -->
+<MessageBox icon={shieldIcon} level="plain" styleClass="w-full bg-secondary! text-left">
 	<strong>{`${$i18n.notes.text.encrypted_lead} `}</strong
 	>{`${$i18n.notes.text.encrypted_info.trimEnd()} `}<ExternalLink
 		ariaLabel={$i18n.core.text.learn_more}

--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -179,7 +179,9 @@
 			</div>
 		</div>
 
-		<MessageBox icon={shieldIcon} level="info" styleClass="w-full text-left">
+		<!-- A soft grey callout (secondary surface) matching the editor's privacy box
+			(NotesPrivacyInfoBox). -->
+		<MessageBox icon={shieldIcon} level="plain" styleClass="w-full bg-secondary! text-left">
 			<strong>{`${$i18n.notes.text.encrypted_lead} `}</strong
 			>{`${$i18n.notes.share.text.protects_body.trimEnd()} `}<ExternalLink
 				ariaLabel={$i18n.core.text.learn_more}


### PR DESCRIPTION
# Motivation

The "End-to-end encrypted" privacy box appears in both the note editor and the share screen. They were styled inconsistently (editor grey, share blue), and the grey used the tertiary surface. Unify them on a single soft grey.

# Changes

- Both privacy boxes — editor (`NotesPrivacyInfoBox`) and share (`ShareNoteContent`) — now use the `--color-background-secondary` surface via `bg-secondary!` on the shared `MessageBox` (`level="plain"`).
- This supersedes the share box's original blue `info` level and the tertiary grey, keeping the two boxes consistent.

# Tests

- `npm run check` (svelte-check): 0 errors / 0 warnings.
- prettier + eslint: clean.
- `vitest` notes component suite: 41 tests pass.

---

_Part of the Notes-screen polish stack. Base: `style/frontend/notes-share-spacing` — merge after it._
