### PR TITLE
feat(frontend): integrate ICP into Liquidium flows

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
@@ -16,14 +15,11 @@
 
 	let { market }: Props = $props();
 
-	// Hard-coded teaser row (e.g. ICP) advertises the asset with disabled rates.
-	let isTeaser = $derived(market.teaser === true);
-
-	let token = $derived(isTeaser ? ICP_TOKEN : LIQUIDIUM_ASSET_TOKENS[market.asset]);
+	let token = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
 
 	// Actions live in the hero / section headers, so markets rows are informational only:
-	// a teaser or an unavailable pool (frozen / cap) shows "Coming soon" instead of rates.
-	let comingSoon = $derived(isTeaser || !market.available);
+	// an unavailable pool (frozen / cap) shows "Coming soon" instead of rates.
+	let comingSoon = $derived(!market.available);
 </script>
 
 {#snippet rates()}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
@@ -15,10 +15,7 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
 	import { ZERO } from '$lib/constants/app.constants';
-	import {
-		LIQUIDIUM_ICP_TEASER_MARKET,
-		LIQUIDIUM_POLL_INTERVAL_MILLIS
-	} from '$lib/constants/liquidium.constants';
+	import { LIQUIDIUM_POLL_INTERVAL_MILLIS } from '$lib/constants/liquidium.constants';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -141,7 +138,7 @@
 
 				{#snippet content()}
 					<div class="flex w-full flex-col">
-						{#each [...$liquidiumMarkets, LIQUIDIUM_ICP_TEASER_MARKET] as market (market.poolId)}
+						{#each $liquidiumMarkets as market (market.poolId)}
 							<LiquidiumMarketCard {market} />
 						{/each}
 					</div>

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Chain } from '@liquidium/client';
 	import { setContext } from 'svelte';
+	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumBorrowForm from '$lib/components/liquidium/borrow/LiquidiumBorrowForm.svelte';
 	import LiquidiumBorrowProgress from '$lib/components/liquidium/borrow/LiquidiumBorrowProgress.svelte';
@@ -81,9 +82,14 @@
 			: undefined
 	);
 
-	// Borrowed asset is delivered to the user's own oisy address on the pool's chain.
+	// Borrowed asset is delivered to the user's own oisy address on the pool's chain:
+	// native BTC address for a BTC pool, ICRC account for an ICP-chain pool, else ETH.
 	let receiverAddress = $derived(
-		selectedMarket?.chain === 'BTC' ? $btcAddressMainnet : $ethAddress
+		selectedMarket?.chain === 'BTC'
+			? $btcAddressMainnet
+			: selectedMarket?.chain === 'ICP'
+				? $icrcAccountIdentifierText
+				: $ethAddress
 	);
 
 	const goToStep = (stepName: WizardStepsLiquidiumBorrow) => {

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayIcrcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayIcrcWizard.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { Chain } from '@liquidium/client';
+	import { getContext } from 'svelte';
+	import { sendIcp } from '$icp/services/ic-send.services';
+	import { getTokenFee } from '$icp/utils/token.utils';
+	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
+	import LiquidiumRepayForm from '$lib/components/liquidium/repay/LiquidiumRepayForm.svelte';
+	import LiquidiumRepayProgress from '$lib/components/liquidium/repay/LiquidiumRepayProgress.svelte';
+	import LiquidiumRepayReview from '$lib/components/liquidium/repay/LiquidiumRepayReview.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS } from '$lib/constants/liquidium.constants';
+	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { ProgressStepsLiquidiumRepay } from '$lib/enums/progress-steps';
+	import { WizardStepsLiquidiumRepay } from '$lib/enums/wizard-steps';
+	import {
+		computeLiquidiumRepayPreview,
+		executeLiquidiumRepay
+	} from '$lib/services/liquidium-repay.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { WizardStep } from '$lib/types/wizard';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		reserve: LiquidiumReserve;
+		portfolio: LiquidiumPortfolio;
+		amount: OptionAmount;
+		repayProgressStep: string;
+		maxRepay?: bigint;
+		inflowFee?: bigint;
+		inflowFeeUnavailable?: boolean;
+		currentStep?: WizardStep;
+		onSelectToken?: () => void;
+		onClose: () => void;
+		onNext: () => void;
+		onBack: () => void;
+	}
+
+	let {
+		reserve,
+		portfolio,
+		amount = $bindable(),
+		repayProgressStep = $bindable(),
+		maxRepay,
+		inflowFee,
+		inflowFeeUnavailable,
+		currentStep,
+		onSelectToken,
+		onClose,
+		onNext,
+		onBack
+	}: Props = $props();
+
+	const { sendToken, sendTokenDecimals, sendTokenSymbol, sendTokenExchangeRate, sendBalance } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	// Flat ICRC/ICP ledger fee, deducted by the ledger on top of the transfer (no gas/UTXO).
+	let ledgerFee = $derived(getTokenFee($sendToken));
+
+	let parsedAmount = $derived(
+		nonNullish(amount) && !invalidAmount(amount)
+			? parseToken({ value: `${amount}`, unitName: $sendTokenDecimals })
+			: undefined
+	);
+
+	// Pairwise USD from the position itself (no asset-price dependency): the repaid share of the
+	// position's debt. Repaying improves the (aggregate) projected health factor.
+	let repayUsd = $derived(
+		reserve.borrowed > ZERO && nonNullish(parsedAmount)
+			? (Number(parsedAmount) / Number(reserve.borrowed)) * reserve.borrowedUsd
+			: 0
+	);
+
+	let preview = $derived(computeLiquidiumRepayPreview({ portfolio, repayUsd }));
+
+	let validateRepayAmount = $derived.by(() => {
+		const balance = $sendBalance;
+		const inflow = inflowFee;
+		const fee = ledgerFee ?? ZERO;
+
+		return (userAmount: bigint): Error | undefined =>
+			nonNullish(inflow) && nonNullish(balance) && userAmount + inflow + fee > balance
+				? new Error($i18n.liquidium.text.insufficient_funds_for_fee)
+				: undefined;
+	});
+
+	const repay = async () => {
+		if (isNullish($authIdentity) || isNullish($ethAddress) || isNullish(inflowFee)) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed } });
+			return;
+		}
+
+		if (isNullish(parsedAmount)) {
+			toastsError({ msg: { text: $i18n.send.assertion.amount_invalid } });
+			return;
+		}
+
+		// The ICP pool settles on the ICP ledger (ICP-chain transfer).
+		const ledgerCanisterId = LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS[reserve.asset];
+
+		if (isNullish(ledgerCanisterId)) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed } });
+			return;
+		}
+
+		const amountBaseUnits = parsedAmount;
+		const identity = $authIdentity;
+
+		onNext();
+
+		try {
+			await executeLiquidiumRepay({
+				identity,
+				ethAddress: $ethAddress,
+				poolId: reserve.poolId,
+				chain: Chain.ICP,
+				asset: reserve.asset,
+				amount: amountBaseUnits,
+				inflowFee,
+				displayAmount: `${amount}`,
+				progress: (step) => (repayProgressStep = step),
+				broadcast: async ({ target, amount: transferAmount }) => {
+					const blockIndex = await sendIcp({
+						identity,
+						ledgerCanisterId,
+						to: target.address,
+						amount: transferAmount
+					});
+
+					return `${blockIndex}`;
+				}
+			});
+
+			repayProgressStep = ProgressStepsLiquidiumRepay.DONE;
+
+			setTimeout(onClose, 750);
+		} catch (err: unknown) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed }, err });
+
+			onBack();
+		}
+	};
+</script>
+
+{#snippet feeDisplay()}
+	<FeeDisplay
+		decimals={$sendTokenDecimals}
+		exchangeRate={$sendTokenExchangeRate}
+		feeAmount={ledgerFee}
+		symbol={$sendTokenSymbol}
+	>
+		{#snippet label()}{$i18n.liquidium.text.transaction_fee}{/snippet}
+	</FeeDisplay>
+{/snippet}
+
+{#if currentStep?.name === WizardStepsLiquidiumRepay.REVIEW}
+	<LiquidiumRepayReview
+		{amount}
+		{feeDisplay}
+		{inflowFee}
+		{onBack}
+		onConfirm={repay}
+		{preview}
+		{reserve}
+	/>
+{:else if currentStep?.name === WizardStepsLiquidiumRepay.REPAYING}
+	<LiquidiumRepayProgress {repayProgressStep} />
+{:else}
+	<LiquidiumRepayForm
+		{feeDisplay}
+		{inflowFee}
+		{inflowFeeUnavailable}
+		{maxRepay}
+		{onClose}
+		onCustomErrorValidate={validateRepayAmount}
+		{onNext}
+		{onSelectToken}
+		{preview}
+		{reserve}
+		totalFee={ledgerFee}
+		bind:amount
+	/>
+{/if}

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayModal.svelte
@@ -5,6 +5,7 @@
 	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumRepayBtcWizard from '$lib/components/liquidium/repay/LiquidiumRepayBtcWizard.svelte';
 	import LiquidiumRepayEthWizard from '$lib/components/liquidium/repay/LiquidiumRepayEthWizard.svelte';
+	import LiquidiumRepayIcrcWizard from '$lib/components/liquidium/repay/LiquidiumRepayIcrcWizard.svelte';
 	import LiquidiumRepayTokensList from '$lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte';
 	import TokenActionContext from '$lib/components/send/TokenActionContext.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
@@ -160,6 +161,21 @@
 		{:else if nonNullish($liquidiumPortfolio)}
 			{#if selectedReserve.chain === 'BTC'}
 				<LiquidiumRepayBtcWizard
+					{currentStep}
+					{inflowFee}
+					{inflowFeeUnavailable}
+					{maxRepay}
+					onBack={modal.back}
+					onClose={close}
+					onNext={modal.next}
+					onSelectToken={enterTokensList}
+					portfolio={$liquidiumPortfolio}
+					reserve={selectedReserve}
+					bind:amount
+					bind:repayProgressStep
+				/>
+			{:else if selectedReserve.chain === 'ICP'}
+				<LiquidiumRepayIcrcWizard
 					{currentStep}
 					{inflowFee}
 					{inflowFeeUnavailable}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyIcrcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyIcrcWizard.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { Chain } from '@liquidium/client';
+	import { getContext } from 'svelte';
+	import { sendIcp } from '$icp/services/ic-send.services';
+	import { getTokenFee } from '$icp/utils/token.utils';
+	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
+	import LiquidiumSupplyForm from '$lib/components/liquidium/supply/LiquidiumSupplyForm.svelte';
+	import LiquidiumSupplyProgress from '$lib/components/liquidium/supply/LiquidiumSupplyProgress.svelte';
+	import LiquidiumSupplyReview from '$lib/components/liquidium/supply/LiquidiumSupplyReview.svelte';
+	import { ZERO } from '$lib/constants/app.constants';
+	import { LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS } from '$lib/constants/liquidium.constants';
+	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+	import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+	import { executeLiquidiumSupply } from '$lib/services/liquidium-supply.services';
+	import { i18n } from '$lib/stores/i18n.store';
+	import { SEND_CONTEXT_KEY, type SendContext } from '$lib/stores/send.store';
+	import { toastsError } from '$lib/stores/toasts.store';
+	import type { LiquidiumMarket } from '$lib/types/liquidium';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { WizardStep } from '$lib/types/wizard';
+	import { invalidAmount } from '$lib/utils/input.utils';
+	import { parseToken } from '$lib/utils/parse.utils';
+
+	interface Props {
+		market: LiquidiumMarket;
+		amount: OptionAmount;
+		supplyProgressStep: string;
+		inflowFee?: bigint;
+		inflowFeeUnavailable?: boolean;
+		currentStep?: WizardStep;
+		onSelectToken?: () => void;
+		onClose: () => void;
+		onNext: () => void;
+		onBack: () => void;
+	}
+
+	let {
+		market,
+		amount = $bindable(),
+		supplyProgressStep = $bindable(),
+		inflowFee,
+		inflowFeeUnavailable,
+		currentStep,
+		onSelectToken,
+		onClose,
+		onNext,
+		onBack
+	}: Props = $props();
+
+	const { sendToken, sendTokenDecimals, sendTokenSymbol, sendTokenExchangeRate, sendBalance } =
+		getContext<SendContext>(SEND_CONTEXT_KEY);
+
+	// Flat ICRC/ICP ledger fee, deducted by the ledger on top of the transfer (no gas/UTXO).
+	let ledgerFee = $derived(getTokenFee($sendToken));
+
+	let parsedAmount = $derived(
+		nonNullish(amount) && !invalidAmount(amount)
+			? parseToken({ value: `${amount}`, unitName: $sendTokenDecimals })
+			: undefined
+	);
+
+	let validateSupplyAmount = $derived.by(() => {
+		const balance = $sendBalance;
+		const inflow = inflowFee;
+		const fee = ledgerFee ?? ZERO;
+
+		return (userAmount: bigint): Error | undefined =>
+			nonNullish(inflow) && nonNullish(balance) && userAmount + inflow + fee > balance
+				? new Error($i18n.liquidium.text.insufficient_funds_for_fee)
+				: undefined;
+	});
+
+	const supply = async () => {
+		if (isNullish($authIdentity) || isNullish($ethAddress) || isNullish(inflowFee)) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed } });
+			return;
+		}
+
+		if (isNullish(parsedAmount)) {
+			toastsError({ msg: { text: $i18n.send.assertion.amount_invalid } });
+			return;
+		}
+
+		// The ICP pool settles on the ICP ledger (ICP-chain transfer).
+		const ledgerCanisterId = LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS[market.asset];
+
+		if (isNullish(ledgerCanisterId)) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed } });
+			return;
+		}
+
+		const amountBaseUnits = parsedAmount;
+		const identity = $authIdentity;
+
+		onNext();
+
+		try {
+			await executeLiquidiumSupply({
+				identity,
+				ethAddress: $ethAddress,
+				poolId: market.poolId,
+				chain: Chain.ICP,
+				asset: market.asset,
+				amount: amountBaseUnits,
+				inflowFee,
+				displayAmount: `${amount}`,
+				progress: (step) => (supplyProgressStep = step),
+				broadcast: async ({ target, amount: transferAmount }) => {
+					const blockIndex = await sendIcp({
+						identity,
+						ledgerCanisterId,
+						to: target.address,
+						amount: transferAmount
+					});
+
+					return `${blockIndex}`;
+				}
+			});
+
+			supplyProgressStep = ProgressStepsLiquidiumSupply.DONE;
+
+			setTimeout(onClose, 750);
+		} catch (err: unknown) {
+			toastsError({ msg: { text: $i18n.liquidium.text.transaction_failed }, err });
+
+			onBack();
+		}
+	};
+</script>
+
+{#snippet feeDisplay()}
+	<FeeDisplay
+		decimals={$sendTokenDecimals}
+		exchangeRate={$sendTokenExchangeRate}
+		feeAmount={ledgerFee}
+		symbol={$sendTokenSymbol}
+	>
+		{#snippet label()}{$i18n.liquidium.text.transaction_fee}{/snippet}
+	</FeeDisplay>
+{/snippet}
+
+{#if currentStep?.name === WizardStepsLiquidiumSupply.REVIEW}
+	<LiquidiumSupplyReview {amount} {feeDisplay} {inflowFee} {market} {onBack} onConfirm={supply} />
+{:else if currentStep?.name === WizardStepsLiquidiumSupply.SUPPLYING}
+	<LiquidiumSupplyProgress {supplyProgressStep} />
+{:else}
+	<LiquidiumSupplyForm
+		{feeDisplay}
+		{inflowFee}
+		{inflowFeeUnavailable}
+		{market}
+		{onClose}
+		onCustomErrorValidate={validateSupplyAmount}
+		{onNext}
+		{onSelectToken}
+		totalFee={ledgerFee}
+		bind:amount
+	/>
+{/if}

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
@@ -5,6 +5,7 @@
 	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumSupplyBtcWizard from '$lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.svelte';
 	import LiquidiumSupplyEthWizard from '$lib/components/liquidium/supply/LiquidiumSupplyEthWizard.svelte';
+	import LiquidiumSupplyIcrcWizard from '$lib/components/liquidium/supply/LiquidiumSupplyIcrcWizard.svelte';
 	import LiquidiumSupplyTokensList from '$lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte';
 	import TokenActionContext from '$lib/components/send/TokenActionContext.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
@@ -146,6 +147,19 @@
 			</LiquidiumSelectTokenForm>
 		{:else if selectedMarket.chain === 'BTC'}
 			<LiquidiumSupplyBtcWizard
+				{currentStep}
+				{inflowFee}
+				{inflowFeeUnavailable}
+				market={selectedMarket}
+				onBack={modal.back}
+				onClose={close}
+				onNext={modal.next}
+				onSelectToken={enterTokensList}
+				bind:amount
+				bind:supplyProgressStep
+			/>
+		{:else if selectedMarket.chain === 'ICP'}
+			<LiquidiumSupplyIcrcWizard
 				{currentStep}
 				{inflowFee}
 				{inflowFeeUnavailable}

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Chain } from '@liquidium/client';
 	import { setContext } from 'svelte';
+	import { icrcAccountIdentifierText } from '$icp/derived/ic.derived';
 	import LiquidiumSelectTokenForm from '$lib/components/liquidium/LiquidiumSelectTokenForm.svelte';
 	import LiquidiumWithdrawForm from '$lib/components/liquidium/withdraw/LiquidiumWithdrawForm.svelte';
 	import LiquidiumWithdrawProgress from '$lib/components/liquidium/withdraw/LiquidiumWithdrawProgress.svelte';
@@ -83,8 +84,14 @@
 			: undefined
 	);
 
+	// Withdrawn asset is delivered to the user's own oisy address on the pool's chain:
+	// native BTC address for a BTC pool, ICRC account for an ICP-chain pool, else ETH.
 	let receiverAddress = $derived(
-		selectedReserve?.chain === 'BTC' ? $btcAddressMainnet : $ethAddress
+		selectedReserve?.chain === 'BTC'
+			? $btcAddressMainnet
+			: selectedReserve?.chain === 'ICP'
+				? $icrcAccountIdentifierText
+				: $ethAddress
 	);
 
 	const goToStep = (stepName: WizardStepsLiquidiumWithdraw) => {

--- a/src/frontend/src/lib/constants/liquidium.constants.ts
+++ b/src/frontend/src/lib/constants/liquidium.constants.ts
@@ -1,3 +1,4 @@
+import { ICP_LEDGER_CANISTER_ID } from '$env/networks/networks.icp.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
 import { IC_CKBTC_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env';
@@ -10,7 +11,6 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { OptionCanisterIdText } from '$lib/types/canister';
-import type { LiquidiumMarket } from '$lib/types/liquidium';
 import type { Token } from '$lib/types/token';
 
 // Provider id for the earning-provider registry.
@@ -22,30 +22,19 @@ export const LIQUIDIUM_ASSET_TOKENS: Record<string, Token> = {
 	BTC: BTC_MAINNET_TOKEN,
 	ETH: ETHEREUM_TOKEN,
 	USDC: USDC_TOKEN,
-	USDT: USDT_TOKEN
+	USDT: USDT_TOKEN,
+	ICP: ICP_TOKEN
 };
 
-// Hard-coded ICP teaser appended to the Markets box until Liquidium lists ICP.
-// Advertises the asset with disabled actions; carries its own token for the logo so
-// it stays out of the shared asset/network icon sets. TODO: remove once ICP is live.
-export const LIQUIDIUM_ICP_TEASER_MARKET: LiquidiumMarket = {
-	poolId: 'icp-teaser',
-	asset: ICP_TOKEN.symbol,
-	// SDK-chain-style id (cf. 'BTC'/'ETH'); inert here since the teaser never opens a modal.
-	chain: 'ICP',
-	supplyApy: 0,
-	borrowApy: 0,
-	frozen: false,
-	available: true,
-	teaser: true
-};
-
-// ck-ledger backing each asset, for the AUT's backend `TokenId`.
+// ck-ledger backing each asset, for the AUT's backend `TokenId`. Keyed by symbol: the
+// ck twin is the same regardless of transfer chain (native BTC and ckBTC both settle on
+// the ckBTC ledger); ICP maps to its own ledger.
 export const LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS: Record<string, OptionCanisterIdText> = {
 	BTC: IC_CKBTC_LEDGER_CANISTER_ID,
 	ETH: IC_CKETH_LEDGER_CANISTER_ID,
 	USDC: IC_CKUSDC_LEDGER_CANISTER_ID,
-	USDT: IC_CKUSDT_LEDGER_CANISTER_ID
+	USDT: IC_CKUSDT_LEDGER_CANISTER_ID,
+	ICP: ICP_LEDGER_CANISTER_ID
 };
 
 // Display bands — Liquidium publishes no discrete cut-offs, so oisy picks its own

--- a/src/frontend/src/lib/types/liquidium.ts
+++ b/src/frontend/src/lib/types/liquidium.ts
@@ -18,9 +18,6 @@ export interface LiquidiumMarket {
 	frozen: boolean;
 	// Not frozen and under supply cap; else renders as "Coming soon".
 	available: boolean;
-	// Hard-coded teaser row (e.g. ICP before it is listed): shows "Coming soon..."
-	// instead of rates and keeps both actions disabled. TODO: remove once listed.
-	teaser?: boolean;
 }
 
 export interface LiquidiumReserve {

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumMarketCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumMarketCard.spec.ts
@@ -41,11 +41,13 @@ describe('LiquidiumMarketCard', () => {
 		expect(container).not.toHaveTextContent(en.liquidium.text.supply_label);
 	});
 
-	it('shows "Coming soon" for the teaser row', () => {
+	it('renders an ICP-chain market with its rates', () => {
 		const { container } = render(LiquidiumMarketCard, {
-			props: { market: market({ teaser: true, asset: 'ICP', chain: 'ICP' }) }
+			props: { market: market({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' }) }
 		});
 
-		expect(container).toHaveTextContent(en.liquidium.text.coming_soon_teaser);
+		expect(container).toHaveTextContent('ICP');
+		expect(container).toHaveTextContent(en.liquidium.text.supply_label);
+		expect(container).not.toHaveTextContent(en.liquidium.text.coming_soon_teaser);
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayIcrcWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayIcrcWizard.spec.ts
@@ -1,0 +1,109 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import LiquidiumRepayIcrcWizard from '$lib/components/liquidium/repay/LiquidiumRepayIcrcWizard.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
+import * as addressesStore from '$lib/derived/address.derived';
+import { ProgressStepsLiquidiumRepay } from '$lib/enums/progress-steps';
+import { WizardStepsLiquidiumRepay } from '$lib/enums/wizard-steps';
+import * as liquidiumRepayServices from '$lib/services/liquidium-repay.services';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import type { WizardStep } from '$lib/types/wizard';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
+import en from '$tests/mocks/i18n.mock';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+
+describe('LiquidiumRepayIcrcWizard', () => {
+	const reserve: LiquidiumReserve = {
+		poolId: 'pool-icp',
+		asset: 'ICP',
+		chain: 'ICP',
+		supplyApy: 0,
+		borrowApy: 10,
+		deposited: ZERO,
+		depositedDecimals: 8,
+		borrowed: 100_000_000n,
+		borrowedDecimals: 8,
+		debtInterest: ZERO,
+		suppliedUsd: 0,
+		borrowedUsd: 12
+	};
+
+	const portfolio: LiquidiumPortfolio = {
+		reserves: [reserve],
+		totalSuppliedUsd: 100,
+		totalBorrowedUsd: 12,
+		netValueUsd: 88,
+		availableBorrowsUsd: 50,
+		weightedLiquidationThresholdBps: 8_000,
+		healthFactorPercent: 80
+	};
+
+	const context = () =>
+		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })]]);
+
+	const step = (name: WizardStepsLiquidiumRepay): WizardStep => ({ name, title: name });
+
+	const baseProps = {
+		reserve,
+		portfolio,
+		amount: 1,
+		repayProgressStep: ProgressStepsLiquidiumRepay.INITIALIZATION,
+		maxRepay: 100_000_000n,
+		inflowFee: 50n,
+		onClose: () => {},
+		onNext: () => {},
+		onBack: () => {}
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockAuthStore();
+		vi.spyOn(addressesStore, 'ethAddress', 'get').mockImplementation(() =>
+			readable(mockEthAddress)
+		);
+	});
+
+	it('renders the form step', () => {
+		const { container } = render(LiquidiumRepayIcrcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumRepay.REPAY) },
+			context: context()
+		});
+
+		expect(container).toBeTruthy();
+	});
+
+	it('renders the progress step', () => {
+		const { container } = render(LiquidiumRepayIcrcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumRepay.REPAYING) },
+			context: context()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.starting_to_repay);
+	});
+
+	it('repays the ICP pool on confirm', async () => {
+		const executeSpy = vi
+			.spyOn(liquidiumRepayServices, 'executeLiquidiumRepay')
+			.mockResolvedValue(undefined);
+
+		const onNext = vi.fn();
+
+		const { getByTestId } = render(LiquidiumRepayIcrcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumRepay.REVIEW), onNext },
+			context: context()
+		});
+
+		await fireEvent.click(getByTestId(STAKE_REVIEW_FORM_BUTTON));
+
+		await waitFor(() => {
+			expect(onNext).toHaveBeenCalledOnce();
+			expect(executeSpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ chain: 'ICP', asset: 'ICP', poolId: 'pool-icp', inflowFee: 50n })
+			);
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyIcrcWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyIcrcWizard.spec.ts
@@ -1,0 +1,100 @@
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import LiquidiumSupplyIcrcWizard from '$lib/components/liquidium/supply/LiquidiumSupplyIcrcWizard.svelte';
+import { STAKE_REVIEW_FORM_BUTTON } from '$lib/constants/test-ids.constants';
+import * as addressesStore from '$lib/derived/address.derived';
+import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
+import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
+import * as liquidiumSupplyServices from '$lib/services/liquidium-supply.services';
+import { SEND_CONTEXT_KEY, initSendContext, type SendContext } from '$lib/stores/send.store';
+import type { LiquidiumMarket } from '$lib/types/liquidium';
+import type { WizardStep } from '$lib/types/wizard';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
+import en from '$tests/mocks/i18n.mock';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+
+describe('LiquidiumSupplyIcrcWizard', () => {
+	const market: LiquidiumMarket = {
+		poolId: 'pool-icp',
+		asset: 'ICP',
+		chain: 'ICP',
+		supplyApy: 6,
+		borrowApy: 10,
+		frozen: false,
+		available: true
+	};
+
+	const context = () =>
+		new Map<symbol, SendContext>([[SEND_CONTEXT_KEY, initSendContext({ token: ICP_TOKEN })]]);
+
+	const step = (name: WizardStepsLiquidiumSupply): WizardStep => ({ name, title: name });
+
+	const baseProps = {
+		market,
+		amount: 1,
+		supplyProgressStep: ProgressStepsLiquidiumSupply.INITIALIZATION,
+		inflowFee: 50n,
+		onClose: () => {},
+		onNext: () => {},
+		onBack: () => {}
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockAuthStore();
+		vi.spyOn(addressesStore, 'ethAddress', 'get').mockImplementation(() =>
+			readable(mockEthAddress)
+		);
+	});
+
+	it('renders the form step', () => {
+		const { container } = render(LiquidiumSupplyIcrcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.SUPPLY) },
+			context: context()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_apy);
+	});
+
+	it('renders the review step', () => {
+		const { container } = render(LiquidiumSupplyIcrcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.REVIEW) },
+			context: context()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.supply_apy);
+	});
+
+	it('renders the progress step', () => {
+		const { container } = render(LiquidiumSupplyIcrcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.SUPPLYING) },
+			context: context()
+		});
+
+		expect(container).toHaveTextContent(en.liquidium.text.starting_to_supply);
+	});
+
+	it('supplies the ICP pool on confirm', async () => {
+		const executeSpy = vi
+			.spyOn(liquidiumSupplyServices, 'executeLiquidiumSupply')
+			.mockResolvedValue(undefined);
+
+		const onNext = vi.fn();
+
+		const { getByTestId } = render(LiquidiumSupplyIcrcWizard, {
+			props: { ...baseProps, currentStep: step(WizardStepsLiquidiumSupply.REVIEW), onNext },
+			context: context()
+		});
+
+		await fireEvent.click(getByTestId(STAKE_REVIEW_FORM_BUTTON));
+
+		await waitFor(() => {
+			expect(onNext).toHaveBeenCalledOnce();
+			expect(executeSpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ chain: 'ICP', asset: 'ICP', poolId: 'pool-icp', inflowFee: 50n })
+			);
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

This PR adds the native ICP pool to the Liquidium lend/borrow surface, replacing the hard-coded "Coming soon" ICP teaser. Supply, Borrow, Repay, and Withdraw all work for ICP end-to-end via the ICP ledger.

