### PR TITLE
fix(frontend): keep hero buttons unclickable while the hero is a skeleton

### DIFF
--- a/src/frontend/src/lib/components/hero/ButtonHero.svelte
+++ b/src/frontend/src/lib/components/hero/ButtonHero.svelte
@@ -15,12 +15,18 @@
 	let { icon, label, onclick, disabled = false, testId, ariaLabel }: Props = $props();
 
 	const { loading } = getContext<HeroContext>(HERO_CONTEXT_KEY);
+
+	// Every call site derives `disabled` from its own booleans, so it always hands Button an
+	// explicit true/false and Button's `disabled ?? initialising` fallback never fires. Fold
+	// the skeleton state in here, otherwise a hero button stays clickable while it renders
+	// as a skeleton.
+	let isDisabled = $derived(disabled || $loading);
 </script>
 
 <Button
 	{ariaLabel}
 	colorStyle="tertiary-main-card"
-	{disabled}
+	disabled={isDisabled}
 	initialising={$loading}
 	{onclick}
 	paddingSmall

--- a/src/frontend/src/tests/lib/components/buy/BuyButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/buy/BuyButton.spec.ts
@@ -24,6 +24,10 @@ describe('BuyButton', () => {
 
 		mockContextStore = initHeroContext();
 
+		// initHeroContext starts as loading, which now disables the button; these cases are
+		// about a hero that has finished loading.
+		mockContextStore.loading.set(false);
+
 		mockContextStore.inflowActionsDisabled.set(false);
 
 		vi.spyOn(onramperEnv, 'ONRAMPER_API_KEY', 'get').mockImplementation(

--- a/src/frontend/src/tests/lib/components/hero/ButtonHero.spec.ts
+++ b/src/frontend/src/tests/lib/components/hero/ButtonHero.spec.ts
@@ -1,0 +1,82 @@
+import ButtonHero from '$lib/components/hero/ButtonHero.svelte';
+import { HERO_CONTEXT_KEY, initHeroContext, type HeroContext } from '$lib/stores/hero.store';
+import { render, waitFor } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+
+describe('ButtonHero', () => {
+	let mockContextStore: HeroContext;
+
+	const mockContext = (store: HeroContext) => new Map([[HERO_CONTEXT_KEY, store]]);
+
+	const testId = 'button-hero';
+
+	const mockOnClick = vi.fn();
+
+	const icon = createRawSnippet(() => ({ render: () => '<svg></svg>' }));
+	const label = createRawSnippet(() => ({ render: () => '<span>Action</span>' }));
+
+	const renderButton = (props: { disabled?: boolean } = {}) =>
+		render(ButtonHero, {
+			props: { icon, label, onclick: mockOnClick, ariaLabel: 'Action', testId, ...props },
+			context: mockContext(mockContextStore)
+		});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockContextStore = initHeroContext();
+		mockContextStore.loading.set(false);
+	});
+
+	it('should be enabled when idle', () => {
+		const { getByTestId } = renderButton();
+
+		expect(getByTestId(testId)).toBeEnabled();
+	});
+
+	it('should be disabled when the caller disables it', () => {
+		const { getByTestId } = renderButton({ disabled: true });
+
+		expect(getByTestId(testId)).toBeDisabled();
+	});
+
+	// Every call site computes `disabled` from its own booleans, so it always passes an
+	// explicit `false` when its own conditions are clear. The skeleton state must still win.
+	it('should be disabled while the hero is initialising, even when the caller passes disabled false', async () => {
+		mockContextStore.loading.set(true);
+
+		const { getByTestId } = renderButton({ disabled: false });
+
+		const button = getByTestId(testId) as HTMLButtonElement;
+
+		await waitFor(() => {
+			expect(button).toBeDisabled();
+		});
+
+		button.click();
+
+		expect(mockOnClick).not.toHaveBeenCalled();
+	});
+
+	it('should become enabled once the hero finished initialising', async () => {
+		mockContextStore.loading.set(true);
+
+		const { getByTestId } = renderButton({ disabled: false });
+
+		const button = getByTestId(testId) as HTMLButtonElement;
+
+		await waitFor(() => {
+			expect(button).toBeDisabled();
+		});
+
+		mockContextStore.loading.set(false);
+
+		await waitFor(() => {
+			expect(button).toBeEnabled();
+		});
+
+		button.click();
+
+		expect(mockOnClick).toHaveBeenCalledOnce();
+	});
+});

--- a/src/frontend/src/tests/lib/components/send/SendButton.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendButton.spec.ts
@@ -24,6 +24,10 @@ describe('SendButton', () => {
 
 		mockContextStore = initHeroContext();
 
+		// initHeroContext starts as loading, which now disables the button; these cases are
+		// about a hero that has finished loading.
+		mockContextStore.loading.set(false);
+
 		mockContextStore.outflowActionsDisabled.set(false);
 
 		isIcMintingAccount.set(false);


### PR DESCRIPTION
# Motivation

`Button` decides its own disabled state with a nullish fallback:

```svelte
disabled={disabled ?? (loading || initialising)}
```

The fallback therefore only fires when `disabled` is `null` / `undefined`. But `ButtonHero` defaults `disabled` to `false` and every one of its seven call sites derives the prop from its own booleans (`$isBusy || $inflowActionsDisabled`, `$networkBitcoinMainnetDisabled || …`, …), so `ButtonHero` always hands `Button` an explicit `true` / `false`. The fallback never fires.

The visible consequence: while the hero is still loading its balances and renders its actions as pulsing skeletons, all seven hero buttons — Receive, Send, Swap, Buy and the three Convert variants — remain clickable. A user can open Send before the balance is known.

Surfaced by a Copilot review comment on #13608, which adds a `loading` prop to `ButtonHero`. The root cause is older than that PR and independent of it, so it is fixed here against `main` instead of inside the stack.

# Changes

- Fold the hero's loading state into the `disabled` that `ButtonHero` forwards to `Button`, so the skeleton state actually blocks clicks. `initialising` is still passed separately, since it also drives the skeleton styling.
- The `BuyButton` and `SendButton` specs asserted their buttons were enabled while `initHeroContext()` was still in its initial loading state — they encoded the bug. They now set loading to `false` for the cases that are about a hero which has finished loading.

`Button` itself is left alone: the same nullish fallback affects every button in the app, and changing it there is a far larger blast radius than this bug warrants.

# Tests

- New `ButtonHero.spec.ts` (the component had no spec): enabled when idle, disabled when the caller disables it, disabled while the hero is initialising even when the caller passes `disabled={false}`, and enabled again once loading clears.
- Both new cases were confirmed to **fail** against unmodified `main` before the fix and pass after it, so they pin the actual defect rather than the implementation.
- All specs touching the hero context or a `ButtonHero` call site pass: 47 files, 315 tests (`hero`, `buy`, `send`, `receive`, `swap`, `btc/convert`).
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` and `npm run check:tests` clean.
- Note: `ExchangeBalance.spec.ts` has 2 failing privacy-mode cases. They fail identically on unmodified `main` and are unrelated to this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Claude Opus 5 (claude-opus-5)
