### PR TITLE
feat(frontend): token selector step for Liquidium Withdraw

### DIFF
--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte
@@ -31,6 +31,8 @@
 		preview: LiquidiumWithdrawPreview;
 		amount: OptionAmount;
 		confirmChecked: boolean;
+		// Opens the token-selection step; when set, the token logo becomes a selector.
+		onSelectToken?: () => void;
 		onClose: () => void;
 		onNext: () => void;
 	}
@@ -43,6 +45,7 @@
 		preview,
 		amount = $bindable(),
 		confirmChecked = $bindable(),
+		onSelectToken,
 		onClose,
 		onNext
 	}: Props = $props();
@@ -131,7 +134,8 @@
 			autofocus={isDesktop()}
 			displayUnit={inputUnit}
 			exchangeRate={withdrawPrice}
-			isSelectable={false}
+			isSelectable={nonNullish(onSelectToken)}
+			onClick={onSelectToken}
 			onCustomErrorValidate={validateWithdrawAmount}
 			showTokenNetwork
 			token={withdrawToken}

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { setContext } from 'svelte';
+	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumWithdrawForm from '$lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte';
 	import LiquidiumWithdrawProgress from '$lib/components/liquidium/withdraw/LiquidiumWithdrawProgress.svelte';
 	import LiquidiumWithdrawReview from '$lib/components/liquidium/withdraw/LiquidiumWithdrawReview.svelte';
+	import LiquidiumWithdrawTokensList from '$lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumWithdrawWizardSteps } from '$lib/config/lend-borrow.config';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
@@ -16,6 +19,11 @@
 		executeLiquidiumWithdraw
 	} from '$lib/services/liquidium-withdraw.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		initModalTokensListContext,
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
@@ -23,12 +31,18 @@
 	import { invalidAmount } from '$lib/utils/input.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	interface Props {
-		reserve: LiquidiumReserve;
+		// Supplied position to withdraw from; token-less launches pick one via the picker.
+		reserve?: LiquidiumReserve;
 	}
 
 	let { reserve }: Props = $props();
+
+	// Seeded from the initial prop only; later switches happen through the picker.
+	// svelte-ignore state_referenced_locally
+	let selectedReserve = $state<LiquidiumReserve | undefined>(reserve);
 
 	let modal: WizardModal<WizardStepsLiquidiumWithdraw> | undefined = $state();
 	let currentStep: WizardStep<WizardStepsLiquidiumWithdraw> | undefined = $state();
@@ -36,18 +50,29 @@
 	let confirmChecked = $state(false);
 	let withdrawProgressStep: string = $state(ProgressStepsLiquidiumWithdraw.INITIALIZATION);
 
+	const tokensListContext = initModalTokensListContext({ tokens: [] });
+	setContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY, tokensListContext);
+
 	const steps: WizardSteps<WizardStepsLiquidiumWithdraw> = $derived(
 		liquidiumWithdrawWizardSteps({ i18n: $i18n })
 	);
 
-	let withdrawToken = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
-	let withdrawPrice = $derived($liquidiumAssetPrices[reserve.asset] ?? 0);
+	let withdrawToken = $derived(
+		nonNullish(selectedReserve) ? LIQUIDIUM_ASSET_TOKENS[selectedReserve.asset] : undefined
+	);
+	let withdrawPrice = $derived(
+		nonNullish(selectedReserve) ? ($liquidiumAssetPrices[selectedReserve.asset] ?? 0) : 0
+	);
 
 	let withdrawUsd = $derived((Number(amount) || 0) * withdrawPrice);
 
 	let preview = $derived(
-		nonNullish($liquidiumPortfolio)
-			? computeLiquidiumWithdrawPreview({ portfolio: $liquidiumPortfolio, reserve, withdrawUsd })
+		nonNullish($liquidiumPortfolio) && nonNullish(selectedReserve)
+			? computeLiquidiumWithdrawPreview({
+					portfolio: $liquidiumPortfolio,
+					reserve: selectedReserve,
+					withdrawUsd
+				})
 			: undefined
 	);
 
@@ -57,13 +82,49 @@
 			: undefined
 	);
 
-	let receiverAddress = $derived(reserve.chain === 'BTC' ? $btcAddressMainnet : $ethAddress);
+	let receiverAddress = $derived(
+		selectedReserve?.chain === 'BTC' ? $btcAddressMainnet : $ethAddress
+	);
 
