### PR TITLE
feat(frontend): surface ck asset rails in Liquidium supply/borrow

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
@@ -4,14 +4,15 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		reserve: LiquidiumReserve;
@@ -19,7 +20,9 @@
 
 	let { reserve }: Props = $props();
 
-	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+	let token = $derived(
+		liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+	);
 
 	let borrowedAmount = $derived(
 		formatToken({ value: reserve.borrowed, unitName: reserve.borrowedDecimals })

--- a/src/frontend/src/lib/components/liquidium/LiquidiumBorrowingCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumBorrowingCard.svelte
@@ -5,15 +5,16 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Assets → Borrowings tab row; no action, clicks through to the provider page.
@@ -26,7 +27,9 @@
 		void goto(AppPath.ProvidersLiquidium);
 	};
 
-	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+	let token = $derived(
+		liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+	);
 
 	let borrowedAmount = $derived(
 		formatToken({ value: reserve.borrowed, unitName: reserve.borrowedDecimals })

--- a/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumMarketCard.svelte
@@ -3,11 +3,13 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatStakeApyNumber } from '$lib/utils/format.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
+	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
 		market: LiquidiumMarket;
@@ -15,7 +17,9 @@
 
 	let { market }: Props = $props();
 
-	let token = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
+	let token = $derived(
+		liquidiumMarketToken({ chain: market.chain, asset: market.asset, tokens: $tokens })
+	);
 
 	// Actions live in the hero / section headers, so markets rows are informational only:
 	// an unavailable pool (frozen / cap) shows "Coming soon" instead of rates.
