### PR TITLE
feat(frontend): token selector step for Liquidium Supply

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumSelectTokenForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSelectTokenForm.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import ButtonGroup from '$lib/components/ui/ButtonGroup.svelte';
+	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionAmount } from '$lib/types/send';
+
+	interface Props {
+		onSelectToken: () => void;
+		onClose: () => void;
+		children?: Snippet;
+	}
+
+	let { onSelectToken, onClose, children }: Props = $props();
+
+	// No token is chosen yet, so the amount is inert until one is picked; TokenInput
+	// still requires a bindable amount plus its info/balance snippets.
+	let amount = $state<OptionAmount>();
+</script>
+
+<ContentWithToolbar>
+	<div class="mb-8">
+		<TokenInput isSelectable onClick={onSelectToken} showTokenNetwork token={undefined} bind:amount>
+			{#snippet title()}{$i18n.core.text.amount}{/snippet}
+			{#snippet amountInfo()}{/snippet}
+			{#snippet balance()}{/snippet}
+		</TokenInput>
+	</div>
+
+	{@render children?.()}
+
+	{#snippet toolbar()}
+		<ButtonGroup>
+			<ButtonCancel onclick={onClose} />
+			<Button disabled onclick={onSelectToken}>{$i18n.send.text.review}</Button>
+		</ButtonGroup>
+	{/snippet}
+</ContentWithToolbar>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
@@ -36,6 +36,7 @@
 		inflowFee?: bigint;
 		inflowFeeUnavailable?: boolean;
 		currentStep?: WizardStep;
+		onSelectToken?: () => void;
 		onClose: () => void;
 		onNext: () => void;
 		onBack: () => void;
@@ -48,6 +49,7 @@
 		inflowFee,
 		inflowFeeUnavailable,
 		currentStep,
+		onSelectToken,
 		onClose,
 		onNext,
 		onBack
@@ -171,6 +173,7 @@
 			{onClose}
 			onCustomErrorValidate={validateSupplyAmount}
 			{onNext}
+			{onSelectToken}
 			totalFee={utxosFee?.feeSatoshis}
 			bind:amount
 		/>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte
@@ -44,6 +44,7 @@
 		inflowFee?: bigint;
 		inflowFeeUnavailable?: boolean;
 		currentStep?: WizardStep;
+		onSelectToken?: () => void;
 		onClose: () => void;
 		onNext: () => void;
 		onBack: () => void;
@@ -56,6 +57,7 @@
 		inflowFee,
 		inflowFeeUnavailable,
 		currentStep,
+		onSelectToken,
 		onClose,
 		onNext,
 		onBack
@@ -250,6 +252,7 @@
 				{onClose}
 				onCustomErrorValidate={validateSupplyAmount}
 				{onNext}
+				{onSelectToken}
 				totalFee={$maxGasFee}
 				bind:amount
 			/>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext, type Snippet } from 'svelte';
 	import LiquidiumProviderFee from '$lib/components/liquidium/supply/LiquidiumProviderFee.svelte';
 	import LiquidiumSupplyAgreement from '$lib/components/liquidium/supply/LiquidiumSupplyAgreement.svelte';
@@ -29,6 +29,8 @@
 		onCustomErrorValidate?: (userAmount: bigint) => Error | undefined;
 		// Per-rail fee row (EthFeeDisplay / BtcUtxosFeeDisplay).
 		feeDisplay: Snippet;
+		// Opens the token-selection step; when set, the token logo becomes a selector.
+		onSelectToken?: () => void;
 		onClose: () => void;
 		onNext: () => void;
 	}
@@ -41,6 +43,7 @@
 		inflowFeeUnavailable = false,
 		onCustomErrorValidate,
 		feeDisplay,
+		onSelectToken,
 		onClose,
 		onNext
 	}: Props = $props();
@@ -74,6 +77,8 @@
 <StakeForm
 	autofocus={isDesktop()}
 	disabled={!agreementChecked || feeMissing || inflowFeeUnavailable}
+	isSelectable={nonNullish(onSelectToken)}
+	onClick={onSelectToken}
 	{onClose}
 	{onCustomErrorValidate}
 	{onNext}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
@@ -18,7 +18,8 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		initModalTokensListContext,
-		MODAL_TOKENS_LIST_CONTEXT_KEY
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
@@ -41,7 +42,8 @@
 		nonNullish(selectedMarket) ? LIQUIDIUM_ASSET_TOKENS[selectedMarket.asset] : undefined
 	);
 
