### PR TITLE
fix(frontend): recover OneSec EVM->ICP deposits stranded at the forwarding address

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -183,6 +183,9 @@ export const CODE_REGENERATE_INTERVAL_IN_SECONDS = 45;
 
 // Active user transactions polling
 export const ACTIVE_USER_TRANSACTIONS_POLL_INTERVAL_MILLIS = 5 * 1_000; // 5 seconds
+// Minimum delay between two `forward_evm_to_icp` re-notifications for the same
+// pending OneSec EVM→ICP row (notifying is an update call, polling is 5s).
+export const ONESEC_FORWARDING_NOTIFY_INTERVAL_MILLIS = SECONDS_IN_MINUTE * 1_000; // 1 minute
 
 // User Snapshot
 export const USER_SNAPSHOT_TIMER_INTERVAL_MILLIS = SECONDS_IN_MINUTE * 5 * 1_000; // 5 minutes in milliseconds

--- a/src/frontend/src/lib/services/onesec-swap.services.ts
+++ b/src/frontend/src/lib/services/onesec-swap.services.ts
@@ -8,6 +8,7 @@ import { send } from '$eth/services/send.services';
 import type { IcToken } from '$icp/types/ic-token';
 import { isIcToken } from '$icp/validation/ic-token.validation';
 import { getAgent } from '$lib/actors/agents.ic';