+	const goToStep = (stepName: WizardStepsLiquidiumWithdraw) => {
+		if (nonNullish(modal)) {
+			goToWizardStep({ modal, steps, stepName });
+		}
+	};
+
+	// Always enter the picker with a clean query so it never reopens filtered from a
+	// previous visit (mirrors the swap / trade-deposit flows).
+	const enterTokensList = () => {
+		tokensListContext.setFilterQuery('');
+		goToStep(WizardStepsLiquidiumWithdraw.TOKENS_LIST);
+	};
+
+	// Cancelling the picker returns to the Withdraw step — the amount form when a position
+	// is chosen, or the select-token prompt on a neutral launch.
+	const closeTokensList = () => {
+		tokensListContext.setFilterQuery('');
+		goToStep(WizardStepsLiquidiumWithdraw.WITHDRAW);
+	};
+
+	const selectReserve = (nextReserve: LiquidiumReserve) => {
+		selectedReserve = nextReserve;
+		// The typed amount is token-specific; drop it when switching.
+		amount = undefined;
+		confirmChecked = false;
+		closeTokensList();
+	};
+
+	// The modal is not guaranteed to unmount between opens, so restore every piece of
+	// launch state — including the selected reserve and the picker filters — back to what
+	// the initial prop implies; otherwise the next open (or a neutral launch) inherits the
+	// previously picked token / a stale filter query.
 	const reset = () => {
+		selectedReserve = reserve;
 		amount = undefined;
 		confirmChecked = false;
 		withdrawProgressStep = ProgressStepsLiquidiumWithdraw.INITIALIZATION;
 		currentStep = undefined;
+		tokensListContext.resetFilters();
 	};
 
 	const close = () => closeModal(reset);
@@ -75,7 +136,8 @@
 			isNullish(identity) ||
 			isNullish($ethAddress) ||
 			isNullish(receiverAddress) ||
-			isNullish(parsedAmount)
+			isNullish(parsedAmount) ||
+			isNullish(selectedReserve)
 		) {
 			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed } });
 			return;
@@ -83,6 +145,7 @@
 
 		const amountBaseUnits = parsedAmount;
 		const receiver = receiverAddress;
+		const { poolId, asset } = selectedReserve;
 
 		modal?.next();
 
