### PR TITLE
fix(frontend): confirm a copied share link inline instead of via a toast

### DIFF
--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -230,7 +230,7 @@
 					</span>
 				{/if}
 				<ButtonIcon
-					ariaLabel={copied ? $i18n.notes.share.text.link_copied : $i18n.core.text.copy}
+					ariaLabel={`${$i18n.core.text.copy}: ${createdLink}`}
 					onclick={onCopyLink}
 					testId={NOTES_SHARE_LINK_COPY}
 				>

--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -225,7 +225,7 @@
 			<div class="flex items-center gap-2 rounded-lg border border-brand-subtle-20 py-2 pr-1 pl-3">
 				<span class="min-w-0 flex-1 truncate text-secondary">{createdLink}</span>
 				{#if copied}
-					<span class="shrink-0 text-xs text-success-primary">
+					<span class="shrink-0 text-xs text-success-primary" aria-live="polite" role="status">
 						{$i18n.notes.share.text.link_copied}
 					</span>
 				{/if}

--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import type { Identity } from '@icp-sdk/core/agent';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
+	import IconCopy from '$lib/components/icons/IconCopy.svelte';
+	import IconCircleCheck from '$lib/components/icons/lucide/IconCircleCheck.svelte';
 	import IconShieldCheck from '$lib/components/icons/lucide/IconShieldCheck.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import ButtonIcon from '$lib/components/ui/ButtonIcon.svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Copy from '$lib/components/ui/Copy.svelte';
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import PillButton from '$lib/components/ui/PillButton.svelte';
@@ -29,6 +31,7 @@
 	import { replaceIcErrorFields } from '$lib/utils/error.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { personalNotePreviewParts } from '$lib/utils/personal-note.utils';
+	import { copyText } from '$lib/utils/share.utils';
 
 	interface Props {
 		note: PersonalNoteUi;
@@ -53,6 +56,22 @@
 	let busy = $state(false);
 	let createdLink = $state<string | undefined>();
 	let atCap = $state(false);
+	let copied = $state(false);
+	let copiedTimeout: ReturnType<typeof setTimeout> | undefined;
+
+	// Confirm the copy inline on the control itself: a floating toast would be
+	// hidden behind the mobile share bottom sheet.
+	const onCopyLink = async () => {
+		if (createdLink === undefined) {
+			return;
+		}
+		await copyText(createdLink);
+		copied = true;
+		clearTimeout(copiedTimeout);
+		copiedTimeout = setTimeout(() => (copied = false), 2000);
+	};
+
+	onDestroy(() => clearTimeout(copiedTimeout));
 
 	// The count query gates the UI; the backend `TooManyShares` rejection stays
 	// authoritative. A failed count is non-fatal — leave the action enabled and
@@ -205,11 +224,24 @@
 
 			<div class="flex items-center gap-2 rounded-lg border border-brand-subtle-20 py-2 pr-1 pl-3">
 				<span class="min-w-0 flex-1 truncate text-secondary">{createdLink}</span>
-				<Copy
+				{#if copied}
+					<span class="shrink-0 text-xs text-success-primary">
+						{$i18n.notes.share.text.link_copied}
+					</span>
+				{/if}
+				<ButtonIcon
+					ariaLabel={copied ? $i18n.notes.share.text.link_copied : $i18n.core.text.copy}
+					onclick={onCopyLink}
 					testId={NOTES_SHARE_LINK_COPY}
-					text={$i18n.notes.share.text.link_copied}
-					value={createdLink}
-				/>
+				>
+					{#snippet icon()}
+						{#if copied}
+							<span class="text-success-primary"><IconCircleCheck /></span>
+						{:else}
+							<IconCopy />
+						{/if}
+					{/snippet}
+				</ButtonIcon>
 			</div>
 		</div>
 

--- a/src/frontend/src/tests/lib/components/notes/ShareNoteContent.spec.ts
+++ b/src/frontend/src/tests/lib/components/notes/ShareNoteContent.spec.ts
@@ -4,12 +4,14 @@ import { OISY_NOTES_DOCS_URL } from '$lib/constants/oisy.constants';
 import {
 	NOTES_SHARE_CAP_MESSAGE,
 	NOTES_SHARE_CREATE_BUTTON,
-	NOTES_SHARE_DONE_BUTTON
+	NOTES_SHARE_DONE_BUTTON,
+	NOTES_SHARE_LINK_COPY
 } from '$lib/constants/test-ids.constants';
 import { PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
 import * as shareServices from '$lib/services/personal-note-share.services';
 import { trackPersonalNoteShare } from '$lib/services/personal-notes-analytics.services';
 import type { PersonalNoteUi } from '$lib/types/personal-note';
+import * as shareUtils from '$lib/utils/share.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
@@ -78,6 +80,29 @@ describe('ShareNoteContent', () => {
 			singleUse: false,
 			expiry: '24h'
 		});
+	});
+
+	it('confirms a copied link inline, without a toast (visible over the bottom sheet)', async () => {
+		vi.spyOn(shareServices, 'getActiveShareCount').mockResolvedValue(0);
+		vi.spyOn(shareServices, 'createNoteShare').mockResolvedValue({
+			link: 'https://oisy.com/notes/share/tok#k=KEY',
+			token: 'tok'
+		});
+		const copySpy = vi.spyOn(shareUtils, 'copyText').mockResolvedValue();
+
+		const { getByTestId, container } = render(ShareNoteContent, { props: baseProps() });
+
+		await fireEvent.click(getByTestId(NOTES_SHARE_CREATE_BUTTON));
+		await waitFor(() => expect(getByTestId(NOTES_SHARE_LINK_COPY)).toBeInTheDocument());
+
+		// The confirmation is not shown before copying.
+		expect(container).not.toHaveTextContent(en.notes.share.text.link_copied);
+
+		await fireEvent.click(getByTestId(NOTES_SHARE_LINK_COPY));
+
+		expect(copySpy).toHaveBeenCalledExactlyOnceWith('https://oisy.com/notes/share/tok#k=KEY');
+
+		await waitFor(() => expect(container).toHaveTextContent(en.notes.share.text.link_copied));
 	});
 
 	it('tracks a create failure without leaking the note text', async () => {


### PR DESCRIPTION
# Motivation

Copying a personal-note **share link** in the creator dialog fires a floating "Link copied!" toast. On **mobile** that toast is anchored to the bottom of the viewport and is hidden behind the share **bottom sheet**, so the user gets no confirmation.

# Changes

- `ShareNoteContent.svelte` (link-ready state only): the copy control now copies via `copyText` (raw clipboard, **no toast**) and flips to a **check icon + "Link copied!"** inline for ~2s, then reverts. The floating toast is no longer used for this action.
- Accessibility (from Copilot review): the inline confirmation is a `role="status" aria-live="polite"` live region so it's announced, and the copy button's `aria-label` stays action-oriented (`"Copy: <link>"`) rather than becoming the status.

# Tests

- `npm run format` / `npm run lint` / `npm run check` / `npm run check:tests` pass.
- `ShareNoteContent.spec.ts`: new case asserts clicking copy calls `copyText` with the link and shows the inline "Link copied!" confirmation (and that it isn't shown beforehand). Existing cases green (6/6).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.8 (claude-opus-4-8)

