### PR TITLE
feat(frontend): redesign Borrowed/Supplied sections

### DIFF
--- a/src/frontend/src/lib/components/borrowings/BorrowingsList.svelte
+++ b/src/frontend/src/lib/components/borrowings/BorrowingsList.svelte
@@ -14,7 +14,7 @@
 		<p class="py-10 text-center text-tertiary">{$i18n.borrowings.text.no_borrowings}</p>
 	{:else}
 		{#each borrowReserves as reserve (reserve.poolId)}
-			<LiquidiumBorrowingCard {reserve} variant="holdings" />
+			<LiquidiumBorrowingCard {reserve} />
 		{/each}
 	{/if}
 </div>

--- a/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
+++ b/src/frontend/src/lib/components/earning/EarningYearlyAmount.svelte
@@ -20,6 +20,7 @@
 		showAsSuccess?: boolean;
 		showWithShortenedLabel?: boolean;
 		fallback?: Snippet;
+		children?: Snippet;
 	}
 
 	const {
@@ -31,7 +32,8 @@
 		showAsSuccess = false,
 		showAsError = false,
 		showWithShortenedLabel = false,
-		fallback
+		fallback,
+		children
 	}: Props = $props();
 
 	let formattedCurrency = $derived(
@@ -73,6 +75,7 @@
 		class:text-tertiary={!positiveAmount}
 		in:fade
 	>
+		{@render children?.()}
 		{`${showPlusSign && positiveAmount ? '+' : showMinusSign && hasAmount ? '−' : ''}${yearlyAmount}`}
 	</span>
 {:else if nonNullish(fallback)}

--- a/src/frontend/src/lib/components/earning/EarningsList.svelte
+++ b/src/frontend/src/lib/components/earning/EarningsList.svelte
@@ -103,7 +103,7 @@
 								)}
 						/>
 					{:else}
-						<LiquidiumPositionCard reserve={position.reserve} variant="holdings" />
+						<LiquidiumPositionCard reserve={position.reserve} />
 					{/if}
 				</div>
 			{/each}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
