### PR TITLE
feat(frontend): update Liquidium page hero component

### DIFF
--- a/src/frontend/src/lib/components/borrow/ActiveLoansCard.svelte
+++ b/src/frontend/src/lib/components/borrow/ActiveLoansCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
@@ -18,9 +19,15 @@
 		widthClass?: string;
 		showHealthFactor?: boolean;
 		showWithShortenedLabel?: boolean;
+		buttons?: Snippet;
 	}
 
-	let { widthClass, showHealthFactor = true, showWithShortenedLabel = false }: Props = $props();
+	let {
+		widthClass,
+		showHealthFactor = true,
+		showWithShortenedLabel = false,
+		buttons
+	}: Props = $props();
 
 	let hasDebt = $derived($liquidiumTotalBorrowedUsd > 0);
 
@@ -31,7 +38,7 @@
 	);
 </script>
 
-<StakeContentCard {widthClass}>
+<StakeContentCard {buttons} {widthClass}>
 	{#snippet content()}
 		<div class="text-sm font-bold">{$i18n.borrow.text.active_loans}</div>
 

--- a/src/frontend/src/lib/components/liquidium/LiquidiumHealthFactor.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumHealthFactor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { liquidiumHealthLevel } from '$lib/utils/liquidium.utils';
 
@@ -6,9 +7,10 @@
 		percent: number;
 		label?: string;
 		showBar?: boolean;
+		badge?: Snippet;
 	}
 
-	let { percent, label, showBar = true }: Props = $props();
+	let { percent, label, showBar = true, badge }: Props = $props();
 
 	let level = $derived(liquidiumHealthLevel(percent));
 
@@ -17,7 +19,10 @@
 
 <div class="flex w-full flex-col gap-2">
 	<div class="flex items-center justify-between text-sm">
-		<span class="text-tertiary">{label ?? $i18n.liquidium.text.projected_health_factor}</span>
+		<span class="flex items-center gap-2">
+			<span class="text-tertiary">{label ?? $i18n.liquidium.text.projected_health_factor}</span>
+			{@render badge?.()}
+		</span>
 		<span
 			class="font-bold"
 			class:text-error-primary={level === 'critical'}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumSummary.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSummary.svelte
@@ -1,22 +1,37 @@
 <script lang="ts">
 	import ActiveLoansCard from '$lib/components/borrow/ActiveLoansCard.svelte';
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
+	import IconCircleCheck from '$lib/components/icons/lucide/IconCircleCheck.svelte';
 	import LiquidiumHealthFactor from '$lib/components/liquidium/LiquidiumHealthFactor.svelte';
+	import LiquidiumBorrowModal from '$lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte';
+	import LiquidiumSupplyModal from '$lib/components/liquidium/supply/LiquidiumSupplyModal.svelte';
 	import StakeContentCard from '$lib/components/stake/StakeContentCard.svelte';
+	import Badge from '$lib/components/ui/Badge.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { modalLiquidiumBorrow, modalLiquidiumSupply } from '$lib/derived/modal.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
 	import type { LiquidiumPortfolio } from '$lib/types/liquidium';
+	import type { BadgeVariant } from '$lib/types/style';
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { liquidiumNetInterestUsd, liquidiumSupplyInterestUsd } from '$lib/utils/liquidium.utils';
+	import {
+		liquidiumHealthLevel,
+		liquidiumNetInterestUsd,
+		liquidiumSupplyInterestUsd
+	} from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		portfolio: LiquidiumPortfolio | null;
 	}
 
 	let { portfolio }: Props = $props();
+
+	const supplyModalId = Symbol();
+	const borrowModalId = Symbol();
 
 	let hasDebt = $derived((portfolio?.totalBorrowedUsd ?? 0) > 0);
 	let healthFactorPercent = $derived(portfolio?.healthFactorPercent ?? 100);
@@ -60,10 +75,62 @@
 				}) ?? ''
 		})
 	);
