### PR TITLE
style(frontend): revert three-sided read-only token dropdown (#13479)

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -179,16 +179,11 @@
 	<button
 		class="flex h-full items-center gap-1 px-3 transition-colors"
 		class:bg-primary={readOnlyAmount}
-		class:border-r={readOnlyAmount}
-		class:border-r-solid={readOnlyAmount}
-		class:border-r-tertiary={readOnlyAmount}
-		class:border-y={readOnlyAmount}
-		class:border-y-solid={readOnlyAmount}
-		class:border-y-tertiary={readOnlyAmount}
-		class:hover:border-r-brand-primary={readOnlyAmount && isSelectable}
-		class:hover:border-y-brand-primary={readOnlyAmount && isSelectable}
-		class:rounded-e-lg={readOnlyAmount}
-		class:rounded-none={readOnlyAmount}
+		class:border={readOnlyAmount}
+		class:border-solid={readOnlyAmount}
+		class:border-tertiary={readOnlyAmount}
+		class:hover:border-brand-primary={readOnlyAmount && isSelectable}
+		class:rounded-lg={readOnlyAmount}
 		class:shadow-inner={readOnlyAmount}
 		disabled={!isSelectable}
 		onclick={onClick}


### PR DESCRIPTION
# Motivation

Reverts #13479 ("box the read-only token dropdown on three sides only"). The three-sided border treatment on the read-only leg's dropdown is being rolled back.

# Changes

- Revert the `TokenInputContent.svelte` change from #13479: the read-only dropdown returns to a full `border` + `rounded-lg` (dropping `border-r`/`border-y`/`rounded-e-lg`). No other behavior affected.

# Tests

`npm run check` clean.
