### PR TITLE
feat(frontend): disable Liquidium Borrow button without a supply position

### DIFF
--- a/src/frontend/src/lib/components/liquidium/LiquidiumSummary.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumSummary.svelte
@@ -37,6 +37,9 @@
 	let healthFactorPercent = $derived(portfolio?.healthFactorPercent ?? 100);
 
 	let totalSuppliedUsd = $derived(portfolio?.totalSuppliedUsd ?? 0);
+	// Borrowing power comes from supplied collateral, so without any supply there is
+	// nothing to borrow against — gate the action until the user supplies something.
+	let hasSupply = $derived(totalSuppliedUsd > 0);
 	let formattedTotalSupplied = $derived(
 		formatCurrency({
 			value: totalSuppliedUsd,
@@ -163,7 +166,7 @@
 
 	<ActiveLoansCard showHealthFactor={false} showWithShortenedLabel widthClass="sm:w-1/2">
 		{#snippet buttons()}
-			<Button onclick={() => modalStore.openLiquidiumBorrow(borrowModalId)}>
+			<Button disabled={!hasSupply} onclick={() => modalStore.openLiquidiumBorrow(borrowModalId)}>
 				{$i18n.liquidium.text.action_borrow}
 			</Button>
 		{/snippet}

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
@@ -152,7 +152,12 @@ describe('LiquidiumSummary', () => {
 		});
 
 		it('disables the Borrow button when there is no supply position', () => {
-			const noSupply: LiquidiumPortfolio = { ...portfolio, totalSuppliedUsd: 0 };
+			const noSupply: LiquidiumPortfolio = {
+				...portfolio,
+				reserves: portfolio.reserves.map((reserve) => ({ ...reserve, suppliedUsd: 0 })),
+				totalSuppliedUsd: 0,
+				netValueUsd: 0
+			};
 
 			const { getByRole } = render(LiquidiumSummary, { props: { portfolio: noSupply } });
 

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumSummary.spec.ts
@@ -150,5 +150,25 @@ describe('LiquidiumSummary', () => {
 
 			expect(get(modalStore)?.type).toBe('liquidium-borrow');
 		});
+
+		it('disables the Borrow button when there is no supply position', () => {
+			const noSupply: LiquidiumPortfolio = { ...portfolio, totalSuppliedUsd: 0 };
+
+			const { getByRole } = render(LiquidiumSummary, { props: { portfolio: noSupply } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeDisabled();
+		});
+
+		it('disables the Borrow button in the empty state', () => {
+			const { getByRole } = render(LiquidiumSummary, { props: { portfolio: null } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeDisabled();
+		});
+
+		it('enables the Borrow button when there is a supply position', () => {
+			const { getByRole } = render(LiquidiumSummary, { props: { portfolio } });
+
+			expect(getByRole('button', { name: en.liquidium.text.action_borrow })).toBeEnabled();
+		});
 	});
 });


### PR DESCRIPTION
## Motivation

On the Liquidium provider page the **Borrow** action was always clickable, even for users with no supply position. Since borrowing power derives entirely from supplied collateral, such a user can never open a valid borrow — the action leads to a dead-end flow.

This gates the Borrow button on whether the user actually has a supply position.

## Changes

- `LiquidiumSummary.svelte`: disable the **Borrow** button when `totalSuppliedUsd <= 0` (no supply position), via a new `hasSupply` derived.

## Tests

- Added `LiquidiumSummary.spec.ts` cases: Borrow disabled with no supply position, disabled in the empty state, and enabled once there is a supply position.
- Made the no-supply test fixture internally consistent (zeroed reserve `suppliedUsd` and `netValueUsd`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (claude-opus-4-8)
