### PR TITLE
fix(frontend): price ERC20 ICP tokens at the native ICP rate on every chain

### DIFF
--- a/src/frontend/src/lib/derived/exchange.derived.ts
+++ b/src/frontend/src/lib/derived/exchange.derived.ts
@@ -1,4 +1,5 @@
 import { EXCHANGE_DISABLED } from '$env/exchange.env';
+import { ICP_TOKEN_GROUP_ID } from '$env/tokens/groups/groups.icp.env';
 import {
 	ARBITRUM_ETH_TOKEN_ID,
 	ARBITRUM_SEPOLIA_ETH_TOKEN_ID
@@ -30,7 +31,6 @@ import {
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import type { Erc20Token } from '$eth/types/erc20';
-import { isErc20Icp } from '$eth/utils/token.utils';
 import type { IcCkToken } from '$icp/types/ic-token';
 import { allIcrcTokens } from '$lib/derived/all-tokens.derived';
 import { exchangeStore } from '$lib/stores/exchange.store';
@@ -94,13 +94,20 @@ export const exchanges: Readable<ExchangesData> = derivedMemo(
 					...tokens.reduce((inner, token) => ({ ...inner, [token.id]: currentPrice }), {})
 				};
 			}, {}),
-			...$erc20Tokens.filter(isErc20Icp).reduce(
-				(acc, { id }) => ({
-					...acc,
-					[id]: icpPrice
-				}),
-				{}
-			),
+			// ERC20 representations of ICP are the same asset bridged onto EVM chains, grouped
+			// under the ICP token group. They are priced at the native ICP rate rather than
+			// per-contract: the token shares one contract address across Ethereum/Base/Arbitrum
+			// (so an address-keyed price would collide), and not every chain is listed on the
+			// price provider (e.g. Arbitrum). Pegging to ICP is chain- and provider-independent.
+			...$erc20Tokens
+				.filter(({ groupData }) => groupData?.id === ICP_TOKEN_GROUP_ID)
+				.reduce(
+					(acc, { id }) => ({
+						...acc,
+						[id]: icpPrice
+					}),
+					{}
+				),
 			...$icrcTokens.reduce((acc, token) => {
 				const { id, ledgerCanisterId, exchangeCoinId } = token;
 

--- a/src/frontend/src/lib/derived/exchange.derived.ts
+++ b/src/frontend/src/lib/derived/exchange.derived.ts
@@ -31,6 +31,7 @@ import {
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import type { Erc20Token } from '$eth/types/erc20';
+import { isErc20Icp } from '$eth/utils/token.utils';
 import type { IcCkToken } from '$icp/types/ic-token';
 import { allIcrcTokens } from '$lib/derived/all-tokens.derived';
 import { exchangeStore } from '$lib/stores/exchange.store';
@@ -99,8 +100,10 @@ export const exchanges: Readable<ExchangesData> = derivedMemo(
 			// per-contract: the token shares one contract address across Ethereum/Base/Arbitrum
 			// (so an address-keyed price would collide), and not every chain is listed on the
 			// price provider (e.g. Arbitrum). Pegging to ICP is chain- and provider-independent.
+			// `isErc20Icp` additionally covers the legacy wrapped-ICP token on Ethereum, which
+			// predates the token group and may still exist in a user's custom-token list.
 			...$erc20Tokens
-				.filter(({ groupData }) => groupData?.id === ICP_TOKEN_GROUP_ID)
+				.filter((token) => isErc20Icp(token) || token.groupData?.id === ICP_TOKEN_GROUP_ID)
 				.reduce(
 					(acc, { id }) => ({
 						...acc,

--- a/src/frontend/src/tests/lib/derived/exchange.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/exchange.derived.spec.ts
@@ -1,5 +1,8 @@
 import * as exchangeEnv from '$env/exchange.env';
+import { ARBITRUM_MAINNET_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { ICP_TOKEN_GROUP } from '$env/tokens/groups/groups.icp.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import {
 	ARBITRUM_ETH_TOKEN_ID,
@@ -33,7 +36,6 @@ import {
 	SOLANA_LOCAL_TOKEN_ID,
 	SOLANA_TOKEN_ID
 } from '$env/tokens/tokens.sol.env';
-import { ERC20_ICP_ADDRESS, ERC20_ICP_SYMBOL } from '$eth/constants/erc20-icp.constants';
 import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc4626CustomTokensStore } from '$eth/stores/erc4626-custom-tokens.store';
@@ -405,33 +407,45 @@ describe('exchange.derived', () => {
 			expect(result?.[mockValidErc4626Token.id]).toEqual(mockErc4626TokenPrice);
 		});
 
-		it('should return values for ERC20 token ICP', () => {
+		it('should price ERC20 ICP tokens at the native ICP rate on every chain, independently of a per-contract price', () => {
+			// The ERC20 ICP token shares one contract address across Ethereum, Base and
+			// Arbitrum and is grouped under the ICP token group. It must resolve to the native
+			// ICP price even though no price is set under its contract address in the store
+			// (mirroring chains the price provider does not list, e.g. Arbitrum).
+			const sharedAddress = '0x00f3C42833C3170159af4E92dbb451Fb3F708917';
+
+			const icpErc20Ethereum: Erc20Token = {
+				...mockValidErc20Token,
+				id: parseTokenId('Erc20IcpEthereumId'),
+				symbol: 'ICP',
+				address: sharedAddress,
+				network: ETHEREUM_NETWORK,
+				groupData: ICP_TOKEN_GROUP
+			};
+			const icpErc20Base: Erc20Token = {
+				...icpErc20Ethereum,
+				id: parseTokenId('Erc20IcpBaseId'),
+				network: BASE_NETWORK
+			};
+			const icpErc20Arbitrum: Erc20Token = {
+				...icpErc20Ethereum,
+				id: parseTokenId('Erc20IcpArbitrumId'),
+				network: ARBITRUM_MAINNET_NETWORK
+			};
+
 			erc20CustomTokensStore.setAll([
-				{
-					data: {
-						...mockErc20DefaultToken,
-						symbol: ERC20_ICP_SYMBOL,
-						address: ERC20_ICP_ADDRESS,
-						network: ETHEREUM_NETWORK,
-						enabled: true
-					},
-					certified: false
-				}
+				{ data: { ...icpErc20Ethereum, enabled: true }, certified: false },
+				{ data: { ...icpErc20Base, enabled: true }, certified: false },
+				{ data: { ...icpErc20Arbitrum, enabled: true }, certified: false }
 			]);
 
-			exchangeStore.set([
-				{ ethereum: ethPrice },
-				{ bitcoin: btcPrice },
-				{ 'internet-computer': icpPrice },
-				{ solana: solPrice },
-				{ binancecoin: bnbPrice },
-				{ 'polygon-ecosystem-token': polPrice }
-			]);
+			exchangeStore.set([{ 'internet-computer': icpPrice }]);
 
-			expect(get(exchanges)).toStrictEqual({
-				...expectedExchanges,
-				[mockErc20DefaultToken.id]: icpPrice
-			});
+			const result = get(exchanges);
+
+			expect(result?.[icpErc20Ethereum.id]).toEqual(icpPrice);
+			expect(result?.[icpErc20Base.id]).toEqual(icpPrice);
+			expect(result?.[icpErc20Arbitrum.id]).toEqual(icpPrice);
 		});
 
 		it('should return values for ICRC tokens', () => {

--- a/src/frontend/src/tests/lib/derived/exchange.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/exchange.derived.spec.ts
@@ -36,6 +36,7 @@ import {
 	SOLANA_LOCAL_TOKEN_ID,
 	SOLANA_TOKEN_ID
 } from '$env/tokens/tokens.sol.env';
+import { ERC20_ICP_ADDRESS, ERC20_ICP_SYMBOL } from '$eth/constants/erc20-icp.constants';
 import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import { erc4626CustomTokensStore } from '$eth/stores/erc4626-custom-tokens.store';
@@ -446,6 +447,29 @@ describe('exchange.derived', () => {
 			expect(result?.[icpErc20Ethereum.id]).toEqual(icpPrice);
 			expect(result?.[icpErc20Base.id]).toEqual(icpPrice);
 			expect(result?.[icpErc20Arbitrum.id]).toEqual(icpPrice);
+		});
+
+		it('should price the legacy wrapped-ICP custom token on Ethereum at the native ICP rate', () => {
+			// The legacy wrapped-ICP token was removed from the curated list, so a surviving
+			// copy in a user's custom-token list carries no ICP group data. It is still pegged
+			// to the native ICP price by `isErc20Icp` (symbol + address + Ethereum network).
+			erc20CustomTokensStore.setAll([
+				{
+					data: {
+						...mockErc20DefaultToken,
+						symbol: ERC20_ICP_SYMBOL,
+						address: ERC20_ICP_ADDRESS,
+						network: ETHEREUM_NETWORK,
+						groupData: undefined,
+						enabled: true
+					},
+					certified: false
+				}
+			]);
+
+			exchangeStore.set([{ 'internet-computer': icpPrice }]);
+
+			expect(get(exchanges)?.[mockErc20DefaultToken.id]).toEqual(icpPrice);
 		});
 
 		it('should return values for ICRC tokens', () => {


### PR DESCRIPTION
# Motivation

With backend price loading enabled (staging), the ERC20 ICP tokens on Ethereum, Base and Arbitrum stopped showing a price, while all other prices were fine.

Root cause: the `exchanges` derived store pegs ERC20 ICP to the native ICP price via `isErc20Icp`, which matches the **legacy** wrapped-ICP contract on Ethereum (`0x054B8f…`). That token was removed as a curated token (#11449), and the current ERC20 ICP tokens (`0x00f3C4…`, added on Ethereum/Base/Arbitrum in #12495 and siblings) do not match it — so the peg silently became a no-op.

The tokens then fell back to address-keyed pricing, which is fine in the pure-frontend path (CoinGecko is queried per contract for every enabled token) but breaks once the backend serves prices:

- The backend only prices the caller's **registered custom tokens** plus the always-on natives. Default tokens a user has never explicitly toggled — like these ERC20 ICP tokens — are never priced.
- The three ERC20 ICP tokens share a **single contract address** across the three chains, so an address-keyed price collides; whichever chain the backend can price "wins" for all three.
- The price provider does not list every chain for that contract (e.g. Arbitrum returns no data), so even a registered chain may yield nothing.

Net effect: no price for the ERC20 ICP tokens until a user happens to register a chain the provider does list (e.g. Base), which then bleeds onto all three via the address collision.

# Changes

- `exchange.derived.ts`: peg ERC20 ICP tokens to the native ICP rate by **ICP token-group membership** (`groupData?.id === ICP_TOKEN_GROUP_ID`). Every current ERC20 ICP token now resolves to the native ICP price regardless of chain, provider coverage, or the shared-address collision, and the peg stays correct if the contract address changes again.
- Keep `isErc20Icp` in the same filter so the **legacy** wrapped-ICP token on Ethereum (`0x054B8f…`, no token group) still gets the ICP price for any user who still holds it as a custom token.

# Tests

- Rewrote the "ERC20 token ICP" derived-store test to cover all three chains (Ethereum, Base, Arbitrum) sharing one contract address, asserting each resolves to the native ICP price **with no per-contract price present in the store** — mirroring chains the provider does not list (e.g. Arbitrum).
- Added a test for the legacy wrapped-ICP custom token on Ethereum (no ICP group data) still pegging to the native ICP price via `isErc20Icp`.
- `npm run check`, `npm run check:tests`, `npm run lint`, and the `exchange.derived` spec (27 tests) pass locally.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8