### PR TITLE
feat(frontend): upgrade to Liquidium v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@icp-sdk/auth": "^6.2.0",
 				"@icp-sdk/canisters": "~3.1.0",
 				"@icp-sdk/core": "^4.2.1",
-				"@liquidium/client": "^0.4.1",
+				"@liquidium/client": "^0.5.0",
 				"@metamask/detect-provider": "^2.0.0",
 				"@plausible-analytics/tracker": "^0.4.5",
 				"@reown/walletkit": "^1.5.5",
@@ -1512,9 +1512,9 @@
 			}
 		},
 		"node_modules/@liquidium/client": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@liquidium/client/-/client-0.4.1.tgz",
-			"integrity": "sha512-6VC+MlMlzAdml6Le0Q1mYQuzZlf+z+RihxA4i4pdVYS9FGmnMLNn0LksrB7WBZyM1H5OVQgfC6jNqwBPYmxyuw==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@liquidium/client/-/client-0.5.0.tgz",
+			"integrity": "sha512-KKe89QiuFLW5gbR9dQTd9lsviX+aUCkZ8mzfqiv9YSyZZxB2ZOOqElXqLlig0G0XhdnnwJwi635tagrZRBx0ww==",
 			"license": "MIT",
 			"dependencies": {
 				"@dfinity/utils": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"@icp-sdk/auth": "^6.2.0",
 		"@icp-sdk/canisters": "~3.1.0",
 		"@icp-sdk/core": "^4.2.1",
-		"@liquidium/client": "^0.4.1",
+		"@liquidium/client": "^0.5.0",
 		"@metamask/detect-provider": "^2.0.0",
 		"@plausible-analytics/tracker": "^0.4.5",
 		"@reown/walletkit": "^1.5.5",

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { Chain } from '@liquidium/client';
 	import { setContext } from 'svelte';
 	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumBorrowForm from '$lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte';
@@ -144,7 +145,7 @@
 
 		const amountBaseUnits = parsedAmount;
 		const receiver = receiverAddress;
-		const { poolId, asset } = selectedMarket;
+		const { poolId, asset, chain } = selectedMarket;
 
 		modal?.next();
 
@@ -153,6 +154,7 @@
 				identity,
 				ethAddress: $ethAddress,
 				poolId,
+				chain: chain as Chain,
 				asset,
 				amount: amountBaseUnits,
 				receiverAddress: receiver,

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { Chain } from '@liquidium/client';
 	import { getContext, setContext } from 'svelte';
 	import UtxosFeeLoader from '$btc/components/fee/UtxosFeeLoader.svelte';
 	import BtcUtxosFeeDisplay from '$btc/components/send/BtcUtxosFeeDisplay.svelte';
@@ -189,6 +190,7 @@
 				identity: $authIdentity,
 				ethAddress: $ethAddress,
 				poolId: reserve.poolId,
+				chain: Chain.BTC,
 				asset: reserve.asset,
 				amount: amountBaseUnits,
 				inflowFee,

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayEthWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayEthWizard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { Chain } from '@liquidium/client';
 	import { getContext, setContext, untrack } from 'svelte';
 	import { writable } from 'svelte/store';
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
@@ -199,6 +200,7 @@
 				identity: $authIdentity,
 				ethAddress: $ethAddress,
 				poolId: reserve.poolId,
+				chain: Chain.ETH,
 				asset: reserve.asset,
 				amount: amountBaseUnits,
 				inflowFee,

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { Chain } from '@liquidium/client';
 	import { getContext, setContext } from 'svelte';
 	import UtxosFeeLoader from '$btc/components/fee/UtxosFeeLoader.svelte';
 	import BtcUtxosFeeDisplay from '$btc/components/send/BtcUtxosFeeDisplay.svelte';
@@ -174,6 +175,7 @@
 				identity: $authIdentity,
 				ethAddress: $ethAddress,
 				poolId: market.poolId,
+				chain: Chain.BTC,
 				asset: market.asset,
 				amount: amountBaseUnits,
 				inflowFee,

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { Chain } from '@liquidium/client';
 	import { getContext, setContext, untrack } from 'svelte';
 	import { writable } from 'svelte/store';
 	import EthFeeContext from '$eth/components/fee/EthFeeContext.svelte';
@@ -182,6 +183,7 @@
 				identity: $authIdentity,
 				ethAddress: $ethAddress,
 				poolId: market.poolId,
+				chain: Chain.ETH,
 				asset: market.asset,
 				amount: amountBaseUnits,
 				inflowFee,

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { Chain } from '@liquidium/client';
 	import { setContext } from 'svelte';
 	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumWithdrawForm from '$lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte';
@@ -145,7 +146,7 @@
 
 		const amountBaseUnits = parsedAmount;
 		const receiver = receiverAddress;
-		const { poolId, asset } = selectedReserve;
+		const { poolId, asset, chain } = selectedReserve;
 
 		modal?.next();
 
@@ -154,6 +155,7 @@
 				identity,
 				ethAddress: $ethAddress,
 				poolId,
+				chain: chain as Chain,
 				asset,
 				amount: amountBaseUnits,
 				receiverAddress: receiver,

--- a/src/frontend/src/lib/services/liquidium-borrow.services.ts
+++ b/src/frontend/src/lib/services/liquidium-borrow.services.ts
@@ -66,11 +66,12 @@ export const computeLiquidiumBorrowPreview = ({
 };
 
 // Borrow is a `signMessage` outflow (no oisy broadcast): resolve profile → `lending.borrow`
-// → record an AUT so the modal closes before settlement. Funds land at `receiverAddress`.
+// → record an AUT so the modal closes before settlement. Funds land at `receiver` on `chain`.
 export const executeLiquidiumBorrow = async ({
 	identity,
 	ethAddress,
 	poolId,
+	chain,
 	asset,
 	amount,
 	receiverAddress,
@@ -81,6 +82,7 @@ export const executeLiquidiumBorrow = async ({
 	identity: Identity;
 	ethAddress: EthAddress;
 	poolId: string;
+	chain: Chain;
 	asset: string;
 	amount: bigint;
 	receiverAddress: string;
@@ -99,7 +101,8 @@ export const executeLiquidiumBorrow = async ({
 		profileId,
 		poolId,
 		amount,
-		receiverAddress,
+		chain,
+		receiver: receiverAddress,
 		signerWalletAddress: ethAddress,
 		signerChain: Chain.ETH,
 		signerWalletAdapter: liquidiumWalletAdapter({ identity })

--- a/src/frontend/src/lib/services/liquidium-repay.services.ts
+++ b/src/frontend/src/lib/services/liquidium-repay.services.ts
@@ -20,7 +20,7 @@ import {
 } from '$lib/utils/liquidium.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
-import { SupplyAction, type NativeAddressSupplyTarget } from '@liquidium/client';
+import { SupplyAction, type Chain, type SupplyTarget } from '@liquidium/client';
 
 export interface LiquidiumRepayPreview {
 	projectedHealthPercent: number;
@@ -82,19 +82,21 @@ export const computeLiquidiumRepayPreview = ({
 // Broadcasts `amount` base units (gross = repay + provider fee) to the native target and returns
 // the txid the AUT poller correlates on. Implemented by the wizard (per-chain fee/UTXO machinery).
 export type LiquidiumRepayBroadcast = (params: {
-	target: NativeAddressSupplyTarget;
+	target: SupplyTarget;
 	amount: bigint;
 }) => Promise<string>;
 
 // Repays `amount` (base units) of `asset`'s debt: resolve profile → broadcast the transfer →
 // record an AUT so the modal can close before settlement. Repaying is an inflow on the supply
-// path (`SupplyAction.repayment`), so this mirrors `executeLiquidiumSupply` exactly — the only
-// rail v1 assets return is `nativeAddress`, and the protocol deducts its inflow fee from the
-// inflow, so we transfer `amount + inflowFee` to credit the net `amount` against the debt.
+// path (`SupplyAction.repayment`), so this mirrors `executeLiquidiumSupply` exactly — we drive
+// the transfer rail and broadcast to the flat `SupplyTarget` address, and the protocol deducts
+// its inflow fee from the inflow, so we transfer `amount + inflowFee` to credit the net `amount`
+// against the debt.
 export const executeLiquidiumRepay = async ({
 	identity,
 	ethAddress,
 	poolId,
+	chain,
 	asset,
 	amount,
 	inflowFee,
@@ -106,6 +108,7 @@ export const executeLiquidiumRepay = async ({
 	identity: Identity;
 	ethAddress: EthAddress;
 	poolId: string;
+	chain: Chain;
 	asset: string;
 	amount: bigint;
 	inflowFee: bigint;
@@ -121,14 +124,9 @@ export const executeLiquidiumRepay = async ({
 	const flow = await liquidiumClient({ identity }).lending.supply({
 		profileId,
 		poolId,
+		chain,
 		action: SupplyAction.repayment
 	});
-
-	if (flow.target.type !== 'nativeAddress') {
-		throw new Error(
-			`Liquidium repay: unsupported "${flow.target.type}" target for ${asset} (only nativeAddress is supported)`
-		);
-	}
 
 	progress?.(ProgressStepsLiquidiumRepay.TRANSFER);
 

--- a/src/frontend/src/lib/services/liquidium-supply.services.ts
+++ b/src/frontend/src/lib/services/liquidium-supply.services.ts
@@ -33,8 +33,8 @@ export const estimateLiquidiumInflowFee = async ({
 	asset: Asset;
 	chain: Chain;
 }): Promise<bigint> => {
-	// `asset`/`chain` reach us as the SDK's wide enums; the protocol only ships supported
-	// pairs, so narrow to the correlated `AssetIdentifier` union at this single boundary.
+	// `asset`/`chain` reach us as the SDK's wide enums; the protocol only ships supported pairs.
+	// We type-assert to the correlated `AssetIdentifier` shape at this boundary to satisfy the SDK's typing.
 	const { totalFee } = await liquidiumClient({ identity }).lending.estimateInflowFee({
 		asset,
 		chain

--- a/src/frontend/src/lib/services/liquidium-supply.services.ts
+++ b/src/frontend/src/lib/services/liquidium-supply.services.ts
@@ -17,8 +17,9 @@ import type { Identity } from '@icp-sdk/core/agent';
 import {
 	SupplyAction,
 	type Asset,
+	type AssetIdentifier,
 	type Chain,
-	type NativeAddressSupplyTarget
+	type SupplyTarget
 } from '@liquidium/client';
 
 // Liquidium's per-inflow processing fee (base units of `asset`), deducted by the
@@ -32,10 +33,12 @@ export const estimateLiquidiumInflowFee = async ({
 	asset: Asset;
 	chain: Chain;
 }): Promise<bigint> => {
+	// `asset`/`chain` reach us as the SDK's wide enums; the protocol only ships supported
+	// pairs, so narrow to the correlated `AssetIdentifier` union at this single boundary.
 	const { totalFee } = await liquidiumClient({ identity }).lending.estimateInflowFee({
 		asset,
 		chain
-	});
+	} as AssetIdentifier);
 
 	return totalFee;
 };
@@ -44,7 +47,7 @@ export const estimateLiquidiumInflowFee = async ({
 // target and returns the txid the AUT poller correlates on. Implemented by the
 // wizard, which owns oisy's per-chain fee/UTXO machinery.
 export type LiquidiumSupplyBroadcast = (params: {
-	target: NativeAddressSupplyTarget;
+	target: SupplyTarget;
 	amount: bigint;
 }) => Promise<string>;
 
@@ -53,12 +56,13 @@ export type LiquidiumSupplyBroadcast = (params: {
 //
 // The protocol deducts its inflow fee from the inflow, so we transfer
 // `amount + inflowFee` to credit the user's `amount` (the recorded position stays net).
-// Only the `nativeAddress` rail is supported (the only one v1 assets return via the
-// SDK's `resolveSupplyTarget`); `icrcAccount` would need contract-interaction, which we don't request.
+// We only drive the transfer rail (`lending.supply` without a wallet adapter), which
+// returns the flat `SupplyTarget` address oisy broadcasts to.
 export const executeLiquidiumSupply = async ({
 	identity,
 	ethAddress,
 	poolId,
+	chain,
 	asset,
 	amount,
 	inflowFee,
@@ -70,6 +74,7 @@ export const executeLiquidiumSupply = async ({
 	identity: Identity;
 	ethAddress: EthAddress;
 	poolId: string;
+	chain: Chain;
 	asset: string;
 	amount: bigint;
 	inflowFee: bigint;
@@ -85,14 +90,9 @@ export const executeLiquidiumSupply = async ({
 	const flow = await liquidiumClient({ identity }).lending.supply({
 		profileId,
 		poolId,
+		chain,
 		action: SupplyAction.deposit
 	});
-
-	if (flow.target.type !== 'nativeAddress') {
-		throw new Error(
-			`Liquidium supply: unsupported "${flow.target.type}" target for ${asset} (only nativeAddress is supported)`
-		);
-	}
 
 	progress?.(ProgressStepsLiquidiumSupply.TRANSFER);
 

--- a/src/frontend/src/lib/services/liquidium-withdraw.services.ts
+++ b/src/frontend/src/lib/services/liquidium-withdraw.services.ts
@@ -76,6 +76,7 @@ export const executeLiquidiumWithdraw = async ({
 	identity,
 	ethAddress,
 	poolId,
+	chain,
 	asset,
 	amount,
 	receiverAddress,
@@ -86,6 +87,7 @@ export const executeLiquidiumWithdraw = async ({
 	identity: Identity;
 	ethAddress: EthAddress;
 	poolId: string;
+	chain: Chain;
 	asset: string;
 	amount: bigint;
 	receiverAddress: string;
@@ -104,7 +106,8 @@ export const executeLiquidiumWithdraw = async ({
 		profileId,
 		poolId,
 		amount,
-		receiverAddress,
+		chain,
+		receiver: receiverAddress,
 		signerWalletAddress: ethAddress,
 		signerChain: Chain.ETH,
 		signerWalletAdapter: liquidiumWalletAdapter({ identity })

--- a/src/frontend/src/tests/lib/services/liquidium-borrow.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-borrow.services.spec.ts
@@ -38,6 +38,7 @@ describe('liquidium-borrow.services', () => {
 			identity: mockIdentity,
 			ethAddress,
 			poolId,
+			chain: 'BTC',
 			asset: 'BTC',
 			amount: 100_000_000n,
 			receiverAddress,
@@ -63,7 +64,8 @@ describe('liquidium-borrow.services', () => {
 				profileId,
 				poolId,
 				amount: 100_000_000n,
-				receiverAddress,
+				chain: 'BTC',
+				receiver: receiverAddress,
 				signerWalletAddress: ethAddress,
 				signerChain: 'ETH'
 			})

--- a/src/frontend/src/tests/lib/services/liquidium-repay.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-repay.services.spec.ts
@@ -15,7 +15,7 @@ import * as liquidiumServices from '$lib/services/liquidium.services';
 import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import type { NativeAddressSupplyTarget, SupplyFlow, SupplyTarget } from '@liquidium/client';
+import type { SupplyFlow, SupplyTarget } from '@liquidium/client';
 
 vi.mock('$lib/api/liquidium.api', () => ({ liquidiumClient: vi.fn() }));
 vi.mock('$lib/services/liquidium.services', () => ({ getOrCreateLiquidiumProfile: vi.fn() }));
@@ -135,8 +135,7 @@ describe('liquidium-repay.services', () => {
 			activeUserTransactionsServices.createActiveUserTransaction
 		);
 
-		const nativeTarget: NativeAddressSupplyTarget = {
-			type: 'nativeAddress',
+		const nativeTarget: SupplyTarget = {
 			poolId,
 			asset: 'BTC',
 			chain: 'BTC',
@@ -161,6 +160,7 @@ describe('liquidium-repay.services', () => {
 				identity: mockIdentity,
 				ethAddress,
 				poolId,
+				chain: 'BTC',
 				asset: 'BTC',
 				amount: 100_000_000n,
 				inflowFee: 50n,
@@ -184,7 +184,12 @@ describe('liquidium-repay.services', () => {
 
 			await run();
 
-			expect(supply).toHaveBeenCalledExactlyOnceWith({ profileId, poolId, action: 'repayment' });
+			expect(supply).toHaveBeenCalledExactlyOnceWith({
+				profileId,
+				poolId,
+				chain: 'BTC',
+				action: 'repayment'
+			});
 			// Gross transfer = net repayment (100_000_000) + provider inflow fee (50).
 			expect(broadcast).toHaveBeenCalledExactlyOnceWith({
 				target: nativeTarget,
@@ -247,6 +252,7 @@ describe('liquidium-repay.services', () => {
 				identity: mockIdentity,
 				ethAddress,
 				poolId,
+				chain: 'BTC',
 				asset: 'BTC',
 				amount: 100_000_000n,
 				inflowFee: 50n,
@@ -261,25 +267,6 @@ describe('liquidium-repay.services', () => {
 			const [[arg]] = createActiveUserTransaction.mock.calls;
 
 			expect(arg).not.toHaveProperty('progressStep');
-		});
-
-		it('rejects an icrcAccount target and registers nothing', async () => {
-			supply.mockResolvedValue(
-				buildFlow({
-					type: 'icrcAccount',
-					poolId,
-					asset: 'BTC',
-					chain: 'BTC',
-					action: 'repayment',
-					owner: 'aaaaa-aa',
-					subaccount: new Uint8Array(),
-					account: 'icrc-account-text'
-				})
-			);
-
-			await expect(run()).rejects.toThrow('unsupported');
-			expect(broadcast).not.toHaveBeenCalled();
-			expect(createActiveUserTransaction).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/services/liquidium-supply.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-supply.services.spec.ts
@@ -7,7 +7,7 @@ import { executeLiquidiumSupply } from '$lib/services/liquidium-supply.services'
 import * as liquidiumServices from '$lib/services/liquidium.services';
 import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import type { NativeAddressSupplyTarget, SupplyFlow, SupplyTarget } from '@liquidium/client';
+import type { SupplyFlow, SupplyTarget } from '@liquidium/client';
 
 vi.mock('$lib/api/liquidium.api', () => ({ liquidiumClient: vi.fn() }));
 vi.mock('$lib/services/liquidium.services', () => ({ getOrCreateLiquidiumProfile: vi.fn() }));
@@ -28,8 +28,7 @@ describe('liquidium-supply.services', () => {
 		activeUserTransactionsServices.createActiveUserTransaction
 	);
 
-	const nativeTarget: NativeAddressSupplyTarget = {
-		type: 'nativeAddress',
+	const nativeTarget: SupplyTarget = {
 		poolId,
 		asset: 'BTC',
 		chain: 'BTC',
@@ -54,6 +53,7 @@ describe('liquidium-supply.services', () => {
 			identity: mockIdentity,
 			ethAddress,
 			poolId,
+			chain: 'BTC',
 			asset: 'BTC',
 			amount: 100_000_000n,
 			inflowFee: 50n,
@@ -77,7 +77,12 @@ describe('liquidium-supply.services', () => {
 
 		await run();
 
-		expect(supply).toHaveBeenCalledExactlyOnceWith({ profileId, poolId, action: 'deposit' });
+		expect(supply).toHaveBeenCalledExactlyOnceWith({
+			profileId,
+			poolId,
+			chain: 'BTC',
+			action: 'deposit'
+		});
 		// Gross transfer = net supply (100_000_000) + provider inflow fee (50).
 		expect(broadcast).toHaveBeenCalledExactlyOnceWith({
 			target: nativeTarget,
@@ -155,24 +160,5 @@ describe('liquidium-supply.services', () => {
 		expect(externalRefs).toEqual(
 			expect.arrayContaining([{ key: LIQUIDIUM_EXTERNAL_REF_KEYS.TXID, value: '0xhash' }])
 		);
-	});
-
-	it('rejects an icrcAccount target and registers nothing', async () => {
-		supply.mockResolvedValue(
-			buildFlow({
-				type: 'icrcAccount',
-				poolId,
-				asset: 'BTC',
-				chain: 'BTC',
-				action: 'deposit',
-				owner: 'aaaaa-aa',
-				subaccount: new Uint8Array(),
-				account: 'icrc-account-text'
-			})
-		);
-
-		await expect(run()).rejects.toThrow('unsupported');
-		expect(broadcast).not.toHaveBeenCalled();
-		expect(createActiveUserTransaction).not.toHaveBeenCalled();
 	});
 });

--- a/src/frontend/src/tests/lib/services/liquidium-wallet-adapter.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-wallet-adapter.services.spec.ts
@@ -15,8 +15,7 @@ describe('liquidium-wallet-adapter.services', () => {
 
 	const baseRequest: Omit<SignMessageRequest, 'chain'> = {
 		message: 'sign me',
-		actionType: 'create-account',
-		transferMode: 'native'
+		actionType: 'create-account'
 	};
 
 	describe('signMessage', () => {

--- a/src/frontend/src/tests/lib/services/liquidium-withdraw.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium-withdraw.services.spec.ts
@@ -39,6 +39,7 @@ describe('liquidium-withdraw.services', () => {
 			identity: mockIdentity,
 			ethAddress,
 			poolId,
+			chain: 'BTC',
 			asset: 'BTC',
 			amount: 50_000_000n,
 			receiverAddress,
@@ -64,7 +65,8 @@ describe('liquidium-withdraw.services', () => {
 				profileId,
 				poolId,
 				amount: 50_000_000n,
-				receiverAddress,
+				chain: 'BTC',
+				receiver: receiverAddress,
 				signerWalletAddress: ethAddress,
 				signerChain: 'ETH'
 			})

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -53,6 +53,7 @@ const buildPool = (overrides: Partial<Pool> = {}): Pool => ({
 	lendingIndex: ZERO,
 	borrowIndex: ZERO,
 	sameAssetBorrowing: false,
+	sameAssetBorrowingDustThreshold: ZERO,
 	...overrides
 });
 


### PR DESCRIPTION
# Motivation

We need to Liquidium SDK v0.5.0. This version contains quite a few breaking changes (https://github.com/Liquidium-Inc/liquidium-sdk/releases/tag/%40liquidium%2Fclient%400.5.0), therefore all these updates.
