### PR TITLE
feat(frontend): token selector step for Liquidium Borrow

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumSelectTokenForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSelectTokenForm.svelte
@@ -11,10 +11,11 @@
 	interface Props {
 		onSelectToken: () => void;
 		onClose: () => void;
+		topBanner?: Snippet;
 		children?: Snippet;
 	}
 
-	let { onSelectToken, onClose, children }: Props = $props();
+	let { onSelectToken, onClose, children, topBanner }: Props = $props();
 
 	// No token is chosen yet, so the amount is inert until one is picked; TokenInput
 	// still requires a bindable amount plus its info/balance snippets.
@@ -22,6 +23,8 @@
 </script>
 
 <ContentWithToolbar>
+	{@render topBanner?.()}
+
 	<div class="mb-8">
 		<TokenInput isSelectable onClick={onSelectToken} showTokenNetwork token={undefined} bind:amount>
 			{#snippet title()}{$i18n.core.text.amount}{/snippet}

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte
@@ -3,6 +3,7 @@
 	import { getMinimumBorrowAmount } from '@liquidium/client';
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import LiquidiumHealthFactor from '$lib/components/liquidium/LiquidiumHealthFactor.svelte';
+	import LiquidiumBorrowSummary from '$lib/components/liquidium/borrow/LiquidiumBorrowSummary.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -14,17 +15,14 @@
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { LIQUIDIUM_BORROWING_POWER_TOLERANCE } from '$lib/constants/liquidium.constants';
-	import { currentCurrency } from '$lib/derived/currency.derived';
-	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import type { LiquidiumBorrowPreview } from '$lib/services/liquidium-borrow.services';
-	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
 	import { isDesktop } from '$lib/utils/device.utils';
-	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+	import { formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 
@@ -36,6 +34,8 @@
 		preview: LiquidiumBorrowPreview;
 		amount: OptionAmount;
 		confirmChecked: boolean;
+		// Opens the token-selection step; when set, the token logo becomes a selector.
+		onSelectToken?: () => void;
 		onClose: () => void;
 		onNext: () => void;
 	}
@@ -48,6 +48,7 @@
 		preview,
 		amount = $bindable(),
 		confirmChecked = $bindable(),
+		onSelectToken,
 		onClose,
 		onNext
 	}: Props = $props();
@@ -82,14 +83,6 @@
 	let belowMinimum = $derived(
 		hasAmount && nonNullish(parsedAmount) && parsedAmount < getMinimumBorrowAmount(market.asset)
 	);
