### PR TITLE
feat(frontend): surface ck asset rails in Liquidium withdraw/repay

### DIFF
--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte
@@ -32,8 +32,14 @@
 				token: liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
 			}))
 			.filter(
+				// Exclude only the currently-selected rail, keyed by (poolId, chain): a pool now
+				// yields one entry per rail, so keying on poolId alone would hide the other rail too.
 				(entry): entry is { reserve: LiquidiumReserve; token: Token } =>
-					nonNullish(entry.token) && entry.reserve.poolId !== selectedReserve?.poolId
+					nonNullish(entry.token) &&
+					!(
+						entry.reserve.poolId === selectedReserve?.poolId &&
+						entry.reserve.chain === selectedReserve?.chain
+					)
 			)
 	);
 

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte
@@ -32,8 +32,14 @@
 				token: liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
 			}))
 			.filter(
+				// Exclude only the currently-selected rail, keyed by (poolId, chain): a pool now
+				// yields one entry per rail, so keying on poolId alone would hide the other rail too.
 				(entry): entry is { reserve: LiquidiumReserve; token: Token } =>
-					nonNullish(entry.token) && entry.reserve.poolId !== selectedReserve?.poolId
+					nonNullish(entry.token) &&
+					!(
+						entry.reserve.poolId === selectedReserve?.poolId &&
+						entry.reserve.chain === selectedReserve?.chain
+					)
 			)
 	);
 

--- a/src/frontend/src/lib/constants/liquidium.constants.ts
+++ b/src/frontend/src/lib/constants/liquidium.constants.ts
@@ -27,9 +27,9 @@ export const LIQUIDIUM_ADVERTISED_TOKENS: Token[] = [
 	ICP_TOKEN
 ];
 
-// Display order for the Markets list, applied as a stable sort on top of the order Liquidium
-// returns (see `orderLiquidiumMarkets`). Primary key: the lending pool, by asset symbol. Assets
-// not listed keep their received order, after the listed ones.
+// Display order for the Markets list and the withdraw/repay pickers, applied as a stable sort on
+// top of the order Liquidium returns (see `orderLiquidiumRails`). Primary key: the lending pool,
+// by asset symbol. Assets not listed keep their received order, after the listed ones.
 export const LIQUIDIUM_POOL_ORDER: string[] = ['BTC', 'ETH', 'ICP', 'USDC', 'USDT'];
 
 // Transfer-network order, the final tiebreaker after "native rail first" — so extra networks

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -17,7 +17,7 @@ import {
 	liquidiumBorrowingPowerPotentialUsd,
 	liquidiumNetInterestUsd,
 	liquidiumReserveRails,
-	orderLiquidiumMarkets
+	orderLiquidiumRails
 } from '$lib/utils/liquidium.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { AssetPrices } from '@liquidium/client';
