### PR TITLE
feat(frontend): NEAR Intents active transactions

### DIFF
--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -187,6 +187,12 @@
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.NEAR_INTENTS
 	);
 
+	// OneSec and NEAR Intents both close the modal at initiation and settle in the
+	// background via the Active User Transactions store.
+	const isActiveTransactionSwap = $derived(
+		isNearIntentsProvider || $swapAmountsStore?.selectedProvider?.provider === SwapProvider.ONE_SEC
+	);
+
 	const isApproveNeeded = $derived(
 		!isNearIntentsProvider &&
 			$swapAmountsStore?.selectedProvider?.type === VeloraSwapTypes.MARKET &&
@@ -376,15 +382,13 @@
 
 			progress(ProgressStepsSwap.DONE);
 
-			// For OneSec swaps, the foreground completes once the user's funds have
-			// left their wallet; success/failure of the background phase is tracked
-			// separately via the AUT store. Other providers (Velora, Near) still
-			// complete fully inside `await` and reach this point only on success.
+			// For OneSec and NEAR Intents swaps, the foreground completes once the
+			// user's funds have left their wallet; success/failure of the background
+			// phase is tracked separately via the AUT store, so we fire `submitted`
+			// here. Velora still completes fully inside `await` and reaches this point
+			// only on success.
 			trackEvent({
-				name:
-					$swapAmountsStore?.selectedProvider?.provider === SwapProvider.ONE_SEC
-						? TRACK_COUNT_SWAP_SUBMITTED
-						: TRACK_COUNT_SWAP_SUCCESS,
+				name: isActiveTransactionSwap ? TRACK_COUNT_SWAP_SUBMITTED : TRACK_COUNT_SWAP_SUCCESS,
 				metadata: swapTrackingMetadata
 			});
 
@@ -483,8 +487,7 @@
 					sendWithApproval={swapEmitsApprovalSteps}
 					sendWithTransfer={isTransferNeeded}
 					{swapProgressStep}
-					swapWithActiveTransaction={$swapAmountsStore?.selectedProvider?.provider ===
-						SwapProvider.ONE_SEC}
+					swapWithActiveTransaction={isActiveTransactionSwap}
 				/>
 			{/if}
 		{/key}

--- a/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
+++ b/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
@@ -21,6 +21,7 @@
 		liquidiumActionKey,
 		toLiquidiumExternalRefsMap
 	} from '$lib/utils/liquidium-active-tx.utils';
