### PR TITLE
fix(frontend): validate BTC UTXOs in Liquidium repay/supply

### DIFF
--- a/src/frontend/src/btc/utils/btc-send.utils.ts
+++ b/src/frontend/src/btc/utils/btc-send.utils.ts
@@ -38,6 +38,8 @@ export const mapUtxosFeeErrorToMessage = ({
 			return i18n.send.assertion.insufficient_funds_verbose_btc;
 		case BtcPrepareSendError.InsufficientBalanceForFee:
 			return i18n.fee.assertion.insufficient_funds_for_fee;
+		case BtcPrepareSendError.MinimumBalance:
+			return i18n.send.assertion.minimum_btc_amount;
 		case BtcPrepareSendError.UtxoLocked:
 			return i18n.send.assertion.btc_utxo_locked;
 		case BtcPrepareSendError.PendingTransactionsNotAvailable:

--- a/src/frontend/src/btc/utils/btc-send.utils.ts
+++ b/src/frontend/src/btc/utils/btc-send.utils.ts
@@ -1,5 +1,7 @@
+import { BtcPrepareSendError, type UtxosFee } from '$btc/types/btc-send';
 import { BTC_DECIMALS } from '$env/tokens/tokens.btc.env';
 import type { Amount } from '$lib/types/send';
+import { nonNullish } from '@dfinity/utils';
 
 export const convertNumberToSatoshis = ({ amount }: { amount: Amount }): bigint =>
 	// Numbers like 0.00004 can be stored internally by JS as 0.0000399999999...
@@ -10,4 +12,37 @@ export const convertNumberToSatoshis = ({ amount }: { amount: Amount }): bigint 
 export const convertSatoshisToBtc = (satoshis: bigint): string => {
 	const btcValue = Number(satoshis) / 10 ** BTC_DECIMALS;
 	return btcValue.toFixed(BTC_DECIMALS).replace(/\.?0+$/, '');
+};
+
+/**
+ * True when the frontend UTXO selection cannot fund a broadcast — the selection
+ * reported an error or picked no UTXOs (e.g. the balance is only in unconfirmed
+ * UTXOs). Such a result must never be handed to the signer.
+ */
+export const isInvalidUtxosFee = ({ error, utxos }: UtxosFee): boolean =>
+	nonNullish(error) || utxos.length === 0;
+
+/**
+ * User-facing message for an unusable UTXO selection (mirrors the warnings shown
+ * by `BtcSendWarnings` on the regular send form).
+ */
+export const mapUtxosFeeErrorToMessage = ({
+	utxosFee: { error },
+	i18n
+}: {
+	utxosFee: UtxosFee;
+	i18n: I18n;
+}): string => {
+	switch (error) {
+		case BtcPrepareSendError.InsufficientBalance:
+			return i18n.send.assertion.insufficient_funds_verbose_btc;
+		case BtcPrepareSendError.InsufficientBalanceForFee:
+			return i18n.fee.assertion.insufficient_funds_for_fee;
+		case BtcPrepareSendError.UtxoLocked:
+			return i18n.send.assertion.btc_utxo_locked;
+		case BtcPrepareSendError.PendingTransactionsNotAvailable:
+			return i18n.send.assertion.pending_transactions_not_available;
+		default:
+			return i18n.send.info.no_available_utxos;
+	}
 };

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte
@@ -3,13 +3,22 @@
 	import { getContext, setContext } from 'svelte';
 	import UtxosFeeLoader from '$btc/components/fee/UtxosFeeLoader.svelte';
 	import BtcUtxosFeeDisplay from '$btc/components/send/BtcUtxosFeeDisplay.svelte';
-	import { sendBtc } from '$btc/services/btc-send.services';
+	import {
+		handleBtcValidationError,
+		sendBtc,
+		validateBtcSend
+	} from '$btc/services/btc-send.services';
 	import {
 		initUtxosFeeStore,
 		UTXOS_FEE_CONTEXT_KEY,
 		type UtxosFeeContext
 	} from '$btc/stores/utxos-fee.store';
-	import { convertSatoshisToBtc } from '$btc/utils/btc-send.utils';
+	import { BtcValidationError } from '$btc/types/btc-send';
+	import {
+		convertSatoshisToBtc,
+		isInvalidUtxosFee,
+		mapUtxosFeeErrorToMessage
+	} from '$btc/utils/btc-send.utils';
 	import LiquidiumRepayForm from '$lib/components/liquidium/repay/LiquidiumRepayForm.svelte';
 	import LiquidiumRepayProgress from '$lib/components/liquidium/repay/LiquidiumRepayProgress.svelte';
 	import LiquidiumRepayReview from '$lib/components/liquidium/repay/LiquidiumRepayReview.svelte';
@@ -100,14 +109,22 @@
 	let validateRepayAmount = $derived.by(() => {
 		const balance = $sendBalance;
 		const inflow = inflowFee;
-		const networkFee = utxosFee?.feeSatoshis;
+		const fee = utxosFee;
 
-		return (userAmount: bigint): Error | undefined =>
-			nonNullish(inflow) &&
-			nonNullish(balance) &&
-			userAmount + inflow + (networkFee ?? ZERO) > balance
+		return (userAmount: bigint): Error | undefined => {
+			// The displayed balance can include UTXOs the signer cannot spend yet (e.g.
+			// unconfirmed inflows), so a failed UTXO selection must block the form even
+			// when the balance check below would pass.
+			if (nonNullish(fee) && isInvalidUtxosFee(fee)) {
+				return new Error(mapUtxosFeeErrorToMessage({ utxosFee: fee, i18n: $i18n }));
+			}
+
+			return nonNullish(inflow) &&
+				nonNullish(balance) &&
+				userAmount + inflow + (fee?.feeSatoshis ?? ZERO) > balance
 				? new Error($i18n.liquidium.text.insufficient_funds_for_fee)
 				: undefined;
+		};
 	});
 
 	const repay = async () => {
@@ -128,13 +145,44 @@
 			return;
 		}
 
+		// A failed UTXO selection (error or empty set) cannot fund the broadcast — e.g.
+		// the balance is only in unconfirmed UTXOs — and the signer would reject it.
+		if (isInvalidUtxosFee(utxosFee)) {
+			toastsError({ msg: { text: mapUtxosFeeErrorToMessage({ utxosFee, i18n: $i18n }) } });
+			return;
+		}
+
 		// BTC sent from the BTC address, but the profile is ETH-owned → look it up by ETH address.
 		const source = $btcAddressMainnet;
 		const btcNetwork = network;
 		const preparedUtxosFee = utxosFee;
 		const amountBaseUnits = parsedAmount;
+		const identity = $authIdentity;
 
 		onNext();
+
+		// Last line of defense before broadcasting (mirrors BtcSendTokenWizard): re-checks
+		// the prepared UTXOs against pending transactions and current fees, for the gross
+		// transfer that is actually sent (net repayment + inflow fee).
+		try {
+			await validateBtcSend({
+				utxosFee: preparedUtxosFee,
+				source,
+				amount: convertSatoshisToBtc(amountBaseUnits + inflowFee),
+				network: btcNetwork,
+				identity
+			});
+		} catch (err: unknown) {
+			if (err instanceof BtcValidationError) {
+				handleBtcValidationError({ err });
+			} else {
+				toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed }, err });
+			}
+
+			onBack();
+
+			return;
+		}
 
 		try {
 			await executeLiquidiumRepay({

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
@@ -3,13 +3,22 @@
 	import { getContext, setContext } from 'svelte';
 	import UtxosFeeLoader from '$btc/components/fee/UtxosFeeLoader.svelte';
 	import BtcUtxosFeeDisplay from '$btc/components/send/BtcUtxosFeeDisplay.svelte';
-	import { sendBtc } from '$btc/services/btc-send.services';
+	import {
+		handleBtcValidationError,
+		sendBtc,
+		validateBtcSend
+	} from '$btc/services/btc-send.services';
 	import {
 		initUtxosFeeStore,
 		UTXOS_FEE_CONTEXT_KEY,
 		type UtxosFeeContext
 	} from '$btc/stores/utxos-fee.store';
-	import { convertSatoshisToBtc } from '$btc/utils/btc-send.utils';
+	import { BtcValidationError } from '$btc/types/btc-send';
+	import {
+		convertSatoshisToBtc,
+		isInvalidUtxosFee,
+		mapUtxosFeeErrorToMessage
+	} from '$btc/utils/btc-send.utils';
 	import LiquidiumSupplyForm from '$lib/components/liquidium/supply/LiquidiumSupplyForm.svelte';
 	import LiquidiumSupplyProgress from '$lib/components/liquidium/supply/LiquidiumSupplyProgress.svelte';
 	import LiquidiumSupplyReview from '$lib/components/liquidium/supply/LiquidiumSupplyReview.svelte';
@@ -85,14 +94,22 @@
 	let validateSupplyAmount = $derived.by(() => {
 		const balance = $sendBalance;
 		const inflow = inflowFee;
-		const networkFee = utxosFee?.feeSatoshis;
+		const fee = utxosFee;
 
-		return (userAmount: bigint): Error | undefined =>
-			nonNullish(inflow) &&
-			nonNullish(balance) &&
-			userAmount + inflow + (networkFee ?? ZERO) > balance
+		return (userAmount: bigint): Error | undefined => {
+			// The displayed balance can include UTXOs the signer cannot spend yet (e.g.
+			// unconfirmed inflows), so a failed UTXO selection must block the form even
+			// when the balance check below would pass.
+			if (nonNullish(fee) && isInvalidUtxosFee(fee)) {
+				return new Error(mapUtxosFeeErrorToMessage({ utxosFee: fee, i18n: $i18n }));
+			}
+
+			return nonNullish(inflow) &&
+				nonNullish(balance) &&
+				userAmount + inflow + (fee?.feeSatoshis ?? ZERO) > balance
 				? new Error($i18n.liquidium.text.insufficient_funds_for_fee)
 				: undefined;
+		};
 	});
 
 	const supply = async () => {
@@ -113,13 +130,44 @@
 			return;
 		}
 
+		// A failed UTXO selection (error or empty set) cannot fund the broadcast — e.g.
+		// the balance is only in unconfirmed UTXOs — and the signer would reject it.
+		if (isInvalidUtxosFee(utxosFee)) {
+			toastsError({ msg: { text: mapUtxosFeeErrorToMessage({ utxosFee, i18n: $i18n }) } });
+			return;
+		}
+
 		// BTC sent from the BTC address, but the profile is ETH-owned → look it up by ETH address.
 		const source = $btcAddressMainnet;
 		const btcNetwork = network;
 		const preparedUtxosFee = utxosFee;
 		const amountBaseUnits = parsedAmount;
+		const identity = $authIdentity;
 
 		onNext();
+
+		// Last line of defense before broadcasting (mirrors BtcSendTokenWizard): re-checks
+		// the prepared UTXOs against pending transactions and current fees, for the gross
+		// transfer that is actually sent (net supply + inflow fee).
+		try {
+			await validateBtcSend({
+				utxosFee: preparedUtxosFee,
+				source,
+				amount: convertSatoshisToBtc(amountBaseUnits + inflowFee),
+				network: btcNetwork,
+				identity
+			});
+		} catch (err: unknown) {
+			if (err instanceof BtcValidationError) {
+				handleBtcValidationError({ err });
+			} else {
+				toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed }, err });
+			}
+
+			onBack();
+
+			return;
+		}
 
 		try {
 			await executeLiquidiumSupply({

--- a/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
@@ -1,5 +1,13 @@
-import { convertNumberToSatoshis, convertSatoshisToBtc } from '$btc/utils/btc-send.utils';
+import { BtcPrepareSendError } from '$btc/types/btc-send';
+import {
+	convertNumberToSatoshis,
+	convertSatoshisToBtc,
+	isInvalidUtxosFee,
+	mapUtxosFeeErrorToMessage
+} from '$btc/utils/btc-send.utils';
 import { ZERO } from '$lib/constants/app.constants';
+import { mockUtxosFee } from '$tests/mocks/btc.mock';
+import en from '$tests/mocks/i18n.mock';
 
 describe('convertNumberToSatoshis', () => {
 	it('converts number to Satoshis correctly', () => {
@@ -21,5 +29,52 @@ describe('convertSatoshisToBtc', () => {
 		expect(convertSatoshisToBtc(ZERO)).toEqual('0');
 		expect(convertSatoshisToBtc(4000n)).toEqual('0.00004');
 		expect(convertSatoshisToBtc(1n)).toEqual('0.00000001');
+	});
+});
+
+describe('isInvalidUtxosFee', () => {
+	it('returns false for a usable UTXO selection', () => {
+		expect(isInvalidUtxosFee(mockUtxosFee)).toBeFalsy();
+	});
+
+	it('returns true when the selection reported an error', () => {
+		expect(
+			isInvalidUtxosFee({ ...mockUtxosFee, error: BtcPrepareSendError.InsufficientBalance })
+		).toBeTruthy();
+	});
+
+	it('returns true when no UTXOs were selected', () => {
+		expect(isInvalidUtxosFee({ feeSatoshis: ZERO, utxos: [] })).toBeTruthy();
+	});
+});
+
+describe('mapUtxosFeeErrorToMessage', () => {
+	it.each([
+		{
+			error: BtcPrepareSendError.InsufficientBalance,
+			expected: en.send.assertion.insufficient_funds_verbose_btc
+		},
+		{
+			error: BtcPrepareSendError.InsufficientBalanceForFee,
+			expected: en.fee.assertion.insufficient_funds_for_fee
+		},
+		{
+			error: BtcPrepareSendError.UtxoLocked,
+			expected: en.send.assertion.btc_utxo_locked
+		},
+		{
+			error: BtcPrepareSendError.PendingTransactionsNotAvailable,
+			expected: en.send.assertion.pending_transactions_not_available
+		}
+	])('maps $error to its message', ({ error, expected }) => {
+		expect(mapUtxosFeeErrorToMessage({ utxosFee: { ...mockUtxosFee, error }, i18n: en })).toBe(
+			expected
+		);
+	});
+
+	it('falls back to the no-available-UTXOs message', () => {
+		expect(
+			mapUtxosFeeErrorToMessage({ utxosFee: { feeSatoshis: ZERO, utxos: [] }, i18n: en })
+		).toBe(en.send.info.no_available_utxos);
 	});
 });

--- a/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
@@ -59,6 +59,10 @@ describe('mapUtxosFeeErrorToMessage', () => {
 			expected: en.fee.assertion.insufficient_funds_for_fee
 		},
 		{
+			error: BtcPrepareSendError.MinimumBalance,
+			expected: en.send.assertion.minimum_btc_amount
+		},
+		{
 			error: BtcPrepareSendError.UtxoLocked,
 			expected: en.send.assertion.btc_utxo_locked
 		},

--- a/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.spec.ts
@@ -4,21 +4,29 @@ import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
+import {
+	BtcPrepareSendError,
+	BtcSendValidationError,
+	BtcValidationError
+} from '$btc/types/btc-send';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import * as bitcoinApi from '$icp/api/bitcoin.api';
 import LiquidiumRepayBtcWizard from '$lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte';
 import { ZERO } from '$lib/constants/app.constants';
+import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
 import * as addressesStore from '$lib/derived/address.derived';
 import { ProgressStepsLiquidiumRepay } from '$lib/enums/progress-steps';
 import { WizardStepsLiquidiumRepay } from '$lib/enums/wizard-steps';
+import * as liquidiumRepayServices from '$lib/services/liquidium-repay.services';
 import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import type { WizardStep } from '$lib/types/wizard';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
-import { mockBtcAddress, mockUtxosFee } from '$tests/mocks/btc.mock';
+import { mockBtcAddress, mockUtxo, mockUtxosFee } from '$tests/mocks/btc.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockContextMap } from '$tests/utils/context.test-utils';
 import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
 describe('LiquidiumRepayBtcWizard', () => {
@@ -119,5 +127,90 @@ describe('LiquidiumRepayBtcWizard', () => {
 		});
 
 		expect(container).toHaveTextContent(en.liquidium.text.starting_to_repay);
+	});
+
+	describe('confirm gating', () => {
+		beforeEach(() => {
+			allUtxosStore.setAllUtxos({ allUtxos: [mockUtxo] });
+			feeRatePercentilesStore.setFeeRateFromPercentiles({ feeRateFromPercentiles: 1000n });
+			btcPendingSentTransactionsStore.setPendingTransactions({
+				address: mockBtcAddress,
+				pendingTransactions: []
+			});
+
+			vi.spyOn(addressesStore, 'ethAddress', 'get').mockImplementation(() =>
+				readable(mockEthAddress)
+			);
+			vi.spyOn(liquidiumRepayServices, 'executeLiquidiumRepay').mockResolvedValue(undefined);
+		});
+
+		const renderReview = ({ onNext = () => {}, onBack = () => {} } = {}) =>
+			render(LiquidiumRepayBtcWizard, {
+				props: {
+					...baseProps,
+					currentStep: step(WizardStepsLiquidiumRepay.REVIEW),
+					onNext,
+					onBack
+				},
+				context: context()
+			});
+
+		const clickConfirm = async (getByTestId: (id: string) => HTMLElement) => {
+			await waitFor(() => {
+				expect(btcUtxosService.prepareBtcSend).toHaveBeenCalled();
+			});
+
+			await fireEvent.click(getByTestId(STAKE_REVIEW_FORM_BUTTON));
+		};
+
+		it('does not repay when the UTXO selection failed', async () => {
+			// A selection error (e.g. balance only in unconfirmed UTXOs) means the prepared
+			// UTXOs cannot fund the broadcast — the signer would reject the transaction.
+			vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
+				feeSatoshis: ZERO,
+				utxos: [],
+				error: BtcPrepareSendError.UtxoLocked
+			});
+
+			const onNext = vi.fn();
+
+			const { getByTestId } = renderReview({ onNext });
+
+			await clickConfirm(getByTestId);
+
+			expect(onNext).not.toHaveBeenCalled();
+			expect(liquidiumRepayServices.executeLiquidiumRepay).not.toHaveBeenCalled();
+		});
+
+		it('validates the prepared UTXOs before repaying', async () => {
+			const { getByTestId } = renderReview();
+
+			await clickConfirm(getByTestId);
+
+			await waitFor(() => {
+				expect(btcSendServices.validateBtcSend).toHaveBeenCalledWith(
+					expect.objectContaining({ utxosFee: mockUtxosFee })
+				);
+				expect(liquidiumRepayServices.executeLiquidiumRepay).toHaveBeenCalledOnce();
+			});
+		});
+
+		it('aborts the repayment when the send validation fails', async () => {
+			vi.spyOn(btcSendServices, 'validateBtcSend').mockRejectedValue(
+				new BtcValidationError(BtcSendValidationError.UtxoLocked)
+			);
+
+			const onBack = vi.fn();
+
+			const { getByTestId } = renderReview({ onBack });
+
+			await clickConfirm(getByTestId);
+
+			await waitFor(() => {
+				expect(onBack).toHaveBeenCalledOnce();
+			});
+
+			expect(liquidiumRepayServices.executeLiquidiumRepay).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.spec.ts
@@ -4,20 +4,29 @@ import * as btcUtxosService from '$btc/services/btc-utxos.service';
 import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
+import {
+	BtcPrepareSendError,
+	BtcSendValidationError,
+	BtcValidationError
+} from '$btc/types/btc-send';
 import { convertSatoshisToBtc } from '$btc/utils/btc-send.utils';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import * as bitcoinApi from '$icp/api/bitcoin.api';
 import LiquidiumSupplyBtcWizard from '$lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
 import * as addressesStore from '$lib/derived/address.derived';
 import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
 import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import * as liquidiumSupplyServices from '$lib/services/liquidium-supply.services';
 import type { WizardStep } from '$lib/types/wizard';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockBtcAddress, mockUtxo, mockUtxosFee } from '$tests/mocks/btc.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockContextMap } from '$tests/utils/context.test-utils';
 import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
-import { render, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
 describe('LiquidiumSupplyBtcWizard', () => {
@@ -102,6 +111,95 @@ describe('LiquidiumSupplyBtcWizard', () => {
 		});
 
 		expect(container).toHaveTextContent(en.liquidium.text.starting_to_supply);
+	});
+
+	describe('confirm gating', () => {
+		const populateStores = () => {
+			allUtxosStore.setAllUtxos({ allUtxos: [mockUtxo] });
+			feeRatePercentilesStore.setFeeRateFromPercentiles({ feeRateFromPercentiles: 1000n });
+			btcPendingSentTransactionsStore.setPendingTransactions({
+				address: mockBtcAddress,
+				pendingTransactions: []
+			});
+		};
+
+		beforeEach(() => {
+			populateStores();
+
+			vi.spyOn(addressesStore, 'ethAddress', 'get').mockImplementation(() =>
+				readable(mockEthAddress)
+			);
+			vi.spyOn(liquidiumSupplyServices, 'executeLiquidiumSupply').mockResolvedValue(undefined);
+		});
+
+		const renderReview = ({ onNext = () => {}, onBack = () => {} } = {}) =>
+			render(LiquidiumSupplyBtcWizard, {
+				props: {
+					...baseProps,
+					currentStep: step(WizardStepsLiquidiumSupply.REVIEW),
+					onNext,
+					onBack
+				},
+				context: context()
+			});
+
+		const clickConfirm = async (getByTestId: (id: string) => HTMLElement) => {
+			await waitFor(() => {
+				expect(btcUtxosService.prepareBtcSend).toHaveBeenCalled();
+			});
+
+			await fireEvent.click(getByTestId(STAKE_REVIEW_FORM_BUTTON));
+		};
+
+		it('does not supply when the UTXO selection failed', async () => {
+			// A selection error (e.g. balance only in unconfirmed UTXOs) means the prepared
+			// UTXOs cannot fund the broadcast — the signer would reject the transaction.
+			vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
+				feeSatoshis: ZERO,
+				utxos: [],
+				error: BtcPrepareSendError.UtxoLocked
+			});
+
+			const onNext = vi.fn();
+
+			const { getByTestId } = renderReview({ onNext });
+
+			await clickConfirm(getByTestId);
+
+			expect(onNext).not.toHaveBeenCalled();
+			expect(liquidiumSupplyServices.executeLiquidiumSupply).not.toHaveBeenCalled();
+		});
+
+		it('validates the prepared UTXOs before supplying', async () => {
+			const { getByTestId } = renderReview();
+
+			await clickConfirm(getByTestId);
+
+			await waitFor(() => {
+				expect(btcSendServices.validateBtcSend).toHaveBeenCalledWith(
+					expect.objectContaining({ utxosFee: mockUtxosFee })
+				);
+				expect(liquidiumSupplyServices.executeLiquidiumSupply).toHaveBeenCalledOnce();
+			});
+		});
+
+		it('aborts the supply when the send validation fails', async () => {
+			vi.spyOn(btcSendServices, 'validateBtcSend').mockRejectedValue(
+				new BtcValidationError(BtcSendValidationError.UtxoLocked)
+			);
+
+			const onBack = vi.fn();
+
+			const { getByTestId } = renderReview({ onBack });
+
+			await clickConfirm(getByTestId);
+
+			await waitFor(() => {
+				expect(onBack).toHaveBeenCalledOnce();
+			});
+
+			expect(liquidiumSupplyServices.executeLiquidiumSupply).not.toHaveBeenCalled();
+		});
 	});
 
 	it('selects UTXOs for the gross transfer (supply amount + inflow fee)', async () => {


### PR DESCRIPTION
# Motivation

The Liquidium BTC repay and supply wizards did not validate the UTXO selection the way the regular BTC send flow does. The displayed balance can include UTXOs the signer cannot spend yet (e.g. unconfirmed inflows), so a failed or empty UTXO selection could pass the wizard's balance check and be handed to the signer, which then rejects the broadcast. The send flow already guards against this via `BtcSendWarnings` (form-level) and `validateBtcSend` (pre-broadcast); the Liquidium flows should behave identically.
