### PR TITLE
chore(frontend): ignore .claude worktrees in git & eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .idea/
 **/*~
 
+# Claude Code local worktrees, settings and artifacts (nothing under .claude is shared)
+.claude/
+
 # ESLint and Prettier
 .eslintcache
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,6 @@ yarn.lock
 /target
 
 .dfx
+
+# Claude Code local worktrees & artifacts
+.claude

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,3 @@ yarn.lock
 /target
 
 .dfx
-
-# Claude Code local worktrees & artifacts
-.claude

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,6 +94,7 @@ export default [
 		ignores: [
 			'**/.DS_Store',
 			'**/node_modules',
+			'.claude',
 			'build',
 			'.dfx',
 			'.svelte-kit',


### PR DESCRIPTION
# Motivation

Claude Code creates local git worktrees and artifacts under `.claude/` (the repo root holds ~90 full worktree checkouts under `.claude/worktrees/`). Nothing under `.claude` is shared, but it wasn't excluded from our tooling:

- `.gitignore` didn't list `.claude`, so it showed up as untracked.
- ESLint flat config only skips `node_modules`/`.git` by default and does **not** read `.gitignore`, so `eslint .` traversed into `.claude/` — from the repo root that means crawling every nested worktree checkout.

Prettier needs no dedicated entry: it reads `.gitignore` by default (verified with Prettier 3.9), and the repo's glob doesn't descend into dot-directories anyway. So `.gitignore` + the ESLint ignore are the minimal, non-redundant set.

# Changes

- `.gitignore`: ignore `.claude/`.
- `eslint.config.mjs`: add `.claude` to the flat-config `ignores` list.

# Tests

Verified in an isolated repro:
- With only `.gitignore`, `eslint .` still lints files under `.claude/` (flat config ignores `.gitignore`) → the ESLint entry is required.
- Bare `.claude` (no trailing `/**`) correctly prunes the directory during `eslint .` traversal, matching the existing `build`/`.dfx` entries.
- Prettier honors `.gitignore` on its own → no `.prettierignore` entry needed.