### PR TITLE
feat(frontend): update Trading tab placeholder

### DIFF
--- a/src/frontend/src/lib/components/tokens/Assets.svelte
+++ b/src/frontend/src/lib/components/tokens/Assets.svelte
@@ -29,6 +29,7 @@
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { modalManageTokens, modalManageTokensData } from '$lib/derived/modal.derived';
 	import { routeCollection, routeNetwork, routeNft } from '$lib/derived/nav.derived';
+	import { oisyTradeHasAssets } from '$lib/derived/oisy-trade.derived';
 	import { PLAUSIBLE_EVENTS } from '$lib/enums/plausible';
 	import { TokenTypes } from '$lib/enums/token-types';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -172,7 +173,10 @@
 				</ManageTokensButton>
 			{:else if activeTab === TokenTypes.EARNING}
 				<GoToEarnButton />
-			{:else if activeTab === TokenTypes.TRADING}
+			{:else if activeTab === TokenTypes.TRADING && $oisyTradeHasAssets}
+				<!-- Empty Trading tab shows its own Go-to-Trade button inside the
+				     onboarding info box (see TradingList); only the populated list
+				     needs the button down here. -->
 				<GoToTradeButton />
 			{:else if activeTab === TokenTypes.BORROWINGS}
 				<GoToBorrowButton />

--- a/src/frontend/src/lib/components/trading/OisyTradeInfoBox.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeInfoBox.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
 	import IconClock from '$lib/components/icons/lucide/IconClock.svelte';
 	import IconCoins from '$lib/components/icons/lucide/IconCoins.svelte';
 	import IconNetworks from '$lib/components/icons/lucide/IconNetworks.svelte';
@@ -10,6 +12,15 @@
 	import { PLAUSIBLE_EVENT_SOURCE_LOCATIONS } from '$lib/enums/plausible';
 	import { buildLearnMoreEvent } from '$lib/services/analytics.services';
 	import { i18n } from '$lib/stores/i18n.store';
+
+	// Optional trailing content (e.g. a "Go to Trade" button) rendered as the last
+	// element inside the box — used by the Assets Trading tab onboarding placeholder.
+	// The Trade page doesn't pass it, so the box there is unchanged.
+	interface Props {
+		footer?: Snippet;
+	}
+
+	let { footer }: Props = $props();
 </script>
 
 <!-- Scroll target for the hero "Learn more" link (see OisyTradeProviderHero). -->
@@ -39,9 +50,14 @@
 		{/snippet}
 
 		{#snippet content()}
-			<p class="mt-4 text-sm text-secondary">{$i18n.trading.info.description}</p>
+			<!-- Flex `order` reorders the three items responsively: on mobile the
+			     footer button sits between the text and the fact boxes; on desktop
+			     it drops to the end (last element in the box). -->
+			<p class="order-1 mt-4 text-sm text-secondary">{$i18n.trading.info.description}</p>
 
-			<div class="mt-6 grid w-full grid-cols-1 gap-3 text-center text-sm md:grid-cols-3">
+			<div
+				class="order-3 mt-6 grid w-full grid-cols-1 gap-3 text-center text-sm md:order-2 md:grid-cols-3"
+			>
 				<FactBox>
 					{#snippet icon()}
 						<span class="rounded-full bg-brand-subtle-20 p-4 text-primary">
@@ -90,6 +106,12 @@
 					{/snippet}
 				</FactBox>
 			</div>
+
+			{#if nonNullish(footer)}
+				<div class="order-2 my-4 flex w-full justify-center md:order-3">
+					{@render footer()}
+				</div>
+			{/if}
 		{/snippet}
 	</StakeContentSection>
 </div>

--- a/src/frontend/src/lib/components/trading/TradingList.svelte
+++ b/src/frontend/src/lib/components/trading/TradingList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { OISY_TRADE_ENABLED } from '$env/oisy-trade';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
+	import GoToTradeButton from '$lib/components/trading/GoToTradeButton.svelte';
+	import OisyTradeInfoBox from '$lib/components/trading/OisyTradeInfoBox.svelte';
 	import TradingAssets from '$lib/components/trading/TradingAssets.svelte';
 	import TradingListSkeleton from '$lib/components/trading/TradingListSkeleton.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
@@ -26,7 +28,11 @@
 	{:else if $oisyTradeHasAssets}
 		<TradingAssets />
 	{:else}
-		<p class="py-10 text-center text-tertiary">{$i18n.trading.text.no_trades}</p>
+		<OisyTradeInfoBox>
+			{#snippet footer()}
+				<GoToTradeButton />
+			{/snippet}
+		</OisyTradeInfoBox>
 	{/if}
 {:else}
 	<EmptyState

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1684,7 +1684,6 @@
 			"intro": "Place and manage limit orders on-chain, directly from your wallet.",
 			"learn_more": "Learn more",
 			"provider_name": "OISY Trade",
-			"no_trades": "You don't have any deposits or active orders",
 			"go_to_trade": "Go to Trade"
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1684,7 +1684,6 @@
 			"intro": "",
 			"learn_more": "",
 			"provider_name": "",
-			"no_trades": "",
 			"go_to_trade": ""
 		},
 		"page": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1361,7 +1361,6 @@ interface I18nTrading {
 		intro: string;
 		learn_more: string;
 		provider_name: string;
-		no_trades: string;
 		go_to_trade: string;
 	};
 	page: {

--- a/src/frontend/src/tests/lib/components/trading/TradingList.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingList.svelte.spec.ts
@@ -81,8 +81,8 @@ describe('TradingList', () => {
 		setPrivacyMode({ enabled: false });
 	});
 
-	it('should render the empty placeholder when the user has no assets', () => {
-		// Loaded (balances non-null) but empty → the empty placeholder rather than the skeleton.
+	it('should render the onboarding info box with a go-to-trade button when the user has no assets', () => {
+		// Loaded (balances non-null) but empty → the onboarding info box rather than the skeleton.
 		oisyTradeStore.set({
 			pairs: undefined,
 			supportedTokens: undefined,
@@ -90,11 +90,11 @@ describe('TradingList', () => {
 			orders: undefined
 		});
 
-		const { getByText, queryByTestId } = render(TradingList);
+		const { getByText, getByTestId } = render(TradingList);
 
-		expect(getByText(en.trading.text.no_trades)).toBeInTheDocument();
-		// The go-to-trade button now lives in the Assets footer, not the list itself.
-		expect(queryByTestId(TRADING_GOTO_BUTTON)).toBeNull();
+		expect(getByText(en.trading.info.title)).toBeInTheDocument();
+		// The empty state now hosts the go-to-trade button inside the info box.
+		expect(getByTestId(TRADING_GOTO_BUTTON)).toBeInTheDocument();
 	});
 
 	it('renders only the assets section once the user has assets', () => {


### PR DESCRIPTION
# Motivation

We want to display a better placeholder in the Trading tab when user doesn't have any positions yet.

<img width="1622" height="896" alt="Screenshot 2026-07-08 at 14 50 46" src="https://github.com/user-attachments/assets/4ab7f508-7a91-4975-85c4-c130caad68a9" />
