### PR TITLE
feat(frontend): enable Bitcoin WalletConnect in staging and local

### DIFF
--- a/src/frontend/src/env/btc-wallet-connect.env.ts
+++ b/src/frontend/src/env/btc-wallet-connect.env.ts
@@ -1,9 +1,11 @@
+import { LOCAL, STAGING } from '$lib/constants/app.constants';
+
 // Gate for the Bitcoin (bip122) WalletConnect surface (namespace advertisement, `getAccountAddresses`
 // session property/method, `signMessage` and `signPsbt`).
 //
-// Disabled until the signer can sign an arbitrary digest under the BTC key. Today signing goes
-// through `generic_sign_with_ecdsa` (schema `0xff`), whose key does not match the advertised P2WPKH
-// address (schema `0x00`), so `signMessage` fails the recovery check and `signPsbt` hands the dApp a
-// signature for the wrong key. Re-enable once chain-fusion-signer exposes a `btc_sign_prehash`-style
-// endpoint that signs under the BTC schema.
-export const BTC_WALLET_CONNECT_ENABLED = false;
+// Enabled in staging and local only, for testing. Still off in production and beta: today signing
+// goes through `generic_sign_with_ecdsa` (schema `0xff`), whose key does not match the advertised
+// P2WPKH address (schema `0x00`), so `signMessage` fails the recovery check and `signPsbt` hands the
+// dApp a signature for the wrong key. Enable in production once chain-fusion-signer exposes a
+// `btc_sign_prehash`-style endpoint that signs under the BTC schema.
+export const BTC_WALLET_CONNECT_ENABLED = STAGING || LOCAL;

--- a/src/frontend/src/env/btc-wallet-connect.env.ts
+++ b/src/frontend/src/env/btc-wallet-connect.env.ts
@@ -3,9 +3,10 @@ import { LOCAL, STAGING } from '$lib/constants/app.constants';
 // Gate for the Bitcoin (bip122) WalletConnect surface (namespace advertisement, `getAccountAddresses`
 // session property/method, `signMessage` and `signPsbt`).
 //
-// Enabled in staging and local only, for testing. Still off in production and beta: today signing
-// goes through `generic_sign_with_ecdsa` (schema `0xff`), whose key does not match the advertised
-// P2WPKH address (schema `0x00`), so `signMessage` fails the recovery check and `signPsbt` hands the
-// dApp a signature for the wrong key. Enable in production once chain-fusion-signer exposes a
-// `btc_sign_prehash`-style endpoint that signs under the BTC schema.
-export const BTC_WALLET_CONNECT_ENABLED = STAGING || LOCAL;
+// Enabled on local and staging only, for testing — not on beta nor production (ic). `STAGING`
+// already covers the test_fe / audit / e2e environments. Kept off in production and beta because
+// signing still goes through `generic_sign_with_ecdsa` (schema `0xff`), whose key does not match the
+// advertised P2WPKH address (schema `0x00`), so `signMessage` fails the recovery check and `signPsbt`
+// hands the dApp a signature for the wrong key. Enable in production once chain-fusion-signer exposes
+// a `btc_sign_prehash`-style endpoint that signs under the BTC schema.
+export const BTC_WALLET_CONNECT_ENABLED = LOCAL || STAGING;


### PR DESCRIPTION
# Motivation

Bitcoin (bip122) support over WalletConnect was hard-disabled behind `BTC_WALLET_CONNECT_ENABLED = false`. We want it back on in staging (and local) so it can be tested, with production following in a later release.

# Changes

- Gate `BTC_WALLET_CONNECT_ENABLED` on the environment: `STAGING || LOCAL` instead of a hardcoded `false`. It is now enabled in staging and local, and remains off in production and beta.
- Kept the signer caveat in the comment: signing still goes through `generic_sign_with_ecdsa` (schema `0xff`), whose key does not match the advertised P2WPKH address (schema `0x00`), so `signMessage` fails the recovery check and `signPsbt` returns a signature for the wrong key. Production stays gated off until chain-fusion-signer exposes a `btc_sign_prehash`-style endpoint that signs under the BTC schema.

# Tests

- `wallet-connect.providers`, `wallet-connect-handlers.services`, and `btc/services/wallet-connect.services` suites pass (41 tests). These mock the flag via getters, so they are unaffected by the value change.
- prettier + eslint (`--max-warnings 0`) clean on the touched file.