-	setContext(MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] }));
+	const tokensListContext = initModalTokensListContext({ tokens: [] });
+	setContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY, tokensListContext);
 
 	let inflowFee = $state<bigint | undefined>();
 	// The estimate failed (e.g. stale oracle price): surface a retry message and block submit.
@@ -81,24 +83,43 @@
 		}
 	};
 
+	// Always enter the picker with a clean query so it never reopens filtered from a
+	// previous visit (mirrors the swap / trade-deposit flows).
+	const enterTokensList = () => {
+		tokensListContext.setFilterQuery('');
+		goToStep(WizardStepsLiquidiumSupply.TOKENS_LIST);
+	};
+
+	// Cancelling the picker returns to the Supply step — the amount form when a market
+	// is chosen, or the select-token prompt on a neutral launch.
+	const closeTokensList = () => {
+		tokensListContext.setFilterQuery('');
+		goToStep(WizardStepsLiquidiumSupply.SUPPLY);
+	};
+
 	const selectMarket = (nextMarket: LiquidiumMarket) => {
 		selectedMarket = nextMarket;
 		// The typed amount is token-specific; drop it when switching.
 		amount = undefined;
-		goToStep(WizardStepsLiquidiumSupply.SUPPLY);
+		closeTokensList();
 	};
 
+	// The modal is not guaranteed to unmount between opens, so restore every piece of
+	// launch state — including the selected market, its fee estimate and the picker
+	// filters — back to what the initial prop implies; otherwise the next open (or a
+	// neutral launch) inherits the previously picked token / a stale fee-error / a
+	// stale filter query.
 	const reset = () => {
+		selectedMarket = market;
 		amount = undefined;
+		inflowFee = undefined;
+		inflowFeeUnavailable = false;
 		supplyProgressStep = ProgressStepsLiquidiumSupply.INITIALIZATION;
 		currentStep = undefined;
+		tokensListContext.resetFilters();
 	};
 
 	const close = () => closeModal(reset);
-
-	// Cancelling the picker returns to the Supply step — the amount form when a market
-	// is chosen, or the select-token prompt on a neutral launch.
-	const closeTokensList = () => goToStep(WizardStepsLiquidiumSupply.SUPPLY);
 </script>
 
 <TokenActionContext {token}>
@@ -118,10 +139,7 @@
 				{selectedMarket}
 			/>
 		{:else if isNullish(selectedMarket)}
-			<LiquidiumSelectTokenForm
-				onClose={close}
-				onSelectToken={() => goToStep(WizardStepsLiquidiumSupply.TOKENS_LIST)}
-			>
+			<LiquidiumSelectTokenForm onClose={close} onSelectToken={enterTokensList}>
 				<MessageBox styleClass="sm:text-sm !items-center">
 					{$i18n.liquidium.text.supply_collateral_info}
 				</MessageBox>
@@ -135,7 +153,7 @@
 				onBack={modal.back}
 				onClose={close}
 				onNext={modal.next}
-				onSelectToken={() => goToStep(WizardStepsLiquidiumSupply.TOKENS_LIST)}
+				onSelectToken={enterTokensList}
 				bind:amount
 				bind:supplyProgressStep
 			/>
@@ -148,7 +166,7 @@
 				onBack={modal.back}
 				onClose={close}
 				onNext={modal.next}
