### PR TITLE
chore(build): deploy oisy_trade locally and seed all local ck/native markets

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -57,6 +57,8 @@
 			"wasm": "target/oisy_trade.wasm.gz",
 			"shrink": false,
 			"specified_id": "sy2xe-miaaa-aaaar-qb7sq-cai",
+			"init_arg": "(variant { Init = record { mode = variant { GeneralAvailability }; max_orders_per_chunk = 100 : nat32; instruction_budget = 1_000_000_000 : nat64 } })",
+			"post_install": "scripts/seed.oisy_trade.sh",
 			"remote": {
 				"id": {
 					"ic": "sy2xe-miaaa-aaaar-qb7sq-cai",

--- a/scripts/deploy.oisy_trade.sh
+++ b/scripts/deploy.oisy_trade.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local-only setup for the OISY Trade DEX (`oisy_trade`).
+#
+# On mainnet/staging/test the canister is remote (see `remote.id` in dfx.json),
+# so it is neither installed nor seeded there — those environments point the
+# frontend at the already-running production canister. Locally no such canister
+# exists until we install the pinned release Wasm and give it a live market to
+# trade against, which is what this script does:
+#
+#   1. Install `oisy_trade` in GeneralAvailability mode so any local identity can
+#      place orders (order registration itself stays controller-gated, and the
+#      local deploy identity is the controller).
+#   2. Register the ICP/ckUSDC trading pair.
+#
+# Mainnet lists ICP/ckUSDT, but ckUSDT has no local ledger and no testnet twin to
+# wire it as a local wallet token; ckUSDC is the only stablecoin available as a
+# local wallet token, so it stands in for the quote leg. The pair parameters
+# mirror the production ICP/ckUSDT market (same 8/6 decimals and ~$1 price scale).
+#
+# max_orders_per_chunk / instruction_budget are conservative local-dev defaults —
+# production tuning lives in the external oisy-trade deploy, not this repo.
+
+dfx deploy oisy_trade --argument '(variant {
+  Init = record {
+    mode = variant { GeneralAvailability };
+    max_orders_per_chunk = 100 : nat32;
+    instruction_budget = 1_000_000_000 : nat64;
+  }
+})'
+
+ICP_LEDGER_ID="$(dfx canister id icp_ledger)"
+CKUSDC_LEDGER_ID="$(dfx canister id ckusdc_ledger)"
+
+# Idempotent: on a re-run this returns `Err TradingPairAlreadyExists`, which
+# `dfx canister call` still reports as a successful call, so the script does not
+# abort under `set -e`.
+dfx canister call oisy_trade add_trading_pair "(record {
+  base = record {
+    id = record { ledger_id = principal \"$ICP_LEDGER_ID\" };
+    metadata = record { symbol = \"ICP\"; decimals = 8 : nat8 };
+  };
+  quote = record {
+    id = record { ledger_id = principal \"$CKUSDC_LEDGER_ID\" };
+    metadata = record { symbol = \"ckUSDC\"; decimals = 6 : nat8 };
+  };
+  tick_size = 1_000 : nat;
+  lot_size = 1_000_000 : nat;
+  maker_fee_bps = 0 : nat16;
+  taker_fee_bps = 20 : nat16;
+  min_notional = 5_000_000 : nat;
+  max_notional = opt (9_000_000_000_000 : nat);
+})"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ dfx deploy ckusdc_index
 dfx deploy icp_swap_factory
 dfx deploy icp_swap_pool
 
-scripts/deploy.oisy_trade.sh
+dfx deploy oisy_trade
 
 dfx deploy internet_identity
 dfx deploy cycles_ledger

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,6 +21,8 @@ dfx deploy ckusdc_index
 dfx deploy icp_swap_factory
 dfx deploy icp_swap_pool
 
+scripts/deploy.oisy_trade.sh
+
 dfx deploy internet_identity
 dfx deploy cycles_ledger
 dfx deploy cycles_depositor

--- a/scripts/seed.oisy_trade.sh
+++ b/scripts/seed.oisy_trade.sh
@@ -4,38 +4,58 @@ set -euo pipefail
 # `post_install` hook for the `oisy_trade` canister (see dfx.json). dfx runs this
 # from the project root right after installing the canister, and only when it
 # actually installs it — i.e. locally, since `oisy_trade` is remote on every
-# other network. It seeds the ICP/ckUSDC trading pair so the Trade surface has a
-# live market to exercise end-to-end on a local replica. The install argument
-# (GeneralAvailability mode + chunk tuning) is set via the canister's `init_arg`
-# in dfx.json.
+# other network. It seeds a trading pair for every pairwise market among the four
+# ck/native tokens that exist locally (ICP, ckBTC, ckETH, ckUSDC), so the Trade
+# surface has live order books to exercise end-to-end on a local replica. The
+# install argument (GeneralAvailability mode + chunk tuning) is set via the
+# canister's `init_arg` in dfx.json.
 #
-# Mainnet lists ICP/ckUSDT, but ckUSDT has no local ledger and no testnet twin to
-# wire it as a local wallet token; ckUSDC is the only stablecoin available as a
-# local wallet token, so it stands in for the quote leg. The pair parameters
-# mirror the production ICP/ckUSDT market (same 8/6 decimals and ~$1 price scale).
+# ckUSDC stands in for the mainnet ckUSDT quote leg: ckUSDT has no local ledger
+# and no testnet twin to wire it as a local wallet token, whereas ckUSDC already
+# is one — so the local deposit picker (which matches DEX tokens to wallet tokens
+# by ledger id) can resolve it. The other three are the real local ledgers.
 #
+# Parameters are local-dev-only: they only need to be *valid*, not price-accurate.
 # `add_trading_pair` is controller-gated; the local deploy identity is the
-# canister controller, so this call is authorized.
+# canister controller, so these calls are authorized.
 
 ICP_LEDGER_ID="$(dfx canister id icp_ledger)"
 CKUSDC_LEDGER_ID="$(dfx canister id ckusdc_ledger)"
+CKBTC_LEDGER_ID="$(dfx canister id ckbtc_ledger)"
+CKETH_LEDGER_ID="$(dfx canister id cketh_ledger)"
 
-# Idempotent: on a re-run this returns `Err TradingPairAlreadyExists`, which
-# `dfx canister call` still reports as a successful call, so the script does not
-# abort under `set -e`.
-dfx canister call oisy_trade add_trading_pair "(record {
-  base = record {
-    id = record { ledger_id = principal \"$ICP_LEDGER_ID\" };
-    metadata = record { symbol = \"ICP\"; decimals = 8 : nat8 };
-  };
-  quote = record {
-    id = record { ledger_id = principal \"$CKUSDC_LEDGER_ID\" };
-    metadata = record { symbol = \"ckUSDC\"; decimals = 6 : nat8 };
-  };
-  tick_size = 1_000 : nat;
-  lot_size = 1_000_000 : nat;
-  maker_fee_bps = 0 : nat16;
-  taker_fee_bps = 20 : nat16;
-  min_notional = 5_000_000 : nat;
-  max_notional = opt (9_000_000_000_000 : nat);
-})"
+# add_pair BASE_LEDGER BASE_SYMBOL BASE_DECIMALS \
+#          QUOTE_LEDGER QUOTE_SYMBOL QUOTE_DECIMALS \
+#          TICK_SIZE LOT_SIZE MIN_NOTIONAL MAX_NOTIONAL
+#
+# TICK_SIZE * LOT_SIZE must be a multiple of 10^BASE_DECIMALS so every fill
+# settles to an exact integer quote amount. MAX_NOTIONAL is a raw candid fragment
+# (`null` or `opt (N : nat)`). Idempotent: a re-run returns
+# `Err TradingPairAlreadyExists`, which `dfx canister call` still reports as a
+# successful call, so `set -e` does not trip.
+add_pair() {
+  dfx canister call oisy_trade add_trading_pair "(record {
+    base = record {
+      id = record { ledger_id = principal \"$1\" };
+      metadata = record { symbol = \"$2\"; decimals = $3 : nat8 };
+    };
+    quote = record {
+      id = record { ledger_id = principal \"$4\" };
+      metadata = record { symbol = \"$5\"; decimals = $6 : nat8 };
+    };
+    tick_size = $7 : nat;
+    lot_size = $8 : nat;
+    maker_fee_bps = 0 : nat16;
+    taker_fee_bps = 20 : nat16;
+    min_notional = $9 : nat;
+    max_notional = ${10};
+  })"
+}
+
+# base                 sym   dec  quote                sym    dec  tick                  lot                   min_notional          max_notional
+add_pair "$ICP_LEDGER_ID"   ICP   8  "$CKUSDC_LEDGER_ID" ckUSDC 6  1_000                 1_000_000             5_000_000             "opt (9_000_000_000_000 : nat)"
+add_pair "$CKBTC_LEDGER_ID" ckBTC 8  "$CKUSDC_LEDGER_ID" ckUSDC 6  1_000                 1_000_000             5_000_000             "opt (9_000_000_000_000 : nat)"
+add_pair "$CKETH_LEDGER_ID" ckETH 18 "$CKUSDC_LEDGER_ID" ckUSDC 6  1_000                 1_000_000_000_000_000 5_000_000             "opt (9_000_000_000_000 : nat)"
+add_pair "$CKBTC_LEDGER_ID" ckBTC 8  "$CKETH_LEDGER_ID"  ckETH  18 1_000_000_000_000_000 1_000_000             1_000_000_000_000_000 "null"
+add_pair "$CKBTC_LEDGER_ID" ckBTC 8  "$ICP_LEDGER_ID"    ICP    8  1_000_000             1_000_000             100_000_000           "null"
+add_pair "$CKETH_LEDGER_ID" ckETH 18 "$ICP_LEDGER_ID"    ICP    8  1_000_000             1_000_000_000_000_000 100_000_000           "null"

--- a/scripts/seed.oisy_trade.sh
+++ b/scripts/seed.oisy_trade.sh
@@ -53,9 +53,9 @@ add_pair() {
 }
 
 # base                 sym   dec  quote                sym    dec  tick                  lot                   min_notional          max_notional
-add_pair "$ICP_LEDGER_ID"   ICP   8  "$CKUSDC_LEDGER_ID" ckUSDC 6  1_000                 1_000_000             5_000_000             "opt (9_000_000_000_000 : nat)"
-add_pair "$CKBTC_LEDGER_ID" ckBTC 8  "$CKUSDC_LEDGER_ID" ckUSDC 6  1_000                 1_000_000             5_000_000             "opt (9_000_000_000_000 : nat)"
-add_pair "$CKETH_LEDGER_ID" ckETH 18 "$CKUSDC_LEDGER_ID" ckUSDC 6  1_000                 1_000_000_000_000_000 5_000_000             "opt (9_000_000_000_000 : nat)"
-add_pair "$CKBTC_LEDGER_ID" ckBTC 8  "$CKETH_LEDGER_ID"  ckETH  18 1_000_000_000_000_000 1_000_000             1_000_000_000_000_000 "null"
-add_pair "$CKBTC_LEDGER_ID" ckBTC 8  "$ICP_LEDGER_ID"    ICP    8  1_000_000             1_000_000             100_000_000           "null"
-add_pair "$CKETH_LEDGER_ID" ckETH 18 "$ICP_LEDGER_ID"    ICP    8  1_000_000             1_000_000_000_000_000 100_000_000           "null"
+add_pair "$ICP_LEDGER_ID" ICP 8 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"
+add_pair "$CKBTC_LEDGER_ID" ckBTC 8 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"
+add_pair "$CKETH_LEDGER_ID" ckETH 18 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000_000_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"
+add_pair "$CKBTC_LEDGER_ID" ckBTC 8 "$CKETH_LEDGER_ID" ckETH 18 1_000_000_000_000_000 1_000_000 1_000_000_000_000_000 "null"
+add_pair "$CKBTC_LEDGER_ID" ckBTC 8 "$ICP_LEDGER_ID" ICP 8 1_000_000 1_000_000 100_000_000 "null"
+add_pair "$CKETH_LEDGER_ID" ckETH 18 "$ICP_LEDGER_ID" ICP 8 1_000_000 1_000_000_000_000_000 100_000_000 "null"

--- a/scripts/seed.oisy_trade.sh
+++ b/scripts/seed.oisy_trade.sh
@@ -1,34 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Local-only setup for the OISY Trade DEX (`oisy_trade`).
-#
-# On mainnet/staging/test the canister is remote (see `remote.id` in dfx.json),
-# so it is neither installed nor seeded there — those environments point the
-# frontend at the already-running production canister. Locally no such canister
-# exists until we install the pinned release Wasm and give it a live market to
-# trade against, which is what this script does:
-#
-#   1. Install `oisy_trade` in GeneralAvailability mode so any local identity can
-#      place orders (order registration itself stays controller-gated, and the
-#      local deploy identity is the controller).
-#   2. Register the ICP/ckUSDC trading pair.
+# `post_install` hook for the `oisy_trade` canister (see dfx.json). dfx runs this
+# from the project root right after installing the canister, and only when it
+# actually installs it — i.e. locally, since `oisy_trade` is remote on every
+# other network. It seeds the ICP/ckUSDC trading pair so the Trade surface has a
+# live market to exercise end-to-end on a local replica. The install argument
+# (GeneralAvailability mode + chunk tuning) is set via the canister's `init_arg`
+# in dfx.json.
 #
 # Mainnet lists ICP/ckUSDT, but ckUSDT has no local ledger and no testnet twin to
 # wire it as a local wallet token; ckUSDC is the only stablecoin available as a
 # local wallet token, so it stands in for the quote leg. The pair parameters
 # mirror the production ICP/ckUSDT market (same 8/6 decimals and ~$1 price scale).
 #
-# max_orders_per_chunk / instruction_budget are conservative local-dev defaults —
-# production tuning lives in the external oisy-trade deploy, not this repo.
-
-dfx deploy oisy_trade --argument '(variant {
-  Init = record {
-    mode = variant { GeneralAvailability };
-    max_orders_per_chunk = 100 : nat32;
-    instruction_budget = 1_000_000_000 : nat64;
-  }
-})'
+# `add_trading_pair` is controller-gated; the local deploy identity is the
+# canister controller, so this call is authorized.
 
 ICP_LEDGER_ID="$(dfx canister id icp_ledger)"
 CKUSDC_LEDGER_ID="$(dfx canister id ckusdc_ledger)"

--- a/scripts/seed.oisy_trade.sh
+++ b/scripts/seed.oisy_trade.sh
@@ -52,7 +52,6 @@ add_pair() {
   })"
 }
 
-# base sym dec  quote sym dec  tick lot min_notional max_notional
 add_pair "$ICP_LEDGER_ID" ICP 8 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"
 add_pair "$CKBTC_LEDGER_ID" ckBTC 8 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"
 add_pair "$CKETH_LEDGER_ID" ckETH 18 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000_000_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"

--- a/scripts/seed.oisy_trade.sh
+++ b/scripts/seed.oisy_trade.sh
@@ -52,7 +52,7 @@ add_pair() {
   })"
 }
 
