### PR TITLE
fix(frontend): uniform background for read-only token input

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -16,7 +16,7 @@
 		displayUnit?: DisplayUnit;
 		exchangeRate?: number;
 		disabled?: boolean;
-		readOnly?: boolean;
+		readOnlyAmount?: boolean;
 		placeholder?: string;
 		errorType?: TokenActionErrorType;
 		// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
@@ -41,7 +41,7 @@
 		displayUnit = 'token',
 		exchangeRate,
 		disabled = false,
-		readOnly = false,
+		readOnlyAmount = false,
 		placeholder = '0',
 		errorType = $bindable(),
 		error = $bindable(),
@@ -82,7 +82,7 @@
 		{onCustomErrorValidate}
 		{onCustomValidate}
 		{placeholder}
-		{readOnly}
+		{readOnlyAmount}
 		{showTokenNetwork}
 		{title}
 		{token}

--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -136,7 +136,7 @@
 		styleClass="h-14 text-3xl"
 	>
 		<div
-			style={readOnly ? '--input-background: var(--color-background-disabled-alt);' : undefined}
+			style={readOnly ? '--input-background: transparent;' : undefined}
 			class="flex h-full w-full items-center"
 		>
 			{#if token}

--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -138,8 +138,6 @@
 		<div
 			style={readOnly ? '--input-background: var(--color-background-disabled-alt);' : undefined}
 			class="flex h-full w-full items-center"
-			class:overflow-hidden={readOnly}
-			class:rounded-l-lg={readOnly}
 		>
 			{#if token}
 				{#if displayUnit === 'token'}

--- a/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
@@ -13,14 +13,16 @@
 </script>
 
 <div
-	class={`flex w-full items-center rounded-lg border border-solid shadow-inner transition-colors duration-250 ${styleClass ?? ''}`}
-	class:bg-disabled-alt={readOnly}
+	class={`flex w-full items-center rounded-lg transition-colors duration-250 ${styleClass ?? ''}`}
 	class:bg-primary={!readOnly}
+	class:border={!readOnly}
 	class:border-brand-primary={!readOnly && focused && !error}
-	class:border-error-solid={error}
-	class:border-tertiary={!error && (readOnly || !focused)}
+	class:border-error-solid={!readOnly && error}
+	class:border-solid={!readOnly}
+	class:border-tertiary={!readOnly && !error && !focused}
 	class:focus-within:border-2={!readOnly}
 	class:hover:border-brand-primary={!readOnly && !error}
+	class:shadow-inner={!readOnly}
 >
 	{@render children()}
 </div>

--- a/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
@@ -4,25 +4,31 @@
 	interface Props {
 		focused?: boolean;
 		error?: boolean;
-		readOnly?: boolean;
+		readOnlyAmount?: boolean;
 		styleClass?: string;
 		children: Snippet;
 	}
 
-	let { focused = false, error = false, readOnly = false, styleClass, children }: Props = $props();
+	let {
+		focused = false,
+		error = false,
+		readOnlyAmount = false,
+		styleClass,
+		children
+	}: Props = $props();
 </script>
 
 <div
 	class={`flex w-full items-center rounded-lg transition-colors duration-250 ${styleClass ?? ''}`}
-	class:bg-primary={!readOnly}
-	class:border={!readOnly}
-	class:border-brand-primary={!readOnly && focused && !error}
-	class:border-error-solid={!readOnly && error}
-	class:border-solid={!readOnly}
-	class:border-tertiary={!readOnly && !error && !focused}
-	class:focus-within:border-2={!readOnly}
-	class:hover:border-brand-primary={!readOnly && !error}
-	class:shadow-inner={!readOnly}
+	class:bg-primary={!readOnlyAmount}
+	class:border={!readOnlyAmount}
+	class:border-brand-primary={!readOnlyAmount && focused && !error}
+	class:border-error-solid={!readOnlyAmount && error}
+	class:border-solid={!readOnlyAmount}
+	class:border-tertiary={!readOnlyAmount && !error && !focused}
+	class:focus-within:border-2={!readOnlyAmount}
+	class:hover:border-brand-primary={!readOnlyAmount && !error}
+	class:shadow-inner={!readOnlyAmount}
 >
 	{@render children()}
 </div>

--- a/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
@@ -13,7 +13,9 @@
 </script>
 
 <div
-	class={`flex w-full items-center rounded-lg border border-solid bg-primary shadow-inner transition-colors duration-250 ${styleClass ?? ''}`}
+	class={`flex w-full items-center rounded-lg border border-solid shadow-inner transition-colors duration-250 ${styleClass ?? ''}`}
+	class:bg-disabled-alt={readOnly}
+	class:bg-primary={!readOnly}
 	class:border-brand-primary={!readOnly && focused && !error}
 	class:border-error-solid={error}
 	class:border-tertiary={!error && (readOnly || !focused)}

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -163,6 +163,8 @@
 					bind:tokenAmount={amount}
 				/>
 			{/if}
+		{:else if readOnlyAmount}
+			<div class="w-full pl-3 font-bold text-disabled">—</div>
 		{:else}
 			<button class="h-full w-full pl-3 text-base" onclick={onClick}
 				>{$i18n.tokens.text.select_token}</button

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -177,12 +177,11 @@
 	<button
 		class="flex h-full items-center gap-1 px-3 transition-colors"
 		class:bg-primary={readOnlyAmount}
-		class:border-r={readOnlyAmount}
+		class:border={readOnlyAmount}
 		class:border-solid={readOnlyAmount}
 		class:border-tertiary={readOnlyAmount}
-		class:border-y={readOnlyAmount}
 		class:hover:border-brand-primary={readOnlyAmount && isSelectable}
-		class:rounded-r-lg={readOnlyAmount}
+		class:rounded-lg={readOnlyAmount}
 		class:shadow-inner={readOnlyAmount}
 		disabled={!isSelectable}
 		onclick={onClick}

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -170,9 +170,23 @@
 		{/if}
 	</div>
 
-	<div class="h-3/4 w-[1px] bg-disabled"></div>
+	{#if !readOnly}
+		<div class="h-3/4 w-[1px] bg-disabled"></div>
+	{/if}
 
-	<button class="flex h-full gap-1 px-3" disabled={!isSelectable} onclick={onClick}>
+	<button
+		class="flex h-full items-center gap-1 px-3 transition-colors"
+		class:bg-primary={readOnly}
+		class:border-r={readOnly}
+		class:border-solid={readOnly}
+		class:border-tertiary={readOnly}
+		class:border-y={readOnly}
+		class:hover:border-brand-primary={readOnly && isSelectable}
+		class:rounded-r-lg={readOnly}
+		class:shadow-inner={readOnly}
+		disabled={!isSelectable}
+		onclick={onClick}
+	>
 		{#if token}
 			<TokenLogo data={token} logoSize="xs" />
 			<div class="ml-2 text-sm font-semibold">{getTokenDisplaySymbol(token)}</div>

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -25,7 +25,7 @@
 		displayUnit?: DisplayUnit;
 		exchangeRate?: number;
 		disabled?: boolean;
-		readOnly?: boolean;
+		readOnlyAmount?: boolean;
 		placeholder?: string;
 		errorType?: TokenActionErrorType;
 		// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
@@ -52,7 +52,7 @@
 		displayUnit = 'token',
 		exchangeRate,
 		disabled = false,
-		readOnly = false,
+		readOnlyAmount = false,
 		placeholder = '0',
 		errorType = $bindable(),
 		error = $bindable(),
@@ -125,11 +125,11 @@
 <TokenInputContainer
 	error={nonNullish(errorType) || nonNullish(error)}
 	{focused}
-	{readOnly}
+	{readOnlyAmount}
 	styleClass="h-14 text-3xl"
 >
 	<div
-		style={readOnly ? '--input-background: transparent;' : undefined}
+		style={readOnlyAmount ? '--input-background: transparent;' : undefined}
 		class="flex h-full w-full items-center"
 	>
 		{#if token}
@@ -170,20 +170,20 @@
 		{/if}
 	</div>
 
-	{#if !readOnly}
+	{#if !readOnlyAmount}
 		<div class="h-3/4 w-[1px] bg-disabled"></div>
 	{/if}
 
 	<button
 		class="flex h-full items-center gap-1 px-3 transition-colors"
-		class:bg-primary={readOnly}
-		class:border-r={readOnly}
-		class:border-solid={readOnly}
-		class:border-tertiary={readOnly}
-		class:border-y={readOnly}
-		class:hover:border-brand-primary={readOnly && isSelectable}
-		class:rounded-r-lg={readOnly}
-		class:shadow-inner={readOnly}
+		class:bg-primary={readOnlyAmount}
+		class:border-r={readOnlyAmount}
+		class:border-solid={readOnlyAmount}
+		class:border-tertiary={readOnlyAmount}
+		class:border-y={readOnlyAmount}
+		class:hover:border-brand-primary={readOnlyAmount && isSelectable}
+		class:rounded-r-lg={readOnlyAmount}
+		class:shadow-inner={readOnlyAmount}
 		disabled={!isSelectable}
 		onclick={onClick}
 	>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -263,7 +263,7 @@
 			isSelectable={nonNullish(baseSymbol)}
 			onClick={onSelectQuoteGuarded}
 			onCustomValidate={onQuoteCustomValidate}
-			readOnly={true}
+			readOnlyAmount={true}
 			showTokenNetwork
 			token={quoteToken}
 		>

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '$lib/utils/oisy-trade.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 
 describe('LimitOrderTradePairBox', () => {
@@ -190,7 +191,7 @@ describe('LimitOrderTradePairBox', () => {
 
 		// No base yet: the quote list is filtered by the base's markets, so the
 		// quote selector must stay inert until a base is chosen.
-		const { getAllByText } = render(LimitOrderTradePairBox, {
+		const { getAllByRole } = render(LimitOrderTradePairBox, {
 			props: {
 				...baseProps,
 				baseSymbol: undefined,
@@ -201,8 +202,10 @@ describe('LimitOrderTradePairBox', () => {
 			}
 		});
 
-		// Both legs show "Select token" without a token; the quote one is second.
-		const [, quoteSelect] = getAllByText(en.tokens.text.select_token);
+		// Without a base the quote selector is the sole disabled button; clicking
+		// it must not open the quote picker.
+		const quoteSelect = getAllByRole('button').find((button) => button.hasAttribute('disabled'));
+		assertNonNullish(quoteSelect);
 		await fireEvent.click(quoteSelect);
 
 		expect(onSelectQuote).not.toHaveBeenCalled();


### PR DESCRIPTION
# Motivation

In the read-only leg of the limit-order pair box (e.g. "You pay at most"), the muted/disabled background was only applied to the amount input sub-area, filling it up to the token-selector separator while the token pill kept the primary background. The result was an unbalanced two-tone box: a grey block on the left ending abruptly at the separator, and white under the token pill.

# Changes

- Move the read-only muted background from the input sub-area to the whole `TokenInputContainer`, so the entire box (input area + token selector) reads as a single uniformly muted, non-editable field.
- Drop the now-unneeded `overflow-hidden` / `rounded-l-lg` clipping classes on the input wrapper — they only existed to clip the standalone grey block into the rounded left corner.

# Tests

- `npm run format`, lint (`--max-warnings 0`) pass on the changed components.
- `TokenInput.spec.ts` and `LimitOrderTradePairBox.svelte.spec.ts` pass (10 tests).