### PR TITLE
feat(backend): Enforce II delegation guard in production

### DIFF
--- a/src/backend/src/delegation.rs
+++ b/src/backend/src/delegation.rs
@@ -7,13 +7,14 @@ use shared::types::delegation::IIDelegationChain;
 
 use crate::state::read_config;
 
-const PRODUCTION_ECDSA_KEY_NAME: &str = "key_1";
-
 /// Reads the II verification parameters (known II canister IDs, IC root key,
 /// and whether the delegation guard is enabled) from the backend configuration.
 ///
-/// The guard is enabled for every environment **except** production
-/// (`ecdsa_key_name == "key_1"`).
+/// The guard is enabled in **every** environment, including production. It was
+/// historically disabled on production (`ecdsa_key_name == "key_1"`) because the
+/// delegation-chain verification failed on mainnet's sharded `canister_ranges`
+/// certificate path; once that verification is fixed, production enforces the
+/// same II delegation check as staging and local.
 pub(crate) fn read_ii_verification_config() -> (Vec<Principal>, Vec<u8>, bool) {
     read_config(|config| {
         let ii_ids = config.ii_canister_id.map(|id| vec![id]).unwrap_or_default();
@@ -21,7 +22,7 @@ pub(crate) fn read_ii_verification_config() -> (Vec<Principal>, Vec<u8>, bool) {
             .ic_root_key_raw
             .clone()
             .expect("IC root key not configured");
-        let guard_enabled = config.ecdsa_key_name != PRODUCTION_ECDSA_KEY_NAME;
+        let guard_enabled = true;
         (ii_ids, root_key, guard_enabled)
     })
 }
@@ -29,8 +30,8 @@ pub(crate) fn read_ii_verification_config() -> (Vec<Principal>, Vec<u8>, bool) {
 /// Requires a valid II delegation chain for non-controller callers.
 ///
 /// When `guard_enabled` is `false` the check is a no-op and `Ok(())` is
-/// returned immediately.  This is the case for **production** deployments
-/// (`ecdsa_key_name == "key_1"`); local and staging deployments pass `true`.
+/// returned immediately. All environments (production, staging, local) pass
+/// `true`; `false` is only used to exercise the disabled path in tests.
 ///
 /// Controllers bypass the check entirely and `Ok(())` is returned regardless
 /// of whether a chain is provided.  For all other callers the chain must be

--- a/src/backend/src/delegation.rs
+++ b/src/backend/src/delegation.rs
@@ -12,9 +12,12 @@ use crate::state::read_config;
 ///
 /// The guard is enabled in **every** environment, including production. It was
 /// historically disabled on production (`ecdsa_key_name == "key_1"`) because the
-/// delegation-chain verification failed on mainnet's sharded `canister_ranges`
-/// certificate path; once that verification is fixed, production enforces the
-/// same II delegation check as staging and local.
+/// delegation-chain verification only looked up the legacy
+/// `subnet/<subnet_id>/canister_ranges` certificate path, which mainnet no
+/// longer serves on non-root subnets (it moved to the sharded
+/// `canister_ranges/<subnet_id>` tree), producing `canister_ranges-entry not
+/// found`. Now that `ic-signature-verification` handles the sharded path,
+/// production enforces the same II delegation check as staging and local.
 pub(crate) fn read_ii_verification_config() -> (Vec<Principal>, Vec<u8>, bool) {
     read_config(|config| {
         let ii_ids = config.ii_canister_id.map(|id| vec![id]).unwrap_or_default();

--- a/src/backend/tests/it/bitcoin.rs
+++ b/src/backend/tests/it/bitcoin.rs
@@ -56,7 +56,7 @@ fn test_add_pending_transaction_requires_delegation_chain() {
 }
 
 #[test]
-fn test_add_pending_transaction_without_delegation_chain_passes_when_guard_disabled() {
+fn test_add_pending_transaction_enforces_guard_under_production_config() {
     let pic_setup = setup_with_production_config();
 
     let caller = Principal::from_text(CALLER).unwrap();
@@ -78,11 +78,11 @@ fn test_add_pending_transaction_without_delegation_chain_passes_when_guard_disab
         .expect("Canister call failed");
 
     assert!(
-        !matches!(
+        matches!(
             add_response,
             Err(BtcAddPendingTransactionError::InvalidDelegationChain { .. })
         ),
-        "Delegation guard is disabled, should not get InvalidDelegationChain: {add_response:?}"
+        "Guard is enforced in production, expected InvalidDelegationChain: {add_response:?}"
     );
 }
 
@@ -226,7 +226,7 @@ fn test_get_pending_transactions_requires_delegation_chain() {
 }
 
 #[test]
-fn test_get_pending_transactions_without_delegation_chain_passes_when_guard_disabled() {
+fn test_get_pending_transactions_enforces_guard_under_production_config() {
     let pic_setup = setup_with_production_config();
     let caller = Principal::from_text(CALLER).unwrap();
     pic_setup.ensure_user_profile(caller);
@@ -245,11 +245,11 @@ fn test_get_pending_transactions_without_delegation_chain_passes_when_guard_disa
         .expect("Canister call failed");
 
     assert!(
-        !matches!(
+        matches!(
             response,
             Err(BtcGetPendingTransactionsError::InvalidDelegationChain { .. })
         ),
-        "Delegation guard is disabled, should not get InvalidDelegationChain: {response:?}"
+        "Guard is enforced in production, expected InvalidDelegationChain: {response:?}"
     );
 }
 

--- a/src/backend/tests/it/signer.rs
+++ b/src/backend/tests/it/signer.rs
@@ -987,7 +987,7 @@ fn test_allow_signing_requires_delegation_chain() {
 }
 
 #[test]
-fn test_allow_signing_without_delegation_chain_passes_when_guard_disabled() {
+fn test_allow_signing_enforces_guard_under_production_config() {
     let pic_setup = setup_with_production_config();
     let caller = Principal::from_text(CALLER).unwrap();
     pic_setup.ensure_user_profile(caller);
@@ -995,11 +995,11 @@ fn test_allow_signing_without_delegation_chain_passes_when_guard_disabled() {
     let result = call_allow_signing_with_delegation(&pic_setup, caller, None);
 
     assert!(
-        !matches!(
+        matches!(
             result,
             Err(AllowSigningError::InvalidDelegationChain { .. })
         ),
-        "Delegation guard is disabled, should not get InvalidDelegationChain: {result:?}"
+        "Guard is enforced in production, expected InvalidDelegationChain: {result:?}"
     );
 }
 


### PR DESCRIPTION
# Motivation

The II delegation-chain guard is a no-op in production. `read_ii_verification_config` disabled it whenever `ecdsa_key_name == "key_1"`, so `allow_signing`, `btc_add_pending_transaction` and `btc_get_pending_transactions` accept any registered principal in the live environment without the Internet Identity delegation-chain proof that staging and local require. This PR removes the production exemption so the guard runs everywhere.

## Why the exemption existed, and why it is now obsolete

The guard was disabled in #12087 because delegation verification was failing on mainnet with `canister_ranges-entry not found`. Root cause: `ic-signature-verification` v0.1.0/v0.2.0 only looked up the legacy `subnet/<subnet_id>/canister_ranges` certificate path, which mainnet no longer serves on non-root subnets (it moved to the sharded `canister_ranges/<subnet_id>` path).

That is already fixed in the crate version compiled into the backend today. #12214 bumped `ic-signature-verification` to **0.3.0** and its `verify_delegation` tries the sharded `canister_ranges/<subnet_id>` path first, falling back to the legacy path, returning `canister_ranges-entry not found` only if both are absent. `Cargo.lock` currently resolves to 0.3.0 with no later change.

The same PR (#12214) that shipped this fix also reintroduced the production exemption "for insurance" — so the exemption was redundant from the start. The separate inline-the-crate draft (#12086) is superseded: upstream 0.3.0 already implements that exact logic.

# Changes

- `read_ii_verification_config` returns `guard_enabled = true` unconditionally; the `PRODUCTION_ECDSA_KEY_NAME` special-case is removed.
- Doc comments updated.
- The three production-config integration tests now assert the guard rejects a missing/invalid chain (`..._enforces_guard_under_production_config`) instead of bypassing it.

# Tests

- Backend lib type-checks; updated integration tests assert enforcement under production config; full `it` suite runs in CI.
- Pre-rollout smoke test (cannot be done from CI): exercise `allow_signing` on staging with a real II session, then a mainnet canary, to confirm the live delegation round-trip before promoting to prod.
