### PR TITLE
fix(backend): prune a creator's expired note shares on create

### DIFF
--- a/src/backend/src/personal_notes/share/service.rs
+++ b/src/backend/src/personal_notes/share/service.rs
@@ -19,35 +19,19 @@ use crate::{
     },
 };
 
-/// Counts a creator's *active* (unexpired) shares by range-scanning the
-/// by-creator index, so the cap check never touches the (potentially much
-/// larger) primary token-keyed map. Takes the map directly — rather than
-/// re-entering `read_state`/`mutate_state` — so it can be called from inside
-/// an existing state borrow without a `RefCell` double-borrow panic. Mirrors
-/// `personal_notes::service::count_notes_in_map`.
-fn active_share_count_in(
-    by_creator: &crate::types::maps::PersonalNoteSharesByCreatorMap,
-    creator: Principal,
-    now_ns: u64,
-) -> usize {
-    let prefix = StoredPrincipal(creator);
-    let start = PersonalNoteShareCreatorKey(prefix, PersonalNoteShareToken(String::new()));
-    by_creator
-        .range(start..)
-        .take_while(|entry| entry.key().0 == prefix)
-        .filter(|entry| entry.value() > now_ns)
-        .count()
-}
-
-/// Scans one creator's slice of the by-creator index in a single pass,
-/// returning their active (unexpired) share count and the tokens of their
-/// expired shares. The caller removes the expired ones (see
-/// `create_personal_note_share`) so a creator can't mint near-immediate-expiry
-/// shares that stop counting toward the cap on the next call yet linger in
-/// storage until the hourly sweep — which would let one user's stored volume
-/// grow past the active-share cap up to the create rate-limit ceiling. Bounds
-/// work to the one creator, like `active_share_count_in`, and takes the map
-/// directly so it can run inside an existing state borrow.
+/// Range-scans one creator's slice of the by-creator index in a single pass,
+/// returning their *active* (unexpired) share count and the tokens of their
+/// *expired* shares. Scanning the by-creator index — rather than the
+/// (potentially much larger) primary token-keyed map — keeps this cheap, and
+/// taking the map directly (rather than re-entering `read_state` /
+/// `mutate_state`) lets it run inside an existing state borrow without a
+/// `RefCell` double-borrow panic.
+///
+/// `create_personal_note_share` removes the returned expired tokens before the
+/// cap check, so a creator can't mint near-immediate-expiry shares that stop
+/// counting toward the cap on the next call yet linger in storage until the
+/// hourly sweep — which would let one user's stored volume grow past the
+/// active-share cap up to the create rate-limit ceiling.
 fn partition_creator_shares(
     by_creator: &crate::types::maps::PersonalNoteSharesByCreatorMap,
     creator: Principal,
@@ -68,6 +52,18 @@ fn partition_creator_shares(
         }
     }
     (active, expired)
+}
+
+/// A creator's *active* (unexpired) share count, for the read-only count path
+/// (`get_personal_note_shares_count`), which needs the count but not the
+/// expired tokens. Thin wrapper over [`partition_creator_shares`] (an empty
+/// `Vec` does not allocate). Mirrors `personal_notes::service::count_notes_in_map`.
+fn active_share_count_in(
+    by_creator: &crate::types::maps::PersonalNoteSharesByCreatorMap,
+    creator: Principal,
+    now_ns: u64,
+) -> usize {
+    partition_creator_shares(by_creator, creator, now_ns).0
 }
 
 /// Removes a share from both the primary and by-creator maps. Used by

