### PR TITLE
DO NOT MERGE - fix(frontend): let a toast opt into rendering above overlays

### DIFF
--- a/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
+++ b/src/frontend/src/lib/components/notes/ShareNoteContent.svelte
@@ -206,6 +206,7 @@
 			<div class="flex items-center gap-2 rounded-lg border border-brand-subtle-20 py-2 pr-1 pl-3">
 				<span class="min-w-0 flex-1 truncate text-secondary">{createdLink}</span>
 				<Copy
+					overlay
 					testId={NOTES_SHARE_LINK_COPY}
 					text={$i18n.notes.share.text.link_copied}
 					value={createdLink}

--- a/src/frontend/src/lib/components/ui/Copy.svelte
+++ b/src/frontend/src/lib/components/ui/Copy.svelte
@@ -14,14 +14,17 @@
 		link?: boolean;
 		transparent?: boolean;
 		inline?: boolean;
+		// Render the confirmation toast above overlays (e.g. copying from within a
+		// bottom sheet). See ToastMsg `overlay`.
+		overlay?: boolean;
 	}
 
-	const { text, value, testId, inline = false, ...rest }: Props = $props();
+	const { text, value, testId, inline = false, overlay = false, ...rest }: Props = $props();
 
 	const handleClick = async (e: MouseEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
-		await copyToClipboard({ value, text });
+		await copyToClipboard({ value, text, overlay });
 	};
 </script>
 

--- a/src/frontend/src/lib/components/ui/Toasts.svelte
+++ b/src/frontend/src/lib/components/ui/Toasts.svelte
@@ -19,6 +19,9 @@
 	let hasErrors = $derived(
 		toasts.find(({ level }) => ['error', 'warn'].includes(level)) !== undefined
 	);
