### PR TITLE
refactor(frontend): extract TokenInputContent from TokenInput

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInput.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInput.svelte
@@ -1,24 +1,13 @@
 <script lang="ts">
-	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
-	import IconExpandMore from '$lib/components/icons/IconExpandMore.svelte';
-	import IconPlus from '$lib/components/icons/lucide/IconPlus.svelte';
-	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
-	import TokenInputContainer from '$lib/components/tokens/TokenInputContainer.svelte';
-	import TokenInputCurrencyFiat from '$lib/components/tokens/TokenInputCurrencyFiat.svelte';
-	import TokenInputCurrencyToken from '$lib/components/tokens/TokenInputCurrencyToken.svelte';
-	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
-	import { logoSizes } from '$lib/constants/components.constants';
+	import TokenInputContent from '$lib/components/tokens/TokenInputContent.svelte';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
-	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
-	import { invalidAmount } from '$lib/utils/input.utils';
-	import { tryParseToken } from '$lib/utils/parse.utils';
-	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
 		token?: Token;
@@ -70,46 +59,6 @@
 	}: Props = $props();
 
 	let focused = $state(false);
-	const onFocus = () => (focused = true);
-	const onBlur = () => (focused = false);
-
-	const onInput = () => {
-		amountSetToMax = false;
-	};
-
-	const validate = () => {
-		if (invalidAmount(amount) || isNullish(token)) {
-			errorType = undefined;
-			error = undefined;
-			return;
-		}
-
-		// `tryParseToken` returns `undefined` for an out-of-range amount (e.g. a
-		// user typing `1e400`) instead of throwing an unhandled error inside this
-		// debounced callback. Treat it as an invalid amount so the input shows its
-		// error state without running the custom validators on a missing value.
-		const parsedValue = tryParseToken({
-			value: `${amount}`,
-			unitName: token.decimals
-		});
-
-		if (isNullish(parsedValue)) {
-			errorType = 'invalid-amount';
-			error = new Error($i18n.send.assertion.amount_invalid);
-			return;
-		}
-
-		errorType = onCustomValidate(parsedValue);
-		error = onCustomErrorValidate(parsedValue);
-	};
-
-	const debounceValidate = debounce(validate, 300);
-
-	$effect(() => {
-		[amount, token];
-
-		debounceValidate();
-	});
 </script>
 
 <div
@@ -119,92 +68,30 @@
 	class:border-brand-subtle-20={focused}
 	class:border-secondary={!focused}
 >
