### PR TITLE
build(signer): bump chain-fusion-signer to v0.5.1

### DIFF
--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -20,7 +20,7 @@ print_help() {
 
 DFX_NETWORK="${DFX_NETWORK:-local}"
 
-SIGNER_RELEASE="v0.3.0"
+SIGNER_RELEASE="v0.5.1"
 SIGNER_RELEASE_URL="https://github.com/dfinity/chain-fusion-signer/releases/download/${SIGNER_RELEASE}"
 # shellcheck disable=SC2034 # This variable is used - see ${!asset_url} below.
 CANDID_URL="${SIGNER_RELEASE_URL}/signer.did"

--- a/src/declarations/signer/signer.did
+++ b/src/declarations/signer/signer.did
@@ -1,7 +1,29 @@
 type Account = record { owner : principal; subaccount : opt blob };
 type Arg = variant { Upgrade; Init : InitArg };
+// # Bip341 variant of Schnorr Aux.
+type Bip341 = record {
+	// Merkle tree root hash.
+	merkle_root_hash : blob
+};
 type BitcoinAddressType = variant { P2WPKH };
-type BitcoinNetwork = variant { mainnet; regtest; testnet };
+type BtcSignPrehashError = variant {
+	// The supplied hash was not valid hex or was not a 32-byte digest.
+	InvalidHash : record { msg : text };
+	// An inter-canister call error from the threshold signature API.
+	SigningError : text;
+	// Payment failed.
+	PaymentError : PaymentError
+};
+type BtcSignPrehashRequest = record {
+	// Hex-encoded 32-byte digest to sign under the caller's Bitcoin key.
+	hash : text
+};
+type BtcSignPrehashResponse = record {
+	// Hex-encoded 64-byte ECDSA signature (`r || s`), as returned by the management canister.
+	// The caller recovers the recovery id (and any encoding it needs) from the known public
+	// key.
+	signature : text
+};
 type BtcTxOutput = record { destination_address : text; sent_satoshis : nat64 };
 type BuildP2wpkhTxError = variant {
 	NotEnoughFunds : record { available : nat64; required : nat64 };
@@ -11,6 +33,7 @@ type BuildP2wpkhTxError = variant {
 	InvalidSourceAddress : GetAddressResponse
 };
 type CallerPaysIcrc2Tokens = record { ledger : principal };
+// Copy of the synonymous Rosetta type.
 type CanisterStatusResultV2 = record {
 	controller : principal;
 	status : CanisterStatusType;
@@ -22,12 +45,27 @@ type CanisterStatusResultV2 = record {
 	idle_cycles_burned_per_day : nat;
 	module_hash : opt blob
 };
-type CanisterStatusType = variant { stopped; stopping; running };
+// # Canister Status Type
+//
+// Status of a canister.
+//
+// See [`CanisterStatusResult::status`].
+type CanisterStatusType = variant {
+	// The canister is stopped.
+	stopped;
+	// The canister is stopping.
+	stopping;
+	// The canister is running.
+	running
+};
 type Config = record {
 	ecdsa_key_name : text;
+	// Root of trust for checking canister signatures.
 	ic_root_key_raw : opt blob;
+	// Payment canister ID.
 	cycles_ledger : principal
 };
+// Copy of synonymous Rosetta type.
 type DefiniteCanisterSettingsArgs = record {
 	controller : principal;
 	freezing_threshold : nat;
@@ -35,20 +73,54 @@ type DefiniteCanisterSettingsArgs = record {
 	memory_allocation : nat;
 	compute_allocation : nat
 };
-type EcdsaCurve = variant { secp256k1 };
-type EcdsaKeyId = record { name : text; curve : EcdsaCurve };
-type EcdsaPublicKeyArgument = record {
+// # ECDSA Curve.
+type EcdsaCurve = variant {
+	// secp256k1
+	secp256k1
+};
+// # ECDSA Key ID.
+//
+// See [`EcdsaPublicKeyArgs::key_id`] and [`SignWithEcdsaArgs::key_id`].
+type EcdsaKeyId = record {
+	// Name of the key.
+	name : text;
+	// Curve of the key.
+	curve : EcdsaCurve
+};
+// # ECDSA Public Key Args.
+//
+// Argument type of [`ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
+type EcdsaPublicKeyArgs = record {
+	// The key ID.
 	key_id : EcdsaKeyId;
+	// Canister id, default to the canister id of the caller if `None`.
 	canister_id : opt principal;
+	// A vector of variable length byte strings.
 	derivation_path : vec blob
 };
-type EcdsaPublicKeyResponse = record { public_key : blob; chain_code : blob };
+// # ECDSA Public Key Result.
+//
+// Result type of [`ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
+type EcdsaPublicKeyResult = record {
+	// An ECDSA public key encoded in SEC1 compressed form.
+	public_key : blob;
+	// Can be used to deterministically derive child keys of the [`public_key`](Self::public_key).
+	chain_code : blob
+};
 type EthAddressError = variant {
-	SigningError : record { RejectionCode_1; text };
+	// An inter-canister call error from the threshold signature API.
+	SigningError : text;
+	// Payment failed.
 	PaymentError : PaymentError
 };
-type EthAddressRequest = record { "principal" : opt principal };
-type EthAddressResponse = record { address : text };
+type EthAddressRequest = record {
+	// The principal owning the Ethereum address.  Default: The caller.
+	"principal" : opt principal
+};
+type EthAddressResponse = record {
+	// The Ethereum address.
+	address : text
+};
 type EthPersonalSignRequest = record { message : text };
 type EthPersonalSignResponse = record { signature : text };
 type EthSignPrehashRequest = record { hash : text };
@@ -68,20 +140,26 @@ type GetAddressError = variant {
 	PaymentError : PaymentError
 };
 type GetAddressRequest = record {
-	network : BitcoinNetwork;
+	network : Network;
 	address_type : BitcoinAddressType
 };
 type GetAddressResponse = record { address : text };
 type GetBalanceRequest = record {
-	network : BitcoinNetwork;
+	network : Network;
 	address_type : BitcoinAddressType;
 	min_confirmations : opt nat32
 };
 type GetBalanceResponse = record { balance : nat64 };
 type HttpRequest = record {
+	// The requested path and query string, for example `/some/path?foo=bar`.
+	//
+	// Note: This does NOT contain the domain, port or protocol.
 	url : text;
+	// The HTTP method of the request, such as `GET` or `POST`.
 	method : text;
+	// The complete body of the HTTP request
 	body : blob;
+	// The HTTP request headers
 	headers : vec record { text; text }
 };
 type HttpResponse = record {
@@ -91,10 +169,27 @@ type HttpResponse = record {
 };
 type InitArg = record {
 	ecdsa_key_name : text;
+	// Root of trust for checking canister signatures.
 	ic_root_key_der : opt blob;
+	// Payment canister ID.
 	cycles_ledger : opt principal
 };
-type Outpoint = record { txid : blob; vout : nat32 };
+type Network = variant {
+	// Bitcoin Mainnet.
+	mainnet;
+	// Bitcoin Regtest.
+	regtest;
+	// Bitcoin Testnet4.
+	testnet
+};
+// A reference to a transaction output.
+type OutPoint = record {
+	// A cryptographic hash of the transaction.
+	// A transaction can output multiple UTXOs.
+	txid : blob;
+	// The index of the output within the transaction.
+	vout : nat32
+};
 type PatronPaysIcrc2Tokens = record { ledger : principal; patron : Account };
 type PaymentError = variant {
 	LedgerWithdrawFromError : record {
@@ -108,13 +203,23 @@ type PaymentError = variant {
 		ledger : principal
 	};
 	UnsupportedPaymentType;
-	InsufficientFunds : record { needed : nat64; available : nat64 }
+	InsufficientFunds : record { needed : nat; available : nat }
 };
+// How a caller states that they will pay.
 type PaymentType = variant {
+	// A patron is paying, on behalf of the caller, from an account on the specified ledger.
 	PatronPaysIcrc2Tokens : PatronPaysIcrc2Tokens;
+	// The caller is paying with cycles attached to the call.
+	//
+	// Note: This is available to inter-canister aclls only; not to ingress messages.
+	//
+	// Note: The API does not require additional arguments to support this payment type.
 	AttachedCycles;
+	// The caller is paying with cycles from their main account on the cycles ledger.
 	CallerPaysIcrc2Cycles;
+	// The caller is paying with tokens from their main account on the specified ledger.
 	CallerPaysIcrc2Tokens : CallerPaysIcrc2Tokens;
+	// A patron is paying with cycles on behalf of the caller.
 	PatronPaysIcrc2Cycles : Account
 };
 type RejectionCode = variant {
@@ -126,43 +231,60 @@ type RejectionCode = variant {
 	SysFatal;
 	CanisterReject
 };
-type RejectionCode_1 = variant {
-	NoError;
-	CanisterError;
-	SysTransient;
-	DestinationInvalid;
-	Unknown;
-	SysFatal;
-	CanisterReject
-};
 type Result = variant { Ok : GetAddressResponse; Err : GetAddressError };
 type Result_1 = variant { Ok : GetBalanceResponse; Err : GetAddressError };
 type Result_10 = variant {
-	Ok : record { SignWithEcdsaResponse };
+	Ok : record { EcdsaPublicKeyResult };
+	Err : EthAddressError
+};
+type Result_11 = variant {
+	Ok : record { SignWithEcdsaResult };
 	Err : EthAddressError
 };
 type Result_2 = variant { Ok : SendBtcResponse; Err : SendBtcError };
 type Result_3 = variant { Ok : SignBtcResponse; Err : SendBtcError };
-type Result_4 = variant { Ok : EthAddressResponse; Err : EthAddressError };
-type Result_5 = variant { Ok : EthPersonalSignResponse; Err : EthAddressError };
-type Result_6 = variant { Ok : EthSignPrehashResponse; Err : EthAddressError };
-type Result_7 = variant {
-	Ok : record { EcdsaPublicKeyResponse };
-	Err : EthAddressError
+type Result_4 = variant {
+	Ok : BtcSignPrehashResponse;
+	Err : BtcSignPrehashError
 };
+type Result_5 = variant { Ok : EthAddressResponse; Err : EthAddressError };
+type Result_6 = variant { Ok : EthPersonalSignResponse; Err : EthAddressError };
+type Result_7 = variant { Ok : EthSignPrehashResponse; Err : EthAddressError };
 type Result_8 = variant {
-	Ok : record { SignWithEcdsaResponse };
+	Ok : record { EcdsaPublicKeyResult };
 	Err : EthAddressError
 };
 type Result_9 = variant {
-	Ok : record { EcdsaPublicKeyResponse };
+	Ok : record { SignWithEcdsaResult };
 	Err : EthAddressError
 };
-type SchnorrAlgorithm = variant { ed25519; bip340secp256k1 };
-type SchnorrKeyId = record { algorithm : SchnorrAlgorithm; name : text };
-type SchnorrPublicKeyArgument = record {
+// # Schnorr Algorithm.
+//
+// See [`SchnorrKeyId::algorithm`].
+type SchnorrAlgorithm = variant {
+	// ed25519.
+	ed25519;
+	// BIP-340 secp256k1.
+	bip340secp256k1
+};
+// # Schnorr Aux.
+type SchnorrAux = variant { bip341 : Bip341 };
+// # Schnorr Key ID.
+type SchnorrKeyId = record {
+	// Algorithm of the key.
+	algorithm : SchnorrAlgorithm;
+	// Name of the key.
+	name : text
+};
+// # Schnorr Public Key Args.
+//
+// Argument type of [`schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key).
+type SchnorrPublicKeyArgs = record {
+	// The key ID.
 	key_id : SchnorrKeyId;
+	// Canister id, default to the canister id of the caller if `None`.
 	canister_id : opt principal;
+	// A vector of variable length byte strings.
 	derivation_path : vec blob
 };
 type SendBtcError = variant {
@@ -172,22 +294,42 @@ type SendBtcError = variant {
 };
 type SendBtcRequest = record {
 	fee_satoshis : opt nat64;
-	network : BitcoinNetwork;
+	network : Network;
 	utxos_to_spend : vec Utxo;
 	address_type : BitcoinAddressType;
 	outputs : vec BtcTxOutput
 };
 type SendBtcResponse = record { txid : text };
 type SignBtcResponse = record { txid : text; signed_transaction_hex : text };
-type SignWithEcdsaArgument = record {
+// # Sign With ECDSA Args.
+//
+// Argument type of [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
+type SignWithEcdsaArgs = record {
+	// The key ID.
 	key_id : EcdsaKeyId;
+	// A vector of variable length byte strings.
 	derivation_path : vec blob;
+	// Hash of the message with length of 32 bytes.
 	message_hash : blob
 };
-type SignWithEcdsaResponse = record { signature : blob };
-type SignWithSchnorrArgument = record {
+// # Sign With ECDSA Result.
+//
+// Result type of [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
+type SignWithEcdsaResult = record {
+	// Encoded as the concatenation of the SEC1 encodings of the two values `r` and `s`.
+	signature : blob
+};
+// # Sign With Schnorr Args.
+//
+// Argument type of [`sign_with_schnorr`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_schnorr).
+type SignWithSchnorrArgs = record {
+	// Schnorr auxiliary inputs.
+	aux : opt SchnorrAux;
+	// The key ID.
 	key_id : SchnorrKeyId;
+	// A vector of variable length byte strings.
 	derivation_path : vec blob;
+	// Message to be signed.
 	message : blob
 };
 type TransferFromError = variant {
@@ -201,7 +343,8 @@ type TransferFromError = variant {
 	TooOld;
 	InsufficientFunds : record { balance : nat }
 };
-type Utxo = record { height : nat32; value : nat64; outpoint : Outpoint };
+// An unspent transaction output.
+type Utxo = record { height : nat32; value : nat64; outpoint : OutPoint };
 type WithdrawFromError = variant {
 	GenericError : record { message : text; error_code : nat };
 	TemporarilyUnavailable;
@@ -212,7 +355,7 @@ type WithdrawFromError = variant {
 	TooOld;
 	FailedToWithdrawFrom : record {
 		withdraw_from_block : opt nat;
-		rejection_code : RejectionCode_1;
+		rejection_code : RejectionCode;
 		refund_block : opt nat;
 		approval_refund_block : opt nat;
 		rejection_reason : text
@@ -220,29 +363,254 @@ type WithdrawFromError = variant {
 	InsufficientFunds : record { balance : nat }
 };
 service : (Arg) -> {
+	// Returns the Bitcoin address of the caller.
+	//
+	// # Details
+	// - Gets the principal's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Converts the public key to a P2WPKH address.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
 	btc_caller_address : (GetAddressRequest, opt PaymentType) -> (Result);
+	// Returns the Bitcoin balance of the caller's address.
+	//
+	// > This method is DEPRECATED. Canister developers are advised to call `bitcoin_get_balance()` on
+	// > the Bitcoin (mainnet or testnet) canister.
+	//
+	// # Details
+	// - Gets the principal's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Converts the public key to a P2WPKH address.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Gets the Bitcoin balance from [the deprecated system Bitcoin API](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_balance)
+	// - Costs: See [Bitcoin API fees and pricing](https://internetcomputer.org/docs/current/references/bitcoin-how-it-works#api-fees-and-pricing)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
 	btc_caller_balance : (GetBalanceRequest, opt PaymentType) -> (Result_1);
+	// Creates, signs and sends a BTC transaction from the caller's address.
+	//
+	// # Details
+	// - Gets the principal's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Converts the public key to a P2WPKH address.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - For every transaction input:
+	// - Calls `sign_with_ecdsa(..)` on that input.
+	// - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	// - Sends the transaction with `bitcoin_api::send_transaction(..)`
+	// - Costs: See [Bitcoin API fees and pricing](https://internetcomputer.org/docs/current/references/bitcoin-how-it-works#api-fees-and-pricing)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
 	btc_caller_send : (SendBtcRequest, opt PaymentType) -> (Result_2);
+	// Creates and signs a BTC transaction from the caller's address without broadcasting it.
+	//
+	// # Details
+	// - Gets the principal's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Converts the public key to a P2WPKH address.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - For every transaction input:
+	// - Calls `sign_with_ecdsa(..)` on that input.
+	// - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
 	btc_caller_sign : (SendBtcRequest, opt PaymentType) -> (Result_3);
+	// Signs a precomputed 32-byte digest under the caller's Bitcoin key.
+	//
+	// # Details
+	// This is the Bitcoin counterpart of `eth_sign_prehash`: it signs an arbitrary hash with the
+	// caller's BTC key (schema `Btc`), so the signature verifies against the caller's P2WPKH address.
+	// Unlike `btc_caller_sign`, which builds and signs a transaction from supplied UTXOs, this signs
+	// any digest, which is what arbitrary message / PSBT signing (e.g. `WalletConnect` `signMessage` /
+	// `signPsbt`) requires. `generic_sign_with_ecdsa` cannot serve this: it derives a different
+	// (schema `Generic`) key whose signatures do not match the BTC address.
+	//
+	// - Signs the message hash with `management_canister::ecdsa::sign_with_ecdsa(..)`
+	// - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	//
+	// Returns the raw 64-byte ECDSA signature (`r || s`) as hex; the caller recovers the recovery id
+	// from the known public key.
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	btc_sign_prehash : (BtcSignPrehashRequest, opt PaymentType) -> (Result_4);
+	// Show the canister configuration.
 	config : () -> (Config) query;
-	eth_address : (EthAddressRequest, opt PaymentType) -> (Result_4);
-	eth_address_of_caller : (opt PaymentType) -> (Result_4);
-	eth_personal_sign : (EthPersonalSignRequest, opt PaymentType) -> (Result_5);
-	eth_sign_prehash : (EthSignPrehashRequest, opt PaymentType) -> (Result_6);
+	// Returns the Ethereum address of a specified user.
+	//
+	// If no user is specified, the caller's address is returned.
+	//
+	// # Details
+	// - Gets the specified user's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Converts the public key to an Ethereum address.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	eth_address : (EthAddressRequest, opt PaymentType) -> (Result_5);
+	// Returns the Ethereum address of the caller.
+	//
+	// # Details
+	// - Gets the caller's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Converts the public key to an Ethereum address.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	eth_address_of_caller : (opt PaymentType) -> (Result_5);
+	// Computes an Ethereum signature for a hex-encoded message according to [EIP-191](https://eips.ethereum.org/EIPS/eip-191).
+	//
+	// # Details
+	// - Formats the message as `\x19Ethereum Signed Message:\n<length><message>`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Hashes the message.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Gets the caller's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Signs the message hash with `management_canister::ecdsa::sign_with_ecdsa(..)`
+	// - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	eth_personal_sign : (EthPersonalSignRequest, opt PaymentType) -> (Result_6);
+	// Computes an Ethereum signature for a precomputed hash.
+	//
+	// # Details
+	// Note: This is the same as `eth_personal_sign` but with a precomputed hash, so ingress message
+	// size is small regardless of the message length.
+	//
+	// - Gets the caller's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Signs the message hash with `management_canister::ecdsa::sign_with_ecdsa(..)`
+	// - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	eth_sign_prehash : (EthSignPrehashRequest, opt PaymentType) -> (Result_7);
+	// Computes an Ethereum signature for an [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction.
+	//
+	// # Details
+	// - Formats the transaction as an `Eip1559TransactionRequest`.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Hashes the transaction.
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Gets the caller's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	// - Signs the transaction with `management_canister::ecdsa::sign_with_ecdsa(..)`
+	// - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
 	eth_sign_transaction : (EthSignTransactionRequest, opt PaymentType) -> (
-		Result_6
+		Result_7
 	);
-	generic_caller_ecdsa_public_key : (
-		EcdsaPublicKeyArgument,
-		opt PaymentType
-	) -> (Result_7);
-	generic_sign_with_ecdsa : (opt PaymentType, SignWithEcdsaArgument) -> (
+	// Returns the generic ECDSA public key of the caller.
+	//
+	// Note: This is an exact dual of the canister [`ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key) method.  The argument and response types are also the same.
+	//
+	// # Warnings
+	// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+	// unintended sub-keys are not requested.
+	//
+	// # Details
+	// - Calls `management_canister::ecdsa::ecdsa_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	generic_caller_ecdsa_public_key : (EcdsaPublicKeyArgs, opt PaymentType) -> (
 		Result_8
 	);
+	// Signs a message using the caller's ECDSA key.
+	//
+	// Note: This is an exact dual of the canister [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa) method.  The argument and response types are also the same.
+	//
+	// # Warnings
+	// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+	// unintended sub-keys are not requested.
+	//
+	// # Details
+	// - Calls `management_canister::ecdsa::sign_with_ecdsa(..)`
+	// - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	generic_sign_with_ecdsa : (opt PaymentType, SignWithEcdsaArgs) -> (Result_9);
+	// API method to get cycle balance and burn rate.
 	get_canister_status : () -> (CanisterStatusResultV2);
+	// Processes external HTTP requests.
 	http_request : (HttpRequest) -> (HttpResponse) query;
-	schnorr_public_key : (SchnorrPublicKeyArgument, opt PaymentType) -> (
-		Result_9
-	);
-	schnorr_sign : (SignWithSchnorrArgument, opt PaymentType) -> (Result_10)
+	// Returns the Schnorr public key of the caller or specified principal.
+	//
+	// Note: This is an exact dual of the canister [`schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key) method.  The argument and response types are also the same.
+	//
+	// # Arguments
+	// - `arg`: The same `SchnorrPublicKeyArgs` as the management canister argument.  The semantics are
+	// identical but the meaning of the fields in the new context deserve some explanation.
+	// - `arg.canister_id`: The principal of the canister or user for which the Chain Fusion Signer
+	// has issued the public key.  If `None`, the caller's public key is returned.
+	// - `arg.derivation_path`: The derivation path to the public key.  The caller is responsible for
+	// ensuring that the derivation path is used to namespace appropriately and to ensure that
+	// unintended sub-keys are not requested.  At minimum, it is recommended to use `vec!["NAME OF
+	// YOUR APP".into_bytes()]`.  The maximum derivation path length is 254, one less than when
+	// calling the management canister.
+	// - `arg.key_id`: The ID of the root threshold key to use.  E.g. `key_1` or `test_key_1`.  See <https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#key-derivation>
+	// for details.
+	// - `payment`: The payment type to use.  If omitted or `None`, it will be assumed that cycles have
+	// been attached.
+	//
+	// # Warnings
+	// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+	// derivation paths are used to namespace appropriately and to ensure that unintended sub-keys
+	// are not requested.
+	// - It is recommended that, at minimum, the derivation path should be `vec!["NAME OF YOUR
+	// APP".into_bytes()]`
+	//
+	// # Details
+	// - Calls `management_canister::schnorr::schnorr_public_key(..)`
+	// - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	schnorr_public_key : (SchnorrPublicKeyArgs, opt PaymentType) -> (Result_10);
+	// Signs a message using the caller's Schnorr key.
+	//
+	// Note: This is an exact dual of the canister [`sign_with_schnorr`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_schnorr) method.  The argument and response types are also the same.
+	//
+	// # Arguments
+	// - `arg`: The same `SignWithSchnorrArgs` as the management canister argument.  The semantics are
+	// identical but the meaning of the fields in the new context deserve some explanation.
+	// - `arg.message`: The data to sign.  Note that if you have a large amount of data, you are
+	// probably better off hashing the data and then signing the hash.
+	// - `arg.derivation_path`: The derivation path to the public key.  The caller is responsible for
+	// ensuring that the derivation path is used to namespace appropriately and to ensure that
+	// unintended sub-keys are not requested.  At minimum, it is recommended to use `vec!["NAME OF
+	// YOUR APP".into_bytes()]`.  The maximum derivation path length is 254, one less than when
+	// calling the management canister.
+	// - `arg.key_id`: The ID of the root threshold key to use.  E.g. `key_1` or `test_key_1`.  See <https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#key-derivation>
+	// for details.
+	// - `payment`: The payment type to use.  If omitted or `None`, it will be assumed that cycles have
+	// been attached.
+	//
+	// # Warnings
+	// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+	// derivation paths are used to namespace appropriately and to ensure that unintended sub-keys
+	// are not requested.
+	// - It is recommended that, at minimum, the derivation path should be `vec!["NAME OF YOUR
+	// APP".into_bytes()]`
+	//
+	// # Details
+	// - Calls `management_canister::schnorr::sign_with_schnorr(..)`
+	// - Costs: See [Fees for the t-Schnorr production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-schnorr-production-key)
+	//
+	// # Panics
+	// - If the caller is the anonymous user.
+	schnorr_sign : (SignWithSchnorrArgs, opt PaymentType) -> (Result_11)
 }

--- a/src/declarations/signer/signer.did.d.ts
+++ b/src/declarations/signer/signer.did.d.ts
@@ -15,8 +15,49 @@ export interface Account {
 	subaccount: [] | [Uint8Array];
 }
 export type Arg = { Upgrade: null } | { Init: InitArg };
+/**
+ * # Bip341 variant of Schnorr Aux.
+ */
+export interface Bip341 {
+	/**
+	 * Merkle tree root hash.
+	 */
+	merkle_root_hash: Uint8Array;
+}
 export type BitcoinAddressType = { P2WPKH: null };
-export type BitcoinNetwork = { mainnet: null } | { regtest: null } | { testnet: null };
+export type BtcSignPrehashError =
+	| {
+			/**
+			 * The supplied hash was not valid hex or was not a 32-byte digest.
+			 */
+			InvalidHash: { msg: string };
+	  }
+	| {
+			/**
+			 * An inter-canister call error from the threshold signature API.
+			 */
+			SigningError: string;
+	  }
+	| {
+			/**
+			 * Payment failed.
+			 */
+			PaymentError: PaymentError;
+	  };
+export interface BtcSignPrehashRequest {
+	/**
+	 * Hex-encoded 32-byte digest to sign under the caller's Bitcoin key.
+	 */
+	hash: string;
+}
+export interface BtcSignPrehashResponse {
+	/**
+	 * Hex-encoded 64-byte ECDSA signature (`r || s`), as returned by the management canister.
+	 * The caller recovers the recovery id (and any encoding it needs) from the known public
+	 * key.
+	 */
+	signature: string;
+}
 export interface BtcTxOutput {
 	destination_address: string;
 	sent_satoshis: bigint;
@@ -32,6 +73,9 @@ export type BuildP2wpkhTxError =
 export interface CallerPaysIcrc2Tokens {
 	ledger: Principal;
 }
+/**
+ * Copy of the synonymous Rosetta type.
+ */
 export interface CanisterStatusResultV2 {
 	controller: Principal;
 	status: CanisterStatusType;
@@ -43,12 +87,46 @@ export interface CanisterStatusResultV2 {
 	idle_cycles_burned_per_day: bigint;
 	module_hash: [] | [Uint8Array];
 }
-export type CanisterStatusType = { stopped: null } | { stopping: null } | { running: null };
+/**
+ * # Canister Status Type
+ *
+ * Status of a canister.
+ *
+ * See [`CanisterStatusResult::status`].
+ */
+export type CanisterStatusType =
+	| {
+			/**
+			 * The canister is stopped.
+			 */
+			stopped: null;
+	  }
+	| {
+			/**
+			 * The canister is stopping.
+			 */
+			stopping: null;
+	  }
+	| {
+			/**
+			 * The canister is running.
+			 */
+			running: null;
+	  };
 export interface Config {
 	ecdsa_key_name: string;
+	/**
+	 * Root of trust for checking canister signatures.
+	 */
 	ic_root_key_raw: [] | [Uint8Array];
+	/**
+	 * Payment canister ID.
+	 */
 	cycles_ledger: Principal;
 }
+/**
+ * Copy of synonymous Rosetta type.
+ */
 export interface DefiniteCanisterSettingsArgs {
 	controller: Principal;
 	freezing_threshold: bigint;
@@ -56,26 +134,84 @@ export interface DefiniteCanisterSettingsArgs {
 	memory_allocation: bigint;
 	compute_allocation: bigint;
 }
-export type EcdsaCurve = { secp256k1: null };
+/**
+ * # ECDSA Curve.
+ */
+export type EcdsaCurve = {
+	/**
+	 * secp256k1
+	 */
+	secp256k1: null;
+};
+/**
+ * # ECDSA Key ID.
+ *
+ * See [`EcdsaPublicKeyArgs::key_id`] and [`SignWithEcdsaArgs::key_id`].
+ */
 export interface EcdsaKeyId {
+	/**
+	 * Name of the key.
+	 */
 	name: string;
+	/**
+	 * Curve of the key.
+	 */
 	curve: EcdsaCurve;
 }
-export interface EcdsaPublicKeyArgument {
+/**
+ * # ECDSA Public Key Args.
+ *
+ * Argument type of [`ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
+ */
+export interface EcdsaPublicKeyArgs {
+	/**
+	 * The key ID.
+	 */
 	key_id: EcdsaKeyId;
+	/**
+	 * Canister id, default to the canister id of the caller if `None`.
+	 */
 	canister_id: [] | [Principal];
+	/**
+	 * A vector of variable length byte strings.
+	 */
 	derivation_path: Array<Uint8Array>;
 }
-export interface EcdsaPublicKeyResponse {
+/**
+ * # ECDSA Public Key Result.
+ *
+ * Result type of [`ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key).
+ */
+export interface EcdsaPublicKeyResult {
+	/**
+	 * An ECDSA public key encoded in SEC1 compressed form.
+	 */
 	public_key: Uint8Array;
+	/**
+	 * Can be used to deterministically derive child keys of the [`public_key`](Self::public_key).
+	 */
 	chain_code: Uint8Array;
 }
 export type EthAddressError =
-	{ SigningError: [RejectionCode_1, string] } | { PaymentError: PaymentError };
+	| {
+			/**
+			 * An inter-canister call error from the threshold signature API.
+			 */
+			SigningError: string;
+	  }
+	| {
+			/**
+			 * Payment failed.
+			 */
+			PaymentError: PaymentError;
+	  };
 export interface EthAddressRequest {
 	principal: [] | [Principal];
 }
 export interface EthAddressResponse {
+	/**
+	 * The Ethereum address.
+	 */
 	address: string;
 }
 export interface EthPersonalSignRequest {
@@ -102,14 +238,14 @@ export interface EthSignTransactionRequest {
 }
 export type GetAddressError = { InternalError: { msg: string } } | { PaymentError: PaymentError };
 export interface GetAddressRequest {
-	network: BitcoinNetwork;
+	network: Network;
 	address_type: BitcoinAddressType;
 }
 export interface GetAddressResponse {
 	address: string;
 }
 export interface GetBalanceRequest {
-	network: BitcoinNetwork;
+	network: Network;
 	address_type: BitcoinAddressType;
 	min_confirmations: [] | [number];
 }
@@ -117,9 +253,23 @@ export interface GetBalanceResponse {
 	balance: bigint;
 }
 export interface HttpRequest {
+	/**
+	 * The requested path and query string, for example `/some/path?foo=bar`.
+	 *
+	 * Note: This does NOT contain the domain, port or protocol.
+	 */
 	url: string;
+	/**
+	 * The HTTP method of the request, such as `GET` or `POST`.
+	 */
 	method: string;
+	/**
+	 * The complete body of the HTTP request
+	 */
 	body: Uint8Array;
+	/**
+	 * The HTTP request headers
+	 */
 	headers: Array<[string, string]>;
 }
 export interface HttpResponse {
@@ -129,11 +279,46 @@ export interface HttpResponse {
 }
 export interface InitArg {
 	ecdsa_key_name: string;
+	/**
+	 * Root of trust for checking canister signatures.
+	 */
 	ic_root_key_der: [] | [Uint8Array];
+	/**
+	 * Payment canister ID.
+	 */
 	cycles_ledger: [] | [Principal];
 }
-export interface Outpoint {
+export type Network =
+	| {
+			/**
+			 * Bitcoin Mainnet.
+			 */
+			mainnet: null;
+	  }
+	| {
+			/**
+			 * Bitcoin Regtest.
+			 */
+			regtest: null;
+	  }
+	| {
+			/**
+			 * Bitcoin Testnet4.
+			 */
+			testnet: null;
+	  };
+/**
+ * A reference to a transaction output.
+ */
+export interface OutPoint {
+	/**
+	 * A cryptographic hash of the transaction.
+	 * A transaction can output multiple UTXOs.
+	 */
 	txid: Uint8Array;
+	/**
+	 * The index of the output within the transaction.
+	 */
 	vout: number;
 }
 export interface PatronPaysIcrc2Tokens {
@@ -157,21 +342,45 @@ export type PaymentError =
 	  }
 	| { UnsupportedPaymentType: null }
 	| { InsufficientFunds: { needed: bigint; available: bigint } };
+/**
+ * How a caller states that they will pay.
+ */
 export type PaymentType =
-	| { PatronPaysIcrc2Tokens: PatronPaysIcrc2Tokens }
-	| { AttachedCycles: null }
-	| { CallerPaysIcrc2Cycles: null }
-	| { CallerPaysIcrc2Tokens: CallerPaysIcrc2Tokens }
-	| { PatronPaysIcrc2Cycles: Account };
+	| {
+			/**
+			 * A patron is paying, on behalf of the caller, from an account on the specified ledger.
+			 */
+			PatronPaysIcrc2Tokens: PatronPaysIcrc2Tokens;
+	  }
+	| {
+			/**
+			 * The caller is paying with cycles attached to the call.
+			 *
+			 * Note: This is available to inter-canister aclls only; not to ingress messages.
+			 *
+			 * Note: The API does not require additional arguments to support this payment type.
+			 */
+			AttachedCycles: null;
+	  }
+	| {
+			/**
+			 * The caller is paying with cycles from their main account on the cycles ledger.
+			 */
+			CallerPaysIcrc2Cycles: null;
+	  }
+	| {
+			/**
+			 * The caller is paying with tokens from their main account on the specified ledger.
+			 */
+			CallerPaysIcrc2Tokens: CallerPaysIcrc2Tokens;
+	  }
+	| {
+			/**
+			 * A patron is paying with cycles on behalf of the caller.
+			 */
+			PatronPaysIcrc2Cycles: Account;
+	  };
 export type RejectionCode =
-	| { NoError: null }
-	| { CanisterError: null }
-	| { SysTransient: null }
-	| { DestinationInvalid: null }
-	| { Unknown: null }
-	| { SysFatal: null }
-	| { CanisterReject: null };
-export type RejectionCode_1 =
 	| { NoError: null }
 	| { CanisterError: null }
 	| { SysTransient: null }
@@ -181,23 +390,68 @@ export type RejectionCode_1 =
 	| { CanisterReject: null };
 export type Result = { Ok: GetAddressResponse } | { Err: GetAddressError };
 export type Result_1 = { Ok: GetBalanceResponse } | { Err: GetAddressError };
-export type Result_10 = { Ok: [SignWithEcdsaResponse] } | { Err: EthAddressError };
+export type Result_10 = { Ok: [EcdsaPublicKeyResult] } | { Err: EthAddressError };
+export type Result_11 = { Ok: [SignWithEcdsaResult] } | { Err: EthAddressError };
 export type Result_2 = { Ok: SendBtcResponse } | { Err: SendBtcError };
 export type Result_3 = { Ok: SignBtcResponse } | { Err: SendBtcError };
-export type Result_4 = { Ok: EthAddressResponse } | { Err: EthAddressError };
-export type Result_5 = { Ok: EthPersonalSignResponse } | { Err: EthAddressError };
-export type Result_6 = { Ok: EthSignPrehashResponse } | { Err: EthAddressError };
-export type Result_7 = { Ok: [EcdsaPublicKeyResponse] } | { Err: EthAddressError };
-export type Result_8 = { Ok: [SignWithEcdsaResponse] } | { Err: EthAddressError };
-export type Result_9 = { Ok: [EcdsaPublicKeyResponse] } | { Err: EthAddressError };
-export type SchnorrAlgorithm = { ed25519: null } | { bip340secp256k1: null };
+export type Result_4 = { Ok: BtcSignPrehashResponse } | { Err: BtcSignPrehashError };
+export type Result_5 = { Ok: EthAddressResponse } | { Err: EthAddressError };
+export type Result_6 = { Ok: EthPersonalSignResponse } | { Err: EthAddressError };
+export type Result_7 = { Ok: EthSignPrehashResponse } | { Err: EthAddressError };
+export type Result_8 = { Ok: [EcdsaPublicKeyResult] } | { Err: EthAddressError };
+export type Result_9 = { Ok: [SignWithEcdsaResult] } | { Err: EthAddressError };
+/**
+ * # Schnorr Algorithm.
+ *
+ * See [`SchnorrKeyId::algorithm`].
+ */
+export type SchnorrAlgorithm =
+	| {
+			/**
+			 * ed25519.
+			 */
+			ed25519: null;
+	  }
+	| {
+			/**
+			 * BIP-340 secp256k1.
+			 */
+			bip340secp256k1: null;
+	  };
+/**
+ * # Schnorr Aux.
+ */
+export type SchnorrAux = { bip341: Bip341 };
+/**
+ * # Schnorr Key ID.
+ */
 export interface SchnorrKeyId {
+	/**
+	 * Algorithm of the key.
+	 */
 	algorithm: SchnorrAlgorithm;
+	/**
+	 * Name of the key.
+	 */
 	name: string;
 }
-export interface SchnorrPublicKeyArgument {
+/**
+ * # Schnorr Public Key Args.
+ *
+ * Argument type of [`schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key).
+ */
+export interface SchnorrPublicKeyArgs {
+	/**
+	 * The key ID.
+	 */
 	key_id: SchnorrKeyId;
+	/**
+	 * Canister id, default to the canister id of the caller if `None`.
+	 */
 	canister_id: [] | [Principal];
+	/**
+	 * A vector of variable length byte strings.
+	 */
 	derivation_path: Array<Uint8Array>;
 }
 export type SendBtcError =
@@ -206,7 +460,7 @@ export type SendBtcError =
 	| { PaymentError: PaymentError };
 export interface SendBtcRequest {
 	fee_satoshis: [] | [bigint];
-	network: BitcoinNetwork;
+	network: Network;
 	utxos_to_spend: Array<Utxo>;
 	address_type: BitcoinAddressType;
 	outputs: Array<BtcTxOutput>;
@@ -218,17 +472,57 @@ export interface SignBtcResponse {
 	txid: string;
 	signed_transaction_hex: string;
 }
-export interface SignWithEcdsaArgument {
+/**
+ * # Sign With ECDSA Args.
+ *
+ * Argument type of [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
+ */
+export interface SignWithEcdsaArgs {
+	/**
+	 * The key ID.
+	 */
 	key_id: EcdsaKeyId;
+	/**
+	 * A vector of variable length byte strings.
+	 */
 	derivation_path: Array<Uint8Array>;
+	/**
+	 * Hash of the message with length of 32 bytes.
+	 */
 	message_hash: Uint8Array;
 }
-export interface SignWithEcdsaResponse {
+/**
+ * # Sign With ECDSA Result.
+ *
+ * Result type of [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
+ */
+export interface SignWithEcdsaResult {
+	/**
+	 * Encoded as the concatenation of the SEC1 encodings of the two values `r` and `s`.
+	 */
 	signature: Uint8Array;
 }
-export interface SignWithSchnorrArgument {
+/**
+ * # Sign With Schnorr Args.
+ *
+ * Argument type of [`sign_with_schnorr`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_schnorr).
+ */
+export interface SignWithSchnorrArgs {
+	/**
+	 * Schnorr auxiliary inputs.
+	 */
+	aux: [] | [SchnorrAux];
+	/**
+	 * The key ID.
+	 */
 	key_id: SchnorrKeyId;
+	/**
+	 * A vector of variable length byte strings.
+	 */
 	derivation_path: Array<Uint8Array>;
+	/**
+	 * Message to be signed.
+	 */
 	message: Uint8Array;
 }
 export type TransferFromError =
@@ -243,10 +537,13 @@ export type TransferFromError =
 	| { CreatedInFuture: { ledger_time: bigint } }
 	| { TooOld: null }
 	| { InsufficientFunds: { balance: bigint } };
+/**
+ * An unspent transaction output.
+ */
 export interface Utxo {
 	height: number;
 	value: bigint;
-	outpoint: Outpoint;
+	outpoint: OutPoint;
 }
 export type WithdrawFromError =
 	| {
@@ -261,7 +558,7 @@ export type WithdrawFromError =
 	| {
 			FailedToWithdrawFrom: {
 				withdraw_from_block: [] | [bigint];
-				rejection_code: RejectionCode_1;
+				rejection_code: RejectionCode;
 				refund_block: [] | [bigint];
 				approval_refund_block: [] | [bigint];
 				rejection_reason: string;
@@ -269,25 +566,286 @@ export type WithdrawFromError =
 	  }
 	| { InsufficientFunds: { balance: bigint } };
 export interface _SERVICE {
+	/**
+	 * Returns the Bitcoin address of the caller.
+	 *
+	 * # Details
+	 * - Gets the principal's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Converts the public key to a P2WPKH address.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
 	btc_caller_address: ActorMethod<[GetAddressRequest, [] | [PaymentType]], Result>;
+	/**
+	 * Returns the Bitcoin balance of the caller's address.
+	 *
+	 * > This method is DEPRECATED. Canister developers are advised to call `bitcoin_get_balance()` on
+	 * > the Bitcoin (mainnet or testnet) canister.
+	 *
+	 * # Details
+	 * - Gets the principal's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Converts the public key to a P2WPKH address.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Gets the Bitcoin balance from [the deprecated system Bitcoin API](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_balance)
+	 * - Costs: See [Bitcoin API fees and pricing](https://internetcomputer.org/docs/current/references/bitcoin-how-it-works#api-fees-and-pricing)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
 	btc_caller_balance: ActorMethod<[GetBalanceRequest, [] | [PaymentType]], Result_1>;
+	/**
+	 * Creates, signs and sends a BTC transaction from the caller's address.
+	 *
+	 * # Details
+	 * - Gets the principal's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Converts the public key to a P2WPKH address.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - For every transaction input:
+	 * - Calls `sign_with_ecdsa(..)` on that input.
+	 * - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	 * - Sends the transaction with `bitcoin_api::send_transaction(..)`
+	 * - Costs: See [Bitcoin API fees and pricing](https://internetcomputer.org/docs/current/references/bitcoin-how-it-works#api-fees-and-pricing)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
 	btc_caller_send: ActorMethod<[SendBtcRequest, [] | [PaymentType]], Result_2>;
+	/**
+	 * Creates and signs a BTC transaction from the caller's address without broadcasting it.
+	 *
+	 * # Details
+	 * - Gets the principal's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Converts the public key to a P2WPKH address.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - For every transaction input:
+	 * - Calls `sign_with_ecdsa(..)` on that input.
+	 * - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
 	btc_caller_sign: ActorMethod<[SendBtcRequest, [] | [PaymentType]], Result_3>;
+	/**
+	 * Signs a precomputed 32-byte digest under the caller's Bitcoin key.
+	 *
+	 * # Details
+	 * This is the Bitcoin counterpart of `eth_sign_prehash`: it signs an arbitrary hash with the
+	 * caller's BTC key (schema `Btc`), so the signature verifies against the caller's P2WPKH address.
+	 * Unlike `btc_caller_sign`, which builds and signs a transaction from supplied UTXOs, this signs
+	 * any digest, which is what arbitrary message / PSBT signing (e.g. `WalletConnect` `signMessage` /
+	 * `signPsbt`) requires. `generic_sign_with_ecdsa` cannot serve this: it derives a different
+	 * (schema `Generic`) key whose signatures do not match the BTC address.
+	 *
+	 * - Signs the message hash with `management_canister::ecdsa::sign_with_ecdsa(..)`
+	 * - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	 *
+	 * Returns the raw 64-byte ECDSA signature (`r || s`) as hex; the caller recovers the recovery id
+	 * from the known public key.
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	btc_sign_prehash: ActorMethod<[BtcSignPrehashRequest, [] | [PaymentType]], Result_4>;
+	/**
+	 * Show the canister configuration.
+	 */
 	config: ActorMethod<[], Config>;
-	eth_address: ActorMethod<[EthAddressRequest, [] | [PaymentType]], Result_4>;
-	eth_address_of_caller: ActorMethod<[[] | [PaymentType]], Result_4>;
-	eth_personal_sign: ActorMethod<[EthPersonalSignRequest, [] | [PaymentType]], Result_5>;
-	eth_sign_prehash: ActorMethod<[EthSignPrehashRequest, [] | [PaymentType]], Result_6>;
-	eth_sign_transaction: ActorMethod<[EthSignTransactionRequest, [] | [PaymentType]], Result_6>;
-	generic_caller_ecdsa_public_key: ActorMethod<
-		[EcdsaPublicKeyArgument, [] | [PaymentType]],
-		Result_7
-	>;
-	generic_sign_with_ecdsa: ActorMethod<[[] | [PaymentType], SignWithEcdsaArgument], Result_8>;
+	/**
+	 * Returns the Ethereum address of a specified user.
+	 *
+	 * If no user is specified, the caller's address is returned.
+	 *
+	 * # Details
+	 * - Gets the specified user's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Converts the public key to an Ethereum address.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	eth_address: ActorMethod<[EthAddressRequest, [] | [PaymentType]], Result_5>;
+	/**
+	 * Returns the Ethereum address of the caller.
+	 *
+	 * # Details
+	 * - Gets the caller's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Converts the public key to an Ethereum address.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	eth_address_of_caller: ActorMethod<[[] | [PaymentType]], Result_5>;
+	/**
+	 * Computes an Ethereum signature for a hex-encoded message according to [EIP-191](https://eips.ethereum.org/EIPS/eip-191).
+	 *
+	 * # Details
+	 * - Formats the message as `\x19Ethereum Signed Message:\n<length><message>`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Hashes the message.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Gets the caller's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Signs the message hash with `management_canister::ecdsa::sign_with_ecdsa(..)`
+	 * - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	eth_personal_sign: ActorMethod<[EthPersonalSignRequest, [] | [PaymentType]], Result_6>;
+	/**
+	 * Computes an Ethereum signature for a precomputed hash.
+	 *
+	 * # Details
+	 * Note: This is the same as `eth_personal_sign` but with a precomputed hash, so ingress message
+	 * size is small regardless of the message length.
+	 *
+	 * - Gets the caller's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Signs the message hash with `management_canister::ecdsa::sign_with_ecdsa(..)`
+	 * - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	eth_sign_prehash: ActorMethod<[EthSignPrehashRequest, [] | [PaymentType]], Result_7>;
+	/**
+	 * Computes an Ethereum signature for an [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction.
+	 *
+	 * # Details
+	 * - Formats the transaction as an `Eip1559TransactionRequest`.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Hashes the transaction.
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Gets the caller's public key with `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 * - Signs the transaction with `management_canister::ecdsa::sign_with_ecdsa(..)`
+	 * - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	eth_sign_transaction: ActorMethod<[EthSignTransactionRequest, [] | [PaymentType]], Result_7>;
+	/**
+	 * Returns the generic ECDSA public key of the caller.
+	 *
+	 * Note: This is an exact dual of the canister [`ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key) method.  The argument and response types are also the same.
+	 *
+	 * # Warnings
+	 * - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+	 * unintended sub-keys are not requested.
+	 *
+	 * # Details
+	 * - Calls `management_canister::ecdsa::ecdsa_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	generic_caller_ecdsa_public_key: ActorMethod<[EcdsaPublicKeyArgs, [] | [PaymentType]], Result_8>;
+	/**
+	 * Signs a message using the caller's ECDSA key.
+	 *
+	 * Note: This is an exact dual of the canister [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa) method.  The argument and response types are also the same.
+	 *
+	 * # Warnings
+	 * - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+	 * unintended sub-keys are not requested.
+	 *
+	 * # Details
+	 * - Calls `management_canister::ecdsa::sign_with_ecdsa(..)`
+	 * - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	generic_sign_with_ecdsa: ActorMethod<[[] | [PaymentType], SignWithEcdsaArgs], Result_9>;
+	/**
+	 * API method to get cycle balance and burn rate.
+	 */
 	get_canister_status: ActorMethod<[], CanisterStatusResultV2>;
+	/**
+	 * Processes external HTTP requests.
+	 */
 	http_request: ActorMethod<[HttpRequest], HttpResponse>;
-	schnorr_public_key: ActorMethod<[SchnorrPublicKeyArgument, [] | [PaymentType]], Result_9>;
-	schnorr_sign: ActorMethod<[SignWithSchnorrArgument, [] | [PaymentType]], Result_10>;
+	/**
+	 * Returns the Schnorr public key of the caller or specified principal.
+	 *
+	 * Note: This is an exact dual of the canister [`schnorr_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-schnorr_public_key) method.  The argument and response types are also the same.
+	 *
+	 * # Arguments
+	 * - `arg`: The same `SchnorrPublicKeyArgs` as the management canister argument.  The semantics are
+	 * identical but the meaning of the fields in the new context deserve some explanation.
+	 * - `arg.canister_id`: The principal of the canister or user for which the Chain Fusion Signer
+	 * has issued the public key.  If `None`, the caller's public key is returned.
+	 * - `arg.derivation_path`: The derivation path to the public key.  The caller is responsible for
+	 * ensuring that the derivation path is used to namespace appropriately and to ensure that
+	 * unintended sub-keys are not requested.  At minimum, it is recommended to use `vec!["NAME OF
+	 * YOUR APP".into_bytes()]`.  The maximum derivation path length is 254, one less than when
+	 * calling the management canister.
+	 * - `arg.key_id`: The ID of the root threshold key to use.  E.g. `key_1` or `test_key_1`.  See <https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#key-derivation>
+	 * for details.
+	 * - `payment`: The payment type to use.  If omitted or `None`, it will be assumed that cycles have
+	 * been attached.
+	 *
+	 * # Warnings
+	 * - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+	 * derivation paths are used to namespace appropriately and to ensure that unintended sub-keys
+	 * are not requested.
+	 * - It is recommended that, at minimum, the derivation path should be `vec!["NAME OF YOUR
+	 * APP".into_bytes()]`
+	 *
+	 * # Details
+	 * - Calls `management_canister::schnorr::schnorr_public_key(..)`
+	 * - Costs: [Execution cycles](https://internetcomputer.org/docs/current/developer-docs/gas-cost#execution)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	schnorr_public_key: ActorMethod<[SchnorrPublicKeyArgs, [] | [PaymentType]], Result_10>;
+	/**
+	 * Signs a message using the caller's Schnorr key.
+	 *
+	 * Note: This is an exact dual of the canister [`sign_with_schnorr`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_schnorr) method.  The argument and response types are also the same.
+	 *
+	 * # Arguments
+	 * - `arg`: The same `SignWithSchnorrArgs` as the management canister argument.  The semantics are
+	 * identical but the meaning of the fields in the new context deserve some explanation.
+	 * - `arg.message`: The data to sign.  Note that if you have a large amount of data, you are
+	 * probably better off hashing the data and then signing the hash.
+	 * - `arg.derivation_path`: The derivation path to the public key.  The caller is responsible for
+	 * ensuring that the derivation path is used to namespace appropriately and to ensure that
+	 * unintended sub-keys are not requested.  At minimum, it is recommended to use `vec!["NAME OF
+	 * YOUR APP".into_bytes()]`.  The maximum derivation path length is 254, one less than when
+	 * calling the management canister.
+	 * - `arg.key_id`: The ID of the root threshold key to use.  E.g. `key_1` or `test_key_1`.  See <https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#key-derivation>
+	 * for details.
+	 * - `payment`: The payment type to use.  If omitted or `None`, it will be assumed that cycles have
+	 * been attached.
+	 *
+	 * # Warnings
+	 * - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+	 * derivation paths are used to namespace appropriately and to ensure that unintended sub-keys
+	 * are not requested.
+	 * - It is recommended that, at minimum, the derivation path should be `vec!["NAME OF YOUR
+	 * APP".into_bytes()]`
+	 *
+	 * # Details
+	 * - Calls `management_canister::schnorr::sign_with_schnorr(..)`
+	 * - Costs: See [Fees for the t-Schnorr production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-schnorr-production-key)
+	 *
+	 * # Panics
+	 * - If the caller is the anonymous user.
+	 */
+	schnorr_sign: ActorMethod<[SignWithSchnorrArgs, [] | [PaymentType]], Result_11>;
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/declarations/signer/signer.factory.certified.did.js
+++ b/src/declarations/signer/signer.factory.certified.did.js
@@ -13,14 +13,14 @@ export const idlFactory = ({ IDL }) => {
 		cycles_ledger: IDL.Opt(IDL.Principal)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
-	const BitcoinNetwork = IDL.Variant({
+	const Network = IDL.Variant({
 		mainnet: IDL.Null,
 		regtest: IDL.Null,
 		testnet: IDL.Null
 	});
 	const BitcoinAddressType = IDL.Variant({ P2WPKH: IDL.Null });
 	const GetAddressRequest = IDL.Record({
-		network: BitcoinNetwork,
+		network: Network,
 		address_type: BitcoinAddressType
 	});
 	const Account = IDL.Record({
@@ -40,7 +40,7 @@ export const idlFactory = ({ IDL }) => {
 		PatronPaysIcrc2Cycles: Account
 	});
 	const GetAddressResponse = IDL.Record({ address: IDL.Text });
-	const RejectionCode_1 = IDL.Variant({
+	const RejectionCode = IDL.Variant({
 		NoError: IDL.Null,
 		CanisterError: IDL.Null,
 		SysTransient: IDL.Null,
@@ -62,7 +62,7 @@ export const idlFactory = ({ IDL }) => {
 		TooOld: IDL.Null,
 		FailedToWithdrawFrom: IDL.Record({
 			withdraw_from_block: IDL.Opt(IDL.Nat),
-			rejection_code: RejectionCode_1,
+			rejection_code: RejectionCode,
 			refund_block: IDL.Opt(IDL.Nat),
 			approval_refund_block: IDL.Opt(IDL.Nat),
 			rejection_reason: IDL.Text
@@ -96,8 +96,8 @@ export const idlFactory = ({ IDL }) => {
 		}),
 		UnsupportedPaymentType: IDL.Null,
 		InsufficientFunds: IDL.Record({
-			needed: IDL.Nat64,
-			available: IDL.Nat64
+			needed: IDL.Nat,
+			available: IDL.Nat
 		})
 	});
 	const GetAddressError = IDL.Variant({
@@ -109,7 +109,7 @@ export const idlFactory = ({ IDL }) => {
 		Err: GetAddressError
 	});
 	const GetBalanceRequest = IDL.Record({
-		network: BitcoinNetwork,
+		network: Network,
 		address_type: BitcoinAddressType,
 		min_confirmations: IDL.Opt(IDL.Nat32)
 	});
@@ -118,14 +118,14 @@ export const idlFactory = ({ IDL }) => {
 		Ok: GetBalanceResponse,
 		Err: GetAddressError
 	});
-	const Outpoint = IDL.Record({
+	const OutPoint = IDL.Record({
 		txid: IDL.Vec(IDL.Nat8),
 		vout: IDL.Nat32
 	});
 	const Utxo = IDL.Record({
 		height: IDL.Nat32,
 		value: IDL.Nat64,
-		outpoint: Outpoint
+		outpoint: OutPoint
 	});
 	const BtcTxOutput = IDL.Record({
 		destination_address: IDL.Text,
@@ -133,7 +133,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const SendBtcRequest = IDL.Record({
 		fee_satoshis: IDL.Opt(IDL.Nat64),
-		network: BitcoinNetwork,
+		network: Network,
 		utxos_to_spend: IDL.Vec(Utxo),
 		address_type: BitcoinAddressType,
 		outputs: IDL.Vec(BtcTxOutput)
@@ -166,6 +166,17 @@ export const idlFactory = ({ IDL }) => {
 		Ok: SignBtcResponse,
 		Err: SendBtcError
 	});
+	const BtcSignPrehashRequest = IDL.Record({ hash: IDL.Text });
+	const BtcSignPrehashResponse = IDL.Record({ signature: IDL.Text });
+	const BtcSignPrehashError = IDL.Variant({
+		InvalidHash: IDL.Record({ msg: IDL.Text }),
+		SigningError: IDL.Text,
+		PaymentError: PaymentError
+	});
+	const Result_4 = IDL.Variant({
+		Ok: BtcSignPrehashResponse,
+		Err: BtcSignPrehashError
+	});
 	const Config = IDL.Record({
 		ecdsa_key_name: IDL.Text,
 		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8)),
@@ -176,22 +187,22 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const EthAddressResponse = IDL.Record({ address: IDL.Text });
 	const EthAddressError = IDL.Variant({
-		SigningError: IDL.Tuple(RejectionCode_1, IDL.Text),
+		SigningError: IDL.Text,
 		PaymentError: PaymentError
 	});
-	const Result_4 = IDL.Variant({
+	const Result_5 = IDL.Variant({
 		Ok: EthAddressResponse,
 		Err: EthAddressError
 	});
 	const EthPersonalSignRequest = IDL.Record({ message: IDL.Text });
 	const EthPersonalSignResponse = IDL.Record({ signature: IDL.Text });
-	const Result_5 = IDL.Variant({
+	const Result_6 = IDL.Variant({
 		Ok: EthPersonalSignResponse,
 		Err: EthAddressError
 	});
 	const EthSignPrehashRequest = IDL.Record({ hash: IDL.Text });
 	const EthSignPrehashResponse = IDL.Record({ signature: IDL.Text });
-	const Result_6 = IDL.Variant({
+	const Result_7 = IDL.Variant({
 		Ok: EthSignPrehashResponse,
 		Err: EthAddressError
 	});
@@ -207,27 +218,27 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const EcdsaCurve = IDL.Variant({ secp256k1: IDL.Null });
 	const EcdsaKeyId = IDL.Record({ name: IDL.Text, curve: EcdsaCurve });
-	const EcdsaPublicKeyArgument = IDL.Record({
+	const EcdsaPublicKeyArgs = IDL.Record({
 		key_id: EcdsaKeyId,
 		canister_id: IDL.Opt(IDL.Principal),
 		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8))
 	});
-	const EcdsaPublicKeyResponse = IDL.Record({
+	const EcdsaPublicKeyResult = IDL.Record({
 		public_key: IDL.Vec(IDL.Nat8),
 		chain_code: IDL.Vec(IDL.Nat8)
 	});
-	const Result_7 = IDL.Variant({
-		Ok: IDL.Tuple(EcdsaPublicKeyResponse),
+	const Result_8 = IDL.Variant({
+		Ok: IDL.Tuple(EcdsaPublicKeyResult),
 		Err: EthAddressError
 	});
-	const SignWithEcdsaArgument = IDL.Record({
+	const SignWithEcdsaArgs = IDL.Record({
 		key_id: EcdsaKeyId,
 		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8)),
 		message_hash: IDL.Vec(IDL.Nat8)
 	});
-	const SignWithEcdsaResponse = IDL.Record({ signature: IDL.Vec(IDL.Nat8) });
-	const Result_8 = IDL.Variant({
-		Ok: IDL.Tuple(SignWithEcdsaResponse),
+	const SignWithEcdsaResult = IDL.Record({ signature: IDL.Vec(IDL.Nat8) });
+	const Result_9 = IDL.Variant({
+		Ok: IDL.Tuple(SignWithEcdsaResult),
 		Err: EthAddressError
 	});
 	const CanisterStatusType = IDL.Variant({
@@ -272,22 +283,25 @@ export const idlFactory = ({ IDL }) => {
 		algorithm: SchnorrAlgorithm,
 		name: IDL.Text
 	});
-	const SchnorrPublicKeyArgument = IDL.Record({
+	const SchnorrPublicKeyArgs = IDL.Record({
 		key_id: SchnorrKeyId,
 		canister_id: IDL.Opt(IDL.Principal),
 		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8))
 	});
-	const Result_9 = IDL.Variant({
-		Ok: IDL.Tuple(EcdsaPublicKeyResponse),
+	const Result_10 = IDL.Variant({
+		Ok: IDL.Tuple(EcdsaPublicKeyResult),
 		Err: EthAddressError
 	});
-	const SignWithSchnorrArgument = IDL.Record({
+	const Bip341 = IDL.Record({ merkle_root_hash: IDL.Vec(IDL.Nat8) });
+	const SchnorrAux = IDL.Variant({ bip341: Bip341 });
+	const SignWithSchnorrArgs = IDL.Record({
+		aux: IDL.Opt(SchnorrAux),
 		key_id: SchnorrKeyId,
 		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8)),
 		message: IDL.Vec(IDL.Nat8)
 	});
-	const Result_10 = IDL.Variant({
-		Ok: IDL.Tuple(SignWithEcdsaResponse),
+	const Result_11 = IDL.Variant({
+		Ok: IDL.Tuple(SignWithEcdsaResult),
 		Err: EthAddressError
 	});
 
@@ -296,30 +310,27 @@ export const idlFactory = ({ IDL }) => {
 		btc_caller_balance: IDL.Func([GetBalanceRequest, IDL.Opt(PaymentType)], [Result_1], []),
 		btc_caller_send: IDL.Func([SendBtcRequest, IDL.Opt(PaymentType)], [Result_2], []),
 		btc_caller_sign: IDL.Func([SendBtcRequest, IDL.Opt(PaymentType)], [Result_3], []),
+		btc_sign_prehash: IDL.Func([BtcSignPrehashRequest, IDL.Opt(PaymentType)], [Result_4], []),
 		config: IDL.Func([], [Config]),
-		eth_address: IDL.Func([EthAddressRequest, IDL.Opt(PaymentType)], [Result_4], []),
-		eth_address_of_caller: IDL.Func([IDL.Opt(PaymentType)], [Result_4], []),
-		eth_personal_sign: IDL.Func([EthPersonalSignRequest, IDL.Opt(PaymentType)], [Result_5], []),
-		eth_sign_prehash: IDL.Func([EthSignPrehashRequest, IDL.Opt(PaymentType)], [Result_6], []),
+		eth_address: IDL.Func([EthAddressRequest, IDL.Opt(PaymentType)], [Result_5], []),
+		eth_address_of_caller: IDL.Func([IDL.Opt(PaymentType)], [Result_5], []),
+		eth_personal_sign: IDL.Func([EthPersonalSignRequest, IDL.Opt(PaymentType)], [Result_6], []),
+		eth_sign_prehash: IDL.Func([EthSignPrehashRequest, IDL.Opt(PaymentType)], [Result_7], []),
 		eth_sign_transaction: IDL.Func(
 			[EthSignTransactionRequest, IDL.Opt(PaymentType)],
-			[Result_6],
-			[]
-		),
-		generic_caller_ecdsa_public_key: IDL.Func(
-			[EcdsaPublicKeyArgument, IDL.Opt(PaymentType)],
 			[Result_7],
 			[]
 		),
-		generic_sign_with_ecdsa: IDL.Func(
-			[IDL.Opt(PaymentType), SignWithEcdsaArgument],
+		generic_caller_ecdsa_public_key: IDL.Func(
+			[EcdsaPublicKeyArgs, IDL.Opt(PaymentType)],
 			[Result_8],
 			[]
 		),
+		generic_sign_with_ecdsa: IDL.Func([IDL.Opt(PaymentType), SignWithEcdsaArgs], [Result_9], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
 		http_request: IDL.Func([HttpRequest], [HttpResponse]),
-		schnorr_public_key: IDL.Func([SchnorrPublicKeyArgument, IDL.Opt(PaymentType)], [Result_9], []),
-		schnorr_sign: IDL.Func([SignWithSchnorrArgument, IDL.Opt(PaymentType)], [Result_10], [])
+		schnorr_public_key: IDL.Func([SchnorrPublicKeyArgs, IDL.Opt(PaymentType)], [Result_10], []),
+		schnorr_sign: IDL.Func([SignWithSchnorrArgs, IDL.Opt(PaymentType)], [Result_11], [])
 	});
 };
 

--- a/src/declarations/signer/signer.factory.did.js
+++ b/src/declarations/signer/signer.factory.did.js
@@ -13,14 +13,14 @@ export const idlFactory = ({ IDL }) => {
 		cycles_ledger: IDL.Opt(IDL.Principal)
 	});
 	const Arg = IDL.Variant({ Upgrade: IDL.Null, Init: InitArg });
-	const BitcoinNetwork = IDL.Variant({
+	const Network = IDL.Variant({
 		mainnet: IDL.Null,
 		regtest: IDL.Null,
 		testnet: IDL.Null
 	});
 	const BitcoinAddressType = IDL.Variant({ P2WPKH: IDL.Null });
 	const GetAddressRequest = IDL.Record({
-		network: BitcoinNetwork,
+		network: Network,
 		address_type: BitcoinAddressType
 	});
 	const Account = IDL.Record({
@@ -40,7 +40,7 @@ export const idlFactory = ({ IDL }) => {
 		PatronPaysIcrc2Cycles: Account
 	});
 	const GetAddressResponse = IDL.Record({ address: IDL.Text });
-	const RejectionCode_1 = IDL.Variant({
+	const RejectionCode = IDL.Variant({
 		NoError: IDL.Null,
 		CanisterError: IDL.Null,
 		SysTransient: IDL.Null,
@@ -62,7 +62,7 @@ export const idlFactory = ({ IDL }) => {
 		TooOld: IDL.Null,
 		FailedToWithdrawFrom: IDL.Record({
 			withdraw_from_block: IDL.Opt(IDL.Nat),
-			rejection_code: RejectionCode_1,
+			rejection_code: RejectionCode,
 			refund_block: IDL.Opt(IDL.Nat),
 			approval_refund_block: IDL.Opt(IDL.Nat),
 			rejection_reason: IDL.Text
@@ -96,8 +96,8 @@ export const idlFactory = ({ IDL }) => {
 		}),
 		UnsupportedPaymentType: IDL.Null,
 		InsufficientFunds: IDL.Record({
-			needed: IDL.Nat64,
-			available: IDL.Nat64
+			needed: IDL.Nat,
+			available: IDL.Nat
 		})
 	});
 	const GetAddressError = IDL.Variant({
@@ -109,7 +109,7 @@ export const idlFactory = ({ IDL }) => {
 		Err: GetAddressError
 	});
 	const GetBalanceRequest = IDL.Record({
-		network: BitcoinNetwork,
+		network: Network,
 		address_type: BitcoinAddressType,
 		min_confirmations: IDL.Opt(IDL.Nat32)
 	});
@@ -118,14 +118,14 @@ export const idlFactory = ({ IDL }) => {
 		Ok: GetBalanceResponse,
 		Err: GetAddressError
 	});
-	const Outpoint = IDL.Record({
+	const OutPoint = IDL.Record({
 		txid: IDL.Vec(IDL.Nat8),
 		vout: IDL.Nat32
 	});
 	const Utxo = IDL.Record({
 		height: IDL.Nat32,
 		value: IDL.Nat64,
-		outpoint: Outpoint
+		outpoint: OutPoint
 	});
 	const BtcTxOutput = IDL.Record({
 		destination_address: IDL.Text,
@@ -133,7 +133,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const SendBtcRequest = IDL.Record({
 		fee_satoshis: IDL.Opt(IDL.Nat64),
-		network: BitcoinNetwork,
+		network: Network,
 		utxos_to_spend: IDL.Vec(Utxo),
 		address_type: BitcoinAddressType,
 		outputs: IDL.Vec(BtcTxOutput)
@@ -166,6 +166,17 @@ export const idlFactory = ({ IDL }) => {
 		Ok: SignBtcResponse,
 		Err: SendBtcError
 	});
+	const BtcSignPrehashRequest = IDL.Record({ hash: IDL.Text });
+	const BtcSignPrehashResponse = IDL.Record({ signature: IDL.Text });
+	const BtcSignPrehashError = IDL.Variant({
+		InvalidHash: IDL.Record({ msg: IDL.Text }),
+		SigningError: IDL.Text,
+		PaymentError: PaymentError
+	});
+	const Result_4 = IDL.Variant({
+		Ok: BtcSignPrehashResponse,
+		Err: BtcSignPrehashError
+	});
 	const Config = IDL.Record({
 		ecdsa_key_name: IDL.Text,
 		ic_root_key_raw: IDL.Opt(IDL.Vec(IDL.Nat8)),
@@ -176,22 +187,22 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const EthAddressResponse = IDL.Record({ address: IDL.Text });
 	const EthAddressError = IDL.Variant({
-		SigningError: IDL.Tuple(RejectionCode_1, IDL.Text),
+		SigningError: IDL.Text,
 		PaymentError: PaymentError
 	});
-	const Result_4 = IDL.Variant({
+	const Result_5 = IDL.Variant({
 		Ok: EthAddressResponse,
 		Err: EthAddressError
 	});
 	const EthPersonalSignRequest = IDL.Record({ message: IDL.Text });
 	const EthPersonalSignResponse = IDL.Record({ signature: IDL.Text });
-	const Result_5 = IDL.Variant({
+	const Result_6 = IDL.Variant({
 		Ok: EthPersonalSignResponse,
 		Err: EthAddressError
 	});
 	const EthSignPrehashRequest = IDL.Record({ hash: IDL.Text });
 	const EthSignPrehashResponse = IDL.Record({ signature: IDL.Text });
-	const Result_6 = IDL.Variant({
+	const Result_7 = IDL.Variant({
 		Ok: EthSignPrehashResponse,
 		Err: EthAddressError
 	});
@@ -207,27 +218,27 @@ export const idlFactory = ({ IDL }) => {
 	});
 	const EcdsaCurve = IDL.Variant({ secp256k1: IDL.Null });
 	const EcdsaKeyId = IDL.Record({ name: IDL.Text, curve: EcdsaCurve });
-	const EcdsaPublicKeyArgument = IDL.Record({
+	const EcdsaPublicKeyArgs = IDL.Record({
 		key_id: EcdsaKeyId,
 		canister_id: IDL.Opt(IDL.Principal),
 		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8))
 	});
-	const EcdsaPublicKeyResponse = IDL.Record({
+	const EcdsaPublicKeyResult = IDL.Record({
 		public_key: IDL.Vec(IDL.Nat8),
 		chain_code: IDL.Vec(IDL.Nat8)
 	});
-	const Result_7 = IDL.Variant({
-		Ok: IDL.Tuple(EcdsaPublicKeyResponse),
+	const Result_8 = IDL.Variant({
+		Ok: IDL.Tuple(EcdsaPublicKeyResult),
 		Err: EthAddressError
 	});
-	const SignWithEcdsaArgument = IDL.Record({
+	const SignWithEcdsaArgs = IDL.Record({
 		key_id: EcdsaKeyId,
 		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8)),
 		message_hash: IDL.Vec(IDL.Nat8)
 	});
-	const SignWithEcdsaResponse = IDL.Record({ signature: IDL.Vec(IDL.Nat8) });
-	const Result_8 = IDL.Variant({
-		Ok: IDL.Tuple(SignWithEcdsaResponse),
+	const SignWithEcdsaResult = IDL.Record({ signature: IDL.Vec(IDL.Nat8) });
+	const Result_9 = IDL.Variant({
+		Ok: IDL.Tuple(SignWithEcdsaResult),
 		Err: EthAddressError
 	});
 	const CanisterStatusType = IDL.Variant({
@@ -272,22 +283,25 @@ export const idlFactory = ({ IDL }) => {
 		algorithm: SchnorrAlgorithm,
 		name: IDL.Text
 	});
-	const SchnorrPublicKeyArgument = IDL.Record({
+	const SchnorrPublicKeyArgs = IDL.Record({
 		key_id: SchnorrKeyId,
 		canister_id: IDL.Opt(IDL.Principal),
 		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8))
 	});
-	const Result_9 = IDL.Variant({
-		Ok: IDL.Tuple(EcdsaPublicKeyResponse),
+	const Result_10 = IDL.Variant({
+		Ok: IDL.Tuple(EcdsaPublicKeyResult),
 		Err: EthAddressError
 	});
-	const SignWithSchnorrArgument = IDL.Record({
+	const Bip341 = IDL.Record({ merkle_root_hash: IDL.Vec(IDL.Nat8) });
+	const SchnorrAux = IDL.Variant({ bip341: Bip341 });
+	const SignWithSchnorrArgs = IDL.Record({
+		aux: IDL.Opt(SchnorrAux),
 		key_id: SchnorrKeyId,
 		derivation_path: IDL.Vec(IDL.Vec(IDL.Nat8)),
 		message: IDL.Vec(IDL.Nat8)
 	});
-	const Result_10 = IDL.Variant({
-		Ok: IDL.Tuple(SignWithEcdsaResponse),
+	const Result_11 = IDL.Variant({
+		Ok: IDL.Tuple(SignWithEcdsaResult),
 		Err: EthAddressError
 	});
 
@@ -296,30 +310,27 @@ export const idlFactory = ({ IDL }) => {
 		btc_caller_balance: IDL.Func([GetBalanceRequest, IDL.Opt(PaymentType)], [Result_1], []),
 		btc_caller_send: IDL.Func([SendBtcRequest, IDL.Opt(PaymentType)], [Result_2], []),
 		btc_caller_sign: IDL.Func([SendBtcRequest, IDL.Opt(PaymentType)], [Result_3], []),
+		btc_sign_prehash: IDL.Func([BtcSignPrehashRequest, IDL.Opt(PaymentType)], [Result_4], []),
 		config: IDL.Func([], [Config], ['query']),
-		eth_address: IDL.Func([EthAddressRequest, IDL.Opt(PaymentType)], [Result_4], []),
-		eth_address_of_caller: IDL.Func([IDL.Opt(PaymentType)], [Result_4], []),
-		eth_personal_sign: IDL.Func([EthPersonalSignRequest, IDL.Opt(PaymentType)], [Result_5], []),
-		eth_sign_prehash: IDL.Func([EthSignPrehashRequest, IDL.Opt(PaymentType)], [Result_6], []),
+		eth_address: IDL.Func([EthAddressRequest, IDL.Opt(PaymentType)], [Result_5], []),
+		eth_address_of_caller: IDL.Func([IDL.Opt(PaymentType)], [Result_5], []),
+		eth_personal_sign: IDL.Func([EthPersonalSignRequest, IDL.Opt(PaymentType)], [Result_6], []),
+		eth_sign_prehash: IDL.Func([EthSignPrehashRequest, IDL.Opt(PaymentType)], [Result_7], []),
 		eth_sign_transaction: IDL.Func(
 			[EthSignTransactionRequest, IDL.Opt(PaymentType)],
-			[Result_6],
-			[]
-		),
-		generic_caller_ecdsa_public_key: IDL.Func(
-			[EcdsaPublicKeyArgument, IDL.Opt(PaymentType)],
 			[Result_7],
 			[]
 		),
-		generic_sign_with_ecdsa: IDL.Func(
-			[IDL.Opt(PaymentType), SignWithEcdsaArgument],
+		generic_caller_ecdsa_public_key: IDL.Func(
+			[EcdsaPublicKeyArgs, IDL.Opt(PaymentType)],
 			[Result_8],
 			[]
 		),
+		generic_sign_with_ecdsa: IDL.Func([IDL.Opt(PaymentType), SignWithEcdsaArgs], [Result_9], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
-		schnorr_public_key: IDL.Func([SchnorrPublicKeyArgument, IDL.Opt(PaymentType)], [Result_9], []),
-		schnorr_sign: IDL.Func([SignWithSchnorrArgument, IDL.Opt(PaymentType)], [Result_10], [])
+		schnorr_public_key: IDL.Func([SchnorrPublicKeyArgs, IDL.Opt(PaymentType)], [Result_10], []),
+		schnorr_sign: IDL.Func([SignWithSchnorrArgs, IDL.Opt(PaymentType)], [Result_11], [])
 	});
 };
 

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -1,6 +1,6 @@
 import type { BtcAddress } from '$btc/types/address';
 import type {
-	BitcoinNetwork,
+	Network as BitcoinNetwork,
 	EthSignTransactionRequest,
 	SendBtcResponse,
 	SignBtcResponse

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -1,6 +1,6 @@
 import type { BtcAddress } from '$btc/types/address';
 import type {
-	BitcoinNetwork,
+	Network as BitcoinNetwork,
 	EthAddressRequest,
 	EthPersonalSignRequest,
 	EthSignPrehashRequest,
@@ -268,6 +268,7 @@ export class SignerCanister extends Canister<SignerService> {
 
 		const response = await schnorr_sign(
 			{
+				aux: [],
 				key_id: keyId,
 				derivation_path: mapDerivationPath(derivationPath),
 				message

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -56,10 +56,7 @@ export const mapSignerCanisterGetEthAddressError = (
 	err: EthAddressError
 ): CanisterInternalError => {
 	if ('SigningError' in err) {
-		const [code, addOns] = err.SigningError;
-		return new CanisterInternalError(
-			`Signing error: ${JSON.stringify(code, jsonReplacer)} ${addOns}`
-		);
+		return new CanisterInternalError(`Signing error: ${err.SigningError}`);
 	}
 
 	if ('PaymentError' in err) {

--- a/src/frontend/src/lib/types/api.ts
+++ b/src/frontend/src/lib/types/api.ts
@@ -20,7 +20,7 @@ import type {
 	BtcTxOutput,
 	EcdsaKeyId,
 	SchnorrKeyId,
-	BitcoinNetwork as SignerBitcoinNetwork,
+	Network as SignerBitcoinNetwork,
 	Utxo as SignerUtxo
 } from '$declarations/signer/signer.did';
 import type { IcToken } from '$icp/types/ic-token';

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -1,5 +1,5 @@
 import type { Network as BackendBitcoinNetwork } from '$declarations/backend/backend.did';
-import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
+import type { Network as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
 import { SUPPORTED_ARBITRUM_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { SUPPORTED_BASE_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.base.env';
 import { SUPPORTED_BSC_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.bsc.env';

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -1,7 +1,6 @@
 import type {
 	EthAddressResponse,
 	EthSignTransactionRequest,
-	RejectionCode_1,
 	_SERVICE as SignerService
 } from '$declarations/signer/signer.did';
 import { SOLANA_KEY_ID } from '$env/networks/networks.sol.env';
@@ -333,39 +332,19 @@ describe('signer.canister', () => {
 			await expect(getEthAddress()).rejects.toThrow(mockResponseError);
 		});
 
-		const signingErrors = [
-			'NoError',
-			'CanisterError',
-			'SysTransient',
-			'DestinationInvalid',
-			'Unknown',
-			'SysFatal',
-			'CanisterReject'
-		];
+		it('should throw an error if eth_address throws a SigningError', async () => {
+			const SigningError = 'test';
 
-		it.each(signingErrors)(
-			'should throw an error if eth_address throws a SigningError for %s',
-			async (error) => {
-				const rejectionCode: RejectionCode_1 = {
-					[`${error}`]: null
-				} as RejectionCode_1;
+			service.eth_address.mockResolvedValue({ Err: { SigningError } });
 
-				const addOns = 'test';
+			const { getEthAddress } = await createSignerCanister({
+				serviceOverride: service
+			});
 
-				const SigningError: [RejectionCode_1, string] = [rejectionCode, addOns];
-				const response = { SigningError };
-
-				service.eth_address.mockResolvedValue({ Err: response });
-
-				const { getEthAddress } = await createSignerCanister({
-					serviceOverride: service
-				});
-
-				await expect(getEthAddress()).rejects.toThrow(
-					new CanisterInternalError(`Signing error: ${JSON.stringify(rejectionCode)} ${addOns}`)
-				);
-			}
-		);
+			await expect(getEthAddress()).rejects.toThrow(
+				new CanisterInternalError(`Signing error: ${SigningError}`)
+			);
+		});
 
 		it('should throw a SignerCanisterPaymentError for UnsupportedPaymentType error', async () => {
 			service.eth_address.mockResolvedValue(paymentErrorResponse);
@@ -822,6 +801,7 @@ describe('signer.canister', () => {
 			expect(res).toEqual(signature);
 			expect(service.schnorr_sign).toHaveBeenCalledWith(
 				{
+					aux: [],
 					key_id: SOLANA_KEY_ID,
 					derivation_path: mapDerivationPath(['test']),
 					message

--- a/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
+++ b/src/frontend/src/tests/lib/schema/post-message.schema.spec.ts
@@ -1,5 +1,5 @@
 import type { BtcAddress } from '$btc/types/address';
-import type { BitcoinNetwork as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
+import type { Network as SignerBitcoinNetwork } from '$declarations/signer/signer.did';
 import {
 	IC_CKBTC_INDEX_CANISTER_ID,
 	IC_CKBTC_LEDGER_CANISTER_ID,


### PR DESCRIPTION
# Motivation

chain-fusion-signer `v0.5.1` ships `btc_sign_prehash`, the BTC counterpart of `eth_sign_prehash`, which signs an arbitrary digest under the caller's Bitcoin key. That is the endpoint BTC WalletConnect signing needs (see #13270): `generic_sign_with_ecdsa` signs under the generic key, so the signature never matches the advertised P2WPKH address.

This PR only bumps the pinned signer and adapts to the interface changes, so the WalletConnect work can land on top of a released signer instead of an unreleased ref.

# Changes

- Bump `SIGNER_RELEASE` from `v0.3.0` to `v0.5.1` in `scripts/build.signer.sh`. The candid and wasm are downloaded from the release, and the checked-in declarations are regenerated by the Binding Checks job.
- Adapt to the interface changes between `v0.3.0` and `v0.5.1`:
  - `BitcoinNetwork` is renamed to `Network`; aliased at the import sites so local usage is unchanged.
  - `EthAddressError::SigningError` changes from `record { RejectionCode_1; text }` to `text`; `mapSignerCanisterGetEthAddressError` no longer destructures a tuple, and `RejectionCode_1` is gone from the interface.
  - `SignWithSchnorrArgs` gains `aux : opt SchnorrAux` (BIP-341 tweak); the Solana schnorr call passes `aux: []`.
- The `Result_N` renumbering and the `…Argument`/`…Response` to `…Args`/`…Result` renames are internal to the generated bindings: no application code imports those names, and the shapes are unchanged.

Note: the production signer (`grghe-syaaa-aaaar-qabyq-cai`) does not expose `btc_sign_prehash` yet; the staging one (`tdxud-2yaaa-aaaad-aadiq-cai`) does. This bump does not call the new endpoint, so nothing depends on that.

# Tests

- prettier and eslint `--max-warnings 0` clean on the changed files.
- `signer.canister.spec.ts` updated for the `SigningError` and `aux` changes.
- Type-checking and the regenerated bindings are verified by CI, since generating declarations locally requires dfx.