-				onSelectToken={() => goToStep(WizardStepsLiquidiumSupply.TOKENS_LIST)}
+				onSelectToken={enterTokensList}
 				bind:amount
 				bind:supplyProgressStep
 			/>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Asset, Chain } from '@liquidium/client';
+	import { setContext } from 'svelte';
+	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumSupplyBtcWizard from '$lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte';
 	import LiquidiumSupplyEthWizard from '$lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte';
+	import LiquidiumSupplyTokensList from '$lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte';
 	import TokenActionContext from '$lib/components/send/TokenActionContext.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumSupplyWizardSteps } from '$lib/config/lend-borrow.config';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
@@ -12,21 +16,33 @@
 	import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
 	import { estimateLiquidiumInflowFee } from '$lib/services/liquidium-supply.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		initModalTokensListContext,
+		MODAL_TOKENS_LIST_CONTEXT_KEY
+	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { WizardStep, WizardSteps } from '$lib/types/wizard';
 	import { consoleError } from '$lib/utils/console.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	interface Props {
-		market: LiquidiumMarket;
+		market?: LiquidiumMarket;
 	}
 
 	let { market }: Props = $props();
 
-	let token = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
+	// Seeded from the initial prop only; later switches happen through the picker.
+	// svelte-ignore state_referenced_locally
+	let selectedMarket = $state<LiquidiumMarket | undefined>(market);
 
-	// Provider inflow fee for this asset, passed to the wizard.
+	let token = $derived(
+		nonNullish(selectedMarket) ? LIQUIDIUM_ASSET_TOKENS[selectedMarket.asset] : undefined
+	);
+
+	setContext(MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] }));
+
 	let inflowFee = $state<bigint | undefined>();
 	// The estimate failed (e.g. stale oracle price): surface a retry message and block submit.
 	let inflowFeeUnavailable = $state(false);
