### PR TITLE
style(frontend): tidy the note share link-ready screen

### DIFF
--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -191,25 +191,26 @@
 			</ExternalLink>
 		</MessageBox>
 	{:else}
-		<!-- State B — link ready -->
-		<div class="flex flex-col gap-1">
+		<!-- State B — link ready. A bold label with a grey subtitle per section
+			(gap-2), the two sections separated by the container's gap-4. -->
+		<div class="flex flex-col gap-2">
 			<span class="font-bold text-primary">{$i18n.notes.share.text.link_ready_title}</span>
-			<span class="text-sm text-tertiary">{$i18n.notes.share.text.link_ready_subtitle}</span>
+			<span class="text-tertiary">{$i18n.notes.share.text.link_ready_subtitle}</span>
+
+			<div class="flex items-center gap-2 rounded-lg border border-brand-subtle-20 py-2 pr-1 pl-3">
+				<span class="min-w-0 flex-1 truncate text-secondary">{createdLink}</span>
+				<Copy
+					testId={NOTES_SHARE_LINK_COPY}
+					text={$i18n.notes.share.text.link_copied}
+					value={createdLink}
+				/>
+			</div>
 		</div>
 
-		<div class="flex items-center gap-2 rounded-lg border border-brand-subtle-20 py-1 pr-1 pl-3">
-			<span class="min-w-0 flex-1 truncate font-mono text-xs text-secondary">{createdLink}</span>
-			<Copy
-				testId={NOTES_SHARE_LINK_COPY}
-				text={$i18n.notes.share.text.link_copied}
-				value={createdLink}
-			/>
+		<div class="flex flex-col gap-2">
+			<span class="font-bold text-primary">{recap}</span>
+			<span class="text-tertiary">{replaceOisyPlaceholders($i18n.notes.share.text.reminder)}</span>
 		</div>
-
-		<span class="text-sm text-primary">{recap}</span>
-		<span class="text-xs text-tertiary"
-			>{replaceOisyPlaceholders($i18n.notes.share.text.reminder)}</span
-		>
 	{/if}
 
 	{#snippet toolbar()}


### PR DESCRIPTION
# Motivation

The "Share link ready" screen (State B of the note share flow) drifted from the styling used elsewhere in Notes: the header/subtitle spacing was tighter than the section rhythm, the expiry recap rendered as plain body text rather than a labelled section, and the share URL was shown in small monospace, which was hard to read.

# Changes

- Give each section a **bold label + grey subtitle** at `gap-2`, matching the rest of the Notes screens.
- Group the link box under its subtitle so it hugs the header instead of floating a full section-gap away.
- Render the expiry **recap as a bold label** above the reminder, mirroring the "Share link ready" heading.
- Show the share URL in a **larger, normal-weight font** instead of small monospace.

Scoped to State B only — State A (configure) and the container spacing are untouched.

# Tests

Local quality gates pass on the changed file:

- `npm run format` / `prettier --check` ✓
- `npm run lint` (`eslint --max-warnings 0`) ✓
- `npm run check` (`svelte-check`) — 0 errors, 0 warnings ✓

Visual: verified the "Share link ready" screen renders with the tightened header→link spacing, bold recap label, and larger link text.