@@ -90,8 +153,8 @@
 			await executeLiquidiumWithdraw({
 				identity,
 				ethAddress: $ethAddress,
-				poolId: reserve.poolId,
-				asset: reserve.asset,
+				poolId,
+				asset,
 				amount: amountBaseUnits,
 				receiverAddress: receiver,
 				displayAmount: `${amount}`,
@@ -118,14 +181,22 @@
 >
 	{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-	{#if nonNullish($liquidiumPortfolio) && nonNullish(preview)}
+	{#if currentStep?.name === WizardStepsLiquidiumWithdraw.TOKENS_LIST}
+		<LiquidiumWithdrawTokensList
+			onClose={closeTokensList}
+			onSelectReserve={selectReserve}
+			{selectedReserve}
+		/>
+	{:else if isNullish(selectedReserve)}
+		<LiquidiumSelectTokenForm onClose={close} onSelectToken={enterTokensList} />
+	{:else if nonNullish($liquidiumPortfolio) && nonNullish(preview)}
 		{#if currentStep?.name === WizardStepsLiquidiumWithdraw.REVIEW}
 			<LiquidiumWithdrawReview
 				{amount}
 				onBack={() => modal?.back()}
 				onConfirm={withdraw}
 				{preview}
-				{reserve}
+				reserve={selectedReserve}
 				{withdrawPrice}
 			/>
 		{:else if currentStep?.name === WizardStepsLiquidiumWithdraw.WITHDRAWING}
@@ -134,9 +205,10 @@
 			<LiquidiumWithdrawForm
 				onClose={close}
 				onNext={() => modal?.next()}
+				onSelectToken={enterTokensList}
 				portfolio={$liquidiumPortfolio}
 				{preview}
-				{reserve}
+				reserve={selectedReserve}
 				{withdrawPrice}
 				{withdrawToken}
 				bind:amount

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
+	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { liquidiumWithdrawReserves } from '$lib/derived/liquidium.derived';
+	import {
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
+	import type { LiquidiumReserve } from '$lib/types/liquidium';
+	import type { Token } from '$lib/types/token';
+
+	interface Props {
+		// Omitted on a neutral (token-less) launch — then nothing is excluded.
+		selectedReserve?: LiquidiumReserve;
+		onSelectReserve: (reserve: LiquidiumReserve) => void;
+		onClose: () => void;
+	}
+
+	let { selectedReserve, onSelectReserve, onClose }: Props = $props();
+
+	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
+
+	let entries = $derived(
+		$liquidiumWithdrawReserves
+			.map((reserve) => ({ reserve, token: LIQUIDIUM_ASSET_TOKENS[reserve.asset] }))
+			.filter(
+				(entry): entry is { reserve: LiquidiumReserve; token: Token } =>
+					nonNullish(entry.token) && entry.reserve.poolId !== selectedReserve?.poolId
+			)
+	);
+
+	$effect(() => {
+		setTokens(entries.map(({ token }) => token));
+	});
+
+	const onTokenButtonClick = (token: Token) => {
+		const entry = entries.find(({ token: { id } }) => id === token.id);
+
+		if (nonNullish(entry)) {
+			onSelectReserve(entry.reserve);
+		}
+	};
+</script>
+
+<ModalTokensList networkSelectorViewOnly {onTokenButtonClick}>
+	{#snippet tokenListItem(token, onClick)}
+		<ModalTokensListItem {onClick} {token} />
+	{/snippet}
+	{#snippet toolbar()}
+		<ButtonCancel fullWidth onclick={onClose} />
+	{/snippet}
+</ModalTokensList>

--- a/src/frontend/src/lib/config/lend-borrow.config.ts
+++ b/src/frontend/src/lib/config/lend-borrow.config.ts
@@ -76,6 +76,10 @@ export const liquidiumWithdrawWizardSteps = ({
 	{
 		name: WizardStepsLiquidiumWithdraw.WITHDRAWING,
 		title: i18n.liquidium.text.withdrawing
+	},
+	{
+		name: WizardStepsLiquidiumWithdraw.TOKENS_LIST,
+		title: i18n.liquidium.text.select_withdraw_token
 	}
 ];
 

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -6,7 +6,7 @@ import { AppPath } from '$lib/constants/routes.constants';
 import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
 import type { EarningProviderData } from '$lib/types/earning-provider';
-import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
+import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import type { Token } from '$lib/types/token';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import {
@@ -53,6 +53,12 @@ export const liquidiumBorrowMarkets: Readable<LiquidiumMarket[]> = derived(
 					(reserve) => reserve.poolId === poolId && reserve.deposited > ZERO
 				)
 		)
+);
+
+// Positions the user can withdraw from: reserves with a supplied balance.
+export const liquidiumWithdrawReserves: Readable<LiquidiumReserve[]> = derived(
+	liquidiumPortfolio,
+	(portfolio) => (portfolio?.reserves ?? []).filter(({ deposited }) => deposited > ZERO)
 );
 
 // SDK USD prices for the borrow form's USD / fiat math.

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -111,7 +111,8 @@ export enum WizardStepsLiquidiumBorrow {
 export enum WizardStepsLiquidiumWithdraw {
 	WITHDRAW = 'Withdraw',
 	REVIEW = 'Review',
-	WITHDRAWING = 'Withdrawing'
+	WITHDRAWING = 'Withdrawing',
+	TOKENS_LIST = 'Tokens List'
 }
 
 export enum WizardStepsLiquidiumRepay {

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "",
 			"supply_review_subtitle": "",
 			"supplying": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "Transakce se nezdařila",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Zkontrolovat poskytnutí",
 			"supply_review_subtitle": "Poskytuješ",
 			"supplying": "Probíhá poskytnutí",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "Transaktion fehlgeschlagen",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Bereitstellung prüfen",
 			"supply_review_subtitle": "Du stellst bereit",
 			"supplying": "Bereitstellung läuft",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "Transaction failed",
 			"select_supply_token": "Select token to supply",
 			"select_borrow_token": "Select token to borrow",
+			"select_withdraw_token": "Select token to withdraw",
 			"supply_review": "Review supply",
 			"supply_review_subtitle": "You supply",
 			"supplying": "Supplying",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "La transacción falló",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Revisar suministro",
 			"supply_review_subtitle": "Suministras",
 			"supplying": "Suministrando",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "La transaction a échoué",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Vérifier l'apport",
 			"supply_review_subtitle": "Vous fournissez",
 			"supplying": "Fourniture en cours",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "लेन-देन विफल रहा",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "जमा की समीक्षा करें",
 			"supply_review_subtitle": "आप जमा कर रहे हैं",
 			"supplying": "जमा हो रहा है",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "Transazione non riuscita",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Rivedi fornitura",
 			"supply_review_subtitle": "Fornisci",
 			"supplying": "Fornitura in corso",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "トランザクションが失敗しました",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "供給内容を確認",
 			"supply_review_subtitle": "供給する",
 			"supplying": "供給中",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "트랜잭션 실패",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "공급 검토",
 			"supply_review_subtitle": "공급 금액",
 			"supplying": "공급 중",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "Transakcja nie powiodła się",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Sprawdź dostarczenie",
 			"supply_review_subtitle": "Dostarczasz",
 			"supplying": "Trwa dostarczanie",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "A transação falhou",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Rever fornecimento",
 			"supply_review_subtitle": "Forneces",
 			"supplying": "A fornecer",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "Транзакция не удалась",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Проверить предоставление",
 			"supply_review_subtitle": "Ты предоставляешь",
 			"supplying": "Предоставление в процессе",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "Giao dịch thất bại",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "Xem lại khoản cung cấp",
 			"supply_review_subtitle": "Bạn cung cấp",
 			"supplying": "Đang cung cấp",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2387,6 +2387,7 @@
 			"transaction_failed": "交易失败",
 			"select_supply_token": "",
 			"select_borrow_token": "",
+			"select_withdraw_token": "",
 			"supply_review": "查看提供详情",
 			"supply_review_subtitle": "您提供",
 			"supplying": "提供中",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1923,6 +1923,7 @@ interface I18nLiquidium {
 		transaction_failed: string;
 		select_supply_token: string;
 		select_borrow_token: string;
+		select_withdraw_token: string;
 		supply_review: string;
 		supply_review_subtitle: string;
 		supplying: string;

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -7,6 +7,7 @@ import type {
 	WizardStepsLimitOrder,
 	WizardStepsLiquidiumBorrow,
 	WizardStepsLiquidiumSupply,
+	WizardStepsLiquidiumWithdraw,
 	WizardStepsReceive,
 	WizardStepsScanner,
 	WizardStepsSend,
@@ -32,7 +33,8 @@ type StepName =
 	| WizardStepsTradingWithdraw
 	| WizardStepsLimitOrder
 	| WizardStepsLiquidiumSupply
-	| WizardStepsLiquidiumBorrow;
+	| WizardStepsLiquidiumBorrow
+	| WizardStepsLiquidiumWithdraw;
 
 export const goToWizardStep = <T extends StepName>({
 	modal,

--- a/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.spec.ts
@@ -1,0 +1,129 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumWithdrawTokensList from '$lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import {
+	initModalTokensListContext,
+	MODAL_TOKENS_LIST_CONTEXT_KEY
+} from '$lib/stores/modal-tokens-list.store';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('LiquidiumWithdrawTokensList', () => {
+	const btcReserve: LiquidiumReserve = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		deposited: 1_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 1000,
+		borrowedUsd: 0
+	};
+
+	const usdcReserve: LiquidiumReserve = {
+		poolId: 'pool-usdc',
+		asset: 'USDC',
+		chain: 'ETH',
+		supplyApy: 3,
+		borrowApy: 4,
+		deposited: 2_000n,
+		depositedDecimals: 6,
+		borrowed: ZERO,
+		borrowedDecimals: 6,
+		suppliedUsd: 2000,
+		borrowedUsd: 0
+	};
+
+	const portfolio = (reserves: LiquidiumReserve[]): LiquidiumPortfolio => ({
+		reserves,
+		totalSuppliedUsd: 3000,
+		totalBorrowedUsd: 0,
+		netValueUsd: 3000,
+		availableBorrowsUsd: 1500,
+		weightedLiquidationThresholdBps: 8000,
+		healthFactorPercent: 100
+	});
+
+	const context = new Map([
+		[MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] })]
+	]);
+
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('lists the supplied positions except the selected one', () => {
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, usdcReserve]),
+			assetPrices: {}
+		});
+
+		const { getByTestId, getByText, queryByText } = render(LiquidiumWithdrawTokensList, {
+			props: { selectedReserve: btcReserve, onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
+		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+		// The selected token is hidden from its own picker.
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+	});
+
+	it('excludes positions with no supplied balance', () => {
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, { ...usdcReserve, deposited: ZERO }]),
+			assetPrices: {}
+		});
+
+		const { getByText, queryByText } = render(LiquidiumWithdrawTokensList, {
+			props: { onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
+		expect(queryByText(USDC_TOKEN.symbol)).toBeNull();
+	});
+
+	it('selects the reserve matching the clicked token', async () => {
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, usdcReserve]),
+			assetPrices: {}
+		});
+
+		const onSelectReserve = vi.fn();
+
+		const { getByText } = render(LiquidiumWithdrawTokensList, {
+			props: { selectedReserve: btcReserve, onSelectReserve, onClose: () => {} },
+			context
+		});
+
+		await fireEvent.click(getByText(USDC_TOKEN.symbol));
+
+		expect(onSelectReserve).toHaveBeenCalledWith(usdcReserve);
+	});
+
+	it('lists every supplied position when none is selected (neutral launch)', () => {
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, usdcReserve]),
+			assetPrices: {}
+		});
+
+		const { getByText } = render(LiquidiumWithdrawTokensList, {
+			props: { onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
+		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
@@ -1,9 +1,14 @@
 import {
 	lendBorrowProvidersConfig,
 	liquidiumBorrowWizardSteps,
-	liquidiumSupplyWizardSteps
+	liquidiumSupplyWizardSteps,
+	liquidiumWithdrawWizardSteps
 } from '$lib/config/lend-borrow.config';
-import { WizardStepsLiquidiumBorrow, WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import {
+	WizardStepsLiquidiumBorrow,
+	WizardStepsLiquidiumSupply,
+	WizardStepsLiquidiumWithdraw
+} from '$lib/enums/wizard-steps';
 import { LendBorrowProvider } from '$lib/types/lend-borrow';
 import en from '$tests/mocks/i18n.mock';
 
@@ -31,6 +36,20 @@ describe('lend-borrow.config', () => {
 				{
 					name: WizardStepsLiquidiumBorrow.TOKENS_LIST,
 					title: en.liquidium.text.select_borrow_token
+				}
+			]);
+		});
+	});
+
+	describe('liquidiumWithdrawWizardSteps', () => {
+		it('returns the withdraw wizard steps with expected names and titles', () => {
+			expect(liquidiumWithdrawWizardSteps({ i18n: en })).toStrictEqual([
+				{ name: WizardStepsLiquidiumWithdraw.WITHDRAW, title: en.liquidium.text.action_withdraw },
+				{ name: WizardStepsLiquidiumWithdraw.REVIEW, title: en.liquidium.text.withdraw_review },
+				{ name: WizardStepsLiquidiumWithdraw.WITHDRAWING, title: en.liquidium.text.withdrawing },
+				{
+					name: WizardStepsLiquidiumWithdraw.TOKENS_LIST,
+					title: en.liquidium.text.select_withdraw_token
 				}
 			]);
 		});

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -15,11 +15,12 @@ import {
 	liquidiumNetValueUsd,
 	liquidiumPortfolio,
 	liquidiumSupplyMarkets,
-	liquidiumTotalBorrowedUsd
+	liquidiumTotalBorrowedUsd,
+	liquidiumWithdrawReserves
 } from '$lib/derived/liquidium.derived';
 import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
-import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
+import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import { liquidiumNetInterestUsd } from '$lib/utils/liquidium.utils';
 import { get } from 'svelte/store';
@@ -307,6 +308,40 @@ describe('liquidium derived stores', () => {
 
 		it('is empty by default', () => {
 			expect(get(liquidiumBorrowMarkets)).toEqual([]);
+		});
+	});
+
+	describe('liquidiumWithdrawReserves', () => {
+		const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
+			poolId: 'pool-btc',
+			asset: 'BTC',
+			chain: 'BTC',
+			supplyApy: 5,
+			borrowApy: 9,
+			deposited: 1_000n,
+			depositedDecimals: 8,
+			borrowed: ZERO,
+			borrowedDecimals: 8,
+			suppliedUsd: 1000,
+			borrowedUsd: 0,
+			...overrides
+		});
+
+		it('keeps only reserves with a supplied balance', () => {
+			liquidiumStore.set({
+				markets: [],
+				portfolio: {
+					...portfolio,
+					reserves: [reserve(), reserve({ poolId: 'pool-eth', asset: 'USDC', deposited: ZERO })]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumWithdrawReserves)).toEqual([reserve()]);
+		});
+
+		it('is empty by default', () => {
+			expect(get(liquidiumWithdrawReserves)).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

This PR adds an in-flow token selector to the Withdraw flow, completing the set (Supply and Borrow already have one) and reusing the exact same pattern — adapted to the fact that Withdraw operates on supplied positions (LiquidiumReserve) rather than markets.
