### PR TITLE
feat(frontend): autofocus the trading deposit amount input on desktop

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingDepositForm.svelte
+++ b/src/frontend/src/lib/components/trading/TradingDepositForm.svelte
@@ -23,6 +23,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
+	import { isDesktop } from '$lib/utils/device.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { tryParseToken } from '$lib/utils/parse.utils';
 
@@ -96,6 +97,7 @@
 <ContentWithToolbar>
 	<div class="mb-4">
 		<TokenInput
+			autofocus={isDesktop()}
 			displayUnit={inputUnit}
 			{exchangeRate}
 			isSelectable

--- a/src/frontend/src/tests/lib/components/trading/TradingDepositForm.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingDepositForm.svelte.spec.ts
@@ -1,13 +1,16 @@
 import type { IcToken } from '$icp/types/ic-token';
 import TradingDepositForm from '$lib/components/trading/TradingDepositForm.svelte';
 import {
+	TOKEN_INPUT_CURRENCY_TOKEN,
 	TRADING_DEPOSIT_CONSENT_CHECKBOX,
 	TRADING_DEPOSIT_FORM_REVIEW_BUTTON
 } from '$lib/constants/test-ids.constants';
 import { balancesStore } from '$lib/stores/balances.store';
+import * as deviceUtils from '$lib/utils/device.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { fireEvent, render } from '@testing-library/svelte';
+import type { MockInstance } from 'vitest';
 
 describe('TradingDepositForm', () => {
 	const token: IcToken = { ...mockValidIcToken, symbol: 'ICP', decimals: 8, fee: 10000n };
@@ -110,5 +113,43 @@ describe('TradingDepositForm', () => {
 		await fireEvent.click(getByTestId(TRADING_DEPOSIT_FORM_REVIEW_BUTTON));
 
 		expect(onNext).toHaveBeenCalledOnce();
+	});
+
+	describe('amount input autofocus', () => {
+		let isDesktopSpy: MockInstance<typeof deviceUtils.isDesktop>;
+
+		beforeEach(() => {
+			isDesktopSpy = vi.spyOn(deviceUtils, 'isDesktop');
+		});
+
+		afterEach(() => {
+			isDesktopSpy.mockRestore();
+		});
+
+		it('should auto-focus the amount input on desktop when a token is selected', () => {
+			isDesktopSpy.mockReturnValue(true);
+
+			const { getByTestId } = render(TradingDepositForm, { props: { ...baseProps } });
+
+			expect(getByTestId(TOKEN_INPUT_CURRENCY_TOKEN)).toHaveFocus();
+		});
+
+		it('should not auto-focus the amount input on mobile', () => {
+			isDesktopSpy.mockReturnValue(false);
+
+			const { getByTestId } = render(TradingDepositForm, { props: { ...baseProps } });
+
+			expect(getByTestId(TOKEN_INPUT_CURRENCY_TOKEN)).not.toHaveFocus();
+		});
+
+		it('should not auto-focus when no token is selected', () => {
+			isDesktopSpy.mockReturnValue(true);
+
+			const { queryByTestId } = render(TradingDepositForm, {
+				props: { ...baseProps, token: undefined }
+			});
+
+			expect(queryByTestId(TOKEN_INPUT_CURRENCY_TOKEN)).not.toBeInTheDocument();
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

The modals on the OISY Trade provider page should focus their keyboard input as soon as they are ready for it, the same way the send, stake and Liquidium forms already do (#13455). The Trade **deposit** modal was missing this: after selecting a token, the amount field was not focused, so the user had to click into it before typing.

This PR covers the deposit modal only. The withdraw modal (and the mobile side) will follow in separate PRs so each can be verified on its own.

# Changes

- `TradingDepositForm.svelte`: pass `autofocus={isDesktop()}` to `TokenInput`. The amount input only renders once a token is selected, so returning from the token picker to the amount step now focuses the field automatically. Gated on `isDesktop()` — matching the just-merged Liquidium/stake convention — so mobile keyboards don't pop open over the form.

# Tests

Added three cases to `TradingDepositForm.svelte.spec.ts` (spying on `isDesktop`, the repo's canonical pattern):

- desktop + token selected → amount input is focused
- mobile → amount input is not focused
- no token selected → amount input is not rendered (nothing to focus)

The desktop/mobile pair is mutation-resistant: flipping the condition fails one of them.

Quality gates run locally: `npm run test` (12/12 for this spec), `npm run check`, `npm run check:tests`, `eslint --max-warnings 0`, `prettier` — all green.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (`claude-opus-4-8`)
