### PR TITLE
feat(frontend): wire btc_sign_prehash in the signer canister, api and errors

### DIFF
--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -93,6 +93,15 @@ export const signPrehash = async ({
 	return signPrehash({ hash });
 };
 
+export const signBtcPrehash = async ({
+	identity,
+	hash
+}: CanisterApiFunctionParams<{ hash: Uint8Array }>): Promise<Uint8Array> => {
+	const { signBtcPrehash } = await signerCanister({ identity });
+
+	return signBtcPrehash({ hash });
+};
+
 export const sendBtc = async ({
 	identity,
 	...params

--- a/src/frontend/src/lib/api/signer.api.ts
+++ b/src/frontend/src/lib/api/signer.api.ts
@@ -94,8 +94,8 @@ export const signPrehash = async ({
 };
 
 export const signBtcPrehash = async ({
-	identity,
-	hash
+	hash,
+	identity
 }: CanisterApiFunctionParams<{ hash: Uint8Array }>): Promise<Uint8Array> => {
 	const { signBtcPrehash } = await signerCanister({ identity });
 

--- a/src/frontend/src/lib/canisters/signer.canister.ts
+++ b/src/frontend/src/lib/canisters/signer.canister.ts
@@ -1,6 +1,7 @@
 import type { BtcAddress } from '$btc/types/address';
 import type {
 	Network as BitcoinNetwork,
+	BtcSignPrehashRequest,
 	EthAddressRequest,
 	EthPersonalSignRequest,
 	EthSignPrehashRequest,
@@ -17,6 +18,7 @@ import { getAgent } from '$lib/actors/agents.ic';
 import { P2WPKH, SIGNER_PAYMENT_TYPE } from '$lib/canisters/signer.constants';
 import {
 	mapSignerCanisterBtcError,
+	mapSignerCanisterBtcSignPrehashError,
 	mapSignerCanisterGetEthAddressError,
 	mapSignerCanisterSendBtcError
 } from '$lib/canisters/signer.errors';
@@ -28,7 +30,14 @@ import type {
 } from '$lib/types/api';
 import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mapDerivationPath } from '$lib/utils/signer.utils';
-import { Canister, createServices, fromDefinedNullable, toNullable } from '@dfinity/utils';
+import {
+	Canister,
+	createServices,
+	fromDefinedNullable,
+	hexStringToUint8Array,
+	toNullable,
+	uint8ArrayToHexString
+} from '@dfinity/utils';
 
 export class SignerCanister extends Canister<SignerService> {
 	static async create({
@@ -175,6 +184,28 @@ export class SignerCanister extends Canister<SignerService> {
 		}
 
 		throw mapSignerCanisterGetEthAddressError(response.Err);
+	};
+
+	signBtcPrehash = async ({ hash }: { hash: Uint8Array }): Promise<Uint8Array> => {
+		const { btc_sign_prehash } = this.caller({
+			certified: true
+		});
+
+		// The signer signs the digest under the caller's BTC key (schema `0x00`), matching the
+		// advertised P2WPKH address — unlike `generic_sign_with_ecdsa`, which signs under a generic
+		// key. The response is a raw `r || s`; the caller recovers the recovery id from the known
+		// public key (see `encodeRecoverableSignature`).
+		const request: BtcSignPrehashRequest = { hash: uint8ArrayToHexString(hash) };
+		const response = await btc_sign_prehash(request, [SIGNER_PAYMENT_TYPE]);
+
+		if ('Ok' in response) {
+			const {
+				Ok: { signature }
+			} = response;
+			return hexStringToUint8Array(signature);
+		}
+
+		throw mapSignerCanisterBtcSignPrehashError(response.Err);
 	};
 
 	sendBtc = async ({

--- a/src/frontend/src/lib/canisters/signer.errors.ts
+++ b/src/frontend/src/lib/canisters/signer.errors.ts
@@ -1,4 +1,5 @@
 import type {
+	BtcSignPrehashError,
 	EthAddressError,
 	PaymentError,
 	GetAddressError as SignerCanisterBtcError,
@@ -50,6 +51,21 @@ export const mapSignerCanisterSendBtcError = (
 		return new CanisterInternalError(JSON.stringify(err.BuildP2wpkhError, jsonReplacer));
 	}
 	return new CanisterInternalError('Unknown SignerCanisterSendBtcError');
+};
+
+export const mapSignerCanisterBtcSignPrehashError = (
+	err: BtcSignPrehashError
+): CanisterInternalError => {
+	if ('InvalidHash' in err) {
+		return new CanisterInternalError(err.InvalidHash.msg);
+	}
+	if ('SigningError' in err) {
+		return new CanisterInternalError(`Signing error: ${err.SigningError}`);
+	}
+	if ('PaymentError' in err) {
+		return new SignerCanisterPaymentError(err.PaymentError);
+	}
+	return new CanisterInternalError('Unknown BtcSignPrehashError');
 };
 
 export const mapSignerCanisterGetEthAddressError = (

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -13,7 +13,7 @@ import type { CreateCanisterOptions } from '$lib/types/canister';
 import { mapDerivationPath } from '$lib/utils/signer.utils';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { jsonReplacer } from '@dfinity/utils';
+import { hexStringToUint8Array, jsonReplacer, uint8ArrayToHexString } from '@dfinity/utils';
 import type { ActorSubclass } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 import { mock } from 'vitest-mock-extended';
@@ -504,6 +504,48 @@ describe('signer.canister', () => {
 			const res = signPrehash(signPrehashParams);
 
 			await expect(res).rejects.toThrow();
+		});
+	});
+
+	describe('signBtcPrehash', () => {
+		const hash = Uint8Array.from([1, 2, 3, 4]);
+		const signatureHex = 'aabbccdd';
+
+		it('signs a prehash under the BTC key', async () => {
+			service.btc_sign_prehash.mockResolvedValue({ Ok: { signature: signatureHex } });
+
+			const { signBtcPrehash } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			const res = await signBtcPrehash({ hash });
+
+			expect(res).toEqual(hexStringToUint8Array(signatureHex));
+			expect(service.btc_sign_prehash).toHaveBeenCalledWith({ hash: uint8ArrayToHexString(hash) }, [
+				SIGNER_PAYMENT_TYPE
+			]);
+		});
+
+		it('should throw an error if btc_sign_prehash throws', async () => {
+			service.btc_sign_prehash.mockImplementation(() => {
+				throw mockResponseError;
+			});
+
+			const { signBtcPrehash } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			await expect(signBtcPrehash({ hash })).rejects.toThrow(mockResponseError);
+		});
+
+		it('maps an Err response to a signer error', async () => {
+			service.btc_sign_prehash.mockResolvedValue({ Err: { InvalidHash: { msg: 'bad hash' } } });
+
+			const { signBtcPrehash } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			await expect(signBtcPrehash({ hash })).rejects.toThrow('bad hash');
 		});
 	});
 

--- a/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
+++ b/src/frontend/src/tests/lib/canisters/signer.canister.spec.ts
@@ -538,14 +538,53 @@ describe('signer.canister', () => {
 			await expect(signBtcPrehash({ hash })).rejects.toThrow(mockResponseError);
 		});
 
-		it('maps an Err response to a signer error', async () => {
+		it('should throw an error if btc_sign_prehash returns an InvalidHash error', async () => {
 			service.btc_sign_prehash.mockResolvedValue({ Err: { InvalidHash: { msg: 'bad hash' } } });
 
 			const { signBtcPrehash } = await createSignerCanister({
 				serviceOverride: service
 			});
 
-			await expect(signBtcPrehash({ hash })).rejects.toThrow('bad hash');
+			await expect(signBtcPrehash({ hash })).rejects.toThrow(new CanisterInternalError('bad hash'));
+		});
+
+		it('should throw an error if btc_sign_prehash returns a SigningError', async () => {
+			const SigningError = 'test';
+
+			service.btc_sign_prehash.mockResolvedValue({ Err: { SigningError } });
+
+			const { signBtcPrehash } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			await expect(signBtcPrehash({ hash })).rejects.toThrow(
+				new CanisterInternalError(`Signing error: ${SigningError}`)
+			);
+		});
+
+		it('should throw a SignerCanisterPaymentError if btc_sign_prehash returns a payment error', async () => {
+			service.btc_sign_prehash.mockResolvedValue(paymentErrorResponse);
+
+			const { signBtcPrehash } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			await expect(signBtcPrehash({ hash })).rejects.toThrow(
+				new SignerCanisterPaymentError(paymentErrorResponse.Err.PaymentError)
+			);
+		});
+
+		it('should throw an error if btc_sign_prehash returns an unknown error variant', async () => {
+			// @ts-expect-error we test this in purposes
+			service.btc_sign_prehash.mockResolvedValue(genericErrorResponse);
+
+			const { signBtcPrehash } = await createSignerCanister({
+				serviceOverride: service
+			});
+
+			await expect(signBtcPrehash({ hash })).rejects.toThrow(
+				new CanisterInternalError('Unknown BtcSignPrehashError')
+			);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The signer exposes `btc_sign_prehash` since chain-fusion-signer v0.5.1 (pinned in #13551), but nothing in OISY calls it yet. It is the Bitcoin counterpart of `eth_sign_prehash`: it signs an arbitrary 32-byte digest under the caller's **BTC** key, which matches the P2WPKH address OISY advertises — unlike `generic_sign_with_ecdsa`, which signs under the signer's generic key.

This PR only wires the method through the signer layer. No caller is changed, so there is no behaviour change; the consumer (BTC WalletConnect `signMessage` / `signPsbt`) follows in #13527.

# Changes

- `signer.canister.ts`: add `btcSignPrehash({ hash })`. Takes the digest as `Uint8Array`, hex-encodes it for the candid `BtcSignPrehashRequest`, and decodes the hex `r || s` response back to `Uint8Array`.
- `signer.api.ts`: add the `signBtcPrehash` API wrapper, mirroring `signPrehash` (its ETH twin).
- `signer.errors.ts`: add `mapSignerCanisterBtcSignPrehashError` covering the `BtcSignPrehashError` variants (`InvalidHash`, `SigningError`, `PaymentError`).

The endpoint returns a raw `r || s` with no recovery id; recovering it from the known public key is the caller's job and stays out of this PR.

# Tests

- `signer.canister.spec.ts`: added coverage for `btcSignPrehash` — success (asserts the hex encode/decode round-trip and the request payload), the raw-throw path, and every `mapSignerCanisterBtcSignPrehashError` branch: `InvalidHash`, `SigningError`, `PaymentError` and the unknown-variant fallback. Spec passes (60).
- prettier and eslint `--max-warnings 0` clean on the changed files.
- `tsc -p tsconfig.spec.json` adds no new errors (the 11 pre-existing liquidium errors are identical on `main`).
