### PR TITLE
feat(backend)!: add Velora variant to active-user-transaction data

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -29,6 +29,10 @@ type ActiveUserTransactionData = variant {
 	// source/destination leg (EVM and Solana); the deposit address, its
 	// optional memo, and origin/destination tx hashes ride in `external_refs`.
 	NearIntents : NearIntentsData;
+	// Velora (`ParaSwap`) EVM swap. A single variant covers both execution
+	// modes, discriminated by the `mode` field; the auction id, order hash,
+	// transaction hash and nonce ride in `external_refs`.
+	Velora : VeloraData;
 	// Liquidium lend/borrow flow. A single variant covers all four actions
 	// (supply, borrow, repay, withdraw).
 	Liquidium : LiquidiumData
@@ -1275,6 +1279,21 @@ type Utxo = record {
 	// The outpoint of the UTXO.
 	outpoint : Outpoint
 };
+// Velora (`ParaSwap`) swap payload. Settlement is tracked off-chain — by auction
+// id (`Delta`) or by transaction hash plus nonce (`Market`) — so those
+// pointers, and the learned-mid-flow settlement / refund tx hashes, live in
+// `external_refs`; only the canonical immutable fields are captured here.
+type VeloraData = record {
+	mode : VeloraSwapMode;
+	source_token : TokenId;
+	// Source-token amount in base units.
+	amount : nat;
+	dest_token : TokenId
+};
+// Which Velora execution mode an active transaction tracks. Determines how the
+// frontend polls for settlement: `Delta` by auction id against Velora's Delta
+// API, `Market` by transaction receipt on the source chain.
+type VeloraSwapMode = variant { Delta; Market };
 service : (Arg) -> {
 	// Adds one or more dismissed notifications to the user's profile.
 	//

--- a/src/backend/src/active_user_transactions/model.rs
+++ b/src/backend/src/active_user_transactions/model.rs
@@ -229,6 +229,9 @@ fn validate_data(data: &ActiveUserTransactionData) -> Result<(), ActiveUserTrans
         ActiveUserTransactionData::NearIntents(d) => {
             require_positive_amount(&d.amount)?;
         }
+        ActiveUserTransactionData::Velora(d) => {
+            require_positive_amount(&d.amount)?;
+        }
     }
     Ok(())
 }
@@ -306,9 +309,10 @@ mod tests {
             ActiveUserTransactionData, ActiveUserTransactionError, ActiveUserTransactionRef,
             ActiveUserTransactionStatus, CreateActiveUserTransactionRequest, LiquidiumAction,
             LiquidiumData, NearIntentsData, OneSecEvmToIcpData, OneSecIcpToEvmData,
-            UpdateActiveUserTransactionRequest, MAX_ACTIVE_USER_TRANSACTIONS_PER_USER,
-            MAX_LIQUIDIUM_POOL_ID_LEN,
+            UpdateActiveUserTransactionRequest, VeloraData, VeloraSwapMode,
+            MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_LIQUIDIUM_POOL_ID_LEN,
         },
+        custom_token::ErcTokenId,
         token_id::TokenId,
     };
 