@@ -56,7 +60,9 @@
 	{/snippet}
 
 	{#snippet title()}
-		<span class="text-sm font-bold sm:text-base">{market.asset}</span>
+		<span class="text-sm font-bold sm:text-base"
+			>{nonNullish(token) ? getTokenDisplaySymbol(token) : market.asset}</span
+		>
 	{/snippet}
 
 	{#snippet description()}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumPositionCard.svelte
@@ -6,15 +6,16 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import Badge from '$lib/components/ui/Badge.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { AppPath } from '$lib/constants/routes.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Assets → Earning tab row; no action, clicks through to the provider page.
@@ -27,7 +28,9 @@
 		void goto(AppPath.ProvidersLiquidium);
 	};
 
-	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+	let token = $derived(
+		liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+	);
 
 	let suppliedAmount = $derived(
 		formatToken({ value: reserve.deposited, unitName: reserve.depositedDecimals })

--- a/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
@@ -138,7 +138,7 @@
 
 				{#snippet content()}
 					<div class="flex w-full flex-col">
-						{#each $liquidiumMarkets as market (market.poolId)}
+						{#each $liquidiumMarkets as market (`${market.poolId}-${market.chain}`)}
 							<LiquidiumMarketCard {market} />
 						{/each}
 					</div>

--- a/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
@@ -4,14 +4,15 @@
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		reserve: LiquidiumReserve;
@@ -19,7 +20,9 @@
 
 	let { reserve }: Props = $props();
 
-	let token = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+	let token = $derived(
+		liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+	);
 
 	let suppliedAmount = $derived(
 		formatToken({ value: reserve.deposited, unitName: reserve.depositedDecimals })

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowModal.svelte
@@ -11,10 +11,10 @@
 	import LiquidiumBorrowTokensList from '$lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumBorrowWizardSteps } from '$lib/config/lend-borrow.config';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { btcAddressMainnet, ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { liquidiumAssetPrices, liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { ProgressStepsLiquidiumBorrow } from '$lib/enums/progress-steps';
 	import { WizardStepsLiquidiumBorrow } from '$lib/enums/wizard-steps';
 	import {
@@ -32,6 +32,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { WizardStep, WizardSteps } from '$lib/types/wizard';
 	import { invalidAmount } from '$lib/utils/input.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
@@ -61,7 +62,13 @@
 	);
 
 	let borrowToken = $derived(
-		nonNullish(selectedMarket) ? LIQUIDIUM_ASSET_TOKENS[selectedMarket.asset] : undefined
+		nonNullish(selectedMarket)
+			? liquidiumMarketToken({
+					chain: selectedMarket.chain,
+					asset: selectedMarket.asset,
+					tokens: $tokens
+				})
+			: undefined
 	);
 	let borrowPrice = $derived(
 		nonNullish(selectedMarket) ? ($liquidiumAssetPrices[selectedMarket.asset] ?? 0) : 0

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowReview.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowReview.svelte
@@ -8,7 +8,7 @@
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import type { LiquidiumBorrowPreview } from '$lib/services/liquidium-borrow.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { LendBorrowProvider } from '$lib/types/lend-borrow';
@@ -16,6 +16,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import { formatStakeApyNumber } from '$lib/utils/format.utils';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		market: LiquidiumMarket;
@@ -30,7 +31,9 @@
 
 	const liquidium = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM];
 
-	let borrowToken = $derived(LIQUIDIUM_ASSET_TOKENS[market.asset]);
+	let borrowToken = $derived(
+		liquidiumMarketToken({ chain: market.chain, asset: market.asset, tokens: $tokens })
+	);
 	let healthLevel = $derived(preview.healthLevel);
 </script>
 

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte
@@ -4,14 +4,15 @@
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { liquidiumBorrowMarkets } from '$lib/derived/liquidium.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import {
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import type { Token } from '$lib/types/token';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Omitted on a neutral (token-less) launch — then nothing is excluded.
@@ -26,10 +27,17 @@
 
 	let entries = $derived(
 		$liquidiumBorrowMarkets
-			.map((market) => ({ market, token: LIQUIDIUM_ASSET_TOKENS[market.asset] }))
+			.map((market) => ({
+				market,
+				token: liquidiumMarketToken({ chain: market.chain, asset: market.asset, tokens: $tokens })
+			}))
 			.filter(
 				(entry): entry is { market: LiquidiumMarket; token: Token } =>
-					nonNullish(entry.token) && entry.market.poolId !== selectedMarket?.poolId
+					nonNullish(entry.token) &&
+					!(
+						entry.market.poolId === selectedMarket?.poolId &&
+						entry.market.chain === selectedMarket?.chain
+					)
 			)
 	);
 

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayIcrcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayIcrcWizard.svelte
@@ -2,7 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { Chain } from '@liquidium/client';
 	import { getContext } from 'svelte';
-	import { sendIcp } from '$icp/services/ic-send.services';
+	import { sendIcp, sendIcrc } from '$icp/services/ic-send.services';
 	import { getTokenFee } from '$icp/utils/token.utils';
 	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import LiquidiumRepayForm from '$lib/components/liquidium/repay/LiquidiumRepayForm.svelte';
@@ -101,7 +101,7 @@
 			return;
 		}
 
-		// The ICP pool settles on the ICP ledger (ICP-chain transfer).
+		// ICP-chain assets (ICP / ckBTC / ckUSDC / ckUSDT) settle on their ICRC ledger.
 		const ledgerCanisterId = LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS[reserve.asset];
 
 		if (isNullish(ledgerCanisterId)) {
@@ -111,6 +111,8 @@
 
 		const amountBaseUnits = parsedAmount;
 		const identity = $authIdentity;
+		// ICP settles through the ICP ledger's transfer; ck assets through the generic ICRC ledger.
+		const transfer = reserve.asset === 'ICP' ? sendIcp : sendIcrc;
 
 		onNext();
 
@@ -126,7 +128,7 @@
 				displayAmount: `${amount}`,
 				progress: (step) => (repayProgressStep = step),
 				broadcast: async ({ target, amount: transferAmount }) => {
-					const blockIndex = await sendIcp({
+					const blockIndex = await transfer({
 						identity,
 						ledgerCanisterId,
 						to: target.address,

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayModal.svelte
@@ -10,10 +10,10 @@
 	import TokenActionContext from '$lib/components/send/TokenActionContext.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumRepayWizardSteps } from '$lib/config/lend-borrow.config';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { ProgressStepsLiquidiumRepay } from '$lib/enums/progress-steps';
 	import { WizardStepsLiquidiumRepay } from '$lib/enums/wizard-steps';
 	import { getLiquidiumMaxRepayAmount } from '$lib/services/liquidium-repay.services';
@@ -28,6 +28,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { WizardStep, WizardSteps } from '$lib/types/wizard';
 	import { consoleError } from '$lib/utils/console.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
@@ -43,7 +44,13 @@
 	let selectedReserve = $state<LiquidiumReserve | undefined>(reserve);
 
 	let token = $derived(
-		nonNullish(selectedReserve) ? LIQUIDIUM_ASSET_TOKENS[selectedReserve.asset] : undefined
+		nonNullish(selectedReserve)
+			? liquidiumMarketToken({
+					chain: selectedReserve.chain,
+					asset: selectedReserve.asset,
+					tokens: $tokens
+				})
+			: undefined
 	);
 
 	const tokensListContext = initModalTokensListContext({ tokens: [] });

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte
@@ -4,14 +4,15 @@
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { liquidiumRepayReserves } from '$lib/derived/liquidium.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import {
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import type { Token } from '$lib/types/token';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Omitted on a neutral (token-less) launch — then nothing is excluded.
@@ -26,7 +27,10 @@
 
 	let entries = $derived(
 		$liquidiumRepayReserves
-			.map((reserve) => ({ reserve, token: LIQUIDIUM_ASSET_TOKENS[reserve.asset] }))
+			.map((reserve) => ({
+				reserve,
+				token: liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+			}))
 			.filter(
 				(entry): entry is { reserve: LiquidiumReserve; token: Token } =>
 					nonNullish(entry.token) && entry.reserve.poolId !== selectedReserve?.poolId

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyIcrcWizard.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyIcrcWizard.svelte
@@ -2,7 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { Chain } from '@liquidium/client';
 	import { getContext } from 'svelte';
-	import { sendIcp } from '$icp/services/ic-send.services';
+	import { sendIcp, sendIcrc } from '$icp/services/ic-send.services';
 	import { getTokenFee } from '$icp/utils/token.utils';
 	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import LiquidiumSupplyForm from '$lib/components/liquidium/supply/LiquidiumSupplyForm.svelte';
@@ -84,7 +84,7 @@
 			return;
 		}
 
-		// The ICP pool settles on the ICP ledger (ICP-chain transfer).
+		// ICP-chain assets (ICP / ckBTC / ckUSDC / ckUSDT) settle on their ICRC ledger.
 		const ledgerCanisterId = LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS[market.asset];
 
 		if (isNullish(ledgerCanisterId)) {
@@ -94,6 +94,8 @@
 
 		const amountBaseUnits = parsedAmount;
 		const identity = $authIdentity;
+		// ICP settles through the ICP ledger's transfer; ck assets through the generic ICRC ledger.
+		const transfer = market.asset === 'ICP' ? sendIcp : sendIcrc;
 
 		onNext();
 
@@ -109,7 +111,7 @@
 				displayAmount: `${amount}`,
 				progress: (step) => (supplyProgressStep = step),
 				broadcast: async ({ target, amount: transferAmount }) => {
-					const blockIndex = await sendIcp({
+					const blockIndex = await transfer({
 						identity,
 						ledgerCanisterId,
 						to: target.address,

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyModal.svelte
@@ -11,8 +11,8 @@
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumSupplyWizardSteps } from '$lib/config/lend-borrow.config';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { ProgressStepsLiquidiumSupply } from '$lib/enums/progress-steps';
 	import { WizardStepsLiquidiumSupply } from '$lib/enums/wizard-steps';
 	import { estimateLiquidiumInflowFee } from '$lib/services/liquidium-supply.services';
@@ -26,6 +26,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { WizardStep, WizardSteps } from '$lib/types/wizard';
 	import { consoleError } from '$lib/utils/console.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
@@ -40,7 +41,13 @@
 	let selectedMarket = $state<LiquidiumMarket | undefined>(market);
 
 	let token = $derived(
-		nonNullish(selectedMarket) ? LIQUIDIUM_ASSET_TOKENS[selectedMarket.asset] : undefined
+		nonNullish(selectedMarket)
+			? liquidiumMarketToken({
+					chain: selectedMarket.chain,
+					asset: selectedMarket.asset,
+					tokens: $tokens
+				})
+			: undefined
 	);
 
 	const tokensListContext = initModalTokensListContext({ tokens: [] });

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte
@@ -4,14 +4,15 @@
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { liquidiumSupplyMarkets } from '$lib/derived/liquidium.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import {
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import type { Token } from '$lib/types/token';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Omitted on a neutral (token-less) launch — then nothing is excluded.
@@ -26,10 +27,17 @@
 
 	let entries = $derived(
 		$liquidiumSupplyMarkets
-			.map((market) => ({ market, token: LIQUIDIUM_ASSET_TOKENS[market.asset] }))
+			.map((market) => ({
+				market,
+				token: liquidiumMarketToken({ chain: market.chain, asset: market.asset, tokens: $tokens })
+			}))
 			.filter(
 				(entry): entry is { market: LiquidiumMarket; token: Token } =>
-					nonNullish(entry.token) && entry.market.poolId !== selectedMarket?.poolId
+					nonNullish(entry.token) &&
+					!(
+						entry.market.poolId === selectedMarket?.poolId &&
+						entry.market.chain === selectedMarket?.chain
+					)
 			)
 	);
 

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawModal.svelte
@@ -10,10 +10,10 @@
 	import LiquidiumWithdrawTokensList from '$lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import { liquidiumWithdrawWizardSteps } from '$lib/config/lend-borrow.config';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { btcAddressMainnet, ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { liquidiumAssetPrices, liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import { ProgressStepsLiquidiumWithdraw } from '$lib/enums/progress-steps';
 	import { WizardStepsLiquidiumWithdraw } from '$lib/enums/wizard-steps';
 	import {
@@ -31,6 +31,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { WizardStep, WizardSteps } from '$lib/types/wizard';
 	import { invalidAmount } from '$lib/utils/input.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 	import { closeModal } from '$lib/utils/modal.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
@@ -60,7 +61,13 @@
 	);
 
 	let withdrawToken = $derived(
-		nonNullish(selectedReserve) ? LIQUIDIUM_ASSET_TOKENS[selectedReserve.asset] : undefined
+		nonNullish(selectedReserve)
+			? liquidiumMarketToken({
+					chain: selectedReserve.chain,
+					asset: selectedReserve.asset,
+					tokens: $tokens
+				})
+			: undefined
 	);
 	let withdrawPrice = $derived(
 		nonNullish(selectedReserve) ? ($liquidiumAssetPrices[selectedReserve.asset] ?? 0) : 0

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawReview.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawReview.svelte
@@ -8,13 +8,14 @@
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import type { LiquidiumWithdrawPreview } from '$lib/services/liquidium-withdraw.services';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { LendBorrowProvider } from '$lib/types/lend-borrow';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import type { OptionAmount } from '$lib/types/send';
 	import { replaceOisyPlaceholders } from '$lib/utils/i18n.utils';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		reserve: LiquidiumReserve;
@@ -29,7 +30,9 @@
 
 	const liquidium = lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM];
 
-	let withdrawToken = $derived(LIQUIDIUM_ASSET_TOKENS[reserve.asset]);
+	let withdrawToken = $derived(
+		liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+	);
 	let healthLevel = $derived(preview.healthLevel);
 </script>
 

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte
@@ -4,14 +4,15 @@
 	import ModalTokensList from '$lib/components/tokens/ModalTokensList.svelte';
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
-	import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 	import { liquidiumWithdrawReserves } from '$lib/derived/liquidium.derived';
+	import { tokens } from '$lib/derived/tokens.derived';
 	import {
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import type { Token } from '$lib/types/token';
+	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Omitted on a neutral (token-less) launch — then nothing is excluded.
@@ -26,7 +27,10 @@
 
 	let entries = $derived(
 		$liquidiumWithdrawReserves
-			.map((reserve) => ({ reserve, token: LIQUIDIUM_ASSET_TOKENS[reserve.asset] }))
+			.map((reserve) => ({
+				reserve,
+				token: liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+			}))
 			.filter(
 				(entry): entry is { reserve: LiquidiumReserve; token: Token } =>
 					nonNullish(entry.token) && entry.reserve.poolId !== selectedReserve?.poolId

--- a/src/frontend/src/lib/constants/liquidium.constants.ts
+++ b/src/frontend/src/lib/constants/liquidium.constants.ts
@@ -16,15 +16,16 @@ import type { Token } from '$lib/types/token';
 // Provider id for the earning-provider registry.
 export const LIQUIDIUM_PROVIDER_ID = 'liquidium';
 
-// Market asset symbol → oisy token (for logo/label); unmapped future assets fall
-// back to symbol-only.
-export const LIQUIDIUM_ASSET_TOKENS: Record<string, Token> = {
-	BTC: BTC_MAINNET_TOKEN,
-	ETH: ETHEREUM_TOKEN,
-	USDC: USDC_TOKEN,
-	USDT: USDT_TOKEN,
-	ICP: ICP_TOKEN
-};
+// Advertised v1 asset set, for the Earn-card Networks/Assets icon rows only (a static
+// marketing summary, distinct from the live per-market display token which is resolved
+// by (chain, asset) via `liquidiumMarketToken`).
+export const LIQUIDIUM_ADVERTISED_TOKENS: Token[] = [
+	BTC_MAINNET_TOKEN,
+	ETHEREUM_TOKEN,
+	USDC_TOKEN,
+	USDT_TOKEN,
+	ICP_TOKEN
+];
 
 // ck-ledger backing each asset, for the AUT's backend `TokenId`. Keyed by symbol: the
 // ck twin is the same regardless of transfer chain (native BTC and ckBTC both settle on

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -1,7 +1,7 @@
 import { goto } from '$app/navigation';
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import { ZERO } from '$lib/constants/app.constants';
-import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
+import { LIQUIDIUM_ADVERTISED_TOKENS } from '$lib/constants/liquidium.constants';
 import { AppPath } from '$lib/constants/routes.constants';
 import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
@@ -126,7 +126,7 @@ export const liquidiumHealthFactorPercent: Readable<number | null> = derived(
 
 // Deduped icons for the advertised v1 asset set (Earn card Networks/Assets rows).
 const liquidiumCardIcons = (pick: (token: Token) => string | undefined): string[] => [
-	...Object.values(LIQUIDIUM_ASSET_TOKENS).reduce<Set<string>>((acc, token) => {
+	...LIQUIDIUM_ADVERTISED_TOKENS.reduce<Set<string>>((acc, token) => {
 		const icon = pick(token);
 		return nonNullish(icon) ? acc.add(icon) : acc;
 	}, new Set())

--- a/src/frontend/src/lib/services/liquidium.services.ts
+++ b/src/frontend/src/lib/services/liquidium.services.ts
@@ -4,7 +4,7 @@ import { liquidiumWalletAdapter } from '$lib/services/liquidium-wallet-adapter.s
 import { liquidiumStore } from '$lib/stores/liquidium.store';
 import type { NullishIdentity } from '$lib/types/identity';
 import { consoleError } from '$lib/utils/console.utils';
-import { mapLiquidiumMarket, mapLiquidiumPortfolio } from '$lib/utils/liquidium.utils';
+import { mapLiquidiumMarketRails, mapLiquidiumPortfolio } from '$lib/utils/liquidium.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Chain, type AssetPrices } from '@liquidium/client';
@@ -60,7 +60,7 @@ export const loadLiquidium = async ({
 				return {};
 			})
 		]);
-		const markets = pools.map(mapLiquidiumMarket);
+		const markets = pools.flatMap(mapLiquidiumMarketRails);
 
 		const profileId = nonNullish(ethAddress) ? await accounts.getProfileId(ethAddress) : null;
 

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -1,4 +1,9 @@
 import type { TokenId } from '$declarations/backend/backend.did';
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { ZERO } from '$lib/constants/app.constants';
 import {
 	LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS,
@@ -7,9 +12,17 @@ import {
 	type LiquidiumHealthLevel
 } from '$lib/constants/liquidium.constants';
 import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import type { Token } from '$lib/types/token';
+import { findTwinToken } from '$lib/utils/token.utils';
 import { assertNonNullish, isNullish } from '@dfinity/utils';
 import { Principal } from '@icp-sdk/core/principal';
-import type { Pool, UserPositionSummary, UserReserve } from '@liquidium/client';
+import {
+	Chain,
+	isAssetIdentifier,
+	type Pool,
+	type UserPositionSummary,
+	type UserReserve
+} from '@liquidium/client';
 
 // Backend `TokenId` for a Liquidium AUT record — the ck-asset ledger backing the asset.
 export const liquidiumAssetTokenId = (asset: string): TokenId => {
@@ -18,6 +31,54 @@ export const liquidiumAssetTokenId = (asset: string): TokenId => {
 	assertNonNullish(ledgerCanisterId, `No ICRC ledger configured for Liquidium asset ${asset}`);
 
 	return { Icrc: Principal.fromText(ledgerCanisterId) };
+};
+
+// Display token (logo/label) for a Liquidium market/reserve. Keyed by (chain, asset)
+// because the same symbol maps to a different oisy token per chain: native BTC vs
+// ckBTC, ERC-20 USDC/USDT vs their ck twins. ICP-chain ck assets resolve from the
+// runtime token list via their twin symbol; native/ERC assets and ICP are static.
+export const liquidiumMarketToken = ({
+	chain,
+	asset,
+	tokens
+}: {
+	chain: string;
+	asset: string;
+	tokens: Token[];
+}): Token | undefined => {
+	if (chain === 'ICP') {
+		switch (asset) {
+			case 'ICP':
+				return ICP_TOKEN;
+			case 'BTC':
+				return findTwinToken({ tokenToPair: BTC_MAINNET_TOKEN, tokens });
+			case 'USDC':
+				return findTwinToken({ tokenToPair: USDC_TOKEN, tokens });
+			case 'USDT':
+				return findTwinToken({ tokenToPair: USDT_TOKEN, tokens });
+			default:
+				return undefined;
+		}
+	}
+
+	if (chain === 'BTC' && asset === 'BTC') {
+		return BTC_MAINNET_TOKEN;
+	}
+
+	if (chain === 'ETH') {
+		switch (asset) {
+			case 'ETH':
+				return ETHEREUM_TOKEN;
+			case 'USDC':
+				return USDC_TOKEN;
+			case 'USDT':
+				return USDT_TOKEN;
+			default:
+				return undefined;
+		}
+	}
+
+	return undefined;
 };
 
 // Scaled protocol rate → percentage.
@@ -190,6 +251,25 @@ export const mapLiquidiumMarket = (pool: Pool): LiquidiumMarket => ({
 	frozen: pool.frozen,
 	available: !pool.frozen && isUnderSupplyCap(pool)
 });
+
+// Transfer rails a pool asset supports: its native/ERC chain plus the ICP (ck-ledger)
+// rail where the protocol offers one. A single lending pool is shared across rails (e.g.
+// ETH/USDC and ICP/ckUSDC settle in the same USDC pool), so this is a per-asset transfer
+// choice, not separate pools. Derived from the SDK's own identifier guard so it stays
+// correct if the protocol adds pairs.
+export const liquidiumSupportedRails = (asset: string): string[] =>
+	Object.values(Chain).filter((chain) => isAssetIdentifier({ chain, asset }));
+
+// Expands one pool into a market per supported transfer rail (`market.chain` is the rail,
+// not the pool's backing chain). Both rails of an asset carry identical pool economics
+// (APY / LTV / availability) and share `poolId`; they differ only by transfer chain, which
+// drives the display token, the supply/repay transfer rail and the borrow/withdraw
+// delivery chain. Holdings stay per-pool — this expansion is for the market/entry surface only.
+export const mapLiquidiumMarketRails = (pool: Pool): LiquidiumMarket[] => {
+	const base = mapLiquidiumMarket(pool);
+
+	return liquidiumSupportedRails(pool.asset).map((chain) => ({ ...base, chain }));
+};
 
 export const mapLiquidiumReserve = ({
 	position,

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
@@ -1,6 +1,6 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import LiquidiumBorrowedRow from '$lib/components/liquidium/LiquidiumBorrowedRow.svelte';
 import { ZERO } from '$lib/constants/app.constants';
-import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
@@ -25,7 +25,7 @@ describe('LiquidiumBorrowedRow', () => {
 
 	it('renders the symbol, token name and network', () => {
 		const { container } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
-		const usdc = LIQUIDIUM_ASSET_TOKENS.USDC;
+		const usdc = USDC_TOKEN;
 
 		expect(container).toHaveTextContent('USDC');
 		expect(container).toHaveTextContent(usdc.name);

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
@@ -1,6 +1,6 @@
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import LiquidiumSuppliedRow from '$lib/components/liquidium/LiquidiumSuppliedRow.svelte';
 import { ZERO } from '$lib/constants/app.constants';
-import { LIQUIDIUM_ASSET_TOKENS } from '$lib/constants/liquidium.constants';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
@@ -25,7 +25,7 @@ describe('LiquidiumSuppliedRow', () => {
 
 	it('renders the symbol, token name and network', () => {
 		const { container } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
-		const btc = LIQUIDIUM_ASSET_TOKENS.BTC;
+		const btc = BTC_MAINNET_TOKEN;
 
 		expect(container).toHaveTextContent('BTC');
 		expect(container).toHaveTextContent(btc.name);

--- a/src/frontend/src/tests/lib/services/liquidium.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium.services.spec.ts
@@ -12,7 +12,7 @@ vi.mock('$lib/api/liquidium.api', () => ({
 }));
 
 vi.mock('$lib/utils/liquidium.utils', () => ({
-	mapLiquidiumMarket: vi.fn(),
+	mapLiquidiumMarketRails: vi.fn(),
 	mapLiquidiumPortfolio: vi.fn()
 }));
 
@@ -46,7 +46,7 @@ describe('liquidium.services', () => {
 			market: { listPools, getAssetPrices },
 			positions: { getUserReserves, getUserPositionSummary }
 		} as unknown as ReturnType<typeof liquidiumApi.liquidiumClient>);
-		vi.mocked(liquidiumUtils.mapLiquidiumMarket).mockReturnValue(market);
+		vi.mocked(liquidiumUtils.mapLiquidiumMarketRails).mockReturnValue([market]);
 		vi.mocked(liquidiumUtils.mapLiquidiumPortfolio).mockReturnValue(portfolio);
 		getAssetPrices.mockResolvedValue({});
 	});

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -1,3 +1,7 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { ZERO } from '$lib/constants/app.constants';
 import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import {
@@ -6,6 +10,7 @@ import {
 	liquidiumFreeCollateralUsd,
 	liquidiumHealthFactorPercent,
 	liquidiumHealthLevel,
+	liquidiumMarketToken,
 	liquidiumMaxLtv,
 	liquidiumMaxSupplyApy,
 	liquidiumMinBorrowApy,
@@ -15,7 +20,9 @@ import {
 	liquidiumProjectedHealthPercent,
 	liquidiumResultingLtvPercent,
 	liquidiumSupplyInterestUsd,
+	liquidiumSupportedRails,
 	mapLiquidiumMarket,
+	mapLiquidiumMarketRails,
 	mapLiquidiumPortfolio,
 	mapLiquidiumReserve
 } from '$lib/utils/liquidium.utils';
@@ -104,6 +111,44 @@ describe('liquidium.utils', () => {
 			expect(
 				mapLiquidiumMarket(buildPool({ totalSupply: 50n, supplyCap: 100n })).available
 			).toBeTruthy();
+		});
+	});
+
+	describe('liquidiumSupportedRails', () => {
+		it('offers the native + ICP (ck) rails for BTC', () => {
+			expect(liquidiumSupportedRails('BTC')).toEqual(['BTC', 'ICP']);
+		});
+
+		it('offers the ERC-20 + ICP (ck) rails for the stablecoins', () => {
+			expect(liquidiumSupportedRails('USDC')).toEqual(['ETH', 'ICP']);
+			expect(liquidiumSupportedRails('USDT')).toEqual(['ETH', 'ICP']);
+		});
+
+		it('offers only the ICP rail for ICP', () => {
+			expect(liquidiumSupportedRails('ICP')).toEqual(['ICP']);
+		});
+	});
+
+	describe('mapLiquidiumMarketRails', () => {
+		it('expands a pool into one market per transfer rail, sharing pool economics + poolId', () => {
+			const markets = mapLiquidiumMarketRails(buildPool());
+
+			expect(markets.map(({ chain }) => chain)).toEqual(['BTC', 'ICP']);
+			expect(
+				markets.every(({ poolId, asset }) => poolId === 'pool-btc' && asset === 'BTC')
+			).toBeTruthy();
+			// Same pool → identical rates/availability across rails; only the transfer chain differs.
+			expect(markets[0].supplyApy).toBe(markets[1].supplyApy);
+			expect(markets[0].available).toBe(markets[1].available);
+		});
+
+		it('leaves a single-rail asset (ICP) as one market', () => {
+			const markets = mapLiquidiumMarketRails(
+				buildPool({ id: 'pool-icp', asset: 'ICP', chain: 'ICP' })
+			);
+
+			expect(markets).toHaveLength(1);
+			expect(markets[0].chain).toBe('ICP');
 		});
 	});
 
@@ -690,6 +735,35 @@ describe('liquidium.utils', () => {
 			// Health is derived from the bps fields: (1 − 4000/8000) × 100 = 50%.
 			expect(portfolio.healthFactorPercent).toBeCloseTo(50);
 			expect(portfolio.reserves).toHaveLength(1);
+		});
+	});
+
+	describe('liquidiumMarketToken', () => {
+		it('resolves native BTC on the BTC chain', () => {
+			expect(liquidiumMarketToken({ chain: 'BTC', asset: 'BTC', tokens: [] })).toBe(
+				BTC_MAINNET_TOKEN
+			);
+		});
+
+		it('resolves ERC-20 stablecoins on the ETH chain', () => {
+			expect(liquidiumMarketToken({ chain: 'ETH', asset: 'USDC', tokens: [] })).toBe(USDC_TOKEN);
+			expect(liquidiumMarketToken({ chain: 'ETH', asset: 'USDT', tokens: [] })).toBe(USDT_TOKEN);
+		});
+
+		it('resolves native ICP on the ICP chain', () => {
+			expect(liquidiumMarketToken({ chain: 'ICP', asset: 'ICP', tokens: [] })).toBe(ICP_TOKEN);
+		});
+
+		it('does not collapse a ck asset onto its native/ERC token — needs the twin from the list', () => {
+			// The same symbol on the ICP chain is a ck twin, never the native BTC / ERC-20 token; with
+			// no twin in the list it resolves to nothing rather than the wrong (native/ERC) token.
+			expect(liquidiumMarketToken({ chain: 'ICP', asset: 'BTC', tokens: [] })).toBeUndefined();
+			expect(liquidiumMarketToken({ chain: 'ICP', asset: 'USDC', tokens: [] })).toBeUndefined();
+		});
+
+		it('returns undefined for an unsupported (chain, asset) pair', () => {
+			expect(liquidiumMarketToken({ chain: 'BTC', asset: 'USDC', tokens: [] })).toBeUndefined();
+			expect(liquidiumMarketToken({ chain: 'SOL', asset: 'SOL', tokens: [] })).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Adds the Internet Computer (ck) transfer rails — ckBTC, ckUSDC, ckUSDT — to Liquidium, alongside the native ICP support merged in #13554. They show up as ordinary entries in the Supply/Borrow token selectors; picking one routes the flow through the ICP rail.

Grounded in the SDK model (@liquidium/client@0.5.0): there is one lending pool per asset, and "ck vs native/ERC" is a transfer rail selected per call — e.g. ETH/USDC and ICP/ckUSDC settle in the same USDC pool (MarketModule.findPool). So this surfaces the existing pools over their ck rails rather than adding pools.
