### PR TITLE
style(frontend): hide read-only token dropdown until a token is set

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -166,7 +166,7 @@
 		{:else if readOnlyAmount}
 			<div class="w-full pl-3 font-bold text-disabled">—</div>
 		{:else}
-			<button class="h-full w-full pl-3 text-base" onclick={onClick}
+			<button class="h-full w-full pl-3 text-base" onclick={onClick} type="button"
 				>{$i18n.tokens.text.select_token}</button
 			>
 		{/if}
@@ -176,34 +176,37 @@
 		<div class="h-3/4 w-[1px] bg-disabled"></div>
 	{/if}
 
-	<button
-		class="flex h-full items-center gap-1 px-3 transition-colors"
-		class:bg-primary={readOnlyAmount}
-		class:border={readOnlyAmount}
-		class:border-solid={readOnlyAmount}
-		class:border-tertiary={readOnlyAmount}
-		class:hover:border-brand-primary={readOnlyAmount && isSelectable}
-		class:rounded-lg={readOnlyAmount}
-		class:shadow-inner={readOnlyAmount}
-		disabled={!isSelectable}
-		onclick={onClick}
-	>
-		{#if token}
-			<TokenLogo data={token} logoSize="xs" />
-			<div class="ml-2 text-sm font-semibold">{getTokenDisplaySymbol(token)}</div>
-		{:else}
-			<span
-				style={`width: ${logoSizes['xs']}; height: ${logoSizes['xs']};`}
-				class="flex items-center justify-center rounded-full bg-brand-primary text-primary-inverted"
-			>
-				<IconPlus />
-			</span>
-		{/if}
+	{#if !readOnlyAmount || isSelectable}
+		<button
+			class="flex h-full items-center gap-1 px-3 transition-colors"
+			class:bg-primary={readOnlyAmount}
+			class:border={readOnlyAmount}
+			class:border-solid={readOnlyAmount}
+			class:border-tertiary={readOnlyAmount}
+			class:hover:border-brand-primary={readOnlyAmount && isSelectable}
+			class:rounded-lg={readOnlyAmount}
+			class:shadow-inner={readOnlyAmount}
+			disabled={!isSelectable}
+			onclick={onClick}
+			type="button"
+		>
+			{#if token}
+				<TokenLogo data={token} logoSize="xs" />
+				<div class="ml-2 text-sm font-semibold">{getTokenDisplaySymbol(token)}</div>
+			{:else}
+				<span
+					style={`width: ${logoSizes['xs']}; height: ${logoSizes['xs']};`}
+					class="flex items-center justify-center rounded-full bg-brand-primary text-primary-inverted"
+				>
+					<IconPlus />
+				</span>
+			{/if}
 
-		{#if isSelectable}
-			<IconExpandMore />
-		{/if}
-	</button>
+			{#if isSelectable}
+				<IconExpandMore />
+			{/if}
+		</button>
+	{/if}
 </TokenInputContainer>
 
 <div class="mt-2 flex min-h-6 items-center justify-between text-sm">

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '$lib/utils/oisy-trade.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
-import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 
 describe('LimitOrderTradePairBox', () => {
@@ -186,11 +185,12 @@ describe('LimitOrderTradePairBox', () => {
 		expect(onSelectQuote).toHaveBeenCalledOnce();
 	});
 
-	it('does not invoke onSelectQuote until a base token is picked', async () => {
+	it('does not render the quote selector until a base token is picked', () => {
 		const onSelectQuote = vi.fn();
 
 		// No base yet: the quote list is filtered by the base's markets, so the
-		// quote selector must stay inert until a base is chosen.
+		// quote leg shows only the dash placeholder and its selector is not
+		// rendered until a base is chosen — there is nothing to open the picker.
 		const { getAllByRole } = render(LimitOrderTradePairBox, {
 			props: {
 				...baseProps,
@@ -202,12 +202,10 @@ describe('LimitOrderTradePairBox', () => {
 			}
 		});
 
-		// Without a base the quote selector is the sole disabled button; clicking
-		// it must not open the quote picker.
-		const quoteSelect = getAllByRole('button').find((button) => button.hasAttribute('disabled'));
-		assertNonNullish(quoteSelect);
-		await fireEvent.click(quoteSelect);
+		// The quote selector was the sole disabled button; without a base it is gone.
+		const disabledSelect = getAllByRole('button').find((button) => button.hasAttribute('disabled'));
 
+		expect(disabledSelect).toBeUndefined();
 		expect(onSelectQuote).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
# Motivation

On the read-only leg ("You get at least"), before a token is derived the field shows a `—` placeholder but still rendered a boxed dropdown next to it. In this "dash mode" there is nothing to pick, so the dropdown is noise.

# Changes

- In `TokenInputContent.svelte`, gate the token-selector dropdown button behind `!readOnlyAmount || nonNullish(token)`, so the read-only leg shows only the `—` until a token is set. Editable legs (which always render the dropdown) and the read-only leg with a token are unchanged.

# Tests

`npm run check` clean.
