### PR TITLE
feat(frontend): token selector step for Liquidium Repay

### DIFF
--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte
@@ -41,6 +41,7 @@
 		inflowFee?: bigint;
 		inflowFeeUnavailable?: boolean;
 		currentStep?: WizardStep;
+		onSelectToken?: () => void;
 		onClose: () => void;
 		onNext: () => void;
 		onBack: () => void;
@@ -55,6 +56,7 @@
 		inflowFee,
 		inflowFeeUnavailable,
 		currentStep,
+		onSelectToken,
 		onClose,
 		onNext,
 		onBack
@@ -194,6 +196,7 @@
 			{onClose}
 			onCustomErrorValidate={validateRepayAmount}
 			{onNext}
+			{onSelectToken}
 			{preview}
 			{reserve}
 			totalFee={utxosFee?.feeSatoshis}

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayEthWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayEthWizard.svelte
@@ -49,6 +49,7 @@
 		inflowFee?: bigint;
 		inflowFeeUnavailable?: boolean;
 		currentStep?: WizardStep;
+		onSelectToken?: () => void;
 		onClose: () => void;
 		onNext: () => void;
 		onBack: () => void;
@@ -63,6 +64,7 @@
 		inflowFee,
 		inflowFeeUnavailable,
 		currentStep,
+		onSelectToken,
 		onClose,
 		onNext,
 		onBack
@@ -268,6 +270,7 @@
 				{onClose}
 				onCustomErrorValidate={validateRepayAmount}
 				{onNext}
+				{onSelectToken}
 				{preview}
 				{reserve}
 				totalFee={$maxGasFee}

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayForm.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayForm.svelte
@@ -32,6 +32,8 @@
 		onCustomErrorValidate?: (userAmount: bigint) => Error | undefined;
 		// Per-rail fee row (EthFeeDisplay / BtcUtxosFeeDisplay).
 		feeDisplay: Snippet;
+		// Opens the token-selection step; when set, the token logo becomes a selector.
+		onSelectToken?: () => void;
 		onClose: () => void;
 		onNext: () => void;
 	}
@@ -46,6 +48,7 @@
 		inflowFeeUnavailable = false,
 		onCustomErrorValidate,
 		feeDisplay,
+		onSelectToken,
 		onClose,
 		onNext
 	}: Props = $props();
@@ -87,7 +90,9 @@
 <StakeForm
 	autofocus={isDesktop()}
 	disabled={feeMissing || inflowFeeUnavailable}
+	isSelectable={nonNullish(onSelectToken)}
 	maxAmount={maxRepay}
+	onClick={onSelectToken}
 	{onClose}
 	onCustomErrorValidate={validateAmount}
 	{onNext}

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayModal.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Asset, Chain } from '@liquidium/client';
+	import { setContext } from 'svelte';
+	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumRepayBtcWizard from '$lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte';
 	import LiquidiumRepayEthWizard from '$lib/components/liquidium/repay/LiquidiumRepayEthWizard.svelte';
+	import LiquidiumRepayTokensList from '$lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte';
 	import TokenActionContext from '$lib/components/send/TokenActionContext.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumRepayWizardSteps } from '$lib/config/lend-borrow.config';
@@ -15,19 +18,35 @@
 	import { getLiquidiumMaxRepayAmount } from '$lib/services/liquidium-repay.services';
 	import { estimateLiquidiumInflowFee } from '$lib/services/liquidium-supply.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import {
+		initModalTokensListContext,
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { WizardStep, WizardSteps } from '$lib/types/wizard';
 	import { consoleError } from '$lib/utils/console.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
+	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
 	interface Props {
-		reserve: LiquidiumReserve;
+		// Position with debt to repay; token-less launches pick one via the picker.
+		reserve?: LiquidiumReserve;
 	}
 
 	let { reserve }: Props = $props();
 
