### PR TITLE
feat(frontend): show the OISY Trade logo next to the provider name in the deposit flow

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/src/frontend/src/lib/components/trading/TradingDepositForm.svelte
+++ b/src/frontend/src/lib/components/trading/TradingDepositForm.svelte
@@ -150,7 +150,7 @@
 		<ModalValue>
 			{#snippet label()}{$i18n.trading.deposit.to}{/snippet}
 			{#snippet mainValue()}
-				<span class="flex items-center gap-2">
+				<span class="inline-flex items-center gap-2">
 					<span class="flex" aria-hidden="true">
 						<OisyTradeMark size="22" />
 					</span>

--- a/src/frontend/src/lib/components/trading/TradingDepositForm.svelte
+++ b/src/frontend/src/lib/components/trading/TradingDepositForm.svelte
@@ -5,6 +5,7 @@
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
+	import OisyTradeMark from '$lib/components/trading/OisyTradeMark.svelte';
 	import TradingDepositInfoBox from '$lib/components/trading/TradingDepositInfoBox.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
@@ -148,7 +149,12 @@
 	<div class="mb-4">
 		<ModalValue>
 			{#snippet label()}{$i18n.trading.deposit.to}{/snippet}
-			{#snippet mainValue()}{$i18n.trading.text.provider_name}{/snippet}
+			{#snippet mainValue()}
+				<span class="flex items-center gap-2">
+					<OisyTradeMark size="22" />
+					{$i18n.trading.text.provider_name}
+				</span>
+			{/snippet}
 		</ModalValue>
 	</div>
 

--- a/src/frontend/src/lib/components/trading/TradingDepositForm.svelte
+++ b/src/frontend/src/lib/components/trading/TradingDepositForm.svelte
@@ -151,7 +151,9 @@
 			{#snippet label()}{$i18n.trading.deposit.to}{/snippet}
 			{#snippet mainValue()}
 				<span class="flex items-center gap-2">
-					<OisyTradeMark size="22" />
+					<span class="flex" aria-hidden="true">
+						<OisyTradeMark size="22" />
+					</span>
 					{$i18n.trading.text.provider_name}
 				</span>
 			{/snippet}

--- a/src/frontend/src/lib/components/trading/TradingDepositReview.svelte
+++ b/src/frontend/src/lib/components/trading/TradingDepositReview.svelte
@@ -5,6 +5,7 @@
 	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
 	import SwapFee from '$lib/components/swap/SwapFee.svelte';
 	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
+	import OisyTradeMark from '$lib/components/trading/OisyTradeMark.svelte';
 	import TradingDepositInfoBox from '$lib/components/trading/TradingDepositInfoBox.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
@@ -77,7 +78,12 @@
 
 		<ModalValue>
 			{#snippet label()}{$i18n.trading.deposit.to}{/snippet}
-			{#snippet mainValue()}{$i18n.trading.text.provider_name}{/snippet}
+			{#snippet mainValue()}
+				<span class="flex items-center gap-2">
+					<OisyTradeMark size="22" />
+					{$i18n.trading.text.provider_name}
+				</span>
+			{/snippet}
 		</ModalValue>
 
 		{#if nonNullish(ledgerFee)}

--- a/src/frontend/src/lib/components/trading/TradingDepositReview.svelte
+++ b/src/frontend/src/lib/components/trading/TradingDepositReview.svelte
@@ -80,7 +80,9 @@
 			{#snippet label()}{$i18n.trading.deposit.to}{/snippet}
 			{#snippet mainValue()}
 				<span class="flex items-center gap-2">
-					<OisyTradeMark size="22" />
+					<span class="flex" aria-hidden="true">
+						<OisyTradeMark size="22" />
+					</span>
 					{$i18n.trading.text.provider_name}
 				</span>
 			{/snippet}

--- a/src/frontend/src/lib/components/trading/TradingDepositReview.svelte
+++ b/src/frontend/src/lib/components/trading/TradingDepositReview.svelte
@@ -79,7 +79,7 @@
 		<ModalValue>
 			{#snippet label()}{$i18n.trading.deposit.to}{/snippet}
 			{#snippet mainValue()}
-				<span class="flex items-center gap-2">
+				<span class="inline-flex items-center gap-2">
 					<span class="flex" aria-hidden="true">
 						<OisyTradeMark size="22" />
 					</span>

--- a/src/frontend/src/tests/lib/components/trading/TradingDepositForm.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingDepositForm.svelte.spec.ts
@@ -43,10 +43,15 @@ describe('TradingDepositForm', () => {
 		expect(getByText(en.trading.deposit.consent)).toBeInTheDocument();
 	});
 
-	it('should render the OISY Trade logo next to the provider name', () => {
-		const { getByLabelText } = render(TradingDepositForm, { props: { ...baseProps } });
+	it('should render the OISY Trade logo, hidden from assistive tech', () => {
+		const { container } = render(TradingDepositForm, { props: { ...baseProps } });
 
-		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
+		const mark = container.querySelector('[aria-label="OISY Trade"]');
+
+		expect(mark).toBeInTheDocument();
+		// Decorative next to its own text label: must stay inside an aria-hidden
+		// wrapper so screen readers don't announce "OISY Trade" twice.
+		expect(mark?.closest('[aria-hidden="true"]')).not.toBeNull();
 	});
 
 	it('should disable the review button when there is no consent', () => {

--- a/src/frontend/src/tests/lib/components/trading/TradingDepositForm.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingDepositForm.svelte.spec.ts
@@ -43,6 +43,12 @@ describe('TradingDepositForm', () => {
 		expect(getByText(en.trading.deposit.consent)).toBeInTheDocument();
 	});
 
+	it('should render the OISY Trade logo next to the provider name', () => {
+		const { getByLabelText } = render(TradingDepositForm, { props: { ...baseProps } });
+
+		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
+	});
+
 	it('should disable the review button when there is no consent', () => {
 		const { getByTestId } = render(TradingDepositForm, { props: { ...baseProps } });
 

--- a/src/frontend/src/tests/lib/components/trading/TradingDepositReview.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingDepositReview.svelte.spec.ts
@@ -41,10 +41,15 @@ describe('TradingDepositReview', () => {
 		expect(getByText(en.trading.deposit.transaction_fee)).toBeInTheDocument();
 	});
 
-	it('should render the OISY Trade logo next to the provider name', () => {
-		const { getByLabelText } = render(TradingDepositReview, { props: { ...baseProps } });
+	it('should render the OISY Trade logo, hidden from assistive tech', () => {
+		const { container } = render(TradingDepositReview, { props: { ...baseProps } });
 
-		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
+		const mark = container.querySelector('[aria-label="OISY Trade"]');
+
+		expect(mark).toBeInTheDocument();
+		// Decorative next to its own text label: must stay inside an aria-hidden
+		// wrapper so screen readers don't announce "OISY Trade" twice.
+		expect(mark?.closest('[aria-hidden="true"]')).not.toBeNull();
 	});
 
 	it('should render the fee breakdown in fiat when an exchange rate is available', () => {

--- a/src/frontend/src/tests/lib/components/trading/TradingDepositReview.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingDepositReview.svelte.spec.ts
@@ -41,6 +41,12 @@ describe('TradingDepositReview', () => {
 		expect(getByText(en.trading.deposit.transaction_fee)).toBeInTheDocument();
 	});
 
+	it('should render the OISY Trade logo next to the provider name', () => {
+		const { getByLabelText } = render(TradingDepositReview, { props: { ...baseProps } });
+
+		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
+	});
+
 	it('should render the fee breakdown in fiat when an exchange rate is available', () => {
 		exchangesMock.set({ [token.id]: { usd: 7 } });
 


### PR DESCRIPTION
# Motivation

The Swap modal renders a provider logo before the provider name, but the OISY Trade deposit "To" row showed "OISY Trade" as plain text. This adds the OISY Trade brand mark for visual parity, in both the deposit form and the review step.

# Changes

- Render `OisyTradeMark` before the "OISY Trade" name in the "To" row of the deposit form and the review step.
- Size the mark (22px) to match the adjacent network logo and the Swap provider logo pattern.
- Use `inline-flex items-center gap-2` on the wrapper span so it stays inline-level inside `ModalValue`, matching the withdraw flow.
- Wrap the mark in an `aria-hidden` span at both call sites so screen readers announce "OISY Trade" once (via the adjacent text) instead of twice (review feedback).
- Add tests asserting the logo renders and stays inside an `aria-hidden` wrapper (guarding the decorative fix against regressions) in both the form and the review.

# Tests

- `vitest` for `TradingDepositForm` and `TradingDepositReview` specs — green (logo + aria-hidden assertions included).
- `npm run lint` and `npm run check:tests` — 0 errors, 0 warnings.

|Form|Review|
|---|---|
|<img width="575" height="646" alt="image" src="https://github.com/user-attachments/assets/639fb6a3-5215-4382-ad45-acc5219f820c" />|<img width="575" height="646" alt="image" src="https://github.com/user-attachments/assets/693f2caa-ec71-4f3f-a0bf-d644ac7dbf41" />|

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (`claude-opus-4-8`)