+
+	// Yearly net-interest chip: green when earning, red when paying, neutral at zero.
+	let netInterestVariant: BadgeVariant = $derived(
+		netInterestUsd > 0 ? 'success' : netInterestUsd < 0 ? 'error' : 'default'
+	);
+	let netInterestChip = $derived(
+		netInterestUsd > 0
+			? `+${netInterestYearly}`
+			: netInterestUsd < 0
+				? `−${netInterestYearly}`
+				: netInterestYearly
+	);
+
+	let healthLevel = $derived(liquidiumHealthLevel(healthFactorPercent));
+
+	// Label + colour paired per branch so they can't drift out of sync.
+	let healthStatus: { label: string; variant: BadgeVariant } = $derived(
+		!hasDebt
+			? { label: $i18n.liquidium.text.health_no_debt, variant: 'default' }
+			: healthLevel === 'healthy'
+				? { label: $i18n.liquidium.text.health_healthy, variant: 'success' }
+				: healthLevel === 'at-risk'
+					? { label: $i18n.liquidium.text.health_at_risk, variant: 'warning' }
+					: { label: $i18n.liquidium.text.health_critical, variant: 'error' }
+	);
 </script>
 
-<div class="mt-6 flex w-full flex-col gap-3 sm:flex-row">
-	<StakeContentCard widthClass="sm:w-1/3">
+<div
+	class="mt-6 flex w-full flex-col gap-4 rounded-xl border border-solid border-disabled bg-secondary p-4"
+>
+	<div class="flex items-center justify-between gap-2">
+		<div class="flex flex-col gap-1">
+			<span class="text-sm font-bold">{$i18n.liquidium.text.net_value}</span>
+
+			<span class="text-2xl font-bold">{formattedNetValue}</span>
+		</div>
+
+		<Badge variant={netInterestVariant} width="w-fit">{netInterestChip}</Badge>
+	</div>
+
+	<LiquidiumHealthFactor label={$i18n.liquidium.text.health_factor} percent={healthFactorPercent}>
+		{#snippet badge()}
+			<Badge variant={healthStatus.variant} width="w-fit">
+				<span class="flex items-center gap-2">
+					{#if hasDebt && healthLevel === 'healthy'}
+						<IconCircleCheck size="14" />
+					{/if}
+					{healthStatus.label}
+				</span>
+			</Badge>
+		{/snippet}
+	</LiquidiumHealthFactor>
+</div>
+
+<div class="mt-3 flex w-full flex-col gap-3 sm:flex-row">
+	<StakeContentCard widthClass="sm:w-1/2">
 		{#snippet content()}
 			<div class="text-sm font-bold">
 				{$i18n.liquidium.text.total_supplied}
@@ -86,38 +153,28 @@
 				{/if}
 			</div>
 		{/snippet}
-	</StakeContentCard>
 
-	<ActiveLoansCard showHealthFactor={false} showWithShortenedLabel widthClass="sm:w-1/3" />
-
-	<StakeContentCard widthClass="sm:w-1/3">
-		{#snippet content()}
-			<div class="text-sm font-bold">{$i18n.liquidium.text.net_value}</div>
-
-			<div class="my-1 text-lg font-bold sm:text-xl">{formattedNetValue}</div>
-
-			<div
-				class="text-sm font-bold sm:text-base"
-				class:text-error-primary={netInterestUsd < 0}
-				class:text-success-primary={netInterestUsd > 0}
-				class:text-tertiary={netInterestUsd === 0}
-			>
-				{$i18n.liquidium.text.apy_suffix}
-				{netInterestUsd > 0
-					? `+${netInterestYearly}`
-					: netInterestUsd < 0
-						? `−${netInterestYearly}`
-						: netInterestYearly}
-			</div>
+		{#snippet buttons()}
+			<Button colorStyle="success" onclick={() => modalStore.openLiquidiumSupply(supplyModalId)}>
+				{$i18n.liquidium.text.action_supply}
+			</Button>
 		{/snippet}
 	</StakeContentCard>
+
+	<ActiveLoansCard showHealthFactor={false} showWithShortenedLabel widthClass="sm:w-1/2">
+		{#snippet buttons()}
+			<Button onclick={() => modalStore.openLiquidiumBorrow(borrowModalId)}>
+				{$i18n.liquidium.text.action_borrow}
+			</Button>
+		{/snippet}
+	</ActiveLoansCard>
 </div>
 
-{#if hasDebt}
-	<div class="mt-5 w-full">
-		<LiquidiumHealthFactor
-			label={$i18n.liquidium.text.health_factor}
-			percent={healthFactorPercent}
-		/>
-	</div>
+<!-- Neutral launches: no market prop, so both open on the select-token step. -->
+{#if $modalLiquidiumSupply && $modalStore?.id === supplyModalId}
+	<LiquidiumSupplyModal />
+{/if}
+
+{#if $modalLiquidiumBorrow && $modalStore?.id === borrowModalId}
+	<LiquidiumBorrowModal />
 {/if}

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
@@ -7,7 +7,6 @@
 	import LiquidiumBorrowReview from '$lib/components/liquidium/borrow/LiquidiumBorrowReview.svelte';
 	import LiquidiumBorrowSummary from '$lib/components/liquidium/borrow/LiquidiumBorrowSummary.svelte';
 	import LiquidiumBorrowTokensList from '$lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte';
-	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumBorrowWizardSteps } from '$lib/config/lend-borrow.config';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
@@ -194,10 +193,6 @@
 					<LiquidiumBorrowSummary portfolio={$liquidiumPortfolio} />
 				{/if}
 			{/snippet}
-
-			<MessageBox styleClass="sm:text-sm !items-center">
-				{$i18n.liquidium.text.borrow_risk_info}
-			</MessageBox>
 		</LiquidiumSelectTokenForm>
 	{:else if nonNullish($liquidiumPortfolio) && nonNullish(preview)}
 		{#if currentStep?.name === WizardStepsLiquidiumBorrow.REVIEW}

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "",
 			"health_factor": "",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "",
 			"markets": "",
 			"total_supplied": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Poskytni Bitcoin. Půjč si stablecoiny. Zůstaň nativní.",
 			"health_factor": "Faktor zdraví",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Čistá hodnota",
 			"markets": "Trhy",
 			"total_supplied": "Celkem poskytnuto",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Bitcoin bereitstellen. Stablecoins leihen. Nativ bleiben.",
 			"health_factor": "Gesundheitsfaktor",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Nettowert",
 			"markets": "Märkte",
 			"total_supplied": "Insgesamt bereitgestellt",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Supply Bitcoin. Borrow Stablecoins. Stay Native.",
 			"health_factor": "Health factor",
+			"health_no_debt": "No debt",
+			"health_healthy": "Healthy",
+			"health_at_risk": "At risk",
+			"health_critical": "Critical",
 			"net_value": "Net value",
 			"markets": "Markets",
 			"total_supplied": "Total supplied",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Suministra Bitcoin. Pide prestadas stablecoins. Mantente nativo.",
 			"health_factor": "Factor de salud",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Valor neto",
 			"markets": "Mercados",
 			"total_supplied": "Total suministrado",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Fournissez du Bitcoin. Empruntez des stablecoins. Restez natif.",
 			"health_factor": "Facteur de santé",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Valeur nette",
 			"markets": "Marchés",
 			"total_supplied": "Total fourni",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Bitcoin जमा करें। स्टेबलकॉइन उधार लें। नेटिव बने रहें।",
 			"health_factor": "स्वास्थ्य कारक",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "नेट वैल्यू",
 			"markets": "मार्केट्स",
 			"total_supplied": "कुल जमा",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Fornisci Bitcoin. Prendi in prestito stablecoin. Resta nativo.",
 			"health_factor": "Fattore di salute",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Valore netto",
 			"markets": "Mercati",
 			"total_supplied": "Totale fornito",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Bitcoinを供給。ステーブルコインを借入。ネイティブのまま。",
 			"health_factor": "ヘルスファクター",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "純資産価値",
 			"markets": "マーケット",
 			"total_supplied": "合計供給額",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Bitcoin 공급. 스테이블코인 대출. 네이티브 유지.",
 			"health_factor": "건강 지수",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "순자산 가치",
 			"markets": "마켓",
 			"total_supplied": "총 공급액",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Dostarcz Bitcoin. Pożycz stablecoiny. Pozostań natywny.",
 			"health_factor": "Wskaźnik zdrowia",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Wartość netto",
 			"markets": "Rynki",
 			"total_supplied": "Łącznie dostarczono",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Fornece Bitcoin. Pede stablecoins emprestadas. Mantém-te nativo.",
 			"health_factor": "Fator de saúde",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Valor líquido",
 			"markets": "Mercados",
 			"total_supplied": "Total fornecido",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Предоставь Bitcoin. Займи стейблкоины. Оставайся нативным.",
 			"health_factor": "Коэффициент здоровья",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Чистая стоимость",
 			"markets": "Рынки",
 			"total_supplied": "Всего предоставлено",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "Cung cấp Bitcoin. Vay stablecoin. Giữ nguyên bản địa.",
 			"health_factor": "Hệ số sức khỏe",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "Giá trị ròng",
 			"markets": "Thị trường",
 			"total_supplied": "Tổng đã cung cấp",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2368,6 +2368,10 @@
 		"text": {
 			"description": "提供 Bitcoin。借入稳定币。保持原生。",
 			"health_factor": "健康系数",
+			"health_no_debt": "",
+			"health_healthy": "",
+			"health_at_risk": "",
+			"health_critical": "",
 			"net_value": "净值",
 			"markets": "市场",
 			"total_supplied": "总供应量",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1904,6 +1904,10 @@ interface I18nLiquidium {
 	text: {
 		description: string;
 		health_factor: string;
+		health_no_debt: string;
+		health_healthy: string;
+		health_at_risk: string;
+		health_critical: string;
 		net_value: string;
 		markets: string;
 		total_supplied: string;

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
@@ -1,8 +1,10 @@
 import LiquidiumSummary from '$lib/components/liquidium/LiquidiumSummary.svelte';
 import { ZERO } from '$lib/constants/app.constants';
+import { modalStore } from '$lib/stores/modal.store';
 import type { LiquidiumPortfolio } from '$lib/types/liquidium';
 import en from '$tests/mocks/i18n.mock';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 
 describe('LiquidiumSummary', () => {
 	const portfolio: LiquidiumPortfolio = {
@@ -82,17 +84,26 @@ describe('LiquidiumSummary', () => {
 		expect(container).not.toHaveTextContent('+$40.00');
 	});
 
-	it('hides the health factor bar when there is no debt', () => {
-		const { container } = render(LiquidiumSummary, { props: { portfolio } });
+	it('always shows the health factor, with a "No debt" status when there is no debt', () => {
+		const noDebt: LiquidiumPortfolio = {
+			...portfolio,
+			totalBorrowedUsd: 0,
+			healthFactorPercent: 100
+		};
 
-		expect(container).not.toHaveTextContent(en.liquidium.text.health_factor);
+		const { container } = render(LiquidiumSummary, { props: { portfolio: noDebt } });
+
+		expect(container).toHaveTextContent(en.liquidium.text.health_factor);
+		expect(container).toHaveTextContent(en.liquidium.text.health_no_debt);
+		expect(container).toHaveTextContent('100%');
 	});
 
-	it('shows the health factor bar when there is debt', () => {
+	it('shows the health factor with a status badge when there is debt', () => {
 		const withDebt: LiquidiumPortfolio = {
 			...portfolio,
 			totalBorrowedUsd: 500,
 			netValueUsd: 500,
+			// 42% falls in the at-risk band (15%–50%).
 			healthFactorPercent: 42
 		};
 
@@ -100,5 +111,44 @@ describe('LiquidiumSummary', () => {
 
 		expect(container).toHaveTextContent(en.liquidium.text.health_factor);
 		expect(container).toHaveTextContent('42%');
+		expect(container).toHaveTextContent(en.liquidium.text.health_at_risk);
+	});
+
+	it('shows the net value with a neutral yearly chip when there is no interest', () => {
+		const { container } = render(LiquidiumSummary, { props: { portfolio: null } });
+
+		expect(container).toHaveTextContent(en.liquidium.text.net_value);
+		// No net interest → neutral "$0.00/yr" chip, no sign.
+		expect(container).not.toHaveTextContent('+$0.00');
+		expect(container).not.toHaveTextContent('−$0.00');
+	});
+
+	describe('action buttons', () => {
+		beforeEach(() => {
+			modalStore.close();
+		});
+
+		it('renders Supply and Borrow buttons even in the empty state', () => {
+			const { getByRole } = render(LiquidiumSummary, { props: { portfolio: null } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_supply })).toBeInTheDocument();
+			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeInTheDocument();
+		});
+
+		it('opens the neutral supply modal from the Supply button', async () => {
+			const { getByRole } = render(LiquidiumSummary, { props: { portfolio } });
+
+			await fireEvent.click(getByRole('button', { name: en.liquidium.text.action_supply }));
+
+			expect(get(modalStore)?.type).toBe('liquidium-supply');
+		});
+
+		it('opens the neutral borrow modal from the Borrow button', async () => {
+			const { getByRole } = render(LiquidiumSummary, { props: { portfolio } });
+
+			await fireEvent.click(getByRole('button', { name: en.liquidium.text.action_borrow }));
+
+			expect(get(modalStore)?.type).toBe('liquidium-borrow');
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

We need to update the Liquidium page hero component according to the new specs.

<img width="609" height="629" alt="Screenshot 2026-07-14 at 09 05 11" src="https://github.com/user-attachments/assets/cf919ae9-43d5-4f30-80b2-a8b2c600f8d6" />