@@ -25,7 +25,7 @@ import { derived, type Readable } from 'svelte/store';
 
 export const liquidiumMarkets: Readable<LiquidiumMarket[]> = derived(
 	liquidiumStore,
-	({ markets }) => orderLiquidiumMarkets(markets)
+	({ markets }) => orderLiquidiumRails(markets)
 );
 
 export const liquidiumPortfolio: Readable<LiquidiumPortfolio | null> = derived(
@@ -58,23 +58,29 @@ export const liquidiumBorrowMarkets: Readable<LiquidiumMarket[]> = derived(
 );
 
 // Positions the user can withdraw from: reserves with a supplied balance, expanded per
-// transfer rail so a BTC/USDC/USDT position offers both native and ck (ICP) delivery.
+// transfer rail so a BTC/USDC/USDT position offers both native and ck (ICP) delivery, ordered
+// like the Markets list (pool, then native rail first).
 export const liquidiumWithdrawReserves: Readable<LiquidiumReserve[]> = derived(
 	liquidiumPortfolio,
 	(portfolio) =>
-		(portfolio?.reserves ?? [])
-			.filter(({ deposited }) => deposited > ZERO)
-			.flatMap(liquidiumReserveRails)
+		orderLiquidiumRails(
+			(portfolio?.reserves ?? [])
+				.filter(({ deposited }) => deposited > ZERO)
+				.flatMap(liquidiumReserveRails)
+		)
 );
 
 // Positions the user can repay: reserves with outstanding debt, expanded per transfer rail
-// so a BTC/USDC/USDT debt can be repaid with either the native asset or its ck twin.
+// so a BTC/USDC/USDT debt can be repaid with either the native asset or its ck twin, ordered
+// like the Markets list (pool, then native rail first).
 export const liquidiumRepayReserves: Readable<LiquidiumReserve[]> = derived(
 	liquidiumPortfolio,
 	(portfolio) =>
-		(portfolio?.reserves ?? [])
-			.filter(({ borrowed }) => borrowed > ZERO)
-			.flatMap(liquidiumReserveRails)
+		orderLiquidiumRails(
+			(portfolio?.reserves ?? [])
+				.filter(({ borrowed }) => borrowed > ZERO)
+				.flatMap(liquidiumReserveRails)
+		)
 );
 
 // SDK USD prices for the borrow form's USD / fiat math.

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -15,7 +15,8 @@ import {
 	liquidiumMaxSupplyApy as computeMaxSupplyApy,
 	liquidiumMinBorrowApy as computeMinBorrowApy,
 	liquidiumBorrowingPowerPotentialUsd,
-	liquidiumNetInterestUsd
+	liquidiumNetInterestUsd,
+	liquidiumReserveRails
 } from '$lib/utils/liquidium.utils';
 import { nonNullish } from '@dfinity/utils';
 import type { AssetPrices } from '@liquidium/client';
@@ -55,16 +56,24 @@ export const liquidiumBorrowMarkets: Readable<LiquidiumMarket[]> = derived(
 		)
 );
 
-// Positions the user can withdraw from: reserves with a supplied balance.
+// Positions the user can withdraw from: reserves with a supplied balance, expanded per
+// transfer rail so a BTC/USDC/USDT position offers both native and ck (ICP) delivery.
 export const liquidiumWithdrawReserves: Readable<LiquidiumReserve[]> = derived(
 	liquidiumPortfolio,
-	(portfolio) => (portfolio?.reserves ?? []).filter(({ deposited }) => deposited > ZERO)
+	(portfolio) =>
+		(portfolio?.reserves ?? [])
+			.filter(({ deposited }) => deposited > ZERO)
+			.flatMap(liquidiumReserveRails)
 );
 
-// Positions the user can repay: reserves with outstanding debt.
+// Positions the user can repay: reserves with outstanding debt, expanded per transfer rail
+// so a BTC/USDC/USDT debt can be repaid with either the native asset or its ck twin.
 export const liquidiumRepayReserves: Readable<LiquidiumReserve[]> = derived(
 	liquidiumPortfolio,
-	(portfolio) => (portfolio?.reserves ?? []).filter(({ borrowed }) => borrowed > ZERO)
+	(portfolio) =>
+		(portfolio?.reserves ?? [])
+			.filter(({ borrowed }) => borrowed > ZERO)
+			.flatMap(liquidiumReserveRails)
 );
 
 // SDK USD prices for the borrow form's USD / fiat math.

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -274,18 +274,22 @@ export const mapLiquidiumMarketRails = (pool: Pool): LiquidiumMarket[] => {
 };
 
 // The ck (non-native) rail is the ICP-chain rail of a non-ICP asset; every other rail is native.
-const isNativeRail = ({ chain, asset }: LiquidiumMarket): boolean =>
+const isNativeRail = ({ chain, asset }: { chain: string; asset: string }): boolean =>
 	chain !== 'ICP' || asset === 'ICP';
 
