### PR TITLE
feat(frontend): sort Liquidium markets by pool, native rail, then network

### DIFF
--- a/src/frontend/src/lib/constants/liquidium.constants.ts
+++ b/src/frontend/src/lib/constants/liquidium.constants.ts
@@ -27,6 +27,15 @@ export const LIQUIDIUM_ADVERTISED_TOKENS: Token[] = [
 	ICP_TOKEN
 ];
 
+// Display order for the Markets list, applied as a stable sort on top of the order Liquidium
+// returns (see `orderLiquidiumMarkets`). Primary key: the lending pool, by asset symbol. Assets
+// not listed keep their received order, after the listed ones.
+export const LIQUIDIUM_POOL_ORDER: string[] = ['BTC', 'ETH', 'ICP', 'USDC', 'USDT'];
+
+// Transfer-network order, the final tiebreaker after "native rail first" — so extra networks
+// slot in predictably if the protocol adds them.
+export const LIQUIDIUM_NETWORK_ORDER: string[] = ['BTC', 'ETH', 'ICP'];
+
 // ck-ledger backing each asset, for the AUT's backend `TokenId`. Keyed by symbol: the
 // ck twin is the same regardless of transfer chain (native BTC and ckBTC both settle on
 // the ckBTC ledger); ICP maps to its own ledger.

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -15,7 +15,8 @@ import {
 	liquidiumMaxSupplyApy as computeMaxSupplyApy,
 	liquidiumMinBorrowApy as computeMinBorrowApy,
 	liquidiumBorrowingPowerPotentialUsd,
-	liquidiumNetInterestUsd
+	liquidiumNetInterestUsd,
+	orderLiquidiumMarkets
 } from '$lib/utils/liquidium.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { AssetPrices } from '@liquidium/client';