-
-	const formatUsd = (value: number) =>
-		formatCurrency({
-			value,
-			currency: $currentCurrency,
-			exchangeRate: $currencyExchangeStore,
-			language: $currentLanguage
-		});
 
 	let minBorrowFormatted = $derived(
 		nonNullish(borrowToken)
@@ -134,25 +127,15 @@
 </script>
 
 <ContentWithToolbar>
-	<div class="mb-4 flex flex-col rounded-xl bg-secondary p-3">
-		<ModalValue>
-			{#snippet label()}{$i18n.liquidium.text.collateral}{/snippet}
-			{#snippet mainValue()}{formatUsd(portfolio.totalSuppliedUsd)}{/snippet}
-		</ModalValue>
-
-		<ModalValue>
-			{#snippet label()}{$i18n.liquidium.text.borrowing_power}{/snippet}
-			{#snippet mainValue()}{formatUsd(portfolio.availableBorrowsUsd)}{/snippet}
-		</ModalValue>
-	</div>
+	<LiquidiumBorrowSummary {portfolio} />
 
 	<div class="mb-6">
-		<!-- Token fixed by the market for now; a selectable step comes later. -->
 		<TokenInput
 			autofocus={isDesktop()}
 			displayUnit={inputUnit}
 			exchangeRate={borrowPrice}
-			isSelectable={false}
+			isSelectable={nonNullish(onSelectToken)}
+			onClick={onSelectToken}
 			onCustomErrorValidate={validateBorrowAmount}
 			showTokenNetwork
 			token={borrowToken}

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { setContext } from 'svelte';
+	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumBorrowForm from '$lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte';
 	import LiquidiumBorrowProgress from '$lib/components/liquidium/borrow/LiquidiumBorrowProgress.svelte';
 	import LiquidiumBorrowReview from '$lib/components/liquidium/borrow/LiquidiumBorrowReview.svelte';
+	import LiquidiumBorrowSummary from '$lib/components/liquidium/borrow/LiquidiumBorrowSummary.svelte';
+	import LiquidiumBorrowTokensList from '$lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte';
+	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumBorrowWizardSteps } from '$lib/config/lend-borrow.config';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
@@ -16,6 +21,11 @@
 		executeLiquidiumBorrow
 	} from '$lib/services/liquidium-borrow.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		initModalTokensListContext,
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
@@ -23,13 +33,18 @@
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	interface Props {
 		// Borrow market (asset/pool); collateral is the whole portfolio, none is selected.
-		market: LiquidiumMarket;
+		market?: LiquidiumMarket;
 	}
 
 	let { market }: Props = $props();
+
+	// Seeded from the initial prop only; later switches happen through the picker.
+	// svelte-ignore state_referenced_locally
+	let selectedMarket = $state<LiquidiumMarket | undefined>(market);
 
 	let modal: WizardModal<WizardStepsLiquidiumBorrow> | undefined = $state();
 	let currentStep: WizardStep<WizardStepsLiquidiumBorrow> | undefined = $state();
@@ -37,12 +52,19 @@
 	let confirmChecked = $state(false);
 	let borrowProgressStep: string = $state(ProgressStepsLiquidiumBorrow.INITIALIZATION);
 
+	const tokensListContext = initModalTokensListContext({ tokens: [] });
+	setContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY, tokensListContext);
+
 	const steps: WizardSteps<WizardStepsLiquidiumBorrow> = $derived(
 		liquidiumBorrowWizardSteps({ i18n: $i18n })
 	);
 
-	let borrowToken = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
-	let borrowPrice = $derived($liquidiumAssetPrices[market.asset] ?? 0);
+	let borrowToken = $derived(
+		nonNullish(selectedMarket) ? LIQUIDIUM_ASSET_TOKENS[selectedMarket.asset] : undefined
+	);
+	let borrowPrice = $derived(
+		nonNullish(selectedMarket) ? ($liquidiumAssetPrices[selectedMarket.asset] ?? 0) : 0
+	);
 
 	let newBorrowUsd = $derived((Number(amount) || 0) * borrowPrice);
 
@@ -60,13 +82,49 @@
 	);
 
 	// Borrowed asset is delivered to the user's own oisy address on the pool's chain.
-	let receiverAddress = $derived(market.chain === 'BTC' ? $btcAddressMainnet : $ethAddress);
+	let receiverAddress = $derived(
+		selectedMarket?.chain === 'BTC' ? $btcAddressMainnet : $ethAddress
+	);
 
+	const goToStep = (stepName: WizardStepsLiquidiumBorrow) => {
+		if (nonNullish(modal)) {
+			goToWizardStep({ modal, steps, stepName });
+		}
+	};
+
+	// Always enter the picker with a clean query so it never reopens filtered from a
+	// previous visit (mirrors the swap / trade-deposit flows).
+	const enterTokensList = () => {
+		tokensListContext.setFilterQuery('');
+		goToStep(WizardStepsLiquidiumBorrow.TOKENS_LIST);
+	};
+
+	// Cancelling the picker returns to the Borrow step — the amount form when a market
+	// is chosen, or the select-token prompt on a neutral launch.
+	const closeTokensList = () => {
+		tokensListContext.setFilterQuery('');
+		goToStep(WizardStepsLiquidiumBorrow.BORROW);
+	};
+
+	const selectMarket = (nextMarket: LiquidiumMarket) => {
+		selectedMarket = nextMarket;
+		// The typed amount is token-specific; drop it when switching.
+		amount = undefined;
+		confirmChecked = false;
+		closeTokensList();
+	};
+
+	// The modal is not guaranteed to unmount between opens, so restore every piece of
+	// launch state — including the selected market and the picker filters — back to what
+	// the initial prop implies; otherwise the next open (or a neutral launch) inherits the
+	// previously picked token / a stale filter query.
 	const reset = () => {
+		selectedMarket = market;
 		amount = undefined;
 		confirmChecked = false;
 		borrowProgressStep = ProgressStepsLiquidiumBorrow.INITIALIZATION;
 		currentStep = undefined;
+		tokensListContext.resetFilters();
 	};
 
 	const close = () => closeModal(reset);
@@ -78,7 +136,8 @@
 			isNullish(identity) ||
 			isNullish($ethAddress) ||
 			isNullish(receiverAddress) ||
-			isNullish(parsedAmount)
+			isNullish(parsedAmount) ||
+			isNullish(selectedMarket)
 		) {
 			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed } });
 			return;
