### PR TITLE
style(frontend): flatten the note editor field

### DIFF
--- a/src/frontend/src/lib/components/notes/InputPersonalNote.svelte
+++ b/src/frontend/src/lib/components/notes/InputPersonalNote.svelte
@@ -61,10 +61,11 @@
 <div style="--input-font-size: var(--text-base)" class="flex w-full flex-1 flex-col gap-2">
 	<!-- A flat, bordered white field (same box style as the read-only note view) —
 		no tinted panel and no redundant "Note" label; the accessible name moves to
-		aria-label. -->
+		aria-label. The border brightens to brand-primary on focus (like the app's
+		text inputs) so the active field is distinguishable from its resting state. -->
 	<textarea
 		bind:this={textarea}
-		class="min-h-32 w-full flex-1 resize-none overflow-y-auto rounded-lg border border-brand-subtle-20 bg-primary p-4 text-base font-normal text-primary outline-none placeholder:text-tertiary md:flex-auto md:max-h-[calc(80dvh_-_28rem)]"
+		class="min-h-32 w-full flex-1 resize-none overflow-y-auto rounded-lg border border-brand-subtle-20 bg-primary p-4 text-base font-normal text-primary outline-none transition-colors placeholder:text-tertiary focus:border-brand-primary md:flex-auto md:max-h-[calc(80dvh_-_28rem)]"
 		aria-label={$i18n.notes.text.note_label}
 		data-tid={NOTES_INPUT}
 		{disabled}

--- a/src/frontend/src/lib/components/notes/InputPersonalNote.svelte
+++ b/src/frontend/src/lib/components/notes/InputPersonalNote.svelte
@@ -58,24 +58,23 @@
 	});
 </script>
 
-<div style="--input-font-size: var(--text-base)" class="flex w-full flex-1 flex-col">
-	<label
-		class="flex w-full flex-1 flex-col gap-2 rounded-lg bg-brand-subtle-10 p-4 text-sm md:p-6 md:text-base md:font-bold"
-	>
-		{$i18n.notes.text.note_label}
-		<textarea
-			bind:this={textarea}
-			class="min-h-32 w-full flex-1 resize-none overflow-y-auto rounded-md bg-primary p-3 text-base font-normal text-primary outline-none placeholder:text-tertiary md:flex-auto md:max-h-[calc(80dvh_-_28rem)]"
-			data-tid={NOTES_INPUT}
-			{disabled}
-			placeholder={$i18n.notes.text.placeholder}
-			bind:value></textarea>
-		{#if isTooLong}
-			<p class="text-error-primary" transition:slide={SLIDE_DURATION}>
-				{replacePlaceholders($i18n.notes.text.too_long, {
-					$maxCharacters: `${MAX_PERSONAL_NOTE_LENGTH}`
-				})}
-			</p>
-		{/if}
-	</label>
+<div style="--input-font-size: var(--text-base)" class="flex w-full flex-1 flex-col gap-2">
+	<!-- A flat, bordered white field (same box style as the read-only note view) —
+		no tinted panel and no redundant "Note" label; the accessible name moves to
+		aria-label. -->
+	<textarea
+		bind:this={textarea}
+		class="min-h-32 w-full flex-1 resize-none overflow-y-auto rounded-lg border border-brand-subtle-20 bg-primary p-4 text-base font-normal text-primary outline-none placeholder:text-tertiary md:flex-auto md:max-h-[calc(80dvh_-_28rem)]"
+		aria-label={$i18n.notes.text.note_label}
+		data-tid={NOTES_INPUT}
+		{disabled}
+		placeholder={$i18n.notes.text.placeholder}
+		bind:value></textarea>
+	{#if isTooLong}
+		<p class="text-error-primary" transition:slide={SLIDE_DURATION}>
+			{replacePlaceholders($i18n.notes.text.too_long, {
+				$maxCharacters: `${MAX_PERSONAL_NOTE_LENGTH}`
+			})}
+		</p>
+	{/if}
 </div>


### PR DESCRIPTION
# Motivation

The note editor wrapped the textarea in a blue tinted panel with a redundant "Note" label on top. It read heavier than the rest of the notes surface and didn't match the read-only note view.

# Changes

- Drop the `bg-brand-subtle-10` panel and the "Note" label from the editor.
- Turn the textarea into a flat white bordered field, reusing the read-only note view's box style (`rounded-lg border border-brand-subtle-20 p-4`), so viewing and editing a note now share one container style.
- Move the (now hidden) label's accessible name to `aria-label` on the textarea — no a11y regression.

# Tests

- `npm run check` (svelte-check): 0 errors / 0 warnings.
- prettier + eslint (`--max-warnings 0`): clean.
- `vitest` notes component suite: 41 tests pass.
