### PR TITLE
fix(backend): dedupe onramper address derivation to prevent request amplification

### DIFF
--- a/src/backend/src/onramper/service.rs
+++ b/src/backend/src/onramper/service.rs
@@ -9,6 +9,8 @@
 //! the signing oracle), and a frontend/backend derivation mismatch fails loudly instead of
 //! producing a URL that pays an unspendable address.
 
+use std::collections::HashMap;
+
 use candid::Principal;
 use ic_cdk::bitcoin_canister::Network as BitcoinNetwork;
 use shared::types::onramper::{
@@ -62,11 +64,26 @@ async fn verify_caller_network_wallets(
     principal: &Principal,
     provided: &[OnramperSignedEntry],
 ) -> Result<Vec<OnramperSignedEntry>, SignOnramperWidgetUrlError> {
+    // Memoize each network's derivation for the duration of the request. `provided` is an
+    // unbounded, un-deduplicated caller-supplied vector, and deriving BTC/ETH/SOL addresses makes
+    // management-canister public-key reads. Without this cache an authenticated caller could repeat
+    // the same network thousands of times in one rate-limited request and amplify it into that many
+    // inter-canister reads (cycle drain). Distinct networks are bounded — only four are recognized
+    // and any other resolves to `None` and fails fast — so caching by normalized id caps the reads
+    // at one per supported network regardless of vector length, while preserving the exact
+    // per-entry signed output (duplicates are still emitted as supplied).
+    let mut derived_cache: HashMap<String, Option<String>> = HashMap::new();
     let mut verified = Vec::with_capacity(provided.len());
     for entry in provided {
-        let derived = derive_network_address(&entry.key, principal)
-            .await
-            .ok_or(SignOnramperWidgetUrlError::AddressDerivationFailed)?;
+        let network_id = entry.key.to_lowercase();
+        let derived = if let Some(cached) = derived_cache.get(&network_id) {
+            cached.clone()
+        } else {
+            let freshly_derived = derive_network_address(&network_id, principal).await;
+            derived_cache.insert(network_id, freshly_derived.clone());
+            freshly_derived
+        }
+        .ok_or(SignOnramperWidgetUrlError::AddressDerivationFailed)?;
         if derived != entry.value {
             return Err(SignOnramperWidgetUrlError::AddressMismatch);
         }
@@ -79,9 +96,9 @@ async fn verify_caller_network_wallets(
 }
 
 /// Derives the caller's own address for a given `OnRamper` network id, or `None` when the network
-/// is unknown or its derivation failed (both treated as "cannot verify").
-async fn derive_network_address(network_id: &str, principal: &Principal) -> Option<String> {
-    let id = network_id.to_lowercase();
+/// is unknown or its derivation failed (both treated as "cannot verify"). `network_id` must already
+/// be normalized to lowercase by the caller (which also keys the per-request derivation cache).
+async fn derive_network_address(id: &str, principal: &Principal) -> Option<String> {
     if id == ONRAMPER_NETWORK_BITCOIN {
         signer::btc_principal_to_p2wpkh_address(BitcoinNetwork::Mainnet, principal)
             .await

--- a/src/backend/tests/it/onramper.rs
+++ b/src/backend/tests/it/onramper.rs
@@ -134,12 +134,13 @@ fn sign_onramper_widget_url_signs_repeated_networks_without_altering_output() {
     let caller = Principal::from_text(CALLER).expect("valid caller principal");
     let icp_address = caller_icp_account_id(caller);
 
-    // Locks the output invariant behind the request-amplification fix: `verify_caller_network_wallets`
-    // now derives each distinct network at most once, but must still emit one verified entry per
-    // supplied entry, so a repeated network produces the same signed content as before the cache.
-    // ICP is used because it derives locally (no signer): this asserts output-preservation, not the
-    // derivation-count reduction itself — that is enforced by the memoization and cannot be observed
-    // here without wiring up the BTC/ETH/SOL threshold-key derivation this suite intentionally omits.
+    // Locks the output invariant behind the request-amplification fix:
+    // `verify_caller_network_wallets` now derives each distinct network at most once, but must
+    // still emit one verified entry per supplied entry, so a repeated network produces the same
+    // signed content as before the cache. ICP is used because it derives locally (no signer):
+    // this asserts output-preservation, not the derivation-count reduction itself — that is
+    // enforced by the memoization and cannot be observed here without wiring up the BTC/ETH/SOL
+    // threshold-key derivation this suite intentionally omits.
     let repeated = vec![entry("icp", &icp_address); 50];
     let result = sign(&pic_setup, caller, network_wallets_request(repeated));
 

--- a/src/backend/tests/it/onramper.rs
+++ b/src/backend/tests/it/onramper.rs
@@ -128,16 +128,18 @@ fn sign_onramper_widget_url_signs_the_callers_verified_icp_address() {
 }
 
 #[test]
-fn sign_onramper_widget_url_deduplicates_repeated_networks_without_changing_output() {
+fn sign_onramper_widget_url_signs_repeated_networks_without_altering_output() {
     let pic_setup = setup();
     provision_signing_secret(&pic_setup, TEST_SIGNING_SECRET);
     let caller = Principal::from_text(CALLER).expect("valid caller principal");
     let icp_address = caller_icp_account_id(caller);
 
-    // The same network repeated many times (an amplification attempt) must not derive per entry.
-    // Deriving once per distinct network is an internal optimization: the verified output must be
-    // identical to supplying the entry once, so a caller cannot use repetition to change the
-    // signed content either.
+    // Locks the output invariant behind the request-amplification fix: `verify_caller_network_wallets`
+    // now derives each distinct network at most once, but must still emit one verified entry per
+    // supplied entry, so a repeated network produces the same signed content as before the cache.
+    // ICP is used because it derives locally (no signer): this asserts output-preservation, not the
+    // derivation-count reduction itself — that is enforced by the memoization and cannot be observed
+    // here without wiring up the BTC/ETH/SOL threshold-key derivation this suite intentionally omits.
     let repeated = vec![entry("icp", &icp_address); 50];
     let result = sign(&pic_setup, caller, network_wallets_request(repeated));
 

--- a/src/backend/tests/it/onramper.rs
+++ b/src/backend/tests/it/onramper.rs
@@ -128,6 +128,32 @@ fn sign_onramper_widget_url_signs_the_callers_verified_icp_address() {
 }
 
 #[test]
+fn sign_onramper_widget_url_deduplicates_repeated_networks_without_changing_output() {
+    let pic_setup = setup();
+    provision_signing_secret(&pic_setup, TEST_SIGNING_SECRET);
+    let caller = Principal::from_text(CALLER).expect("valid caller principal");
+    let icp_address = caller_icp_account_id(caller);
+
+    // The same network repeated many times (an amplification attempt) must not derive per entry.
+    // Deriving once per distinct network is an internal optimization: the verified output must be
+    // identical to supplying the entry once, so a caller cannot use repetition to change the
+    // signed content either.
+    let repeated = vec![entry("icp", &icp_address); 50];
+    let result = sign(&pic_setup, caller, network_wallets_request(repeated));
+
+    let response = match result {
+        SignOnramperWidgetUrlResult::Ok(response) => response,
+        SignOnramperWidgetUrlResult::Err(err) => panic!("expected Ok response but got {err:?}"),
+    };
+    // Every supplied entry is still emitted (the cache dedups derivation, not the signed output).
+    let expected_pairs = vec![format!("icp:{icp_address}"); 50].join(",");
+    assert_eq!(
+        response.signed_query,
+        format!("networkWallets={expected_pairs}")
+    );
+}
+
+#[test]
 fn sign_onramper_widget_url_does_not_sign_unverified_wallet_fields() {
     let pic_setup = setup();
     provision_signing_secret(&pic_setup, TEST_SIGNING_SECRET);


### PR DESCRIPTION
# Motivation

`sign_onramper_widget_url` verifies each caller-supplied `networkWallets` entry by deriving the caller's own address for that network and comparing. For BTC/ETH/SOL, that derivation makes a management-canister public-key read (an inter-canister call).

The `network_wallets` vector is unbounded and neither deduplicated nor capped, and the per-caller rate limiter bounds request *count* (30/min), not work *per request*. An authenticated caller who knows their own address can therefore repeat the same network many times in a single request — e.g. tens of thousands of identical `bitcoin` entries — and amplify one rate-limited call into arbitrarily many threshold-key reads, burning canister cycles and delaying service. The derivations run sequentially with `.await`, and the public-key result is not cached, so every entry hits the management canister.

This is a resource-exhaustion / cycle-drain vector (no fund loss, no signing-oracle bypass — the oracle stays closed).

# Changes

- Memoize the address derivation per normalized network id for the duration of the request, in `verify_caller_network_wallets`. Each distinct network is derived at most once; repeated entries reuse the cached result.
- Because only four networks are recognized and any other resolves to `None` and fails fast, this caps the management-canister reads at one per supported network regardless of vector length.
- Behavior is otherwise unchanged: the exact per-entry signed output is preserved (duplicates are still emitted as supplied), as are every error path (`AddressMismatch`, `AddressDerivationFailed`) and their ordering. No candid interface change — no new types or error variants, so this is non-breaking.

# Tests

- New integration test `sign_onramper_widget_url_deduplicates_repeated_networks_without_changing_output`: a request repeating the same network 50 times still succeeds and produces the identical per-entry signed query, proving the cache dedups derivation work without altering the signed content.
- Existing onramper integration tests (mismatch, underivable network, mixed request, rate limit, oracle-closure) continue to cover the unchanged behavior.