@@ -493,6 +497,46 @@ mod tests {
         req.data = near_intents_data(0);
         let err = create(&mut map, principal(), req, 1).unwrap_err();
         assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    fn velora_data(amount: u64, mode: VeloraSwapMode) -> ActiveUserTransactionData {
+        ActiveUserTransactionData::Velora(VeloraData {
+            mode,
+            source_token: TokenId::Erc20(
+                ErcTokenId("0x0000000000000000000000000000000000000abc".to_string()),
+                1,
+            ),
+            dest_token: TokenId::Erc20(
+                ErcTokenId("0x0000000000000000000000000000000000000def".to_string()),
+                1,
+            ),
+            amount: Nat::from(amount),
+        })
+    }
+
+    #[test]
+    fn velora_create_roundtrip() {
+        // Both modes share one variant, so both must survive create unchanged —
+        // the mode is what the FE poller routes on.
+        for mode in [VeloraSwapMode::Delta, VeloraSwapMode::Market] {
+            let (mut map, _mm) = setup();
+            let mut req = create_req("velora-1");
+            req.data = velora_data(7_500, mode.clone());
+            let tx = create(&mut map, principal(), req, 1).expect("create");
+            assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+            assert_eq!(tx.data, velora_data(7_500, mode));
+        }
+    }
+
+    #[test]
+    fn velora_zero_amount_rejected() {
+        for mode in [VeloraSwapMode::Delta, VeloraSwapMode::Market] {
+            let (mut map, _mm) = setup();
+            let mut req = create_req("velora-1");
+            req.data = velora_data(0, mode);
+            let err = create(&mut map, principal(), req, 1).unwrap_err();
+            assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+        }
     }
 
     #[test]

--- a/src/backend/tests/it/active_user_transactions.rs
+++ b/src/backend/tests/it/active_user_transactions.rs
@@ -6,8 +6,10 @@ use shared::types::{
     active_user_transaction::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
         ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
-        NearIntentsData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
+        NearIntentsData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData,
+        VeloraSwapMode,
     },
+    custom_token::ErcTokenId,
     result_types::{
         ActiveUserTransactionResult, DeleteActiveUserTransactionResult,
         GetActiveUserTransactionsResult,
@@ -214,6 +216,59 @@ fn create_near_intents_variant_roundtrip() {
             assert_eq!(tx.external_refs.len(), 1);
         }
         ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+}
+
+#[test]
+fn create_velora_variant_roundtrip() {
+    // Both Velora modes share one variant; the mode must survive the canister
+    // round-trip untouched, since the FE poller routes on it.
+    for (mode, id) in [
+        (VeloraSwapMode::Delta, "velora-delta"),
+        (VeloraSwapMode::Market, "velora-market"),
+    ] {
+        let pic = setup();
+        let user = caller();
+        pic.ensure_user_profile(user);
+
+        let data = ActiveUserTransactionData::Velora(VeloraData {
+            mode,
+            source_token: TokenId::Erc20(
+                ErcTokenId("0x0000000000000000000000000000000000000abc".to_string()),
+                1,
+            ),
+            dest_token: TokenId::Erc20(
+                ErcTokenId("0x0000000000000000000000000000000000000def".to_string()),
+                1,
+            ),
+            amount: Nat::from(7_500u64),
+        });
+
+        let created = pic
+            .update::<ActiveUserTransactionResult>(
+                user,
+                "create_active_user_transaction",
+                CreateActiveUserTransactionRequest {
+                    id: id.to_string(),
+                    data: data.clone(),
+                    progress_step: Some("initialization".to_string()),
+                    external_refs: vec![ActiveUserTransactionRef {
+                        key: "velora_auction_id".to_string(),
+                        value: "11111111-1111-4111-8111-111111111111".to_string(),
+                    }],
+                },
+            )
+            .expect("create_active_user_transaction call should succeed");
+
+        match created {
+            ActiveUserTransactionResult::Ok(tx) => {
+                assert_eq!(tx.id, id);
+                assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+                assert_eq!(tx.data, data);
+                assert_eq!(tx.external_refs.len(), 1);
+            }
+            ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
+        }
     }
 }
 

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -29,6 +29,10 @@ type ActiveUserTransactionData = variant {
 	// source/destination leg (EVM and Solana); the deposit address, its
 	// optional memo, and origin/destination tx hashes ride in `external_refs`.
 	NearIntents : NearIntentsData;
+	// Velora (`ParaSwap`) EVM swap. A single variant covers both execution
+	// modes, discriminated by the `mode` field; the auction id, order hash,
+	// transaction hash and nonce ride in `external_refs`.
+	Velora : VeloraData;
 	// Liquidium lend/borrow flow. A single variant covers all four actions
 	// (supply, borrow, repay, withdraw).
 	Liquidium : LiquidiumData
@@ -1275,6 +1279,21 @@ type Utxo = record {
 	// The outpoint of the UTXO.
 	outpoint : Outpoint
 };
+// Velora (`ParaSwap`) swap payload. Settlement is tracked off-chain — by auction
+// id (`Delta`) or by transaction hash plus nonce (`Market`) — so those
+// pointers, and the learned-mid-flow settlement / refund tx hashes, live in
+// `external_refs`; only the canonical immutable fields are captured here.
+type VeloraData = record {
+	mode : VeloraSwapMode;
+	source_token : TokenId;
+	// Source-token amount in base units.
+	amount : nat;
+	dest_token : TokenId
+};
+// Which Velora execution mode an active transaction tracks. Determines how the
+// frontend polls for settlement: `Delta` by auction id against Velora's Delta
+// API, `Market` by transaction receipt on the source chain.
+type VeloraSwapMode = variant { Delta; Market };
 service : (Arg) -> {
 	// Adds one or more dismissed notifications to the user's profile.
 	//

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -61,6 +61,14 @@ export type ActiveUserTransactionData =
 	  }
 	| {
 			/**
+			 * Velora (`ParaSwap`) EVM swap. A single variant covers both execution
+			 * modes, discriminated by the `mode` field; the auction id, order hash,
+			 * transaction hash and nonce ride in `external_refs`.
+			 */
+			Velora: VeloraData;
+	  }
+	| {
+			/**
 			 * Liquidium lend/borrow flow. A single variant covers all four actions
 			 * (supply, borrow, repay, withdraw).
 			 */
@@ -1976,6 +1984,27 @@ export interface Utxo {
 	 */
 	outpoint: Outpoint;
 }
+/**
+ * Velora (`ParaSwap`) swap payload. Settlement is tracked off-chain — by auction
+ * id (`Delta`) or by transaction hash plus nonce (`Market`) — so those
+ * pointers, and the learned-mid-flow settlement / refund tx hashes, live in
+ * `external_refs`; only the canonical immutable fields are captured here.
+ */
+export interface VeloraData {
+	mode: VeloraSwapMode;
+	source_token: TokenId;
+	/**
+	 * Source-token amount in base units.
+	 */
+	amount: bigint;
+	dest_token: TokenId;
+}
+/**
+ * Which Velora execution mode an active transaction tracks. Determines how the
+ * frontend polls for settlement: `Delta` by auction id against Velora's Delta
+ * API, `Market` by transaction receipt on the source chain.
+ */
+export type VeloraSwapMode = { Delta: null } | { Market: null };
 export interface _SERVICE {
 	/**
 	 * Adds one or more dismissed notifications to the user's profile.

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -251,6 +251,16 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const VeloraSwapMode = IDL.Variant({
+		Delta: IDL.Null,
+		Market: IDL.Null
+	});
+	const VeloraData = IDL.Record({
+		mode: VeloraSwapMode,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
 	const LiquidiumAction = IDL.Variant({
 		Withdraw: IDL.Null,
 		Repay: IDL.Null,
@@ -267,6 +277,7 @@ export const idlFactory = ({ IDL }) => {
 		OneSecEvmToIcp: OneSecEvmToIcpData,
 		OneSecIcpToEvm: OneSecIcpToEvmData,
 		NearIntents: NearIntentsData,
+		Velora: VeloraData,
 		Liquidium: LiquidiumData
 	});
 	const CreateActiveUserTransactionRequest = IDL.Record({

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -251,6 +251,16 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const VeloraSwapMode = IDL.Variant({
+		Delta: IDL.Null,
+		Market: IDL.Null
+	});
+	const VeloraData = IDL.Record({
+		mode: VeloraSwapMode,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
 	const LiquidiumAction = IDL.Variant({
 		Withdraw: IDL.Null,
 		Repay: IDL.Null,
@@ -267,6 +277,7 @@ export const idlFactory = ({ IDL }) => {
 		OneSecEvmToIcp: OneSecEvmToIcpData,
 		OneSecIcpToEvm: OneSecIcpToEvmData,
 		NearIntents: NearIntentsData,
+		Velora: VeloraData,
 		Liquidium: LiquidiumData
 	});
 	const CreateActiveUserTransactionRequest = IDL.Record({

--- a/src/shared/src/types/active_user_transaction.rs
+++ b/src/shared/src/types/active_user_transaction.rs
@@ -81,6 +81,10 @@ pub enum ActiveUserTransactionData {
     /// source/destination leg (EVM and Solana); the deposit address, its
     /// optional memo, and origin/destination tx hashes ride in `external_refs`.
     NearIntents(NearIntentsData),
+    /// Velora (`ParaSwap`) EVM swap. A single variant covers both execution
+    /// modes, discriminated by the `mode` field; the auction id, order hash,
+    /// transaction hash and nonce ride in `external_refs`.
+    Velora(VeloraData),
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -126,6 +130,28 @@ pub struct LiquidiumData {
 /// captured here.
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct NearIntentsData {
+    pub source_token: TokenId,
+    pub dest_token: TokenId,
+    /// Source-token amount in base units.
+    pub amount: Nat,
+}
+
+/// Which Velora execution mode an active transaction tracks. Determines how the
+/// frontend polls for settlement: `Delta` by auction id against Velora's Delta
+/// API, `Market` by transaction receipt on the source chain.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum VeloraSwapMode {
+    Delta,
+    Market,
+}
+
+/// Velora (`ParaSwap`) swap payload. Settlement is tracked off-chain — by auction
+/// id (`Delta`) or by transaction hash plus nonce (`Market`) — so those
+/// pointers, and the learned-mid-flow settlement / refund tx hashes, live in
+/// `external_refs`; only the canonical immutable fields are captured here.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct VeloraData {
+    pub mode: VeloraSwapMode,
     pub source_token: TokenId,
     pub dest_token: TokenId,
     /// Source-token amount in base units.
@@ -199,9 +225,10 @@ mod tests {
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
         ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
         GetActiveUserTransactionsResponse, LiquidiumAction, LiquidiumData, NearIntentsData,
-        OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest,
+        OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData,
+        VeloraSwapMode,
     };
-    use crate::types::token_id::TokenId;
+    use crate::types::{custom_token::ErcTokenId, token_id::TokenId};
 
     fn sample_record() -> ActiveUserTransaction {
         ActiveUserTransaction {
@@ -271,6 +298,41 @@ mod tests {
             amount: Nat::from(250_000u64),
         });
         assert_eq!(roundtrip(&original), original);
+    }
+
+    fn erc20(address: &str, chain_id: u64) -> TokenId {
+        TokenId::Erc20(ErcTokenId(address.to_string()), chain_id)
+    }
+
+    #[test]
+    fn velora_delta_variant_roundtrips() {
+        let original = ActiveUserTransactionData::Velora(VeloraData {
+            mode: VeloraSwapMode::Delta,
+            source_token: erc20("0x0000000000000000000000000000000000000abc", 1),
+            dest_token: erc20("0x0000000000000000000000000000000000000def", 1),
+            amount: Nat::from(7_500u64),
+        });
+        assert_eq!(roundtrip(&original), original);
+    }
+
+    #[test]
+    fn velora_market_variant_roundtrips() {
+        // Market is the only mode reachable from a native source coin, so the
+        // round-trip covers `EvmNative` on the source side too.
+        let original = ActiveUserTransactionData::Velora(VeloraData {
+            mode: VeloraSwapMode::Market,
+            source_token: TokenId::EvmNative(8453),
+            dest_token: erc20("0x0000000000000000000000000000000000000def", 8453),
+            amount: Nat::from(1_250u64),
+        });
+        assert_eq!(roundtrip(&original), original);
+    }
+
+    #[test]
+    fn velora_swap_mode_roundtrips() {
+        for mode in [VeloraSwapMode::Delta, VeloraSwapMode::Market] {
+            assert_eq!(roundtrip(&mode), mode);
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Motivation

BREAKING CHANGE: ActiveUserTransactionData gains a Velora variant. Because this type is returned by create_active_user_transaction, update_active_user_transaction, and get_active_user_transactions, a client built against the previous candid interface cannot decode an active transaction whose data is Velora. Only newer frontends create such rows.

