### PR TITLE
ci(frontend): surface bundle-size warnings honestly without blocking merges

### DIFF
--- a/.github/workflows/frontend-bundle-check.yml
+++ b/.github/workflows/frontend-bundle-check.yml
@@ -29,8 +29,14 @@ jobs:
       - name: Get bundle size
         id: get-size
         run: |
-          SIZE=$(du -sk build/_app/immutable/**/*.js{,.gz} 2>/dev/null | awk '{sum += $1} END {print sum}')
-          echo "Base branch bundle size: $SIZE KB"
+          shopt -s globstar nullglob
+          FILES=(build/_app/immutable/**/*.js build/_app/immutable/**/*.js.gz)
+          if (( ${#FILES[@]} == 0 )); then
+            echo "::error::No JS bundles found under build/_app/immutable — did the build output layout change?"
+            exit 1
+          fi
+          SIZE=$(du -sk "${FILES[@]}" | awk '{sum += $1} END {print sum}')
+          echo "Base branch bundle size: $SIZE KB (${#FILES[@]} files)"
           echo "size=$SIZE" >> $GITHUB_OUTPUT
 
   build-pr:
@@ -55,8 +61,14 @@ jobs:
       - name: Get bundle size
         id: get-size
         run: |
-          SIZE=$(du -sk build/_app/immutable/**/*.js{,.gz} 2>/dev/null | awk '{sum += $1} END {print sum}')
-          echo "PR bundle size: $SIZE KB"
+          shopt -s globstar nullglob
+          FILES=(build/_app/immutable/**/*.js build/_app/immutable/**/*.js.gz)
+          if (( ${#FILES[@]} == 0 )); then
+            echo "::error::No JS bundles found under build/_app/immutable — did the build output layout change?"
+            exit 1
+          fi
+          SIZE=$(du -sk "${FILES[@]}" | awk '{sum += $1} END {print sum}')
+          echo "PR bundle size: $SIZE KB (${#FILES[@]} files)"
           echo "size=$SIZE" >> $GITHUB_OUTPUT
 
   compare-sizes:
@@ -67,27 +79,23 @@ jobs:
     steps:
       - name: Compare bundle sizes
         run: |
-          BASE_SIZE=$BASE_SIZE
-          PR_SIZE=$PR_SIZE
+          if ! [[ $BASE_SIZE =~ ^[0-9]+$ && $PR_SIZE =~ ^[0-9]+$ && $BASE_SIZE -gt 0 && $PR_SIZE -gt 0 ]]; then
+            echo "::error::Missing or invalid bundle sizes (base='${BASE_SIZE}', pr='${PR_SIZE}') — refusing to pass vacuously."
+            exit 1
+          fi
 
           DIFF=$((PR_SIZE - BASE_SIZE))
-
-          if (( BASE_SIZE > 0 )); then
-            PERCENT=$((100 * DIFF / BASE_SIZE))
-          else
-            PERCENT=0
-          fi
+          PERCENT=$((100 * DIFF / BASE_SIZE))
 
           echo "Base bundle size: ${BASE_SIZE} KB"
           echo "PR bundle size:   ${PR_SIZE} KB"
           echo "::notice::Difference:       ${DIFF} KB"
           echo "::notice::Percent change:   ${PERCENT}%"
-          echo "::endgroup::"
 
           MAX_KB=100
           MAX_PERCENT=10
 
-           if (( DIFF > MAX_KB )); then
+          if (( DIFF > MAX_KB )); then
             echo "🚨 Bundle size increased by ${DIFF}KB, over the limit of ${MAX_KB}KB."
             exit 1
           fi

--- a/.github/workflows/frontend-bundle-check.yml
+++ b/.github/workflows/frontend-bundle-check.yml
@@ -32,10 +32,11 @@ jobs:
           shopt -s globstar nullglob
           FILES=(build/_app/immutable/**/*.js build/_app/immutable/**/*.js.gz)
           if (( ${#FILES[@]} == 0 )); then
-            echo "::error::No JS bundles found under build/_app/immutable — did the build output layout change?"
-            exit 1
+            echo "::warning::No JS bundles found under build/_app/immutable — did the build output layout change?"
+            SIZE=0
+          else
+            SIZE=$(du -sk "${FILES[@]}" | awk '{sum += $1} END {print sum}')
           fi
-          SIZE=$(du -sk "${FILES[@]}" | awk '{sum += $1} END {print sum}')
           echo "Base branch bundle size: $SIZE KB (${#FILES[@]} files)"
           echo "size=$SIZE" >> $GITHUB_OUTPUT
 
@@ -64,10 +65,11 @@ jobs:
           shopt -s globstar nullglob
           FILES=(build/_app/immutable/**/*.js build/_app/immutable/**/*.js.gz)
           if (( ${#FILES[@]} == 0 )); then
-            echo "::error::No JS bundles found under build/_app/immutable — did the build output layout change?"
-            exit 1
+            echo "::warning::No JS bundles found under build/_app/immutable — did the build output layout change?"
+            SIZE=0
+          else
+            SIZE=$(du -sk "${FILES[@]}" | awk '{sum += $1} END {print sum}')
           fi
-          SIZE=$(du -sk "${FILES[@]}" | awk '{sum += $1} END {print sum}')
           echo "PR bundle size: $SIZE KB (${#FILES[@]} files)"
           echo "size=$SIZE" >> $GITHUB_OUTPUT
 
@@ -80,8 +82,8 @@ jobs:
       - name: Compare bundle sizes
         run: |
           if ! [[ $BASE_SIZE =~ ^[0-9]+$ && $PR_SIZE =~ ^[0-9]+$ && $BASE_SIZE -gt 0 && $PR_SIZE -gt 0 ]]; then
-            echo "::error::Missing or invalid bundle sizes (base='${BASE_SIZE}', pr='${PR_SIZE}') — refusing to pass vacuously."
-            exit 1
+            echo "::warning::Bundle sizes could not be measured (base='${BASE_SIZE}', pr='${PR_SIZE}') — the size comparison is informative only, please check the build jobs."
+            exit 0
           fi
 
           DIFF=$((PR_SIZE - BASE_SIZE))
@@ -96,16 +98,12 @@ jobs:
           MAX_PERCENT=10
 
           if (( DIFF > MAX_KB )); then
-            echo "🚨 Bundle size increased by ${DIFF}KB, over the limit of ${MAX_KB}KB."
-            exit 1
+            echo "::warning::🚨 Bundle size increased by ${DIFF}KB, over the informative limit of ${MAX_KB}KB."
+          elif (( PERCENT > MAX_PERCENT )); then
+            echo "::warning::🚨 Bundle size increased by ${PERCENT}%, over the informative limit of ${MAX_PERCENT}%."
+          else
+            echo "✅ Bundle size within acceptable limits."
           fi
-
-          if (( PERCENT > MAX_PERCENT )); then
-            echo "🚨 Bundle size increased by ${PERCENT}%, over the limit of ${MAX_PERCENT}%."
-            exit 1
-          fi
-
-          echo "✅ Bundle size within acceptable limits."
     env:
       BASE_SIZE: ${{ needs.build-base-branch.outputs.size }}
       PR_SIZE: ${{ needs.build-pr.outputs.size }}


### PR DESCRIPTION
# Motivation

Two problems with the bundle-size check, in opposite directions:

1. **It could pass vacuously.** The `Get bundle size` steps use `build/_app/immutable/**/*.js{,.gz}` in a shell where `globstar` is off and errors are silenced with `2>/dev/null`, so if the glob ever stops matching (build layout change, failed post-processing) the size comes back empty, flows into the comparison as 0, and the check reports "✅ within acceptable limits" without having measured anything.
2. **It could block merges we want.** The team treats bundle size as informative — sometimes a feature is worth its size cost — so threshold breaches should warn, not gate.

# Changes

- Enable `globstar`/`nullglob` in both `Get bundle size` steps and collect the matched files explicitly; when nothing matches, emit a `::warning::` annotation instead of silently reporting an empty size.
- In `compare-sizes`, validate both sizes before doing arithmetic; when they are missing/invalid, warn that the comparison could not be made instead of claiming success.
- Size-threshold breaches (>100 KB or >10%) now emit `::warning::` annotations instead of `exit 1` — **the job always succeeds and never blocks a merge**.
- Remove the no-op `BASE_SIZE=$BASE_SIZE` / `PR_SIZE=$PR_SIZE` self-assignments and the unmatched `::endgroup::`.

Measurement method (`du -sk` over `.js` + `.js.gz`) and thresholds are unchanged; only the reporting semantics changed (fail → warn, silent → warn).

# Tests

- Verified against a real production build (`DFX_NETWORK=ic npm run build`): the hardened step matches 50+ files and reports the same total (11708 KB) as the old glob on the current layout.
- Verified the no-files path emits the warning and `size=0` (comparison then warns "could not be measured" and exits 0).
- `prettier --check` passes on the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiZ8mmts9aZCCANKQfQ1Xi