+	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumReserve } from '$lib/types/liquidium';
+	import { isMobile } from '$lib/utils/device.utils';
+	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+
+	interface Props {
+		reserve: LiquidiumReserve;
+	}
+
+	let { reserve }: Props = $props();
+
+	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+
+	let borrowedAmount = $derived(
+		formatToken({ value: reserve.borrowed, unitName: reserve.borrowedDecimals })
+	);
+
+	// Yearly cost at the current borrow APR.
+	let currentlyPaying = $derived((reserve.borrowedUsd * reserve.borrowApy) / 100);
+
+	let borrowedValue = $derived(
+		formatCurrency({
+			value: reserve.borrowedUsd,
+			currency: $currentCurrency,
+			exchangeRate: $currencyExchangeStore,
+			language: $currentLanguage
+		})
+	);
+</script>
+
+<LogoButton hover={false}>
+	{#snippet logo()}
+		<span class="sm:mr-2 flex">
+			{#if nonNullish(token)}
+				<TokenLogo
+					badge={{ type: 'network' }}
+					color="white"
+					data={token}
+					logoSize={isMobile() ? 'sm' : 'lg'}
+				/>
+			{/if}
+		</span>
+	{/snippet}
+
+	{#snippet title()}
+		<span class="text-sm font-normal sm:text-base">
+			<span class="font-bold">{reserve.asset}</span>
+			{#if nonNullish(token)}
+				· {borrowedAmount} {reserve.asset}
+			{/if}
+		</span>
+	{/snippet}
+
+	{#snippet description()}
+		{#if nonNullish(token)}
+			<TokenNameAndNetwork data={token} />
+		{/if}
+	{/snippet}
+
+	{#snippet titleEnd()}
+		<span class="text-error-primary">{borrowedValue}</span>
+	{/snippet}
+
+	{#snippet descriptionEnd()}
+		<EarningYearlyAmount showAsError showMinusSign showWithShortenedLabel value={currentlyPaying}>
+			{formatStakeApyNumber(reserve.borrowApy)}% {$i18n.borrow.text.apr} ·
+		</EarningYearlyAmount>
+	{/snippet}
+</LogoButton>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumBorrowingCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumBorrowingCard.svelte
@@ -2,33 +2,25 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { goto } from '$app/navigation';
 	import LiquidiumProviderTag from '$lib/components/liquidium/LiquidiumProviderTag.svelte';
-	import LiquidiumRepayModal from '$lib/components/liquidium/repay/LiquidiumRepayModal.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import { modalLiquidiumRepay } from '$lib/derived/modal.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
 
 	interface Props {
+		// Assets → Borrowings tab row; no action, clicks through to the provider page.
 		reserve: LiquidiumReserve;
-		// 'provider': provider-page row with a Repay action (default).
-		// 'holdings': Assets → Borrowings tab row; no action, clicks through to the provider page.
-		variant?: 'provider' | 'holdings';
 	}
 
-	let { reserve, variant = 'provider' }: Props = $props();
-
-	const modalId = Symbol();
+	let { reserve }: Props = $props();
 
 	const goToProvider = () => {
 		void goto(AppPath.ProvidersLiquidium);
@@ -50,29 +42,12 @@
 	);
 </script>
 
-{#snippet repayAction()}
-	<span class="ml-2 flex">
-		<Button
-			colorStyle="secondary-light"
-			onclick={() => modalStore.openLiquidiumRepay(modalId)}
-			paddingSmall
-		>
-			{$i18n.liquidium.text.action_repay}
-		</Button>
-	</span>
-{/snippet}
-
 {#snippet providerTag()}
 	<LiquidiumProviderTag />
 {/snippet}
 
 <div class="flex w-full flex-col">
-	<LogoButton
-		action={variant === 'provider' ? repayAction : undefined}
-		hover={variant === 'holdings'}
-		onClick={variant === 'holdings' ? goToProvider : undefined}
-		subtitle={variant === 'holdings' ? providerTag : undefined}
-	>
+	<LogoButton onClick={goToProvider} subtitle={providerTag}>
 		{#snippet logo()}
 			<span class="mr-2 flex">
 				{#if nonNullish(token)}
@@ -109,9 +84,4 @@
 			</span>
 		{/snippet}
 	</LogoButton>
-
-	<!-- Outside LogoButton's <button> to keep valid HTML. -->
-	{#if variant === 'provider' && $modalLiquidiumRepay && $modalStore?.id === modalId}
-		<LiquidiumRepayModal {reserve} />
-	{/if}
 </div>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
@@ -3,33 +3,25 @@
 	import { goto } from '$app/navigation';
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import LiquidiumProviderTag from '$lib/components/liquidium/LiquidiumProviderTag.svelte';
-	import LiquidiumWithdrawModal from '$lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import { modalLiquidiumWithdraw } from '$lib/derived/modal.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
 
 	interface Props {
+		// Assets → Earning tab row; no action, clicks through to the provider page.
 		reserve: LiquidiumReserve;
-		// 'provider': provider-page row with a Withdraw action (default).
-		// 'holdings': Assets → Earning tab row; no action, clicks through to the provider page.
-		variant?: 'provider' | 'holdings';
 	}
 
-	let { reserve, variant = 'provider' }: Props = $props();
-
-	const modalId = Symbol();
+	let { reserve }: Props = $props();
 
 	const goToProvider = () => {
 		void goto(AppPath.ProvidersLiquidium);
@@ -54,29 +46,12 @@
 	);
 </script>
 
-{#snippet withdrawAction()}
-	<span class="ml-2 flex">
-		<Button
-			colorStyle="secondary-light"
-			onclick={() => modalStore.openLiquidiumWithdraw(modalId)}
-			paddingSmall
-		>
-			{$i18n.liquidium.text.action_withdraw}
-		</Button>
-	</span>
-{/snippet}
-
 {#snippet providerTag()}
 	<LiquidiumProviderTag />
 {/snippet}
 
 <div class="flex w-full flex-col">
-	<LogoButton
-		action={variant === 'provider' ? withdrawAction : undefined}
-		hover={variant === 'holdings'}
-		onClick={variant === 'holdings' ? goToProvider : undefined}
-		subtitle={variant === 'holdings' ? providerTag : undefined}
-	>
+	<LogoButton onClick={goToProvider} subtitle={providerTag}>
 		{#snippet logo()}
 			<span class="mr-2 flex">
 				{#if nonNullish(token)}
@@ -124,9 +99,4 @@
 			</span>
 		{/snippet}
 	</LogoButton>
-
-	<!-- Outside LogoButton's <button> to keep valid HTML. -->
-	{#if variant === 'provider' && $modalLiquidiumWithdraw && $modalStore?.id === modalId}
-		<LiquidiumWithdrawModal {reserve} />
-	{/if}
 </div>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
@@ -4,12 +4,15 @@
 	import { LEND_BORROW_ENABLED } from '$env/lend-borrow';
 	import { LIQUIDIUM_ENABLED } from '$env/liquidium';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
-	import LiquidiumBorrowingCard from '$lib/components/liquidium/LiquidiumBorrowingCard.svelte';
+	import LiquidiumBorrowedRow from '$lib/components/liquidium/LiquidiumBorrowedRow.svelte';
 	import LiquidiumInfoBox from '$lib/components/liquidium/LiquidiumInfoBox.svelte';
 	import LiquidiumMarketCard from '$lib/components/liquidium/LiquidiumMarketCard.svelte';
-	import LiquidiumPositionCard from '$lib/components/liquidium/LiquidiumPositionCard.svelte';
 	import LiquidiumProviderHero from '$lib/components/liquidium/LiquidiumProviderHero.svelte';
+	import LiquidiumSuppliedRow from '$lib/components/liquidium/LiquidiumSuppliedRow.svelte';
+	import LiquidiumRepayModal from '$lib/components/liquidium/repay/LiquidiumRepayModal.svelte';
+	import LiquidiumWithdrawModal from '$lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte';
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
 	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
 	import { ZERO } from '$lib/constants/app.constants';
 	import {
@@ -20,12 +23,18 @@
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { liquidiumMarkets, liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { modalLiquidiumRepay, modalLiquidiumWithdraw } from '$lib/derived/modal.derived';
 	import { loadLiquidium } from '$lib/services/liquidium.services';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { modalStore } from '$lib/stores/modal.store';
 	import { LendBorrowProvider } from '$lib/types/lend-borrow';
 	import { replaceOisyPlaceholders, resolveText } from '$lib/utils/i18n.utils';
 
 	const liquidium = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM];
+
+	// Section-header actions launch neutral (token-less) modals that open on their picker.
+	const withdrawModalId = Symbol();
+	const repayModalId = Symbol();
 
 	let infoBoxRef = $state<HTMLElement | undefined>();
 
@@ -68,14 +77,29 @@
 					<h4>{$i18n.liquidium.text.supplied}</h4>
 				{/snippet}
 
+				{#snippet action()}
+					<Button
+						colorStyle="secondary-light"
+						onclick={() => modalStore.openLiquidiumWithdraw(withdrawModalId)}
+						paddingSmall
+					>
+						{$i18n.liquidium.text.action_withdraw}
+					</Button>
+				{/snippet}
+
 				{#snippet content()}
 					<div class="flex w-full flex-col gap-4">
 						{#each supplyReserves as reserve (reserve.poolId)}
-							<LiquidiumPositionCard {reserve} />
+							<LiquidiumSuppliedRow {reserve} />
 						{/each}
 					</div>
 				{/snippet}
 			</StakeContentSection>
+
+			<!-- Neutral launch: no reserve prop, so it opens on the select-token step. -->
+			{#if $modalLiquidiumWithdraw && $modalStore?.id === withdrawModalId}
+				<LiquidiumWithdrawModal />
+			{/if}
 		{/if}
 
 		{#if LIQUIDIUM_ENABLED && borrowReserves.length > 0}
@@ -84,14 +108,29 @@
 					<h4>{$i18n.liquidium.text.borrowed}</h4>
 				{/snippet}
 
+				{#snippet action()}
+					<Button
+						colorStyle="success-light"
+						onclick={() => modalStore.openLiquidiumRepay(repayModalId)}
+						paddingSmall
+					>
+						{$i18n.liquidium.text.action_repay}
+					</Button>
+				{/snippet}
+
 				{#snippet content()}
 					<div class="flex w-full flex-col gap-4">
 						{#each borrowReserves as reserve (reserve.poolId)}
-							<LiquidiumBorrowingCard {reserve} />
+							<LiquidiumBorrowedRow {reserve} />
 						{/each}
 					</div>
 				{/snippet}
 			</StakeContentSection>
+
+			<!-- Neutral launch: no reserve prop, so it opens on the select-token step. -->
+			{#if $modalLiquidiumRepay && $modalStore?.id === repayModalId}
+				<LiquidiumRepayModal />
+			{/if}
 		{/if}
 
 		{#if LIQUIDIUM_ENABLED && $liquidiumMarkets.length > 0}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import { nonNullish } from '@dfinity/utils';
+	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
+	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
+	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
+	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { LiquidiumReserve } from '$lib/types/liquidium';
+	import { isMobile } from '$lib/utils/device.utils';
+	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+
+	interface Props {
+		reserve: LiquidiumReserve;
+	}
+
+	let { reserve }: Props = $props();
+
+	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+
+	let suppliedAmount = $derived(
+		formatToken({ value: reserve.deposited, unitName: reserve.depositedDecimals })
+	);
+
+	// Yearly interest at the current supply APY.
+	let currentlyEarning = $derived((reserve.suppliedUsd * reserve.supplyApy) / 100);
+
+	let suppliedValue = $derived(
+		formatCurrency({
+			value: reserve.suppliedUsd,
+			currency: $currentCurrency,
+			exchangeRate: $currencyExchangeStore,
+			language: $currentLanguage
+		})
+	);
+</script>
+
+<LogoButton hover={false}>
+	{#snippet logo()}
+		<span class="sm:mr-2 flex">
+			{#if nonNullish(token)}
+				<TokenLogo
+					badge={{ type: 'network' }}
+					color="white"
+					data={token}
+					logoSize={isMobile() ? 'sm' : 'lg'}
+				/>
+			{/if}
+		</span>
+	{/snippet}
+
+	{#snippet title()}
+		<span class="text-sm font-normal sm:text-base">
+			<span class="font-bold">{reserve.asset}</span>
+			{#if nonNullish(token)}
+				· {suppliedAmount} {reserve.asset}
+			{/if}
+		</span>
+	{/snippet}
+
+	{#snippet description()}
+		{#if nonNullish(token)}
+			<TokenNameAndNetwork data={token} />
+		{/if}
+	{/snippet}
+
+	{#snippet titleEnd()}
+		<span>{suppliedValue}</span>
+	{/snippet}
+
+	{#snippet descriptionEnd()}
+		<EarningYearlyAmount showAsSuccess showPlusSign showWithShortenedLabel value={currentlyEarning}>
+			{formatStakeApyNumber(reserve.supplyApy)}% {$i18n.liquidium.text.apy_suffix} ·
+		</EarningYearlyAmount>
+	{/snippet}
+</LogoButton>

--- a/src/frontend/src/lib/styles/global/button.scss
+++ b/src/frontend/src/lib/styles/global/button.scss
@@ -32,6 +32,7 @@ a.as-button {
 	&.tertiary-main-card,
 	&.muted,
 	&.success,
+	&.success-light,
 	&.error {
 		justify-content: center;
 
@@ -55,6 +56,7 @@ a.as-button {
 	&.tertiary-main-card,
 	&.muted,
 	&.success,
+	&.success-light,
 	&.error {
 		font-weight: var(--font-weight-bold);
 
@@ -205,6 +207,45 @@ a.as-button {
 	&.secondary-light.loading {
 		@apply text-brand-primary-alt;
 		@apply bg-brand-subtle-10;
+	}
+
+	// SUCCESS LIGHT
+	&.success-light:not([disabled]):not(.disabled):not(.loading):not(.link) {
+		@apply text-success-primary;
+
+		&:not(.transparent) {
+			@apply bg-success-subtle-10;
+		}
+
+		&.transparent {
+			@apply bg-transparent;
+		}
+
+		&:hover {
+			@apply text-success-primary;
+			@apply bg-success-subtle-20;
+		}
+
+		&:active {
+			@apply text-success-primary;
+			@apply bg-success-subtle-30;
+		}
+
+		&:focus-visible {
+			@apply text-success-primary;
+			@apply bg-success-subtle-10;
+		}
+	}
+
+	&.success-light.disabled:not(.loading):not(.link),
+	&.success-light[disabled]:not(.loading):not(.link) {
+		@apply text-disabled;
+		@apply bg-disabled;
+	}
+
+	&.success-light.loading {
+		@apply text-success-primary;
+		@apply bg-success-subtle-10;
 	}
 
 	// TERTIARY

--- a/src/frontend/src/lib/types/style.ts
+++ b/src/frontend/src/lib/types/style.ts
@@ -7,7 +7,8 @@ export type ButtonColorStyle =
 	| 'tertiary-alt'
 	| 'muted'
 	| 'error'
-	| 'success';
+	| 'success'
+	| 'success-light';
 
 export type BadgeVariant =
 	| 'default'

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
@@ -1,0 +1,49 @@
+import LiquidiumBorrowedRow from '$lib/components/liquidium/LiquidiumBorrowedRow.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+import type { LiquidiumReserve } from '$lib/types/liquidium';
+import { formatStakeApyNumber } from '$lib/utils/format.utils';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumBorrowedRow', () => {
+	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
+		poolId: 'pool-usdc',
+		asset: 'USDC',
+		chain: 'ETH',
+		supplyApy: 0,
+		borrowApy: 4,
+		deposited: ZERO,
+		depositedDecimals: 6,
+		// 1 USDC (6 decimals).
+		borrowed: 1_000_000n,
+		borrowedDecimals: 6,
+		suppliedUsd: 0,
+		borrowedUsd: 100,
+		...overrides
+	});
+
+	it('renders the symbol, token name and network', () => {
+		const { container } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
+		const usdc = LIQUIDIUM_ASSET_TOKENS.USDC;
+
+		expect(container).toHaveTextContent('USDC');
+		expect(container).toHaveTextContent(usdc.name);
+		expect(container).toHaveTextContent(usdc.network.name);
+	});
+
+	it('renders the borrow APR and the yearly cost as a negative amount', () => {
+		const { container } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
+
+		expect(container).toHaveTextContent(`${formatStakeApyNumber(4)}%`);
+		expect(container).toHaveTextContent(en.borrow.text.apr);
+		// currentlyPaying = 100 * 4 / 100 = $4/yr, shown as −$4.00/yr.
+		expect(container).toHaveTextContent('−$4.00');
+	});
+
+	it('does not render a per-row action button', () => {
+		const { queryByText } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
+
+		expect(queryByText(en.liquidium.text.action_repay)).not.toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowingCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowingCard.spec.ts
@@ -13,6 +13,7 @@ vi.mock('$app/navigation', () => ({
 	goto: vi.fn()
 }));
 
+// Assets → Borrowings tab holdings row: no action, clicks through to the provider page.
 describe('LiquidiumBorrowingCard', () => {
 	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
 		poolId: 'pool-btc',
@@ -46,47 +47,25 @@ describe('LiquidiumBorrowingCard', () => {
 		expect(container.textContent).toContain('−');
 	});
 
-	it('renders a Repay action button', () => {
-		const { getByText } = render(LiquidiumBorrowingCard, { props: { reserve: reserve() } });
-
-		expect(getByText(en.liquidium.text.action_repay)).toBeInTheDocument();
-	});
-
-	it('does not render the provider tag in the provider variant', () => {
+	it('renders the Liquidium provider tag', () => {
 		const { container } = render(LiquidiumBorrowingCard, { props: { reserve: reserve() } });
 
-		expect(container).not.toHaveTextContent(
+		expect(container).toHaveTextContent(
 			lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
 		);
 	});
 
-	describe('holdings variant', () => {
-		it('does not render the Repay action button', () => {
-			const { queryByText } = render(LiquidiumBorrowingCard, {
-				props: { reserve: reserve(), variant: 'holdings' }
-			});
+	it('does not render a Repay action button', () => {
+		const { queryByText } = render(LiquidiumBorrowingCard, { props: { reserve: reserve() } });
 
-			expect(queryByText(en.liquidium.text.action_repay)).not.toBeInTheDocument();
-		});
+		expect(queryByText(en.liquidium.text.action_repay)).not.toBeInTheDocument();
+	});
 
-		it('renders the Liquidium provider tag', () => {
-			const { container } = render(LiquidiumBorrowingCard, {
-				props: { reserve: reserve(), variant: 'holdings' }
-			});
+	it('navigates to the Liquidium provider page when clicked', async () => {
+		const { getByRole } = render(LiquidiumBorrowingCard, { props: { reserve: reserve() } });
 
-			expect(container).toHaveTextContent(
-				lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
-			);
-		});
+		await fireEvent.click(getByRole('button'));
 
-		it('navigates to the Liquidium provider page when clicked', async () => {
-			const { getByRole } = render(LiquidiumBorrowingCard, {
-				props: { reserve: reserve(), variant: 'holdings' }
-			});
-
-			await fireEvent.click(getByRole('button'));
-
-			expect(goto).toHaveBeenCalledWith(AppPath.ProvidersLiquidium);
-		});
+		expect(goto).toHaveBeenCalledWith(AppPath.ProvidersLiquidium);
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
@@ -3,19 +3,17 @@ import LiquidiumPositionCard from '$lib/components/liquidium/LiquidiumPositionCa
 import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
 import { ZERO } from '$lib/constants/app.constants';
 import { AppPath } from '$lib/constants/routes.constants';
-import { modalLiquidiumWithdraw } from '$lib/derived/modal.derived';
-import { modalStore } from '$lib/stores/modal.store';
 import { LendBorrowProvider } from '$lib/types/lend-borrow';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
 import { fireEvent, render } from '@testing-library/svelte';
-import { get } from 'svelte/store';
 
 vi.mock('$app/navigation', () => ({
 	goto: vi.fn()
 }));
 
+// Assets → Earning tab holdings row: no action, clicks through to the provider page.
 describe('LiquidiumPositionCard', () => {
 	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
 		poolId: 'pool-btc',
@@ -33,10 +31,9 @@ describe('LiquidiumPositionCard', () => {
 		...overrides
 	});
 
-	it('renders the supplied asset, APY and amount', () => {
+	it('renders the supplied asset and APY', () => {
 		const { container } = render(LiquidiumPositionCard, { props: { reserve: reserve() } });
 
-		// The "Supplied" label lives on the section header now, not the card.
 		expect(container).toHaveTextContent('BTC');
 		expect(container).toHaveTextContent(en.liquidium.text.apy_suffix);
 		expect(container).toHaveTextContent(`${formatStakeApyNumber(5)}%`);
@@ -50,61 +47,25 @@ describe('LiquidiumPositionCard', () => {
 		expect(container).not.toHaveTextContent('/year');
 	});
 
-	it('renders a zero APY position (default badge variant)', () => {
-		const { container } = render(LiquidiumPositionCard, {
-			props: { reserve: reserve({ supplyApy: 0 }) }
-		});
-
-		expect(container).toHaveTextContent(`${formatStakeApyNumber(0)}%`);
-	});
-
-	it('opens the withdraw modal from the Withdraw button', async () => {
-		modalStore.close();
-
-		const { getByRole } = render(LiquidiumPositionCard, { props: { reserve: reserve() } });
-
-		await fireEvent.click(getByRole('button', { name: en.liquidium.text.action_withdraw }));
-
-		expect(get(modalLiquidiumWithdraw)).toBeTruthy();
-
-		modalStore.close();
-	});
-
-	it('does not render the provider tag in the provider variant', () => {
+	it('renders the Liquidium provider tag', () => {
 		const { container } = render(LiquidiumPositionCard, { props: { reserve: reserve() } });
 
-		expect(container).not.toHaveTextContent(
+		expect(container).toHaveTextContent(
 			lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
 		);
 	});
 
-	describe('holdings variant', () => {
-		it('does not render the Withdraw action button', () => {
-			const { queryByText } = render(LiquidiumPositionCard, {
-				props: { reserve: reserve(), variant: 'holdings' }
-			});
+	it('does not render a Withdraw action button', () => {
+		const { queryByText } = render(LiquidiumPositionCard, { props: { reserve: reserve() } });
 
-			expect(queryByText(en.liquidium.text.action_withdraw)).not.toBeInTheDocument();
-		});
+		expect(queryByText(en.liquidium.text.action_withdraw)).not.toBeInTheDocument();
+	});
 
-		it('renders the Liquidium provider tag', () => {
-			const { container } = render(LiquidiumPositionCard, {
-				props: { reserve: reserve(), variant: 'holdings' }
-			});
+	it('navigates to the Liquidium provider page when clicked', async () => {
+		const { getByRole } = render(LiquidiumPositionCard, { props: { reserve: reserve() } });
 
-			expect(container).toHaveTextContent(
-				lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
-			);
-		});
+		await fireEvent.click(getByRole('button'));
 
-		it('navigates to the Liquidium provider page when clicked', async () => {
-			const { getByRole } = render(LiquidiumPositionCard, {
-				props: { reserve: reserve(), variant: 'holdings' }
-			});
-
-			await fireEvent.click(getByRole('button'));
-
-			expect(goto).toHaveBeenCalledWith(AppPath.ProvidersLiquidium);
-		});
+		expect(goto).toHaveBeenCalledWith(AppPath.ProvidersLiquidium);
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumPositionCard.spec.ts
@@ -44,7 +44,7 @@ describe('LiquidiumPositionCard', () => {
 			props: { reserve: reserve({ suppliedUsd: 0 }) }
 		});
 
-		expect(container).not.toHaveTextContent('/year');
+		expect(container).not.toHaveTextContent('/yr');
 	});
 
 	it('renders the Liquidium provider tag', () => {

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
@@ -1,0 +1,49 @@
+import LiquidiumSuppliedRow from '$lib/components/liquidium/LiquidiumSuppliedRow.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+import type { LiquidiumReserve } from '$lib/types/liquidium';
+import { formatStakeApyNumber } from '$lib/utils/format.utils';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('LiquidiumSuppliedRow', () => {
+	const reserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'BTC',
+		supplyApy: 5,
+		borrowApy: 0,
+		// 1 BTC in satoshis.
+		deposited: 100_000_000n,
+		depositedDecimals: 8,
+		borrowed: ZERO,
+		borrowedDecimals: 8,
+		suppliedUsd: 1000,
+		borrowedUsd: 0,
+		...overrides
+	});
+
+	it('renders the symbol, token name and network', () => {
+		const { container } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
+		const btc = LIQUIDIUM_ASSET_TOKENS.BTC;
+
+		expect(container).toHaveTextContent('BTC');
+		expect(container).toHaveTextContent(btc.name);
+		expect(container).toHaveTextContent(btc.network.name);
+	});
+
+	it('renders the supply APY and yearly earning', () => {
+		const { container } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
+
+		expect(container).toHaveTextContent(`${formatStakeApyNumber(5)}%`);
+		expect(container).toHaveTextContent(en.liquidium.text.apy_suffix);
+		// currentlyEarning = 1000 * 5 / 100 = $50/yr.
+		expect(container).toHaveTextContent('$50.00');
+	});
+
+	it('does not render a per-row action button', () => {
+		const { queryByText } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
+
+		expect(queryByText(en.liquidium.text.action_withdraw)).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
# Motivation

As the next step of Liquidium page redesign, we need to update the Borrowed and Supplied sections according to the new specs.

<img width="608" height="470" alt="Screenshot 2026-07-14 at 16 16 06" src="https://github.com/user-attachments/assets/09b754c0-7350-43a5-8a87-b9b0c5bf98db" />
