### PR TITLE
chore(scripts): update LLM canister release URL

### DIFF
--- a/scripts/build.llm.sh
+++ b/scripts/build.llm.sh
@@ -19,7 +19,7 @@ EOF
 DFX_NETWORK="${DFX_NETWORK:-local}"
 export LLM_BUILDENV="$DFX_NETWORK"
 
-LLM_RELEASE_URL="https://github.com/dfinity/llm/releases/latest/download/"
+LLM_RELEASE_URL="https://github.com/dfinity/llm/releases/download/v0.3.1"
 # shellcheck disable=SC2034 # This variable is used - see ${!asset_url} below.
 CANDID_URL="${LLM_RELEASE_URL}/llm-canister-ollama.did"
 # shellcheck disable=SC2034 # This variable is used - see ${!asset_url} below.


### PR DESCRIPTION
# Motivation

The LLM canister's latest release has breaking changes, which we need to reflect on the OISY side. However, it is not recommended to do so yet before everything is finalized. Instead, for the time being, we should strictly point to v0.3.1 while downloading LLM candid and WASM files.

This is the same change as #13609, which landed on `main` after `release/v2.5.3/1` was cut, so the release branch would otherwise still pull the `latest` LLM assets.

# Changes

- Cherry-pick of #13609 (`d8484b1`) onto `release/v2.5.3/1`: pin `LLM_RELEASE_URL` in `scripts/build.llm.sh` to `https://github.com/dfinity/llm/releases/download/v0.3.1` instead of `releases/latest/download/`.

# Tests

- No code changes beyond the one URL constant; `scripts/build.llm.sh` on this branch is byte-identical to the version already on `main`.
- Verified with `git diff origin/main -- scripts/build.llm.sh` (empty).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 5 (`claude-opus-5`)