-# base                 sym   dec  quote                sym    dec  tick                  lot                   min_notional          max_notional
+# base sym dec  quote sym dec  tick lot min_notional max_notional
 add_pair "$ICP_LEDGER_ID" ICP 8 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"
 add_pair "$CKBTC_LEDGER_ID" ckBTC 8 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"
 add_pair "$CKETH_LEDGER_ID" ckETH 18 "$CKUSDC_LEDGER_ID" ckUSDC 6 1_000 1_000_000_000_000_000 5_000_000 "opt (9_000_000_000_000 : nat)"


### PR DESCRIPTION
# Motivation

Local `dfx` deploys never installed the `oisy_trade` DEX (it is remote on all other networks), so the Trade surface had no live markets to exercise end-to-end on a local replica.

# Changes

- `dfx.json`: give `oisy_trade` an `init_arg` (install in `GeneralAvailability` mode with conservative chunk tuning) and a `post_install` hook that seeds the trading pairs. Both fire **only locally** — `oisy_trade` is remote on every other network, so dfx never installs it there.
- `scripts/seed.oisy_trade.sh`: the `post_install` hook. Table-driven `add_pair` helper that registers **every pairwise market among the four tokens with a local ledger + wallet wiring** — ICP, ckBTC, ckETH, ckUSDC (6 pairs): ICP/ckUSDC, ckBTC/ckUSDC, ckETH/ckUSDC, ckBTC/ckETH, ckBTC/ICP, ckETH/ICP. Idempotent (re-runs return `TradingPairAlreadyExists`, still a successful call).
- `scripts/deploy.sh`: adds the uniform `dfx deploy oisy_trade` line after the ICP Swap canisters.
- **Why ckUSDC, not ckUSDT:** mainnet quotes in ckUSDT, but ckUSDT has no local ledger and no testnet twin to wire it as a local wallet token; ckUSDC already is one, and the deposit picker matches DEX tokens to wallet tokens by ledger id. All four seeded tokens are local wallet tokens, so every pair is depositable/tradeable locally.
- Params are local-dev-only — valid, not price-accurate. For each pair `tick_size × lot_size` is a multiple of `10^base_decimals` so fills settle to exact integer quote amounts. The local `oisy_trade` id auto-flows to `VITE_LOCAL_OISY_TRADE_CANISTER_ID` once in `.dfx/local/canister_ids.json`.

# Tests

- `shellcheck scripts/seed.oisy_trade.sh` passes.
- Divisibility rule (`tick × lot ≡ 0 mod 10^base_decimals`) verified for all 6 pairs.
- The `init_arg` and representative `add_trading_pair` requests typecheck against `oisy_trade.did` via `didc encode`.
- dfx accepts the `dfx.json` config (deserializes cleanly).
- Local-dev-only tooling; no production runtime behavior changes.