### PR TITLE
style(frontend): refresh the shared note outro screen

### DIFF
--- a/src/frontend/src/lib/components/notes/SharedNoteOutro.svelte
+++ b/src/frontend/src/lib/components/notes/SharedNoteOutro.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import IconCircleCheck from '$lib/components/icons/lucide/IconCircleCheck.svelte';
+	import IconNotebook from '$lib/components/icons/lucide/IconNotebook.svelte';
 	import { OISY_URL } from '$lib/constants/oisy.constants';
 	import {
 		NOTES_SHARE_RECIPIENT_DISCOVER_BUTTON,
@@ -16,11 +17,14 @@
 	]);
 </script>
 
-<div class="flex flex-1 flex-col gap-5 py-4 text-center" data-tid={NOTES_SHARE_RECIPIENT_OUTRO}>
-	<span class="text-sm font-bold text-brand-primary"
-		>{replaceOisyPlaceholders($i18n.notes.share.recipient.outro_eyebrow)}</span
-	>
-	<h1 class="text-2xl font-bold text-primary">{$i18n.notes.share.recipient.outro_title}</h1>
+<div
+	class="flex flex-1 flex-col items-center gap-5 py-4 text-center"
+	data-tid={NOTES_SHARE_RECIPIENT_OUTRO}
+>
+	<div class="text-brand-primary"><IconNotebook size="48" /></div>
+	<h1 class="text-2xl font-bold text-primary">
+		{replaceOisyPlaceholders($i18n.notes.share.recipient.outro_title)}
+	</h1>
 	<p class="text-tertiary">{replaceOisyPlaceholders($i18n.notes.share.recipient.outro_subtitle)}</p>
 
 	<ul class="flex flex-col gap-2 text-secondary">
@@ -35,7 +39,7 @@
 	<!-- Same-tab navigation: the outro is the end of the flow with no other action,
 	     so there is nothing to return to — opening a new tab would only litter. -->
 	<a
-		class="as-button primary inline-flex w-full items-center justify-center gap-2 rounded-xl px-3 py-2 no-underline"
+		class="as-button primary mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl px-3 py-2 no-underline"
 		data-tid={NOTES_SHARE_RECIPIENT_DISCOVER_BUTTON}
 		href={OISY_URL}
 		onclick={() =>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2695,11 +2695,10 @@
 				"single_use_caveat": "Single-use link — once you close or reload this page, the note is gone for good. Copy it now if you need it.",
 				"copy_note": "Copy note",
 				"note_copied": "Note copied!",
-				"outro_eyebrow": "You just opened a note kept private by $oisy_short",
-				"outro_title": "It keeps your assets just as safe",
+				"outro_title": "$oisy_short kept this note private, and keeps your assets just as safe",
 				"outro_subtitle": "$oisy_short is a fully onchain, self-custody wallet for Bitcoin, Ethereum, Solana, ICP and more.",
 				"outro_feature_multichain": "Bitcoin, Ethereum, Solana & ICP in one place",
-				"outro_feature_onchain": "100% onchain — no extension, no seed phrase",
+				"outro_feature_onchain": "100% onchain, no extension, no seed phrase",
 				"outro_feature_encrypted": "Your keys and your data, encrypted end-to-end",
 				"discover": "Discover OISY",
 				"unavailable_title": "This link has expired or already been used"

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2695,7 +2695,6 @@
 				"single_use_caveat": "",
 				"copy_note": "",
 				"note_copied": "",
-				"outro_eyebrow": "",
 				"outro_title": "",
 				"outro_subtitle": "",
 				"outro_feature_multichain": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -2220,7 +2220,6 @@ interface I18nNotes {
 			single_use_caveat: string;
 			copy_note: string;
 			note_copied: string;
-			outro_eyebrow: string;
 			outro_title: string;
 			outro_subtitle: string;
 			outro_feature_multichain: string;


### PR DESCRIPTION
# Motivation

The shared-note recipient outro screen led with two stacked lines — a small
eyebrow ("You just opened a note kept private by OISY") above the headline
("It keeps your assets just as safe") — with no visual anchor and the Discover
CTA sitting flush against the feature list.

# Changes

- Merge the eyebrow and title into a single headline: "OISY kept this note
  private, and keeps your assets just as safe".
- Replace the eyebrow line with the Notes menu icon (`IconNotebook`, size 48,
  brand-primary) centered above the headline, matching the icon-above-title
  pattern already used on the locked screen.
- Add top margin to the "Discover OISY" button so it separates from the
  feature bullets.
- Drop the em-dash from the onchain feature copy ("100% onchain, no extension,
  no seed phrase").
- Remove the now-unused `outro_eyebrow` i18n key and regenerate locale files +
  `i18n.d.ts` via `npm run i18n`.

# Tests

- `npm run check` (svelte-check): 0 errors.
- `npx eslint` on the changed component: clean.
- `npx prettier --check` on changed files: clean.
- `SharedNoteRecipientPage.spec.ts`: 4/4 passing.