### PR TITLE
feat(frontend): update Liquidium markets section

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
-	import LiquidiumBorrowModal from '$lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte';
-	import LiquidiumSupplyModal from '$lib/components/liquidium/supply/LiquidiumSupplyModal.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
-	import Button from '$lib/components/ui/Button.svelte';
+	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
-	import { ZERO } from '$lib/constants/app.constants';
 	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
-	import { liquidiumPortfolio } from '$lib/derived/liquidium.derived';
-	import { modalLiquidiumBorrow, modalLiquidiumSupply } from '$lib/derived/modal.derived';
 	import { i18n } from '$lib/stores/i18n.store';
-	import { modalStore } from '$lib/stores/modal.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatStakeApyNumber } from '$lib/utils/format.utils';
@@ -22,107 +16,67 @@
 
 	let { market }: Props = $props();
 
-	// Per-card id so only the clicked card's modal opens.
-	const modalId = Symbol();
-
-	// Hard-coded teaser row: advertise the asset with "Coming soon..." and disabled actions.
+	// Hard-coded teaser row (e.g. ICP) advertises the asset with disabled rates.
 	let isTeaser = $derived(market.teaser === true);
 
 	let token = $derived(isTeaser ? ICP_TOKEN : LIQUIDIUM_ASSET_TOKENS[market.asset]);
 
-	// Can't borrow a token you supplied (withdraw instead).
-	let isSupplied = $derived(
-		($liquidiumPortfolio?.reserves ?? []).some(
-			({ poolId, deposited }) => poolId === market.poolId && deposited > ZERO
-		)
-	);
-
-	// Can't supply a token you borrowed (repay instead).
-	let isBorrowed = $derived(
-		($liquidiumPortfolio?.reserves ?? []).some(
-			({ poolId, borrowed }) => poolId === market.poolId && borrowed > ZERO
-		)
-	);
-
-	// Needs borrowing power and an unsupplied token; kept disabled (not hidden) otherwise.
-	let canBorrow = $derived(
-		nonNullish($liquidiumPortfolio) && $liquidiumPortfolio.availableBorrowsUsd > 0 && !isSupplied
-	);
+	// Actions live in the hero / section headers, so markets rows are informational only:
+	// a teaser or an unavailable pool (frozen / cap) shows "Coming soon" instead of rates.
+	let comingSoon = $derived(isTeaser || !market.available);
 </script>
 