--- a/src/backend/src/personal_notes/share/service.rs
+++ b/src/backend/src/personal_notes/share/service.rs
@@ -302,7 +302,8 @@ mod tests {
         tokens.sort();
         assert_eq!(tokens, vec!["a-old1".to_string(), "a-old2".to_string()]);
 
-        // A creator with no expired entries yields an empty prune list.
+        // Scoping check: scanning bob's slice returns bob's own expired token
+        // and zero active shares, with none of alice's entries leaking in.
         let (bob_active, bob_expired) = partition_creator_shares(&map, bob, now);
         assert_eq!(bob_active, 0);
         assert_eq!(bob_expired.len(), 1);

--- a/src/backend/src/personal_notes/share/service.rs
+++ b/src/backend/src/personal_notes/share/service.rs
@@ -97,17 +97,18 @@ pub fn create_personal_note_share(
     let token = PersonalNoteShareToken(request.token);
 
     mutate_state(|s| {
-        if s.personal_note_shares.contains_key(&token) {
-            return Err(PersonalNoteShareError::DuplicateToken);
-        }
-        // Reclaim the caller's own expired shares before the cap check, so
-        // near-immediate-expiry shares can't accumulate in storage between
-        // creates (they'd evade the active-only count yet linger until the
-        // hourly sweep). Scoped to this one creator, so it stays cheap.
+        // Reclaim the caller's own expired shares first, so near-immediate-expiry
+        // shares can't accumulate in storage between creates (they would evade the
+        // active-only cap count yet linger until the hourly sweep), and so an
+        // expired share frees its token for reuse rather than lingering as a
+        // spurious `DuplicateToken`. Scoped to this one creator, so it stays cheap.
         let (active_count, expired) =
             partition_creator_shares(&s.personal_note_shares_by_creator, creator, now);
         for stale in expired {
             remove_share(s, &stale, creator);
+        }
+        if s.personal_note_shares.contains_key(&token) {
+            return Err(PersonalNoteShareError::DuplicateToken);
         }
         if new_share_exceeds_cap(active_count) {
             return Err(PersonalNoteShareError::TooManyShares);

--- a/src/backend/src/personal_notes/share/service.rs
+++ b/src/backend/src/personal_notes/share/service.rs
@@ -39,6 +39,37 @@ fn active_share_count_in(
         .count()
 }
 
+/// Scans one creator's slice of the by-creator index in a single pass,
+/// returning their active (unexpired) share count and the tokens of their
+/// expired shares. The caller removes the expired ones (see
+/// `create_personal_note_share`) so a creator can't mint near-immediate-expiry
+/// shares that stop counting toward the cap on the next call yet linger in
+/// storage until the hourly sweep — which would let one user's stored volume
+/// grow past the active-share cap up to the create rate-limit ceiling. Bounds
+/// work to the one creator, like `active_share_count_in`, and takes the map
+/// directly so it can run inside an existing state borrow.
+fn partition_creator_shares(
+    by_creator: &crate::types::maps::PersonalNoteSharesByCreatorMap,
+    creator: Principal,
+    now_ns: u64,
+) -> (usize, Vec<PersonalNoteShareToken>) {
+    let prefix = StoredPrincipal(creator);
+    let start = PersonalNoteShareCreatorKey(prefix, PersonalNoteShareToken(String::new()));
+    let mut active = 0usize;
+    let mut expired = Vec::new();
+    for entry in by_creator
+        .range(start..)
+        .take_while(|entry| entry.key().0 == prefix)
+    {
+        if entry.value() > now_ns {
+            active += 1;
+        } else {
+            expired.push(entry.key().1.clone());
+        }
+    }
+    (active, expired)
+}
+
 /// Removes a share from both the primary and by-creator maps. Used by
 /// `consume_personal_note_share` (on success, and as opportunistic cleanup
 /// when it finds an already-expired entry) and by the periodic prune sweep.
@@ -69,11 +100,16 @@ pub fn create_personal_note_share(
         if s.personal_note_shares.contains_key(&token) {
             return Err(PersonalNoteShareError::DuplicateToken);
         }
-        if new_share_exceeds_cap(active_share_count_in(
-            &s.personal_note_shares_by_creator,
-            creator,
-            now,
-        )) {
+        // Reclaim the caller's own expired shares before the cap check, so
+        // near-immediate-expiry shares can't accumulate in storage between
+        // creates (they'd evade the active-only count yet linger until the
+        // hourly sweep). Scoped to this one creator, so it stays cheap.
+        let (active_count, expired) =
+            partition_creator_shares(&s.personal_note_shares_by_creator, creator, now);
+        for stale in expired {
+            remove_share(s, &stale, creator);
+        }
+        if new_share_exceeds_cap(active_count) {
             return Err(PersonalNoteShareError::TooManyShares);
         }
 
@@ -225,5 +261,53 @@ mod tests {
         assert_eq!(active_share_count_in(&map, alice, now), 1);
         assert_eq!(active_share_count_in(&map, bob, now), 1);
         assert_eq!(active_share_count_in(&map, test_principal(3), now), 0);
+    }
+
+    #[test]
+    fn partition_returns_active_count_and_only_this_creators_expired_tokens() {
+        let mut map = in_memory_by_creator_map();
+        let alice = test_principal(1);
+        let bob = test_principal(2);
+        let now = 1_000_000_000u64;
+
+        map.insert(
+            PersonalNoteShareCreatorKey(
+                StoredPrincipal(alice),
+                PersonalNoteShareToken("a-active".into()),
+            ),
+            now + 1, // active
+        );
+        map.insert(
+            PersonalNoteShareCreatorKey(
+                StoredPrincipal(alice),
+                PersonalNoteShareToken("a-old1".into()),
+            ),
+            now, // expired (expiry is inclusive: expires_at_ns <= now)
+        );
+        map.insert(
+            PersonalNoteShareCreatorKey(
+                StoredPrincipal(alice),
+                PersonalNoteShareToken("a-old2".into()),
+            ),
+            now - 5, // expired
+        );
+        map.insert(
+            PersonalNoteShareCreatorKey(
+                StoredPrincipal(bob),
+                PersonalNoteShareToken("b-old".into()),
+            ),
+            now - 5, // expired, but a different creator — must not leak into alice's list
+        );
+
+        let (active, expired) = partition_creator_shares(&map, alice, now);
+        assert_eq!(active, 1);
+        let mut tokens: Vec<String> = expired.into_iter().map(|token| token.0).collect();
+        tokens.sort();
+        assert_eq!(tokens, vec!["a-old1".to_string(), "a-old2".to_string()]);
+
+        // A creator with no expired entries yields an empty prune list.
+        let (bob_active, bob_expired) = partition_creator_shares(&map, bob, now);
+        assert_eq!(bob_active, 0);
+        assert_eq!(bob_expired.len(), 1);
     }
 }

--- a/src/backend/tests/it/personal_note_shares.rs
+++ b/src/backend/tests/it/personal_note_shares.rs
@@ -273,6 +273,48 @@ fn expired_shares_are_unavailable_to_every_endpoint() {
     );
 }
 
+// A creator's expired shares are reclaimed from storage on their next create,
+// so they can't be used to accumulate entries past the active-share cap. The
+// reclamation is observable because it frees the expired share's token for
+// reuse (before the fix, the stale entry lingered until the hourly sweep and
+// the reuse returned `DuplicateToken`).
+//
+// The share is expired with a few seconds of advance rather than hours, so the
+// create-path prune is the *only* thing that can reclaim it: the hourly
+// housekeeping sweep cannot have fired in that window, which keeps the test
+// from passing for the wrong reason.
+#[test]
+fn creating_a_share_prunes_the_callers_own_expired_shares() {
+    const ONE_SEC_NS: u64 = 1_000_000_000;
+
+    let pic_setup = setup();
+    let alice = Principal::from_text(CALLER).unwrap();
+    pic_setup.ensure_user_profile(alice);
+    let now = now_ns(&pic_setup);
+
+    let stale = token(1);
+    create_share(&pic_setup, alice, &stale, now + 2 * ONE_SEC_NS, false)
+        .expect("create should succeed");
+    assert_eq!(shares_count(&pic_setup, alice), 1);
+
+    // Advance just past the share's expiry: it stops counting toward the cap
+    // but, until reclaimed, still occupies its slot in storage.
+    pic_setup.pic.advance_time(Duration::from_secs(5));
+    pic_setup.pic.tick();
+    assert_eq!(
+        shares_count(&pic_setup, alice),
+        0,
+        "an expired share does not count toward the cap"
+    );
+
+    // Re-creating with the same token succeeds only because the expired entry
+    // was pruned on this create; a lingering entry would collide.
+    let now = now_ns(&pic_setup);
+    create_share(&pic_setup, alice, &stale, now + ONE_HOUR_NS, false)
+        .expect("re-creating with the pruned token should succeed");
+    assert_eq!(shares_count(&pic_setup, alice), 1);
+}
+
 // -------------------------------------------------------------------------------------------------
 // - Rate limiting
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Motivation

The per-user active-share cap (`MAX_PERSONAL_NOTE_SHARES_PER_USER`) is enforced by counting only *unexpired* entries in the by-creator index. But `validate_expiry` accepts any timestamp strictly in the future, and expired shares stay persisted in both share maps until the hourly housekeeping sweep removes them.

This let an authenticated user repeatedly create shares with near-immediate expiries (e.g. `now + 1ns`): each stops counting toward the cap on the next call yet still occupies storage. A single user could thus grow their stored volume past the intended ~100-share cap up to the create rate-limit ceiling (20 shares/min, up to 10KB each) until the next sweep reclaimed them. Bounded and self-healing, but it defeats the cap's storage-bounding purpose.

# Changes

- Add `partition_creator_shares`: a single-pass scan over one creator's slice of the by-creator index that returns the active count and the tokens of that creator's expired shares. Scoped per-creator, like `active_share_count_in`, so it stays cheap.
- In `create_personal_note_share`, reclaim the caller's own expired shares (from both maps) before the cap check, so a creator can no longer accumulate expired-but-unpruned shares between creates.
- Prune before the duplicate-token check, so an expired share also frees its token for reuse instead of returning a spurious `DuplicateToken` until the hourly sweep.
- `get_personal_note_shares_count` is a query, so pruning there would be discarded on IC; it is left untouched.

No candid interface change.

# Tests

- Unit test `partition_returns_active_count_and_only_this_creators_expired_tokens`: covers the active/expired split and per-creator scoping.
- Integration test `creating_a_share_prunes_the_callers_own_expired_shares`: expires a share within a window too short for the hourly housekeeping sweep, then re-creates with the same token, so the create-path prune is the only thing that can reclaim it. Verified it fails with `DuplicateToken` when the fix is reverted (confirming it is not a false pass).
- Full `personal_note_shares` integration suite and native `cargo clippy` pass locally. Wasm-target clippy relies on CI.