-// Stable display order for the Markets list, layered on the order Liquidium returns:
+// Stable display order for a list of Liquidium rail entries (markets or position reserves),
+// layered on the order Liquidium returns:
 //  1. pool, by asset, per LIQUIDIUM_POOL_ORDER — unlisted assets keep their received order, last;
 //  2. native rail before the ck rail within a pool (BTC before ckBTC, USDC before ckUSDC);
 //  3. transfer-network order (LIQUIDIUM_NETWORK_ORDER) as the final tiebreaker.
-// Markets that tie on every key keep their received order (Array.sort is stable).
-export const orderLiquidiumMarkets = (markets: LiquidiumMarket[]): LiquidiumMarket[] => {
+// Entries that tie on every key keep their received order (Array.sort is stable). Shared by the
+// Markets list and the withdraw/repay pickers so positions and markets order identically.
+export const orderLiquidiumRails = <T extends { asset: string; chain: string }>(
+	entries: T[]
+): T[] => {
 	// Unlisted assets rank after the listed ones, keeping their first-seen (received) order so
 	// each pool's rails stay grouped.
-	const receivedAssets = [...new Set(markets.map(({ asset }) => asset))];
+	const receivedAssets = [...new Set(entries.map(({ asset }) => asset))];
 
 	const poolRank = (asset: string): number => {
 		const known = LIQUIDIUM_POOL_ORDER.indexOf(asset);
@@ -297,7 +301,7 @@ export const orderLiquidiumMarkets = (markets: LiquidiumMarket[]): LiquidiumMark
 		return known >= 0 ? known : LIQUIDIUM_NETWORK_ORDER.length;
 	};
 
-	return [...markets].sort(
+	return [...entries].sort(
 		(a, b) =>
 			poolRank(a.asset) - poolRank(b.asset) ||
 			Number(isNativeRail(b)) - Number(isNativeRail(a)) ||
@@ -333,8 +337,14 @@ export const mapLiquidiumReserve = ({
 // `chain`, which drives the display token, the repay transfer rail and the withdraw delivery
 // chain. A single-rail asset (ICP) yields one unchanged entry. Kept picker-only — the mapped
 // portfolio reserves stay one-per-pool so dashboard rows and USD totals never double-count.
-export const liquidiumReserveRails = (reserve: LiquidiumReserve): LiquidiumReserve[] =>
-	liquidiumSupportedRails(reserve.asset).map((chain) => ({ ...reserve, chain }));
+export const liquidiumReserveRails = (reserve: LiquidiumReserve): LiquidiumReserve[] => {
+	// Fall back to the reserve's own (native) chain if the SDK guard reports no rails for the
+	// asset, so a position can never silently drop out of the withdraw/repay picker. Rail
+	// display order is applied downstream by `orderLiquidiumRails`, not here.
+	const rails = liquidiumSupportedRails(reserve.asset);
+
+	return (rails.length > 0 ? rails : [reserve.chain]).map((chain) => ({ ...reserve, chain }));
+};
 
 export const mapLiquidiumPortfolio = ({
 	reserves,

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -292,6 +292,16 @@ export const mapLiquidiumReserve = ({
 	borrowedUsd: scaledUsdToNumber({ value: borrowedUsd, decimals: usdDecimals })
 });
 
+// Expands one position into an entry per supported transfer rail, so the withdraw/repay
+// pickers can offer both the native rail and the ICP (ck-ledger) rail for the same pool
+// balance — the position-surface counterpart of `mapLiquidiumMarketRails`. The entries share
+// `poolId` and all position economics (deposited / borrowed / USD); they differ only by
+// `chain`, which drives the display token, the repay transfer rail and the withdraw delivery
+// chain. A single-rail asset (ICP) yields one unchanged entry. Kept picker-only — the mapped
+// portfolio reserves stay one-per-pool so dashboard rows and USD totals never double-count.
+export const liquidiumReserveRails = (reserve: LiquidiumReserve): LiquidiumReserve[] =>
+	liquidiumSupportedRails(reserve.asset).map((chain) => ({ ...reserve, chain }));
+
 export const mapLiquidiumPortfolio = ({
 	reserves,
 	summary

--- a/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayTokensList.spec.ts
@@ -11,6 +11,22 @@ import {
 import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import { fireEvent, render } from '@testing-library/svelte';
 
+// ck twins so the ICP (ck) rail resolves a display token in the picker; the native rails
+// resolve statically and need no token list.
+vi.mock('$lib/derived/tokens.derived', async (importOriginal) => {
+	const { readable } = await import('svelte/store');
+	const { mockValidIcCkToken } = await import('$tests/mocks/ic-tokens.mock');
+	const { parseTokenId } = await import('$lib/validation/token.validation');
+
+	return {
+		...(await importOriginal<Record<string, unknown>>()),
+		tokens: readable([
+			{ ...mockValidIcCkToken, id: parseTokenId('ckBTC'), symbol: 'ckBTC' },
+			{ ...mockValidIcCkToken, id: parseTokenId('ckUSDC'), symbol: 'ckUSDC' }
+		])
+	};
+});
+
 describe('LiquidiumRepayTokensList', () => {
 	const btcReserve: LiquidiumReserve = {
 		poolId: 'pool-btc',
@@ -125,5 +141,30 @@ describe('LiquidiumRepayTokensList', () => {
 
 		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
 		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+	});
+
+	it('offers both the native and the ck (ICP) rail for a multi-rail position', () => {
+		liquidiumStore.set({ markets: [], portfolio: portfolio([btcReserve]), assetPrices: {} });
+
+		const { getByText } = render(LiquidiumRepayTokensList, {
+			props: { onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
+		expect(getByText('ckBTC')).toBeInTheDocument();
+	});
+
+	it('excludes only the selected rail, keeping the other rail of the same pool', () => {
+		liquidiumStore.set({ markets: [], portfolio: portfolio([btcReserve]), assetPrices: {} });
+
+		const { getByText, queryByText } = render(LiquidiumRepayTokensList, {
+			// The native BTC rail is selected → hidden; its ck (ICP → ckBTC) rail must remain.
+			props: { selectedReserve: btcReserve, onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+		expect(getByText('ckBTC')).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.spec.ts
@@ -11,6 +11,22 @@ import {
 import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import { fireEvent, render } from '@testing-library/svelte';
 
+// ck twins so the ICP (ck) rail resolves a display token in the picker; the native rails
+// resolve statically and need no token list.
+vi.mock('$lib/derived/tokens.derived', async (importOriginal) => {
+	const { readable } = await import('svelte/store');
+	const { mockValidIcCkToken } = await import('$tests/mocks/ic-tokens.mock');
+	const { parseTokenId } = await import('$lib/validation/token.validation');
+
+	return {
+		...(await importOriginal<Record<string, unknown>>()),
+		tokens: readable([
+			{ ...mockValidIcCkToken, id: parseTokenId('ckBTC'), symbol: 'ckBTC' },
+			{ ...mockValidIcCkToken, id: parseTokenId('ckUSDC'), symbol: 'ckUSDC' }
+		])
+	};
+});
+
 describe('LiquidiumWithdrawTokensList', () => {
 	const btcReserve: LiquidiumReserve = {
 		poolId: 'pool-btc',
@@ -125,5 +141,30 @@ describe('LiquidiumWithdrawTokensList', () => {
 
 		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
 		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+	});
+
+	it('offers both the native and the ck (ICP) rail for a multi-rail position', () => {
+		liquidiumStore.set({ markets: [], portfolio: portfolio([btcReserve]), assetPrices: {} });
+
+		const { getByText } = render(LiquidiumWithdrawTokensList, {
+			props: { onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
+		expect(getByText('ckBTC')).toBeInTheDocument();
+	});
+
+	it('excludes only the selected rail, keeping the other rail of the same pool', () => {
+		liquidiumStore.set({ markets: [], portfolio: portfolio([btcReserve]), assetPrices: {} });
+
+		const { getByText, queryByText } = render(LiquidiumWithdrawTokensList, {
+			// The native BTC rail is selected → hidden; its ck (ICP → ckBTC) rail must remain.
+			props: { selectedReserve: btcReserve, onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+		expect(getByText('ckBTC')).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -328,7 +328,7 @@ describe('liquidium derived stores', () => {
 			...overrides
 		});
 
-		it('keeps only reserves with a supplied balance', () => {
+		it('keeps only positions with a supplied balance, expanded per rail', () => {
 			liquidiumStore.set({
 				markets: [],
 				portfolio: {
@@ -338,7 +338,40 @@ describe('liquidium derived stores', () => {
 				assetPrices: {}
 			});
 
-			expect(get(liquidiumWithdrawReserves)).toEqual([reserve()]);
+			// The zero-balance USDC position is dropped; the BTC position stays and expands into
+			// its native (BTC) and ck (ICP → ckBTC) rails.
+			expect(get(liquidiumWithdrawReserves)).toEqual([reserve(), reserve({ chain: 'ICP' })]);
+		});
+
+		it('expands a stablecoin position into its native and ck (ICP) rails', () => {
+			liquidiumStore.set({
+				markets: [],
+				portfolio: {
+					...portfolio,
+					reserves: [reserve({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' })]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumWithdrawReserves)).toEqual([
+				reserve({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' }),
+				reserve({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ICP' })
+			]);
+		});
+
+		it('leaves a single-rail position (ICP) as one entry', () => {
+			liquidiumStore.set({
+				markets: [],
+				portfolio: {
+					...portfolio,
+					reserves: [reserve({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumWithdrawReserves)).toEqual([
+				reserve({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
+			]);
 		});
 
 		it('is empty by default', () => {
@@ -362,7 +395,7 @@ describe('liquidium derived stores', () => {
 			...overrides
 		});
 
-		it('keeps only reserves with outstanding debt', () => {
+		it('keeps only positions with outstanding debt, expanded per rail', () => {
 			liquidiumStore.set({
 				markets: [],
 				portfolio: {
@@ -372,7 +405,24 @@ describe('liquidium derived stores', () => {
 				assetPrices: {}
 			});
 
-			expect(get(liquidiumRepayReserves)).toEqual([reserve()]);
+			// The zero-debt BTC position is dropped; the USDC debt stays and expands into its
+			// native (ETH → USDC) and ck (ICP → ckUSDC) rails.
+			expect(get(liquidiumRepayReserves)).toEqual([reserve(), reserve({ chain: 'ICP' })]);
+		});
+
+		it('leaves a single-rail position (ICP) as one entry', () => {
+			liquidiumStore.set({
+				markets: [],
+				portfolio: {
+					...portfolio,
+					reserves: [reserve({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumRepayReserves)).toEqual([
+				reserve({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
+			]);
 		});
 
 		it('is empty by default', () => {

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -400,6 +400,22 @@ describe('liquidium derived stores', () => {
 			]);
 		});
 
+		it('orders the picker across pools (BTC before USDC), native rail first', () => {
+			// USDC seeded before BTC to prove the picker re-orders rather than following portfolio order.
+			liquidiumStore.set({
+				markets: [],
+				portfolio: {
+					...portfolio,
+					reserves: [reserve({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' }), reserve()]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumWithdrawReserves).map(({ asset, chain }) => `${asset}-${chain}`)).toEqual(
+				['BTC-BTC', 'BTC-ICP', 'USDC-ETH', 'USDC-ICP']
+			);
+		});
+
 		it('is empty by default', () => {
 			expect(get(liquidiumWithdrawReserves)).toEqual([]);
 		});
@@ -448,6 +464,25 @@ describe('liquidium derived stores', () => {
 
 			expect(get(liquidiumRepayReserves)).toEqual([
 				reserve({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
+			]);
+		});
+
+		it('orders the picker across pools (BTC before USDC), native rail first', () => {
+			// USDC seeded before BTC to prove the picker re-orders rather than following portfolio order.
+			liquidiumStore.set({
+				markets: [],
+				portfolio: {
+					...portfolio,
+					reserves: [reserve(), reserve({ poolId: 'pool-btc', asset: 'BTC', chain: 'BTC' })]
+				},
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumRepayReserves).map(({ asset, chain }) => `${asset}-${chain}`)).toEqual([
+				'BTC-BTC',
+				'BTC-ICP',
+				'USDC-ETH',
+				'USDC-ICP'
 			]);
 		});
 

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -26,7 +26,7 @@ import {
 	mapLiquidiumMarketRails,
 	mapLiquidiumPortfolio,
 	mapLiquidiumReserve,
-	orderLiquidiumMarkets
+	orderLiquidiumRails
 } from '$lib/utils/liquidium.utils';
 import {
 	RATE_SCALE,
@@ -199,9 +199,20 @@ describe('liquidium.utils', () => {
 			expect(rails).toHaveLength(1);
 			expect(rails[0].chain).toBe('ICP');
 		});
+
+		it('falls back to the native chain when no rails are configured for the asset', () => {
+			// An asset the SDK guard does not recognize yields no supported rails; the position must
+			// still be withdrawable/repayable on its own (native) chain rather than vanishing.
+			const rails = liquidiumReserveRails(
+				buildReserve({ poolId: 'pool-foo', asset: 'FOO', chain: 'ETH' })
+			);
+
+			expect(rails).toHaveLength(1);
+			expect(rails[0].chain).toBe('ETH');
+		});
 	});
 
-	describe('orderLiquidiumMarkets', () => {
+	describe('orderLiquidiumRails', () => {
 		const buildMarket = (overrides: Partial<LiquidiumMarket> = {}): LiquidiumMarket => ({
 			poolId: 'pool-btc',
 			asset: 'BTC',
@@ -230,7 +241,7 @@ describe('liquidium.utils', () => {
 			// Received in a scrambled pool order to prove the sort re-orders it.
 			const markets = [usdc, ckUsdc, ckBtc, nativeBtc, usdt, ckUsdt, icp, eth];
 
-			expect(keys(orderLiquidiumMarkets(markets))).toEqual([
+			expect(keys(orderLiquidiumRails(markets))).toEqual([
 				'BTC-BTC',
 				'BTC-ICP',
 				'ETH-ETH',
@@ -243,15 +254,15 @@ describe('liquidium.utils', () => {
 		});
 
 		it('puts the native rail before its ck rail within a pool', () => {
-			expect(keys(orderLiquidiumMarkets([ckBtc, nativeBtc]))).toEqual(['BTC-BTC', 'BTC-ICP']);
-			expect(keys(orderLiquidiumMarkets([ckUsdc, usdc]))).toEqual(['USDC-ETH', 'USDC-ICP']);
+			expect(keys(orderLiquidiumRails([ckBtc, nativeBtc]))).toEqual(['BTC-BTC', 'BTC-ICP']);
+			expect(keys(orderLiquidiumRails([ckUsdc, usdc]))).toEqual(['USDC-ETH', 'USDC-ICP']);
 		});
 
 		it('breaks ties between same-pool native rails by network order', () => {
 			// Two native rails (neither is the ICP ck rail) → decided by LIQUIDIUM_NETWORK_ORDER.
 			const btcOnEth = buildMarket({ chain: 'ETH' });
 
-			expect(keys(orderLiquidiumMarkets([btcOnEth, nativeBtc]))).toEqual(['BTC-BTC', 'BTC-ETH']);
+			expect(keys(orderLiquidiumRails([btcOnEth, nativeBtc]))).toEqual(['BTC-BTC', 'BTC-ETH']);
 		});
 
 		it('keeps assets outside the pool order last, in their received order and grouped', () => {
@@ -259,7 +270,7 @@ describe('liquidium.utils', () => {
 			const fooIcp = buildMarket({ poolId: 'pool-foo', asset: 'FOO', chain: 'ICP' });
 			const barEth = buildMarket({ poolId: 'pool-bar', asset: 'BAR', chain: 'ETH' });
 
-			expect(keys(orderLiquidiumMarkets([barEth, fooEth, nativeBtc, fooIcp, icp]))).toEqual([
+			expect(keys(orderLiquidiumRails([barEth, fooEth, nativeBtc, fooIcp, icp]))).toEqual([
 				'BTC-BTC',
 				'ICP-ICP',
 				'BAR-ETH',
@@ -270,13 +281,31 @@ describe('liquidium.utils', () => {
 
 		it('does not mutate the input array', () => {
 			const markets = [icp, nativeBtc];
-			orderLiquidiumMarkets(markets);
+			orderLiquidiumRails(markets);
 
 			expect(keys(markets)).toEqual(['ICP-ICP', 'BTC-BTC']);
 		});
 
 		it('handles an empty list', () => {
-			expect(orderLiquidiumMarkets([])).toEqual([]);
+			expect(orderLiquidiumRails([])).toEqual([]);
+		});
+
+		it('orders position reserves the same way (generic over asset + chain)', () => {
+			// Same sort drives the withdraw/repay pickers: reserve-shaped entries order by pool then
+			// native rail first, identically to the markets above.
+			const reserves = [
+				{ poolId: 'pool-usdc', asset: 'USDC', chain: 'ICP' },
+				{ poolId: 'pool-btc', asset: 'BTC', chain: 'ICP' },
+				{ poolId: 'pool-btc', asset: 'BTC', chain: 'BTC' },
+				{ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' }
+			];
+
+			expect(orderLiquidiumRails(reserves).map(({ asset, chain }) => `${asset}-${chain}`)).toEqual([
+				'BTC-BTC',
+				'BTC-ICP',
+				'USDC-ETH',
+				'USDC-ICP'
+			]);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -18,6 +18,7 @@ import {
 	liquidiumProjectedHealthAfterRepayPercent,
 	liquidiumProjectedHealthAfterWithdrawPercent,
 	liquidiumProjectedHealthPercent,
+	liquidiumReserveRails,
 	liquidiumResultingLtvPercent,
 	liquidiumSupplyInterestUsd,
 	liquidiumSupportedRails,
@@ -149,6 +150,53 @@ describe('liquidium.utils', () => {
 
 			expect(markets).toHaveLength(1);
 			expect(markets[0].chain).toBe('ICP');
+		});
+	});
+
+	describe('liquidiumReserveRails', () => {
+		const buildReserve = (overrides: Partial<LiquidiumReserve> = {}): LiquidiumReserve => ({
+			poolId: 'pool-usdc',
+			asset: 'USDC',
+			chain: 'ETH',
+			supplyApy: 5,
+			borrowApy: 9,
+			deposited: 1_000n,
+			depositedDecimals: 6,
+			borrowed: ZERO,
+			borrowedDecimals: 6,
+			suppliedUsd: 1000,
+			borrowedUsd: 0,
+			...overrides
+		});
+
+		it('expands a position into one entry per transfer rail, keeping poolId + balances', () => {
+			const rails = liquidiumReserveRails(buildReserve());
+
+			expect(rails.map(({ chain }) => chain)).toEqual(['ETH', 'ICP']);
+			// Same pool balance across rails; only the transfer chain differs.
+			expect(
+				rails.every(
+					({ poolId, asset, deposited }) =>
+						poolId === 'pool-usdc' && asset === 'USDC' && deposited === 1_000n
+				)
+			).toBeTruthy();
+		});
+
+		it('offers the native + ck (ICP) rails for BTC', () => {
+			expect(
+				liquidiumReserveRails(buildReserve({ poolId: 'pool-btc', asset: 'BTC' })).map(
+					({ chain }) => chain
+				)
+			).toEqual(['BTC', 'ICP']);
+		});
+
+		it('leaves a single-rail position (ICP) as one entry', () => {
+			const rails = liquidiumReserveRails(
+				buildReserve({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
+			);
+
+			expect(rails).toHaveLength(1);
+			expect(rails[0].chain).toBe('ICP');
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Liquidium's SDK supports the ICP (ck-ledger) rail for the BTC, USDC and USDT pools: a single pool is shared across rails, so a position can settle on-chain either as the native asset (BTC / ERC-20 USDC / ERC-20 USDT) or as its chain-key twin (ckBTC / ckUSDC / ckUSDT). #13557 already surfaced both rails on the supply/borrow (market) surface, but the withdraw and repay flows still only offered the native rail — so a position supplied with ckUSDC could only be withdrawn as ERC-20 USDC to the user's Ethereum address, and could only be repaid with ERC-20 USDC, never with the ck twin.

The withdraw receiver plumbing, the asset-generic ICRC repay wizard and the ck-ledger lookups were all already in place; they were simply never reached, because withdraw/repay positions collapse to a single `chain` (the pool's backing chain) and so never offered the ICP rail.

# Changes

- Add `liquidiumReserveRails`, the position-surface counterpart of `mapLiquidiumMarketRails`: it expands one reserve into an entry per supported transfer rail (native + ICP ck), sharing `poolId` and all balances and differing only by `chain`.
- Expand the withdraw and repay picker reserves (`liquidiumWithdrawReserves` / `liquidiumRepayReserves`) through it, so a BTC/USDC/USDT position now offers both its native rail and the ICP (ck) rail — ckBTC/ckUSDC/ckUSDT delivery on withdraw and payment on repay. The expansion is picker-only; the mapped portfolio reserves stay one-per-pool, so dashboard rows and USD totals never double-count.
- Key the pickers' "hide the currently-selected position" filter on `(poolId, chain)` instead of `poolId` alone, so selecting one rail no longer hides the other rail of the same pool.
- Order the withdraw/repay pickers through the shared `orderLiquidiumRails` sort (generalized from #13579's `orderLiquidiumMarkets`, now on `main`) so positions and markets list identically — native rail first, then pool order — with `liquidiumReserveRails` falling back to the native rail if the SDK guard returns none, so a position never drops from the picker.

Everything downstream already keys on `reserve.chain`: the ck display token, the ICRC ledger transfer, the `chain: Chain.ICP` delivery and the AUT bookkeeping. Native remains the default; the ck rail is the added, opt-in picker entry.

# Tests

- `liquidium.utils.spec`: `liquidiumReserveRails` expands per rail (USDC → ETH + ICP, BTC → BTC + ICP), keeps poolId and balances, leaves a single-rail asset (ICP) as one entry, and falls back to the native rail for an asset with no configured rails; `orderLiquidiumRails` orders both markets and position reserves (pool, then native rail first).
- `liquidium.derived.spec`: withdraw/repay reserves expand per rail after the deposited/borrowed filter, a single-rail (ICP) position stays one entry, and the picker is ordered across pools (BTC before USDC, native rail first).
- `LiquidiumWithdrawTokensList.spec` / `LiquidiumRepayTokensList.spec`: both the native and the ck rail render for a multi-rail position, and the exclusion hides only the selected rail while keeping the other rail of the same pool.
- Gates green on the branch: `format`, `lint`, `check`, `check:tests`, and the affected vitest specs (129 passed). The full coverage suite is left to CI.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 4.8 (claude-opus-4-8)
