### PR TITLE
feat(backend): rate-limit the personal-notes vetKey endpoints

### DIFF
--- a/src/backend/src/api/personal_notes.rs
+++ b/src/backend/src/api/personal_notes.rs
@@ -12,7 +12,11 @@ use crate::{
     personal_notes::service,
     utils::{
         guards::{caller_is_not_anonymous, caller_is_registered_user},
-        rate_limiter::{self, DELETE_PERSONAL_NOTE_RATE_LIMITER, SET_PERSONAL_NOTE_RATE_LIMITER},
+        rate_limiter::{
+            self, VetKeyRateLimiters, DELETE_PERSONAL_NOTE_RATE_LIMITER,
+            GET_PERSONAL_NOTES_ENCRYPTED_VETKEY_RATE_LIMITER,
+            GET_PERSONAL_NOTES_VETKEY_PUBLIC_KEY_RATE_LIMITER, SET_PERSONAL_NOTE_RATE_LIMITER,
+        },
     },
 };
 
@@ -78,6 +82,11 @@ pub fn get_personal_notes_count() -> GetPersonalNotesCountResult {
 pub async fn get_personal_notes_encrypted_vetkey(
     transport_key: ByteBuf,
 ) -> PersonalNotesVetkeyResult {
+    if let Err(e) =
+        GET_PERSONAL_NOTES_ENCRYPTED_VETKEY_RATE_LIMITER.with(VetKeyRateLimiters::check_caller)
+    {
+        return PersonalNotesVetkeyResult::Err(PersonalNoteError::RateLimited(e));
+    }
     service::get_encrypted_vetkey(transport_key).await.into()
 }
 
@@ -91,5 +100,10 @@ pub async fn get_personal_notes_encrypted_vetkey(
 /// Errors are enumerated by `PersonalNoteError`.
 #[update(guard = "caller_is_registered_user")]
 pub async fn get_personal_notes_vetkey_public_key() -> PersonalNotesVetkeyResult {
+    if let Err(e) =
+        GET_PERSONAL_NOTES_VETKEY_PUBLIC_KEY_RATE_LIMITER.with(VetKeyRateLimiters::check_caller)
+    {
+        return PersonalNotesVetkeyResult::Err(PersonalNoteError::RateLimited(e));
+    }
     service::get_vetkey_public_key().await.into()
 }

--- a/src/backend/src/utils/rate_limiter.rs
+++ b/src/backend/src/utils/rate_limiter.rs
@@ -217,9 +217,21 @@ impl VetKeyRateLimiters {
     pub fn check_at(&self, caller: Principal, now_ns: u64) -> Result<(), RateLimitError> {
         self.caller_minute.check_at(caller, now_ns)?;
         self.caller_hour.check_at(caller, now_ns)?;
+        // The global tiers bucket every caller under a fixed key; remap the
+        // error's `caller` to the real caller so a global-tier rejection is not
+        // reported as anonymous.
         self.global_minute
-            .check_at(Principal::anonymous(), now_ns)?;
-        self.global_hour.check_at(Principal::anonymous(), now_ns)?;
+            .check_at(Principal::anonymous(), now_ns)
+            .map_err(|mut e| {
+                e.caller = caller;
+                e
+            })?;
+        self.global_hour
+            .check_at(Principal::anonymous(), now_ns)
+            .map_err(|mut e| {
+                e.caller = caller;
+                e
+            })?;
         Ok(())
     }
 }
@@ -522,6 +534,9 @@ mod tests {
         let err = rl.check_at(test_principal(21), ONE_SEC).unwrap_err();
         assert_eq!(err.max_calls, 20);
         assert_eq!(err.window_ns, 60 * ONE_SEC);
+        // The global tier buckets under `Principal::anonymous()` internally, but
+        // the error must report the real caller, not the bucket key.
+        assert_eq!(err.caller, test_principal(21));
     }
 
     #[test]

--- a/src/backend/src/utils/rate_limiter.rs
+++ b/src/backend/src/utils/rate_limiter.rs
@@ -172,19 +172,62 @@ impl RateLimiter {
         caller_calls.push_back(now_ns);
         Ok(())
     }
+
+    /// Checks the limit for `caller` at `now_ns` **without recording** the call
+    /// and without creating a `HashMap` entry for a previously-unseen caller.
+    /// Lets a caller peek a tier before any tier records, so a rejected call
+    /// leaves no state behind.
+    pub fn check_only(&self, caller: Principal, now_ns: u64) -> Result<(), RateLimitError> {
+        let calls = self.calls.borrow();
+        let window_start = now_ns.saturating_sub(self.window_ns);
+        let in_window = calls.get(&caller).map_or(0, |caller_calls| {
+            caller_calls
+                .iter()
+                .filter(|&&timestamp| timestamp > window_start)
+                .count()
+        });
+
+        if in_window >= self.max_calls as usize {
+            return Err(RateLimitError {
+                max_calls: self.max_calls,
+                window_ns: self.window_ns,
+                caller,
+            });
+        }
+        Ok(())
+    }
+
+    /// Records a call for `caller` at `now_ns`, pruning timestamps that have
+    /// aged out of the window. Does not enforce the limit — call only after
+    /// [`Self::check_only`] has confirmed the tier is within limits.
+    pub fn record(&self, caller: Principal, now_ns: u64) {
+        let mut calls = self.calls.borrow_mut();
+        let caller_calls = calls.entry(caller).or_default();
+
+        let window_start = now_ns.saturating_sub(self.window_ns);
+        while let Some(&front) = caller_calls.front() {
+            if front <= window_start {
+                caller_calls.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        caller_calls.push_back(now_ns);
+    }
 }
 
 /// Two-tier rate limiter for a vetKey endpoint: a per-caller limit plus a
 /// shared global limit, each over a short (per-minute) and a long (per-hour)
 /// window, backed by four [`RateLimiter`]s.
 ///
-/// The per-caller tiers are checked **before** the global tiers, so a call
-/// rejected by the caller's own limit never increments the global counters — a
-/// single caller cannot exhaust the global budget and deny the endpoint to
-/// everyone else. The global tiers bucket every caller under one fixed key
-/// (`Principal::anonymous`, never a real registered caller on these endpoints),
-/// capping aggregate load against a many-principals flood the per-caller tiers
-/// cannot see.
+/// Every tier is peeked before any tier records (see [`Self::check_at`]), so a
+/// rejected call leaves no state: a per-caller rejection never touches the
+/// global counters, and a call the global tier rejects never creates a
+/// per-caller `HashMap` entry. The global tiers bucket every caller under one
+/// fixed key (`Principal::anonymous`, never a real registered caller on these
+/// endpoints), capping aggregate load against a many-principals flood the
+/// per-caller tiers cannot see.
 pub(crate) struct VetKeyRateLimiters {
     caller_minute: RateLimiter,
     caller_hour: RateLimiter,
@@ -211,27 +254,38 @@ impl VetKeyRateLimiters {
         self.check_at(msg_caller(), ic_cdk::api::time())
     }
 
-    /// Checks every tier for `caller` at `now_ns` — per-caller tiers first, then
-    /// the global tiers — returning on the first tier that rejects. Exposed for
-    /// testability (inject the caller and timestamp).
+    /// Checks every tier for `caller` at `now_ns`. All tiers are peeked with
+    /// [`RateLimiter::check_only`] first and only recorded once every tier
+    /// passes, so a rejected call records nothing — no per-caller entry is
+    /// created for a call the global tier rejects, and a per-caller rejection
+    /// never touches the global counters. Exposed for testability (inject the
+    /// caller and timestamp).
     pub fn check_at(&self, caller: Principal, now_ns: u64) -> Result<(), RateLimitError> {
-        self.caller_minute.check_at(caller, now_ns)?;
-        self.caller_hour.check_at(caller, now_ns)?;
-        // The global tiers bucket every caller under a fixed key; remap the
-        // error's `caller` to the real caller so a global-tier rejection is not
-        // reported as anonymous.
+        let global_bucket = Principal::anonymous();
+
+        // Peek every tier without recording. The global tiers bucket under a
+        // fixed key, so remap a global rejection's `caller` back to the real
+        // caller (otherwise it reports as anonymous).
+        self.caller_minute.check_only(caller, now_ns)?;
+        self.caller_hour.check_only(caller, now_ns)?;
         self.global_minute
-            .check_at(Principal::anonymous(), now_ns)
+            .check_only(global_bucket, now_ns)
             .map_err(|mut e| {
                 e.caller = caller;
                 e
             })?;
         self.global_hour
-            .check_at(Principal::anonymous(), now_ns)
+            .check_only(global_bucket, now_ns)
             .map_err(|mut e| {
                 e.caller = caller;
                 e
             })?;
+
+        // Every tier is within limits — record the call.
+        self.caller_minute.record(caller, now_ns);
+        self.caller_hour.record(caller, now_ns);
+        self.global_minute.record(global_bucket, now_ns);
+        self.global_hour.record(global_bucket, now_ns);
         Ok(())
     }
 }
@@ -562,5 +616,53 @@ mod tests {
         // Global is now at 20 → the next distinct caller trips the global tier.
         let err = rl.check_at(test_principal(20), ONE_SEC).unwrap_err();
         assert_eq!(err.max_calls, 20);
+    }
+
+    #[test]
+    fn check_only_does_not_record() {
+        let rl = RateLimiter::new(1, 10 * ONE_SEC);
+        let caller = test_principal(1);
+
+        // Repeated peeks never trip the limit — nothing is recorded.
+        assert!(rl.check_only(caller, ONE_SEC).is_ok());
+        assert!(rl.check_only(caller, ONE_SEC).is_ok());
+        assert!(rl.check_only(caller, ONE_SEC).is_ok());
+    }
+
+    #[test]
+    fn record_then_check_only_reflects_the_recorded_call() {
+        let rl = RateLimiter::new(1, 10 * ONE_SEC);
+        let caller = test_principal(1);
+
+        rl.record(caller, ONE_SEC);
+
+        let err = rl.check_only(caller, 2 * ONE_SEC).unwrap_err();
+        assert_eq!(err.max_calls, 1);
+        assert_eq!(err.caller, caller);
+    }
+
+    #[test]
+    fn vetkey_global_rejection_does_not_consume_caller_budget() {
+        let rl = VetKeyRateLimiters::new();
+
+        // Saturate the global minute tier with 20 distinct callers.
+        for id in 1..=20u8 {
+            assert!(
+                rl.check_at(test_principal(id), ONE_SEC).is_ok(),
+                "caller {id}"
+            );
+        }
+
+        // A fresh caller is rejected by the global tier — and records nothing.
+        let caller = test_principal(21);
+        assert!(rl.check_at(caller, ONE_SEC).is_err());
+
+        // A minute later the global window has slid; the caller still has its
+        // full per-minute budget (the rejected attempt consumed nothing).
+        let later = 61 * ONE_SEC;
+        assert!(rl.check_at(caller, later).is_ok());
+        assert!(rl.check_at(caller, later).is_ok());
+        let err = rl.check_at(caller, later).unwrap_err();
+        assert_eq!(err.max_calls, 2);
     }
 }

--- a/src/backend/src/utils/rate_limiter.rs
+++ b/src/backend/src/utils/rate_limiter.rs
@@ -225,7 +225,7 @@ impl RateLimiter {
 /// rejected call leaves no state: a per-caller rejection never touches the
 /// global counters, and a call the global tier rejects never creates a
 /// per-caller `HashMap` entry. The global tiers bucket every caller under one
-/// fixed key (`Principal::anonymous`, never a real registered caller on these
+/// fixed key (`Principal::anonymous()`, never a real registered caller on these
 /// endpoints), capping aggregate load against a many-principals flood the
 /// per-caller tiers cannot see.
 pub(crate) struct VetKeyRateLimiters {

--- a/src/backend/src/utils/rate_limiter.rs
+++ b/src/backend/src/utils/rate_limiter.rs
@@ -72,6 +72,18 @@ thread_local! {
     /// token-guessing search space.
     pub(crate) static CONSUME_PERSONAL_NOTE_SHARE_ANONYMOUS_RATE_LIMITER: RateLimiter =
         RateLimiter::new(600, 60 * 1_000_000_000);
+
+    /// Rate-limits `get_personal_notes_encrypted_vetkey` — the paid vetKD
+    /// derivation. Per-caller (2/min, 10/hour) is checked before a shared
+    /// global (20/min, 100/hour). See [`VetKeyRateLimiters`].
+    pub(crate) static GET_PERSONAL_NOTES_ENCRYPTED_VETKEY_RATE_LIMITER: VetKeyRateLimiters =
+        VetKeyRateLimiters::new();
+
+    /// Rate-limits `get_personal_notes_vetkey_public_key`, with the same tiers
+    /// as the encrypted endpoint but its own independent counters. See
+    /// [`VetKeyRateLimiters`].
+    pub(crate) static GET_PERSONAL_NOTES_VETKEY_PUBLIC_KEY_RATE_LIMITER: VetKeyRateLimiters =
+        VetKeyRateLimiters::new();
 }
 
 /// Per-caller sliding-window rate limiter for IC canister methods.
@@ -162,6 +174,62 @@ impl RateLimiter {
     }
 }
 
+/// Two-tier rate limiter for a vetKey endpoint: a per-caller limit plus a
+/// shared global limit, each over a short (per-minute) and a long (per-hour)
+/// window, backed by four [`RateLimiter`]s.
+///
+/// The per-caller tiers are checked **before** the global tiers, so a call
+/// rejected by the caller's own limit never increments the global counters — a
+/// single caller cannot exhaust the global budget and deny the endpoint to
+/// everyone else. The global tiers bucket every caller under one fixed key
+/// (`Principal::anonymous`, never a real registered caller on these endpoints),
+/// capping aggregate load against a many-principals flood the per-caller tiers
+/// cannot see.
+pub(crate) struct VetKeyRateLimiters {
+    caller_minute: RateLimiter,
+    caller_hour: RateLimiter,
+    global_minute: RateLimiter,
+    global_hour: RateLimiter,
+}
+
+impl VetKeyRateLimiters {
+    const HOUR_NS: u64 = 60 * 60 * 1_000_000_000;
+    const MINUTE_NS: u64 = 60 * 1_000_000_000;
+
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            caller_minute: RateLimiter::new(2, Self::MINUTE_NS),
+            caller_hour: RateLimiter::new(10, Self::HOUR_NS),
+            global_minute: RateLimiter::new(20, Self::MINUTE_NS),
+            global_hour: RateLimiter::new(100, Self::HOUR_NS),
+        }
+    }
+
+    /// Checks every tier for the current IC caller at the current IC time.
+    pub fn check_caller(&self) -> Result<(), RateLimitError> {
+        self.check_at(msg_caller(), ic_cdk::api::time())
+    }
+
+    /// Checks every tier for `caller` at `now_ns` — per-caller tiers first, then
+    /// the global tiers — returning on the first tier that rejects. Exposed for
+    /// testability (inject the caller and timestamp).
+    pub fn check_at(&self, caller: Principal, now_ns: u64) -> Result<(), RateLimitError> {
+        self.caller_minute.check_at(caller, now_ns)?;
+        self.caller_hour.check_at(caller, now_ns)?;
+        self.global_minute
+            .check_at(Principal::anonymous(), now_ns)?;
+        self.global_hour.check_at(Principal::anonymous(), now_ns)?;
+        Ok(())
+    }
+}
+
+impl Default for VetKeyRateLimiters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use candid::Principal;
@@ -171,7 +239,7 @@ mod tests {
         signer::{topup::TopUpCyclesLedgerError, AllowSigningError, GetAllowedCyclesError},
     };
 
-    use super::RateLimiter;
+    use super::{RateLimiter, VetKeyRateLimiters};
 
     fn test_principal(id: u8) -> Principal {
         Principal::from_slice(&[id])
@@ -405,5 +473,79 @@ mod tests {
         assert_eq!(e.max_calls, 1);
         assert_eq!(e.window_ns, 60 * ONE_SEC);
         assert_eq!(e.caller, caller);
+    }
+
+    #[test]
+    fn vetkey_per_caller_minute_limit() {
+        let rl = VetKeyRateLimiters::new();
+        let caller = test_principal(1);
+
+        assert!(rl.check_at(caller, ONE_SEC).is_ok());
+        assert!(rl.check_at(caller, 2 * ONE_SEC).is_ok());
+
+        let err = rl.check_at(caller, 3 * ONE_SEC).unwrap_err();
+        assert_eq!(err.max_calls, 2);
+        assert_eq!(err.window_ns, 60 * ONE_SEC);
+    }
+
+    #[test]
+    fn vetkey_per_caller_hour_limit() {
+        let rl = VetKeyRateLimiters::new();
+        let caller = test_principal(1);
+
+        // 61s apart so the per-minute tier (2/min) never trips; the per-hour
+        // tier (10/hour) then rejects the 11th call.
+        for i in 0..10u64 {
+            let t = ONE_SEC + i * 61 * ONE_SEC;
+            assert!(rl.check_at(caller, t).is_ok(), "call {i} should pass");
+        }
+
+        let err = rl
+            .check_at(caller, ONE_SEC + 10 * 61 * ONE_SEC)
+            .unwrap_err();
+        assert_eq!(err.max_calls, 10);
+        assert_eq!(err.window_ns, 60 * 60 * ONE_SEC);
+    }
+
+    #[test]
+    fn vetkey_global_minute_limit_across_callers() {
+        let rl = VetKeyRateLimiters::new();
+
+        // 20 distinct callers, one call each — the global per-minute cap is 20.
+        for id in 1..=20u8 {
+            assert!(
+                rl.check_at(test_principal(id), ONE_SEC).is_ok(),
+                "caller {id}"
+            );
+        }
+
+        let err = rl.check_at(test_principal(21), ONE_SEC).unwrap_err();
+        assert_eq!(err.max_calls, 20);
+        assert_eq!(err.window_ns, 60 * ONE_SEC);
+    }
+
+    #[test]
+    fn vetkey_per_caller_rejection_does_not_consume_global() {
+        let rl = VetKeyRateLimiters::new();
+        let heavy = test_principal(1);
+
+        // Heavy caller: 2 pass (2 global slots used); the 3rd is rejected by the
+        // per-caller minute tier and must NOT touch the global counter.
+        assert!(rl.check_at(heavy, ONE_SEC).is_ok());
+        assert!(rl.check_at(heavy, ONE_SEC).is_ok());
+        assert!(rl.check_at(heavy, ONE_SEC).is_err());
+
+        // 18 more distinct callers must still fit (global left = 20 - 2 = 18); if
+        // the rejected 3rd call had consumed a global slot, only 17 would fit.
+        for id in 2..=19u8 {
+            assert!(
+                rl.check_at(test_principal(id), ONE_SEC).is_ok(),
+                "caller {id}"
+            );
+        }
+
+        // Global is now at 20 → the next distinct caller trips the global tier.
+        let err = rl.check_at(test_principal(20), ONE_SEC).unwrap_err();
+        assert_eq!(err.max_calls, 20);
     }
 }


### PR DESCRIPTION
# Motivation

The personal-notes vetKey endpoints (`get_personal_notes_encrypted_vetkey`, `get_personal_notes_vetkey_public_key`) were the only personal-notes update endpoints without rate limiting. This brings them in line with the other guarded backend endpoints (`set_personal_note`, `delete_personal_note`, `allow_signing`, …).

Part of OISY-3076.

# Changes

- Add `VetKeyRateLimiters` in `utils/rate_limiter.rs`: a per-caller tier (2/min, 10/hour) plus a shared-global tier (20/min, 100/hour), each backed by the existing `RateLimiter`. All four tiers are peeked (via a new non-recording `RateLimiter::check_only`) before any is recorded, so a rejected call records nothing — a per-caller rejection never touches the global counters, and a globally-rejected call creates no per-caller `HashMap` entry.
- Guard both vetKey endpoints in `api/personal_notes.rs`, returning `PersonalNoteError::RateLimited` on trip (no `.did` change — the variant already exists).
- On a global-tier trip, remap the `RateLimitError`'s `caller` back to the real caller (the global tiers bucket internally under a fixed key) — from Copilot review.

# Tests

- New unit tests in `rate_limiter.rs`: per-caller minute and hour limits, the global minute limit across callers (and that a global-tier error reports the real caller), that a per-caller rejection does not consume the global budget, that `check_only` is non-recording, and that a global rejection consumes no per-caller budget.
- `cargo test -p backend --lib rate_limiter` — 21 passed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (`claude-opus-4-8`)