-	<div class="space-between mb-2 flex justify-between text-sm font-bold">
-		{@render title?.()}
-		{#if showTokenNetwork && nonNullish(token)}
-			<div class="flex text-xs font-normal text-tertiary">
-				<span class="mr-1 text-sm">On {token.network.name}</span>
-				<NetworkLogo network={token.network} />
-			</div>
-		{/if}
-	</div>
-
-	<TokenInputContainer
-		error={nonNullish(errorType) || nonNullish(error)}
-		{focused}
+	<TokenInputContent
+		{name}
+		{amountInfo}
+		{autofocus}
+		{balance}
+		{disabled}
+		{displayUnit}
+		{exchangeRate}
+		{isSelectable}
+		{loading}
+		{onClick}
+		{onCustomErrorValidate}
+		{onCustomValidate}
+		{placeholder}
 		{readOnly}
-		styleClass="h-14 text-3xl"
-	>
-		<div
-			style={readOnly ? '--input-background: var(--color-background-disabled-alt);' : undefined}
-			class="flex h-full w-full items-center"
-			class:overflow-hidden={readOnly}
-			class:rounded-l-lg={readOnly}
-		>
-			{#if token}
-				{#if displayUnit === 'token'}
-					<TokenInputCurrencyToken
-						{name}
-						{autofocus}
-						decimals={token.decimals}
-						{disabled}
-						error={nonNullish(errorType)}
-						{loading}
-						{onBlur}
-						{onFocus}
-						{onInput}
-						{placeholder}
-						bind:value={amount}
-					/>
-				{:else if displayUnit === 'usd'}
-					<TokenInputCurrencyFiat
-						{name}
-						{autofocus}
-						{disabled}
-						error={nonNullish(errorType)}
-						{exchangeRate}
-						{loading}
-						{onBlur}
-						{onFocus}
-						{onInput}
-						{placeholder}
-						tokenDecimals={token.decimals}
-						bind:tokenAmount={amount}
-					/>
-				{/if}
-			{:else}
-				<button class="h-full w-full pl-3 text-base" onclick={onClick}
-					>{$i18n.tokens.text.select_token}</button
-				>
-			{/if}
-		</div>
-
-		<div class="h-3/4 w-[1px] bg-disabled"></div>
-
-		<button class="flex h-full gap-1 px-3" disabled={!isSelectable} onclick={onClick}>
-			{#if token}
-				<TokenLogo data={token} logoSize="xs" />
-				<div class="ml-2 text-sm font-semibold">{getTokenDisplaySymbol(token)}</div>
-			{:else}
-				<span
-					style={`width: ${logoSizes['xs']}; height: ${logoSizes['xs']};`}
-					class="flex items-center justify-center rounded-full bg-brand-primary text-primary-inverted"
-				>
-					<IconPlus />
-				</span>
-			{/if}
-
-			{#if isSelectable}
-				<IconExpandMore />
-			{/if}
-		</button>
-	</TokenInputContainer>
-
-	<div class="mt-2 flex min-h-6 items-center justify-between text-sm">
-		{@render amountInfo()}
-
-		{@render balance()}
-	</div>
+		{showTokenNetwork}
+		{title}
+		{token}
+		bind:amount
+		bind:errorType
+		bind:error
+		bind:amountSetToMax
+		bind:focused
+	/>
 </div>
 
 {#if nonNullish(error)}

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	import { debounce, isNullish, nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
+	import IconExpandMore from '$lib/components/icons/IconExpandMore.svelte';
+	import IconPlus from '$lib/components/icons/lucide/IconPlus.svelte';
+	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
+	import TokenInputContainer from '$lib/components/tokens/TokenInputContainer.svelte';
+	import TokenInputCurrencyFiat from '$lib/components/tokens/TokenInputCurrencyFiat.svelte';
+	import TokenInputCurrencyToken from '$lib/components/tokens/TokenInputCurrencyToken.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import { logoSizes } from '$lib/constants/components.constants';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { DisplayUnit } from '$lib/types/swap';
+	import type { Token } from '$lib/types/token';
+	import type { TokenActionErrorType } from '$lib/types/token-action';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { tryParseToken } from '$lib/utils/parse.utils';
+	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+
+	interface Props {
+		token?: Token;
+		amount: OptionAmount;
+		name?: string;
+		displayUnit?: DisplayUnit;
+		exchangeRate?: number;
+		disabled?: boolean;
+		readOnly?: boolean;
+		placeholder?: string;
+		errorType?: TokenActionErrorType;
+		// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
+		error?: Error;
+		amountSetToMax?: boolean;
+		loading?: boolean;
+		isSelectable?: boolean;
+		autofocus?: boolean;
+		// Exposed so a host can react to the input focus (e.g. to style an outer card).
+		focused?: boolean;
+		onCustomValidate?: (userAmount: bigint) => TokenActionErrorType;
+		onCustomErrorValidate?: (userAmount: bigint) => Error | undefined;
+		showTokenNetwork?: boolean;
+		onClick?: () => void;
+		title?: Snippet;
+		amountInfo: Snippet;
+		balance: Snippet;
+	}
+
+	let {
+		token,
+		amount = $bindable(),
+		name = 'token-input',
+		displayUnit = 'token',
+		exchangeRate,
+		disabled = false,
+		readOnly = false,
+		placeholder = '0',
+		errorType = $bindable(),
+		error = $bindable(),
+		amountSetToMax = $bindable(false),
+		loading = false,
+		isSelectable = true,
+		autofocus = false,
+		focused = $bindable(false),
+		onCustomValidate = () => undefined,
+		onCustomErrorValidate = () => undefined,
+		showTokenNetwork = false,
+		onClick,
+		title,
+		amountInfo,
+		balance
+	}: Props = $props();
+
+	const onFocus = () => (focused = true);
+	const onBlur = () => (focused = false);
+
+	const onInput = () => {
+		amountSetToMax = false;
+	};
+
+	const validate = () => {
+		if (invalidAmount(amount) || isNullish(token)) {
+			errorType = undefined;
+			error = undefined;
+			return;
+		}
+
+		// `tryParseToken` returns `undefined` for an out-of-range amount (e.g. a
+		// user typing `1e400`) instead of throwing an unhandled error inside this
+		// debounced callback. Treat it as an invalid amount so the input shows its
+		// error state without running the custom validators on a missing value.
+		const parsedValue = tryParseToken({
+			value: `${amount}`,
+			unitName: token.decimals
+		});
+
+		if (isNullish(parsedValue)) {
+			errorType = 'invalid-amount';
+			error = new Error($i18n.send.assertion.amount_invalid);
+			return;
+		}
+
+		errorType = onCustomValidate(parsedValue);
+		error = onCustomErrorValidate(parsedValue);
+	};
+
+	const debounceValidate = debounce(validate, 300);
+
+	$effect(() => {
+		[amount, token];
+
+		debounceValidate();
+	});
+</script>
+
+<div class="space-between mb-2 flex justify-between text-sm font-bold">
+	{@render title?.()}
+	{#if showTokenNetwork && nonNullish(token)}
+		<div class="flex text-xs font-normal text-tertiary">
+			<span class="mr-1 text-sm">On {token.network.name}</span>
+			<NetworkLogo network={token.network} />
+		</div>
+	{/if}
+</div>
+
+<TokenInputContainer
+	error={nonNullish(errorType) || nonNullish(error)}
+	{focused}
+	{readOnly}
+	styleClass="h-14 text-3xl"
+>
+	<div
+		style={readOnly ? '--input-background: var(--color-background-disabled-alt);' : undefined}
+		class="flex h-full w-full items-center"
+		class:overflow-hidden={readOnly}
+		class:rounded-l-lg={readOnly}
+	>
+		{#if token}
+			{#if displayUnit === 'token'}
+				<TokenInputCurrencyToken
+					{name}
+					{autofocus}
+					decimals={token.decimals}
+					{disabled}
+					error={nonNullish(errorType)}
+					{loading}
+					{onBlur}
+					{onFocus}
+					{onInput}
+					{placeholder}
+					bind:value={amount}
+				/>
+			{:else if displayUnit === 'usd'}
+				<TokenInputCurrencyFiat
+					{name}
+					{autofocus}
+					{disabled}
+					error={nonNullish(errorType)}
+					{exchangeRate}
+					{loading}
+					{onBlur}
+					{onFocus}
+					{onInput}
+					{placeholder}
+					tokenDecimals={token.decimals}
+					bind:tokenAmount={amount}
+				/>
+			{/if}
+		{:else}
+			<button class="h-full w-full pl-3 text-base" onclick={onClick}
+				>{$i18n.tokens.text.select_token}</button
+			>
+		{/if}
+	</div>
+
+	<div class="h-3/4 w-[1px] bg-disabled"></div>
+
+	<button class="flex h-full gap-1 px-3" disabled={!isSelectable} onclick={onClick}>
+		{#if token}
+			<TokenLogo data={token} logoSize="xs" />
+			<div class="ml-2 text-sm font-semibold">{getTokenDisplaySymbol(token)}</div>
+		{:else}
+			<span
+				style={`width: ${logoSizes['xs']}; height: ${logoSizes['xs']};`}
+				class="flex items-center justify-center rounded-full bg-brand-primary text-primary-inverted"
+			>
+				<IconPlus />
+			</span>
+		{/if}
+
+		{#if isSelectable}
+			<IconExpandMore />
+		{/if}
+	</button>
+</TokenInputContainer>
+
+<div class="mt-2 flex min-h-6 items-center justify-between text-sm">
+	{@render amountInfo()}
+
+	{@render balance()}
+</div>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { IcToken } from '$icp/types/ic-token';
-	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
+	import TokenInputContent from '$lib/components/tokens/TokenInputContent.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
@@ -169,7 +169,7 @@
 <div class="rounded-lg border border-disabled bg-secondary px-3 py-1">
 	<!-- Base row: shared amount input + token selector -->
 	<div class="py-2">
-		<TokenInput
+		<TokenInputContent
 			displayUnit={inputUnit}
 			exchangeRate={baseExchangeRate}
 			isSelectable
@@ -218,7 +218,7 @@
 					{/if}
 				{/if}
 			{/snippet}
-		</TokenInput>
+		</TokenInputContent>
 		{#if nonNullish(amountError)}
 			<p class="mt-1 text-xs text-error-primary">{amountError}</p>
 		{/if}
@@ -233,7 +233,7 @@
 
 	<!-- Quote row: shared token selector with a read-only, non-editable derived amount -->
 	<div class="py-2">
-		<TokenInput
+		<TokenInputContent
 			amount={quoteAmountValue}
 			disabled={true}
 			displayUnit={inputUnit}
@@ -283,6 +283,6 @@
 					{/if}
 				{/if}
 			{/snippet}
-		</TokenInput>
+		</TokenInputContent>
 	</div>
 </div>


### PR DESCRIPTION
# Motivation

The limit-order trade pair box reuses the shared `TokenInput` from Swap for its "You buy" / "You pay at most" selectors. But `TokenInput` renders its own bordered card, and the trade pair box already wraps both legs in its own container — so each token selector ended up nested in a redundant inner card.

# Changes

- Extract the inner content of `TokenInput` (title, amount input strip, token selector, amount/balance footer + the validation logic) into a new `TokenInputContent` component.
- `TokenInput` now delegates to `TokenInputContent` inside its existing bordered card, so all current consumers render identically (pure refactor, no behaviour change for Swap/Send/Convert/etc.).
- `LimitOrderTradePairBox` uses `TokenInputContent` directly, dropping the redundant inner card so only its own container remains.

# Tests

- `npm run lint -- --max-warnings 0`, `npm run check` (no new errors), and the affected specs (`TokenInput.spec.ts`, `LimitOrderTradePairBox.svelte.spec.ts`) pass.
