### PR TITLE
feat(frontend): show the OISY Trade logo next to the provider name in the withdraw flow

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/src/frontend/src/lib/components/trading/WithdrawForm.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawForm.svelte
@@ -5,6 +5,7 @@
 	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
+	import OisyTradeMark from '$lib/components/trading/OisyTradeMark.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
@@ -150,7 +151,12 @@
 
 	<ModalValue>
 		{#snippet label()}{$i18n.trading.withdraw.from}{/snippet}
-		{#snippet mainValue()}{OISY_TRADE_PROVIDER_NAME}{/snippet}
+		{#snippet mainValue()}
+			<span class="flex items-center gap-2">
+				<OisyTradeMark size="22" />
+				{OISY_TRADE_PROVIDER_NAME}
+			</span>
+		{/snippet}
 	</ModalValue>
 
 	<FeeDisplay

--- a/src/frontend/src/lib/components/trading/WithdrawForm.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawForm.svelte
@@ -152,7 +152,7 @@
 	<ModalValue>
 		{#snippet label()}{$i18n.trading.withdraw.from}{/snippet}
 		{#snippet mainValue()}
-			<span class="flex items-center gap-2">
+			<span class="inline-flex items-center gap-2">
 				<OisyTradeMark size="22" />
 				{OISY_TRADE_PROVIDER_NAME}
 			</span>

--- a/src/frontend/src/lib/components/trading/WithdrawForm.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawForm.svelte
@@ -153,7 +153,9 @@
 		{#snippet label()}{$i18n.trading.withdraw.from}{/snippet}
 		{#snippet mainValue()}
 			<span class="inline-flex items-center gap-2">
-				<OisyTradeMark size="22" />
+				<span class="flex" aria-hidden="true">
+					<OisyTradeMark size="22" />
+				</span>
 				{OISY_TRADE_PROVIDER_NAME}
 			</span>
 		{/snippet}

--- a/src/frontend/src/lib/components/trading/WithdrawReview.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawReview.svelte
@@ -58,7 +58,9 @@
 		{#snippet label()}{$i18n.trading.withdraw.from}{/snippet}
 		{#snippet mainValue()}
 			<span class="inline-flex items-center gap-2">
-				<OisyTradeMark size="22" />
+				<span class="flex" aria-hidden="true">
+					<OisyTradeMark size="22" />
+				</span>
 				{OISY_TRADE_PROVIDER_NAME}
 			</span>
 		{/snippet}

--- a/src/frontend/src/lib/components/trading/WithdrawReview.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawReview.svelte
@@ -4,6 +4,7 @@
 	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import NetworkLogo from '$lib/components/networks/NetworkLogo.svelte';
 	import SendTokenReview from '$lib/components/tokens/SendTokenReview.svelte';
+	import OisyTradeMark from '$lib/components/trading/OisyTradeMark.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
 	import ButtonBack from '$lib/components/ui/ButtonBack.svelte';
 	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
@@ -55,7 +56,12 @@
 
 	<ModalValue>
 		{#snippet label()}{$i18n.trading.withdraw.from}{/snippet}
-		{#snippet mainValue()}{OISY_TRADE_PROVIDER_NAME}{/snippet}
+		{#snippet mainValue()}
+			<span class="flex items-center gap-2">
+				<OisyTradeMark size="22" />
+				{OISY_TRADE_PROVIDER_NAME}
+			</span>
+		{/snippet}
 	</ModalValue>
 
 	<FeeDisplay

--- a/src/frontend/src/lib/components/trading/WithdrawReview.svelte
+++ b/src/frontend/src/lib/components/trading/WithdrawReview.svelte
@@ -57,7 +57,7 @@
 	<ModalValue>
 		{#snippet label()}{$i18n.trading.withdraw.from}{/snippet}
 		{#snippet mainValue()}
-			<span class="flex items-center gap-2">
+			<span class="inline-flex items-center gap-2">
 				<OisyTradeMark size="22" />
 				{OISY_TRADE_PROVIDER_NAME}
 			</span>

--- a/src/frontend/src/tests/lib/components/trading/WithdrawForm.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawForm.svelte.spec.ts
@@ -48,13 +48,18 @@ describe('WithdrawForm', () => {
 		expect(container).toHaveTextContent(en.trading.withdraw.you_receive);
 	});
 
-	it('renders the OISY Trade logo next to the provider name', () => {
-		const { getByLabelText } = render(WithdrawForm, {
+	it('renders the OISY Trade logo, hidden from assistive tech', () => {
+		const { container } = render(WithdrawForm, {
 			props: baseProps,
 			context: mockContext()
 		});
 
-		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
+		const mark = container.querySelector('[aria-label="OISY Trade"]');
+
+		expect(mark).toBeInTheDocument();
+		// Decorative next to its own text label: must stay inside an aria-hidden
+		// wrapper so screen readers don't announce "OISY Trade" twice.
+		expect(mark?.closest('[aria-hidden="true"]')).not.toBeNull();
 	});
 
 	it('disables the review button while the amount is invalid', () => {

--- a/src/frontend/src/tests/lib/components/trading/WithdrawForm.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawForm.svelte.spec.ts
@@ -48,6 +48,15 @@ describe('WithdrawForm', () => {
 		expect(container).toHaveTextContent(en.trading.withdraw.you_receive);
 	});
 
+	it('renders the OISY Trade logo next to the provider name', () => {
+		const { getByLabelText } = render(WithdrawForm, {
+			props: baseProps,
+			context: mockContext()
+		});
+
+		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
+	});
+
 	it('disables the review button while the amount is invalid', () => {
 		const { getByTestId } = render(WithdrawForm, {
 			props: baseProps,

--- a/src/frontend/src/tests/lib/components/trading/WithdrawReview.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawReview.svelte.spec.ts
@@ -36,6 +36,15 @@ describe('WithdrawReview', () => {
 		);
 	});
 
+	it('renders the OISY Trade logo next to the provider name', () => {
+		const { getByLabelText } = render(WithdrawReview, {
+			props: baseProps,
+			context: mockContext()
+		});
+
+		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
+	});
+
 	it('calls onBack when the back button is clicked', async () => {
 		const onBack = vi.fn();
 

--- a/src/frontend/src/tests/lib/components/trading/WithdrawReview.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/WithdrawReview.svelte.spec.ts
@@ -36,13 +36,18 @@ describe('WithdrawReview', () => {
 		);
 	});
 
-	it('renders the OISY Trade logo next to the provider name', () => {
-		const { getByLabelText } = render(WithdrawReview, {
+	it('renders the OISY Trade logo, hidden from assistive tech', () => {
+		const { container } = render(WithdrawReview, {
 			props: baseProps,
 			context: mockContext()
 		});
 
-		expect(getByLabelText('OISY Trade')).toBeInTheDocument();
+		const mark = container.querySelector('[aria-label="OISY Trade"]');
+
+		expect(mark).toBeInTheDocument();
+		// Decorative next to its own text label: must stay inside an aria-hidden
+		// wrapper so screen readers don't announce "OISY Trade" twice.
+		expect(mark?.closest('[aria-hidden="true"]')).not.toBeNull();
 	});
 
 	it('calls onBack when the back button is clicked', async () => {


### PR DESCRIPTION
# Motivation

Following #13500, which added the OISY Trade brand mark before the provider name in the deposit flow, this does the same for the withdraw flow. The withdraw form and review showed "OISY Trade" as plain text in the "From" row.

# Changes

- Render `OisyTradeMark` before the "OISY Trade" name in the "From" row of the withdraw form and the review step.
- Size the mark (22px) and layout (`inline-flex items-center gap-2`) to match the deposit flow and the adjacent network logo (review feedback: `inline-flex`, matching the existing network-name row).
- Wrap the mark in an `aria-hidden` span at both call sites so screen readers announce "OISY Trade" once (via the adjacent text) instead of twice, matching the deposit flow.
- Add tests asserting the logo renders and stays inside an `aria-hidden` wrapper (guarding the decorative fix against regressions) in both the form and the review.

# Tests

- `vitest` for `WithdrawForm` and `WithdrawReview` specs — green (logo + aria-hidden assertions included, 16 tests).
- `npm run lint` and `npm run check:tests` — 0 errors, 0 warnings.

|Before|After|
|---|---|
|<img width="570" height="512" alt="image" src="https://github.com/user-attachments/assets/e8606399-43c0-448a-b2ba-c3ab61f7b9d1" />|<img width="570" height="512" alt="image" src="https://github.com/user-attachments/assets/4350952d-5a33-401d-8796-a70d7498e5b1" />|

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model: Claude Opus 4.8 (`claude-opus-4-8`)