+
+	// A toast can opt into rendering above overlays (see ToastMsg `overlay`).
+	let hasOverlay = $derived(toasts.some(({ overlay }) => overlay === true));
 </script>
 
 {#if toasts.length > 0}
@@ -26,6 +29,7 @@
 		class={`wrapper ${position}`}
 		class:elevated
 		class:error={hasErrors}
+		class:overlay={hasOverlay}
 		data-tid="toasts-component"
 	>
 		{#each toasts as msg (msg.id)}
@@ -67,6 +71,13 @@
 		// sheet is still never covered by a background notification.
 		&.elevated {
 			z-index: var(--toast-error-z-index);
+		}
+
+		// Opt-in override for a toast raised explicitly above overlays (e.g. a copy
+		// confirmation shown from within a bottom sheet). Declared after `.error` /
+		// `.elevated` so it wins. Workaround pending inline confirmation feedback.
+		&.overlay {
+			z-index: var(--toast-overlay-z-index);
 		}
 
 		// Below the medium breakpoint the mobile bottom navigation is shown, fixed

--- a/src/frontend/src/lib/styles/global/gix.scss
+++ b/src/frontend/src/lib/styles/global/gix.scss
@@ -35,6 +35,11 @@
 	// Error/warn toasts sit above modal blur and bottom sheets so in-flow
 	// failures (e.g. duplicate token import) remain visible.
 	--toast-error-z-index: calc(var(--overlay-z-index) + 4);
+	// Opt-in override for a toast raised explicitly above overlays — a confirmation
+	// shown from within a bottom sheet, whose `BottomSheetConfirmationPopup` wrapper
+	// is a Tailwind `z-50`. This clears that so the confirmation (e.g. copying a
+	// share link) is visible. Temporary workaround pending inline confirmation feedback.
+	--toast-overlay-z-index: 60;
 
 	--overlay-box-shadow: 0 4px 16px 0 #0000001f;
 

--- a/src/frontend/src/lib/types/toast.ts
+++ b/src/frontend/src/lib/types/toast.ts
@@ -17,6 +17,11 @@ export interface ToastMsgUI {
 	icon?: Component;
 	theme?: ToastTheme;
 	renderAsHtml?: boolean;
+	// Temporarily render this toast above overlays (modals / bottom sheets) — for a
+	// confirmation triggered from within a bottom sheet, where the default toast
+	// tiers sit behind it (e.g. copying a share link). Workaround until such
+	// confirmations have inline feedback.
+	overlay?: boolean;
 }
 
 // The shape callers pass to `toastsShow` / `toastsError` — the store assigns the `id`.

--- a/src/frontend/src/lib/utils/clipboard.utils.ts
+++ b/src/frontend/src/lib/utils/clipboard.utils.ts
@@ -1,12 +1,23 @@
 import { toastsShow } from '$lib/stores/toasts.store';
 import { copyText } from '$lib/utils/share.utils';
 
-export const copyToClipboard = async ({ value, text }: { value: string; text: string }) => {
+export const copyToClipboard = async ({
+	value,
+	text,
+	overlay = false
+}: {
+	value: string;
+	text: string;
+	// Render the confirmation toast above overlays (e.g. when copying from within a
+	// bottom sheet). See ToastMsg `overlay`.
+	overlay?: boolean;
+}) => {
 	await copyText(value);
 
 	toastsShow({
 		text,
 		level: 'success',
-		duration: 2000
+		duration: 2000,
+		...(overlay && { overlay: true })
 	});
 };

--- a/src/frontend/src/tests/lib/components/ui/Toasts.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/Toasts.spec.ts
@@ -47,6 +47,22 @@ describe('Toasts', () => {
 		expect(container.querySelector('.wrapper')?.classList).toContain('elevated');
 	});
 
+	it('applies the overlay class when a toast opts into it, not otherwise', () => {
+		toastsStore.show({ level: 'success', text: 'copied', overlay: true });
+
+		const { container } = render(ToastsTest);
+
+		expect(container.querySelector('.wrapper')?.classList).toContain('overlay');
+	});
+
+	it('does not apply the overlay class by default', () => {
+		toastsStore.show({ level: 'success', text: 'copied' });
+
+		const { container } = render(ToastsTest);
+
+		expect(container.querySelector('.wrapper')?.classList).not.toContain('overlay');
+	});
+
 	it('renders a toast per level with its icon', () => {
 		(['success', 'warn', 'error', 'info'] as const).forEach((level) =>
 			toastsStore.show({ level, text: level })

--- a/src/frontend/src/tests/lib/utils/clipboard.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/clipboard.utils.spec.ts
@@ -49,5 +49,16 @@ describe('clipboard.utils', () => {
 				duration: 2000
 			});
 		});
+
+		it('should raise the toast above overlays when overlay is set', async () => {
+			await copyToClipboard({ value, text, overlay: true });
+
+			expect(spyToastsShow).toHaveBeenCalledWith({
+				text,
+				level: 'success',
+				duration: 2000,
+				overlay: true
+			});
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

Copying a personal-note **share link** on mobile shows a "Link copied!" confirmation toast that's hidden behind the share **bottom sheet**: `BottomSheetConfirmationPopup` wraps itself in Tailwind `z-50`, which sits above every toast z-index tier, so the confirmation is never seen.

This is the **per-toast override** approach suggested in review: let a toast opt into rendering above overlays for this specific case, rather than changing global z-index rules. Explicitly a **workaround** until copy confirmations get inline feedback.

# Changes

- `types/toast.ts`: optional `overlay?: boolean` on a toast message.
- `Toasts.svelte`: when a visible toast sets `overlay`, the wrapper takes a new `--toast-overlay-z-index` (declared after `.error` / `.elevated` so it wins).
- `gix.scss`: `--toast-overlay-z-index` set above the `z-50` confirmation-popup wrapper.
- `clipboard.utils.ts` + `Copy.svelte`: thread an optional `overlay` flag through (`Copy` → `copyToClipboard` → `toastsShow`); default off, so all existing toasts are unchanged.
- `ShareNoteContent.svelte`: the share-link copy opts in (`<Copy overlay … />`).

# Tests

- `npm run format` / `npm run lint` / `npm run check` / `npm run check:tests` pass.
- `clipboard.utils.spec`: `copyToClipboard({ overlay: true })` forwards `overlay: true` to the toast (default calls unchanged).
- `Toasts.spec`: the wrapper gets the `overlay` class only when a toast opts in.

# Relationship to #13491 and #13492

Three independent takes on the same bug — pick one:

- **#13491** — systemic: put confirmation popups on the gix z-index scale so any toast shows above them.
- **#13492** — local: inline "Link copied!" confirmation on the control (no toast).
- **this PR** — per-toast `overlay` override: keep the toast, let it opt above overlays. Deliberate workaround; smallest behavioural change to the toast system, but carries a magic z-index above the off-scale `z-50`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.8 (claude-opus-4-8)
