### PR TITLE
style(frontend): tidy the notes list rows and modal padding

### DIFF
--- a/src/frontend/src/lib/components/notes/NoteListItem.svelte
+++ b/src/frontend/src/lib/components/notes/NoteListItem.svelte
@@ -70,14 +70,17 @@
 			<span style="overflow-wrap: anywhere;" class="truncate font-bold text-primary">
 				{parts.title}
 			</span>
-			{#if parts.body !== ''}
-				<span style="overflow-wrap: anywhere;" class="truncate text-tertiary">
-					{parts.body}
-				</span>
-			{/if}
-			<span class="text-xs text-tertiary">{timestamp}</span>
+			<!-- Apple-Notes style meta line: the timestamp leads and the body preview
+				follows on the same line, so every row keeps the same two-line height
+				whether or not the note has body text. -->
+			<span class="flex min-w-0 items-baseline gap-1.5 text-xs">
+				<span class="shrink-0 text-secondary">{timestamp}</span>
+				{#if parts.body !== ''}
+					<span class="min-w-0 flex-1 truncate text-tertiary">{parts.body}</span>
+				{/if}
+			</span>
 		</span>
-		<span class="shrink-0 text-tertiary">
+		<span class="shrink-0 text-disabled">
 			<IconChevronRight />
 		</span>
 	</button>

--- a/src/frontend/src/lib/components/notes/NotesModal.svelte
+++ b/src/frontend/src/lib/components/notes/NotesModal.svelte
@@ -362,7 +362,7 @@
 			short viewports (the list state scrolls inside its own region below, so
 			this stays a no-op there). -->
 		<ContentWithToolbar
-			styleClass="mx-2 flex min-h-0 flex-col items-stretch gap-6 overflow-y-auto pb-0!"
+			styleClass="flex min-h-0 flex-col items-stretch gap-6 overflow-y-auto pb-0!"
 		>
 			{#if showSkeleton}
 				<SkeletonCards rows={3} />


### PR DESCRIPTION
# Motivation

In the Notes list, a note with body text rendered three stacked lines (title, body, timestamp) while a note without body text rendered two — so rows had inconsistent heights and the list lost its vertical rhythm. On top of that, the list step was inset more than the other Notes screens, and the row chevron sat heavier than it needed to.

# Changes

- **Consistent row height** — the body preview now sits on the same line as the timestamp (Apple-Notes style), so every row keeps the same two-line height whether or not it has body text. The timestamp leads (`text-secondary`) and the preview follows (`text-tertiary`), truncating when it runs out of room.
- **Modal padding** — removed the extra `mx-2` on the list step so its horizontal padding matches the note view/editor screens and every other modal (they all already get the standard `--dialog-padding-x`).
- **Lighter chevron** — the trailing chevron uses `text-disabled` (the design system's lightest neutral) so it reads as a quiet affordance in both light and dark themes.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0`, and `npm run check` all pass.
- `NoteListItem.spec.ts` passes (6/6); the existing assertions are layout-agnostic (`toHaveTextContent`), so they still hold after the row restructure.
