### PR TITLE
feat(backend)!: add NearIntents variant to active-user-transaction data

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -25,6 +25,10 @@ type ActiveUserTransaction = record {
 type ActiveUserTransactionData = variant {
 	OneSecEvmToIcp : OneSecEvmToIcpData;
 	OneSecIcpToEvm : OneSecIcpToEvmData;
+	// NEAR Intents (1Click) cross-chain swap. A single variant covers every
+	// source/destination leg (EVM and Solana); the deposit address, its
+	// optional memo, and origin/destination tx hashes ride in `external_refs`.
+	NearIntents : NearIntentsData;
 	// Liquidium lend/borrow flow. A single variant covers all four actions
 	// (supply, borrow, repay, withdraw).
 	Liquidium : LiquidiumData
@@ -768,6 +772,17 @@ type LiquidiumData = record {
 	pool_id : text;
 	// Amount in the token's base units.
 	amount : nat
+};
+// NEAR Intents (1Click) cross-chain swap payload. Settlement is tracked
+// off-chain by polling the 1Click status endpoint keyed by the deposit
+// address, so that address (and its optional memo, plus learned-mid-flow tx
+// hashes) lives in `external_refs`; only the canonical immutable trio is
+// captured here.
+type NearIntentsData = record {
+	source_token : TokenId;
+	// Source-token amount in base units.
+	amount : nat;
+	dest_token : TokenId
 };
 // Bitcoin Network.
 type Network = variant {

--- a/src/backend/src/active_user_transactions/model.rs
+++ b/src/backend/src/active_user_transactions/model.rs
@@ -226,6 +226,9 @@ fn validate_data(data: &ActiveUserTransactionData) -> Result<(), ActiveUserTrans
             require_positive_amount(&d.amount)?;
             require_pool_id(&d.pool_id)?;
         }
+        ActiveUserTransactionData::NearIntents(d) => {
+            require_positive_amount(&d.amount)?;
+        }
     }
     Ok(())
 }
@@ -302,7 +305,7 @@ mod tests {
         active_user_transaction::{
             ActiveUserTransactionData, ActiveUserTransactionError, ActiveUserTransactionRef,
             ActiveUserTransactionStatus, CreateActiveUserTransactionRequest, LiquidiumAction,
-            LiquidiumData, OneSecEvmToIcpData, OneSecIcpToEvmData,
+            LiquidiumData, NearIntentsData, OneSecEvmToIcpData, OneSecIcpToEvmData,
             UpdateActiveUserTransactionRequest, MAX_ACTIVE_USER_TRANSACTIONS_PER_USER,
             MAX_LIQUIDIUM_POOL_ID_LEN,
         },
@@ -461,6 +464,33 @@ mod tests {
         // A canister principal text is at most 63 chars; anything longer can
         // never be a valid pool id.
         req.data = liquidium_data(5_100, &"a".repeat(MAX_LIQUIDIUM_POOL_ID_LEN + 1));
+        let err = create(&mut map, principal(), req, 1).unwrap_err();
+        assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    fn near_intents_data(amount: u64) -> ActiveUserTransactionData {
+        ActiveUserTransactionData::NearIntents(NearIntentsData {
+            source_token: TokenId::EvmNative(8453),
+            dest_token: TokenId::SolNativeMainnet,
+            amount: Nat::from(amount),
+        })
+    }
+
+    #[test]
+    fn near_intents_create_roundtrip() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("near-1");
+        req.data = near_intents_data(250_000);
+        let tx = create(&mut map, principal(), req, 1).expect("create");
+        assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+        assert_eq!(tx.data, near_intents_data(250_000));
+    }
+
+    #[test]
+    fn near_intents_zero_amount_rejected() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("near-1");
+        req.data = near_intents_data(0);
         let err = create(&mut map, principal(), req, 1).unwrap_err();
         assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
     }

--- a/src/backend/tests/it/active_user_transactions.rs
+++ b/src/backend/tests/it/active_user_transactions.rs
@@ -6,7 +6,7 @@ use shared::types::{
     active_user_transaction::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
         ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
-        OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
+        NearIntentsData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
     },
     result_types::{
         ActiveUserTransactionResult, DeleteActiveUserTransactionResult,
@@ -175,6 +175,45 @@ fn create_and_get_roundtrip() {
             assert_eq!(response.transactions[0].id, TX_ID);
         }
         GetActiveUserTransactionsResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+}
