### PR TITLE
feat(frontend): restore the OISY TRADE back arrow when opened from the Trading tab

### DIFF
--- a/src/frontend/src/lib/components/trading/OisyTradeProviderHero.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeProviderHero.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import type { NavigationTarget } from '@sveltejs/kit';
+	import { afterNavigate } from '$app/navigation';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import IconArrowDown from '$lib/components/icons/lucide/IconArrowDown.svelte';
+	import IconBackArrow from '$lib/components/icons/lucide/IconBackArrow.svelte';
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
 	import OisyTradeMark from '$lib/components/trading/OisyTradeMark.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import {
@@ -18,6 +23,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
+	import { back, isTradingPath } from '$lib/utils/nav.utils';
 
 	interface Props {
 		onDeposit: () => void;
@@ -25,6 +31,18 @@
 	}
 
 	let { onDeposit, onWithdraw }: Props = $props();
+
+	// Unlike the other provider heroes, this page is also a top-level destination
+	// reachable from the main navigation, where a back arrow would be redundant.
+	// Only show it when the user drilled in from the Assets → Trading tab, so
+	// popping history returns them to that tab.
+	let fromRoute = $state<NavigationTarget | null>(null);
+
+	afterNavigate(({ from }) => {
+		fromRoute = from;
+	});
+
+	const showBackButton = $derived(isTradingPath(fromRoute?.route.id ?? null));
 
 	const fiat = (value: number): string =>
 		formatCurrency({
@@ -51,6 +69,21 @@
 
 <StakeContentSection>
 	{#snippet title()}
+		{#if showBackButton}
+			<div class="absolute top-0 left-0">
+				<ButtonIcon
+					ariaLabel={$i18n.core.text.back}
+					colorStyle="tertiary"
+					link={false}
+					onclick={() => back({ pop: nonNullish(fromRoute) })}
+				>
+					{#snippet icon()}
+						<IconBackArrow />
+					{/snippet}
+				</ButtonIcon>
+			</div>
+		{/if}
+
 		<div class="flex w-full flex-col items-center text-center">
 			<OisyTradeMark />
 

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeProviderHero.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeProviderHero.svelte.spec.ts
@@ -1,19 +1,24 @@
 import OisyTradeProviderHero from '$lib/components/trading/OisyTradeProviderHero.svelte';
+import { ROUTE_ID_GROUP_APP } from '$lib/constants/routes.constants';
 import { setPrivacyMode } from '$lib/utils/privacy.utils';
 import en from '$tests/mocks/i18n.mock';
+import type { NavigationTarget } from '@sveltejs/kit';
 import { fireEvent, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
 
-const { assetsMock, depositableMock, freeMock, reservedMock, usdMock } = vi.hoisted(() => {
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
-	const { writable: createWritable } = require('svelte/store');
-	return {
-		assetsMock: createWritable([]),
-		depositableMock: createWritable(0),
-		freeMock: createWritable(0),
-		reservedMock: createWritable(0),
-		usdMock: createWritable(0)
-	};
-});
+const { afterNavigateMock, assetsMock, depositableMock, freeMock, reservedMock, usdMock } =
+	vi.hoisted(() => {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const { writable: createWritable } = require('svelte/store');
+		return {
+			afterNavigateMock: vi.fn(),
+			assetsMock: createWritable([]),
+			depositableMock: createWritable(0),
+			freeMock: createWritable(0),
+			reservedMock: createWritable(0),
+			usdMock: createWritable(0)
+		};
+	});
 
 // Isolate the hero from the data layer: drive the four fiat figures directly.
 vi.mock(import('$lib/derived/oisy-trade.derived'), async (importOriginal) => ({
@@ -36,12 +41,23 @@ vi.mock(import('$lib/derived/oisy-trade.derived'), async (importOriginal) => ({
 }));
 
 vi.mock('$app/navigation', () => ({
-	afterNavigate: vi.fn(),
+	afterNavigate: afterNavigateMock,
 	goto: vi.fn()
 }));
 
+// Simulate arriving from a given route by invoking the handler the component
+// registered with afterNavigate, mirroring SvelteKit's post-navigation call.
+const navigateFrom = async (routeId: string | null) => {
+	const from: NavigationTarget | null =
+		routeId === null ? null : ({ route: { id: routeId } } as NavigationTarget);
+	const handler = afterNavigateMock.mock.calls.at(-1)?.[0];
+	handler?.({ from });
+	await tick();
+};
+
 describe('OisyTradeProviderHero', () => {
 	beforeEach(() => {
+		afterNavigateMock.mockClear();
 		assetsMock.set([]);
 		depositableMock.set(0);
 		freeMock.set(0);
@@ -154,5 +170,45 @@ describe('OisyTradeProviderHero', () => {
 		await fireEvent.click(button);
 
 		expect(onWithdraw).toHaveBeenCalledOnce();
+	});
+
+	describe('back arrow', () => {
+		const tradingRouteId = `${ROUTE_ID_GROUP_APP}/trading`;
+
+		it('is hidden by default (page opened as a top-level destination)', () => {
+			const { queryByRole } = render(OisyTradeProviderHero);
+
+			expect(queryByRole('button', { name: en.core.text.back })).toBeNull();
+		});
+
+		it('stays hidden when arriving from a non-trading route', async () => {
+			const { queryByRole } = render(OisyTradeProviderHero);
+
+			await navigateFrom(`${ROUTE_ID_GROUP_APP}/tokens`);
+
+			expect(queryByRole('button', { name: en.core.text.back })).toBeNull();
+		});
+
+		it('appears when arriving from the Assets → Trading tab', async () => {
+			const { queryByRole } = render(OisyTradeProviderHero);
+
+			await navigateFrom(tradingRouteId);
+
+			expect(queryByRole('button', { name: en.core.text.back })).toBeInTheDocument();
+		});
+
+		it('pops history back to the Trading tab when clicked', async () => {
+			const historyBack = vi.spyOn(history, 'back').mockImplementation(() => {});
+
+			const { getByRole } = render(OisyTradeProviderHero);
+
+			await navigateFrom(tradingRouteId);
+
+			await fireEvent.click(getByRole('button', { name: en.core.text.back }));
+
+			expect(historyBack).toHaveBeenCalledOnce();
+
+			historyBack.mockRestore();
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

The OISY TRADE provider page is a top-level destination reachable from the main navigation, so PR #13431 removed its back arrow as redundant. But the page is also reached by clicking a position on the Assets → Trading tab, and from there users had no way back to that tab. The Earning tab already handles this: clicking a position opens the Liquidium provider page, which offers a back arrow to Assets/Earning.

# Changes

- Restore the back arrow in `OisyTradeProviderHero.svelte`, but render it conditionally: only when the referring route is the Trading tab (`isTradingPath`), captured via `afterNavigate`. This mirrors the existing `LiquidiumProviderHero` pattern, with the added guard so the arrow stays hidden when the page is opened from the top-level navigation.
- Clicking the arrow pops history back to the Trading tab.
- Add tests covering: hidden by default, hidden when arriving from a non-trading route, shown when arriving from the Trading tab, and pops history on click.

# Tests

- `npx prettier --check` — clean.
- `npm run lint -- --max-warnings 0` — clean.
- `npm run check:tests` — 0 errors, 0 warnings.
- `npx vitest run .../OisyTradeProviderHero.svelte.spec.ts` — 13/13 passing.

Not verified in a running browser: reaching the arrow live requires an authenticated session with funded DEX positions on the Trading tab. The markup reuses the proven `LiquidiumProviderHero` back-button block, and the conditional behavior is covered by the unit tests.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)