+import { ONESEC_FORWARDING_NOTIFY_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import { authIdentity } from '$lib/derived/auth.derived';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import {
@@ -91,8 +92,10 @@ const getStepLastTransferId = (step: Step): TransferId | undefined => {
 	return undefined;
 };
 
-// Runs detached. Writes the terminal status at the end and persists
-// `TRANSFER_ID` for EVM→ICP rows the first time a step exposes it.
+// Runs detached. Writes the terminal status when the plan completes (or a step
+// reports failed/refunded) and persists `TRANSFER_ID` for EVM→ICP rows the
+// first time a step exposes it. Unexpected throws leave the row pending so the
+// cross-session AUT poller can finish the job.
 const finishOneSecBridgingInSession = async ({
 	identity,
 	id,
@@ -163,11 +166,13 @@ const finishOneSecBridgingInSession = async ({
 		}
 
 		await writeTerminal({ status: { Succeeded: null } });
-	} catch (_: unknown) {
-		await writeTerminal({
-			status: { Failed: null },
-			error: 'OneSec bridge step failed unexpectedly'
-		});
+	} catch (err: unknown) {
+		// The plan threw unexpectedly (network blip, canister unreachable) — the
+		// bridge outcome is unknown, and the user's funds are already committed.
+		// A terminal Failed here would drop the row from the pending poll set and
+		// permanently disable cross-session recovery, so leave it pending: the AUT
+		// poller resumes tracking (and re-notifies OneSec for EVM→ICP deposits).
+		consoleError(err);
 	}
 };
 
@@ -544,7 +549,34 @@ const evmChainFromChainId = (chainId: bigint): EvmChain | undefined => {
 	}
 };
 
-// Discovers TRANSFER_ID for cross-session EVM→ICP rows via `getForwardingStatus`.
+// `forward_evm_to_icp` is the only trigger that makes OneSec sweep a
+// forwarding address — if the in-session closer dies between the EVM deposit
+// and its notify step, no read-only poll will ever move the funds. The poller
+// therefore re-notifies pending EVM→ICP rows, throttled per row because
+// notifying is an update call while the poller ticks every few seconds
+// (between notifications it falls back to the read-only status lookup).
+const lastForwardingNotifyMs = new Map<string, number>();
+
+const shouldNotifyForwarding = (txId: string): boolean => {
+	const now = Date.now();
+	const last = lastForwardingNotifyMs.get(txId);
+
+	if (nonNullish(last) && now - last < ONESEC_FORWARDING_NOTIFY_INTERVAL_MILLIS) {
+		return false;
+	}
+
+	lastForwardingNotifyMs.set(txId, now);
+
+	return true;
+};
+
+export const resetOneSecForwardingNotifyThrottle = (): void => {
+	lastForwardingNotifyMs.clear();
+};
+
+// Discovers TRANSFER_ID for cross-session EVM→ICP rows via the forwarding
+// status, re-notifying OneSec (see `shouldNotifyForwarding`) so a deposit
+// stranded at the forwarding address is picked up again.
 // Forwarding addresses are deterministic per principal, so `response.done` can
 // point at a *prior* swap's id; we require `done.id > BASELINE_TRANSFER_ID` and
 // skip discovery entirely when the baseline ref is missing.
@@ -586,12 +618,12 @@ const tryDiscoverEvmToIcpTransferId = async ({
 	}
 
 	try {
-		const response = await oneSecForwarding().getForwardingStatus(
-			oneSecToken,
-			chain,
-			forwardingAddress,
-			{ owner: data.recipient_principal }
-		);
+		const forwarding = oneSecForwarding();
+		const receiver = { owner: data.recipient_principal };
+
+		const response = shouldNotifyForwarding(tx.id)
+			? await forwarding.forwardEvmToIcp(oneSecToken, chain, forwardingAddress, receiver)
+			: await forwarding.getForwardingStatus(oneSecToken, chain, forwardingAddress, receiver);
 
 		if (isNullish(response.done) || response.done.id <= baseline) {
 			return undefined;
@@ -611,6 +643,8 @@ const tryDiscoverEvmToIcpTransferId = async ({
 			id: tx.id,
 			externalRefs: mergedRefs
 		});
+
+		lastForwardingNotifyMs.delete(tx.id);
 
 		return response.done;
 	} catch (err: unknown) {

--- a/src/frontend/src/tests/lib/services/onesec-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/onesec-swap.services.spec.ts
@@ -2,6 +2,7 @@ import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { send } from '$eth/services/send.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { IcToken } from '$icp/types/ic-token';
+import { ONESEC_FORWARDING_NOTIFY_INTERVAL_MILLIS } from '$lib/constants/app.constants';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
 import {
@@ -9,11 +10,13 @@ import {
 	executeOneSecIcpToEvmBridge,
 	fetchOneSecEvmToIcpQuote,
 	fetchOneSecIcpToEvmQuote,
-	pollOneSecActiveUserTransactions
+	pollOneSecActiveUserTransactions,
+	resetOneSecForwardingNotifyThrottle
 } from '$lib/services/onesec-swap.services';
 import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
 import { ONESEC_EXTERNAL_REF_KEYS } from '$lib/types/onesec-swap';
 import { SwapProvider } from '$lib/types/swap';
+import { consoleError } from '$lib/utils/console.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 import {
 	mockActiveUserTransaction,
@@ -29,11 +32,13 @@ import type * as OneSecBridge from 'onesec-bridge';
 
 const USDC_LEDGER = '53nhb-haaaa-aaaar-qbn5q-cai';
 
-const { getTransfersMock, getTransferMock, getForwardingStatusMock } = vi.hoisted(() => ({
-	getTransfersMock: vi.fn(),
-	getTransferMock: vi.fn(),
-	getForwardingStatusMock: vi.fn()
-}));
+const { getTransfersMock, getTransferMock, getForwardingStatusMock, forwardEvmToIcpMock } =
+	vi.hoisted(() => ({
+		getTransfersMock: vi.fn(),
+		getTransferMock: vi.fn(),
+		getForwardingStatusMock: vi.fn(),
+		forwardEvmToIcpMock: vi.fn()
+	}));
 
 const { mockPlan, mockStep, mockExpectedFee, mockEvmToIcpBuilderObj, mockIcpToEvmBuilderObj } =
 	vi.hoisted(() => {
@@ -83,7 +88,8 @@ vi.mock('onesec-bridge', async (importOriginal) => {
 		getTransfers: getTransfersMock,
 		oneSecForwarding: vi.fn().mockReturnValue({
 			getTransfer: getTransferMock,
-			getForwardingStatus: getForwardingStatusMock
+			getForwardingStatus: getForwardingStatusMock,
+			forwardEvmToIcp: forwardEvmToIcpMock
 		})
 	};
 });
@@ -773,6 +779,32 @@ describe('onesec-swap.services', () => {
 
 				expect(baseEvmToIcpParams.setFailedProgressStep).not.toHaveBeenCalled();
 			});
+
+			it('the in-session closer leaves the row pending when a remaining step throws unexpectedly', async () => {
+				// A thrown step (network blip, canister unreachable) has an unknown
+				// outcome, and the deposit is already on-chain. Writing Failed would
+				// remove the row from the pending poll set and disable the poller's
+				// cross-session recovery (forwarding re-notify), stranding the funds.
+				mockPlan.nextStepToRun
+					.mockReturnValueOnce(mockStep) // foreground: fee
+					.mockReturnValueOnce(mockStep) // foreground: forwarding
+					.mockReturnValueOnce(mockStep) // closer: notify (throws)
+					.mockReturnValue(undefined);
+				mockStep.run
+					.mockResolvedValueOnce({ state: 'succeeded' })
+					.mockResolvedValueOnce({ state: 'succeeded', forwardingAddress })
+					.mockRejectedValueOnce(new Error('canister unreachable'));
+
+				await executeOneSecEvmToIcpBridge({ ...baseEvmToIcpParams, swapId });
+
+				await vi.waitFor(() => {
+					expect(vi.mocked(consoleError)).toHaveBeenCalledWith(
+						expect.objectContaining({ message: 'canister unreachable' })
+					);
+				});
+
+				expect(updateSpy).not.toHaveBeenCalled();
+			});
 		});
 	});
 
@@ -821,6 +853,8 @@ describe('onesec-swap.services', () => {
 			getTransfersMock.mockReset();
 			getTransferMock.mockReset();
 			getForwardingStatusMock.mockReset();
+			forwardEvmToIcpMock.mockReset();
+			resetOneSecForwardingNotifyThrottle();
 		});
 
 		it('no-ops on an empty list and does not call the SDK', async () => {
@@ -1010,10 +1044,10 @@ describe('onesec-swap.services', () => {
 			).resolves.toBeUndefined();
 		});
 
-		describe('EVM→ICP transferId discovery via getForwardingStatus', () => {
+		describe('EVM→ICP transferId discovery and forwarding re-notify', () => {
 			it('discovers the transferId when done.id > baseline, persists it, and advances status via exact lookup', async () => {
 				// baseline = 5; OneSec returns done = 99 → strictly greater, accepted.
-				getForwardingStatusMock.mockResolvedValueOnce({ done: { id: 99n } });
+				forwardEvmToIcpMock.mockResolvedValueOnce({ done: { id: 99n } });
 				getTransferMock.mockResolvedValueOnce({
 					source: { chain: 'Ethereum', amount: sourceAmount },
 					destination: { chain: 'ICP', amount: sourceAmount },
@@ -1031,7 +1065,7 @@ describe('onesec-swap.services', () => {
 					transactions: [evmToIcpPendingTx]
 				});
 
-				expect(getForwardingStatusMock).toHaveBeenCalledExactlyOnceWith(
+				expect(forwardEvmToIcpMock).toHaveBeenCalledExactlyOnceWith(
 					'USDC',
 					'Ethereum',
 					evmToIcpForwardingAddress,
@@ -1056,7 +1090,7 @@ describe('onesec-swap.services', () => {
 			it('does not persist or advance when done.id equals the baseline (stale)', async () => {
 				// baseline = 5; OneSec returns the same `done = 5` from the previous swap
 				// because the new deposit hasn't been processed yet. Must be rejected.
-				getForwardingStatusMock.mockResolvedValueOnce({
+				forwardEvmToIcpMock.mockResolvedValueOnce({
 					done: { id: BigInt(evmToIcpBaselineTransferId) }
 				});
 				getTransfersMock.mockResolvedValueOnce([]);
@@ -1071,14 +1105,14 @@ describe('onesec-swap.services', () => {
 					transactions: [evmToIcpPendingTx]
 				});
 
-				expect(getForwardingStatusMock).toHaveBeenCalledOnce();
+				expect(forwardEvmToIcpMock).toHaveBeenCalledOnce();
 				expect(updateSpy).not.toHaveBeenCalled();
 				expect(getTransferMock).not.toHaveBeenCalled();
 				expect(applySpy).not.toHaveBeenCalled();
 			});
 
 			it('does not persist or advance when done.id is less than the baseline', async () => {
-				getForwardingStatusMock.mockResolvedValueOnce({ done: { id: 1n } });
+				forwardEvmToIcpMock.mockResolvedValueOnce({ done: { id: 1n } });
 				getTransfersMock.mockResolvedValueOnce([]);
 				const updateSpy = vi.spyOn(activeUserTransactionsServices, 'updateActiveUserTransaction');
 
@@ -1091,7 +1125,7 @@ describe('onesec-swap.services', () => {
 				expect(getTransferMock).not.toHaveBeenCalled();
 			});
 
-			it('does not call getForwardingStatus when the baseline ref is missing', async () => {
+			it('does not call the forwarding SDK when the baseline ref is missing', async () => {
 				// Pre-baseline AUT rows (or rows whose foreground bailed before
 				// persisting the baseline) cannot safely discover via `done`,
 				// because we can't tell new from stale. Skip discovery; fall back
@@ -1114,6 +1148,7 @@ describe('onesec-swap.services', () => {
 					]
 				});
 
+				expect(forwardEvmToIcpMock).not.toHaveBeenCalled();
 				expect(getForwardingStatusMock).not.toHaveBeenCalled();
 				expect(updateSpy).not.toHaveBeenCalled();
 			});
@@ -1122,7 +1157,7 @@ describe('onesec-swap.services', () => {
 				// "0" is the sentinel the foreground writes when the user has no
 				// prior completed forwarding. Any positive done.id is strictly
 				// greater than 0 and must be accepted.
-				getForwardingStatusMock.mockResolvedValueOnce({ done: { id: 1n } });
+				forwardEvmToIcpMock.mockResolvedValueOnce({ done: { id: 1n } });
 				getTransferMock.mockResolvedValueOnce({
 					source: { chain: 'Ethereum', amount: sourceAmount },
 					destination: { chain: 'ICP', amount: sourceAmount },
@@ -1162,8 +1197,8 @@ describe('onesec-swap.services', () => {
 				expect(getTransferMock).toHaveBeenCalledExactlyOnceWith({ id: 1n });
 			});
 
-			it('does not persist or advance when getForwardingStatus has no done id', async () => {
-				getForwardingStatusMock.mockResolvedValueOnce({
+			it('does not persist or advance when the forwarding response has no done id', async () => {
+				forwardEvmToIcpMock.mockResolvedValueOnce({
 					status: { CheckingBalance: null }
 				});
 				getTransfersMock.mockResolvedValueOnce([]);
@@ -1178,13 +1213,13 @@ describe('onesec-swap.services', () => {
 					transactions: [evmToIcpPendingTx]
 				});
 
-				expect(getForwardingStatusMock).toHaveBeenCalledOnce();
+				expect(forwardEvmToIcpMock).toHaveBeenCalledOnce();
 				expect(updateSpy).not.toHaveBeenCalled();
 				expect(getTransferMock).not.toHaveBeenCalled();
 				expect(applySpy).not.toHaveBeenCalled();
 			});
 
-			it('does not call getForwardingStatus for ICP→EVM rows', async () => {
+			it('does not call the forwarding SDK for ICP→EVM rows', async () => {
 				getTransfersMock.mockResolvedValueOnce([]);
 
 				await pollOneSecActiveUserTransactions({
@@ -1192,10 +1227,11 @@ describe('onesec-swap.services', () => {
 					transactions: [pendingTx]
 				});
 
+				expect(forwardEvmToIcpMock).not.toHaveBeenCalled();
 				expect(getForwardingStatusMock).not.toHaveBeenCalled();
 			});
 
-			it('does not call getForwardingStatus when the forwarding-address ref is missing', async () => {
+			it('does not call the forwarding SDK when the forwarding-address ref is missing', async () => {
 				getTransfersMock.mockResolvedValueOnce([]);
 
 				await pollOneSecActiveUserTransactions({
@@ -1203,10 +1239,11 @@ describe('onesec-swap.services', () => {
 					transactions: [{ ...evmToIcpPendingTx, external_refs: [] }]
 				});
 
+				expect(forwardEvmToIcpMock).not.toHaveBeenCalled();
 				expect(getForwardingStatusMock).not.toHaveBeenCalled();
 			});
 
-			it('does not call getForwardingStatus when a TRANSFER_ID ref is already present', async () => {
+			it('does not call the forwarding SDK when a TRANSFER_ID ref is already present', async () => {
 				getTransferMock.mockResolvedValueOnce({
 					source: { chain: 'Ethereum', amount: sourceAmount },
 					destination: { chain: 'ICP', amount: sourceAmount },
@@ -1230,12 +1267,13 @@ describe('onesec-swap.services', () => {
 					]
 				});
 
+				expect(forwardEvmToIcpMock).not.toHaveBeenCalled();
 				expect(getForwardingStatusMock).not.toHaveBeenCalled();
 				expect(getTransferMock).toHaveBeenCalledExactlyOnceWith({ id: 7n });
 			});
 
-			it('swallows getForwardingStatus SDK errors so the next tick can retry', async () => {
-				getForwardingStatusMock.mockRejectedValueOnce(new Error('canister unreachable'));
+			it('swallows forwarding SDK errors so the next tick can retry', async () => {
+				forwardEvmToIcpMock.mockRejectedValueOnce(new Error('canister unreachable'));
 				getTransfersMock.mockResolvedValueOnce([]);
 
 				await expect(
@@ -1244,6 +1282,50 @@ describe('onesec-swap.services', () => {
 						transactions: [evmToIcpPendingTx]
 					})
 				).resolves.toBeUndefined();
+			});
+
+			it('re-notifies OneSec on the first poll, then falls back to the read-only status lookup within the throttle window', async () => {
+				forwardEvmToIcpMock.mockResolvedValue({ status: { CheckingBalance: null } });
+				getForwardingStatusMock.mockResolvedValue({ status: { CheckingBalance: null } });
+				getTransfersMock.mockResolvedValue([]);
+
+				await pollOneSecActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [evmToIcpPendingTx]
+				});
+				await pollOneSecActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [evmToIcpPendingTx]
+				});
+
+				expect(forwardEvmToIcpMock).toHaveBeenCalledOnce();
+				expect(getForwardingStatusMock).toHaveBeenCalledOnce();
+			});
+
+			it('re-notifies OneSec again once the throttle interval has elapsed', async () => {
+				vi.useFakeTimers();
+
+				try {
+					forwardEvmToIcpMock.mockResolvedValue({ status: { CheckingBalance: null } });
+					getTransfersMock.mockResolvedValue([]);
+
+					await pollOneSecActiveUserTransactions({
+						identity: mockIdentity,
+						transactions: [evmToIcpPendingTx]
+					});
+
+					vi.setSystemTime(Date.now() + ONESEC_FORWARDING_NOTIFY_INTERVAL_MILLIS);
+
+					await pollOneSecActiveUserTransactions({
+						identity: mockIdentity,
+						transactions: [evmToIcpPendingTx]
+					});
+
+					expect(forwardEvmToIcpMock).toHaveBeenCalledTimes(2);
+					expect(getForwardingStatusMock).not.toHaveBeenCalled();
+				} finally {
+					vi.useRealTimers();
+				}
 			});
 		});
 	});


### PR DESCRIPTION
# Motivation

A user swapped USDC (Ethereum) to ckUSDC via the OneSec bridge: the USDC left their address as a plain transfer to their OneSec forwarding address, but the ckUSDC never arrived. OneSec only sweeps a forwarding address when `forward_evm_to_icp` is called, and that call runs in a detached in-browser closer. If the session dies between the EVM deposit and the notify step, nothing ever triggers the sweep: the cross-session poller only performed read-only lookups, so the deposit stays stranded while the row shows "processing" indefinitely. On top of that, an unexpected closer exception wrote a terminal `Failed` status, which removed the row from the pending poll set and permanently disabled recovery even though the funds were already committed on-chain.

# Changes

- The AUT poller now re-notifies OneSec (`forwardEvmToIcp`, idempotent) for pending EVM→ICP rows that lack a `TRANSFER_ID` ref, so stranded deposits self-heal in any later session. Notifies are throttled to once per minute per row (new `ONESEC_FORWARDING_NOTIFY_INTERVAL_MILLIS`), with the read-only `getForwardingStatus` lookup in between, since the poller ticks every 5s and notifying is an update call.
- `finishOneSecBridgingInSession` no longer writes terminal `Failed` on unexpected throws (network blip, canister unreachable): the outcome is unknown and the funds are committed, so the row stays pending and the poller resumes tracking. SDK-reported `failed`/`refunded` step states still land as `Failed`.
- The throttle map entry is cleared once the transfer id is adopted; `resetOneSecForwardingNotifyThrottle` is exposed for test isolation.

# Tests

- Extended `onesec-swap.services.spec.ts` (64 tests passing): first poll re-notifies, falls back to the read-only lookup within the throttle window, re-notifies after the interval elapses, and a thrown closer step leaves the row pending instead of writing `Failed`.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, and the full frontend suite (16,490 tests) pass locally.
