### PR TITLE
chore(frontend): switch OnRamper to dev/sandbox env

### DIFF
--- a/src/frontend/src/env/rest/onramper.env.ts
+++ b/src/frontend/src/env/rest/onramper.env.ts
@@ -5,7 +5,7 @@ import { LOCAL, STAGING } from '$lib/constants/app.constants';
 export const ONRAMPER_ENABLED = LOCAL || STAGING;
 
 // Set it to 'dev' to use OnRamper Sandbox
-const ONRAMPER_ENV = 'prod';
+const ONRAMPER_ENV = 'dev';
 
 export const isOnRamperDev = (ONRAMPER_ENV as 'dev' | 'prod') === 'dev';
 


### PR DESCRIPTION
# Motivation

Temporary branch to run the OnRamper **sandbox** integration on a test environment.

Prod OnRamper on staging currently fails signature validation (prod account signing secret / activation pending on OnRamper's side). To keep testing the buy flow end-to-end, this flips OnRamper back to the dev/sandbox environment.

# Changes

- `onramper.env.ts`: `ONRAMPER_ENV = 'dev'` → uses `buy.onramper.dev` + `VITE_ONRAMPER_API_KEY_DEV`.

Not intended to merge — for FE2 testing.