@@ -34,16 +50,14 @@
 	$effect(() => {
 		const identity = $authIdentity;
 
-		if (nonNullish(identity)) {
+		if (nonNullish(identity) && nonNullish(selectedMarket)) {
+			const asset = selectedMarket.asset as Asset;
+			const chain = selectedMarket.chain as Chain;
+
+			inflowFee = undefined;
 			inflowFeeUnavailable = false;
 
-			// Market data widens asset/chain to open strings (future assets); narrow to
-			// the SDK's strict mutating-flow types at this boundary.
-			estimateLiquidiumInflowFee({
-				identity,
-				asset: market.asset as Asset,
-				chain: market.chain as Chain
-			})
+			estimateLiquidiumInflowFee({ identity, asset, chain })
 				.then((fee) => (inflowFee = fee))
 				.catch((err: unknown) => {
 					consoleError(err);
@@ -61,6 +75,19 @@
 		liquidiumSupplyWizardSteps({ i18n: $i18n })
 	);
 
+	const goToStep = (stepName: WizardStepsLiquidiumSupply) => {
+		if (nonNullish(modal)) {
+			goToWizardStep({ modal, steps, stepName });
+		}
+	};
+
+	const selectMarket = (nextMarket: LiquidiumMarket) => {
+		selectedMarket = nextMarket;
+		// The typed amount is token-specific; drop it when switching.
+		amount = undefined;
+		goToStep(WizardStepsLiquidiumSupply.SUPPLY);
+	};
+
 	const reset = () => {
 		amount = undefined;
 		supplyProgressStep = ProgressStepsLiquidiumSupply.INITIALIZATION;
@@ -68,44 +95,63 @@
 	};
 
 	const close = () => closeModal(reset);
+
+	// Cancelling the picker returns to the Supply step — the amount form when a market
+	// is chosen, or the select-token prompt on a neutral launch.
+	const closeTokensList = () => goToStep(WizardStepsLiquidiumSupply.SUPPLY);
 </script>
 
-{#if nonNullish(token)}
-	<TokenActionContext {token}>
-		<WizardModal
-			bind:this={modal}
-			disablePointerEvents={currentStep?.name === WizardStepsLiquidiumSupply.SUPPLYING}
-			onClose={close}
-			{steps}
-			bind:currentStep
-		>
-			{#snippet title()}{currentStep?.title ?? ''}{/snippet}
+<TokenActionContext {token}>
+	<WizardModal
+		bind:this={modal}
+		disablePointerEvents={currentStep?.name === WizardStepsLiquidiumSupply.SUPPLYING}
+		onClose={close}
+		{steps}
+		bind:currentStep
+	>
+		{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-			{#if market.chain === 'BTC'}
-				<LiquidiumSupplyBtcWizard
-					{currentStep}
-					{inflowFee}
-					{inflowFeeUnavailable}
-					{market}
-					onBack={modal.back}
-					onClose={close}
-					onNext={modal.next}
-					bind:amount
-					bind:supplyProgressStep
-				/>
-			{:else}
-				<LiquidiumSupplyEthWizard
-					{currentStep}
-					{inflowFee}
-					{inflowFeeUnavailable}
-					{market}
-					onBack={modal.back}
-					onClose={close}
-					onNext={modal.next}
-					bind:amount
-					bind:supplyProgressStep
-				/>
-			{/if}
-		</WizardModal>
-	</TokenActionContext>
-{/if}
+		{#if currentStep?.name === WizardStepsLiquidiumSupply.TOKENS_LIST}
+			<LiquidiumSupplyTokensList
+				onClose={closeTokensList}
+				onSelectMarket={selectMarket}
+				{selectedMarket}
+			/>
+		{:else if isNullish(selectedMarket)}
+			<LiquidiumSelectTokenForm
+				onClose={close}
+				onSelectToken={() => goToStep(WizardStepsLiquidiumSupply.TOKENS_LIST)}
+			>
+				<MessageBox styleClass="sm:text-sm !items-center">
+					{$i18n.liquidium.text.supply_collateral_info}
+				</MessageBox>
+			</LiquidiumSelectTokenForm>
+		{:else if selectedMarket.chain === 'BTC'}
+			<LiquidiumSupplyBtcWizard
+				{currentStep}
+				{inflowFee}
+				{inflowFeeUnavailable}
+				market={selectedMarket}
+				onBack={modal.back}
+				onClose={close}
+				onNext={modal.next}
+				onSelectToken={() => goToStep(WizardStepsLiquidiumSupply.TOKENS_LIST)}
+				bind:amount
+				bind:supplyProgressStep
+			/>
+		{:else}
+			<LiquidiumSupplyEthWizard
+				{currentStep}
+				{inflowFee}
+				{inflowFeeUnavailable}
+				market={selectedMarket}
+				onBack={modal.back}
+				onClose={close}
+				onNext={modal.next}
+				onSelectToken={() => goToStep(WizardStepsLiquidiumSupply.TOKENS_LIST)}
+				bind:amount
+				bind:supplyProgressStep
+			/>
+		{/if}
+	</WizardModal>
+</TokenActionContext>

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
+	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { liquidiumSupplyMarkets } from '$lib/derived/liquidium.derived';
+	import {
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { Token } from '$lib/types/token';
+
+	interface Props {
+		// Omitted on a neutral (token-less) launch — then nothing is excluded.
+		selectedMarket?: LiquidiumMarket;
+		onSelectMarket: (market: LiquidiumMarket) => void;
+		onClose: () => void;
+	}
+
+	let { selectedMarket, onSelectMarket, onClose }: Props = $props();
+
+	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
+
+	let entries = $derived(
+		$liquidiumSupplyMarkets
+			.map((market) => ({ market, token: LIQUIDIUM_ASSET_TOKENS[market.asset] }))
+			.filter(
+				(entry): entry is { market: LiquidiumMarket; token: Token } =>
+					nonNullish(entry.token) && entry.market.poolId !== selectedMarket?.poolId
+			)
+	);
+
+	$effect(() => {
+		setTokens(entries.map(({ token }) => token));
+	});
+
+	const onTokenButtonClick = (token: Token) => {
+		const entry = entries.find(({ token: { id } }) => id === token.id);
+
+		if (nonNullish(entry)) {
+			onSelectMarket(entry.market);
+		}
+	};
+</script>
+
+<ModalTokensList networkSelectorViewOnly {onTokenButtonClick}>
+	{#snippet tokenListItem(token, onClick)}
+		<ModalTokensListItem {onClick} {token} />
+	{/snippet}
+	{#snippet toolbar()}
+		<ButtonCancel fullWidth onclick={onClose} />
+	{/snippet}
+</ModalTokensList>

--- a/src/frontend/src/lib/components/stake/StakeForm.svelte
+++ b/src/frontend/src/lib/components/stake/StakeForm.svelte
@@ -37,6 +37,10 @@
 		maxAmount?: bigint;
 		errorType?: TokenActionErrorType;
 		error?: Error;
+		// Makes the token logo a clickable selector; when set, `onClick` fires on click.
+		// Defaults to a static (non-selectable) token display.
+		isSelectable?: boolean;
+		onClick?: () => void;
 		onCustomValidate?: (userAmount: bigint) => TokenActionErrorType;
 		onCustomErrorValidate?: (userAmount: bigint) => Error | undefined;
 		onClose: () => void;
@@ -55,6 +59,8 @@
 		maxAmount,
 		errorType = $bindable(),
 		error = $bindable(),
+		isSelectable = false,
+		onClick,
 		onCustomValidate,
 		onCustomErrorValidate,
 		onClose,
@@ -92,7 +98,8 @@
 			{autofocus}
 			displayUnit={inputUnit}
 			exchangeRate={$sendTokenExchangeRate}
-			isSelectable={false}
+			{isSelectable}
+			{onClick}
 			{onCustomErrorValidate}
 			{onCustomValidate}
 			showTokenNetwork

--- a/src/frontend/src/lib/config/lend-borrow.config.ts
+++ b/src/frontend/src/lib/config/lend-borrow.config.ts
@@ -34,6 +34,10 @@ export const liquidiumSupplyWizardSteps = ({
 	{
 		name: WizardStepsLiquidiumSupply.SUPPLYING,
 		title: i18n.liquidium.text.supplying
+	},
+	{
+		name: WizardStepsLiquidiumSupply.TOKENS_LIST,
+		title: i18n.liquidium.text.select_supply_token
 	}
 ];
 

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -1,5 +1,6 @@
 import { goto } from '$app/navigation';
 import { EarningCardFields } from '$env/types/env.earning-cards';
+import { ZERO } from '$lib/constants/app.constants';
 import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 import { AppPath } from '$lib/constants/routes.constants';
 import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
@@ -28,6 +29,18 @@ export const liquidiumMarkets: Readable<LiquidiumMarket[]> = derived(
 export const liquidiumPortfolio: Readable<LiquidiumPortfolio | null> = derived(
 	liquidiumStore,
 	({ portfolio }) => portfolio
+);
+
+export const liquidiumSupplyMarkets: Readable<LiquidiumMarket[]> = derived(
+	[liquidiumMarkets, liquidiumPortfolio],
+	([markets, portfolio]) =>
+		markets.filter(
+			({ available, poolId }) =>
+				available &&
+				!(portfolio?.reserves ?? []).some(
+					(reserve) => reserve.poolId === poolId && reserve.borrowed > ZERO
+				)
+		)
 );
 
 // SDK USD prices for the borrow form's USD / fiat math.

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -97,7 +97,8 @@ export enum WizardStepsTradingWithdraw {
 export enum WizardStepsLiquidiumSupply {
 	SUPPLY = 'Supply',
 	REVIEW = 'Review',
-	SUPPLYING = 'Supplying'
+	SUPPLYING = 'Supplying',
+	TOKENS_LIST = 'Tokens List'
 }
 
 export enum WizardStepsLiquidiumBorrow {

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "",
 			"action_withdraw": "",
 			"transaction_failed": "",
+			"select_supply_token": "",
 			"supply_review": "",
 			"supply_review_subtitle": "",
 			"supplying": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Splatit",
 			"action_withdraw": "Vybrat",
 			"transaction_failed": "Transakce se nezdařila",
+			"select_supply_token": "",
 			"supply_review": "Zkontrolovat poskytnutí",
 			"supply_review_subtitle": "Poskytuješ",
 			"supplying": "Probíhá poskytnutí",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Zurückzahlen",
 			"action_withdraw": "Abheben",
 			"transaction_failed": "Transaktion fehlgeschlagen",
+			"select_supply_token": "",
 			"supply_review": "Bereitstellung prüfen",
 			"supply_review_subtitle": "Du stellst bereit",
 			"supplying": "Bereitstellung läuft",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Repay",
 			"action_withdraw": "Withdraw",
 			"transaction_failed": "Transaction failed",
+			"select_supply_token": "Select token to supply",
 			"supply_review": "Review supply",
 			"supply_review_subtitle": "You supply",
 			"supplying": "Supplying",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Reembolsar",
 			"action_withdraw": "Retirar",
 			"transaction_failed": "La transacción falló",
+			"select_supply_token": "",
 			"supply_review": "Revisar suministro",
 			"supply_review_subtitle": "Suministras",
 			"supplying": "Suministrando",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Rembourser",
 			"action_withdraw": "Retirer",
 			"transaction_failed": "La transaction a échoué",
+			"select_supply_token": "",
 			"supply_review": "Vérifier l'apport",
 			"supply_review_subtitle": "Vous fournissez",
 			"supplying": "Fourniture en cours",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "चुकाएं",
 			"action_withdraw": "निकालें",
 			"transaction_failed": "लेन-देन विफल रहा",
+			"select_supply_token": "",
 			"supply_review": "जमा की समीक्षा करें",
 			"supply_review_subtitle": "आप जमा कर रहे हैं",
 			"supplying": "जमा हो रहा है",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Rimborsa",
 			"action_withdraw": "Preleva",
 			"transaction_failed": "Transazione non riuscita",
+			"select_supply_token": "",
 			"supply_review": "Rivedi fornitura",
 			"supply_review_subtitle": "Fornisci",
 			"supplying": "Fornitura in corso",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "返済する",
 			"action_withdraw": "引き出す",
 			"transaction_failed": "トランザクションが失敗しました",
+			"select_supply_token": "",
 			"supply_review": "供給内容を確認",
 			"supply_review_subtitle": "供給する",
 			"supplying": "供給中",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "상환하기",
 			"action_withdraw": "출금",
 			"transaction_failed": "트랜잭션 실패",
+			"select_supply_token": "",
 			"supply_review": "공급 검토",
 			"supply_review_subtitle": "공급 금액",
 			"supplying": "공급 중",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Spłać",
 			"action_withdraw": "Wypłać",
 			"transaction_failed": "Transakcja nie powiodła się",
+			"select_supply_token": "",
 			"supply_review": "Sprawdź dostarczenie",
 			"supply_review_subtitle": "Dostarczasz",
 			"supplying": "Trwa dostarczanie",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Reembolsar",
 			"action_withdraw": "Retirar",
 			"transaction_failed": "A transação falhou",
+			"select_supply_token": "",
 			"supply_review": "Rever fornecimento",
 			"supply_review_subtitle": "Forneces",
 			"supplying": "A fornecer",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Погасить",
 			"action_withdraw": "Вывести",
 			"transaction_failed": "Транзакция не удалась",
+			"select_supply_token": "",
 			"supply_review": "Проверить предоставление",
 			"supply_review_subtitle": "Ты предоставляешь",
 			"supplying": "Предоставление в процессе",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "Hoàn trả",
 			"action_withdraw": "Rút tiền",
 			"transaction_failed": "Giao dịch thất bại",
+			"select_supply_token": "",
 			"supply_review": "Xem lại khoản cung cấp",
 			"supply_review_subtitle": "Bạn cung cấp",
 			"supplying": "Đang cung cấp",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2385,6 +2385,7 @@
 			"action_repay": "还款",
 			"action_withdraw": "提取",
 			"transaction_failed": "交易失败",
+			"select_supply_token": "",
 			"supply_review": "查看提供详情",
 			"supply_review_subtitle": "您提供",
 			"supplying": "提供中",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1921,6 +1921,7 @@ interface I18nLiquidium {
 		action_repay: string;
 		action_withdraw: string;
 		transaction_failed: string;
+		select_supply_token: string;
 		supply_review: string;
 		supply_review_subtitle: string;
 		supplying: string;

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -5,6 +5,7 @@ import type {
 	WizardStepsConvert,
 	WizardStepsHowToConvert,
 	WizardStepsLimitOrder,
+	WizardStepsLiquidiumSupply,
 	WizardStepsReceive,
 	WizardStepsScanner,
 	WizardStepsSend,
@@ -28,7 +29,8 @@ type StepName =
 	| WizardStepsScanner
 	| WizardStepsTradingDeposit
 	| WizardStepsTradingWithdraw
-	| WizardStepsLimitOrder;
+	| WizardStepsLimitOrder
+	| WizardStepsLiquidiumSupply;
 
 export const goToWizardStep = <T extends StepName>({
 	modal,

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSelectTokenForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSelectTokenForm.spec.ts
@@ -1,0 +1,41 @@
+import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
+import en from '$tests/mocks/i18n.mock';
+import { fireEvent, render } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+
+describe('LiquidiumSelectTokenForm', () => {
+	it('shows the select-token prompt with a disabled review action', () => {
+		const { getByText, getByRole } = render(LiquidiumSelectTokenForm, {
+			props: { onSelectToken: () => {}, onClose: () => {} }
+		});
+
+		expect(getByText(en.tokens.text.select_token)).toBeInTheDocument();
+		expect(getByRole('button', { name: en.send.text.review })).toBeDisabled();
+	});
+
+	it('opens the token picker when the input is clicked', async () => {
+		const onSelectToken = vi.fn();
+
+		const { getByText } = render(LiquidiumSelectTokenForm, {
+			props: { onSelectToken, onClose: () => {} }
+		});
+
+		await fireEvent.click(getByText(en.tokens.text.select_token));
+
+		expect(onSelectToken).toHaveBeenCalled();
+	});
+
+	it('renders form-specific children below the input', () => {
+		const { getByTestId } = render(LiquidiumSelectTokenForm, {
+			props: {
+				onSelectToken: () => {},
+				onClose: () => {},
+				children: createRawSnippet(() => ({
+					render: () => `<span data-tid="child-body">Child body content</span>`
+				}))
+			}
+		});
+
+		expect(getByTestId('child-body')).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyTokensList.spec.ts
@@ -1,0 +1,82 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumSupplyTokensList from '$lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte';
+import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import {
+	initModalTokensListContext,
+	MODAL_TOKENS_LIST_CONTEXT_KEY
+} from '$lib/stores/modal-tokens-list.store';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('LiquidiumSupplyTokensList', () => {
+	const btcMarket: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
+	const usdcMarket: LiquidiumMarket = {
+		poolId: 'pool-usdc',
+		asset: 'USDC',
+		chain: 'ETH',
+		supplyApy: 3,
+		borrowApy: 4,
+		frozen: false,
+		available: true
+	};
+
+	const context = new Map([
+		[MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] })]
+	]);
+
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('lists the supply-available tokens except the selected one', () => {
+		liquidiumStore.set({ markets: [btcMarket, usdcMarket], portfolio: null, assetPrices: {} });
+
+		const { getByTestId, getByText, queryByText } = render(LiquidiumSupplyTokensList, {
+			props: { selectedMarket: btcMarket, onSelectMarket: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
+		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+		// The selected token is hidden from its own picker.
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+	});
+
+	it('selects the market matching the clicked token', async () => {
+		liquidiumStore.set({ markets: [btcMarket, usdcMarket], portfolio: null, assetPrices: {} });
+
+		const onSelectMarket = vi.fn();
+
+		const { getByText } = render(LiquidiumSupplyTokensList, {
+			props: { selectedMarket: btcMarket, onSelectMarket, onClose: () => {} },
+			context
+		});
+
+		await fireEvent.click(getByText(USDC_TOKEN.symbol));
+
+		expect(onSelectMarket).toHaveBeenCalledWith(usdcMarket);
+	});
+
+	it('lists every available token when no market is selected (neutral launch)', () => {
+		liquidiumStore.set({ markets: [btcMarket, usdcMarket], portfolio: null, assetPrices: {} });
+
+		const { getByText } = render(LiquidiumSupplyTokensList, {
+			props: { onSelectMarket: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
+		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
@@ -12,7 +12,11 @@ describe('lend-borrow.config', () => {
 			expect(liquidiumSupplyWizardSteps({ i18n: en })).toStrictEqual([
 				{ name: WizardStepsLiquidiumSupply.SUPPLY, title: en.liquidium.text.action_supply },
 				{ name: WizardStepsLiquidiumSupply.REVIEW, title: en.liquidium.text.supply_review },
-				{ name: WizardStepsLiquidiumSupply.SUPPLYING, title: en.liquidium.text.supplying }
+				{ name: WizardStepsLiquidiumSupply.SUPPLYING, title: en.liquidium.text.supplying },
+				{
+					name: WizardStepsLiquidiumSupply.TOKENS_LIST,
+					title: en.liquidium.text.select_supply_token
+				}
 			]);
 		});
 	});

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -13,6 +13,7 @@ import {
 	liquidiumMinBorrowApy,
 	liquidiumNetValueUsd,
 	liquidiumPortfolio,
+	liquidiumSupplyMarkets,
 	liquidiumTotalBorrowedUsd
 } from '$lib/derived/liquidium.derived';
 import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
@@ -219,6 +220,49 @@ describe('liquidium derived stores', () => {
 
 		it('is null by default', () => {
 			expect(get(liquidiumPortfolio)).toBeNull();
+		});
+	});
+
+	describe('liquidiumSupplyMarkets', () => {
+		it('keeps only available markets', () => {
+			liquidiumStore.set({
+				markets: [market(), market({ poolId: 'pool-eth', available: false })],
+				portfolio: null,
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumSupplyMarkets)).toEqual([market()]);
+		});
+
+		it('excludes markets the user has borrowed', () => {
+			liquidiumStore.set({
+				markets: [market(), market({ poolId: 'pool-eth', asset: 'USDC', chain: 'ETH' })],
+				portfolio: {
+					...portfolio,
+					reserves: [
+						{
+							poolId: 'pool-eth',
+							asset: 'USDC',
+							chain: 'ETH',
+							supplyApy: 0,
+							borrowApy: 8,
+							deposited: ZERO,
+							depositedDecimals: 6,
+							borrowed: 1_000n,
+							borrowedDecimals: 6,
+							suppliedUsd: 0,
+							borrowedUsd: 2000
+						}
+					]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumSupplyMarkets)).toEqual([market()]);
+		});
+
+		it('is empty by default', () => {
+			expect(get(liquidiumSupplyMarkets)).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The Liquidium Supply modal only ever supplied the token of the market card it was launched from — there was no way to switch tokens inside the wizard, and no way to open the flow without a pre-selected market. This adds an in-wizard token selector (mirroring the Swap/Trade flows) so the user can change the supplied token from the amount input, and makes the modal usable as a "neutral" entry point (no market pre-selected) for the upcoming box-header "+ Supply" action.