@@ -86,6 +145,7 @@
 
 		const amountBaseUnits = parsedAmount;
 		const receiver = receiverAddress;
+		const { poolId, asset } = selectedMarket;
 
 		modal?.next();
 
@@ -93,8 +153,8 @@
 			await executeLiquidiumBorrow({
 				identity,
 				ethAddress: $ethAddress,
-				poolId: market.poolId,
-				asset: market.asset,
+				poolId,
+				asset,
 				amount: amountBaseUnits,
 				receiverAddress: receiver,
 				displayAmount: `${amount}`,
@@ -121,12 +181,30 @@
 >
 	{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-	{#if nonNullish($liquidiumPortfolio) && nonNullish(preview)}
+	{#if currentStep?.name === WizardStepsLiquidiumBorrow.TOKENS_LIST}
+		<LiquidiumBorrowTokensList
+			onClose={closeTokensList}
+			onSelectMarket={selectMarket}
+			{selectedMarket}
+		/>
+	{:else if isNullish(selectedMarket)}
+		<LiquidiumSelectTokenForm onClose={close} onSelectToken={enterTokensList}>
+			{#snippet topBanner()}
+				{#if nonNullish($liquidiumPortfolio)}
+					<LiquidiumBorrowSummary portfolio={$liquidiumPortfolio} />
+				{/if}
+			{/snippet}
+
+			<MessageBox styleClass="sm:text-sm !items-center">
+				{$i18n.liquidium.text.borrow_risk_info}
+			</MessageBox>
+		</LiquidiumSelectTokenForm>
+	{:else if nonNullish($liquidiumPortfolio) && nonNullish(preview)}
 		{#if currentStep?.name === WizardStepsLiquidiumBorrow.REVIEW}
 			<LiquidiumBorrowReview
 				{amount}
 				{borrowPrice}
-				{market}
+				market={selectedMarket}
 				onBack={() => modal?.back()}
 				onConfirm={borrow}
 				{preview}
@@ -137,9 +215,10 @@
 			<LiquidiumBorrowForm
 				{borrowPrice}
 				{borrowToken}
-				{market}
+				market={selectedMarket}
 				onClose={close}
 				onNext={() => modal?.next()}
+				onSelectToken={enterTokensList}
 				portfolio={$liquidiumPortfolio}
 				{preview}
 				bind:amount

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowSummary.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowSummary.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumPortfolio } from '$lib/types/liquidium';
+	import { formatCurrency } from '$lib/utils/format.utils';
+
+	interface Props {
+		portfolio: LiquidiumPortfolio;
+	}
+
+	let { portfolio }: Props = $props();
+
+	const formatUsd = (value: number) =>
+		formatCurrency({
+			value,
+			currency: $currentCurrency,
+			exchangeRate: $currencyExchangeStore,
+			language: $currentLanguage
+		});
+</script>
+
+<div class="mb-4 flex flex-col rounded-xl bg-secondary p-3">
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.collateral}{/snippet}
+		{#snippet mainValue()}{formatUsd(portfolio.totalSuppliedUsd)}{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}{$i18n.liquidium.text.borrowing_power}{/snippet}
+		{#snippet mainValue()}{formatUsd(portfolio.availableBorrowsUsd)}{/snippet}
+	</ModalValue>
+</div>

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
+	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { liquidiumBorrowMarkets } from '$lib/derived/liquidium.derived';
+	import {
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { Token } from '$lib/types/token';
+
+	interface Props {
+		// Omitted on a neutral (token-less) launch — then nothing is excluded.
+		selectedMarket?: LiquidiumMarket;
+		onSelectMarket: (market: LiquidiumMarket) => void;
+		onClose: () => void;
+	}
+
+	let { selectedMarket, onSelectMarket, onClose }: Props = $props();
+
+	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
+
+	let entries = $derived(
+		$liquidiumBorrowMarkets
+			.map((market) => ({ market, token: LIQUIDIUM_ASSET_TOKENS[market.asset] }))
+			.filter(
+				(entry): entry is { market: LiquidiumMarket; token: Token } =>
+					nonNullish(entry.token) && entry.market.poolId !== selectedMarket?.poolId
+			)
+	);
+
+	$effect(() => {
+		setTokens(entries.map(({ token }) => token));
+	});
+
+	const onTokenButtonClick = (token: Token) => {
+		const entry = entries.find(({ token: { id } }) => id === token.id);
+
+		if (nonNullish(entry)) {
+			onSelectMarket(entry.market);
+		}
+	};
+</script>
+
+<ModalTokensList networkSelectorViewOnly {onTokenButtonClick}>
+	{#snippet tokenListItem(token, onClick)}
+		<ModalTokensListItem {onClick} {token} />
+	{/snippet}
+	{#snippet toolbar()}
+		<ButtonCancel fullWidth onclick={onClose} />
+	{/snippet}
+</ModalTokensList>

--- a/src/frontend/src/lib/config/lend-borrow.config.ts
+++ b/src/frontend/src/lib/config/lend-borrow.config.ts
@@ -55,6 +55,10 @@ export const liquidiumBorrowWizardSteps = ({
 	{
 		name: WizardStepsLiquidiumBorrow.BORROWING,
 		title: i18n.liquidium.text.borrowing
+	},
+	{
+		name: WizardStepsLiquidiumBorrow.TOKENS_LIST,
+		title: i18n.liquidium.text.select_borrow_token
 	}
 ];
 

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -43,6 +43,18 @@ export const liquidiumSupplyMarkets: Readable<LiquidiumMarket[]> = derived(
 		)
 );
 
+export const liquidiumBorrowMarkets: Readable<LiquidiumMarket[]> = derived(
+	[liquidiumMarkets, liquidiumPortfolio],
+	([markets, portfolio]) =>
+		markets.filter(
+			({ available, poolId }) =>
+				available &&
+				!(portfolio?.reserves ?? []).some(
+					(reserve) => reserve.poolId === poolId && reserve.deposited > ZERO
+				)
+		)
+);
+
 // SDK USD prices for the borrow form's USD / fiat math.
 export const liquidiumAssetPrices: Readable<AssetPrices> = derived(
 	liquidiumStore,

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -104,7 +104,8 @@ export enum WizardStepsLiquidiumSupply {
 export enum WizardStepsLiquidiumBorrow {
 	BORROW = 'Borrow',
 	REVIEW = 'Review',
-	BORROWING = 'Borrowing'
+	BORROWING = 'Borrowing',
+	TOKENS_LIST = 'Tokens List'
 }
 
 export enum WizardStepsLiquidiumWithdraw {

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "",
 			"transaction_failed": "",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "",
 			"supply_review_subtitle": "",
 			"supplying": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Vybrat",
 			"transaction_failed": "Transakce se nezdařila",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Zkontrolovat poskytnutí",
 			"supply_review_subtitle": "Poskytuješ",
 			"supplying": "Probíhá poskytnutí",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Abheben",
 			"transaction_failed": "Transaktion fehlgeschlagen",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Bereitstellung prüfen",
 			"supply_review_subtitle": "Du stellst bereit",
 			"supplying": "Bereitstellung läuft",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Withdraw",
 			"transaction_failed": "Transaction failed",
 			"select_supply_token": "Select token to supply",
+			"select_borrow_token": "Select token to borrow",
 			"supply_review": "Review supply",
 			"supply_review_subtitle": "You supply",
 			"supplying": "Supplying",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Retirar",
 			"transaction_failed": "La transacción falló",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Revisar suministro",
 			"supply_review_subtitle": "Suministras",
 			"supplying": "Suministrando",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Retirer",
 			"transaction_failed": "La transaction a échoué",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Vérifier l'apport",
 			"supply_review_subtitle": "Vous fournissez",
 			"supplying": "Fourniture en cours",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "निकालें",
 			"transaction_failed": "लेन-देन विफल रहा",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "जमा की समीक्षा करें",
 			"supply_review_subtitle": "आप जमा कर रहे हैं",
 			"supplying": "जमा हो रहा है",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Preleva",
 			"transaction_failed": "Transazione non riuscita",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Rivedi fornitura",
 			"supply_review_subtitle": "Fornisci",
 			"supplying": "Fornitura in corso",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "引き出す",
 			"transaction_failed": "トランザクションが失敗しました",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "供給内容を確認",
 			"supply_review_subtitle": "供給する",
 			"supplying": "供給中",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "출금",
 			"transaction_failed": "트랜잭션 실패",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "공급 검토",
 			"supply_review_subtitle": "공급 금액",
 			"supplying": "공급 중",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Wypłać",
 			"transaction_failed": "Transakcja nie powiodła się",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Sprawdź dostarczenie",
 			"supply_review_subtitle": "Dostarczasz",
 			"supplying": "Trwa dostarczanie",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Retirar",
 			"transaction_failed": "A transação falhou",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Rever fornecimento",
 			"supply_review_subtitle": "Forneces",
 			"supplying": "A fornecer",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Вывести",
 			"transaction_failed": "Транзакция не удалась",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Проверить предоставление",
 			"supply_review_subtitle": "Ты предоставляешь",
 			"supplying": "Предоставление в процессе",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "Rút tiền",
 			"transaction_failed": "Giao dịch thất bại",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "Xem lại khoản cung cấp",
 			"supply_review_subtitle": "Bạn cung cấp",
 			"supplying": "Đang cung cấp",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2386,6 +2386,7 @@
 			"action_withdraw": "提取",
 			"transaction_failed": "交易失败",
 			"select_supply_token": "",
+			"select_borrow_token": "",
 			"supply_review": "查看提供详情",
 			"supply_review_subtitle": "您提供",
 			"supplying": "提供中",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1922,6 +1922,7 @@ interface I18nLiquidium {
 		action_withdraw: string;
 		transaction_failed: string;
 		select_supply_token: string;
+		select_borrow_token: string;
 		supply_review: string;
 		supply_review_subtitle: string;
 		supplying: string;

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -5,6 +5,7 @@ import type {
 	WizardStepsConvert,
 	WizardStepsHowToConvert,
 	WizardStepsLimitOrder,
+	WizardStepsLiquidiumBorrow,
 	WizardStepsLiquidiumSupply,
 	WizardStepsReceive,
 	WizardStepsScanner,
@@ -30,7 +31,8 @@ type StepName =
 	| WizardStepsTradingDeposit
 	| WizardStepsTradingWithdraw
 	| WizardStepsLimitOrder
-	| WizardStepsLiquidiumSupply;
+	| WizardStepsLiquidiumSupply
+	| WizardStepsLiquidiumBorrow;
 
 export const goToWizardStep = <T extends StepName>({
 	modal,

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSelectTokenForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSelectTokenForm.spec.ts
@@ -25,6 +25,20 @@ describe('LiquidiumSelectTokenForm', () => {
 		expect(onSelectToken).toHaveBeenCalled();
 	});
 
+	it('renders the top banner above the input', () => {
+		const { getByTestId } = render(LiquidiumSelectTokenForm, {
+			props: {
+				onSelectToken: () => {},
+				onClose: () => {},
+				topBanner: createRawSnippet(() => ({
+					render: () => `<span data-tid="top-banner">Top banner content</span>`
+				}))
+			}
+		});
+
+		expect(getByTestId('top-banner')).toBeInTheDocument();
+	});
+
 	it('renders form-specific children below the input', () => {
 		const { getByTestId } = render(LiquidiumSelectTokenForm, {
 			props: {

--- a/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.spec.ts
@@ -1,0 +1,82 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumBorrowTokensList from '$lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte';
+import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import {
+	initModalTokensListContext,
+	MODAL_TOKENS_LIST_CONTEXT_KEY
+} from '$lib/stores/modal-tokens-list.store';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('LiquidiumBorrowTokensList', () => {
+	const btcMarket: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
+	const usdcMarket: LiquidiumMarket = {
+		poolId: 'pool-usdc',
+		asset: 'USDC',
+		chain: 'ETH',
+		supplyApy: 3,
+		borrowApy: 4,
+		frozen: false,
+		available: true
+	};
+
+	const context = new Map([
+		[MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] })]
+	]);
+
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('lists the borrow-available tokens except the selected one', () => {
+		liquidiumStore.set({ markets: [btcMarket, usdcMarket], portfolio: null, assetPrices: {} });
+
+		const { getByTestId, getByText, queryByText } = render(LiquidiumBorrowTokensList, {
+			props: { selectedMarket: btcMarket, onSelectMarket: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
+		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+		// The selected token is hidden from its own picker.
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+	});
+
+	it('selects the market matching the clicked token', async () => {
+		liquidiumStore.set({ markets: [btcMarket, usdcMarket], portfolio: null, assetPrices: {} });
+
+		const onSelectMarket = vi.fn();
+
+		const { getByText } = render(LiquidiumBorrowTokensList, {
+			props: { selectedMarket: btcMarket, onSelectMarket, onClose: () => {} },
+			context
+		});
+
+		await fireEvent.click(getByText(USDC_TOKEN.symbol));
+
+		expect(onSelectMarket).toHaveBeenCalledWith(usdcMarket);
+	});
+
+	it('lists every available token when no market is selected (neutral launch)', () => {
+		liquidiumStore.set({ markets: [btcMarket, usdcMarket], portfolio: null, assetPrices: {} });
+
+		const { getByText } = render(LiquidiumBorrowTokensList, {
+			props: { onSelectMarket: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
+		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
@@ -1,8 +1,9 @@
 import {
 	lendBorrowProvidersConfig,
+	liquidiumBorrowWizardSteps,
 	liquidiumSupplyWizardSteps
 } from '$lib/config/lend-borrow.config';
-import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import { WizardStepsLiquidiumBorrow, WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
 import { LendBorrowProvider } from '$lib/types/lend-borrow';
 import en from '$tests/mocks/i18n.mock';
 
@@ -16,6 +17,20 @@ describe('lend-borrow.config', () => {
 				{
 					name: WizardStepsLiquidiumSupply.TOKENS_LIST,
 					title: en.liquidium.text.select_supply_token
+				}
+			]);
+		});
+	});
+
+	describe('liquidiumBorrowWizardSteps', () => {
+		it('returns the borrow wizard steps with expected names and titles', () => {
+			expect(liquidiumBorrowWizardSteps({ i18n: en })).toStrictEqual([
+				{ name: WizardStepsLiquidiumBorrow.BORROW, title: en.liquidium.text.action_borrow },
+				{ name: WizardStepsLiquidiumBorrow.REVIEW, title: en.liquidium.text.borrow_review },
+				{ name: WizardStepsLiquidiumBorrow.BORROWING, title: en.liquidium.text.borrowing },
+				{
+					name: WizardStepsLiquidiumBorrow.TOKENS_LIST,
+					title: en.liquidium.text.select_borrow_token
 				}
 			]);
 		});

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -5,6 +5,7 @@ import {
 	liquidiumBorrowData,
 	liquidiumBorrowingPowerUsd,
 	liquidiumBorrowInterestUsd,
+	liquidiumBorrowMarkets,
 	liquidiumEarningData,
 	liquidiumHealthFactorPercent,
 	liquidiumMarkets,
@@ -263,6 +264,49 @@ describe('liquidium derived stores', () => {
 
 		it('is empty by default', () => {
 			expect(get(liquidiumSupplyMarkets)).toEqual([]);
+		});
+	});
+
+	describe('liquidiumBorrowMarkets', () => {
+		it('keeps only available markets', () => {
+			liquidiumStore.set({
+				markets: [market(), market({ poolId: 'pool-eth', available: false })],
+				portfolio: null,
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumBorrowMarkets)).toEqual([market()]);
+		});
+
+		it('excludes markets the user has supplied', () => {
+			liquidiumStore.set({
+				markets: [market(), market({ poolId: 'pool-eth', asset: 'USDC', chain: 'ETH' })],
+				portfolio: {
+					...portfolio,
+					reserves: [
+						{
+							poolId: 'pool-eth',
+							asset: 'USDC',
+							chain: 'ETH',
+							supplyApy: 3,
+							borrowApy: 0,
+							deposited: 1_000n,
+							depositedDecimals: 6,
+							borrowed: ZERO,
+							borrowedDecimals: 6,
+							suppliedUsd: 2000,
+							borrowedUsd: 0
+						}
+					]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumBorrowMarkets)).toEqual([market()]);
+		});
+
+		it('is empty by default', () => {
+			expect(get(liquidiumBorrowMarkets)).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

This PR brings the Borrow flow to parity with the recently-added Supply token selector. Users can now switch the borrow asset from inside the flow instead of being locked to the token they launched from, using the exact same picker patterns as Supply.