+
+#[test]
+fn create_near_intents_variant_roundtrip() {
+    let pic = setup();
+    let user = caller();
+    pic.ensure_user_profile(user);
+
+    let data = ActiveUserTransactionData::NearIntents(NearIntentsData {
+        source_token: TokenId::EvmNative(8453),
+        dest_token: TokenId::SolNativeMainnet,
+        amount: Nat::from(250_000u64),
+    });
+
+    let created = pic
+        .update::<ActiveUserTransactionResult>(
+            user,
+            "create_active_user_transaction",
+            CreateActiveUserTransactionRequest {
+                id: TX_ID.to_string(),
+                data: data.clone(),
+                progress_step: Some("initialization".to_string()),
+                external_refs: vec![ActiveUserTransactionRef {
+                    key: "deposit_address".to_string(),
+                    value: "0x00000000000000000000000000000000000000ff".to_string(),
+                }],
+            },
+        )
+        .expect("create_active_user_transaction call should succeed");
+
+    match created {
+        ActiveUserTransactionResult::Ok(tx) => {
+            assert_eq!(tx.id, TX_ID);
+            assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+            assert_eq!(tx.data, data);
+            assert_eq!(tx.external_refs.len(), 1);
+        }
+        ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
     }
 }
 

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -25,6 +25,10 @@ type ActiveUserTransaction = record {
 type ActiveUserTransactionData = variant {
 	OneSecEvmToIcp : OneSecEvmToIcpData;
 	OneSecIcpToEvm : OneSecIcpToEvmData;
+	// NEAR Intents (1Click) cross-chain swap. A single variant covers every
+	// source/destination leg (EVM and Solana); the deposit address, its
+	// optional memo, and origin/destination tx hashes ride in `external_refs`.
+	NearIntents : NearIntentsData;
 	// Liquidium lend/borrow flow. A single variant covers all four actions
 	// (supply, borrow, repay, withdraw).
 	Liquidium : LiquidiumData
@@ -768,6 +772,17 @@ type LiquidiumData = record {
 	pool_id : text;
 	// Amount in the token's base units.
 	amount : nat
+};
+// NEAR Intents (1Click) cross-chain swap payload. Settlement is tracked
+// off-chain by polling the 1Click status endpoint keyed by the deposit
+// address, so that address (and its optional memo, plus learned-mid-flow tx
+// hashes) lives in `external_refs`; only the canonical immutable trio is
+// captured here.
+type NearIntentsData = record {
+	source_token : TokenId;
+	// Source-token amount in base units.
+	amount : nat;
+	dest_token : TokenId
 };
 // Bitcoin Network.
 type Network = variant {

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -53,6 +53,14 @@ export type ActiveUserTransactionData =
 	| { OneSecIcpToEvm: OneSecIcpToEvmData }
 	| {
 			/**
+			 * NEAR Intents (1Click) cross-chain swap. A single variant covers every
+			 * source/destination leg (EVM and Solana); the deposit address, its
+			 * optional memo, and origin/destination tx hashes ride in `external_refs`.
+			 */
+			NearIntents: NearIntentsData;
+	  }
+	| {
+			/**
 			 * Liquidium lend/borrow flow. A single variant covers all four actions
 			 * (supply, borrow, repay, withdraw).
 			 */
@@ -1139,6 +1147,21 @@ export interface LiquidiumData {
 	 * Amount in the token's base units.
 	 */
 	amount: bigint;
+}
+/**
+ * NEAR Intents (1Click) cross-chain swap payload. Settlement is tracked
+ * off-chain by polling the 1Click status endpoint keyed by the deposit
+ * address, so that address (and its optional memo, plus learned-mid-flow tx
+ * hashes) lives in `external_refs`; only the canonical immutable trio is
+ * captured here.
+ */
+export interface NearIntentsData {
+	source_token: TokenId;
+	/**
+	 * Source-token amount in base units.
+	 */
+	amount: bigint;
+	dest_token: TokenId;
 }
 /**
  * Bitcoin Network.

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -246,6 +246,11 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const NearIntentsData = IDL.Record({
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
 	const LiquidiumAction = IDL.Variant({
 		Withdraw: IDL.Null,
 		Repay: IDL.Null,
@@ -261,6 +266,7 @@ export const idlFactory = ({ IDL }) => {
 	const ActiveUserTransactionData = IDL.Variant({
 		OneSecEvmToIcp: OneSecEvmToIcpData,
 		OneSecIcpToEvm: OneSecIcpToEvmData,
+		NearIntents: NearIntentsData,
 		Liquidium: LiquidiumData
 	});
 	const CreateActiveUserTransactionRequest = IDL.Record({

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -246,6 +246,11 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const NearIntentsData = IDL.Record({
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
 	const LiquidiumAction = IDL.Variant({
 		Withdraw: IDL.Null,
 		Repay: IDL.Null,
@@ -261,6 +266,7 @@ export const idlFactory = ({ IDL }) => {
 	const ActiveUserTransactionData = IDL.Variant({
 		OneSecEvmToIcp: OneSecEvmToIcpData,
 		OneSecIcpToEvm: OneSecIcpToEvmData,
+		NearIntents: NearIntentsData,
 		Liquidium: LiquidiumData
 	});
 	const CreateActiveUserTransactionRequest = IDL.Record({

--- a/src/shared/src/types/active_user_transaction.rs
+++ b/src/shared/src/types/active_user_transaction.rs
@@ -77,6 +77,10 @@ pub enum ActiveUserTransactionData {
     /// Liquidium lend/borrow flow. A single variant covers all four actions
     /// (supply, borrow, repay, withdraw).
     Liquidium(LiquidiumData),
+    /// NEAR Intents (1Click) cross-chain swap. A single variant covers every
+    /// source/destination leg (EVM and Solana); the deposit address, its
+    /// optional memo, and origin/destination tx hashes ride in `external_refs`.
+    NearIntents(NearIntentsData),
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -112,6 +116,19 @@ pub struct LiquidiumData {
     /// The asset moved by this action (supplied, borrowed, repaid, withdrawn).
     pub token: TokenId,
     /// Amount in the token's base units.
+    pub amount: Nat,
+}
+
+/// NEAR Intents (1Click) cross-chain swap payload. Settlement is tracked
+/// off-chain by polling the 1Click status endpoint keyed by the deposit
+/// address, so that address (and its optional memo, plus learned-mid-flow tx
+/// hashes) lives in `external_refs`; only the canonical immutable trio is
+/// captured here.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct NearIntentsData {
+    pub source_token: TokenId,
+    pub dest_token: TokenId,
+    /// Source-token amount in base units.
     pub amount: Nat,
 }
 
@@ -181,8 +198,8 @@ mod tests {
     use super::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
         ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
-        GetActiveUserTransactionsResponse, LiquidiumAction, LiquidiumData, OneSecEvmToIcpData,
-        OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
+        GetActiveUserTransactionsResponse, LiquidiumAction, LiquidiumData, NearIntentsData,
+        OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
     };
     use crate::types::token_id::TokenId;
 
@@ -242,6 +259,16 @@ mod tests {
             pool_id: "mxzaz-hqaaa-aaaar-qaada-cai".to_string(),
             token: TokenId::Icrc(Principal::from_text("mxzaz-hqaaa-aaaar-qaada-cai").unwrap()),
             amount: Nat::from(5_100u64),
+        });
+        assert_eq!(roundtrip(&original), original);
+    }
+
+    #[test]
+    fn near_intents_variant_roundtrips() {
+        let original = ActiveUserTransactionData::NearIntents(NearIntentsData {
+            source_token: TokenId::EvmNative(8453),
+            dest_token: TokenId::SolNativeMainnet,
+            amount: Nat::from(250_000u64),
         });
         assert_eq!(roundtrip(&original), original);
     }


### PR DESCRIPTION
# Motivation

NEAR Intents is a cross-chain swap whose settlement is long-running and today is watched only by an in-modal polling loop — closing the modal or tab loses all feedback. To let it register as an Active User Transaction and be driven to completion by the existing global poller (as the OneSec and Liquidium integrations already are), the persisted `ActiveUserTransactionData` needs a NEAR Intents variant.

This PR lands only that backend prerequisite.

BREAKING CHANGE: `ActiveUserTransactionData` gains a `NearIntents` variant. Because this type is returned by `create_active_user_transaction`, `update_active_user_transaction`, and `get_active_user_transactions`, a client built against the previous candid interface cannot decode an active transaction whose `data` is `NearIntents`. Only newer frontends create such rows; deploy the backend ahead of (or together with) the frontend that starts writing them.
