### PR TITLE
feat(frontend): pool wallet Web Workers instead of one per token

### DIFF
--- a/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
+++ b/src/frontend/src/btc/schedulers/btc-wallet.scheduler.ts
@@ -88,8 +88,24 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 		this.timer.stop();
 	}
 
+	protected setRef(data: PostMessageDataRequestBtc | undefined) {
+		const newRef = data?.btcAddress.data;
+
+		// A scheduler re-keyed to another address must not filter or merge against the previous
+		// address's state (mirrors sol-wallet.scheduler.ts).
+		if (this.ref !== newRef) {
+			this.store = {
+				balance: undefined,
+				transactions: {},
+				latestBitcoinBlockHeight: undefined
+			};
+		}
+
+		this.ref = newRef;
+	}
+
 	async start(data: PostMessageDataRequestBtc | undefined) {
-		this.ref = data?.btcAddress.data;
+		this.setRef(data);
 
 		await this.timer.start<PostMessageDataRequestBtc>({
 			interval: WALLET_TIMER_INTERVAL_MILLIS,
@@ -99,6 +115,8 @@ export class BtcWalletScheduler implements Scheduler<PostMessageDataRequestBtc> 
 	}
 
 	async trigger(data: PostMessageDataRequestBtc | undefined) {
+		this.setRef(data);
+
 		await this.timer.trigger<PostMessageDataRequestBtc>({
 			job: this.syncWallet,
 			data

--- a/src/frontend/src/btc/services/worker.btc-wallet.services.ts
+++ b/src/frontend/src/btc/services/worker.btc-wallet.services.ts
@@ -13,7 +13,11 @@ import {
 } from '$lib/stores/address.store';
 import type { OptionCanisterIdText } from '$lib/types/canister';
 import type { WalletWorker } from '$lib/types/listener';
-import type { PostMessage, PostMessageDataRequestBtc } from '$lib/types/post-message';
+import type {
+	PostMessage,
+	PostMessageDataRequestBtc,
+	PostMessageScheduler
+} from '$lib/types/post-message';
 import type { Token, TokenId } from '$lib/types/token';
 import type { WorkerData } from '$lib/types/worker';
 import {
@@ -34,8 +38,14 @@ export class BtcWalletWorker extends AppWorker implements WalletWorker {
 		super(worker);
 
 		this.setOnMessage(
-			({ data: dataMsg }: MessageEvent<PostMessage<BtcPostMessageDataResponseWallet>>) => {
-				const { msg, data } = dataMsg;
+			({ data: dataMsg }: MessageEvent<PostMessageScheduler<BtcPostMessageDataResponseWallet>>) => {
+				const { ref, msg, data } = dataMsg;
+
+				// A pooled worker is shared by several BTC tokens, so drop any message meant for
+				// another token. The scheduler stamps `ref` with the Bitcoin address.
+				if (ref !== this.data.btcAddress.data) {
+					return;
+				}
 
 				switch (msg) {
 					case 'syncBtcWallet':
@@ -97,13 +107,14 @@ export class BtcWalletWorker extends AppWorker implements WalletWorker {
 
 		const hideToast = isRegtestNetwork || isTestnetNetwork || (isMainnetNetwork && !STAGING);
 
-		const worker = await AppWorker.getInstance();
+		const worker = await AppWorker.getInstance({ pooled: true, poolKey: data.btcAddress.data });
 		return new BtcWalletWorker(worker, tokenId, data, hideToast);
 	}
 
 	protected override stopTimer = () => {
-		this.postMessage({
-			msg: 'stopBtcWalletTimer'
+		this.postMessage<PostMessage<PostMessageDataRequestBtc>>({
+			msg: 'stopBtcWalletTimer',
+			data: this.data
 		});
 	};
 

--- a/src/frontend/src/btc/workers/btc-wallet.worker.ts
+++ b/src/frontend/src/btc/workers/btc-wallet.worker.ts
@@ -1,21 +1,60 @@
 import { BtcWalletScheduler } from '$btc/schedulers/btc-wallet.scheduler';
 import type { PostMessage, PostMessageDataRequestBtc } from '$lib/types/post-message';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
-const scheduler: BtcWalletScheduler = new BtcWalletScheduler();
+// Keyed by the Bitcoin address so several BTC tokens can share one pooled worker without their
+// timers clobbering each other. A dedicated worker only ever holds a single entry.
+const schedulers = new Map<string, BtcWalletScheduler>();
+
+const stopAllSchedulers = () => {
+	schedulers.forEach((scheduler) => scheduler.stop());
+	schedulers.clear();
+};
 
 export const onBtcWalletMessage = async ({
 	data: dataMsg
 }: MessageEvent<PostMessage<PostMessageDataRequestBtc>>) => {
 	const { msg, data } = dataMsg;
 
+	const schedulerKey = nonNullish(data) && 'btcAddress' in data ? data.btcAddress.data : undefined;
+
 	switch (msg) {
-		case 'stopBtcWalletTimer':
-			scheduler.stop();
+		case 'stopBtcWalletTimer': {
+			if (isNullish(schedulerKey)) {
+				stopAllSchedulers();
+				return;
+			}
+
+			schedulers.get(schedulerKey)?.stop();
+			schedulers.delete(schedulerKey);
 			return;
-		case 'startBtcWalletTimer':
+		}
+		case 'startBtcWalletTimer': {
+			if (isNullish(schedulerKey)) {
+				return;
+			}
+
+			schedulers.get(schedulerKey)?.stop();
+
+			const scheduler = new BtcWalletScheduler();
+			schedulers.set(schedulerKey, scheduler);
+
 			await scheduler.start(data);
 			return;
-		case 'triggerBtcWalletTimer':
+		}
+		case 'triggerBtcWalletTimer': {
+			if (isNullish(schedulerKey)) {
+				return;
+			}
+
+			let scheduler = schedulers.get(schedulerKey);
+
+			if (isNullish(scheduler)) {
+				scheduler = new BtcWalletScheduler();
+				schedulers.set(schedulerKey, scheduler);
+			}
+
 			await scheduler.trigger(data);
+		}
 	}
 };

--- a/src/frontend/src/icp/schedulers/ic-wallet.scheduler.ts
+++ b/src/frontend/src/icp/schedulers/ic-wallet.scheduler.ts
@@ -51,6 +51,11 @@ export abstract class IcWalletScheduler<
 	}
 
 	async trigger(data: PostMessageDataRequest | undefined) {
+		// A scheduler created by a `trigger` (no prior `start`) would otherwise keep `ref` undefined
+		// and silently drop every sync result via the `isNullish(this.ref)` guard in the postMessage
+		// helpers — the same fix BtcWalletScheduler/SolWalletScheduler already carry.
+		this.setRef(data);
+
 		await this.timer.trigger<PostMessageDataRequest>({
 			job: this.syncWallet,
 			data

--- a/src/frontend/src/icp/services/worker.dip20-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.dip20-wallet.services.ts
@@ -16,7 +16,6 @@ import type {
 } from '$lib/types/post-message';
 import type { TokenId } from '$lib/types/token';
 import type { WorkerData } from '$lib/types/worker';
-import { isIOS } from '$lib/utils/device.utils';
 
 export class Dip20WalletWorker extends AppWorker implements WalletWorker {
 	private constructor(
@@ -75,7 +74,7 @@ export class Dip20WalletWorker extends AppWorker implements WalletWorker {
 	}: IcToken): Promise<Dip20WalletWorker> {
 		await syncWalletFromCache({ tokenId, networkId });
 
-		const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
+		const worker = await AppWorker.getInstance({ pooled: true, poolKey: canisterId });
 		return new Dip20WalletWorker(worker, tokenId, canisterId);
 	}
 

--- a/src/frontend/src/icp/services/worker.icp-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icp-wallet.services.ts
@@ -17,7 +17,6 @@ import type {
 } from '$lib/types/post-message';
 import type { TokenId } from '$lib/types/token';
 import type { WorkerData } from '$lib/types/worker';
-import { isIOS } from '$lib/utils/device.utils';
 import { assertNonNullish } from '@dfinity/utils';
 
 export class IcpWalletWorker extends AppWorker implements WalletWorker {
@@ -82,7 +81,7 @@ export class IcpWalletWorker extends AppWorker implements WalletWorker {
 
 		await syncWalletFromCache({ tokenId, networkId });
 
-		const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
+		const worker = await AppWorker.getInstance({ pooled: true, poolKey: ledgerCanisterId });
 		return new IcpWalletWorker(worker, tokenId, ledgerCanisterId, indexCanisterId);
 	}
 

--- a/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
+++ b/src/frontend/src/icp/services/worker.icrc-wallet.services.ts
@@ -16,7 +16,6 @@ import type {
 } from '$lib/types/post-message';
 import type { TokenId } from '$lib/types/token';
 import type { WorkerData } from '$lib/types/worker';
-import { isIOS } from '$lib/utils/device.utils';
 import { nonNullish } from '@dfinity/utils';
 
 export class IcrcWalletWorker extends AppWorker implements WalletWorker {
@@ -85,7 +84,7 @@ export class IcrcWalletWorker extends AppWorker implements WalletWorker {
 	}: IcToken): Promise<IcrcWalletWorker> {
 		await syncWalletFromCache({ tokenId, networkId });
 
-		const worker = await AppWorker.getInstance({ asSingleton: isIOS() });
+		const worker = await AppWorker.getInstance({ pooled: true, poolKey: ledgerCanisterId });
 		return new IcrcWalletWorker(worker, tokenId, ledgerCanisterId, indexCanisterId, env);
 	}
 

--- a/src/frontend/src/lib/services/_worker.services.ts
+++ b/src/frontend/src/lib/services/_worker.services.ts
@@ -225,9 +225,10 @@ export abstract class AppWorker {
 	 * This is notably useful for testing purposes to ensure that each test starts with a clean state.
 	 */
 	static resetForTesting() {
-		this.#pool.clear();
-		this.#poolRefCounts.clear();
+		// Mirror terminateAllWorkers: terminate live threads before dropping the tracking set —
+		// #liveWorkers is the only handle that can stop them, so clearing it first leaks the threads
+		// and makes them unreachable for any later teardown.
+		AppWorker.terminateAllWorkers();
 		this.#poolSize = undefined;
-		this.#liveWorkers.clear();
 	}
 }

--- a/src/frontend/src/lib/services/_worker.services.ts
+++ b/src/frontend/src/lib/services/_worker.services.ts
@@ -1,5 +1,6 @@
 import { WorkerQueue } from '$lib/services/worker-queue.services';
 import type { WithoutWorkerId, WorkerData, WorkerId } from '$lib/types/worker';
+import { workerPoolSize } from '$lib/utils/device.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
 type MessageHandler = (ev: MessageEvent) => void;
@@ -7,29 +8,33 @@ type MessageHandler = (ev: MessageEvent) => void;
 export abstract class AppWorker {
 	readonly #worker: Worker;
 	readonly #workerId: WorkerId;
-	readonly #isSingleton: boolean;
+	readonly #poolIndex: number | undefined;
 	readonly #queue: WorkerQueue;
 	// TODO: use generics directly in the class so that we can use type WorkerListener
 	#listener: ((ev: MessageEvent) => void) | undefined;
 	#isTerminated = false;
 
-	static #singletonWorker?: Worker;
-	static #singletonRefCount = 0;
+	// Shared worker pool. Wallet workers opt in via `getInstance({ pooled: true })` and are sharded
+	// across a small number of realms (keyed by a stable token id) instead of one realm per token.
+	// The map holds the in-flight creation promise so concurrent callers share a single realm.
+	static #pool = new Map<number, Promise<Worker>>();
+	static #poolRefCounts = new Map<number, number>();
+	static #poolSize: number | undefined;
 
 	// Every underlying Worker ever spawned and not yet terminated, so that all
 	// threads can be torn down at once when the page unloads.
 	static #liveWorkers = new Set<Worker>();
 
 	protected constructor(workerData: WorkerData) {
-		const { worker, isSingleton } = workerData;
+		const { worker, poolIndex } = workerData;
 
 		this.#worker = worker;
 		this.#workerId = crypto.randomUUID();
-		this.#isSingleton = isSingleton;
+		this.#poolIndex = poolIndex;
 		this.#queue = new WorkerQueue(worker);
 
-		if (this.#isSingleton) {
-			AppWorker.#singletonRefCount++;
+		if (nonNullish(poolIndex)) {
+			AppWorker.#poolRefCounts.set(poolIndex, (AppWorker.#poolRefCounts.get(poolIndex) ?? 0) + 1);
 		}
 	}
 
@@ -40,21 +45,65 @@ export abstract class AppWorker {
 		return worker;
 	};
 
-	static #getInstanceAsSingleton = async (): Promise<Worker> => {
-		if (isNullish(this.#singletonWorker)) {
-			this.#singletonWorker = await this.#newInstance();
-			this.#singletonRefCount = 0;
+	static #resolvedPoolSize = (): number => {
+		if (isNullish(this.#poolSize)) {
+			this.#poolSize = workerPoolSize();
 		}
 
-		return this.#singletonWorker;
+		return this.#poolSize;
 	};
 
-	static getInstance = async (
-		{ asSingleton = false }: { asSingleton?: boolean } = { asSingleton: false }
-	): Promise<WorkerData> => {
-		const worker = asSingleton ? await this.#getInstanceAsSingleton() : await this.#newInstance();
+	// Stable, non-negative hash so a given token always maps to the same pool worker across
+	// stop/start cycles — the scheduler on that worker holds per-token delta state.
+	static #hashKey = (key: string): number => {
+		let hash = 0;
 
-		return { worker, isSingleton: asSingleton };
+		for (let i = 0; i < key.length; i++) {
+			hash = (hash * 31 + key.charCodeAt(i)) | 0;
+		}
+
+		return Math.abs(hash);
+	};
+
+	static #poolIndexForKey = (key: string | undefined): number => {
+		const size = this.#resolvedPoolSize();
+
+		if (size <= 1 || isNullish(key)) {
+			return 0;
+		}
+
+		return this.#hashKey(key) % size;
+	};
+
+	static #getPooledWorker = (index: number): Promise<Worker> => {
+		const existing = this.#pool.get(index);
+
+		if (nonNullish(existing)) {
+			return existing;
+		}
+
+		// Store the in-flight promise (not the resolved worker) so concurrent callers targeting the
+		// same index share one realm instead of racing to create duplicates.
+		const created = this.#newInstance();
+
+		this.#pool.set(index, created);
+		this.#poolRefCounts.set(index, 0);
+
+		return created;
+	};
+
+	static getInstance = async ({
+		pooled = false,
+		poolKey
+	}: { pooled?: boolean; poolKey?: string } = {}): Promise<WorkerData> => {
+		if (!pooled) {
+			return { worker: await this.#newInstance() };
+		}
+
+		const poolIndex = this.#poolIndexForKey(poolKey);
+		const worker = await this.#getPooledWorker(poolIndex);
+
+		return { worker, poolIndex };
 	};
 
 	#addMessageListener = (listener: MessageHandler) => {
@@ -72,13 +121,11 @@ export abstract class AppWorker {
 		this.#listener = undefined;
 	};
 
-	#setOnMessageAsSingleton = (listener: MessageHandler) => {
-		this.#addMessageListener(listener);
-	};
-
 	protected setOnMessage = (listener: MessageHandler) => {
-		if (this.#isSingleton) {
-			this.#setOnMessageAsSingleton(listener);
+		// A pooled worker is shared by several wrappers, so each registers its own message listener
+		// and filters by `ref`. A dedicated worker can own the single `onmessage` handler.
+		if (nonNullish(this.#poolIndex)) {
+			this.#addMessageListener(listener);
 			return;
 		}
 
@@ -98,7 +145,7 @@ export abstract class AppWorker {
 
 		this.#isTerminated = true;
 
-		if (!this.#isSingleton) {
+		if (isNullish(this.#poolIndex)) {
 			this.#worker.terminate();
 
 			this.#worker.onmessage = null;
@@ -108,18 +155,21 @@ export abstract class AppWorker {
 			return;
 		}
 
-		// If it's a singleton, multiple `AppWorker` wrappers share the same underlying Worker.
-		// We track wrapper instances (ref count) and terminate the singleton Worker when the last one is destroyed.
+		// A pooled worker is shared: drop this wrapper's listener and only terminate the underlying
+		// Worker once the last wrapper on that pool index is gone.
 		this.#removeListener();
 
-		AppWorker.#singletonRefCount--;
+		const remaining = (AppWorker.#poolRefCounts.get(this.#poolIndex) ?? 1) - 1;
 
-		if (AppWorker.#singletonRefCount <= 0 && nonNullish(AppWorker.#singletonWorker)) {
-			AppWorker.#singletonWorker.terminate();
-			AppWorker.#liveWorkers.delete(AppWorker.#singletonWorker);
-			AppWorker.#singletonWorker = undefined;
-			AppWorker.#singletonRefCount = 0;
+		if (remaining <= 0) {
+			this.#worker.terminate();
+			AppWorker.#liveWorkers.delete(this.#worker);
+			AppWorker.#pool.delete(this.#poolIndex);
+			AppWorker.#poolRefCounts.delete(this.#poolIndex);
+			return;
 		}
+
+		AppWorker.#poolRefCounts.set(this.#poolIndex, remaining);
 	};
 
 	/**
@@ -135,8 +185,8 @@ export abstract class AppWorker {
 		AppWorker.#liveWorkers.forEach((worker) => worker.terminate());
 		AppWorker.#liveWorkers.clear();
 
-		AppWorker.#singletonWorker = undefined;
-		AppWorker.#singletonRefCount = 0;
+		AppWorker.#pool.clear();
+		AppWorker.#poolRefCounts.clear();
 	};
 
 	protected abstract stopTimer(): void;
@@ -159,11 +209,9 @@ export abstract class AppWorker {
 	 * This is notably useful for testing purposes to ensure that each test starts with a clean state.
 	 */
 	static resetForTesting() {
-		if (nonNullish(this.#singletonWorker)) {
-			this.#singletonWorker.terminate();
-			this.#singletonWorker = undefined;
-		}
-		this.#singletonRefCount = 0;
+		this.#pool.clear();
+		this.#poolRefCounts.clear();
+		this.#poolSize = undefined;
 		this.#liveWorkers.clear();
 	}
 }

--- a/src/frontend/src/lib/services/_worker.services.ts
+++ b/src/frontend/src/lib/services/_worker.services.ts
@@ -17,6 +17,8 @@ export abstract class AppWorker {
 	// Shared worker pool. Wallet workers opt in via `getInstance({ pooled: true })` and are sharded
 	// across a small number of realms (keyed by a stable token id) instead of one realm per token.
 	// The map holds the in-flight creation promise so concurrent callers share a single realm.
+	// Ref counts are reserved synchronously in `getInstance` (not on wrapper construction) so a
+	// destroy of the last sibling wrapper racing an in-flight init cannot tear the realm down early.
 	static #pool = new Map<number, Promise<Worker>>();
 	static #poolRefCounts = new Map<number, number>();
 	static #poolSize: number | undefined;
@@ -32,10 +34,6 @@ export abstract class AppWorker {
 		this.#workerId = crypto.randomUUID();
 		this.#poolIndex = poolIndex;
 		this.#queue = new WorkerQueue(worker);
-
-		if (nonNullish(poolIndex)) {
-			AppWorker.#poolRefCounts.set(poolIndex, (AppWorker.#poolRefCounts.get(poolIndex) ?? 0) + 1);
-		}
 	}
 
 	static #newInstance = async (): Promise<Worker> => {
@@ -101,9 +99,27 @@ export abstract class AppWorker {
 		}
 
 		const poolIndex = this.#poolIndexForKey(poolKey);
-		const worker = await this.#getPooledWorker(poolIndex);
+		const created = this.#getPooledWorker(poolIndex);
 
-		return { worker, poolIndex };
+		// Reserve this wrapper's reference before awaiting: a concurrent destroy of the last sibling
+		// wrapper must not see a ref count of zero — it would terminate the realm and this wrapper
+		// would silently attach to a dead Worker.
+		this.#poolRefCounts.set(poolIndex, (this.#poolRefCounts.get(poolIndex) ?? 0) + 1);
+
+		try {
+			return { worker: await created, poolIndex };
+		} catch (err: unknown) {
+			// A failed realm creation (e.g. a stale chunk after a redeploy) must not poison the pool
+			// slot: drop the cached rejection so the next caller retries with a fresh worker. No
+			// wrapper was ever constructed on this realm, so the whole slot bookkeeping goes with it —
+			// unless another caller already cleaned up and recreated the slot.
+			if (this.#pool.get(poolIndex) === created) {
+				this.#pool.delete(poolIndex);
+				this.#poolRefCounts.delete(poolIndex);
+			}
+
+			throw err;
+		}
 	};
 
 	#addMessageListener = (listener: MessageHandler) => {

--- a/src/frontend/src/lib/types/worker.ts
+++ b/src/frontend/src/lib/types/worker.ts
@@ -6,7 +6,9 @@ import type {
 
 export interface WorkerData {
 	worker: Worker;
-	isSingleton: boolean;
+	// Index into the shared worker pool when this wrapper is attached to a pooled (shared) worker.
+	// Undefined for a dedicated worker owned solely by this wrapper.
+	poolIndex?: number;
 }
 
 export type WorkerId = string;

--- a/src/frontend/src/lib/utils/device.utils.ts
+++ b/src/frontend/src/lib/utils/device.utils.ts
@@ -66,6 +66,12 @@ export const workerPoolSize = (): number => {
 		return 1;
 	}
 
+	// No browser context (SSR / non-browser runtime) — reading `navigator` would throw. The worker
+	// pool is never actually exercised there; return the full pool so any caller gets a valid size.
+	if (typeof navigator === 'undefined') {
+		return WORKER_POOL_MAX_SIZE;
+	}
+
 	const cores: number | undefined = navigator.hardwareConcurrency;
 
 	if (isNullish(cores)) {

--- a/src/frontend/src/lib/utils/device.utils.ts
+++ b/src/frontend/src/lib/utils/device.utils.ts
@@ -52,3 +52,21 @@ export const isPWAStandalone = () => {
 
 	return window.matchMedia('(display-mode: standalone)').matches;
 };
+
+// Upper bound for the shared wallet-worker pool on desktop. Wallet sync is I/O-bound, so a small
+// pool is enough to parallelize the CPU-heavy candid decode / mapping across cores while keeping
+// memory far below one dedicated worker per token. Raising it trades memory for first-load CPU
+// throughput.
+const WORKER_POOL_MAX_SIZE = 4;
+
+// Size of the shared worker pool. iOS keeps a single shared worker (memory-constrained); desktop
+// scales with available cores while leaving headroom for the main thread and the other workers.
+export const workerPoolSize = (): number => {
+	if (isIOS()) {
+		return 1;
+	}
+
+	const cores = navigator.hardwareConcurrency;
+
+	return cores >= 2 ? Math.min(cores - 1, WORKER_POOL_MAX_SIZE) : 1;
+};

--- a/src/frontend/src/lib/utils/device.utils.ts
+++ b/src/frontend/src/lib/utils/device.utils.ts
@@ -1,5 +1,5 @@
 import { isNode } from '$lib/utils/env.utils';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 interface UserAgentData {
 	mobile?: boolean;
@@ -66,7 +66,11 @@ export const workerPoolSize = (): number => {
 		return 1;
 	}
 
-	const cores = navigator.hardwareConcurrency;
+	const cores: number | undefined = navigator.hardwareConcurrency;
+
+	if (isNullish(cores)) {
+		return WORKER_POOL_MAX_SIZE;
+	}
 
 	return cores >= 2 ? Math.min(cores - 1, WORKER_POOL_MAX_SIZE) : 1;
 };

--- a/src/frontend/src/sol/services/worker.sol-wallet.services.ts
+++ b/src/frontend/src/sol/services/worker.sol-wallet.services.ts
@@ -37,8 +37,8 @@ export class SolWalletWorker extends AppWorker implements WalletWorker {
 			({ data: dataMsg }: MessageEvent<PostMessageScheduler<SolPostMessageDataResponseWallet>>) => {
 				const { ref, msg, data } = dataMsg;
 
-				// This is an additional guard because it may happen that the worker is initialised as a singleton.
-				// In this case, we need to check if we should treat the message or if the message was intended for another worker.
+				// A pooled worker is shared by several Solana tokens, so drop any message meant for
+				// another token. The scheduler stamps `ref` with the token address + network.
 				if (ref !== `${this.data.tokenAddress ?? SOLANA_TOKEN.symbol}-${this.data.solanaNetwork}`) {
 					return;
 				}
@@ -99,13 +99,17 @@ export class SolWalletWorker extends AppWorker implements WalletWorker {
 			tokenOwnerAddress
 		};
 
-		const worker = await AppWorker.getInstance();
+		const worker = await AppWorker.getInstance({
+			pooled: true,
+			poolKey: `${data.tokenAddress ?? SOLANA_TOKEN.symbol}-${data.solanaNetwork}`
+		});
 		return new SolWalletWorker(worker, tokenId, data);
 	}
 
 	protected override stopTimer = () => {
-		this.postMessage({
-			msg: 'stopSolWalletTimer'
+		this.postMessage<PostMessage<PostMessageDataRequestSol>>({
+			msg: 'stopSolWalletTimer',
+			data: this.data
 		});
 	};
 

--- a/src/frontend/src/sol/workers/sol-wallet.worker.ts
+++ b/src/frontend/src/sol/workers/sol-wallet.worker.ts
@@ -1,21 +1,66 @@
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import type { PostMessage, PostMessageDataRequestSol } from '$lib/types/post-message';
 import { SolWalletScheduler } from '$sol/schedulers/sol-wallet.scheduler';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
-const scheduler: SolWalletScheduler = new SolWalletScheduler();
+// Keyed by token address + network (native SOL falls back to the token symbol) so several Solana
+// tokens can share one pooled worker without their timers clobbering each other. A dedicated
+// worker only ever holds a single entry. Must match the `ref` stamped by SolWalletScheduler and
+// filtered on in worker.sol-wallet.services.ts.
+const schedulers = new Map<string, SolWalletScheduler>();
+
+const stopAllSchedulers = () => {
+	schedulers.forEach((scheduler) => scheduler.stop());
+	schedulers.clear();
+};
 
 export const onSolWalletMessage = async ({
 	data: dataMsg
 }: MessageEvent<PostMessage<PostMessageDataRequestSol>>) => {
 	const { msg, data } = dataMsg;
 
+	const schedulerKey =
+		nonNullish(data) && 'solanaNetwork' in data
+			? `${data.tokenAddress ?? SOLANA_TOKEN.symbol}-${data.solanaNetwork}`
+			: undefined;
+
 	switch (msg) {
-		case 'stopSolWalletTimer':
-			scheduler.stop();
+		case 'stopSolWalletTimer': {
+			if (isNullish(schedulerKey)) {
+				stopAllSchedulers();
+				return;
+			}
+
+			schedulers.get(schedulerKey)?.stop();
+			schedulers.delete(schedulerKey);
 			return;
-		case 'startSolWalletTimer':
+		}
+		case 'startSolWalletTimer': {
+			if (isNullish(schedulerKey)) {
+				return;
+			}
+
+			schedulers.get(schedulerKey)?.stop();
+
+			const scheduler = new SolWalletScheduler();
+			schedulers.set(schedulerKey, scheduler);
+
 			await scheduler.start(data);
 			return;
-		case 'triggerSolWalletTimer':
+		}
+		case 'triggerSolWalletTimer': {
+			if (isNullish(schedulerKey)) {
+				return;
+			}
+
+			let scheduler = schedulers.get(schedulerKey);
+
+			if (isNullish(scheduler)) {
+				scheduler = new SolWalletScheduler();
+				schedulers.set(schedulerKey, scheduler);
+			}
+
 			await scheduler.trigger(data);
+		}
 	}
 };

--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.dispatch.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.dispatch.spec.ts
@@ -1,0 +1,117 @@
+import { onBtcWalletMessage } from '$btc/workers/btc-wallet.worker';
+import type { PostMessage, PostMessageDataRequestBtc } from '$lib/types/post-message';
+import { excludeValidMessageEvents } from '$tests/mocks/workers.mock';
+
+const hoisted = vi.hoisted(() => {
+	const schedulerInstances: {
+		start: ReturnType<typeof vi.fn>;
+		stop: ReturnType<typeof vi.fn>;
+		trigger: ReturnType<typeof vi.fn>;
+	}[] = [];
+
+	return { schedulerInstances };
+});
+
+vi.mock('$btc/schedulers/btc-wallet.scheduler', () => ({
+	BtcWalletScheduler: class {
+		start = vi.fn();
+		stop = vi.fn();
+		trigger = vi.fn();
+
+		constructor() {
+			hoisted.schedulerInstances.push(this);
+		}
+	}
+}));
+
+describe('btc-wallet.worker', () => {
+	describe('onBtcWalletMessage', () => {
+		const invalidMessages = excludeValidMessageEvents([
+			'stopBtcWalletTimer',
+			'startBtcWalletTimer',
+			'triggerBtcWalletTimer'
+		]);
+
+		// The Bitcoin address drives the scheduler key. Distinct addresses per test keep the
+		// module-level scheduler map free of cross-test interference.
+		const btcData = (address: string): PostMessageDataRequestBtc =>
+			({
+				btcAddress: { data: address, certified: false },
+				bitcoinNetwork: 'mainnet',
+				shouldFetchTransactions: false
+			}) as unknown as PostMessageDataRequestBtc;
+
+		const createEvent = ({
+			msg,
+			data
+		}: {
+			msg: string;
+			data?: PostMessageDataRequestBtc;
+		}): MessageEvent<PostMessage<PostMessageDataRequestBtc>> =>
+			({ data: { msg, data } }) as unknown as MessageEvent<PostMessage<PostMessageDataRequestBtc>>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			hoisted.schedulerInstances.length = 0;
+		});
+
+		it('should start a scheduler for the address key', async () => {
+			const data = btcData('bc1-start');
+
+			await onBtcWalletMessage(createEvent({ msg: 'startBtcWalletTimer', data }));
+
+			expect(hoisted.schedulerInstances).toHaveLength(1);
+			expect(hoisted.schedulerInstances[0].start).toHaveBeenCalledExactlyOnceWith(data);
+		});
+
+		it('should trigger a scheduler for the address key', async () => {
+			const data = btcData('bc1-trigger');
+
+			await onBtcWalletMessage(createEvent({ msg: 'triggerBtcWalletTimer', data }));
+
+			expect(hoisted.schedulerInstances).toHaveLength(1);
+			expect(hoisted.schedulerInstances[0].trigger).toHaveBeenCalledExactlyOnceWith(data);
+		});
+
+		it('should stop the scheduler previously started for the key', async () => {
+			const data = btcData('bc1-stop');
+
+			await onBtcWalletMessage(createEvent({ msg: 'startBtcWalletTimer', data }));
+			await onBtcWalletMessage(createEvent({ msg: 'stopBtcWalletTimer', data }));
+
+			expect(hoisted.schedulerInstances).toHaveLength(1);
+			expect(hoisted.schedulerInstances[0].stop).toHaveBeenCalledOnce();
+		});
+
+		it('should keep a separate scheduler per address without clobbering', async () => {
+			const dataA = btcData('bc1-a');
+			const dataB = btcData('bc1-b');
+
+			await onBtcWalletMessage(createEvent({ msg: 'startBtcWalletTimer', data: dataA }));
+			await onBtcWalletMessage(createEvent({ msg: 'startBtcWalletTimer', data: dataB }));
+
+			expect(hoisted.schedulerInstances).toHaveLength(2);
+			expect(hoisted.schedulerInstances[0].start).toHaveBeenCalledExactlyOnceWith(dataA);
+			expect(hoisted.schedulerInstances[1].start).toHaveBeenCalledExactlyOnceWith(dataB);
+			// Starting address B must not stop address A's scheduler.
+			expect(hoisted.schedulerInstances[0].stop).not.toHaveBeenCalled();
+		});
+
+		it('should restart the scheduler for a key, stopping the previous one', async () => {
+			const data = btcData('bc1-restart');
+
+			await onBtcWalletMessage(createEvent({ msg: 'startBtcWalletTimer', data }));
+			await onBtcWalletMessage(createEvent({ msg: 'startBtcWalletTimer', data }));
+
+			expect(hoisted.schedulerInstances).toHaveLength(2);
+			expect(hoisted.schedulerInstances[0].stop).toHaveBeenCalledOnce();
+			expect(hoisted.schedulerInstances[1].start).toHaveBeenCalledExactlyOnceWith(data);
+		});
+
+		it.each(invalidMessages)('should not touch any scheduler when message is %s', async (msg) => {
+			await onBtcWalletMessage(createEvent({ msg, data: btcData('bc1-invalid') }));
+
+			expect(hoisted.schedulerInstances).toHaveLength(0);
+		});
+	});
+});

--- a/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/btc/workers/btc-wallet.worker.spec.ts
@@ -229,6 +229,18 @@ describe('btc-wallet.worker', () => {
 					expect(spyGetCertifiedBalance).toHaveBeenCalledOnce();
 				});
 
+				it('should post the wallet data when triggered without a prior start', async () => {
+					// A trigger can reach a freshly created scheduler (the worker-side dispatch creates one
+					// when the key is unknown), so the ref must be set by trigger itself — otherwise the
+					// sync runs but its result is silently dropped.
+					await scheduler.trigger(startData);
+
+					await awaitJobExecution();
+
+					expect(postMessageMock).toHaveBeenCalledWith(mockPostMessageUncertified);
+					expect(postMessageMock).toHaveBeenCalledWith(mockPostMessageCertified);
+				});
+
 				it('should stop the scheduler', () => {
 					scheduler.stop();
 

--- a/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
+++ b/src/frontend/src/tests/icp/services/worker.icrc-wallet.services.spec.ts
@@ -4,6 +4,7 @@ import {
 	onTransactionsCleanUp
 } from '$icp/services/ic-transactions.services';
 import { IcrcWalletWorker } from '$icp/services/worker.icrc-wallet.services';
+import { AppWorker } from '$lib/services/_worker.services';
 import type { WalletWorker } from '$lib/types/listener';
 import { mockIndexCanisterId, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 
@@ -23,6 +24,15 @@ class MockWorker {
 	postMessage = postMessageSpy;
 	onmessage: ((event: MessageEvent) => void) | null = null;
 	terminate: () => void = vi.fn();
+	// A pooled worker registers its listener via addEventListener; route it onto `onmessage` so the
+	// existing `workerInstance.onmessage?.(...)` triggers below drive the pooled listener.
+	addEventListener = vi.fn((...args: [string, (event: MessageEvent) => void]) => {
+		const [, listener] = args;
+		this.onmessage = listener;
+	});
+	removeEventListener = vi.fn(() => {
+		this.onmessage = null;
+	});
 }
 
 vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
@@ -64,6 +74,7 @@ describe('worker.icrc-wallet.services', () => {
 
 			beforeEach(async () => {
 				vi.clearAllMocks();
+				AppWorker.resetForTesting();
 
 				worker = await IcrcWalletWorker.init(mockToken);
 			});
@@ -248,6 +259,7 @@ describe('worker.icrc-wallet.services', () => {
 
 			beforeEach(async () => {
 				vi.clearAllMocks();
+				AppWorker.resetForTesting();
 
 				worker = await IcrcWalletWorker.init(mockToken);
 			});

--- a/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
+++ b/src/frontend/src/tests/icp/workers/ic-wallet-balance-and-transactions.worker.spec.ts
@@ -481,6 +481,15 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 				expect(spyGetTransactions).toHaveBeenCalledTimes(2);
 			});
 
+			it('should stamp the ref and emit the wallet payload when triggered without a prior start', async () => {
+				// A trigger with no preceding start must still set `ref`; otherwise postMessageWallet
+				// drops every payload (isNullish(this.ref) guard) and the manual refresh syncs nothing.
+				await scheduler.trigger(startData);
+
+				expect(postMessageMock).toHaveBeenCalledWith(mockPostMessageNotCertified);
+				expect(postMessageMock).toHaveBeenCalledWith(mockPostMessageCertified);
+			});
+
 			it('should trigger syncWallet periodically calling the loader', async () => {
 				await scheduler.start(startData);
 
@@ -1066,6 +1075,15 @@ describe('ic-wallet-balance-and-transactions.worker', () => {
 				// query + update = 2
 				expect(spyGetTransactions).toHaveBeenCalledTimes(2);
 				expect(spyGetBalance).toHaveBeenCalledTimes(2);
+			});
+
+			it('should stamp the ref and emit the wallet payload when triggered without a prior start', async () => {
+				// Covers the `canisterId` branch of walletDataRef: a trigger with no preceding start
+				// must still set `ref`, else postMessageWallet drops every payload.
+				await scheduler.trigger(startData);
+
+				expect(postMessageMock).toHaveBeenCalledWith(mockPostMessageNotCertified);
+				expect(postMessageMock).toHaveBeenCalledWith(mockPostMessageCertified);
 			});
 
 			it('should trigger syncWallet periodically calling both loaders', async () => {

--- a/src/frontend/src/tests/lib/services/worker.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/worker.services.spec.ts
@@ -258,6 +258,52 @@ describe('_worker.services', () => {
 
 				expect(next.worker).not.toBe(worker.worker);
 			});
+
+			it('should keep the shared worker alive when the last wrapper is destroyed while another wrapper is still initializing', async () => {
+				const { instance: first, worker } = await createTestWorkerPooled('a');
+
+				// Not awaited on purpose: the ref-count reservation must happen synchronously on the
+				// getInstance call, before the worker promise resolves.
+				const pending = AppWorker.getInstance({ pooled: true, poolKey: 'a' });
+
+				first.destroy();
+
+				expect(worker.worker.terminate).not.toHaveBeenCalled();
+
+				const workerData = await pending;
+
+				expect(workerData.worker).toBe(worker.worker);
+
+				const second = new TestWorker(workerData);
+
+				second.destroy();
+
+				expect(worker.worker.terminate).toHaveBeenCalledOnce();
+			});
+
+			it('should retry the worker creation after a failed one instead of caching the rejection', async () => {
+				class FailingWorker {
+					constructor() {
+						throw new Error('chunk load failed');
+					}
+				}
+
+				vi.stubGlobal('Worker', FailingWorker as unknown as typeof Worker);
+
+				await expect(AppWorker.getInstance({ pooled: true, poolKey: 'a' })).rejects.toThrow(
+					'chunk load failed'
+				);
+
+				vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker);
+
+				const { instance, worker } = await createTestWorkerPooled('a');
+
+				expect(worker.worker).toBeInstanceOf(MockWorker);
+
+				instance.destroy();
+
+				expect(worker.worker.terminate).toHaveBeenCalledOnce();
+			});
 		});
 
 		describe('terminateAllWorkers', () => {

--- a/src/frontend/src/tests/lib/services/worker.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/worker.services.spec.ts
@@ -1,5 +1,6 @@
 import { AppWorker } from '$lib/services/_worker.services';
 import type { WorkerData } from '$lib/types/worker';
+import { workerPoolSize } from '$lib/utils/device.utils';
 
 const postMessageSpy = vi.fn();
 const addEventListenerSpy = vi.fn();
@@ -29,10 +30,23 @@ vi.mock('$lib/workers/workers?worker', () => {
 	};
 });
 
+vi.mock(import('$lib/utils/device.utils'), async (importOriginal) => {
+	const actual = await importOriginal();
+
+	return {
+		...actual,
+		workerPoolSize: vi.fn()
+	};
+});
+
 describe('_worker.services', () => {
 	describe('AppWorker', () => {
 		const listenerSpy = vi.fn();
 		const stopTimerSpy = vi.fn();
+
+		// Pool size 4 keeps the sharding deterministic for the keys used below:
+		// `#hashKey('a') % 4 === 1`, `'b' % 4 === 2`, `'e' % 4 === 1` (collides with `'a'`).
+		const POOL_SIZE = 4;
 
 		class TestWorker extends AppWorker {
 			constructor(worker: WorkerData) {
@@ -54,11 +68,10 @@ describe('_worker.services', () => {
 			return { instance, worker };
 		};
 
-		const createTestWorkerSingleton = async (): Promise<{
-			instance: TestWorker;
-			worker: WorkerData;
-		}> => {
-			const worker = await AppWorker.getInstance({ asSingleton: true });
+		const createTestWorkerPooled = async (
+			poolKey: string
+		): Promise<{ instance: TestWorker; worker: WorkerData }> => {
+			const worker = await AppWorker.getInstance({ pooled: true, poolKey });
 			const instance = new TestWorker(worker);
 			return { instance, worker };
 		};
@@ -73,6 +86,10 @@ describe('_worker.services', () => {
 			vi.stubGlobal('crypto', {
 				randomUUID: vi.fn().mockReturnValueOnce(mockId).mockReturnValueOnce('0000')
 			});
+
+			vi.mocked(workerPoolSize).mockReturnValue(POOL_SIZE);
+
+			AppWorker.resetForTesting();
 		});
 
 		afterEach(() => {
@@ -83,7 +100,7 @@ describe('_worker.services', () => {
 			const worker = await AppWorker.getInstance();
 
 			expect(worker.worker).toBeInstanceOf(Worker);
-			expect(worker.isSingleton).toBeFalsy();
+			expect(worker.poolIndex).toBeUndefined();
 		});
 
 		it('should return different workers by default', async () => {
@@ -91,8 +108,8 @@ describe('_worker.services', () => {
 			const second = await AppWorker.getInstance();
 
 			expect(first.worker).not.toBe(second.worker);
-			expect(first.isSingleton).toBeFalsy();
-			expect(second.isSingleton).toBeFalsy();
+			expect(first.poolIndex).toBeUndefined();
+			expect(second.poolIndex).toBeUndefined();
 		});
 
 		it('should set onmessage listener via setOnMessage', async () => {
@@ -141,24 +158,50 @@ describe('_worker.services', () => {
 			expect(worker.worker.onmessage).toBeNull();
 		});
 
-		describe('as singleton', () => {
-			const params = { asSingleton: true };
-
-			it('should reuse the same worker', async () => {
-				const first = await AppWorker.getInstance(params);
-				const second = await AppWorker.getInstance(params);
+		describe('when pooled', () => {
+			it('should reuse the same worker for the same pool key', async () => {
+				const first = await AppWorker.getInstance({ pooled: true, poolKey: 'a' });
+				const second = await AppWorker.getInstance({ pooled: true, poolKey: 'a' });
 
 				expect(first.worker).toBeInstanceOf(Worker);
 				expect(second.worker).toBeInstanceOf(Worker);
 
 				expect(first.worker).toBe(second.worker);
 
-				expect(first.isSingleton).toBeTruthy();
-				expect(second.isSingleton).toBeTruthy();
+				expect(first.poolIndex).toBe(second.poolIndex);
+				expect(first.poolIndex).toEqual(expect.any(Number));
+			});
+
+			it('should shard keys that hash to different indices onto different workers', async () => {
+				const a = await AppWorker.getInstance({ pooled: true, poolKey: 'a' });
+				const b = await AppWorker.getInstance({ pooled: true, poolKey: 'b' });
+
+				expect(a.poolIndex).not.toBe(b.poolIndex);
+				expect(a.worker).not.toBe(b.worker);
+			});
+
+			it('should share a worker between keys that hash to the same index', async () => {
+				const a = await AppWorker.getInstance({ pooled: true, poolKey: 'a' });
+				const e = await AppWorker.getInstance({ pooled: true, poolKey: 'e' });
+
+				expect(a.poolIndex).toBe(e.poolIndex);
+				expect(a.worker).toBe(e.worker);
+			});
+
+			it('should collapse the pool onto a single worker when the pool size is one (iOS)', async () => {
+				vi.mocked(workerPoolSize).mockReturnValue(1);
+				AppWorker.resetForTesting();
+
+				const a = await AppWorker.getInstance({ pooled: true, poolKey: 'a' });
+				const b = await AppWorker.getInstance({ pooled: true, poolKey: 'b' });
+
+				expect(a.poolIndex).toBe(0);
+				expect(b.poolIndex).toBe(0);
+				expect(a.worker).toBe(b.worker);
 			});
 
 			it("should add a listener to the worker's message event", async () => {
-				const { instance, worker } = await createTestWorkerSingleton();
+				const { instance, worker } = await createTestWorkerPooled('a');
 
 				instance.setListener(listenerSpy);
 
@@ -171,25 +214,28 @@ describe('_worker.services', () => {
 				expect(worker.worker.onmessage).toBeNull();
 			});
 
-			it("should remove the listener from the worker's message event on destroy", async () => {
-				const { instance, worker } = await createTestWorkerSingleton();
+			it('should keep the shared worker alive until the last wrapper is destroyed', async () => {
+				const { instance: first, worker } = await createTestWorkerPooled('a');
+				const { instance: second } = await createTestWorkerPooled('a');
 
-				instance.setListener(listenerSpy);
+				first.setListener(listenerSpy);
+				second.setListener(listenerSpy);
 
-				instance.destroy();
-
-				expect(stopTimerSpy).toHaveBeenCalledExactlyOnceWith();
+				first.destroy();
 
 				expect(worker.worker.removeEventListener).toHaveBeenCalledExactlyOnceWith(
 					'message',
 					listenerSpy
 				);
-
 				expect(worker.worker.terminate).not.toHaveBeenCalled();
+
+				second.destroy();
+
+				expect(worker.worker.terminate).toHaveBeenCalledOnce();
 			});
 
 			it('should not remove the listener twice on destroy', async () => {
-				const { instance, worker } = await createTestWorkerSingleton();
+				const { instance, worker } = await createTestWorkerPooled('a');
 
 				instance.setListener(listenerSpy);
 
@@ -201,14 +247,20 @@ describe('_worker.services', () => {
 					'message',
 					listenerSpy
 				);
+			});
+
+			it('should spawn a fresh worker for a pool index after it was fully released', async () => {
+				const { instance: first, worker } = await createTestWorkerPooled('a');
+
+				first.destroy();
+
+				const { worker: next } = await createTestWorkerPooled('a');
+
+				expect(next.worker).not.toBe(worker.worker);
 			});
 		});
 
 		describe('terminateAllWorkers', () => {
-			beforeEach(() => {
-				AppWorker.resetForTesting();
-			});
-
 			it('should terminate every spawned worker', async () => {
 				const { worker: first } = await createTestWorker();
 				const { worker: second } = await createTestWorker();
@@ -219,14 +271,14 @@ describe('_worker.services', () => {
 				expect(second.worker.terminate).toHaveBeenCalledOnce();
 			});
 
-			it('should terminate the singleton worker and reset it', async () => {
-				const { worker } = await createTestWorkerSingleton();
+			it('should terminate pooled workers and reset the pool', async () => {
+				const { worker } = await createTestWorkerPooled('a');
 
 				AppWorker.terminateAllWorkers();
 
 				expect(worker.worker.terminate).toHaveBeenCalledOnce();
 
-				const next = await AppWorker.getInstance({ asSingleton: true });
+				const next = await AppWorker.getInstance({ pooled: true, poolKey: 'a' });
 
 				expect(next.worker).not.toBe(worker.worker);
 			});

--- a/src/frontend/src/tests/lib/utils/device.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/device.utils.spec.ts
@@ -1,4 +1,11 @@
-import { isDesktop, isIOS, isIPad, isMobile, isPWAStandalone } from '$lib/utils/device.utils';
+import {
+	isDesktop,
+	isIOS,
+	isIPad,
+	isMobile,
+	isPWAStandalone,
+	workerPoolSize
+} from '$lib/utils/device.utils';
 import type * as EnvUtils from '$lib/utils/env.utils';
 
 // isIPad/isIOS short-circuit via isNode(), which is true under the Node test
@@ -252,6 +259,51 @@ describe('device.utils', () => {
 			mockNavigator({ userAgent: 'Mozilla/5.0 (Linux; Android 14)' });
 
 			expect(isIOS()).toBeFalsy();
+		});
+	});
+
+	describe('workerPoolSize', () => {
+		const DESKTOP_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)';
+
+		it('should fall back to the full pool when hardwareConcurrency is unavailable', () => {
+			// Absent on some privacy-hardened / older browsers — assume a capable multi-core desktop
+			// rather than serializing every token's sync onto a single worker thread.
+			mockNavigator({ userAgent: DESKTOP_USER_AGENT });
+
+			expect(workerPoolSize()).toBe(4);
+		});
+
+		it('should return 1 for a genuine single-core device', () => {
+			mockNavigator({ userAgent: DESKTOP_USER_AGENT, hardwareConcurrency: 1 });
+
+			expect(workerPoolSize()).toBe(1);
+		});
+
+		it('should leave one core of headroom for a small core count', () => {
+			mockNavigator({ userAgent: DESKTOP_USER_AGENT, hardwareConcurrency: 2 });
+
+			expect(workerPoolSize()).toBe(1);
+		});
+
+		it('should scale with the core count below the cap', () => {
+			mockNavigator({ userAgent: DESKTOP_USER_AGENT, hardwareConcurrency: 3 });
+
+			expect(workerPoolSize()).toBe(2);
+		});
+
+		it('should cap the pool at the maximum for many cores', () => {
+			mockNavigator({ userAgent: DESKTOP_USER_AGENT, hardwareConcurrency: 16 });
+
+			expect(workerPoolSize()).toBe(4);
+		});
+
+		it('should keep a single shared worker on iOS regardless of cores', () => {
+			mockNavigator({
+				userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+				hardwareConcurrency: 16
+			});
+
+			expect(workerPoolSize()).toBe(1);
 		});
 	});
 });

--- a/src/frontend/src/tests/sol/workers/sol-wallet.worker.spec.ts
+++ b/src/frontend/src/tests/sol/workers/sol-wallet.worker.spec.ts
@@ -1,19 +1,28 @@
 import type { PostMessage, PostMessageDataRequestSol } from '$lib/types/post-message';
-import { SolWalletScheduler } from '$sol/schedulers/sol-wallet.scheduler';
 import { onSolWalletMessage } from '$sol/workers/sol-wallet.worker';
-import { createMockEvent, excludeValidMessageEvents } from '$tests/mocks/workers.mock';
+import { excludeValidMessageEvents } from '$tests/mocks/workers.mock';
 
-vi.mock(import('$sol/schedulers/sol-wallet.scheduler'), async (importOriginal) => {
-	const actual = await importOriginal();
-	const scheduler = actual.SolWalletScheduler;
-	scheduler.prototype.start = vi.fn();
-	scheduler.prototype.stop = vi.fn();
-	scheduler.prototype.trigger = vi.fn();
-	return {
-		...actual,
-		SolWalletScheduler: scheduler
-	};
+const hoisted = vi.hoisted(() => {
+	const schedulerInstances: {
+		start: ReturnType<typeof vi.fn>;
+		stop: ReturnType<typeof vi.fn>;
+		trigger: ReturnType<typeof vi.fn>;
+	}[] = [];
+
+	return { schedulerInstances };
 });
+
+vi.mock('$sol/schedulers/sol-wallet.scheduler', () => ({
+	SolWalletScheduler: class {
+		start = vi.fn();
+		stop = vi.fn();
+		trigger = vi.fn();
+
+		constructor() {
+			hoisted.schedulerInstances.push(this);
+		}
+	}
+}));
 
 describe('sol-wallet.worker', () => {
 	describe('onSolWalletMessage', () => {
@@ -23,67 +32,82 @@ describe('sol-wallet.worker', () => {
 			'triggerSolWalletTimer'
 		]);
 
-		const mockStart = vi.fn();
-		const mockStop = vi.fn();
-		const mockTrigger = vi.fn();
+		// Only `tokenAddress` + `solanaNetwork` drive the scheduler key. Distinct token addresses per
+		// test keep the module-level scheduler map free of cross-test interference.
+		const solData = (tokenAddress?: string): PostMessageDataRequestSol =>
+			({ solanaNetwork: 'mainnet', tokenAddress }) as unknown as PostMessageDataRequestSol;
 
-		const createEvent = (msg: string) =>
-			createMockEvent(msg) as unknown as MessageEvent<PostMessage<PostMessageDataRequestSol>>;
+		const createEvent = ({
+			msg,
+			data
+		}: {
+			msg: string;
+			data?: PostMessageDataRequestSol;
+		}): MessageEvent<PostMessage<PostMessageDataRequestSol>> =>
+			({ data: { msg, data } }) as unknown as MessageEvent<PostMessage<PostMessageDataRequestSol>>;
 
 		beforeEach(() => {
 			vi.clearAllMocks();
-
-			SolWalletScheduler.prototype.start = mockStart;
-			SolWalletScheduler.prototype.stop = mockStop;
-			SolWalletScheduler.prototype.trigger = mockTrigger;
+			hoisted.schedulerInstances.length = 0;
 		});
 
-		it('should stop the scheduler when message is stopSolWalletTimer', async () => {
-			const event = createEvent('stopSolWalletTimer');
+		it('should start a scheduler for the token key', async () => {
+			const data = solData('mint-start');
 
-			await onSolWalletMessage(event);
+			await onSolWalletMessage(createEvent({ msg: 'startSolWalletTimer', data }));
 
-			expect(mockStop).toHaveBeenCalledOnce();
-
-			expect(mockStart).not.toHaveBeenCalled();
-			expect(mockTrigger).not.toHaveBeenCalled();
+			expect(hoisted.schedulerInstances).toHaveLength(1);
+			expect(hoisted.schedulerInstances[0].start).toHaveBeenCalledExactlyOnceWith(data);
 		});
 
-		it('should start the scheduler when message is startSolWalletTimer', async () => {
-			const event = createEvent('startSolWalletTimer');
+		it('should trigger a scheduler for the token key', async () => {
+			const data = solData('mint-trigger');
 
-			await onSolWalletMessage(event);
+			await onSolWalletMessage(createEvent({ msg: 'triggerSolWalletTimer', data }));
 
-			expect(mockStart).toHaveBeenCalledOnce();
-			expect(mockStart).toHaveBeenNthCalledWith(1, event.data.data);
-
-			expect(mockStop).not.toHaveBeenCalled();
-			expect(mockTrigger).not.toHaveBeenCalled();
+			expect(hoisted.schedulerInstances).toHaveLength(1);
+			expect(hoisted.schedulerInstances[0].trigger).toHaveBeenCalledExactlyOnceWith(data);
 		});
 
-		it('should trigger the scheduler when message is triggerSolWalletTimer', async () => {
-			const event = createEvent('triggerSolWalletTimer');
+		it('should stop the scheduler previously started for the key', async () => {
+			const data = solData('mint-stop');
 
-			await onSolWalletMessage(event);
+			await onSolWalletMessage(createEvent({ msg: 'startSolWalletTimer', data }));
+			await onSolWalletMessage(createEvent({ msg: 'stopSolWalletTimer', data }));
 
-			expect(mockTrigger).toHaveBeenCalledOnce();
-			expect(mockTrigger).toHaveBeenNthCalledWith(1, event.data.data);
-
-			expect(mockStart).not.toHaveBeenCalled();
-			expect(mockStop).not.toHaveBeenCalled();
+			expect(hoisted.schedulerInstances).toHaveLength(1);
+			expect(hoisted.schedulerInstances[0].stop).toHaveBeenCalledOnce();
 		});
 
-		it.each(invalidMessages)(
-			'should not call any scheduler method when message is %s',
-			async (msg) => {
-				const event = createEvent(msg);
+		it('should keep a separate scheduler per token key without clobbering', async () => {
+			const dataA = solData('mint-a');
+			const dataB = solData('mint-b');
 
-				await onSolWalletMessage(event);
+			await onSolWalletMessage(createEvent({ msg: 'startSolWalletTimer', data: dataA }));
+			await onSolWalletMessage(createEvent({ msg: 'startSolWalletTimer', data: dataB }));
 
-				expect(mockStart).not.toHaveBeenCalled();
-				expect(mockStop).not.toHaveBeenCalled();
-				expect(mockTrigger).not.toHaveBeenCalled();
-			}
-		);
+			expect(hoisted.schedulerInstances).toHaveLength(2);
+			expect(hoisted.schedulerInstances[0].start).toHaveBeenCalledExactlyOnceWith(dataA);
+			expect(hoisted.schedulerInstances[1].start).toHaveBeenCalledExactlyOnceWith(dataB);
+			// Starting token B must not stop token A's scheduler.
+			expect(hoisted.schedulerInstances[0].stop).not.toHaveBeenCalled();
+		});
+
+		it('should restart the scheduler for a key, stopping the previous one', async () => {
+			const data = solData('mint-restart');
+
+			await onSolWalletMessage(createEvent({ msg: 'startSolWalletTimer', data }));
+			await onSolWalletMessage(createEvent({ msg: 'startSolWalletTimer', data }));
+
+			expect(hoisted.schedulerInstances).toHaveLength(2);
+			expect(hoisted.schedulerInstances[0].stop).toHaveBeenCalledOnce();
+			expect(hoisted.schedulerInstances[1].start).toHaveBeenCalledExactlyOnceWith(data);
+		});
+
+		it.each(invalidMessages)('should not touch any scheduler when message is %s', async (msg) => {
+			await onSolWalletMessage(createEvent({ msg, data: solData('mint-invalid') }));
+
+			expect(hoisted.schedulerInstances).toHaveLength(0);
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

On desktop, OISY spawned one full-bundle Web Worker per enabled token. Each worker is its own V8 isolate that re-compiles the whole worker bundle and stands up its own `@dfinity` agent stack, so a token-heavy wallet ran dozens– hundreds of isolates and grew the tab into the multi-GB range. Worker heaps are the dominant driver of tab memory (and are invisible to `performance.memory`).

Measured on a token-heavy wallet (fresh tab, ~7-min settle, `ps` RSS):
  - Dedicated Web Workers: **~74 → 8 (−89%)**
  - Settled tab RSS: **~1.9 GB → ~0.8 GB (−59%)**
  - Worst boot-time peak RSS: **~3.1 GB → ~1.0 GB (−69%)**
  - Main-thread JS heap: unchanged — the win is entirely worker-side


# Changes

- **Shared worker pool (`_worker.services.ts`).** Replace the iOS-only singleton with a pool of `min(cores - 1, 4)` workers (iOS = 1), sharded by a stable per-token key. The in-flight creation Promise is cached synchronously so concurrent boot-time inits share one realm instead of racing to spawn (and leak) duplicates; a failed worker load drops the slot so the next caller retries. Pooled wrappers filter incoming messages by `ref` and the realm is torn down only when its last wrapper is destroyed.
  - **ICP / ICRC / DIP20 services.** Opt into `getInstance({ pooled: true, poolKey })` keyed by ledger/canister id.
  - **BTC / SOL workers.** Convert the worker-side dispatchers to `Map<key, scheduler>` (BTC by address, SOL by `tokenAddress-network`) so tokens can share a realm without clobbering each other's timers; `stop` messages carry the key; add the missing `ref` guard to the BTC listener.
  - **IC scheduler.** `trigger()` now stamps `ref` (parity with BTC/SOL); it previously left `ref` undefined on a trigger-without-start and silently dropped the sync payload.
  - **`workerPoolSize()`.** A missing `navigator.hardwareConcurrency` now falls back to the full pool (4) rather than collapsing every token onto one thread; a genuine single-core value still maps to 1.


# Tests

Added.
