### PR TITLE
style(frontend): facelift the note view screen

### DIFF
--- a/src/frontend/src/lib/components/notes/NoteText.svelte
+++ b/src/frontend/src/lib/components/notes/NoteText.svelte
@@ -3,9 +3,12 @@
 
 	interface Props {
 		note: string;
+		// 'lg' gives the full-screen note view a larger title and body; 'base'
+		// (default) keeps the compact size used elsewhere (e.g. the shared-note page).
+		size?: 'base' | 'lg';
 	}
 
-	let { note }: Props = $props();
+	let { note, size = 'base' }: Props = $props();
 
 	// First non-empty line is the bold title (matching the list); the rest is the body
 	// with line breaks preserved. URLs in both become safe links (Decision 16): the
@@ -14,14 +17,18 @@
 	const lines = $derived(neutralized.split('\n'));
 	const firstNonEmptyIndex = $derived(lines.findIndex((line) => line.trim() !== ''));
 	const titleText = $derived(firstNonEmptyIndex === -1 ? '' : lines[firstNonEmptyIndex].trim());
+	// Body starts at the next non-empty line, so blank lines typed between the title
+	// and the body don't open a gap; blank lines within the body are still preserved.
+	const bodyLines = $derived(firstNonEmptyIndex === -1 ? [] : lines.slice(firstNonEmptyIndex + 1));
+	const bodyStartIndex = $derived(bodyLines.findIndex((line) => line.trim() !== ''));
 	const bodyText = $derived(
-		firstNonEmptyIndex === -1 ? '' : lines.slice(firstNonEmptyIndex + 1).join('\n')
+		bodyStartIndex === -1 ? '' : bodyLines.slice(bodyStartIndex).join('\n')
 	);
 	const titleSegments = $derived(linkifyPersonalNote(titleText));
 	const bodySegments = $derived(bodyText === '' ? [] : linkifyPersonalNote(bodyText));
 </script>
 
-<p style="overflow-wrap: anywhere;" class="font-bold text-primary">
+<p style="overflow-wrap: anywhere;" class="font-bold text-primary" class:text-xl={size === 'lg'}>
 	{#each titleSegments as segment, index (index)}{#if segment.href}<a
 				class="text-brand-primary underline"
 				href={segment.href}
@@ -30,7 +37,11 @@
 			>{:else}{segment.text}{/if}{/each}
 </p>
 {#if bodySegments.length > 0}
-	<p style="overflow-wrap: anywhere;" class="whitespace-pre-wrap text-primary">
+	<p
+		style="overflow-wrap: anywhere;"
+		class="whitespace-pre-wrap text-primary"
+		class:text-lg={size === 'lg'}
+	>
 		{#each bodySegments as segment, index (index)}{#if segment.href}<a
 					class="text-brand-primary underline"
 					href={segment.href}

--- a/src/frontend/src/lib/components/notes/NoteView.svelte
+++ b/src/frontend/src/lib/components/notes/NoteView.svelte
@@ -138,7 +138,7 @@
 					ariaLabel={$i18n.notes.text.delete_note}
 					colorStyle="error"
 					onclick={() => onDelete(note.id)}
-					styleClass="!flex-none"
+					styleClass="flex-none!"
 					testId={NOTES_VIEW_DELETE_BUTTON}
 					transparent
 				>

--- a/src/frontend/src/lib/components/notes/NoteView.svelte
+++ b/src/frontend/src/lib/components/notes/NoteView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import IconClock from '$lib/components/icons/lucide/IconClock.svelte';
 	import IconPencil from '$lib/components/icons/lucide/IconPencil.svelte';
 	import IconShareArrow from '$lib/components/icons/lucide/IconShareArrow.svelte';
 	import IconTrash from '$lib/components/icons/lucide/IconTrash.svelte';
@@ -46,27 +47,55 @@
 			$updated: formatPersonalNoteTimestamp({ ns: note.updated_at_ns, language: $currentLanguage })
 		});
 	});
+
+	let scrollEl = $state<HTMLDivElement | undefined>();
+	// True while the note overflows and there is more text below the fold — drives a
+	// bottom divider that signals the content scrolls.
+	let hasMoreBelow = $state(false);
+
+	const updateScrollHint = () => {
+		const el = scrollEl;
+		if (isNullish(el)) {
+			return;
+		}
+		hasMoreBelow = el.scrollTop + el.clientHeight < el.scrollHeight - 1;
+	};
+
+	$effect(() => {
+		const el = scrollEl;
+		if (isNullish(el)) {
+			return;
+		}
+		note.note; // recompute when the note content changes
+		updateScrollHint();
+		const observer = new ResizeObserver(updateScrollHint);
+		observer.observe(el);
+		return () => observer.disconnect();
+	});
 </script>
 
 <ContentWithToolbar
 	styleClass="flex min-h-0 flex-col items-stretch gap-4 overflow-y-auto"
 	testId={NOTES_VIEW}
 >
