### PR TITLE
fix(frontend): treat empty amount string as invalid

### DIFF
--- a/src/frontend/src/lib/utils/input.utils.ts
+++ b/src/frontend/src/lib/utils/input.utils.ts
@@ -6,4 +6,4 @@ import type { Nullish } from '@dfinity/zod-schemas';
 export const isNullishOrEmpty = (value: OptionString): value is Nullish<''> => isEmptyString(value);
 
 export const invalidAmount = (amount: OptionAmount): boolean =>
-	isNullish(amount) || Number(amount) < 0;
+	isNullish(amount) || (typeof amount === 'string' && isEmptyString(amount)) || Number(amount) < 0;

--- a/src/frontend/src/tests/lib/utils/input.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/input.utils.spec.ts
@@ -6,12 +6,20 @@ describe('input.utils', () => {
 			expect(invalidAmount(undefined)).toBeTruthy();
 		});
 
+		it('returns true if amount is an empty string', () => {
+			expect(invalidAmount('')).toBeTruthy();
+		});
+
 		it('returns true if amount is less than zero', () => {
 			expect(invalidAmount(-1)).toBeTruthy();
 		});
 
 		it('returns false if amount is correct', () => {
 			expect(invalidAmount(1)).toBeFalsy();
+		});
+
+		it('returns false if amount is a numeric string', () => {
+			expect(invalidAmount('1')).toBeFalsy();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Selecting tokens in the limit-order form immediately flagged "Amount is invalid." before the user typed anything.

The field was empty, but `invalidAmount('')` returned `false`: the check only guarded against nullish and negative values, and `Number('') === 0` (not `< 0`). So `TokenInput.validate()` didn't skip an empty field — it ran `tryParseToken('')`, got null, and set the invalid-amount error the moment a token was selected. The limit-order box surfaces empty amounts as `''` (its amount is a `string`), unlike other forms that keep `undefined`, which is why it hit this path.

An empty input is "no amount", so it should be treated as invalid (i.e. nothing to validate / act on).

# Changes

- `invalidAmount` now also returns `true` for an empty string. This makes `TokenInput`'s existing `invalidAmount(amount)` guard skip validation on an empty field (no premature error on token select) and correctly hardens the button-enable / early-return callers that gate on it.
- Added unit tests for the empty-string and numeric-string cases.

# Tests

- `input.utils` unit tests pass (empty string → invalid, numeric string → valid).
- Consumer component tests pass: `TokenInput`, trading, stake, and liquidium suites (421 tests).
- `npm run check` clean on the change (the lone pre-existing `liquidium-active-tx.utils.ts` type error is unrelated and present on `main`).