@@ -23,7 +24,7 @@ import { derived, type Readable } from 'svelte/store';
 
 export const liquidiumMarkets: Readable<LiquidiumMarket[]> = derived(
 	liquidiumStore,
-	({ markets }) => markets
+	({ markets }) => orderLiquidiumMarkets(markets)
 );
 
 export const liquidiumPortfolio: Readable<LiquidiumPortfolio | null> = derived(

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -271,6 +271,26 @@ export const mapLiquidiumMarketRails = (pool: Pool): LiquidiumMarket[] => {
 	return liquidiumSupportedRails(pool.asset).map((chain) => ({ ...base, chain }));
 };
 
+const isCkBtcMarket = ({ chain, asset }: LiquidiumMarket): boolean =>
+	chain === 'ICP' && asset === 'BTC';
+const isNativeIcpMarket = ({ chain, asset }: LiquidiumMarket): boolean =>
+	chain === 'ICP' && asset === 'ICP';
+
+// Groups the native ICP market right after ckBTC (the ICP rail of the BTC pool). The SDK
+// otherwise returns the ICP pool last and nothing re-orders it. Stable: only the ICP market
+// moves, every other market keeps its relative order; no-op if either ckBTC or ICP is absent.
+export const orderLiquidiumMarkets = (markets: LiquidiumMarket[]): LiquidiumMarket[] => {
+	const icpMarket = markets.find(isNativeIcpMarket);
+	const rest = markets.filter((market) => !isNativeIcpMarket(market));
+	const ckBtcIndex = rest.findIndex(isCkBtcMarket);
+
+	if (isNullish(icpMarket) || ckBtcIndex < 0) {
+		return markets;
+	}
+
+	return [...rest.slice(0, ckBtcIndex + 1), icpMarket, ...rest.slice(ckBtcIndex + 1)];
+};
+
 export const mapLiquidiumReserve = ({
 	position,
 	pool,

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -9,6 +9,8 @@ import {
 	LIQUIDIUM_ASSET_LEDGER_CANISTER_IDS,
 	LIQUIDIUM_HEALTH_AT_RISK_PERCENT,
 	LIQUIDIUM_HEALTH_CRITICAL_PERCENT,
+	LIQUIDIUM_NETWORK_ORDER,
+	LIQUIDIUM_POOL_ORDER,
 	type LiquidiumHealthLevel
 } from '$lib/constants/liquidium.constants';
 import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
@@ -271,24 +273,36 @@ export const mapLiquidiumMarketRails = (pool: Pool): LiquidiumMarket[] => {
 	return liquidiumSupportedRails(pool.asset).map((chain) => ({ ...base, chain }));
 };
 
-const isCkBtcMarket = ({ chain, asset }: LiquidiumMarket): boolean =>
-	chain === 'ICP' && asset === 'BTC';
-const isNativeIcpMarket = ({ chain, asset }: LiquidiumMarket): boolean =>
-	chain === 'ICP' && asset === 'ICP';
+// The ck (non-native) rail is the ICP-chain rail of a non-ICP asset; every other rail is native.
+const isNativeRail = ({ chain, asset }: LiquidiumMarket): boolean =>
+	chain !== 'ICP' || asset === 'ICP';
 
-// Groups the native ICP market right after ckBTC (the ICP rail of the BTC pool). The SDK
-// otherwise returns the ICP pool last and nothing re-orders it. Stable: only the ICP market
-// moves, every other market keeps its relative order; no-op if either ckBTC or ICP is absent.
+// Stable display order for the Markets list, layered on the order Liquidium returns:
+//  1. pool, by asset, per LIQUIDIUM_POOL_ORDER — unlisted assets keep their received order, last;
+//  2. native rail before the ck rail within a pool (BTC before ckBTC, USDC before ckUSDC);
+//  3. transfer-network order (LIQUIDIUM_NETWORK_ORDER) as the final tiebreaker.
+// Markets that tie on every key keep their received order (Array.sort is stable).
 export const orderLiquidiumMarkets = (markets: LiquidiumMarket[]): LiquidiumMarket[] => {
-	const icpMarket = markets.find(isNativeIcpMarket);
-	const rest = markets.filter((market) => !isNativeIcpMarket(market));
-	const ckBtcIndex = rest.findIndex(isCkBtcMarket);
+	// Unlisted assets rank after the listed ones, keeping their first-seen (received) order so
+	// each pool's rails stay grouped.
+	const receivedAssets = [...new Set(markets.map(({ asset }) => asset))];
 
-	if (isNullish(icpMarket) || ckBtcIndex < 0) {
-		return markets;
-	}
+	const poolRank = (asset: string): number => {
+		const known = LIQUIDIUM_POOL_ORDER.indexOf(asset);
+		return known >= 0 ? known : LIQUIDIUM_POOL_ORDER.length + receivedAssets.indexOf(asset);
+	};
 
-	return [...rest.slice(0, ckBtcIndex + 1), icpMarket, ...rest.slice(ckBtcIndex + 1)];
+	const networkRank = (chain: string): number => {
+		const known = LIQUIDIUM_NETWORK_ORDER.indexOf(chain);
+		return known >= 0 ? known : LIQUIDIUM_NETWORK_ORDER.length;
+	};
+
+	return [...markets].sort(
+		(a, b) =>
+			poolRank(a.asset) - poolRank(b.asset) ||
+			Number(isNativeRail(b)) - Number(isNativeRail(a)) ||
+			networkRank(a.chain) - networkRank(b.chain)
+	);
 };
 
 export const mapLiquidiumReserve = ({

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -212,6 +212,27 @@ describe('liquidium derived stores', () => {
 		it('is empty by default', () => {
 			expect(get(liquidiumMarkets)).toEqual([]);
 		});
+
+		it('orders the native ICP market right after ckBTC', () => {
+			// SDK returns the ICP pool last; the store keeps the raw order, the derived groups it.
+			liquidiumStore.set({
+				markets: [
+					market(),
+					market({ asset: 'BTC', chain: 'ICP' }),
+					market({ poolId: 'pool-eth', asset: 'ETH', chain: 'ETH' }),
+					market({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
+				],
+				portfolio: null,
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumMarkets).map(({ asset, chain }) => `${asset}-${chain}`)).toEqual([
+				'BTC-BTC',
+				'BTC-ICP',
+				'ICP-ICP',
+				'ETH-ETH'
+			]);
+		});
 	});
 
 	describe('liquidiumPortfolio', () => {

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -213,12 +213,15 @@ describe('liquidium derived stores', () => {
 			expect(get(liquidiumMarkets)).toEqual([]);
 		});
 
-		it('orders the native ICP market right after ckBTC', () => {
-			// SDK returns the ICP pool last; the store keeps the raw order, the derived groups it.
+		it('sorts markets by pool (native rail first), placing ICP after the ETH pool', () => {
+			// Store keeps the raw order; the derived applies the display sort. USDC seeded before
+			// ETH to prove the derived re-orders rather than passing the store through.
 			liquidiumStore.set({
 				markets: [
 					market(),
 					market({ asset: 'BTC', chain: 'ICP' }),
+					market({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' }),
+					market({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ICP' }),
 					market({ poolId: 'pool-eth', asset: 'ETH', chain: 'ETH' }),
 					market({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
 				],
@@ -229,8 +232,10 @@ describe('liquidium derived stores', () => {
 			expect(get(liquidiumMarkets).map(({ asset, chain }) => `${asset}-${chain}`)).toEqual([
 				'BTC-BTC',
 				'BTC-ICP',
+				'ETH-ETH',
 				'ICP-ICP',
-				'ETH-ETH'
+				'USDC-ETH',
+				'USDC-ICP'
 			]);
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -171,46 +171,60 @@ describe('liquidium.utils', () => {
 		const eth = buildMarket({ poolId: 'pool-eth', asset: 'ETH', chain: 'ETH' });
 		const usdc = buildMarket({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' });
 		const ckUsdc = buildMarket({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ICP' });
+		const usdt = buildMarket({ poolId: 'pool-usdt', asset: 'USDT', chain: 'ETH' });
+		const ckUsdt = buildMarket({ poolId: 'pool-usdt', asset: 'USDT', chain: 'ICP' });
 		const icp = buildMarket({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' });
 
 		const keys = (markets: LiquidiumMarket[]): string[] =>
 			markets.map(({ asset, chain }) => `${asset}-${chain}`);
 
-		it('moves the native ICP market to right after ckBTC, keeping the rest in order', () => {
-			// SDK order: ICP pool last.
-			const markets = [nativeBtc, ckBtc, eth, usdc, ckUsdc, icp];
+		it('sorts by pool then native rail first, placing ICP after the ETH pool', () => {
+			// Received in a scrambled pool order to prove the sort re-orders it.
+			const markets = [usdc, ckUsdc, ckBtc, nativeBtc, usdt, ckUsdt, icp, eth];
 
 			expect(keys(orderLiquidiumMarkets(markets))).toEqual([
 				'BTC-BTC',
 				'BTC-ICP',
-				'ICP-ICP',
 				'ETH-ETH',
-				'USDC-ETH',
-				'USDC-ICP'
-			]);
-		});
-
-		it('is a no-op when ICP already follows ckBTC', () => {
-			const markets = [nativeBtc, ckBtc, icp, eth];
-
-			expect(keys(orderLiquidiumMarkets(markets))).toEqual([
-				'BTC-BTC',
-				'BTC-ICP',
 				'ICP-ICP',
-				'ETH-ETH'
+				'USDC-ETH',
+				'USDC-ICP',
+				'USDT-ETH',
+				'USDT-ICP'
 			]);
 		});
 
-		it('leaves the list unchanged when ckBTC is absent', () => {
-			const markets = [eth, usdc, icp];
-
-			expect(orderLiquidiumMarkets(markets)).toEqual(markets);
+		it('puts the native rail before its ck rail within a pool', () => {
+			expect(keys(orderLiquidiumMarkets([ckBtc, nativeBtc]))).toEqual(['BTC-BTC', 'BTC-ICP']);
+			expect(keys(orderLiquidiumMarkets([ckUsdc, usdc]))).toEqual(['USDC-ETH', 'USDC-ICP']);
 		});
 
-		it('leaves the list unchanged when the native ICP market is absent', () => {
-			const markets = [nativeBtc, ckBtc, eth];
+		it('breaks ties between same-pool native rails by network order', () => {
+			// Two native rails (neither is the ICP ck rail) → decided by LIQUIDIUM_NETWORK_ORDER.
+			const btcOnEth = buildMarket({ chain: 'ETH' });
 
-			expect(orderLiquidiumMarkets(markets)).toEqual(markets);
+			expect(keys(orderLiquidiumMarkets([btcOnEth, nativeBtc]))).toEqual(['BTC-BTC', 'BTC-ETH']);
+		});
+
+		it('keeps assets outside the pool order last, in their received order and grouped', () => {
+			const fooEth = buildMarket({ poolId: 'pool-foo', asset: 'FOO', chain: 'ETH' });
+			const fooIcp = buildMarket({ poolId: 'pool-foo', asset: 'FOO', chain: 'ICP' });
+			const barEth = buildMarket({ poolId: 'pool-bar', asset: 'BAR', chain: 'ETH' });
+
+			expect(keys(orderLiquidiumMarkets([barEth, fooEth, nativeBtc, fooIcp, icp]))).toEqual([
+				'BTC-BTC',
+				'ICP-ICP',
+				'BAR-ETH',
+				'FOO-ETH',
+				'FOO-ICP'
+			]);
+		});
+
+		it('does not mutate the input array', () => {
+			const markets = [icp, nativeBtc];
+			orderLiquidiumMarkets(markets);
+
+			expect(keys(markets)).toEqual(['ICP-ICP', 'BTC-BTC']);
 		});
 
 		it('handles an empty list', () => {

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -3,7 +3,7 @@ import { USDT_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdt.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { ZERO } from '$lib/constants/app.constants';
-import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import {
 	liquidiumBorrowingPowerPotentialUsd,
 	liquidiumBorrowInterestUsd,
@@ -24,7 +24,8 @@ import {
 	mapLiquidiumMarket,
 	mapLiquidiumMarketRails,
 	mapLiquidiumPortfolio,
-	mapLiquidiumReserve
+	mapLiquidiumReserve,
+	orderLiquidiumMarkets
 } from '$lib/utils/liquidium.utils';
 import {
 	RATE_SCALE,
@@ -149,6 +150,71 @@ describe('liquidium.utils', () => {
 
 			expect(markets).toHaveLength(1);
 			expect(markets[0].chain).toBe('ICP');
+		});
+	});
+
+	describe('orderLiquidiumMarkets', () => {
+		const buildMarket = (overrides: Partial<LiquidiumMarket> = {}): LiquidiumMarket => ({
+			poolId: 'pool-btc',
+			asset: 'BTC',
+			chain: 'BTC',
+			supplyApy: 5,
+			borrowApy: 9,
+			frozen: false,
+			available: true,
+			...overrides
+		});
+
+		// Display token per market, keyed `${asset}-${chain}` (ckBTC = BTC-ICP, native ICP = ICP-ICP).
+		const nativeBtc = buildMarket();
+		const ckBtc = buildMarket({ chain: 'ICP' });
+		const eth = buildMarket({ poolId: 'pool-eth', asset: 'ETH', chain: 'ETH' });
+		const usdc = buildMarket({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' });
+		const ckUsdc = buildMarket({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ICP' });
+		const icp = buildMarket({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' });
+
+		const keys = (markets: LiquidiumMarket[]): string[] =>
+			markets.map(({ asset, chain }) => `${asset}-${chain}`);
+
+		it('moves the native ICP market to right after ckBTC, keeping the rest in order', () => {
+			// SDK order: ICP pool last.
+			const markets = [nativeBtc, ckBtc, eth, usdc, ckUsdc, icp];
+
+			expect(keys(orderLiquidiumMarkets(markets))).toEqual([
+				'BTC-BTC',
+				'BTC-ICP',
+				'ICP-ICP',
+				'ETH-ETH',
+				'USDC-ETH',
+				'USDC-ICP'
+			]);
+		});
+
+		it('is a no-op when ICP already follows ckBTC', () => {
+			const markets = [nativeBtc, ckBtc, icp, eth];
+
+			expect(keys(orderLiquidiumMarkets(markets))).toEqual([
+				'BTC-BTC',
+				'BTC-ICP',
+				'ICP-ICP',
+				'ETH-ETH'
+			]);
+		});
+
+		it('leaves the list unchanged when ckBTC is absent', () => {
+			const markets = [eth, usdc, icp];
+
+			expect(orderLiquidiumMarkets(markets)).toEqual(markets);
+		});
+
+		it('leaves the list unchanged when the native ICP market is absent', () => {
+			const markets = [nativeBtc, ckBtc, eth];
+
+			expect(orderLiquidiumMarkets(markets)).toEqual(markets);
+		});
+
+		it('handles an empty list', () => {
+			expect(orderLiquidiumMarkets([])).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

On the Liquidium provider page, the "Markets" section lists the tokens that can be supplied or borrowed. Its order came straight from the Liquidium SDK's pool order and the `Chain` rail expansion, with nothing re-ordering it — so the native ICP pool (returned last by the SDK) rendered last.

This introduces a deliberate, stable display order for the list.

# Changes

- Add `LIQUIDIUM_POOL_ORDER` (`BTC, ETH, ICP, USDC, USDT`) and `LIQUIDIUM_NETWORK_ORDER` (`BTC, ETH, ICP`) constants.
- Add `orderLiquidiumMarkets()` in `liquidium.utils.ts`: a stable multi-key sort layered on the order Liquidium returns:
  1. **pool** by asset per `LIQUIDIUM_POOL_ORDER` — assets not listed keep their received order, after the listed ones (and stay grouped);
  2. **native rail before its ck rail** within a pool (BTC before ckBTC, USDC before ckUSDC — the ICP-chain rail of a non-ICP asset is the ck rail);
  3. **transfer-network order** (`LIQUIDIUM_NETWORK_ORDER`) as the final tiebreaker, so extra networks slot in predictably.

  Markets that tie on every key keep their received order (`Array.sort` is stable), and the input array is not mutated.
- Apply it at the shared `liquidiumMarkets` derived store, which the Markets section iterates (and which the supply/borrow lists derive from, keeping the order consistent).

Resulting order: `BTC, ckBTC, ETH, ICP, USDC, ckUSDC, USDT, ckUSDT`.

# Tests

- Unit tests for `orderLiquidiumMarkets`: pool + native-first ordering, native-before-ck within a pool, network-order tiebreak, unlisted assets kept last in received order and grouped, no input mutation, empty list.
- A derived-store test asserting `liquidiumMarkets` applies the sort end-to-end (seeded out of order to prove it re-orders).
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check:tests`, and the targeted `vitest` specs all pass locally.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — model claude-opus-4-8 (Opus 4.8)