+	import { isNearIntentsActiveUserTransaction } from '$lib/utils/near-intents-active-tx.utils';
 	import {
 		isOneSecActiveUserTransaction,
 		toOneSecExternalRefsMap
@@ -36,6 +37,10 @@
 	let { tx, isUnseen, dismissing, onDismiss }: Props = $props();
 
 	const isOneSec = $derived(isOneSecActiveUserTransaction(tx));
+	const isNearIntents = $derived(isNearIntentsActiveUserTransaction(tx));
+	// OneSec and NEAR Intents are both cross-chain swaps rendered identically
+	// (they share the same display-ref key names in `external_refs`).
+	const isSwap = $derived(isOneSec || isNearIntents);
 	const isLiquidium = $derived(isLiquidiumActiveUserTransaction(tx));
 	const refs = $derived(toOneSecExternalRefsMap(tx.external_refs));
 	const liquidiumRefs = $derived(toLiquidiumExternalRefsMap(tx.external_refs));
@@ -65,9 +70,11 @@
 	const providerName = $derived(
 		isLiquidium
 			? lendBorrowProvidersConfig[LendBorrowProvider.LIQUIDIUM].name
-			: isOneSec
-				? (swapProvidersDetails[SwapProvider.ONE_SEC]?.name ?? '')
-				: undefined
+			: isNearIntents
+				? (swapProvidersDetails[SwapProvider.NEAR_INTENTS]?.name ?? '')
+				: isOneSec
+					? (swapProvidersDetails[SwapProvider.ONE_SEC]?.name ?? '')
+					: undefined
 	);
 
 	const titleText = $derived(
@@ -80,7 +87,7 @@
 					.filter(nonNullish)
 					.join(' ')
 			: [
-					isOneSec ? $i18n.swap.text.swap : undefined,
+					isSwap ? $i18n.swap.text.swap : undefined,
 					refs[ONESEC_EXTERNAL_REF_KEYS.AMOUNT],
 					refs[ONESEC_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL],
 					'→',

--- a/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
@@ -15,6 +15,7 @@
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { pollLiquidiumActiveUserTransactions } from '$lib/services/liquidium-active-tx.services';
 	import { loadLiquidium } from '$lib/services/liquidium.services';
+	import { pollNearIntentsActiveUserTransactions } from '$lib/services/near-intents-active-tx.services';
 	import { pollOneSecActiveUserTransactions } from '$lib/services/onesec-swap.services';
 	import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
 	import { isTerminalActiveUserTransaction } from '$lib/utils/active-user-transactions.utils';
@@ -23,6 +24,10 @@
 		buildLiquidiumTrackingMetadata,
 		isLiquidiumActiveUserTransaction
 	} from '$lib/utils/liquidium-active-tx.utils';
+	import {
+		buildNearIntentsSwapTrackingMetadata,
+		isNearIntentsActiveUserTransaction
+	} from '$lib/utils/near-intents-active-tx.utils';
 	import {
 		buildOneSecSwapTrackingMetadata,
 		isOneSecActiveUserTransaction
@@ -64,6 +69,12 @@
 
 			if (liquidium.length > 0) {
 				await pollLiquidiumActiveUserTransactions({ identity, transactions: liquidium });
+			}
+
+			const nearIntents = $activeUserTransactionsPending.filter(isNearIntentsActiveUserTransaction);
+
+			if (nearIntents.length > 0) {
+				await pollNearIntentsActiveUserTransactions({ identity, transactions: nearIntents });
 			}
 		} catch (err: unknown) {
 			consoleError(err);
@@ -128,6 +139,21 @@
 				trackEvent({
 					name: isSucceeded ? TRACK_COUNT_SWAP_SUCCESS : TRACK_COUNT_SWAP_ERROR,
 					metadata: buildOneSecSwapTrackingMetadata({ tx })
+				});
+
+				if (isSucceeded) {
+					shouldRefresh = true;
+				}
+			} else if (
+				isTerminalActiveUserTransaction(tx) &&
+				!alreadyApplied &&
+				isNearIntentsActiveUserTransaction(tx)
+			) {
+				newlyAppliedIds.push(tx.id);
+
+				trackEvent({
+					name: isSucceeded ? TRACK_COUNT_SWAP_SUCCESS : TRACK_COUNT_SWAP_ERROR,
+					metadata: buildNearIntentsSwapTrackingMetadata({ tx })
 				});
 
 				if (isSucceeded) {

--- a/src/frontend/src/lib/constants/swap.constants.ts
+++ b/src/frontend/src/lib/constants/swap.constants.ts
@@ -40,8 +40,6 @@ export const NEAR_INTENTS_BLOCKCHAIN_MAP: Record<NetworkId, string> = {
 };
 
 export const NEAR_INTENTS_QUOTE_DEADLINE_MS = 3 * 60 * 1000;
-export const NEAR_INTENTS_POLL_INTERVAL_MS = 2_000;
-export const NEAR_INTENTS_POLL_MAX_ATTEMPTS = 120;
 
 export const OISY_DOCS_SWAP_WIDTHDRAW_FROM_ICPSWAP_LINK =
 	'https://docs.oisy.com/using-oisy-wallet/how-tos/swapping-tokens#manually-withdraw-funds-from-icpswap';

--- a/src/frontend/src/lib/services/near-intents-active-tx.services.ts
+++ b/src/frontend/src/lib/services/near-intents-active-tx.services.ts
@@ -1,0 +1,92 @@
+import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import { fetchNearIntentsStatus } from '$lib/rest/near-intents.rest';
+import { applyActiveUserTransactionPollUpdate } from '$lib/services/active-user-transactions.services';
+import {
+	NEAR_INTENTS_EXTERNAL_REF_KEYS,
+	type NearIntentsExternalRefKey
+} from '$lib/types/near-intents';
+import { advanceStatus } from '$lib/utils/active-user-transactions.utils';
+import { consoleError } from '$lib/utils/console.utils';
+import {
+	nearIntentsStatusError,
+	toNearIntentsActiveUserTransactionStatus,
+	toNearIntentsExternalRefs,
+	toNearIntentsExternalRefsMap,
+	toNearIntentsLearnedRefs
+} from '$lib/utils/near-intents-active-tx.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+
+// 1Click `/status` is a stateless REST endpoint keyed by depositAddress (+ the
+// optional depositMemo), both snapshotted in `external_refs` at creation time.
+// The row is re-derived from `/status` each tick, so it resumes across refresh /
+// logout with no SDK "transfer id" gap to work around (the deposit address IS
+// the durable poll key).
+const pollNearIntentsActiveUserTransaction = async ({
+	tx,
+	identity
+}: {
+	tx: ActiveUserTransaction;
+	identity: Identity;
+}): Promise<void> => {
+	try {
+		const refs = toNearIntentsExternalRefsMap(tx.external_refs);
+		const depositAddress = refs[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS];
+		const depositMemo = refs[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO];
+
+		// Not pollable without the deposit address.
+		if (isNullish(depositAddress)) {
+			return;
+		}
+
+		const { status, swapDetails } = await fetchNearIntentsStatus({ depositAddress, depositMemo });
+
+		const candidate = toNearIntentsActiveUserTransactionStatus(status);
+
+		const next = nonNullish(candidate)
+			? advanceStatus({ current: tx.status, candidate })
+			: undefined;
+
+		// Persist newly-learned origin/destination tx hashes even when the status
+		// itself doesn't advance (e.g. row already Executing).
+		const learned = toNearIntentsLearnedRefs(swapDetails);
+		const hasNewRefs = (Object.keys(learned) as NearIntentsExternalRefKey[]).some(
+			(key) => refs[key] !== learned[key]
+		);
+		const externalRefs = hasNewRefs
+			? toNearIntentsExternalRefs({ ...refs, ...learned })
+			: undefined;
+
+		const error = nonNullish(next) && 'Failed' in next ? nearIntentsStatusError(status) : undefined;
+
+		const update = {
+			...(nonNullish(next) ? { status: next } : {}),
+			...(nonNullish(error) ? { error } : {}),
+			...(nonNullish(externalRefs) ? { externalRefs } : {})
+		};
+
+		if (Object.keys(update).length === 0) {
+			return;
+		}
+
+		await applyActiveUserTransactionPollUpdate({ identity, tx, update });
+	} catch (err: unknown) {
+		consoleError(err);
+	}
+};
+
+export const pollNearIntentsActiveUserTransactions = async ({
+	identity,
+	transactions
+}: {
+	identity: Identity;
+	transactions: ActiveUserTransaction[];
+}): Promise<void> => {
+	if (transactions.length === 0) {
+		return;
+	}
+
+	await Promise.all(
+		transactions.map((tx) => pollNearIntentsActiveUserTransaction({ tx, identity }))
+	);
+};

--- a/src/frontend/src/lib/services/near-intents.services.ts
+++ b/src/frontend/src/lib/services/near-intents.services.ts
@@ -1,17 +1,14 @@
 import { NEAR_INTENTS_SWAP_ENABLED } from '$env/rest/near-intents.env';
 import {
 	NEAR_INTENTS_BLOCKCHAIN_MAP,
-	NEAR_INTENTS_POLL_INTERVAL_MS,
-	NEAR_INTENTS_POLL_MAX_ATTEMPTS,
 	NEAR_INTENTS_QUOTE_DEADLINE_MS
 } from '$lib/constants/swap.constants';
 import {
 	fetchNearIntentsQuote,
-	fetchNearIntentsStatus,
 	fetchNearIntentsTokens,
 	submitNearIntentsDeposit
 } from '$lib/rest/near-intents.rest';
-import { NEAR_INTENTS_TERMINAL_STATUSES, type NearIntentsToken } from '$lib/types/near-intents';
+import type { NearIntentsToken } from '$lib/types/near-intents';
 import type { NetworkId } from '$lib/types/network';
 import type { NearIntentsQuoteParams, SwapMappedResult } from '$lib/types/swap';
 import {
@@ -133,31 +130,4 @@ export const submitNearIntentsDepositTx = async ({
 		depositAddress,
 		...(depositMemo ? { memo: depositMemo } : {})
 	});
-};
-
-export const pollNearIntentsStatus = async ({
-	depositAddress,
-	depositMemo
-}: {
-	depositAddress: string;
-	depositMemo?: string;
-}): Promise<void> => {
-	for (let i = 0; i < NEAR_INTENTS_POLL_MAX_ATTEMPTS; i++) {
-		const { status } = await fetchNearIntentsStatus({
-			depositAddress,
-			depositMemo
-		});
-
-		if (NEAR_INTENTS_TERMINAL_STATUSES.includes(status)) {
-			if (status === 'SUCCESS') {
-				return;
-			}
-
-			throw new Error(`NEAR Intents swap ${status.toLowerCase()}`);
-		}
-
-		await new Promise((r) => setTimeout(r, NEAR_INTENTS_POLL_INTERVAL_MS));
-	}
-
-	throw new Error('NEAR Intents swap timed out');
 };

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -748,11 +748,18 @@ const executeNearIntentsSwap = async ({
 
 	progress(ProgressStepsSwap.SWAP);
 
-	await submitNearIntentsDepositTx({
-		depositAddress,
-		txHash,
-		depositMemo: depositMemo ?? undefined
-	});
+	// Optional SDK call: notifies the 1Click service that a deposit has been sent
+	// to the specified address, using the blockchain transaction hash. This step can
+	// speed up swap processing by allowing the system to preemptively verify the deposit.
+	try {
+		await submitNearIntentsDepositTx({
+			depositAddress,
+			txHash,
+			depositMemo: depositMemo ?? undefined
+		});
+	} catch (err: unknown) {
+		consoleError(err);
+	}
 
 	// Register the swap as an Active User Transaction so settlement is tracked by
 	// the global poller (survives modal close, tab close, refresh, logout).

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -46,11 +46,9 @@ import { evmSwapProviders } from '$lib/providers/evm-swap.providers';
 import { icpBridgeProviders } from '$lib/providers/icp-bridge-swap.providers';
 import { solSwapProviders } from '$lib/providers/sol-swap.providers';
 import { swapProviders } from '$lib/providers/swap.providers';
+import { createActiveUserTransaction } from '$lib/services/active-user-transactions.services';
 import { trackEvent } from '$lib/services/analytics.services';
-import {
-	pollNearIntentsStatus,
-	submitNearIntentsDepositTx
-} from '$lib/services/near-intents.services';
+import { submitNearIntentsDepositTx } from '$lib/services/near-intents.services';
 import {
 	executeOneSecEvmToIcpBridge,
 	executeOneSecIcpToEvmBridge
@@ -64,7 +62,10 @@ import {
 	type KongSwapTokensStoreData
 } from '$lib/stores/kong-swap-tokens.store';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
-import type { NearIntentsQuoteResponse } from '$lib/types/near-intents';
+import {
+	NEAR_INTENTS_EXTERNAL_REF_KEYS,
+	type NearIntentsQuoteResponse
+} from '$lib/types/near-intents';
 import type { Amount } from '$lib/types/send';
 import {
 	SwapErrorCodes,
@@ -90,6 +91,11 @@ import type { Token } from '$lib/types/token';
 import { consoleError } from '$lib/utils/console.utils';
 import { toCustomToken } from '$lib/utils/custom-token.utils';
 import { formatToken } from '$lib/utils/format.utils';
+import {
+	toNearIntentsData,
+	toNearIntentsDisplayRefs,
+	toNearIntentsExternalRefs
+} from '$lib/utils/near-intents-active-tx.utils';
 import { isNetworkIdICP, isNetworkIdSOLDevnet, isNetworkIdSolana } from '$lib/utils/network.utils';
 import { parseToken } from '$lib/utils/parse.utils';
 import {
@@ -705,16 +711,25 @@ export const fetchIcpSwap = async ({
 	await waitAndTriggerWallet();
 };
 
+// Foreground resolves once the deposit is submitted (point of no return); the
+// swap then settles in the background, tracked by the AUT poller
+// (`pollNearIntentsActiveUserTransactions`) which drives the row to a terminal
+// state from 1Click's `/status`. The success wallet refresh is wired off the AUT
+// terminal side-effect in `LoaderActiveUserTransactions`, not from here.
 const executeNearIntentsSwap = async ({
+	identity,
 	progress,
 	sourceToken,
+	destinationToken,
 	swapAmount,
 	swapDetails,
 	sendTransaction,
 	enableDestinationToken
 }: {
+	identity: Identity;
 	progress: (step: ProgressStepsSwap) => void;
 	sourceToken: Token;
+	destinationToken: Token;
 	swapAmount: Amount;
 	swapDetails: NearIntentsQuoteResponse;
 	sendTransaction: (params: { amount: bigint; depositAddress: string }) => Promise<string>;
@@ -739,16 +754,40 @@ const executeNearIntentsSwap = async ({
 		depositMemo: depositMemo ?? undefined
 	});
 
-	await pollNearIntentsStatus({
-		depositAddress,
-		depositMemo: depositMemo ?? undefined
-	});
+	// Register the swap as an Active User Transaction so settlement is tracked by
+	// the global poller (survives modal close, tab close, refresh, logout).
+	// Best-effort: the funds have already left the wallet (point of no return), so
+	// a failed create must NOT surface as a swap failure — mirrors OneSec's
+	// `createAutAndDetachCloser`.
+	try {
+		const data = toNearIntentsData({
+			sourceToken,
+			destinationToken,
+			amount: parsedSwapAmount
+		});
+
+		if (nonNullish(data)) {
+			await createActiveUserTransaction({
+				identity,
+				id: crypto.randomUUID(),
+				data,
+				externalRefs: toNearIntentsExternalRefs({
+					...toNearIntentsDisplayRefs({ sourceToken, destinationToken, amount: `${swapAmount}` }),
+					[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS]: depositAddress,
+					...(nonNullish(depositMemo)
+						? { [NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO]: depositMemo }
+						: {})
+				})
+			});
+		}
+	} catch (err: unknown) {
+		consoleError(err);
+	}
 
 	progress(ProgressStepsSwap.UPDATE_UI);
 
+	// Keep the destination token visible while the swap settles in the background.
 	await enableDestinationToken?.();
-
-	await waitAndTriggerWallet();
 };
 
 export const fetchNearIntentsEvmSwap = async ({
@@ -765,8 +804,10 @@ export const fetchNearIntentsEvmSwap = async ({
 	swapDetails
 }: SwapNearIntentsEvmParams): Promise<void> => {
 	await executeNearIntentsSwap({
+		identity,
 		progress,
 		sourceToken,
+		destinationToken,
 		swapAmount,
 		swapDetails,
 		sendTransaction: async ({ amount, depositAddress }) => {
@@ -797,8 +838,10 @@ export const fetchNearIntentsSolSwap = async ({
 	swapDetails
 }: SwapNearIntentsSolParams): Promise<void> => {
 	await executeNearIntentsSwap({
+		identity,
 		progress,
 		sourceToken,
+		destinationToken,
 		swapAmount,
 		swapDetails,
 		sendTransaction: async ({ amount, depositAddress }) =>

--- a/src/frontend/src/lib/types/near-intents.ts
+++ b/src/frontend/src/lib/types/near-intents.ts
@@ -66,12 +66,29 @@ export type NearIntentsSwapStatus =
 	| 'REFUNDED'
 	| 'FAILED';
 
-export const NEAR_INTENTS_TERMINAL_STATUSES: NearIntentsSwapStatus[] = [
-	'SUCCESS',
-	'FAILED',
-	'REFUNDED',
-	'INCOMPLETE_DEPOSIT'
-];
+export const NEAR_INTENTS_EXTERNAL_REF_KEYS = {
+	// Poll keys — the durable, resumable identifiers `GET /status` is keyed by.
+	// Known at quote time, snapshotted at AUT creation so the global poller can
+	// re-derive the swap's state across refresh / logout.
+	DEPOSIT_ADDRESS: 'near_intents_deposit_address',
+	DEPOSIT_MEMO: 'near_intents_deposit_memo',
+	// Optional debug/traceability, learned mid-flow from `/status` swapDetails.
+	ORIGIN_TX_HASH: 'near_intents_origin_tx_hash',
+	DESTINATION_TX_HASH: 'near_intents_destination_tx_hash',
+	// Display + analytics metadata snapshotted at creation time. Reuses the same
+	// key names as OneSec (`$lib/types/onesec-swap`) so the AUT row rendering and
+	// analytics paths are shared rather than duplicated. Stay correct across page
+	// refresh / cross-session resume — even when the user has since disabled the
+	// underlying token.
+	AMOUNT: 'amount',
+	SOURCE_TOKEN_SYMBOL: 'source_token_symbol',
+	SOURCE_NETWORK_SYMBOL: 'source_network_symbol',
+	DESTINATION_TOKEN_SYMBOL: 'destination_token_symbol',
+	DESTINATION_NETWORK_SYMBOL: 'destination_network_symbol'
+} as const;
+
+export type NearIntentsExternalRefKey =
+	(typeof NEAR_INTENTS_EXTERNAL_REF_KEYS)[keyof typeof NEAR_INTENTS_EXTERNAL_REF_KEYS];
 
 export interface NearIntentsTxHash {
 	hash: string;

--- a/src/frontend/src/lib/utils/near-intents-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/near-intents-active-tx.utils.ts
@@ -1,0 +1,217 @@
+import type {
+	ActiveUserTransaction,
+	ActiveUserTransactionData,
+	ActiveUserTransactionRef,
+	ActiveUserTransactionStatus,
+	TokenId as BackendTokenId
+} from '$declarations/backend/backend.did';
+import type { EthereumNetwork } from '$eth/types/network';
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
+import { i18n } from '$lib/stores/i18n.store';
+import {
+	NEAR_INTENTS_EXTERNAL_REF_KEYS,
+	type NearIntentsExternalRefKey,
+	type NearIntentsSwapDetails,
+	type NearIntentsSwapStatus
+} from '$lib/types/near-intents';
+import { SwapProvider } from '$lib/types/swap';
+import type { Token as AppToken } from '$lib/types/token';
+import {
+	isNetworkIdEthereum,
+	isNetworkIdEvm,
+	isNetworkIdSOLDevnet,
+	isNetworkIdSolana
+} from '$lib/utils/network.utils';
+import { isTokenSpl } from '$sol/utils/spl.utils';
+import { nonNullish } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+export const isNearIntentsActiveUserTransaction = (tx: ActiveUserTransaction): boolean =>
+	'NearIntents' in tx.data;
+
+/**
+ * Maps an OISY app token to its canonical backend `TokenId` variant. NEAR
+ * Intents spans EVM (native + ERC-20) and Solana (native + SPL) as both source
+ * and destination, so — unlike OneSec's `Erc20`/`Icrc`-only mapper — this covers
+ * all four. Returns `undefined` for an unmappable token (should not happen for a
+ * NEAR-Intents-supported asset).
+ */
+const appTokenToBackendTokenId = (token: AppToken): BackendTokenId | undefined => {
+	const {
+		network: { id: networkId }
+	} = token;
+
+	if (isTokenErc20(token)) {
+		return { Erc20: [token.address, BigInt(token.network.chainId)] };
+	}
+
+	if (isTokenSpl(token)) {
+		return isNetworkIdSOLDevnet(networkId)
+			? { SplDevnet: token.address }
+			: { SplMainnet: token.address };
+	}
+
+	// Native tokens carry no contract address; disambiguate by network.
+	if (isNetworkIdSolana(networkId)) {
+		return isNetworkIdSOLDevnet(networkId) ? { SolNativeDevnet: null } : { SolNativeMainnet: null };
+	}
+
+	// Native EVM coin (ETH, BNB, POL, …), identified by chain id.
+	if (isNetworkIdEthereum(networkId) || isNetworkIdEvm(networkId)) {
+		return { EvmNative: BigInt((token.network as EthereumNetwork).chainId) };
+	}
+
+	return undefined;
+};
+
+/**
+ * Builds the `NearIntents` AUT data variant carrying the canonical immutable
+ * trio (source token, dest token, source amount in base units). The deposit
+ * address/memo, tx hashes and display symbols ride in `external_refs`. Returns
+ * `undefined` when either token can't be mapped to a backend `TokenId`.
+ */
+export const toNearIntentsData = ({
+	sourceToken,
+	destinationToken,
+	amount
+}: {
+	sourceToken: AppToken;
+	destinationToken: AppToken;
+	amount: bigint;
+}): ActiveUserTransactionData | undefined => {
+	const source_token = appTokenToBackendTokenId(sourceToken);
+	const dest_token = appTokenToBackendTokenId(destinationToken);
+
+	if (nonNullish(source_token) && nonNullish(dest_token)) {
+		return { NearIntents: { source_token, dest_token, amount } };
+	}
+};
+
+/**
+ * Builds a deterministic `(key, value)` external-ref array, dropping empties.
+ * Mirrors `toOneSecExternalRefs`.
+ */
+export const toNearIntentsExternalRefs = (
+	refs: Partial<Record<NearIntentsExternalRefKey, string>>
+): ActiveUserTransactionRef[] =>
+	(Object.keys(refs) as NearIntentsExternalRefKey[])
+		.filter((key) => refs[key] !== undefined && refs[key] !== '')
+		.sort()
+		.map((key) => ({ key, value: refs[key] as string }));
+
+// Wire-format `(key, value)` array → keyed lookup.
+export const toNearIntentsExternalRefsMap = (
+	refs: ActiveUserTransactionRef[]
+): Partial<Record<NearIntentsExternalRefKey, string>> => {
+	const map: Partial<Record<NearIntentsExternalRefKey, string>> = {};
+
+	for (const { key, value } of refs) {
+		map[key as NearIntentsExternalRefKey] = value;
+	}
+
+	return map;
+};
+
+/**
+ * Snapshots the user-facing fields needed to render an AUT row and to fire its
+ * terminal-state analytics events. Uses the same key names as OneSec so the UI
+ * and analytics code is shared. Read back from `tx.external_refs`, so it stays
+ * accurate across page refresh / cross-session resume — even when the user has
+ * since disabled the underlying token.
+ */
+export const toNearIntentsDisplayRefs = ({
+	sourceToken,
+	destinationToken,
+	amount
+}: {
+	sourceToken: AppToken;
+	destinationToken: AppToken;
+	amount: string;
+}): Partial<Record<NearIntentsExternalRefKey, string>> => ({
+	[NEAR_INTENTS_EXTERNAL_REF_KEYS.AMOUNT]: amount,
+	[NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL]: sourceToken.symbol,
+	[NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL]: sourceToken.network.name,
+	[NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]: destinationToken.symbol,
+	[NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL]: destinationToken.network.name
+});
+
+/**
+ * Extracts the newly-learned origin/destination tx hashes from a `/status`
+ * response so the poller can persist them for traceability.
+ */
+export const toNearIntentsLearnedRefs = (
+	swapDetails: NearIntentsSwapDetails
+): Partial<Record<NearIntentsExternalRefKey, string>> => {
+	const origin = swapDetails.originChainTxHashes?.[0]?.hash;
+	const destination = swapDetails.destinationChainTxHashes?.[0]?.hash;
+
+	return {
+		...(nonNullish(origin) ? { [NEAR_INTENTS_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH]: origin } : {}),
+		...(nonNullish(destination)
+			? { [NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_TX_HASH]: destination }
+			: {})
+	};
+};
+
+/**
+ * Maps a 1Click `NearIntentsSwapStatus` to the AUT status enum.
+ *
+ * The 1Click terminal set is only `SUCCESS` / `REFUNDED` / `FAILED`; everything
+ * else is still in flight. Crucially `INCOMPLETE_DEPOSIT` (an underpaid deposit)
+ * is treated as in-flight, NOT terminal: it still resolves to `REFUNDED` (or
+ * `SUCCESS` if topped up) by the quote deadline, and an early `Failed` write on an
+ * AUT row could never be walked back on the backend.
+ */
+export const toNearIntentsActiveUserTransactionStatus = (
+	status: NearIntentsSwapStatus
+): ActiveUserTransactionStatus | undefined => {
+	switch (status) {
+		case 'SUCCESS':
+			return { Succeeded: null };
+		case 'REFUNDED':
+		case 'FAILED':
+			return { Failed: null };
+		case 'PENDING_DEPOSIT':
+		case 'KNOWN_DEPOSIT_TX':
+		case 'INCOMPLETE_DEPOSIT':
+		case 'PROCESSING':
+			return { Executing: null };
+		default:
+			return undefined;
+	}
+};
+
+export const nearIntentsStatusError = (status: NearIntentsSwapStatus): string | undefined => {
+	if (status === 'REFUNDED') {
+		return get(i18n).swap.error.swap_refunded;
+	}
+
+	if (status === 'FAILED') {
+		return get(i18n).swap.error.failed_unexpectedly;
+	}
+
+	return undefined;
+};
+
+/**
+ * Builds the analytics metadata for a NEAR Intents AUT row that has just reached
+ * a terminal status. Same shape as `buildOneSecSwapTrackingMetadata`, resolved
+ * entirely off the row's `external_refs` snapshot so it survives refresh/resume.
+ */
+export const buildNearIntentsSwapTrackingMetadata = ({
+	tx
+}: {
+	tx: ActiveUserTransaction;
+}): Record<string, string> => {
+	const refs = toNearIntentsExternalRefsMap(tx.external_refs);
+
+	return {
+		sourceToken: refs[NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL] ?? '',
+		destinationToken: refs[NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL] ?? '',
+		dApp: SwapProvider.NEAR_INTENTS,
+		tokenAmount: refs[NEAR_INTENTS_EXTERNAL_REF_KEYS.AMOUNT] ?? '',
+		sourceNetwork: refs[NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL] ?? '',
+		destinationNetwork: refs[NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL] ?? '',
+		...(nonNullish(tx.error[0]) ? { error: tx.error[0] } : {})
+	};
+};

--- a/src/frontend/src/sol/components/swap/SwapSolWizard.svelte
+++ b/src/frontend/src/sol/components/swap/SwapSolWizard.svelte
@@ -12,7 +12,7 @@
 	import SwapReview from '$lib/components/swap/SwapReview.svelte';
 	import {
 		TRACK_COUNT_SWAP_ERROR,
-		TRACK_COUNT_SWAP_SUCCESS
+		TRACK_COUNT_SWAP_SUBMITTED
 	} from '$lib/constants/analytics.constants';
 	import { solAddressMainnet } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -225,8 +225,11 @@
 
 			progress(ProgressStepsSwap.DONE);
 
+			// The foreground completes once the user's funds have left their wallet;
+			// success/failure of the background settlement is tracked separately via
+			// the AUT store, so we fire `submitted` here (matching OneSec).
 			trackEvent({
-				name: TRACK_COUNT_SWAP_SUCCESS,
+				name: TRACK_COUNT_SWAP_SUBMITTED,
 				metadata: swapTrackingMetadata
 			});
 
@@ -290,7 +293,7 @@
 					{/snippet}
 				</SwapReview>
 			{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
-				<SwapProgress sendWithTransfer {swapProgressStep} />
+				<SwapProgress sendWithTransfer {swapProgressStep} swapWithActiveTransaction />
 			{/if}
 		{/key}
 	</SolFeeContext>

--- a/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
@@ -1,9 +1,27 @@
 import ActiveUserTransactionItem from '$lib/components/active-user-transactions/ActiveUserTransactionItem.svelte';
 import en from '$lib/i18n/en.json';
-import { mockLiquidiumActiveUserTransaction } from '$tests/mocks/active-user-transactions.mock';
+import {
+	mockLiquidiumActiveUserTransaction,
+	mockNearIntentsActiveUserTransaction
+} from '$tests/mocks/active-user-transactions.mock';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 
 describe('ActiveUserTransactionItem', () => {
+	it('renders NEAR Intents rows as a swap with amount, tokens, networks and provider', () => {
+		const { container } = render(ActiveUserTransactionItem, {
+			props: {
+				tx: mockNearIntentsActiveUserTransaction,
+				isUnseen: false,
+				dismissing: false,
+				onDismiss: vi.fn()
+			}
+		});
+
+		expect(screen.getByText(`${en.swap.text.swap} 1 USDC → USDC`)).toBeInTheDocument();
+		expect(container).toHaveTextContent('Ethereum → Solana');
+		expect(container).toHaveTextContent('NEAR Intents');
+	});
+
 	it('renders Liquidium rows with the action, amount, asset and provider', () => {
 		render(ActiveUserTransactionItem, {
 			props: {

--- a/src/frontend/src/tests/lib/components/loaders/LoaderActiveUserTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderActiveUserTransactions.spec.ts
@@ -13,13 +13,15 @@ import * as activeUserTransactionsServices from '$lib/services/active-user-trans
 import * as analyticsServices from '$lib/services/analytics.services';
 import * as liquidiumPoller from '$lib/services/liquidium-active-tx.services';
 import * as liquidiumServices from '$lib/services/liquidium.services';
+import * as nearIntentsPoller from '$lib/services/near-intents-active-tx.services';
 import * as oneSecPoller from '$lib/services/onesec-swap.services';
 import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
 import { SwapProvider } from '$lib/types/swap';
 import * as walletUtils from '$lib/utils/wallet.utils';
 import {
 	mockActiveUserTransaction,
-	mockLiquidiumActiveUserTransaction
+	mockLiquidiumActiveUserTransaction,
+	mockNearIntentsActiveUserTransaction
 } from '$tests/mocks/active-user-transactions.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -47,6 +49,20 @@ const failed = (id: string) =>
 		id,
 		status: { Failed: null } as const
 	}) satisfies typeof mockActiveUserTransaction;
+
+const pendingNearIntents = (id: string) =>
+	({
+		...mockNearIntentsActiveUserTransaction,
+		id,
+		status: { Pending: null } as const
+	}) satisfies typeof mockNearIntentsActiveUserTransaction;
+
+const succeededNearIntents = (id: string) =>
+	({
+		...mockNearIntentsActiveUserTransaction,
+		id,
+		status: { Succeeded: null } as const
+	}) satisfies typeof mockNearIntentsActiveUserTransaction;
 
 const pendingLiquidium = (id: string) =>
 	({
@@ -181,6 +197,29 @@ describe('LoaderActiveUserTransactions', () => {
 			});
 		});
 
+		it('polls NEAR Intents rows on each tick when present', async () => {
+			const oneSecSpy = vi
+				.spyOn(oneSecPoller, 'pollOneSecActiveUserTransactions')
+				.mockResolvedValue();
+			const nearSpy = vi
+				.spyOn(nearIntentsPoller, 'pollNearIntentsActiveUserTransactions')
+				.mockResolvedValue();
+			const tx = pendingNearIntents('near-a');
+
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: tx });
+
+			render(LoaderActiveUserTransactions);
+
+			await vi.advanceTimersByTimeAsync(ACTIVE_USER_TRANSACTIONS_POLL_INTERVAL_MILLIS);
+
+			expect(oneSecSpy).not.toHaveBeenCalled();
+			expect(nearSpy).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				transactions: [tx]
+			});
+		});
+
 		it('stops polling once all rows reach a terminal state', async () => {
 			const spy = vi.spyOn(oneSecPoller, 'pollOneSecActiveUserTransactions').mockResolvedValue();
 
@@ -250,6 +289,27 @@ describe('LoaderActiveUserTransactions', () => {
 				metadata: expect.objectContaining({ dApp: SwapProvider.ONE_SEC })
 			});
 			expect(appliedFlags()).toEqual({ a: true });
+		});
+
+		it('fires waitAndTriggerWallet and a swap_success event with the NEAR Intents dApp when a NEAR row succeeds', async () => {
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: pendingNearIntents('near-a') });
+
+			render(LoaderActiveUserTransactions);
+			await tick();
+
+			expect(refreshSpy).not.toHaveBeenCalled();
+			expect(trackEventSpy).not.toHaveBeenCalled();
+
+			activeUserTransactionsStore.upsert({ transaction: succeededNearIntents('near-a') });
+			await tick();
+
+			expect(refreshSpy).toHaveBeenCalledOnce();
+			expect(trackEventSpy).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_SWAP_SUCCESS,
+				metadata: expect.objectContaining({ dApp: SwapProvider.NEAR_INTENTS })
+			});
+			expect(appliedFlags()).toEqual({ 'near-a': true });
 		});
 
 		it('fires wallet and Liquidium refreshes plus analytics when a Liquidium row succeeds', async () => {

--- a/src/frontend/src/tests/lib/services/near-intents-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/near-intents-active-tx.services.spec.ts
@@ -1,0 +1,260 @@
+import en from '$lib/i18n/en.json';
+import * as nearIntentsRest from '$lib/rest/near-intents.rest';
+import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
+import { pollNearIntentsActiveUserTransactions } from '$lib/services/near-intents-active-tx.services';
+import {
+	NEAR_INTENTS_EXTERNAL_REF_KEYS,
+	type NearIntentsSwapDetails,
+	type NearIntentsSwapStatus
+} from '$lib/types/near-intents';
+import { mockNearIntentsActiveUserTransaction } from '$tests/mocks/active-user-transactions.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+
+vi.mock('$lib/rest/near-intents.rest', () => ({
+	fetchNearIntentsStatus: vi.fn()
+}));
+
+vi.mock('$lib/utils/console.utils', () => ({
+	consoleError: vi.fn()
+}));
+
+const depositAddress = '0xDepositAddress123';
+
+const pendingTx = mockNearIntentsActiveUserTransaction;
+
+const statusResponse = ({
+	status,
+	swapDetails = {}
+}: {
+	status: NearIntentsSwapStatus;
+	swapDetails?: NearIntentsSwapDetails;
+}) => ({
+	correlationId: 'id',
+	status,
+	updatedAt: '2026-03-16T00:00:00.000Z',
+	quoteResponse: {} as never,
+	swapDetails
+});
+
+describe('near-intents-active-tx.services', () => {
+	describe('pollNearIntentsActiveUserTransactions', () => {
+		let applySpy: ReturnType<typeof vi.spyOn>;
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			applySpy = vi
+				.spyOn(activeUserTransactionsServices, 'applyActiveUserTransactionPollUpdate')
+				.mockResolvedValue();
+		});
+
+		it('no-ops on an empty list and does not call the status endpoint', async () => {
+			await pollNearIntentsActiveUserTransactions({ identity: mockIdentity, transactions: [] });
+
+			expect(nearIntentsRest.fetchNearIntentsStatus).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('skips a row without a deposit-address ref', async () => {
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [{ ...pendingTx, external_refs: [] }]
+			});
+
+			expect(nearIntentsRest.fetchNearIntentsStatus).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('queries /status by deposit address (and memo when present)', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({ status: 'PROCESSING' })
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [
+					{
+						...pendingTx,
+						external_refs: [
+							...pendingTx.external_refs,
+							{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO, value: 'memo-1' }
+						]
+					}
+				]
+			});
+
+			expect(nearIntentsRest.fetchNearIntentsStatus).toHaveBeenCalledExactlyOnceWith({
+				depositAddress,
+				depositMemo: 'memo-1'
+			});
+		});
+
+		it('advances Pending → Executing for an in-flight status', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({ status: 'PROCESSING' })
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [pendingTx]
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({ status: { Executing: null } })
+				})
+			);
+		});
+
+		it('keeps INCOMPLETE_DEPOSIT non-terminal (Executing, never Failed)', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({ status: 'INCOMPLETE_DEPOSIT' })
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [pendingTx]
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({ status: { Executing: null } })
+				})
+			);
+		});
+
+		it('advances to Succeeded on SUCCESS and persists learned tx hashes', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({
+					status: 'SUCCESS',
+					swapDetails: {
+						originChainTxHashes: [{ hash: '0xorigin', explorerUrl: 'https://e/0xorigin' }],
+						destinationChainTxHashes: [{ hash: '0xdest', explorerUrl: 'https://e/0xdest' }]
+					}
+				})
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [pendingTx]
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						status: { Succeeded: null },
+						externalRefs: expect.arrayContaining([
+							{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH, value: '0xorigin' },
+							{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_TX_HASH, value: '0xdest' }
+						])
+					})
+				})
+			);
+		});
+
+		it('maps REFUNDED to Failed with the refunded error text', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({ status: 'REFUNDED' })
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [pendingTx]
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						status: { Failed: null },
+						error: en.swap.error.swap_refunded
+					})
+				})
+			);
+		});
+
+		it('maps FAILED to Failed with the generic failure error text', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({ status: 'FAILED' })
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [pendingTx]
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						status: { Failed: null },
+						error: en.swap.error.failed_unexpectedly
+					})
+				})
+			);
+		});
+
+		it('does not write when the status would not advance and no new refs were learned', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({ status: 'PROCESSING' })
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [{ ...pendingTx, status: { Executing: null } }]
+			});
+
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('persists newly-learned tx hashes even when the status does not advance', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({
+					status: 'PROCESSING',
+					swapDetails: {
+						originChainTxHashes: [{ hash: '0xorigin', explorerUrl: 'https://e/0xorigin' }]
+					}
+				})
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [{ ...pendingTx, status: { Executing: null } }]
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						externalRefs: expect.arrayContaining([
+							{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH, value: '0xorigin' }
+						])
+					})
+				})
+			);
+		});
+
+		it('swallows status-endpoint errors so the next tick can retry', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockRejectedValue(new Error('network'));
+
+			await expect(
+				pollNearIntentsActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [pendingTx]
+				})
+			).resolves.toBeUndefined();
+
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('polls each row in the batch', async () => {
+			vi.mocked(nearIntentsRest.fetchNearIntentsStatus).mockResolvedValue(
+				statusResponse({ status: 'PROCESSING' })
+			);
+
+			await pollNearIntentsActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [pendingTx, { ...pendingTx, id: 'second-row' }]
+			});
+
+			expect(nearIntentsRest.fetchNearIntentsStatus).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/near-intents.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/near-intents.services.spec.ts
@@ -11,7 +11,6 @@ import {
 	fetchNearIntentsSwapQuote,
 	loadNearIntentsTokens,
 	nearIntentsSupportedTokens,
-	pollNearIntentsStatus,
 	submitNearIntentsDepositTx
 } from '$lib/services/near-intents.services';
 import type { NearIntentsToken } from '$lib/types/near-intents';