-	<!-- Long notes scroll inside the box; the metadata and actions stay pinned below. -->
-	<div
-		class="flex min-h-32 flex-1 flex-col gap-2 overflow-y-auto rounded-lg border border-brand-subtle-20 p-4"
-	>
-		<NoteText note={note.note} />
-	</div>
-
-	<!-- Desktop: "Share note" is a quiet blue text link right-aligned opposite the
-	     created/updated line. Mobile: it drops to its own left-aligned line beneath.
-	     Lower-emphasis than Edit by design. -->
-	<div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-		<span class="text-xs text-tertiary">{metaLine}</span>
+	<!-- Metadata + Share on one row at every breakpoint: the created/updated line on
+	     the left, the quiet "Share note" link right-aligned opposite it (lower-emphasis
+	     than Edit by design). The metadata may shrink/wrap on narrow screens; the link
+	     stays intact on the right. -->
+	<div class="flex items-center justify-between gap-2">
+		<span class="flex min-w-0 items-center gap-1.5 text-xs text-tertiary">
+			<IconClock size="14" />
+			{metaLine}
+		</span>
 		{#if nonNullish(onShare)}
-			<div>
-				<Button link onclick={onShare} testId={NOTES_VIEW_SHARE_BUTTON} type="button">
+			<div class="shrink-0">
+				<Button
+					innerStyleClass="items-center"
+					link
+					onclick={onShare}
+					testId={NOTES_VIEW_SHARE_BUTTON}
+					type="button"
+				>
 					<IconShareArrow size="16" />
 					{$i18n.notes.share.text.share_note}
 				</Button>
@@ -74,32 +103,48 @@
 		{/if}
 	</div>
 
-	{#if nonNullish(onEdit)}
-		<!-- Wrap so the button's own flex-1 can't stretch it vertically in this column. -->
-		<div>
-			<Button
-				colorStyle="secondary-light"
-				fullWidth
-				onclick={onEdit}
-				testId={NOTES_VIEW_EDIT_BUTTON}
-			>
-				<IconPencil size="20" />
-				{$i18n.notes.text.edit_note}
-			</Button>
-		</div>
-	{/if}
+	<!-- The note scrolls in place (no box); a bottom divider appears while there is
+		more text below the fold, keeping the actions pinned beneath it. -->
+	<div
+		bind:this={scrollEl}
+		class="flex min-h-32 flex-1 flex-col gap-2 overflow-y-auto border-brand-subtle-20"
+		class:border-b={hasMoreBelow}
+		onscroll={updateScrollHint}
+	>
+		<NoteText note={note.note} size="lg" />
+	</div>
 
-	{#if nonNullish(onDelete)}
-		<div class="flex justify-center">
-			<Button
-				colorStyle="error"
-				onclick={() => onDelete(note.id)}
-				testId={NOTES_VIEW_DELETE_BUTTON}
-				transparent
-			>
-				<IconTrash />
-				{$i18n.notes.text.delete_note}
-			</Button>
+	{#if nonNullish(onEdit) || nonNullish(onDelete)}
+		<!-- Edit and delete share one row to save vertical space: Edit fills the row and
+			delete is a compact, icon-only button (labelled for a11y) beside it. -->
+		<div class="flex items-center gap-2">
+			{#if nonNullish(onEdit)}
+				<!-- flex-1 wrapper so the full-width Edit button fills the row beside delete. -->
+				<div class="flex-1">
+					<Button
+						colorStyle="secondary-light"
+						fullWidth
+						onclick={onEdit}
+						testId={NOTES_VIEW_EDIT_BUTTON}
+					>
+						<IconPencil size="20" />
+						{$i18n.notes.text.edit_note}
+					</Button>
+				</div>
+			{/if}
+
+			{#if nonNullish(onDelete)}
+				<Button
+					ariaLabel={$i18n.notes.text.delete_note}
+					colorStyle="error"
+					onclick={() => onDelete(note.id)}
+					styleClass="flex-none!"
+					testId={NOTES_VIEW_DELETE_BUTTON}
+					transparent
+				>
+					<IconTrash />
+				</Button>
+			{/if}
 		</div>
 	{/if}
 

--- a/src/frontend/src/lib/components/notes/NoteView.svelte
+++ b/src/frontend/src/lib/components/notes/NoteView.svelte
@@ -138,7 +138,7 @@
 					ariaLabel={$i18n.notes.text.delete_note}
 					colorStyle="error"
 					onclick={() => onDelete(note.id)}
-					styleClass="flex-none!"
+					styleClass="!flex-none"
 					testId={NOTES_VIEW_DELETE_BUTTON}
 					transparent
 				>


### PR DESCRIPTION
# Motivation

The read-only note preview read like a form — a bordered text box, base-size type, metadata and actions stacked below — and long notes gave no hint they scrolled. This reworks it to read like a document.

# Changes

- **No box:** the note scrolls in place instead of inside a bordered container; a subtle bottom divider appears only while there is more text below the fold (tracked via scroll position + `ResizeObserver`).
- **Larger type:** title `text-xl`, body `text-lg`, via a new `size` prop on `NoteText` (defaults to the compact size, so the shared-note recipient page is unchanged).
- **Tighter title/body:** blank lines typed between the title and body no longer open a gap; blank lines *within* the body are preserved.
- **Metadata + Share on top:** the created/updated line (now with a clock icon) and the "Share note" link move above the note and share one row at every breakpoint. Also fixed the share icon's vertical alignment (`innerStyleClass="items-center"`).
- **Edit + Delete on one row:** Edit fills the row; Delete is a compact icon-only button (labelled via `aria-label`) — saves a full button row of height.

# Tests

- `npm run check` (svelte-check): 0 errors / 0 warnings.
- prettier + eslint (`--max-warnings 0`): clean.
- `vitest` `NoteView` + `NoteText` suites: 11 tests pass.

---

_Independent PR off `main` — touches only `NoteView` + `NoteText`, which no other notes PR changes._
