### PR TITLE
fix(frontend): reload if a document returns after its workers were terminated

### DIFF
--- a/src/frontend/src/lib/utils/page-unload.utils.ts
+++ b/src/frontend/src/lib/utils/page-unload.utils.ts
@@ -1,6 +1,8 @@
 import { browser } from '$app/environment';
 import { AppWorker } from '$lib/services/_worker.services';
 
+let terminated = false;
+
 const onPageHide = ($event: PageTransitionEvent) => {
 	// When the page enters the back/forward cache it may be restored later, so
 	// its workers must stay alive. Only tear down on a real unload.
@@ -8,7 +10,27 @@ const onPageHide = ($event: PageTransitionEvent) => {
 		return;
 	}
 
+	terminated = true;
+
 	AppWorker.terminateAllWorkers();
+};
+
+const onPageShow = () => {
+	// A document that fired `pagehide` with `persisted: false` is discarded and
+	// can never be shown again, so getting here after a teardown means the
+	// browser misreported the flag. The threads are gone but their wrappers are
+	// not, and `postMessage` would keep queueing into dead workers without ever
+	// erroring — balances would silently stop updating. A reload is the only
+	// recovery. Deliberately not gated on `$event.persisted`: WebKit is known to
+	// misreport it on restore too, which would disable this guard exactly where
+	// it is most needed.
+	if (!terminated) {
+		return;
+	}
+
+	terminated = false;
+
+	window.location.reload();
 };
 
 /**
@@ -19,6 +41,10 @@ const onPageHide = ($event: PageTransitionEvent) => {
  * spawns its own — memory roughly doubles at exactly the moment users watch
  * it. Terminating the workers on `pagehide` releases the old generation
  * immediately instead of waiting for the browser to tear the document down.
+ *
+ * The paired `pageshow` listener is a safety net for browsers that misreport
+ * `persisted`: it reloads a document that came back after its workers were
+ * torn down, turning silent permanent breakage into one reload.
  */
 export const initWorkerCleanupOnPageUnload = () => {
 	if (!browser) {
@@ -26,4 +52,5 @@ export const initWorkerCleanupOnPageUnload = () => {
 	}
 
 	window.addEventListener('pagehide', onPageHide);
+	window.addEventListener('pageshow', onPageShow);
 };

--- a/src/frontend/src/tests/lib/utils/page-unload.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/page-unload.utils.spec.ts
@@ -1,9 +1,40 @@
 import { AppWorker } from '$lib/services/_worker.services';
 import { initWorkerCleanupOnPageUnload } from '$lib/utils/page-unload.utils';
+import type { MockInstance } from 'vitest';
 
 describe('page-unload.utils', () => {
 	describe('initWorkerCleanupOnPageUnload', () => {
-		let terminateAllWorkersSpy: ReturnType<typeof vi.spyOn>;
+		let terminateAllWorkersSpy: MockInstance;
+		let reloadSpy: MockInstance;
+
+		// Captured instead of dispatched on `window`, so the listeners registered
+		// here cannot leak into other test files.
+		const handlers = new Map<string, EventListener>();
+
+		const pageHide = (persisted: boolean) => {
+			const event = new Event('pagehide') as PageTransitionEvent;
+			Object.defineProperty(event, 'persisted', { value: persisted });
+
+			handlers.get('pagehide')?.(event);
+		};
+
+		const pageShow = () => {
+			handlers.get('pageshow')?.(new Event('pageshow'));
+		};
+
+		beforeAll(() => {
+			const addEventListenerSpy = vi
+				.spyOn(window, 'addEventListener')
+				.mockImplementation(() => undefined);
+
+			initWorkerCleanupOnPageUnload();
+
+			addEventListenerSpy.mock.calls.forEach(([type, listener]) => {
+				handlers.set(type, listener as EventListener);
+			});
+
+			addEventListenerSpy.mockRestore();
+		});
 
 		beforeEach(() => {
 			vi.clearAllMocks();
@@ -11,32 +42,66 @@ describe('page-unload.utils', () => {
 			terminateAllWorkersSpy = vi
 				.spyOn(AppWorker, 'terminateAllWorkers')
 				.mockImplementation(() => {});
+
+			Object.defineProperty(window, 'location', {
+				writable: true,
+				value: { reload: vi.fn() }
+			});
+
+			reloadSpy = window.location.reload as unknown as MockInstance;
 		});
 
 		afterEach(() => {
+			// The module tracks teardown in a private flag. Drain it so a test that
+			// tore the workers down does not arm the reload guard for the next one.
+			pageShow();
+
 			terminateAllWorkersSpy.mockRestore();
 		});
 
-		const dispatchPageHide = (persisted: boolean) => {
-			const event = new Event('pagehide') as PageTransitionEvent;
-			Object.defineProperty(event, 'persisted', { value: persisted });
-			window.dispatchEvent(event);
-		};
+		it('should register both pagehide and pageshow listeners', () => {
+			expect(handlers.has('pagehide')).toBeTruthy();
+			expect(handlers.has('pageshow')).toBeTruthy();
+		});
 
 		it('should terminate all workers when the page is really unloading', () => {
-			initWorkerCleanupOnPageUnload();
-
-			dispatchPageHide(false);
+			pageHide(false);
 
 			expect(terminateAllWorkersSpy).toHaveBeenCalledOnce();
 		});
 
 		it('should keep workers alive when the page enters the back/forward cache', () => {
-			initWorkerCleanupOnPageUnload();
-
-			dispatchPageHide(true);
+			pageHide(true);
 
 			expect(terminateAllWorkersSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not reload a document shown without a prior teardown', () => {
+			pageShow();
+
+			expect(reloadSpy).not.toHaveBeenCalled();
+		});
+
+		it('should not reload a document restored after a back/forward cache pagehide', () => {
+			pageHide(true);
+			pageShow();
+
+			expect(reloadSpy).not.toHaveBeenCalled();
+		});
+
+		it('should reload a document shown again after its workers were torn down', () => {
+			pageHide(false);
+			pageShow();
+
+			expect(reloadSpy).toHaveBeenCalledOnce();
+		});
+
+		it('should reload only once per teardown', () => {
+			pageHide(false);
+			pageShow();
+			pageShow();
+
+			expect(reloadSpy).toHaveBeenCalledOnce();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Follow-up hardening for #13523. That PR tears down the worker threads on `pagehide` when `persisted === false`, which is correct by construction: per spec a document that fires `pagehide` with `persisted: false` is being destroyed and can never be shown again.

The risk is a browser that misreports the flag. `terminateAllWorkers()` is deliberately blunt — it terminates the raw `Worker`s and resets the statics, but never sets `#isTerminated` on the live `AppWorker` wrappers, because the document is supposed to be going away. If such a document survives, the wrappers keep `postMessage`-ing into dead threads without ever erroring: balances silently stop updating and the only recovery is a manual reload. WebKit is the plausible offender here, and this repo already treats iOS worker behaviour as divergent (#10390).

# Changes

- `page-unload.utils.ts` tracks teardown in a module-level flag and registers a paired `pageshow` listener that reloads the document when it is shown again after the workers were terminated.
- Deliberately not gated on `$event.persisted`: that flag is unreliable on restore in the same browsers this guards against, so gating on it would disable the net exactly where it is needed.

Zero cost on every correct path — a discarded document never fires `pageshow`, so the handler only ever runs in the buggy case. It converts silent permanent breakage into one reload.

# Tests

- Unit tests cover: both listeners registered; no reload without a prior teardown; no reload after a bfcache `pagehide`; reload after a real teardown; reload only once per teardown. Existing terminate/bfcache cases kept.
- The spec now captures the handlers from the `addEventListener` spy rather than dispatching on `window`, so the listeners it registers cannot leak into other test files, and drains the module flag between cases.
- `npm run lint -- --max-warnings 0` passes. `npm run check` and `tsc --project tsconfig.spec.json` report 14 pre-existing Liquidium errors, identical on clean `main` (verified by stashing) and none in the touched files.
- `worker.services.spec.ts` + `page-unload.utils.spec.ts`: 20 passed.
