### PR TITLE
feat(frontend): show all asset rail icons in Liquidium supplied/borrowed rows

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/stefan.berger/Documents/GitHub/oisy-wallet/node_modules

--- a/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
@@ -48,12 +48,15 @@
 
 <LogoButton hover={false}>
 	{#snippet logo()}
-		<span class="sm:mr-2 flex items-center gap-1">
+		<span class="sm:mr-2 flex items-end">
 			{#if nonNullish(token)}
 				<TokenLogo color="white" data={token} logoSize={isMobile() ? 'sm' : 'lg'} />
 			{/if}
 			{#if networkIcons.length > 0}
-				<OverlappedLogos icons={networkIcons} invertColor />
+				<!-- Start the rail line-up where the single network badge used to sit (bottom-right of
+				     the logo): pull the first icon back onto the logo by its width less the badge's 4px
+				     offset, then let the rest extend to the right. -->
+				<OverlappedLogos icons={networkIcons} invertColor styleClass="-ml-[18px]" />
 			{/if}
 		</span>
 	{/snippet}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
@@ -6,7 +6,10 @@
 	import OverlappedLogos from '$lib/components/ui/OverlappedLogos.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import { liquidiumAssetNetworkIcons } from '$lib/derived/liquidium.derived';
+	import {
+		liquidiumAssetNetworkIcons,
+		liquidiumAssetNetworkNames
+	} from '$lib/derived/liquidium.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -28,6 +31,9 @@
 
 	// Icons for every rail the asset trades on (e.g. USDC → Ethereum + ICP), not just this row's chain.
 	let networkIcons = $derived($liquidiumAssetNetworkIcons[reserve.asset] ?? []);
+
+	// Matching rail names, exposed as the accessible label for the icon-only line-up.
+	let networkNames = $derived($liquidiumAssetNetworkNames[reserve.asset] ?? []);
 
 	let borrowedAmount = $derived(
 		formatToken({ value: reserve.borrowed, unitName: reserve.borrowedDecimals })
@@ -55,8 +61,11 @@
 			{#if networkIcons.length > 0}
 				<!-- Start the rail line-up where the single network badge used to sit (bottom-right of
 				     the logo): pull the first icon back onto the logo by its width less the badge's 4px
-				     offset, then let the rest extend to the right. -->
-				<OverlappedLogos icons={networkIcons} invertColor styleClass="-ml-[18px]" />
+				     offset, then let the rest extend to the right. role="img" + aria-label exposes the
+				     rail names to assistive tech, since the icon alts are only URLs. -->
+				<span class="-ml-[18px]" aria-label={networkNames.join(', ')} role="img">
+					<OverlappedLogos icons={networkIcons} invertColor />
+				</span>
 			{/if}
 		</span>
 	{/snippet}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumBorrowedRow.svelte
@@ -2,10 +2,11 @@
 	import { nonNullish } from '@dfinity/utils';
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
-	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import OverlappedLogos from '$lib/components/ui/OverlappedLogos.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { liquidiumAssetNetworkIcons } from '$lib/derived/liquidium.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -13,6 +14,7 @@
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
 	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
+	import { getTokenDisplayName } from '$lib/utils/token.utils';
 
 	interface Props {
 		reserve: LiquidiumReserve;
@@ -23,6 +25,9 @@
 	let token = $derived(
 		liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
 	);
+
+	// Icons for every rail the asset trades on (e.g. USDC → Ethereum + ICP), not just this row's chain.
+	let networkIcons = $derived($liquidiumAssetNetworkIcons[reserve.asset] ?? []);
 
 	let borrowedAmount = $derived(
 		formatToken({ value: reserve.borrowed, unitName: reserve.borrowedDecimals })
@@ -43,14 +48,12 @@
 
 <LogoButton hover={false}>
 	{#snippet logo()}
-		<span class="sm:mr-2 flex">
+		<span class="sm:mr-2 flex items-center gap-1">
 			{#if nonNullish(token)}
-				<TokenLogo
-					badge={{ type: 'network' }}
-					color="white"
-					data={token}
-					logoSize={isMobile() ? 'sm' : 'lg'}
-				/>
+				<TokenLogo color="white" data={token} logoSize={isMobile() ? 'sm' : 'lg'} />
+			{/if}
+			{#if networkIcons.length > 0}
+				<OverlappedLogos icons={networkIcons} invertColor />
 			{/if}
 		</span>
 	{/snippet}
@@ -66,7 +69,7 @@
 
 	{#snippet description()}
 		{#if nonNullish(token)}
-			<TokenNameAndNetwork data={token} />
+			<span class="text-primary">{getTokenDisplayName(token)}</span>
 		{/if}
 	{/snippet}
 

--- a/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
@@ -48,12 +48,15 @@
 
 <LogoButton hover={false}>
 	{#snippet logo()}
-		<span class="sm:mr-2 flex items-center gap-1">
+		<span class="sm:mr-2 flex items-end">
 			{#if nonNullish(token)}
 				<TokenLogo color="white" data={token} logoSize={isMobile() ? 'sm' : 'lg'} />
 			{/if}
 			{#if networkIcons.length > 0}
-				<OverlappedLogos icons={networkIcons} invertColor />
+				<!-- Start the rail line-up where the single network badge used to sit (bottom-right of
+				     the logo): pull the first icon back onto the logo by its width less the badge's 4px
+				     offset, then let the rest extend to the right. -->
+				<OverlappedLogos icons={networkIcons} invertColor styleClass="-ml-[18px]" />
 			{/if}
 		</span>
 	{/snippet}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
@@ -6,7 +6,10 @@
 	import OverlappedLogos from '$lib/components/ui/OverlappedLogos.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import { liquidiumAssetNetworkIcons } from '$lib/derived/liquidium.derived';
+	import {
+		liquidiumAssetNetworkIcons,
+		liquidiumAssetNetworkNames
+	} from '$lib/derived/liquidium.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -28,6 +31,9 @@
 
 	// Icons for every rail the asset trades on (e.g. USDC → Ethereum + ICP), not just this row's chain.
 	let networkIcons = $derived($liquidiumAssetNetworkIcons[reserve.asset] ?? []);
+
+	// Matching rail names, exposed as the accessible label for the icon-only line-up.
+	let networkNames = $derived($liquidiumAssetNetworkNames[reserve.asset] ?? []);
 
 	let suppliedAmount = $derived(
 		formatToken({ value: reserve.deposited, unitName: reserve.depositedDecimals })
@@ -55,8 +61,11 @@
 			{#if networkIcons.length > 0}
 				<!-- Start the rail line-up where the single network badge used to sit (bottom-right of
 				     the logo): pull the first icon back onto the logo by its width less the badge's 4px
-				     offset, then let the rest extend to the right. -->
-				<OverlappedLogos icons={networkIcons} invertColor styleClass="-ml-[18px]" />
+				     offset, then let the rest extend to the right. role="img" + aria-label exposes the
+				     rail names to assistive tech, since the icon alts are only URLs. -->
+				<span class="-ml-[18px]" aria-label={networkNames.join(', ')} role="img">
+					<OverlappedLogos icons={networkIcons} invertColor />
+				</span>
 			{/if}
 		</span>
 	{/snippet}

--- a/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSuppliedRow.svelte
@@ -2,10 +2,11 @@
 	import { nonNullish } from '@dfinity/utils';
 	import EarningYearlyAmount from '$lib/components/earning/EarningYearlyAmount.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
-	import TokenNameAndNetwork from '$lib/components/tokens/TokenNameAndNetwork.svelte';
 	import LogoButton from '$lib/components/ui/LogoButton.svelte';
+	import OverlappedLogos from '$lib/components/ui/OverlappedLogos.svelte';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { liquidiumAssetNetworkIcons } from '$lib/derived/liquidium.derived';
 	import { tokens } from '$lib/derived/tokens.derived';
 	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -13,6 +14,7 @@
 	import { isMobile } from '$lib/utils/device.utils';
 	import { formatCurrency, formatStakeApyNumber, formatToken } from '$lib/utils/format.utils';
 	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
+	import { getTokenDisplayName } from '$lib/utils/token.utils';
 
 	interface Props {
 		reserve: LiquidiumReserve;
@@ -23,6 +25,9 @@
 	let token = $derived(
 		liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
 	);
+
+	// Icons for every rail the asset trades on (e.g. USDC → Ethereum + ICP), not just this row's chain.
+	let networkIcons = $derived($liquidiumAssetNetworkIcons[reserve.asset] ?? []);
 
 	let suppliedAmount = $derived(
 		formatToken({ value: reserve.deposited, unitName: reserve.depositedDecimals })
@@ -43,14 +48,12 @@
 
 <LogoButton hover={false}>
 	{#snippet logo()}
-		<span class="sm:mr-2 flex">
+		<span class="sm:mr-2 flex items-center gap-1">
 			{#if nonNullish(token)}
-				<TokenLogo
-					badge={{ type: 'network' }}
-					color="white"
-					data={token}
-					logoSize={isMobile() ? 'sm' : 'lg'}
-				/>
+				<TokenLogo color="white" data={token} logoSize={isMobile() ? 'sm' : 'lg'} />
+			{/if}
+			{#if networkIcons.length > 0}
+				<OverlappedLogos icons={networkIcons} invertColor />
 			{/if}
 		</span>
 	{/snippet}
@@ -66,7 +69,7 @@
 
 	{#snippet description()}
 		{#if nonNullish(token)}
-			<TokenNameAndNetwork data={token} />
+			<span class="text-primary">{getTokenDisplayName(token)}</span>
 		{/if}
 	{/snippet}
 

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -4,6 +4,7 @@ import { ZERO } from '$lib/constants/app.constants';
 import { LIQUIDIUM_ADVERTISED_TOKENS } from '$lib/constants/liquidium.constants';
 import { AppPath } from '$lib/constants/routes.constants';
 import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
+import { tokens } from '$lib/derived/tokens.derived';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
 import type { EarningProviderData } from '$lib/types/earning-provider';
 import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
@@ -15,6 +16,7 @@ import {
 	liquidiumMaxSupplyApy as computeMaxSupplyApy,
 	liquidiumMinBorrowApy as computeMinBorrowApy,
 	liquidiumBorrowingPowerPotentialUsd,
+	liquidiumMarketToken,
 	liquidiumNetInterestUsd,
 	orderLiquidiumMarkets
 } from '$lib/utils/liquidium.utils';
@@ -135,6 +137,23 @@ const liquidiumCardIcons = (pick: (token: Token) => string | undefined): string[
 
 export const liquidiumNetworkIcons = liquidiumCardIcons((token) => token.network.icon);
 export const liquidiumAssetIcons = liquidiumCardIcons((token) => token.icon);
+
+// Per-asset network icons for every rail the asset is offered on across all markets, keyed
+// by asset symbol. Lets a per-reserve row show the full rail line-up (e.g. USDC on both
+// Ethereum and ICP) instead of pinning to the single chain of that reserve.
+export const liquidiumAssetNetworkIcons: Readable<Record<string, string[]>> = derived(
+	[liquidiumMarkets, tokens],
+	([$liquidiumMarkets, $tokens]) =>
+		$liquidiumMarkets.reduce<Record<string, string[]>>((acc, { asset, chain }) => {
+			const icon = liquidiumMarketToken({ chain, asset, tokens: $tokens })?.network.icon;
+
+			if (nonNullish(icon) && !(acc[asset] ?? []).includes(icon)) {
+				acc[asset] = [...(acc[asset] ?? []), icon];
+			}
+
+			return acc;
+		}, {})
+);
 
 // Earn-page provider card data (mirrors the Harvest card); action → provider page.
 export const liquidiumEarningData: Readable<EarningProviderData> = derived(

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -143,16 +143,24 @@ export const liquidiumAssetIcons = liquidiumCardIcons((token) => token.icon);
 // Ethereum and ICP) instead of pinning to the single chain of that reserve.
 export const liquidiumAssetNetworkIcons: Readable<Record<string, string[]>> = derived(
 	[liquidiumMarkets, tokens],
-	([$liquidiumMarkets, $tokens]) =>
-		$liquidiumMarkets.reduce<Record<string, string[]>>((acc, { asset, chain }) => {
-			const icon = liquidiumMarketToken({ chain, asset, tokens: $tokens })?.network.icon;
+	([$liquidiumMarkets, $tokens]) => {
+		const iconsByAsset = $liquidiumMarkets.reduce<Map<string, Set<string>>>(
+			(acc, { asset, chain }) => {
+				const icon = liquidiumMarketToken({ chain, asset, tokens: $tokens })?.network.icon;
 
-			if (nonNullish(icon) && !(acc[asset] ?? []).includes(icon)) {
-				acc[asset] = [...(acc[asset] ?? []), icon];
-			}
+				if (nonNullish(icon)) {
+					const set = acc.get(asset) ?? new Set<string>();
+					set.add(icon);
+					acc.set(asset, set);
+				}
 
-			return acc;
-		}, {})
+				return acc;
+			},
+			new Map()
+		);
+
+		return Object.fromEntries([...iconsByAsset.entries()].map(([asset, set]) => [asset, [...set]]));
+	}
 );
 
 // Earn-page provider card data (mirrors the Harvest card); action → provider page.

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -138,29 +138,55 @@ const liquidiumCardIcons = (pick: (token: Token) => string | undefined): string[
 export const liquidiumNetworkIcons = liquidiumCardIcons((token) => token.network.icon);
 export const liquidiumAssetIcons = liquidiumCardIcons((token) => token.icon);
 
-// Per-asset network icons for every rail the asset is offered on across all markets, keyed
-// by asset symbol. Lets a per-reserve row show the full rail line-up (e.g. USDC on both
-// Ethereum and ICP) instead of pinning to the single chain of that reserve.
+// Per-asset network values for every rail the asset is offered on across all markets, keyed
+// by asset symbol and deduped. `pick` selects the value (icon, name, …) from each rail's
+// display token; unresolved rails are skipped.
+const liquidiumAssetRailValues = ({
+	markets,
+	tokens: allTokens,
+	pick
+}: {
+	markets: LiquidiumMarket[];
+	tokens: Token[];
+	pick: (token: Token) => string | undefined;
+}): Record<string, string[]> => {
+	const byAsset = markets.reduce<Map<string, Set<string>>>((acc, { asset, chain }) => {
+		const token = liquidiumMarketToken({ chain, asset, tokens: allTokens });
+		const value = nonNullish(token) ? pick(token) : undefined;
+
+		if (nonNullish(value)) {
+			const set = acc.get(asset) ?? new Set<string>();
+			set.add(value);
+			acc.set(asset, set);
+		}
+
+		return acc;
+	}, new Map());
+
+	return Object.fromEntries([...byAsset.entries()].map(([asset, set]) => [asset, [...set]]));
+};
+
+// Network icons for every rail an asset is offered on (e.g. USDC on both Ethereum and ICP),
+// so a per-reserve row shows the full rail line-up instead of pinning to its own chain.
 export const liquidiumAssetNetworkIcons: Readable<Record<string, string[]>> = derived(
 	[liquidiumMarkets, tokens],
-	([$liquidiumMarkets, $tokens]) => {
-		const iconsByAsset = $liquidiumMarkets.reduce<Map<string, Set<string>>>(
-			(acc, { asset, chain }) => {
-				const icon = liquidiumMarketToken({ chain, asset, tokens: $tokens })?.network.icon;
+	([$liquidiumMarkets, $tokens]) =>
+		liquidiumAssetRailValues({
+			markets: $liquidiumMarkets,
+			tokens: $tokens,
+			pick: (token) => token.network.icon
+		})
+);
 
-				if (nonNullish(icon)) {
-					const set = acc.get(asset) ?? new Set<string>();
-					set.add(icon);
-					acc.set(asset, set);
-				}
-
-				return acc;
-			},
-			new Map()
-		);
-
-		return Object.fromEntries([...iconsByAsset.entries()].map(([asset, set]) => [asset, [...set]]));
-	}
+// Network names for the same rails, used as the accessible label for the icon-only line-up.
+export const liquidiumAssetNetworkNames: Readable<Record<string, string[]>> = derived(
+	[liquidiumMarkets, tokens],
+	([$liquidiumMarkets, $tokens]) =>
+		liquidiumAssetRailValues({
+			markets: $liquidiumMarkets,
+			tokens: $tokens,
+			pick: (token) => token.network.name
+		})
 );
 
 // Earn-page provider card data (mirrors the Harvest card); action → provider page.

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
@@ -1,6 +1,7 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import LiquidiumBorrowedRow from '$lib/components/liquidium/LiquidiumBorrowedRow.svelte';
 import { ZERO } from '$lib/constants/app.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
@@ -23,13 +24,17 @@ describe('LiquidiumBorrowedRow', () => {
 		...overrides
 	});
 
-	it('renders the symbol, token name and network', () => {
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('renders the symbol and token name without the network', () => {
 		const { container } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
 		const usdc = USDC_TOKEN;
 
 		expect(container).toHaveTextContent('USDC');
 		expect(container).toHaveTextContent(usdc.name);
-		expect(container).toHaveTextContent(usdc.network.name);
+		expect(container).not.toHaveTextContent(usdc.network.name);
 	});
 
 	it('renders the borrow APR and the yearly cost as a negative amount', () => {
@@ -45,5 +50,28 @@ describe('LiquidiumBorrowedRow', () => {
 		const { queryByText } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
 
 		expect(queryByText(en.liquidium.text.action_repay)).not.toBeInTheDocument();
+	});
+
+	it('lines up the network icons of the rails the asset trades on', () => {
+		const usdc = USDC_TOKEN;
+		liquidiumStore.set({
+			markets: [
+				{
+					poolId: 'pool-usdc',
+					asset: 'USDC',
+					chain: 'ETH',
+					supplyApy: 3,
+					borrowApy: 4,
+					frozen: false,
+					available: true
+				}
+			],
+			portfolio: null,
+			assetPrices: {}
+		});
+
+		const { getByAltText } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
+
+		expect(getByAltText(`${usdc.network.icon}-0`)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
@@ -74,4 +74,27 @@ describe('LiquidiumBorrowedRow', () => {
 
 		expect(getByAltText(`${usdc.network.icon}-0`)).toBeInTheDocument();
 	});
+
+	it('exposes the rail network names as an accessible label for the icon stack', () => {
+		const usdc = USDC_TOKEN;
+		liquidiumStore.set({
+			markets: [
+				{
+					poolId: 'pool-usdc',
+					asset: 'USDC',
+					chain: 'ETH',
+					supplyApy: 3,
+					borrowApy: 4,
+					frozen: false,
+					available: true
+				}
+			],
+			portfolio: null,
+			assetPrices: {}
+		});
+
+		const { getByRole } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
+
+		expect(getByRole('img', { name: usdc.network.name })).toBeInTheDocument();
+	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumBorrowedRow.spec.ts
@@ -1,10 +1,14 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import LiquidiumBorrowedRow from '$lib/components/liquidium/LiquidiumBorrowedRow.svelte';
 import { ZERO } from '$lib/constants/app.constants';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('LiquidiumBorrowedRow', () => {
@@ -24,8 +28,24 @@ describe('LiquidiumBorrowedRow', () => {
 		...overrides
 	});
 
+	// Seed the ckUSDC twin so the USDC ICP rail resolves via `findTwinToken`.
+	const seedCkUsdcTwin = () => {
+		icrcCustomTokensStore.setAll([
+			{
+				data: {
+					...mockValidIcCkToken,
+					symbol: 'ckUSDC',
+					network: ICP_TOKEN.network,
+					enabled: true
+				} as IcrcCustomToken,
+				certified: false
+			}
+		]);
+	};
+
 	beforeEach(() => {
 		liquidiumStore.reset();
+		icrcCustomTokensStore.resetAll();
 	});
 
 	it('renders the symbol and token name without the network', () => {
@@ -52,8 +72,9 @@ describe('LiquidiumBorrowedRow', () => {
 		expect(queryByText(en.liquidium.text.action_repay)).not.toBeInTheDocument();
 	});
 
-	it('lines up the network icons of the rails the asset trades on', () => {
+	it('lines up an icon for every rail the asset trades on', () => {
 		const usdc = USDC_TOKEN;
+		seedCkUsdcTwin();
 		liquidiumStore.set({
 			markets: [
 				{
@@ -64,15 +85,28 @@ describe('LiquidiumBorrowedRow', () => {
 					borrowApy: 4,
 					frozen: false,
 					available: true
+				},
+				{
+					poolId: 'pool-usdc-icp',
+					asset: 'USDC',
+					chain: 'ICP',
+					supplyApy: 3,
+					borrowApy: 4,
+					frozen: false,
+					available: true
 				}
 			],
 			portfolio: null,
 			assetPrices: {}
 		});
 
-		const { getByAltText } = render(LiquidiumBorrowedRow, { props: { reserve: reserve() } });
+		const { getAllByAltText, getByAltText } = render(LiquidiumBorrowedRow, {
+			props: { reserve: reserve() }
+		});
 
+		// ERC-20 rail first, then the ICP rail — both icons render (alts are `<url>-<index>`).
 		expect(getByAltText(`${usdc.network.icon}-0`)).toBeInTheDocument();
+		expect(getAllByAltText(/-\d+$/)).toHaveLength(2);
 	});
 
 	it('exposes the rail network names as an accessible label for the icon stack', () => {

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
@@ -1,8 +1,10 @@
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import LiquidiumSuppliedRow from '$lib/components/liquidium/LiquidiumSuppliedRow.svelte';
 import { ZERO } from '$lib/constants/app.constants';
+import { liquidiumStore } from '$lib/stores/liquidium.store';
 import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
 
@@ -23,13 +25,19 @@ describe('LiquidiumSuppliedRow', () => {
 		...overrides
 	});
 
-	it('renders the symbol, token name and network', () => {
+	beforeEach(() => {
+		liquidiumStore.reset();
+	});
+
+	it('renders the symbol and token name without the network suffix', () => {
 		const { container } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
 		const btc = BTC_MAINNET_TOKEN;
 
 		expect(container).toHaveTextContent('BTC');
 		expect(container).toHaveTextContent(btc.name);
-		expect(container).toHaveTextContent(btc.network.name);
+		expect(container).not.toHaveTextContent(
+			replacePlaceholders(en.tokens.text.on_network, { $network: btc.network.name })
+		);
 	});
 
 	it('renders the supply APY and yearly earning', () => {
@@ -45,5 +53,28 @@ describe('LiquidiumSuppliedRow', () => {
 		const { queryByText } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
 
 		expect(queryByText(en.liquidium.text.action_withdraw)).not.toBeInTheDocument();
+	});
+
+	it('lines up the network icons of the rails the asset trades on', () => {
+		const btc = BTC_MAINNET_TOKEN;
+		liquidiumStore.set({
+			markets: [
+				{
+					poolId: 'pool-btc',
+					asset: 'BTC',
+					chain: 'BTC',
+					supplyApy: 5,
+					borrowApy: 9,
+					frozen: false,
+					available: true
+				}
+			],
+			portfolio: null,
+			assetPrices: {}
+		});
+
+		const { getByAltText } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
+
+		expect(getByAltText(`${btc.network.icon}-0`)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
@@ -1,4 +1,7 @@
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import LiquidiumSuppliedRow from '$lib/components/liquidium/LiquidiumSuppliedRow.svelte';
 import { ZERO } from '$lib/constants/app.constants';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
@@ -6,6 +9,7 @@ import type { LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import en from '$tests/mocks/i18n.mock';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('LiquidiumSuppliedRow', () => {
@@ -25,8 +29,24 @@ describe('LiquidiumSuppliedRow', () => {
 		...overrides
 	});
 
+	// Seed the ckBTC twin so the BTC ICP rail resolves via `findTwinToken`.
+	const seedCkBtcTwin = () => {
+		icrcCustomTokensStore.setAll([
+			{
+				data: {
+					...mockValidIcCkToken,
+					symbol: 'ckBTC',
+					network: ICP_TOKEN.network,
+					enabled: true
+				} as IcrcCustomToken,
+				certified: false
+			}
+		]);
+	};
+
 	beforeEach(() => {
 		liquidiumStore.reset();
+		icrcCustomTokensStore.resetAll();
 	});
 
 	it('renders the symbol and token name without the network suffix', () => {
@@ -55,8 +75,9 @@ describe('LiquidiumSuppliedRow', () => {
 		expect(queryByText(en.liquidium.text.action_withdraw)).not.toBeInTheDocument();
 	});
 
-	it('lines up the network icons of the rails the asset trades on', () => {
+	it('lines up an icon for every rail the asset trades on', () => {
 		const btc = BTC_MAINNET_TOKEN;
+		seedCkBtcTwin();
 		liquidiumStore.set({
 			markets: [
 				{
@@ -67,15 +88,28 @@ describe('LiquidiumSuppliedRow', () => {
 					borrowApy: 9,
 					frozen: false,
 					available: true
+				},
+				{
+					poolId: 'pool-btc-icp',
+					asset: 'BTC',
+					chain: 'ICP',
+					supplyApy: 5,
+					borrowApy: 9,
+					frozen: false,
+					available: true
 				}
 			],
 			portfolio: null,
 			assetPrices: {}
 		});
 
-		const { getByAltText } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
+		const { getAllByAltText, getByAltText } = render(LiquidiumSuppliedRow, {
+			props: { reserve: reserve() }
+		});
 
+		// Native rail first, then the ICP rail — both icons render (alts are `<url>-<index>`).
 		expect(getByAltText(`${btc.network.icon}-0`)).toBeInTheDocument();
+		expect(getAllByAltText(/-\d+$/)).toHaveLength(2);
 	});
 
 	it('exposes the rail network names as an accessible label for the icon stack', () => {

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSuppliedRow.spec.ts
@@ -77,4 +77,27 @@ describe('LiquidiumSuppliedRow', () => {
 
 		expect(getByAltText(`${btc.network.icon}-0`)).toBeInTheDocument();
 	});
+
+	it('exposes the rail network names as an accessible label for the icon stack', () => {
+		const btc = BTC_MAINNET_TOKEN;
+		liquidiumStore.set({
+			markets: [
+				{
+					poolId: 'pool-btc',
+					asset: 'BTC',
+					chain: 'BTC',
+					supplyApy: 5,
+					borrowApy: 9,
+					frozen: false,
+					available: true
+				}
+			],
+			portfolio: null,
+			assetPrices: {}
+		});
+
+		const { getByRole } = render(LiquidiumSuppliedRow, { props: { reserve: reserve() } });
+
+		expect(getByRole('img', { name: btc.network.name })).toBeInTheDocument();
+	});
 });

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -1,7 +1,12 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import { ZERO } from '$lib/constants/app.constants';
 import { AppPath } from '$lib/constants/routes.constants';
 import {
+	liquidiumAssetNetworkIcons,
 	liquidiumBorrowData,
 	liquidiumBorrowingPowerUsd,
 	liquidiumBorrowInterestUsd,
@@ -237,6 +242,34 @@ describe('liquidium derived stores', () => {
 				'USDC-ETH',
 				'USDC-ICP'
 			]);
+		});
+	});
+
+	describe('liquidiumAssetNetworkIcons', () => {
+		it('is empty by default', () => {
+			expect(get(liquidiumAssetNetworkIcons)).toEqual({});
+		});
+
+		it('maps each asset to the network icons of its rails, deduped across markets', () => {
+			liquidiumStore.set({
+				markets: [
+					market(),
+					// Same asset on the same rail again: the icon must not be duplicated.
+					market({ poolId: 'pool-btc-2', asset: 'BTC', chain: 'BTC' }),
+					market({ poolId: 'pool-eth', asset: 'ETH', chain: 'ETH' }),
+					market({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' }),
+					market({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
+				],
+				portfolio: null,
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumAssetNetworkIcons)).toEqual({
+				BTC: [BTC_MAINNET_TOKEN.network.icon],
+				ETH: [ETHEREUM_TOKEN.network.icon],
+				USDC: [USDC_TOKEN.network.icon],
+				ICP: [ICP_TOKEN.network.icon]
+			});
 		});
 	});
 

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -3,6 +3,8 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { EarningCardFields } from '$env/types/env.earning-cards';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import { ZERO } from '$lib/constants/app.constants';
 import { AppPath } from '$lib/constants/routes.constants';
 import {
@@ -30,7 +32,25 @@ import { liquidiumStore } from '$lib/stores/liquidium.store';
 import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import { formatStakeApyNumber } from '$lib/utils/format.utils';
 import { liquidiumNetInterestUsd } from '$lib/utils/liquidium.utils';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { get } from 'svelte/store';
+
+// Seed the ck twins so the `chain: 'ICP'` rails resolve via `findTwinToken` (native/ERC rails
+// resolve statically). Network set to ICP so the rail icon/name is the ICP network's.
+const seedIcpTwins = () => {
+	const twin = (symbol: string): IcrcCustomToken =>
+		({
+			...mockValidIcCkToken,
+			symbol,
+			network: ICP_TOKEN.network,
+			enabled: true
+		}) as IcrcCustomToken;
+
+	icrcCustomTokensStore.setAll([
+		{ data: twin('ckBTC'), certified: false },
+		{ data: twin('ckUSDC'), certified: false }
+	]);
+};
 
 const mockGoto = vi.fn();
 vi.mock('$app/navigation', () => ({ goto: (...args: unknown[]) => mockGoto(...args) }));
@@ -205,6 +225,7 @@ describe('liquidium derived stores', () => {
 
 	beforeEach(() => {
 		liquidiumStore.reset();
+		icrcCustomTokensStore.resetAll();
 	});
 
 	describe('liquidiumMarkets', () => {
@@ -251,14 +272,18 @@ describe('liquidium derived stores', () => {
 			expect(get(liquidiumAssetNetworkIcons)).toEqual({});
 		});
 
-		it('maps each asset to the network icons of its rails, deduped across markets', () => {
+		it('aggregates every rail of an asset (incl. the ICP twin) and dedupes across markets', () => {
+			seedIcpTwins();
 			liquidiumStore.set({
 				markets: [
 					market(),
 					// Same asset on the same rail again: the icon must not be duplicated.
 					market({ poolId: 'pool-btc-2', asset: 'BTC', chain: 'BTC' }),
+					// Same asset on a different (ICP twin) rail: both rail icons must appear.
+					market({ poolId: 'pool-btc-icp', asset: 'BTC', chain: 'ICP' }),
 					market({ poolId: 'pool-eth', asset: 'ETH', chain: 'ETH' }),
 					market({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' }),
+					market({ poolId: 'pool-usdc-icp', asset: 'USDC', chain: 'ICP' }),
 					market({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
 				],
 				portfolio: null,
@@ -266,9 +291,9 @@ describe('liquidium derived stores', () => {
 			});
 
 			expect(get(liquidiumAssetNetworkIcons)).toEqual({
-				BTC: [BTC_MAINNET_TOKEN.network.icon],
+				BTC: [BTC_MAINNET_TOKEN.network.icon, ICP_TOKEN.network.icon],
 				ETH: [ETHEREUM_TOKEN.network.icon],
-				USDC: [USDC_TOKEN.network.icon],
+				USDC: [USDC_TOKEN.network.icon, ICP_TOKEN.network.icon],
 				ICP: [ICP_TOKEN.network.icon]
 			});
 		});
@@ -279,14 +304,18 @@ describe('liquidium derived stores', () => {
 			expect(get(liquidiumAssetNetworkNames)).toEqual({});
 		});
 
-		it('maps each asset to the network names of its rails, deduped across markets', () => {
+		it('aggregates every rail name of an asset (incl. the ICP twin) and dedupes across markets', () => {
+			seedIcpTwins();
 			liquidiumStore.set({
 				markets: [
 					market(),
 					// Same asset on the same rail again: the name must not be duplicated.
 					market({ poolId: 'pool-btc-2', asset: 'BTC', chain: 'BTC' }),
+					// Same asset on a different (ICP twin) rail: both rail names must appear.
+					market({ poolId: 'pool-btc-icp', asset: 'BTC', chain: 'ICP' }),
 					market({ poolId: 'pool-eth', asset: 'ETH', chain: 'ETH' }),
 					market({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' }),
+					market({ poolId: 'pool-usdc-icp', asset: 'USDC', chain: 'ICP' }),
 					market({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
 				],
 				portfolio: null,
@@ -294,9 +323,9 @@ describe('liquidium derived stores', () => {
 			});
 
 			expect(get(liquidiumAssetNetworkNames)).toEqual({
-				BTC: [BTC_MAINNET_TOKEN.network.name],
+				BTC: [BTC_MAINNET_TOKEN.network.name, ICP_TOKEN.network.name],
 				ETH: [ETHEREUM_TOKEN.network.name],
-				USDC: [USDC_TOKEN.network.name],
+				USDC: [USDC_TOKEN.network.name, ICP_TOKEN.network.name],
 				ICP: [ICP_TOKEN.network.name]
 			});
 		});

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -7,6 +7,7 @@ import { ZERO } from '$lib/constants/app.constants';
 import { AppPath } from '$lib/constants/routes.constants';
 import {
 	liquidiumAssetNetworkIcons,
+	liquidiumAssetNetworkNames,
 	liquidiumBorrowData,
 	liquidiumBorrowingPowerUsd,
 	liquidiumBorrowInterestUsd,
@@ -269,6 +270,34 @@ describe('liquidium derived stores', () => {
 				ETH: [ETHEREUM_TOKEN.network.icon],
 				USDC: [USDC_TOKEN.network.icon],
 				ICP: [ICP_TOKEN.network.icon]
+			});
+		});
+	});
+
+	describe('liquidiumAssetNetworkNames', () => {
+		it('is empty by default', () => {
+			expect(get(liquidiumAssetNetworkNames)).toEqual({});
+		});
+
+		it('maps each asset to the network names of its rails, deduped across markets', () => {
+			liquidiumStore.set({
+				markets: [
+					market(),
+					// Same asset on the same rail again: the name must not be duplicated.
+					market({ poolId: 'pool-btc-2', asset: 'BTC', chain: 'BTC' }),
+					market({ poolId: 'pool-eth', asset: 'ETH', chain: 'ETH' }),
+					market({ poolId: 'pool-usdc', asset: 'USDC', chain: 'ETH' }),
+					market({ poolId: 'pool-icp', asset: 'ICP', chain: 'ICP' })
+				],
+				portfolio: null,
+				assetPrices: {}
+			});
+
+			expect(get(liquidiumAssetNetworkNames)).toEqual({
+				BTC: [BTC_MAINNET_TOKEN.network.name],
+				ETH: [ETHEREUM_TOKEN.network.name],
+				USDC: [USDC_TOKEN.network.name],
+				ICP: [ICP_TOKEN.network.name]
 			});
 		});
 	});


### PR DESCRIPTION
## Motivation

On the Liquidium provider page, the Supplied and Borrowed rows pinned each position to a single network — a "on Ethereum" name suffix plus a single network badge on the token logo. This is misleading: the same asset can trade on several rails (e.g. USDC as ERC-20 USDC on Ethereum and as ckUSDC on ICP), so labelling a USDC row "on Ethereum" wrongly implies it is Ethereum-only.

Instead of pinning to one network, the rows now line up the icons of every rail the asset trades on — the same treatment the Borrow page provider cards already use for their Networks field.

## Changes

- Add `liquidiumAssetNetworkIcons` derived store, keyed by asset symbol → the deduped network icons of every rail the asset is offered on across the live markets (resolved via the existing `liquidiumMarketToken`).
- In `LiquidiumSuppliedRow` and `LiquidiumBorrowedRow`: drop the `on <network>` name suffix (name only now) and the single-network badge, and line up the rail network icons beside the token logo via the existing `OverlappedLogos` component.
- The shared `TokenNameAndNetwork` component is untouched (still used elsewhere with the network suffix); the rows adapt at the call site.
- Anchor the icon line-up where the single network badge used to sit (bottom-right of the logo), with the remaining rails extending to the right.
- Add a `liquidiumAssetNetworkNames` companion derived and expose the rail names as a `role="img"` `aria-label` on each row's icon stack, so the networks stay available to assistive tech now that the text suffix is gone.

Rails are derived from all markets, so an asset shows a rail's icon only where that rail is actually offered; a single-rail asset (ETH, ICP) shows one icon.

## Tests

- New derived-store coverage for `liquidiumAssetNetworkIcons` / `liquidiumAssetNetworkNames`, including a multi-rail + ICP-twin case (seeding the ckBTC/ckUSDC twins so the ICP rails resolve) that asserts per-asset aggregation and dedupe.
- Per-row tests that the full rail icon line-up renders and that the rail names are exposed as an accessible label; updated the previous assertions that expected the single network name/suffix.
- Full Liquidium component + derived suites pass (183 tests); `check`, `check:tests`, lint and prettier are clean.

Not visually verified in a running app — the provider page needs a connected wallet with live Liquidium positions.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (claude-opus-4-8)
