### PR TITLE
fix(frontend): validate sell balance before a price is set

### DIFF
--- a/src/frontend/src/lib/utils/oisy-trade.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade.utils.ts
@@ -366,8 +366,10 @@ export const validateAmount = ({
 		return { ok: false };
 	}
 
+	// A sell spends the base amount outright, so its balance can be checked before a
+	// price is set; a buy's spend is the quote cost, which is only known once priced.
 	const spend = spendAmount({ side, baseAmount, price });
-	if (price > 0 && spend > freeBalance + 1e-9) {
+	if ((side === 'sell' || price > 0) && spend > freeBalance + 1e-9) {
 		return { ok: false, errorKind: 'balance' };
 	}
 

--- a/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
@@ -380,6 +380,19 @@ describe('oisy-trade.utils — limit order', () => {
 			).toBeTruthy();
 		});
 
+		it('flags a sell balance shortfall even without a price', () => {
+			// A sell spends the base amount outright, so the balance is checkable before pricing.
+			expect(
+				validateAmount({ side: 'sell', baseAmount: 10, price: NaN, freeBalance: 5, pair }).errorKind
+			).toBe('balance');
+		});
+
+		it('does not flag a buy balance without a price (spend unknown)', () => {
+			expect(
+				validateAmount({ side: 'buy', baseAmount: 10, price: NaN, freeBalance: 0, pair }).errorKind
+			).toBeUndefined();
+		});
+
 		it('surfaces balance before the lot check', () => {
 			// 10.3 exceeds free 5 AND is not a 0.25 multiple → balance wins.
 			expect(


### PR DESCRIPTION
# Motivation

In the limit-order form, entering a sell amount above your balance (e.g. 233 ICP with a 9 ICP max) showed no error until a price was typed. A sell spends the base token outright, so its balance can — and should — be validated as soon as the amount is entered, independent of the price.

The balance check in `validateAmount` was gated on `price > 0`, which is only necessary for a buy (whose spend is the quote cost, unknown until priced).

# Changes

- In `validateAmount`, run the balance check whenever `side === 'sell' || price > 0`. Sell balance is now flagged before a price is set; buy balance still waits for a price (its spend can't be computed otherwise).
- The Review-enable gate (`isOrderValid`) is unchanged and still independently requires a price, so this only affects the inline balance error, not order submission.

# Tests

- Added `validateAmount` cases: a sell shortfall flags `balance` with `price: NaN`; a buy with no price does not flag balance.
- `oisy-trade.utils` suite passes (78); `eslint` / `prettier` clean.