-	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+	// Seeded from the initial prop only; later switches happen through the picker.
+	// svelte-ignore state_referenced_locally
+	let selectedReserve = $state<LiquidiumReserve | undefined>(reserve);
+
+	let token = $derived(
+		nonNullish(selectedReserve) ? LIQUIDIUM_ASSET_TOKENS[selectedReserve.asset] : undefined
+	);
+
+	const tokensListContext = initModalTokensListContext({ tokens: [] });
+	setContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY, tokensListContext);
 
 	// Provider inflow fee for this asset (repayment is an inflow), passed to the wizard.
 	let inflowFee = $state<bigint | undefined>();
@@ -41,14 +60,18 @@
 	$effect(() => {
 		const identity = $authIdentity;
 
-		if (nonNullish(identity)) {
+		if (nonNullish(identity) && nonNullish(selectedReserve)) {
+			const { asset, chain, poolId } = selectedReserve;
+
+			inflowFee = undefined;
 			inflowFeeUnavailable = false;
+			maxRepay = undefined;
 
 			// Reserve data widens asset/chain to open strings; narrow to the SDK's strict types here.
 			estimateLiquidiumInflowFee({
 				identity,
-				asset: reserve.asset as Asset,
-				chain: reserve.chain as Chain
+				asset: asset as Asset,
+				chain: chain as Chain
 			})
 				.then((fee) => (inflowFee = fee))
 				.catch((err: unknown) => {
@@ -56,7 +79,7 @@
 					inflowFeeUnavailable = true;
 				});
 
-			getLiquidiumMaxRepayAmount({ identity, ethAddress: $ethAddress, poolId: reserve.poolId })
+			getLiquidiumMaxRepayAmount({ identity, ethAddress: $ethAddress, poolId })
 				.then((amount) => (maxRepay = amount ?? undefined))
 				.catch(consoleError);
 		}
@@ -71,27 +94,71 @@
 		liquidiumRepayWizardSteps({ i18n: $i18n })
 	);
 
-	const reset = () => {
+	const goToStep = (stepName: WizardStepsLiquidiumRepay) => {
+		if (nonNullish(modal)) {
+			goToWizardStep({ modal, steps, stepName });
+		}
+	};
+
+	// Always enter the picker with a clean query so it never reopens filtered from a
+	// previous visit (mirrors the swap / trade-deposit flows).
+	const enterTokensList = () => {
+		tokensListContext.setFilterQuery('');
+		goToStep(WizardStepsLiquidiumRepay.TOKENS_LIST);
+	};
+
+	// Cancelling the picker returns to the Repay step — the amount form when a position
+	// is chosen, or the select-token prompt on a neutral launch.
+	const closeTokensList = () => {
+		tokensListContext.setFilterQuery('');
+		goToStep(WizardStepsLiquidiumRepay.REPAY);
+	};
+
+	const selectReserve = (nextReserve: LiquidiumReserve) => {
+		selectedReserve = nextReserve;
+		// The typed amount is token-specific; drop it when switching.
 		amount = undefined;
+		closeTokensList();
+	};
+
+	// The modal is not guaranteed to unmount between opens, so restore every piece of
+	// launch state — including the selected reserve, its fee/debt estimates and the picker
+	// filters — back to what the initial prop implies; otherwise the next open (or a neutral
+	// launch) inherits the previously picked token / a stale fee-error / a stale filter query.
+	const reset = () => {
+		selectedReserve = reserve;
+		amount = undefined;
+		inflowFee = undefined;
+		inflowFeeUnavailable = false;
+		maxRepay = undefined;
 		repayProgressStep = ProgressStepsLiquidiumRepay.INITIALIZATION;
 		currentStep = undefined;
+		tokensListContext.resetFilters();
 	};
 
 	const close = () => closeModal(reset);
 </script>
 
-{#if nonNullish(token) && nonNullish($liquidiumPortfolio)}
-	<TokenActionContext {token}>
-		<WizardModal
-			bind:this={modal}
-			disablePointerEvents={currentStep?.name === WizardStepsLiquidiumRepay.REPAYING}
-			onClose={close}
-			{steps}
-			bind:currentStep
-		>
-			{#snippet title()}{currentStep?.title ?? ''}{/snippet}
+<TokenActionContext {token}>
+	<WizardModal
+		bind:this={modal}
+		disablePointerEvents={currentStep?.name === WizardStepsLiquidiumRepay.REPAYING}
+		onClose={close}
+		{steps}
+		bind:currentStep
+	>
+		{#snippet title()}{currentStep?.title ?? ''}{/snippet}
 
-			{#if reserve.chain === 'BTC'}
+		{#if currentStep?.name === WizardStepsLiquidiumRepay.TOKENS_LIST}
+			<LiquidiumRepayTokensList
+				onClose={closeTokensList}
+				onSelectReserve={selectReserve}
+				{selectedReserve}
+			/>
+		{:else if isNullish(selectedReserve)}
+			<LiquidiumSelectTokenForm onClose={close} onSelectToken={enterTokensList} />
+		{:else if nonNullish($liquidiumPortfolio)}
+			{#if selectedReserve.chain === 'BTC'}
 				<LiquidiumRepayBtcWizard
 					{currentStep}
 					{inflowFee}
@@ -100,8 +167,9 @@
 					onBack={modal.back}
 					onClose={close}
 					onNext={modal.next}
+					onSelectToken={enterTokensList}
 					portfolio={$liquidiumPortfolio}
-					{reserve}
+					reserve={selectedReserve}
 					bind:amount
 					bind:repayProgressStep
 				/>
@@ -114,12 +182,13 @@
 					onBack={modal.back}
 					onClose={close}
 					onNext={modal.next}
+					onSelectToken={enterTokensList}
 					portfolio={$liquidiumPortfolio}
-					{reserve}
+					reserve={selectedReserve}
 					bind:amount
 					bind:repayProgressStep
 				/>
 			{/if}
-		</WizardModal>
-	</TokenActionContext>
-{/if}
+		{/if}
+	</WizardModal>
+</TokenActionContext>

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import { getContext } from 'svelte';
+	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
+	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
+	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { liquidiumRepayReserves } from '$lib/derived/liquidium.derived';
+	import {
+		MODAL_TOKENS_LIST_CONTEXT_KEY,
+		type ModalTokensListContext
+	} from '$lib/stores/modal-tokens-list.store';
+	import type { LiquidiumReserve } from '$lib/types/liquidium';
+	import type { Token } from '$lib/types/token';
+
+	interface Props {
+		// Omitted on a neutral (token-less) launch — then nothing is excluded.
+		selectedReserve?: LiquidiumReserve;
+		onSelectReserve: (reserve: LiquidiumReserve) => void;
+		onClose: () => void;
+	}
+
+	let { selectedReserve, onSelectReserve, onClose }: Props = $props();
+
+	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
+
+	let entries = $derived(
+		$liquidiumRepayReserves
+			.map((reserve) => ({ reserve, token: LIQUIDIUM_ASSET_TOKENS[reserve.asset] }))
+			.filter(
+				(entry): entry is { reserve: LiquidiumReserve; token: Token } =>
+					nonNullish(entry.token) && entry.reserve.poolId !== selectedReserve?.poolId
+			)
+	);
+
+	$effect(() => {
+		setTokens(entries.map(({ token }) => token));
+	});
+
+	const onTokenButtonClick = (token: Token) => {
+		const entry = entries.find(({ token: { id } }) => id === token.id);
+
+		if (nonNullish(entry)) {
+			onSelectReserve(entry.reserve);
+		}
+	};
+</script>
+
+<ModalTokensList networkSelectorViewOnly {onTokenButtonClick}>
+	{#snippet tokenListItem(token, onClick)}
+		<ModalTokensListItem {onClick} {token} />
+	{/snippet}
+	{#snippet toolbar()}
+		<ButtonCancel fullWidth onclick={onClose} />
+	{/snippet}
+</ModalTokensList>

--- a/src/frontend/src/lib/config/lend-borrow.config.ts
+++ b/src/frontend/src/lib/config/lend-borrow.config.ts
@@ -97,5 +97,9 @@ export const liquidiumRepayWizardSteps = ({
 	{
 		name: WizardStepsLiquidiumRepay.REPAYING,
 		title: i18n.liquidium.text.repaying
+	},
+	{
+		name: WizardStepsLiquidiumRepay.TOKENS_LIST,
+		title: i18n.liquidium.text.select_repay_token
 	}
 ];

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -61,6 +61,12 @@ export const liquidiumWithdrawReserves: Readable<LiquidiumReserve[]> = derived(
 	(portfolio) => (portfolio?.reserves ?? []).filter(({ deposited }) => deposited > ZERO)
 );
 
+// Positions the user can repay: reserves with outstanding debt.
+export const liquidiumRepayReserves: Readable<LiquidiumReserve[]> = derived(
+	liquidiumPortfolio,
+	(portfolio) => (portfolio?.reserves ?? []).filter(({ borrowed }) => borrowed > ZERO)
+);
+
 // SDK USD prices for the borrow form's USD / fiat math.
 export const liquidiumAssetPrices: Readable<AssetPrices> = derived(
 	liquidiumStore,

--- a/src/frontend/src/lib/enums/wizard-steps.ts
+++ b/src/frontend/src/lib/enums/wizard-steps.ts
@@ -118,7 +118,8 @@ export enum WizardStepsLiquidiumWithdraw {
 export enum WizardStepsLiquidiumRepay {
 	REPAY = 'Repay',
 	REVIEW = 'Review',
-	REPAYING = 'Repaying'
+	REPAYING = 'Repaying',
+	TOKENS_LIST = 'Tokens List'
 }
 
 export enum WizardStepsClaimStakingReward {

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "",
 			"supply_review_subtitle": "",
 			"supplying": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Zkontrolovat poskytnutí",
 			"supply_review_subtitle": "Poskytuješ",
 			"supplying": "Probíhá poskytnutí",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Bereitstellung prüfen",
 			"supply_review_subtitle": "Du stellst bereit",
 			"supplying": "Bereitstellung läuft",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "Select token to supply",
 			"select_borrow_token": "Select token to borrow",
 			"select_withdraw_token": "Select token to withdraw",
+			"select_repay_token": "Select token to repay",
 			"supply_review": "Review supply",
 			"supply_review_subtitle": "You supply",
 			"supplying": "Supplying",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Revisar suministro",
 			"supply_review_subtitle": "Suministras",
 			"supplying": "Suministrando",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Vérifier l'apport",
 			"supply_review_subtitle": "Vous fournissez",
 			"supplying": "Fourniture en cours",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "जमा की समीक्षा करें",
 			"supply_review_subtitle": "आप जमा कर रहे हैं",
 			"supplying": "जमा हो रहा है",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Rivedi fornitura",
 			"supply_review_subtitle": "Fornisci",
 			"supplying": "Fornitura in corso",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "供給内容を確認",
 			"supply_review_subtitle": "供給する",
 			"supplying": "供給中",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "공급 검토",
 			"supply_review_subtitle": "공급 금액",
 			"supplying": "공급 중",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Sprawdź dostarczenie",
 			"supply_review_subtitle": "Dostarczasz",
 			"supplying": "Trwa dostarczanie",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Rever fornecimento",
 			"supply_review_subtitle": "Forneces",
 			"supplying": "A fornecer",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Проверить предоставление",
 			"supply_review_subtitle": "Ты предоставляешь",
 			"supplying": "Предоставление в процессе",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "Xem lại khoản cung cấp",
 			"supply_review_subtitle": "Bạn cung cấp",
 			"supplying": "Đang cung cấp",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2388,6 +2388,7 @@
 			"select_supply_token": "",
 			"select_borrow_token": "",
 			"select_withdraw_token": "",
+			"select_repay_token": "",
 			"supply_review": "查看提供详情",
 			"supply_review_subtitle": "您提供",
 			"supplying": "提供中",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1924,6 +1924,7 @@ interface I18nLiquidium {
 		select_supply_token: string;
 		select_borrow_token: string;
 		select_withdraw_token: string;
+		select_repay_token: string;
 		supply_review: string;
 		supply_review_subtitle: string;
 		supplying: string;

--- a/src/frontend/src/lib/utils/wizard-modal.utils.ts
+++ b/src/frontend/src/lib/utils/wizard-modal.utils.ts
@@ -6,6 +6,7 @@ import type {
 	WizardStepsHowToConvert,
 	WizardStepsLimitOrder,
 	WizardStepsLiquidiumBorrow,
+	WizardStepsLiquidiumRepay,
 	WizardStepsLiquidiumSupply,
 	WizardStepsLiquidiumWithdraw,
 	WizardStepsReceive,
@@ -34,7 +35,8 @@ type StepName =
 	| WizardStepsLimitOrder
 	| WizardStepsLiquidiumSupply
 	| WizardStepsLiquidiumBorrow
-	| WizardStepsLiquidiumWithdraw;
+	| WizardStepsLiquidiumWithdraw
+	| WizardStepsLiquidiumRepay;
 
 export const goToWizardStep = <T extends StepName>({
 	modal,

--- a/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayTokensList.spec.ts
@@ -1,0 +1,129 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import LiquidiumRepayTokensList from '$lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
+import {
+	initModalTokensListContext,
+	MODAL_TOKENS_LIST_CONTEXT_KEY
+} from '$lib/stores/modal-tokens-list.store';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import { fireEvent, render } from '@testing-library/svelte';
+
+describe('LiquidiumRepayTokensList', () => {
+	const btcReserve: LiquidiumReserve = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 9,
+		deposited: ZERO,
+		depositedDecimals: 8,
+		borrowed: 1_000n,
+		borrowedDecimals: 8,
+		suppliedUsd: 0,
+		borrowedUsd: 1000
+	};
+
+	const usdcReserve: LiquidiumReserve = {
+		poolId: 'pool-usdc',
+		asset: 'USDC',
+		chain: 'ETH',
+		supplyApy: 3,
+		borrowApy: 4,
+		deposited: ZERO,
+		depositedDecimals: 6,
+		borrowed: 2_000n,
+		borrowedDecimals: 6,
+		suppliedUsd: 0,
+		borrowedUsd: 2000
+	};
+
+	const portfolio = (reserves: LiquidiumReserve[]): LiquidiumPortfolio => ({
+		reserves,
+		totalSuppliedUsd: 0,
+		totalBorrowedUsd: 3000,
+		netValueUsd: -3000,
+		availableBorrowsUsd: 0,
+		weightedLiquidationThresholdBps: 8000,
+		healthFactorPercent: 50
+	});
+
+	const context = new Map([
+		[MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] })]
+	]);
+
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('lists the positions with debt except the selected one', () => {
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, usdcReserve]),
+			assetPrices: {}
+		});
+
+		const { getByTestId, getByText, queryByText } = render(LiquidiumRepayTokensList, {
+			props: { selectedReserve: btcReserve, onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByTestId(MODAL_TOKENS_LIST)).toBeInTheDocument();
+		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+		// The selected token is hidden from its own picker.
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+	});
+
+	it('excludes positions with no outstanding debt', () => {
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, { ...usdcReserve, borrowed: ZERO }]),
+			assetPrices: {}
+		});
+
+		const { getByText, queryByText } = render(LiquidiumRepayTokensList, {
+			props: { onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
+		expect(queryByText(USDC_TOKEN.symbol)).toBeNull();
+	});
+
+	it('selects the reserve matching the clicked token', async () => {
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, usdcReserve]),
+			assetPrices: {}
+		});
+
+		const onSelectReserve = vi.fn();
+
+		const { getByText } = render(LiquidiumRepayTokensList, {
+			props: { selectedReserve: btcReserve, onSelectReserve, onClose: () => {} },
+			context
+		});
+
+		await fireEvent.click(getByText(USDC_TOKEN.symbol));
+
+		expect(onSelectReserve).toHaveBeenCalledWith(usdcReserve);
+	});
+
+	it('lists every position with debt when none is selected (neutral launch)', () => {
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, usdcReserve]),
+			assetPrices: {}
+		});
+
+		const { getByText } = render(LiquidiumRepayTokensList, {
+			props: { onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
+		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
+++ b/src/frontend/src/tests/lib/config/lend-borrow.config.spec.ts
@@ -1,11 +1,13 @@
 import {
 	lendBorrowProvidersConfig,
 	liquidiumBorrowWizardSteps,
+	liquidiumRepayWizardSteps,
 	liquidiumSupplyWizardSteps,
 	liquidiumWithdrawWizardSteps
 } from '$lib/config/lend-borrow.config';
 import {
 	WizardStepsLiquidiumBorrow,
+	WizardStepsLiquidiumRepay,
 	WizardStepsLiquidiumSupply,
 	WizardStepsLiquidiumWithdraw
 } from '$lib/enums/wizard-steps';
@@ -50,6 +52,20 @@ describe('lend-borrow.config', () => {
 				{
 					name: WizardStepsLiquidiumWithdraw.TOKENS_LIST,
 					title: en.liquidium.text.select_withdraw_token
+				}
+			]);
+		});
+	});
+
+	describe('liquidiumRepayWizardSteps', () => {
+		it('returns the repay wizard steps with expected names and titles', () => {
+			expect(liquidiumRepayWizardSteps({ i18n: en })).toStrictEqual([
+				{ name: WizardStepsLiquidiumRepay.REPAY, title: en.liquidium.text.action_repay },
+				{ name: WizardStepsLiquidiumRepay.REVIEW, title: en.liquidium.text.repay_review },
+				{ name: WizardStepsLiquidiumRepay.REPAYING, title: en.liquidium.text.repaying },
+				{
+					name: WizardStepsLiquidiumRepay.TOKENS_LIST,
+					title: en.liquidium.text.select_repay_token
 				}
 			]);
 		});

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -14,6 +14,7 @@ import {
 	liquidiumMinBorrowApy,
 	liquidiumNetValueUsd,
 	liquidiumPortfolio,
+	liquidiumRepayReserves,
 	liquidiumSupplyMarkets,
 	liquidiumTotalBorrowedUsd,
 	liquidiumWithdrawReserves
@@ -342,6 +343,40 @@ describe('liquidium derived stores', () => {
 
 		it('is empty by default', () => {
 			expect(get(liquidiumWithdrawReserves)).toEqual([]);
+		});
+	});
+
+	describe('liquidiumRepayReserves', () => {
+		const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
+			poolId: 'pool-usdc',
+			asset: 'USDC',
+			chain: 'ETH',
+			supplyApy: 0,
+			borrowApy: 8,
+			deposited: ZERO,
+			depositedDecimals: 6,
+			borrowed: 1_000n,
+			borrowedDecimals: 6,
+			suppliedUsd: 0,
+			borrowedUsd: 2000,
+			...overrides
+		});
+
+		it('keeps only reserves with outstanding debt', () => {
+			liquidiumStore.set({
+				markets: [],
+				portfolio: {
+					...portfolio,
+					reserves: [reserve(), reserve({ poolId: 'pool-btc', asset: 'BTC', borrowed: ZERO })]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumRepayReserves)).toEqual([reserve()]);
+		});
+
+		it('is empty by default', () => {
+			expect(get(liquidiumRepayReserves)).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

This PR adds an in-flow token selector to the Repay flow, completing the token-selector rollout across all four Liquidium flows (Supply, Borrow, Withdraw already have one). Repay shares Supply's structure — TokenActionContext + BTC/ETH wizards + inflow-fee estimation — so it follows that blueprint, adapted to operate on debt positions (LiquidiumReserve).