@@ -23,8 +22,6 @@ import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import {
 	mockNearIntentsQuoteResponse,
-	mockNearIntentsStatusFailed,
-	mockNearIntentsStatusPending,
 	mockNearIntentsStatusSuccess,
 	mockNearIntentsTokens
 } from '$tests/mocks/near-intents.mock';
@@ -366,55 +363,6 @@ describe('near-intents.services', () => {
 				txHash: '0xHash',
 				depositAddress: '0xDeposit',
 				memo: 'test-memo'
-			});
-		});
-	});
-
-	describe('pollNearIntentsStatus', () => {
-		it('should resolve when status is SUCCESS', async () => {
-			vi.mocked(nearIntentsApi.fetchNearIntentsStatus).mockResolvedValue(
-				mockNearIntentsStatusSuccess
-			);
-
-			await expect(pollNearIntentsStatus({ depositAddress: '0xDeposit' })).resolves.toBeUndefined();
-
-			expect(nearIntentsApi.fetchNearIntentsStatus).toHaveBeenCalledOnce();
-		});
-
-		it('should throw when status is FAILED', async () => {
-			vi.mocked(nearIntentsApi.fetchNearIntentsStatus).mockResolvedValue(
-				mockNearIntentsStatusFailed
-			);
-
-			await expect(pollNearIntentsStatus({ depositAddress: '0xDeposit' })).rejects.toThrow(
-				'NEAR Intents swap failed'
-			);
-		});
-
-		it('should poll multiple times until terminal status', async () => {
-			vi.mocked(nearIntentsApi.fetchNearIntentsStatus)
-				.mockResolvedValueOnce(mockNearIntentsStatusPending)
-				.mockResolvedValueOnce({ ...mockNearIntentsStatusPending, status: 'PROCESSING' })
-				.mockResolvedValueOnce(mockNearIntentsStatusSuccess);
-
-			await pollNearIntentsStatus({ depositAddress: '0xDeposit' });
-
-			expect(nearIntentsApi.fetchNearIntentsStatus).toHaveBeenCalledTimes(3);
-		});
-
-		it('includes depositMemo in status calls', async () => {
-			vi.mocked(nearIntentsApi.fetchNearIntentsStatus).mockResolvedValue(
-				mockNearIntentsStatusSuccess
-			);
-
-			await pollNearIntentsStatus({
-				depositAddress: '0xDeposit',
-				depositMemo: 'test-memo'
-			});
-
-			expect(nearIntentsApi.fetchNearIntentsStatus).toHaveBeenCalledWith({
-				depositAddress: '0xDeposit',
-				depositMemo: 'test-memo'
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -15,6 +15,7 @@ import * as kongBackendApi from '$lib/api/kong_backend.api';
 import { ZERO } from '$lib/constants/app.constants';
 import { PLAUSIBLE_EVENTS, PLAUSIBLE_EVENT_CONTEXTS } from '$lib/enums/plausible';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
 import { trackEvent } from '$lib/services/analytics.services';
 import * as icpSwapBackend from '$lib/services/icp-swap.services';
 import * as nearIntentsServices from '$lib/services/near-intents.services';
@@ -38,7 +39,10 @@ import { fetchVeloraSwapAmount } from '$lib/services/velora-swap.services';
 import { exchangeStore } from '$lib/stores/exchange.store';
 import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
 import type { ICPSwapAmountReply } from '$lib/types/api';
-import type { NearIntentsQuoteResponse } from '$lib/types/near-intents';
+import {
+	NEAR_INTENTS_EXTERNAL_REF_KEYS,
+	type NearIntentsQuoteResponse
+} from '$lib/types/near-intents';
 import { SwapErrorCodes, SwapProvider, type VeloraSwapDetails } from '$lib/types/swap';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { sendSol } from '$sol/services/sol-send.services';
@@ -123,8 +127,11 @@ vi.mock('$lib/services/onesec-swap.services', () => ({
 
 vi.mock('$lib/services/near-intents.services', () => ({
 	fetchNearIntentsSwapQuote: vi.fn(),
-	submitNearIntentsDepositTx: vi.fn(),
-	pollNearIntentsStatus: vi.fn()
+	submitNearIntentsDepositTx: vi.fn()
+}));
+
+vi.mock('$lib/services/active-user-transactions.services', () => ({
+	createActiveUserTransaction: vi.fn()
 }));
 
 vi.mock('$eth/services/send.services', () => ({
@@ -1963,7 +1970,7 @@ describe('swap.services', () => {
 
 			vi.mocked(sendEvm).mockResolvedValue({ hash: '0xTxHash123' });
 			vi.mocked(nearIntentsServices.submitNearIntentsDepositTx).mockResolvedValue(undefined);
-			vi.mocked(nearIntentsServices.pollNearIntentsStatus).mockResolvedValue(undefined);
+			vi.mocked(activeUserTransactionsServices.createActiveUserTransaction).mockResolvedValue();
 		});
 
 		it('should not call setCustomToken when ERC20 destination token is toggleable and already enabled', async () => {
@@ -2072,7 +2079,7 @@ describe('swap.services', () => {
 
 			vi.mocked(sendSol).mockResolvedValue(mockSolSignature());
 			vi.mocked(nearIntentsServices.submitNearIntentsDepositTx).mockResolvedValue(undefined);
-			vi.mocked(nearIntentsServices.pollNearIntentsStatus).mockResolvedValue(undefined);
+			vi.mocked(activeUserTransactionsServices.createActiveUserTransaction).mockResolvedValue();
 		});
 
 		it('should not call setCustomToken when SPL destination token is toggleable and already enabled', async () => {
@@ -2150,7 +2157,7 @@ describe('swap.services', () => {
 
 			vi.mocked(sendEvm).mockResolvedValue({ hash: '0xTxHash123' });
 			vi.mocked(nearIntentsServices.submitNearIntentsDepositTx).mockResolvedValue(undefined);
-			vi.mocked(nearIntentsServices.pollNearIntentsStatus).mockResolvedValue(undefined);
+			vi.mocked(activeUserTransactionsServices.createActiveUserTransaction).mockResolvedValue();
 		});
 
 		it('should execute the full NEAR Intents swap flow using swapDetails directly', async () => {
@@ -2180,9 +2187,15 @@ describe('swap.services', () => {
 				depositAddress,
 				txHash: '0xTxHash123'
 			});
-			expect(nearIntentsServices.pollNearIntentsStatus).toHaveBeenCalledWith({
-				depositAddress
-			});
+			expect(activeUserTransactionsServices.createActiveUserTransaction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					identity: mockIdentity,
+					data: { NearIntents: expect.objectContaining({ amount: 1000000n }) },
+					externalRefs: expect.arrayContaining([
+						{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS, value: depositAddress }
+					])
+				})
+			);
 		});
 
 		it('should report progress steps in correct order', async () => {
@@ -2235,10 +2248,14 @@ describe('swap.services', () => {
 				txHash: '0xTxHash123',
 				depositMemo: 'stellar-memo'
 			});
-			expect(nearIntentsServices.pollNearIntentsStatus).toHaveBeenCalledWith({
-				depositAddress,
-				depositMemo: 'stellar-memo'
-			});
+			expect(activeUserTransactionsServices.createActiveUserTransaction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					externalRefs: expect.arrayContaining([
+						{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS, value: depositAddress },
+						{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO, value: 'stellar-memo' }
+					])
+				})
+			);
 		});
 	});
 
@@ -2254,7 +2271,7 @@ describe('swap.services', () => {
 
 			vi.mocked(sendSol).mockResolvedValue(solTxSignature);
 			vi.mocked(nearIntentsServices.submitNearIntentsDepositTx).mockResolvedValue(undefined);
-			vi.mocked(nearIntentsServices.pollNearIntentsStatus).mockResolvedValue(undefined);
+			vi.mocked(activeUserTransactionsServices.createActiveUserTransaction).mockResolvedValue();
 		});
 
 		it('should execute the full Solana swap flow', async () => {
@@ -2280,9 +2297,15 @@ describe('swap.services', () => {
 				depositAddress,
 				txHash: solTxSignature
 			});
-			expect(nearIntentsServices.pollNearIntentsStatus).toHaveBeenCalledWith({
-				depositAddress
-			});
+			expect(activeUserTransactionsServices.createActiveUserTransaction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					identity: mockIdentity,
+					data: expect.objectContaining({ NearIntents: expect.anything() }),
+					externalRefs: expect.arrayContaining([
+						{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS, value: depositAddress }
+					])
+				})
+			);
 		});
 
 		it('should report progress steps in correct order', async () => {
@@ -2323,10 +2346,14 @@ describe('swap.services', () => {
 				txHash: solTxSignature,
 				depositMemo: 'sol-memo-123'
 			});
-			expect(nearIntentsServices.pollNearIntentsStatus).toHaveBeenCalledWith({
-				depositAddress,
-				depositMemo: 'sol-memo-123'
-			});
+			expect(activeUserTransactionsServices.createActiveUserTransaction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					externalRefs: expect.arrayContaining([
+						{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS, value: depositAddress },
+						{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO, value: 'sol-memo-123' }
+					])
+				})
+			);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/utils/near-intents-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/near-intents-active-tx.utils.spec.ts
@@ -1,0 +1,262 @@
+import type { ActiveUserTransactionRef } from '$declarations/backend/backend.did';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import type { Erc20Token } from '$eth/types/erc20';
+import en from '$lib/i18n/en.json';
+import {
+	NEAR_INTENTS_EXTERNAL_REF_KEYS,
+	type NearIntentsSwapDetails,
+	type NearIntentsSwapStatus
+} from '$lib/types/near-intents';
+import { SwapProvider } from '$lib/types/swap';
+import {
+	buildNearIntentsSwapTrackingMetadata,
+	isNearIntentsActiveUserTransaction,
+	nearIntentsStatusError,
+	toNearIntentsActiveUserTransactionStatus,
+	toNearIntentsData,
+	toNearIntentsDisplayRefs,
+	toNearIntentsExternalRefs,
+	toNearIntentsExternalRefsMap,
+	toNearIntentsLearnedRefs
+} from '$lib/utils/near-intents-active-tx.utils';
+import { parseTokenId } from '$lib/validation/token.validation';
+import type { SplToken } from '$sol/types/spl';
+import {
+	mockActiveUserTransaction,
+	mockNearIntentsActiveUserTransaction
+} from '$tests/mocks/active-user-transactions.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
+
+const USDC_ETHEREUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const USDC_SOLANA = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+const makeErc20Token = (address: string): Erc20Token => ({
+	...mockValidToken,
+	id: parseTokenId(`Erc20-${address}`),
+	standard: { code: 'erc20' },
+	address,
+	network: ETHEREUM_NETWORK
+});
+
+const makeSplToken = (address: string): SplToken => ({
+	...mockValidSplToken,
+	id: parseTokenId(`Spl-${address}`),
+	address
+});
+
+describe('near-intents-active-tx.utils', () => {
+	describe('isNearIntentsActiveUserTransaction', () => {
+		it('returns true for the NearIntents variant', () => {
+			expect(isNearIntentsActiveUserTransaction(mockNearIntentsActiveUserTransaction)).toBeTruthy();
+		});
+
+		it('returns false for a non-NearIntents variant', () => {
+			expect(isNearIntentsActiveUserTransaction(mockActiveUserTransaction)).toBeFalsy();
+		});
+	});
+
+	describe('toNearIntentsData', () => {
+		it('maps an ERC-20 source and an SPL destination', () => {
+			expect(
+				toNearIntentsData({
+					sourceToken: makeErc20Token(USDC_ETHEREUM),
+					destinationToken: makeSplToken(USDC_SOLANA),
+					amount: 1_000_000n
+				})
+			).toEqual({
+				NearIntents: {
+					source_token: { Erc20: [USDC_ETHEREUM, BigInt(ETHEREUM_NETWORK.chainId)] },
+					dest_token: { SplMainnet: USDC_SOLANA },
+					amount: 1_000_000n
+				}
+			});
+		});
+
+		it('maps a native EVM source to EvmNative and a native SOL destination to SolNativeMainnet', () => {
+			expect(
+				toNearIntentsData({
+					sourceToken: ETHEREUM_TOKEN,
+					destinationToken: SOLANA_TOKEN,
+					amount: 5n
+				})
+			).toEqual({
+				NearIntents: {
+					source_token: { EvmNative: BigInt(ETHEREUM_NETWORK.chainId) },
+					dest_token: { SolNativeMainnet: null },
+					amount: 5n
+				}
+			});
+		});
+
+		it('returns undefined when a token cannot be mapped to a backend TokenId', () => {
+			expect(
+				toNearIntentsData({
+					sourceToken: makeErc20Token(USDC_ETHEREUM),
+					destinationToken: mockValidIcToken,
+					amount: 1n
+				})
+			).toBeUndefined();
+		});
+	});
+
+	describe('toNearIntentsExternalRefs', () => {
+		it('returns a sorted list of populated key/value pairs', () => {
+			const refs = toNearIntentsExternalRefs({
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO]: 'memo',
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS]: '0xdep'
+			});
+
+			expect(refs).toEqual([
+				{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS, value: '0xdep' },
+				{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO, value: 'memo' }
+			]);
+		});
+
+		it('skips undefined or empty values', () => {
+			const refs = toNearIntentsExternalRefs({
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS]: '0xdep',
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO]: '',
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH]: undefined
+			});
+
+			expect(refs).toEqual([
+				{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS, value: '0xdep' }
+			]);
+		});
+	});
+
+	describe('toNearIntentsExternalRefsMap', () => {
+		it('turns the wire array into a key/value lookup map', () => {
+			const refs: ActiveUserTransactionRef[] = [
+				{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS, value: '0xdep' },
+				{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.AMOUNT, value: '0.5' }
+			];
+
+			const map = toNearIntentsExternalRefsMap(refs);
+
+			expect(map[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS]).toBe('0xdep');
+			expect(map[NEAR_INTENTS_EXTERNAL_REF_KEYS.AMOUNT]).toBe('0.5');
+			expect(map[NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_MEMO]).toBeUndefined();
+		});
+	});
+
+	describe('toNearIntentsDisplayRefs', () => {
+		it('snapshots source/destination symbols, network names and the raw amount', () => {
+			const sourceToken = { ...mockValidToken, symbol: 'USDC' };
+			const destinationToken = { ...SOLANA_TOKEN, symbol: 'SOL' };
+
+			expect(toNearIntentsDisplayRefs({ sourceToken, destinationToken, amount: '1.5' })).toEqual({
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.AMOUNT]: '1.5',
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL]: 'USDC',
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL]: sourceToken.network.name,
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]: 'SOL',
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL]: destinationToken.network.name
+			});
+		});
+	});
+
+	describe('toNearIntentsLearnedRefs', () => {
+		it('extracts origin and destination tx hashes when present', () => {
+			const swapDetails: NearIntentsSwapDetails = {
+				originChainTxHashes: [{ hash: '0xorigin', explorerUrl: 'https://e/0xorigin' }],
+				destinationChainTxHashes: [{ hash: '0xdest', explorerUrl: 'https://e/0xdest' }]
+			};
+
+			expect(toNearIntentsLearnedRefs(swapDetails)).toEqual({
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH]: '0xorigin',
+				[NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_TX_HASH]: '0xdest'
+			});
+		});
+
+		it('returns an empty object when no tx hashes are available', () => {
+			expect(toNearIntentsLearnedRefs({})).toEqual({});
+		});
+	});
+
+	describe('toNearIntentsActiveUserTransactionStatus', () => {
+		it('maps SUCCESS → Succeeded', () => {
+			expect(toNearIntentsActiveUserTransactionStatus('SUCCESS')).toEqual({ Succeeded: null });
+		});
+
+		it('maps REFUNDED and FAILED → Failed', () => {
+			expect(toNearIntentsActiveUserTransactionStatus('REFUNDED')).toEqual({ Failed: null });
+			expect(toNearIntentsActiveUserTransactionStatus('FAILED')).toEqual({ Failed: null });
+		});
+
+		it('maps every in-flight status → Executing (INCOMPLETE_DEPOSIT is NOT terminal)', () => {
+			const inFlight: NearIntentsSwapStatus[] = [
+				'PENDING_DEPOSIT',
+				'KNOWN_DEPOSIT_TX',
+				'INCOMPLETE_DEPOSIT',
+				'PROCESSING'
+			];
+
+			for (const status of inFlight) {
+				expect(toNearIntentsActiveUserTransactionStatus(status)).toEqual({ Executing: null });
+			}
+		});
+	});
+
+	describe('nearIntentsStatusError', () => {
+		it('returns the refunded message for REFUNDED', () => {
+			expect(nearIntentsStatusError('REFUNDED')).toBe(en.swap.error.swap_refunded);
+		});
+
+		it('returns the failed message for FAILED', () => {
+			expect(nearIntentsStatusError('FAILED')).toBe(en.swap.error.failed_unexpectedly);
+		});
+
+		it('returns undefined for non-terminal statuses', () => {
+			expect(nearIntentsStatusError('SUCCESS')).toBeUndefined();
+			expect(nearIntentsStatusError('PROCESSING')).toBeUndefined();
+		});
+	});
+
+	describe('buildNearIntentsSwapTrackingMetadata', () => {
+		it('reads symbols, network names and amount off the row external_refs snapshot', () => {
+			expect(
+				buildNearIntentsSwapTrackingMetadata({
+					tx: { ...mockNearIntentsActiveUserTransaction, status: { Succeeded: null } }
+				})
+			).toEqual({
+				sourceToken: 'USDC',
+				destinationToken: 'USDC',
+				dApp: SwapProvider.NEAR_INTENTS,
+				tokenAmount: '1',
+				sourceNetwork: 'Ethereum',
+				destinationNetwork: 'Solana'
+			});
+		});
+
+		it('falls back to empty strings when the snapshot refs are missing', () => {
+			expect(
+				buildNearIntentsSwapTrackingMetadata({
+					tx: { ...mockNearIntentsActiveUserTransaction, external_refs: [] }
+				})
+			).toEqual({
+				sourceToken: '',
+				destinationToken: '',
+				dApp: SwapProvider.NEAR_INTENTS,
+				tokenAmount: '',
+				sourceNetwork: '',
+				destinationNetwork: ''
+			});
+		});
+
+		it('includes the error message verbatim when the row carries one', () => {
+			expect(
+				buildNearIntentsSwapTrackingMetadata({
+					tx: {
+						...mockNearIntentsActiveUserTransaction,
+						status: { Failed: null },
+						error: ['boom']
+					}
+				}).error
+			).toBe('boom');
+		});
+	});
+});

