### PR TITLE
feat(frontend): autofocus the trading withdraw amount input on desktop

### DIFF
--- a/src/frontend/src/lib/components/trading/WithdrawForm.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawForm.svelte
@@ -19,6 +19,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
+	import { isDesktop } from '$lib/utils/device.utils';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
@@ -94,6 +95,7 @@
 <ContentWithToolbar>
 	<div class="mb-4">
 		<TokenInput
+			autofocus={isDesktop()}
 			displayUnit={inputUnit}
 			exchangeRate={$sendTokenExchangeRate}
 			isSelectable

--- a/src/frontend/src/tests/lib/components/trading/WithdrawForm.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawForm.svelte.spec.ts
@@ -1,8 +1,13 @@
 import WithdrawForm from '$lib/components/trading/WithdrawForm.svelte';
 import { ZERO } from '$lib/constants/app.constants';
 import { OISY_TRADE_PROVIDER_NAME } from '$lib/constants/oisy-trade.constants';
-import { MAX_BUTTON, TRADING_WITHDRAW_FORM_REVIEW_BUTTON } from '$lib/constants/test-ids.constants';
+import {
+	MAX_BUTTON,
+	TOKEN_INPUT_CURRENCY_TOKEN,
+	TRADING_WITHDRAW_FORM_REVIEW_BUTTON
+} from '$lib/constants/test-ids.constants';
 import { initSendContext, SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+import * as deviceUtils from '$lib/utils/device.utils';
 import { formatToken } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { getMaxTransactionAmount } from '$lib/utils/token.utils';
@@ -10,6 +15,7 @@ import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
+import type { MockInstance } from 'vitest';
 
 describe('WithdrawForm', () => {
 	const free = 500_000_000n;
@@ -150,5 +156,39 @@ describe('WithdrawForm', () => {
 		await fireEvent.click(getByTestId(TRADING_WITHDRAW_FORM_REVIEW_BUTTON));
 
 		expect(onNext).toHaveBeenCalledOnce();
+	});
+
+	describe('amount input autofocus', () => {
+		let isDesktopSpy: MockInstance<typeof deviceUtils.isDesktop>;
+
+		beforeEach(() => {
+			isDesktopSpy = vi.spyOn(deviceUtils, 'isDesktop');
+		});
+
+		afterEach(() => {
+			isDesktopSpy.mockRestore();
+		});
+
+		it('should auto-focus the amount input on desktop', () => {
+			isDesktopSpy.mockReturnValue(true);
+
+			const { getByTestId } = render(WithdrawForm, {
+				props: baseProps,
+				context: mockContext()
+			});
+
+			expect(getByTestId(TOKEN_INPUT_CURRENCY_TOKEN)).toHaveFocus();
+		});
+
+		it('should not auto-focus the amount input on mobile', () => {
+			isDesktopSpy.mockReturnValue(false);
+
+			const { getByTestId } = render(WithdrawForm, {
+				props: baseProps,
+				context: mockContext()
+			});
+
+			expect(getByTestId(TOKEN_INPUT_CURRENCY_TOKEN)).not.toHaveFocus();
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

The modals on the OISY Trade provider page should focus their keyboard input as soon as they are ready for it, the same way the send, stake and Liquidium forms already do (#13455). The Trade **withdraw** modal was missing this: the amount field was not focused, so the user had to click into it before typing.

Follow-up to the deposit-modal PR (#13456), done one-by-one so each can be verified on its own.

# Changes

- `WithdrawForm.svelte`: pass `autofocus={isDesktop()}` to `TokenInput`. The withdraw token comes from the send context and is always set, so the amount input is focused as soon as the form is shown. Gated on `isDesktop()` — matching the deposit modal and the just-merged Liquidium/stake convention — so mobile keyboards don't pop open over the form.

# Tests

Added two cases to `WithdrawForm.svelte.spec.ts` (spying on `isDesktop`, the repo's canonical pattern):

- desktop → amount input is focused
- mobile → amount input is not focused

The pair is mutation-resistant: flipping the condition fails one of them.

Quality gates run locally: `npm run test` (11/11 for this spec), `npm run check`, `npm run check:tests`, `eslint --max-warnings 0`, `prettier` — all green.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (`claude-opus-4-8`)