-<div class="flex w-full flex-col">
-	<LogoButton hover={false}>
-		{#snippet logo()}
-			<span class="mr-2 flex">
-				{#if nonNullish(token)}
-					<TokenLogo
-						badge={{ type: 'network' }}
-						color="white"
-						data={token}
-						logoSize={isMobile() ? 'sm' : 'lg'}
-					/>
-				{/if}
-			</span>
-		{/snippet}
-
-		{#snippet title()}
-			<span class="text-sm sm:text-lg">{market.asset}</span>
-		{/snippet}
-
-		{#snippet subtitle()}
-			{#if !market.available}
-				<span
-					class="ml-2 rounded-full bg-warning-subtle-20 px-2 py-0.5 text-xs text-warning-primary"
-				>
-					{$i18n.liquidium.text.coming_soon}
-				</span>
-			{/if}
-		{/snippet}
-
-		{#snippet description()}
-			{#if isTeaser}
-				<span class="text-success-primary">{$i18n.liquidium.text.coming_soon_teaser}</span>
-			{:else}
-				<span>
-					{$i18n.liquidium.text.supply_label}
-					<span class="text-success-primary">{formatStakeApyNumber(market.supplyApy)}%</span>
-					· {$i18n.liquidium.text.borrow_label}
-					<span class="text-warning-primary">{formatStakeApyNumber(market.borrowApy)}%</span>
-				</span>
-			{/if}
-		{/snippet}
-
-		{#snippet action()}
-			{#if market.available}
-				<div class="flex gap-2">
-					<Button
-						colorStyle="secondary"
-						disabled={isTeaser || !canBorrow}
-						onclick={() => modalStore.openLiquidiumBorrow(modalId)}
-						paddingSmall
-					>
-						{$i18n.liquidium.text.action_borrow}
-					</Button>
-
-					<Button
-						disabled={isTeaser || isBorrowed}
-						onclick={() => modalStore.openLiquidiumSupply(modalId)}
-						paddingSmall
-					>
-						{$i18n.liquidium.text.action_supply}
-					</Button>
-				</div>
-			{/if}
-		{/snippet}
-	</LogoButton>
-
-	<!-- Sibling of LogoButton, not inside its <button> — avoids inheriting button
-		styles and keeps valid HTML. -->
-	{#if market.available && $modalLiquidiumSupply && $modalStore?.id === modalId}
-		<LiquidiumSupplyModal {market} />
+{#snippet rates()}
+	{#if comingSoon}
+		<span class="text-sm font-semibold text-success-primary">
+			{$i18n.liquidium.text.coming_soon_teaser}
+		</span>
+	{:else}
+		<span class="text-sm font-normal">
+			{$i18n.liquidium.text.supply_label}
+			<span class="font-semibold text-success-primary"
+				>{formatStakeApyNumber(market.supplyApy)}%</span
+			>
+			· {$i18n.liquidium.text.borrow_label}
+			<span class="font-semibold text-warning-primary"
+				>{formatStakeApyNumber(market.borrowApy)}%</span
+			>
+		</span>
 	{/if}
+{/snippet}
 
-	{#if market.available && $modalLiquidiumBorrow && $modalStore?.id === modalId}
-		<LiquidiumBorrowModal {market} />
-	{/if}
-</div>
+<LogoButton hover={false}>
+	{#snippet logo()}
+		<span class="sm:mr-2 flex">
+			{#if nonNullish(token)}
+				<TokenLogo
+					badge={{ type: 'network' }}
+					color="white"
+					data={token}
+					logoSize={isMobile() ? 'sm' : 'lg'}
+				/>
+			{/if}
+		</span>
+	{/snippet}
+
+	{#snippet title()}
+		<span class="text-sm font-bold sm:text-base">{market.asset}</span>
+	{/snippet}
+
+	{#snippet description()}
+		<span class="flex flex-col">
+			<!-- Wrapped so name + network stay on one line inside the column. -->
+			{#if nonNullish(token)}
+				<span><TokenNameAndNetwork data={token} /></span>
+			{/if}
+
+			<!-- xs only: the rates that otherwise live in titleEnd. -->
+			<span class="sm:hidden">{@render rates()}</span>
+		</span>
+	{/snippet}
+
+	{#snippet titleEnd()}
+		<!-- On sm+ the rates sit on the right; on xs they drop to the description's second line. -->
+		<span class="hidden sm:block">{@render rates()}</span>
+	{/snippet}
+</LogoButton>

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumMarketCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumMarketCard.spec.ts
@@ -1,7 +1,6 @@
 import LiquidiumMarketCard from '$lib/components/liquidium/LiquidiumMarketCard.svelte';
-import { ZERO } from '$lib/constants/app.constants';
-import { liquidiumStore } from '$lib/stores/liquidium.store';
-import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 
@@ -17,129 +16,36 @@ describe('LiquidiumMarketCard', () => {
 		...overrides
 	});
 
-	const suppliedReserve = (poolId: string): LiquidiumReserve => ({
-		poolId,
-		asset: 'BTC',
-		chain: 'BTC',
-		supplyApy: 5,
-		borrowApy: 9,
-		deposited: 100_000_000n,
-		depositedDecimals: 8,
-		borrowed: ZERO,
-		borrowedDecimals: 8,
-		suppliedUsd: 1000,
-		borrowedUsd: 0
-	});
-
-	const borrowedReserve = (poolId: string): LiquidiumReserve => ({
-		poolId,
-		asset: 'BTC',
-		chain: 'BTC',
-		supplyApy: 5,
-		borrowApy: 9,
-		deposited: ZERO,
-		depositedDecimals: 8,
-		borrowed: 1_000_000n,
-		borrowedDecimals: 8,
-		suppliedUsd: 0,
-		borrowedUsd: 1000
-	});
-
-	const setPortfolio = (overrides: Partial<LiquidiumPortfolio> = {}) =>
-		liquidiumStore.set({
-			markets: [],
-			assetPrices: {},
-			portfolio: {
-				reserves: [],
-				totalSuppliedUsd: 1000,
-				totalBorrowedUsd: 0,
-				netValueUsd: 1000,
-				availableBorrowsUsd: 700,
-				weightedLiquidationThresholdBps: 8000,
-				healthFactorPercent: 100,
-				...overrides
-			}
-		});
-
-	afterEach(() => {
-		liquidiumStore.reset();
-	});
-
-	it('renders the asset and supply/borrow labels', () => {
+	it('renders the asset with supply and borrow rates', () => {
 		const { container } = render(LiquidiumMarketCard, { props: { market: market() } });
 
 		expect(container).toHaveTextContent('BTC');
 		expect(container).toHaveTextContent(en.liquidium.text.supply_label);
 		expect(container).toHaveTextContent(en.liquidium.text.borrow_label);
+		expect(container).toHaveTextContent(`${formatStakeApyNumber(5)}%`);
+		expect(container).toHaveTextContent(`${formatStakeApyNumber(9)}%`);
 	});
 
-	it('does not show "Coming soon" for an available market', () => {
+	it('shows rates instead of "Coming soon" for an available market', () => {
 		const { container } = render(LiquidiumMarketCard, { props: { market: market() } });
 
-		expect(container).not.toHaveTextContent(en.liquidium.text.coming_soon);
+		expect(container).not.toHaveTextContent(en.liquidium.text.coming_soon_teaser);
 	});
 
-	it('shows "Coming soon" for an unavailable market', () => {
+	it('shows "Coming soon" instead of rates for an unavailable market', () => {
 		const { container } = render(LiquidiumMarketCard, {
 			props: { market: market({ available: false }) }
 		});
 
-		expect(container).toHaveTextContent(en.liquidium.text.coming_soon);
+		expect(container).toHaveTextContent(en.liquidium.text.coming_soon_teaser);
+		expect(container).not.toHaveTextContent(en.liquidium.text.supply_label);
 	});
 
-	describe('Borrow button gating', () => {
-		it('is disabled when the user has no borrowing power', () => {
-			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
-
-			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeDisabled();
+	it('shows "Coming soon" for the teaser row', () => {
+		const { container } = render(LiquidiumMarketCard, {
+			props: { market: market({ teaser: true, asset: 'ICP', chain: 'ICP' }) }
 		});
 
-		it('is disabled for a token the user has already supplied', () => {
-			setPortfolio({ reserves: [suppliedReserve('pool-btc')] });
-
-			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
-
-			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeDisabled();
-		});
-
-		it('is enabled with borrowing power on a token the user has not supplied', () => {
-			setPortfolio({ reserves: [suppliedReserve('pool-eth')] });
-
-			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
-
-			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeEnabled();
-		});
-
-		it('is disabled when there is borrowing power but the token is supplied', () => {
-			setPortfolio({ availableBorrowsUsd: 700, reserves: [suppliedReserve('pool-btc')] });
-
-			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
-
-			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeDisabled();
-		});
-	});
-
-	describe('Supply button gating', () => {
-		it('is enabled by default', () => {
-			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
-
-			expect(getByRole('button', { name: en.liquidium.text.action_supply })).toBeEnabled();
-		});
-
-		it('is disabled for a token the user has borrowed', () => {
-			setPortfolio({ totalBorrowedUsd: 1000, reserves: [borrowedReserve('pool-btc')] });
-
-			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
-
-			expect(getByRole('button', { name: en.liquidium.text.action_supply })).toBeDisabled();
-		});
-
-		it('stays enabled when only a different token is borrowed', () => {
-			setPortfolio({ totalBorrowedUsd: 1000, reserves: [borrowedReserve('pool-eth')] });
-
-			const { getByRole } = render(LiquidiumMarketCard, { props: { market: market() } });
-
-			expect(getByRole('button', { name: en.liquidium.text.action_supply })).toBeEnabled();
-		});
+		expect(container).toHaveTextContent(en.liquidium.text.coming_soon_teaser);
 	});
 });


### PR DESCRIPTION
# Motivation

The last section to redesign on the Liquidium page is Markets.

<img width="616" height="380" alt="Screenshot 2026-07-14 at 18 02 23" src="https://github.com/user-attachments/assets/4bce2692-7c29-4de6-b2eb-0286f3c3c611" />