--- a/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
@@ -4,6 +4,7 @@ import type {
 	ActiveUserTransactionError,
 	ActiveUserTransactionRef,
 	LiquidiumData,
+	NearIntentsData,
 	OneSecIcpToEvmData
 } from '$declarations/backend/backend.did';
 import { ZERO } from '$lib/constants/app.constants';
@@ -12,6 +13,7 @@ import type {
 	UpdateActiveUserTransactionParams
 } from '$lib/types/api';
 import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
+import { NEAR_INTENTS_EXTERNAL_REF_KEYS } from '$lib/types/near-intents';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 
 export const mockActiveUserTransactionId = '11111111-1111-4111-8111-111111111111';
@@ -27,6 +29,30 @@ export const mockOneSecIcpToEvmData: OneSecIcpToEvmData = {
 
 export const mockActiveUserTransactionData: ActiveUserTransactionData = {
 	OneSecIcpToEvm: mockOneSecIcpToEvmData
+};
+
+export const mockNearIntentsData: NearIntentsData = {
+	source_token: { Erc20: ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 1n] },
+	dest_token: { SplMainnet: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' },
+	amount: 1_000_000n
+};
+
+export const mockNearIntentsActiveUserTransaction: ActiveUserTransaction = {
+	id: '33333333-3333-4333-8333-333333333333',
+	status: { Pending: null },
+	data: { NearIntents: mockNearIntentsData },
+	progress_step: [],
+	external_refs: [
+		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DEPOSIT_ADDRESS, value: '0xDepositAddress123' },
+		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.AMOUNT, value: '1' },
+		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL, value: 'USDC' },
+		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL, value: 'Ethereum' },
+		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL, value: 'USDC' },
+		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL, value: 'Solana' }
+	],
+	created_at_ns: ZERO,
+	updated_at_ns: ZERO,
+	error: []
 };
 
 export const mockLiquidiumData: LiquidiumData = {

--- a/src/frontend/src/tests/sol/components/swap/SwapSolWizard.spec.ts
+++ b/src/frontend/src/tests/sol/components/swap/SwapSolWizard.spec.ts
@@ -1,6 +1,6 @@
 import {
 	TRACK_COUNT_SWAP_ERROR,
-	TRACK_COUNT_SWAP_SUCCESS
+	TRACK_COUNT_SWAP_SUBMITTED
 } from '$lib/constants/analytics.constants';
 import {
 	SWAP_SWITCH_TOKENS_BUTTON,
@@ -339,7 +339,7 @@ describe('SwapSolWizard', () => {
 			expect(onStartTriggerAmount).toHaveBeenCalledOnce();
 		});
 
-		it('tracks success event after successful swap', async () => {
+		it('tracks submitted event at initiation (settlement is tracked via the AUT store)', async () => {
 			const { getByText } = renderExecution();
 
 			await fireEvent.click(getByText(en.swap.text.swap_button));
@@ -347,7 +347,7 @@ describe('SwapSolWizard', () => {
 
 			expect(analytics.trackEvent).toHaveBeenCalledWith(
 				expect.objectContaining({
-					name: TRACK_COUNT_SWAP_SUCCESS
+					name: TRACK_COUNT_SWAP_SUBMITTED
 				})
 			);
 		});


### PR DESCRIPTION
# Motivation

NEAR Intents is a cross-chain swap (EVM/Solana source → destination on another chain via NEAR's 1Click solver network). Settlement is inherently long-running — up to ~4 minutes — but today the frontend watches it with an awaited, in-memory  poll tied to the open swap modal. Closing the modal, closing the tab, refreshing, or logging out mid-settlement loses all feedback (and the success balance refresh); the swap still settles server-side, the frontend just stops watching.

OISY already solved this exact shape for its other cross-chain provider, OneSec (1Sec), via the backend-persisted **Active User Transactions (AUT)** mechanism. This PR makes NEAR Intents the next consumer: once the deposit is submitted (the point of no return), it registers an AUT row, closes the modal immediately, and drives the swap to a terminal state from the existing global AUT poller — surviving modal close, tab close, refresh, and logout, exactly like OneSec.
