### PR TITLE
chore(build): allow bots to adjust signer-versions.json

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -3,6 +3,7 @@
 
 package.json
 package-lock.json
+signer-versions.json
 Cargo.toml
 Cargo.lock
 rust-toolchain.toml


### PR DESCRIPTION
Adds `signer-versions.json` to `.github/repo_policies/BOT_APPROVED_FILES` so automated bot PRs (e.g. the legacy-signer version bump workflow) can update it, alongside `package.json` and `package-lock.json`.