### PR TITLE
feat(frontend): autofocus for Liquidium forms

### DIFF
--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte
@@ -23,6 +23,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
+	import { isDesktop } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
@@ -148,6 +149,7 @@
 	<div class="mb-6">
 		<!-- Token fixed by the market for now; a selectable step comes later. -->
 		<TokenInput
+			autofocus={isDesktop()}
 			displayUnit={inputUnit}
 			exchangeRate={borrowPrice}
 			isSelectable={false}

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayForm.svelte
@@ -11,6 +11,7 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
+	import { isDesktop } from '$lib/utils/device.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 
@@ -84,6 +85,7 @@
 </script>
 
 <StakeForm
+	autofocus={isDesktop()}
 	disabled={feeMissing || inflowFeeUnavailable}
 	maxAmount={maxRepay}
 	{onClose}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyForm.svelte
@@ -10,6 +10,7 @@
 	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
+	import { isDesktop } from '$lib/utils/device.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 
@@ -71,6 +72,7 @@
 </script>
 
 <StakeForm
+	autofocus={isDesktop()}
 	disabled={!agreementChecked || feeMissing || inflowFeeUnavailable}
 	{onClose}
 	{onCustomErrorValidate}

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte
@@ -18,6 +18,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
+	import { isDesktop } from '$lib/utils/device.utils';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
@@ -127,6 +128,7 @@
 <ContentWithToolbar>
 	<div class="mb-6">
 		<TokenInput
+			autofocus={isDesktop()}
 			displayUnit={inputUnit}
 			exchangeRate={withdrawPrice}
 			isSelectable={false}

--- a/src/frontend/src/lib/components/stake/StakeForm.svelte
+++ b/src/frontend/src/lib/components/stake/StakeForm.svelte
@@ -23,6 +23,9 @@
 	interface Props {
 		amount: OptionAmount;
 		amountSetToMax?: boolean;
+		// Focus the amount input on mount. Callers gate this on `isDesktop()` so
+		// mobile keyboards don't pop open over the form.
+		autofocus?: boolean;
 		disabled?: boolean;
 		destination?: Address;
 		totalFee?: bigint;
@@ -44,6 +47,7 @@
 	let {
 		amount = $bindable(),
 		amountSetToMax = $bindable(false),
+		autofocus = false,
 		disabled,
 		destination,
 		totalFee,
@@ -85,6 +89,7 @@
 <ContentWithToolbar>
 	<div class="mb-8">
 		<TokenInput
+			{autofocus}
 			displayUnit={inputUnit}
 			exchangeRate={$sendTokenExchangeRate}
 			isSelectable={false}


### PR DESCRIPTION
# Motivation

Same as in the other forms, we need to autofocus inputs in all Liquidium modals.