### PR TITLE
feat(frontend): upgrade Velora SDK to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@solana-program/token": "^0.13.0",
 				"@solana-program/token-2022": "^0.9.0",
 				"@solana/kit": "^6.9.0",
-				"@velora-dex/sdk": "^9.5.3",
+				"@velora-dex/sdk": "^10.2.2",
 				"barcode-detector": "^3.1.3",
 				"bech32": "^1.1.4",
 				"bitcoinjs-lib": "^6.1.7",
@@ -5481,9 +5481,9 @@
 			"peer": true
 		},
 		"node_modules/@velora-dex/sdk": {
-			"version": "9.5.4",
-			"resolved": "https://registry.npmjs.org/@velora-dex/sdk/-/sdk-9.5.4.tgz",
-			"integrity": "sha512-nQw039K6PO+Yvq88CHgK6q2uiu6cugTGnX/6Q0fbAFDvrWa+xRMhja7kvRfFMFMccAcOTeJWB/NCCZNr3HjWvg==",
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/@velora-dex/sdk/-/sdk-10.2.2.tgz",
+			"integrity": "sha512-FdH0wiM8tN9URRqPuGwyHm5dekKfAXN6pgSSZmuXkV6CHmcZxxv03zI7Ooot3vBN5I+6KvfX/COqCsFAR4ZFCA==",
 			"license": "MIT",
 			"dependencies": {
 				"@paraswap/core": "2.4.3",
@@ -5496,7 +5496,6 @@
 			"peerDependencies": {
 				"axios": ">=0.25.0 <2.0.0",
 				"ethers": "^5.5.0 || ^6.0.0",
-				"viem": "^2.21.0",
 				"web3": "^4.14.0"
 			},
 			"peerDependenciesMeta": {
@@ -5504,9 +5503,6 @@
 					"optional": true
 				},
 				"ethers": {
-					"optional": true
-				},
-				"viem": {
 					"optional": true
 				},
 				"web3": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"@solana-program/token": "^0.13.0",
 		"@solana-program/token-2022": "^0.9.0",
 		"@solana/kit": "^6.9.0",
-		"@velora-dex/sdk": "^9.5.3",
+		"@velora-dex/sdk": "^10.2.2",
 		"barcode-detector": "^3.1.3",
 		"bech32": "^1.1.4",
 		"bitcoinjs-lib": "^6.1.7",

--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -335,15 +335,15 @@
 					...baseParams,
 					destinationToken: $destinationToken as Erc20Token,
 					receiveAmount: selectedProvider.receiveAmount,
-					isGasless: $isSourceTokenPermitSupported ?? false,
-					destinationNetwork: $destinationToken.network,
-					swapDetails: selectedProvider.swapDetails
+					isGasless: $isSourceTokenPermitSupported ?? false
 				};
 
+				// `swapDetails` is spread inside each branch so that `type` narrows it to the quote
+				// shape of the matching mode.
 				if (selectedProvider.type === VeloraSwapTypes.DELTA) {
-					await fetchVeloraDeltaSwap(params);
+					await fetchVeloraDeltaSwap({ ...params, swapDetails: selectedProvider.swapDetails });
 				} else {
-					await fetchVeloraMarketSwap(params);
+					await fetchVeloraMarketSwap({ ...params, swapDetails: selectedProvider.swapDetails });
 				}
 			} else if (selectedProvider?.provider === SwapProvider.ONE_SEC) {
 				if (!isIcToken($destinationToken) || isNullish($ethAddress)) {

--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -329,15 +329,15 @@
 					...baseParams,
 					destinationToken: $destinationToken as Erc20Token,
 					receiveAmount: selectedProvider.receiveAmount,
-					isGasless: $isSourceTokenPermitSupported ?? false,
-					destinationNetwork: $destinationToken.network,
-					swapDetails: selectedProvider.swapDetails
+					isGasless: $isSourceTokenPermitSupported ?? false
 				};
 
+				// `swapDetails` is spread inside each branch so that `type` narrows it to the quote
+				// shape of the matching mode.
 				if (selectedProvider.type === VeloraSwapTypes.DELTA) {
-					await fetchVeloraDeltaSwap(params);
+					await fetchVeloraDeltaSwap({ ...params, swapDetails: selectedProvider.swapDetails });
 				} else {
-					await fetchVeloraMarketSwap(params);
+					await fetchVeloraMarketSwap({ ...params, swapDetails: selectedProvider.swapDetails });
 				}
 			} else if (selectedProvider?.provider === SwapProvider.ONE_SEC) {
 				if (!isIcToken($destinationToken) || isNullish($ethAddress)) {

--- a/src/frontend/src/eth/utils/eip712.utils.ts
+++ b/src/frontend/src/eth/utils/eip712.utils.ts
@@ -1,4 +1,4 @@
-import type { SignableDeltaOrderData } from '@velora-dex/sdk';
+import type { BuiltDeltaOrder } from '@velora-dex/sdk';
 import { Signature } from 'ethers/crypto';
 import { TypedDataEncoder } from 'ethers/hash';
 
@@ -7,14 +7,15 @@ import { TypedDataEncoder } from 'ethers/hash';
  *
  * This hash can be used for signature verification or as a digest passed to a smart contract.
  *
+ * Velora also returns the hash as `BuiltDeltaOrder.orderHash`, but we re-derive it from the typed
+ * data so that we only ever sign a digest we computed ourselves.
+ *
  * @param params - The EIP-712 structured data including domain, types, and message.
  * @returns A hexadecimal string (prefixed with `0x`) representing the hash of the typed data.
  *
  */
-export const getSignParamsEIP712 = (params: SignableDeltaOrderData): string => {
-	const { domain: orderDomain, types: orderTypes, data } = params;
-	return TypedDataEncoder.hash(orderDomain, orderTypes, data);
-};
+export const getSignParamsEIP712 = ({ domain, types, value }: BuiltDeltaOrder['toSign']): string =>
+	TypedDataEncoder.hash(domain, types, value);
 
 /**
  * Converts a full ECDSA signature (65 bytes) into a compact serialized format (64 bytes).

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -1141,11 +1141,12 @@ export const fetchVeloraDeltaSwap = async ({
 	let builtOrder;
 
 	// The quoted route carries the tokens, the amounts and the destination chain, so the order is
-	// built server-side from it; slippage is expressed in basis points rather than as a floor amount.
+	// built server-side from it; slippage is expressed in basis points, which must be an integer —
+	// rounding guards against IEEE-754 noise in the percent conversion (0.29 * 100 === 28.999…).
 	const deltaOrderBaseParams: BuildDeltaOrderParams = {
 		route: swapDetails.route,
 		side: SWAP_SIDE,
-		slippage: Number(slippageValue) * 100,
+		slippage: Math.round(Number(slippageValue) * 100),
 		owner: userAddress,
 		partner: OISY_URL_HOSTNAME
 	};
@@ -1301,7 +1302,8 @@ export const fetchVeloraMarketSwap = async ({
 		srcToken: geSwapEthTokenAddress(sourceToken),
 		destToken: geSwapEthTokenAddress(destinationToken),
 		srcAmount: swapDetails.srcAmount,
-		slippage: Number(slippageValue) * 100,
+		// Basis points must be an integer — see the rounding note in fetchVeloraDeltaSwap.
+		slippage: Math.round(Number(slippageValue) * 100),
 		priceRoute: swapDetails,
 		userAddress,
 		partner: OISY_URL_HOSTNAME

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -104,7 +104,8 @@ import {
 	calculateSlippage,
 	geSwapEthTokenAddress,
 	getWithdrawableToken,
-	isKongSupportedIcToken
+	isKongSupportedIcToken,
+	slippagePercentToBasisPoints
 } from '$lib/utils/swap.utils';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
@@ -1190,16 +1191,14 @@ export const fetchVeloraDeltaSwap = async ({
 
 	let builtOrder;
 
-	// Slippage is expressed in basis points, which must be an integer — rounding guards against
-	// IEEE-754 noise in the percent conversion (0.29 * 100 === 28.999…).
-	const roundedSlippage = Math.round(Number(slippageValue) * 100);
+	const slippageBasisPoints = slippagePercentToBasisPoints(slippageValue);
 
 	// The quoted route carries the tokens, the amounts and the destination chain, so the order is
 	// built server-side from it.
 	const deltaOrderBaseParams: BuildDeltaOrderParams = {
 		route: swapDetails.route,
 		side: SWAP_SIDE,
-		slippage: roundedSlippage,
+		slippage: slippageBasisPoints,
 		owner: userAddress,
 		partner: OISY_URL_HOSTNAME
 	};
@@ -1249,7 +1248,7 @@ export const fetchVeloraDeltaSwap = async ({
 	// and refuse to sign an order that guarantees less than the user accepted.
 	const minDestAmount = calculateSlippage({
 		quoteAmount: BigInt(swapDetails.route.origin.output.amount),
-		slippagePercentage: roundedSlippage / 100
+		slippagePercentage: slippageBasisPoints / 100
 	});
 
 	if (BigInt(builtOrder.toSign.value.destAmount) < minDestAmount) {
@@ -1376,8 +1375,7 @@ export const fetchVeloraMarketSwap = async ({
 		srcToken: geSwapEthTokenAddress(sourceToken),
 		destToken: geSwapEthTokenAddress(destinationToken),
 		srcAmount: swapDetails.srcAmount,
-		// Basis points must be an integer — see the rounding note in fetchVeloraDeltaSwap.
-		slippage: Math.round(Number(slippageValue) * 100),
+		slippage: slippagePercentToBasisPoints(slippageValue),
 		priceRoute: swapDetails,
 		userAddress,
 		partner: OISY_URL_HOSTNAME

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -37,7 +37,8 @@ import { OISY_URL_HOSTNAME } from '$lib/constants/oisy.constants';
 import {
 	ICP_SWAP_POOL_FEE,
 	SWAP_DELTA_INTERVAL_MS,
-	SWAP_DELTA_TIMEOUT_MS
+	SWAP_DELTA_TIMEOUT_MS,
+	SWAP_SIDE
 } from '$lib/constants/swap.constants';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { PLAUSIBLE_EVENTS, PLAUSIBLE_EVENT_CONTEXTS } from '$lib/enums/plausible';
@@ -84,7 +85,8 @@ import {
 	type SwapNearIntentsEvmParams,
 	type SwapNearIntentsSolParams,
 	type SwapParams,
-	type SwapVeloraParams
+	type SwapVeloraDeltaParams,
+	type SwapVeloraMarketParams
 } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import { consoleError } from '$lib/utils/console.utils';
@@ -106,12 +108,7 @@ import { isTokenSpl } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
-import {
-	constructSimpleSDK,
-	type DeltaAuction,
-	type DeltaPrice,
-	type OptimalRate
-} from '@velora-dex/sdk';
+import { OrderHelpers, constructSimpleSDK, type BuildDeltaOrderParams } from '@velora-dex/sdk';
 import { get } from 'svelte/store';
 
 const checkNeedsApproval = async ({
@@ -1110,14 +1107,13 @@ export const fetchVeloraDeltaSwap = async ({
 	swapAmount,
 	sourceNetwork,
 	slippageValue,
-	destinationNetwork,
 	userAddress,
 	gas,
 	isGasless,
 	maxFeePerGas,
 	maxPriorityFeePerGas,
 	swapDetails
-}: SwapVeloraParams): Promise<void> => {
+}: SwapVeloraDeltaParams): Promise<void> => {
 	// Velora Delta settles by pulling the source token via allowance/permit, which a native coin
 	// (no contract address) can't satisfy without the unimplemented DepositNativeAndPreSign flow.
 	// Native sources are routed to the Market quote upstream (fetchVeloraSwapAmount); fail fast
@@ -1138,29 +1134,19 @@ export const fetchVeloraDeltaSwap = async ({
 
 	const deltaContract = await sdk.delta.getDeltaContract();
 
-	const slippageMinimum = calculateSlippage({
-		// According to Velora's documentation, we must provide `destAmount` as the value after slippage.
-		// Additionally, as confirmed with Velora, we cannot use a formatted token value with decimals when creating a Delta order.
-		// Instead, we should use the raw `destAmount` value returned in the quote response (`swapDetails.destAmount`).
-		// Therefore, when creating a Delta order, always use the `destAmount` from `swapDetails`.
-		quoteAmount: BigInt(swapDetails.destAmount),
-		slippagePercentage: Number(slippageValue)
-	});
-
 	if (isNullish(deltaContract)) {
 		return;
 	}
 
-	let signableOrderData;
+	let builtOrder;
 
-	const deltaOrderBaseParams = {
-		deltaPrice: swapDetails as DeltaPrice,
+	// The quoted route carries the tokens, the amounts and the destination chain, so the order is
+	// built server-side from it; slippage is expressed in basis points rather than as a floor amount.
+	const deltaOrderBaseParams: BuildDeltaOrderParams = {
+		route: swapDetails.route,
+		side: SWAP_SIDE,
+		slippage: Number(slippageValue) * 100,
 		owner: userAddress,
-		srcToken: sourceToken.address,
-		destToken: destinationToken.address,
-		srcAmount: parsedSwapAmount.toString(),
-		destAmount: `${slippageMinimum}`,
-		destChainId: Number(destinationNetwork.chainId),
 		partner: OISY_URL_HOSTNAME
 	};
 
@@ -1177,7 +1163,7 @@ export const fetchVeloraDeltaSwap = async ({
 
 		progress(ProgressStepsSwap.SWAP);
 
-		signableOrderData = await sdk.delta.buildDeltaOrder({
+		builtOrder = await sdk.delta.buildDeltaOrder({
 			...deltaOrderBaseParams,
 			deadline,
 			nonce,
@@ -1201,10 +1187,10 @@ export const fetchVeloraDeltaSwap = async ({
 
 		progress(ProgressStepsSwap.SWAP);
 
-		signableOrderData = await sdk.delta.buildDeltaOrder(deltaOrderBaseParams);
+		builtOrder = await sdk.delta.buildDeltaOrder(deltaOrderBaseParams);
 	}
 
-	const hash = getSignParamsEIP712(signableOrderData);
+	const hash = getSignParamsEIP712(builtOrder.toSign);
 
 	const signature = await signPrehash({
 		hash,
@@ -1214,7 +1200,7 @@ export const fetchVeloraDeltaSwap = async ({
 	const compactSignature = getCompactSignature(signature);
 
 	const deltaAuction = await sdk.delta.postDeltaOrder({
-		order: signableOrderData.data,
+		order: builtOrder.toSign.value,
 		signature: compactSignature
 	});
 
@@ -1241,34 +1227,14 @@ const checkDeltaOrderStatus = async ({
 	while (Date.now() < deadline) {
 		const auction = await sdk.delta.getDeltaOrderById(auctionId);
 
-		if (isExecutedDeltaAuction({ auction })) {
+		// `COMPLETED` means the order settled on every chain, so cross-chain orders need no
+		// separate bridge check — they stay `BRIDGING` until the destination leg lands.
+		if (OrderHelpers.checks.isCompletedAuction(auction)) {
 			return;
 		}
 
 		await new Promise((r) => setTimeout(r, intervalMs));
 	}
-};
-
-const isExecutedDeltaAuction = ({
-	auction,
-	waitForCrosschain = true
-}: {
-	auction: Omit<DeltaAuction, 'signature'>;
-	waitForCrosschain?: boolean;
-}): boolean => {
-	if (auction.status !== 'EXECUTED') {
-		return false;
-	}
-
-	if (
-		waitForCrosschain &&
-		'bridge' in auction.order &&
-		auction.order.bridge.destinationChainId !== 0
-	) {
-		return auction.bridgeStatus === 'filled';
-	}
-
-	return true;
 };
 
 export const fetchVeloraMarketSwap = async ({
@@ -1284,7 +1250,7 @@ export const fetchVeloraMarketSwap = async ({
 	maxFeePerGas,
 	maxPriorityFeePerGas,
 	swapDetails
-}: SwapVeloraParams): Promise<void> => {
+}: SwapVeloraMarketParams): Promise<void> => {
 	const parsedSwapAmount = parseToken({
 		value: `${swapAmount}`,
 		unitName: sourceToken.decimals
@@ -1336,7 +1302,7 @@ export const fetchVeloraMarketSwap = async ({
 		destToken: geSwapEthTokenAddress(destinationToken),
 		srcAmount: swapDetails.srcAmount,
 		slippage: Number(slippageValue) * 100,
-		priceRoute: swapDetails as OptimalRate,
+		priceRoute: swapDetails,
 		userAddress,
 		partner: OISY_URL_HOSTNAME
 	});

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -37,7 +37,8 @@ import { OISY_URL_HOSTNAME } from '$lib/constants/oisy.constants';
 import {
 	ICP_SWAP_POOL_FEE,
 	SWAP_DELTA_INTERVAL_MS,
-	SWAP_DELTA_TIMEOUT_MS
+	SWAP_DELTA_TIMEOUT_MS,
+	SWAP_SIDE
 } from '$lib/constants/swap.constants';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { PLAUSIBLE_EVENTS, PLAUSIBLE_EVENT_CONTEXTS } from '$lib/enums/plausible';
@@ -85,7 +86,8 @@ import {
 	type SwapNearIntentsEvmParams,
 	type SwapNearIntentsSolParams,
 	type SwapParams,
-	type SwapVeloraParams
+	type SwapVeloraDeltaParams,
+	type SwapVeloraMarketParams
 } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import { consoleError } from '$lib/utils/console.utils';
@@ -112,12 +114,7 @@ import { isTokenSpl } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
-import {
-	constructSimpleSDK,
-	type DeltaAuction,
-	type DeltaPrice,
-	type OptimalRate
-} from '@velora-dex/sdk';
+import { OrderHelpers, constructSimpleSDK, type BuildDeltaOrderParams } from '@velora-dex/sdk';
 import { get } from 'svelte/store';
 
 const checkNeedsApproval = async ({
@@ -1160,14 +1157,13 @@ export const fetchVeloraDeltaSwap = async ({
 	swapAmount,
 	sourceNetwork,
 	slippageValue,
-	destinationNetwork,
 	userAddress,
 	gas,
 	isGasless,
 	maxFeePerGas,
 	maxPriorityFeePerGas,
 	swapDetails
-}: SwapVeloraParams): Promise<void> => {
+}: SwapVeloraDeltaParams): Promise<void> => {
 	// Velora Delta settles by pulling the source token via allowance/permit, which a native coin
 	// (no contract address) can't satisfy without the unimplemented DepositNativeAndPreSign flow.
 	// Native sources are routed to the Market quote upstream (fetchVeloraSwapAmount); fail fast
@@ -1188,29 +1184,19 @@ export const fetchVeloraDeltaSwap = async ({
 
 	const deltaContract = await sdk.delta.getDeltaContract();
 
-	const slippageMinimum = calculateSlippage({
-		// According to Velora's documentation, we must provide `destAmount` as the value after slippage.
-		// Additionally, as confirmed with Velora, we cannot use a formatted token value with decimals when creating a Delta order.
-		// Instead, we should use the raw `destAmount` value returned in the quote response (`swapDetails.destAmount`).
-		// Therefore, when creating a Delta order, always use the `destAmount` from `swapDetails`.
-		quoteAmount: BigInt(swapDetails.destAmount),
-		slippagePercentage: Number(slippageValue)
-	});
-
 	if (isNullish(deltaContract)) {
 		return;
 	}
 
-	let signableOrderData;
+	let builtOrder;
 
-	const deltaOrderBaseParams = {
-		deltaPrice: swapDetails as DeltaPrice,
+	// The quoted route carries the tokens, the amounts and the destination chain, so the order is
+	// built server-side from it; slippage is expressed in basis points rather than as a floor amount.
+	const deltaOrderBaseParams: BuildDeltaOrderParams = {
+		route: swapDetails.route,
+		side: SWAP_SIDE,
+		slippage: Number(slippageValue) * 100,
 		owner: userAddress,
-		srcToken: sourceToken.address,
-		destToken: destinationToken.address,
-		srcAmount: parsedSwapAmount.toString(),
-		destAmount: `${slippageMinimum}`,
-		destChainId: Number(destinationNetwork.chainId),
 		partner: OISY_URL_HOSTNAME
 	};
 
@@ -1227,7 +1213,7 @@ export const fetchVeloraDeltaSwap = async ({
 
 		progress(ProgressStepsSwap.SWAP);
 
-		signableOrderData = await sdk.delta.buildDeltaOrder({
+		builtOrder = await sdk.delta.buildDeltaOrder({
 			...deltaOrderBaseParams,
 			deadline,
 			nonce,
@@ -1251,10 +1237,10 @@ export const fetchVeloraDeltaSwap = async ({
 
 		progress(ProgressStepsSwap.SWAP);
 
-		signableOrderData = await sdk.delta.buildDeltaOrder(deltaOrderBaseParams);
+		builtOrder = await sdk.delta.buildDeltaOrder(deltaOrderBaseParams);
 	}
 
-	const hash = getSignParamsEIP712(signableOrderData);
+	const hash = getSignParamsEIP712(builtOrder.toSign);
 
 	const signature = await signPrehash({
 		hash,
@@ -1264,7 +1250,7 @@ export const fetchVeloraDeltaSwap = async ({
 	const compactSignature = getCompactSignature(signature);
 
 	const deltaAuction = await sdk.delta.postDeltaOrder({
-		order: signableOrderData.data,
+		order: builtOrder.toSign.value,
 		signature: compactSignature
 	});
 
@@ -1291,34 +1277,14 @@ const checkDeltaOrderStatus = async ({
 	while (Date.now() < deadline) {
 		const auction = await sdk.delta.getDeltaOrderById(auctionId);
 
-		if (isExecutedDeltaAuction({ auction })) {
+		// `COMPLETED` means the order settled on every chain, so cross-chain orders need no
+		// separate bridge check — they stay `BRIDGING` until the destination leg lands.
+		if (OrderHelpers.checks.isCompletedAuction(auction)) {
 			return;
 		}
 
 		await new Promise((r) => setTimeout(r, intervalMs));
 	}
-};
-
-const isExecutedDeltaAuction = ({
-	auction,
-	waitForCrosschain = true
-}: {
-	auction: Omit<DeltaAuction, 'signature'>;
-	waitForCrosschain?: boolean;
-}): boolean => {
-	if (auction.status !== 'EXECUTED') {
-		return false;
-	}
-
-	if (
-		waitForCrosschain &&
-		'bridge' in auction.order &&
-		auction.order.bridge.destinationChainId !== 0
-	) {
-		return auction.bridgeStatus === 'filled';
-	}
-
-	return true;
 };
 
 export const fetchVeloraMarketSwap = async ({
@@ -1334,7 +1300,7 @@ export const fetchVeloraMarketSwap = async ({
 	maxFeePerGas,
 	maxPriorityFeePerGas,
 	swapDetails
-}: SwapVeloraParams): Promise<void> => {
+}: SwapVeloraMarketParams): Promise<void> => {
 	const parsedSwapAmount = parseToken({
 		value: `${swapAmount}`,
 		unitName: sourceToken.decimals
@@ -1386,7 +1352,7 @@ export const fetchVeloraMarketSwap = async ({
 		destToken: geSwapEthTokenAddress(destinationToken),
 		srcAmount: swapDetails.srcAmount,
 		slippage: Number(slippageValue) * 100,
-		priceRoute: swapDetails as OptimalRate,
+		priceRoute: swapDetails,
 		userAddress,
 		partner: OISY_URL_HOSTNAME
 	});

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -1191,11 +1191,12 @@ export const fetchVeloraDeltaSwap = async ({
 	let builtOrder;
 
 	// The quoted route carries the tokens, the amounts and the destination chain, so the order is
-	// built server-side from it; slippage is expressed in basis points rather than as a floor amount.
+	// built server-side from it; slippage is expressed in basis points, which must be an integer —
+	// rounding guards against IEEE-754 noise in the percent conversion (0.29 * 100 === 28.999…).
 	const deltaOrderBaseParams: BuildDeltaOrderParams = {
 		route: swapDetails.route,
 		side: SWAP_SIDE,
-		slippage: Number(slippageValue) * 100,
+		slippage: Math.round(Number(slippageValue) * 100),
 		owner: userAddress,
 		partner: OISY_URL_HOSTNAME
 	};
@@ -1351,7 +1352,8 @@ export const fetchVeloraMarketSwap = async ({
 		srcToken: geSwapEthTokenAddress(sourceToken),
 		destToken: geSwapEthTokenAddress(destinationToken),
 		srcAmount: swapDetails.srcAmount,
-		slippage: Number(slippageValue) * 100,
+		// Basis points must be an integer — see the rounding note in fetchVeloraDeltaSwap.
+		slippage: Math.round(Number(slippageValue) * 100),
 		priceRoute: swapDetails,
 		userAddress,
 		partner: OISY_URL_HOSTNAME

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -1190,13 +1190,16 @@ export const fetchVeloraDeltaSwap = async ({
 
 	let builtOrder;
 
+	// Slippage is expressed in basis points, which must be an integer — rounding guards against
+	// IEEE-754 noise in the percent conversion (0.29 * 100 === 28.999…).
+	const roundedSlippage = Math.round(Number(slippageValue) * 100);
+
 	// The quoted route carries the tokens, the amounts and the destination chain, so the order is
-	// built server-side from it; slippage is expressed in basis points, which must be an integer —
-	// rounding guards against IEEE-754 noise in the percent conversion (0.29 * 100 === 28.999…).
+	// built server-side from it.
 	const deltaOrderBaseParams: BuildDeltaOrderParams = {
 		route: swapDetails.route,
 		side: SWAP_SIDE,
-		slippage: Math.round(Number(slippageValue) * 100),
+		slippage: roundedSlippage,
 		owner: userAddress,
 		partner: OISY_URL_HOSTNAME
 	};
@@ -1239,6 +1242,20 @@ export const fetchVeloraDeltaSwap = async ({
 		progress(ProgressStepsSwap.SWAP);
 
 		builtOrder = await sdk.delta.buildDeltaOrder(deltaOrderBaseParams);
+	}
+
+	// The server derives the signed on-chain minimum (`destAmount`) from the route and the
+	// slippage; re-derive it from the quoted origin output (the leg the on-chain order settles)
+	// and refuse to sign an order that guarantees less than the user accepted.
+	const minDestAmount = calculateSlippage({
+		quoteAmount: BigInt(swapDetails.route.origin.output.amount),
+		slippagePercentage: roundedSlippage / 100
+	});
+
+	if (BigInt(builtOrder.toSign.value.destAmount) < minDestAmount) {
+		throw new Error(
+			`Slippage exceeded. Velora returned ${builtOrder.toSign.value.destAmount}, expected at least ${minDestAmount}.`
+		);
 	}
 
 	const hash = getSignParamsEIP712(builtOrder.toSign);
@@ -1284,8 +1301,15 @@ const checkDeltaOrderStatus = async ({
 			return;
 		}
 
+		// Terminal failures (failed, expired, cancelled, refunding, refunded)
+		if (OrderHelpers.checks.isFailedAuction(auction)) {
+			throw new Error(`Velora Delta swap ${auction.status.toLowerCase()} (order ${auctionId})`);
+		}
+
 		await new Promise((r) => setTimeout(r, intervalMs));
 	}
+
+	throw new Error(`Velora Delta swap timed out (order ${auctionId})`);
 };
 
 export const fetchVeloraMarketSwap = async ({

--- a/src/frontend/src/lib/services/velora-swap.services.ts
+++ b/src/frontend/src/lib/services/velora-swap.services.ts
@@ -102,7 +102,7 @@ export const fetchVeloraSwapAmount = async ({
 
 		if ('delta' in data) {
 			const destinationTokenToDecimals = formatToken({
-				value: BigInt(data.delta.destAmount),
+				value: BigInt(data.delta.route.destination.output.amount),
 				unitName: destinationToken.decimals
 			});
 

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -14,13 +14,7 @@ import type { Token } from '$lib/types/token';
 import type { RequiredTransactionFeeData } from '$lib/types/transaction';
 import type { OptionSolAddress, SolAddress } from '$sol/types/address';
 import type { Identity } from '@icp-sdk/core/agent';
-import type {
-	BridgePrice,
-	DeltaPrice,
-	OptimalRate,
-	QuoteParams,
-	SimpleFetchSDK
-} from '@velora-dex/sdk';
+import type { DeltaPrice, OptimalRate, QuoteParams, SimpleFetchSDK } from '@velora-dex/sdk';
 
 export type SwapSelectTokenType = 'source' | 'destination';
 
@@ -113,8 +107,15 @@ export type SwapMappedResult =
 			provider: SwapProvider.VELORA;
 			receiveAmount: bigint;
 			receiveOutMinimum?: bigint;
-			swapDetails: VeloraSwapDetails;
-			type: string;
+			swapDetails: DeltaPrice;
+			type: VeloraSwapTypes.DELTA;
+	  }
+	| {
+			provider: SwapProvider.VELORA;
+			receiveAmount: bigint;
+			receiveOutMinimum?: bigint;
+			swapDetails: OptimalRate;
+			type: VeloraSwapTypes.MARKET;
 	  }
 	| {
 			provider: SwapProvider.NEAR_INTENTS;
@@ -227,7 +228,12 @@ export interface FormatSlippageParams {
 	decimals: number;
 }
 
-export type VeloraSwapDetails = DeltaPrice & BridgePrice & OptimalRate;
+/**
+ * Quote payload of either Velora execution mode. The two shapes are mutually exclusive —
+ * `DeltaPrice.partner` is an object while `OptimalRate.partner` is a string — so this is a
+ * union discriminated by `VeloraSwapTypes`, never an intersection.
+ */
+export type VeloraSwapDetails = DeltaPrice | OptimalRate;
 
 export interface GetQuoteParams extends QuoteParams<'all' | 'market'> {
 	destChainId?: number;
@@ -316,7 +322,7 @@ export interface SwapProvidersConfig {
 	website: string;
 }
 
-export interface SwapVeloraParams extends RequiredTransactionFeeData {
+interface SwapVeloraParams extends RequiredTransactionFeeData {
 	identity: Identity;
 	progress: (step: ProgressStep) => void;
 	sourceToken: ErcFungibleToken;
@@ -325,10 +331,16 @@ export interface SwapVeloraParams extends RequiredTransactionFeeData {
 	receiveAmount: bigint;
 	slippageValue: Amount;
 	sourceNetwork: EthereumNetwork;
-	destinationNetwork: EthereumNetwork;
 	userAddress: EthAddress;
-	swapDetails: VeloraSwapDetails;
 	isGasless: boolean;
+}
+
+export interface SwapVeloraDeltaParams extends SwapVeloraParams {
+	swapDetails: DeltaPrice;
+}
+
+export interface SwapVeloraMarketParams extends SwapVeloraParams {
+	swapDetails: OptimalRate;
 }
 
 interface SwapNearIntentsParams {
@@ -363,6 +375,5 @@ export interface CheckDeltaOrderStatusParams {
 }
 
 export interface DeltaSwapResponse {
-	delta: DeltaPrice | BridgePrice;
-	deltaAddress: string;
+	delta: DeltaPrice;
 }

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -16,6 +16,7 @@ import {
 	NEAR_INTENTS_BLOCKCHAIN_MAP,
 	SWAP_DEFAULT_SLIPPAGE_VALUE,
 	SWAP_ETH_TOKEN_PLACEHOLDER,
+	SWAP_SLIPPAGE_VALUE_DECIMALS,
 	swapProvidersDetails
 } from '$lib/constants/swap.constants';
 import { SwapError } from '$lib/services/swap-errors.services';
@@ -27,7 +28,7 @@ import type {
 	NearIntentsToken
 } from '$lib/types/near-intents';
 import type { NetworkId } from '$lib/types/network';
-import type { OptionAmount } from '$lib/types/send';
+import type { Amount, OptionAmount } from '$lib/types/send';
 import {
 	SwapProvider,
 	VeloraSwapTypes,
@@ -156,6 +157,23 @@ export const calculateSlippage = ({
 }): bigint => {
 	const factor = 1 - slippagePercentage / 100;
 	return BigInt(Math.floor(Number(quoteAmount) * factor));
+};
+
+/**
+ * Converts a slippage percentage into the integer basis points some providers (e.g. Velora) require.
+ *
+ * The fractional part is dropped rather than rounded so an order can never allow more slippage
+ * than the user accepted (1.005% must become 100 bps, not 101). Flooring the raw product alone
+ * would lose a whole basis point to IEEE-754 noise (0.29 * 100 === 28.999…), so the value is
+ * first snapped to the {@link SWAP_SLIPPAGE_VALUE_DECIMALS} granularity the slippage input
+ * enforces — that erases the noise while keeping genuine fractional basis points intact. The
+ * absolute value guards against a negative value slipping past input validation and reaching a
+ * provider as negative slippage.
+ */
+export const slippagePercentToBasisPoints = (slippageValue: Amount): number => {
+	const snapped = Math.round(Math.abs(Number(slippageValue)) * 10 ** SWAP_SLIPPAGE_VALUE_DECIMALS);
+	// A percent with SWAP_SLIPPAGE_VALUE_DECIMALS decimals has two fewer of them as basis points
+	return Math.floor(snapped / 10 ** (SWAP_SLIPPAGE_VALUE_DECIMALS - 2));
 };
 
 /**

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -38,8 +38,7 @@ import {
 	type ProviderFee,
 	type Slippage,
 	type SwapMappedResult,
-	type SwapProvidersConfig,
-	type VeloraSwapDetails
+	type SwapProvidersConfig
 } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import { areAddressesEqual } from '$lib/utils/address.utils';
@@ -189,26 +188,20 @@ export const formatReceiveOutMinimum = ({
 	});
 };
 
-export const mapVeloraSwapResult = (swap: DeltaSwapResponse): SwapMappedResult => ({
+export const mapVeloraSwapResult = ({ delta }: DeltaSwapResponse): SwapMappedResult => ({
 	provider: SwapProvider.VELORA,
-	receiveAmount:
-		// Velora does not always return the destination amount in the precision of the destination token (as we would expect).
-		// For example, if we request a swap from USDC-BSC (18 digits) to USDC-BASE (6 digits), the destination amount is returned as if it has 18 digits instead of 6.
-		// This causes issues in the normal formatting of our code, since we expect each amount to be strictly related to its reference token.
-		// To avoid this issue, we could use the `bridgeInfo` data that Velora adds for this specific cases: it specify the correct amount to look at when the bridge is treating tokens with scaling factor.
-		// This is not documented anywhere in Velora documentation, it was the result of a direct conversations with them.
-		// TODO: remove this disclaimer where Velora fixes this issue on their side.
-		'bridgeInfo' in swap.delta
-			? BigInt(swap.delta.bridgeInfo.destAmountAfterBridge)
-			: BigInt(swap.delta.destAmount),
-	swapDetails: swap.delta as VeloraSwapDetails,
+	// The destination step of the route is already denominated in the destination token, on the
+	// destination chain. Reading it here also covers cross-chain quotes whose two tokens have
+	// different decimals — the bridge scaling factor is applied by Velora before we see it.
+	receiveAmount: BigInt(delta.route.destination.output.amount),
+	swapDetails: delta,
 	type: VeloraSwapTypes.DELTA
 });
 
 export const mapVeloraMarketSwapResult = (swap: OptimalRate): SwapMappedResult => ({
 	provider: SwapProvider.VELORA,
 	receiveAmount: BigInt(swap.destAmount),
-	swapDetails: swap as VeloraSwapDetails,
+	swapDetails: swap,
 	type: VeloraSwapTypes.MARKET
 });
 

--- a/src/frontend/src/lib/utils/swap.utils.ts
+++ b/src/frontend/src/lib/utils/swap.utils.ts
@@ -16,7 +16,6 @@ import {
 	NEAR_INTENTS_BLOCKCHAIN_MAP,
 	SWAP_DEFAULT_SLIPPAGE_VALUE,
 	SWAP_ETH_TOKEN_PLACEHOLDER,
-	SWAP_SLIPPAGE_VALUE_DECIMALS,
 	swapProvidersDetails
 } from '$lib/constants/swap.constants';
 import { SwapError } from '$lib/services/swap-errors.services';
@@ -164,16 +163,16 @@ export const calculateSlippage = ({
  *
  * The fractional part is dropped rather than rounded so an order can never allow more slippage
  * than the user accepted (1.005% must become 100 bps, not 101). Flooring the raw product alone
- * would lose a whole basis point to IEEE-754 noise (0.29 * 100 === 28.999…), so the value is
- * first snapped to the {@link SWAP_SLIPPAGE_VALUE_DECIMALS} granularity the slippage input
- * enforces — that erases the noise while keeping genuine fractional basis points intact. The
- * absolute value guards against a negative value slipping past input validation and reaching a
- * provider as negative slippage.
+ * would lose a whole basis point to IEEE-754 noise (0.29 * 100 === 28.999…), so the noise is
+ * rounded away first. The 1e-6 bps precision is deliberately independent of the slippage input's
+ * decimal limit so the invariant holds even for a value that bypassed the input: it only needs to
+ * stay far coarser than float noise (~1e-14) and finer than any granularity a caller could mean.
+ * The absolute value guards against a negative value slipping past input validation and reaching
+ * a provider as negative slippage.
  */
 export const slippagePercentToBasisPoints = (slippageValue: Amount): number => {
-	const snapped = Math.round(Math.abs(Number(slippageValue)) * 10 ** SWAP_SLIPPAGE_VALUE_DECIMALS);
-	// A percent with SWAP_SLIPPAGE_VALUE_DECIMALS decimals has two fewer of them as basis points
-	return Math.floor(snapped / 10 ** (SWAP_SLIPPAGE_VALUE_DECIMALS - 2));
+	const basisPoints = Math.abs(Number(slippageValue)) * 100;
+	return Math.floor(Math.round(basisPoints * 1e6) / 1e6);
 };
 
 /**

--- a/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
@@ -18,12 +18,7 @@ import * as swapServices from '$lib/services/swap.services';
 import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY, type SwapError } from '$lib/stores/swap.store';
 import * as toasts from '$lib/stores/toasts.store';
-import {
-	SwapProvider,
-	VeloraSwapTypes,
-	type SwapMappedResult,
-	type VeloraSwapDetails
-} from '$lib/types/swap';
+import { SwapProvider, VeloraSwapTypes, type SwapMappedResult } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
@@ -36,6 +31,7 @@ import {
 	mockVeloraDeltaProvider,
 	mockVeloraMarketProvider
 } from '$tests/mocks/swap.mocks';
+import { mockVeloraOptimalRate } from '$tests/mocks/velora.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 import { get, readable, writable, type Writable } from 'svelte/store';
 
@@ -338,7 +334,7 @@ describe('SwapEthWizard', () => {
 				provider: SwapProvider.VELORA,
 				receiveAmount: 1000000000n,
 				type: VeloraSwapTypes.MARKET,
-				swapDetails: {} as VeloraSwapDetails
+				swapDetails: mockVeloraOptimalRate
 			}
 		];
 
@@ -682,7 +678,7 @@ describe('SwapEthWizard', () => {
 					provider: SwapProvider.VELORA,
 					receiveAmount: 1000000000n,
 					type: VeloraSwapTypes.MARKET,
-					swapDetails: {} as VeloraSwapDetails
+					swapDetails: mockVeloraOptimalRate
 				}
 			];
 

--- a/src/frontend/src/tests/eth/utils/eip712.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/eip712.utils.spec.ts
@@ -1,5 +1,5 @@
 import { getCompactSignature, getSignParamsEIP712 } from '$eth/utils/eip712.utils';
-import type { DeltaAuctionOrder, SignableDeltaOrderData } from '@velora-dex/sdk';
+import type { BuiltDeltaOrder, DeltaAuctionOrder } from '@velora-dex/sdk';
 import { Signature } from 'ethers/crypto';
 import { TypedDataEncoder } from 'ethers/hash';
 
@@ -37,7 +37,7 @@ describe('EIP - 712 utils methods', () => {
 	describe('getSignParamsEIP712', () => {
 		it('should call TypedDataEncoder.hash with correct parameters and return result', () => {
 			const expectedHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
-			const inputParams: SignableDeltaOrderData = {
+			const inputParams: BuiltDeltaOrder['toSign'] = {
 				domain: {
 					name: 'Velora DEX',
 					version: '1',
@@ -51,7 +51,7 @@ describe('EIP - 712 utils methods', () => {
 						{ name: 'chainId', type: 'uint256' }
 					]
 				},
-				data: {
+				value: {
 					owner: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
 					beneficiary: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
 					srcToken: '0x1111111111111111111111111111111111111111',
@@ -82,14 +82,14 @@ describe('EIP - 712 utils methods', () => {
 			expect(mockTypedDataEncoder.hash).toHaveBeenCalledExactlyOnceWith(
 				inputParams.domain,
 				inputParams.types,
-				inputParams.data
+				inputParams.value
 			);
 			expect(result).toBe(expectedHash);
 		});
 
 		it('should handle different domain configurations', () => {
 			const expectedHash = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef';
-			const inputParams: SignableDeltaOrderData = {
+			const inputParams: BuiltDeltaOrder['toSign'] = {
 				domain: {
 					name: 'Test DEX',
 					version: '2',
@@ -103,7 +103,7 @@ describe('EIP - 712 utils methods', () => {
 						{ name: 'chainId', type: 'uint256' }
 					]
 				},
-				data: {
+				value: {
 					owner: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
 					beneficiary: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
 					srcToken: '0x1111111111111111111111111111111111111111',
@@ -134,14 +134,14 @@ describe('EIP - 712 utils methods', () => {
 			expect(mockTypedDataEncoder.hash).toHaveBeenCalledExactlyOnceWith(
 				inputParams.domain,
 				inputParams.types,
-				inputParams.data
+				inputParams.value
 			);
 			expect(result).toBe(expectedHash);
 		});
 
 		it('should handle empty data object', () => {
 			const expectedHash = '0x0000000000000000000000000000000000000000000000000000000000000000';
-			const inputParams: SignableDeltaOrderData = {
+			const inputParams: BuiltDeltaOrder['toSign'] = {
 				domain: {
 					name: 'Empty Test',
 					version: '1',
@@ -152,7 +152,7 @@ describe('EIP - 712 utils methods', () => {
 					Order: [],
 					Bridge: []
 				},
-				data: {} as DeltaAuctionOrder
+				value: {} as DeltaAuctionOrder
 			};
 
 			vi.spyOn(TypedDataEncoder, 'hash').mockReturnValue(expectedHash);
@@ -162,7 +162,7 @@ describe('EIP - 712 utils methods', () => {
 			expect(mockTypedDataEncoder.hash).toHaveBeenCalledExactlyOnceWith(
 				inputParams.domain,
 				inputParams.types,
-				inputParams.data
+				inputParams.value
 			);
 			expect(result).toBe(expectedHash);
 		});
@@ -245,7 +245,7 @@ describe('EIP - 712 utils methods', () => {
 
 	describe('Integration scenarios', () => {
 		it('should work together in a typical signing flow', () => {
-			const orderData: SignableDeltaOrderData = {
+			const orderData: BuiltDeltaOrder['toSign'] = {
 				domain: {
 					name: 'Velora DEX',
 					version: '1',
@@ -259,7 +259,7 @@ describe('EIP - 712 utils methods', () => {
 						{ name: 'chainId', type: 'uint256' }
 					]
 				},
-				data: {
+				value: {
 					owner: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
 					beneficiary: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
 					srcToken: '0x1111111111111111111111111111111111111111',
@@ -299,7 +299,7 @@ describe('EIP - 712 utils methods', () => {
 			expect(mockTypedDataEncoder.hash).toHaveBeenCalledExactlyOnceWith(
 				orderData.domain,
 				orderData.types,
-				orderData.data
+				orderData.value
 			);
 			expect(hash).toBe(expectedHash);
 

--- a/src/frontend/src/tests/lib/components/swap/SwapDetailsVelora.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapDetailsVelora.spec.ts
@@ -1,17 +1,21 @@
 import SwapDetailsVelora from '$lib/components/swap/SwapDetailsVelora.svelte';
-import { SwapProvider, type VeloraSwapDetails } from '$lib/types/swap';
+import { SwapProvider, VeloraSwapTypes } from '$lib/types/swap';
 import en from '$tests/mocks/i18n.mock';
+import { mockVeloraDeltaPrice, mockVeloraOptimalRate } from '$tests/mocks/velora.mock';
 import { render } from '@testing-library/svelte';
 
 describe('SwapDetailsVelora', () => {
 	const baseProvider = {
 		provider: SwapProvider.VELORA,
-		receiveAmount: 1_000_000n,
-		swapDetails: {} as VeloraSwapDetails
+		receiveAmount: 1_000_000n
 	} as const;
 
 	it('displays the swap details for Delta Swap', () => {
-		const provider = { ...baseProvider, type: 'delta' as const };
+		const provider = {
+			...baseProvider,
+			type: VeloraSwapTypes.DELTA,
+			swapDetails: mockVeloraDeltaPrice
+		} as const;
 
 		const { getByText, queryByText } = render(SwapDetailsVelora, {
 			props: { provider }
@@ -31,7 +35,11 @@ describe('SwapDetailsVelora', () => {
 	});
 
 	it('Displays the swap details for Market Swap', () => {
-		const provider = { ...baseProvider, type: 'market' as const };
+		const provider = {
+			...baseProvider,
+			type: VeloraSwapTypes.MARKET,
+			swapDetails: mockVeloraOptimalRate
+		} as const;
 
 		const { getByText, queryByText } = render(SwapDetailsVelora, {
 			props: { provider }

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -1,6 +1,6 @@
 import type { PoolMetadata } from '$declarations/icp_swap_pool/icp_swap_pool.did';
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { createPermit } from '$eth/services/eip2612-permit.services';
 import { loadCustomTokens as loadCustomErc20Tokens } from '$eth/services/erc20.services';
 import { send as sendEvm } from '$eth/services/send.services';
@@ -43,7 +43,7 @@ import {
 	NEAR_INTENTS_EXTERNAL_REF_KEYS,
 	type NearIntentsQuoteResponse
 } from '$lib/types/near-intents';
-import { SwapErrorCodes, SwapProvider, type VeloraSwapDetails } from '$lib/types/swap';
+import { SwapErrorCodes, SwapProvider } from '$lib/types/swap';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { sendSol } from '$sol/services/sol-send.services';
 import { loadCustomTokens as loadCustomSplTokens } from '$sol/services/spl.services';
@@ -58,8 +58,12 @@ import { mockNearIntentsQuoteResponse } from '$tests/mocks/near-intents.mock';
 import { mockSolSignature } from '$tests/mocks/sol-signatures.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
-import { mockVeloraSwapDetails } from '$tests/mocks/velora.mock';
-import { constructSimpleSDK } from '@velora-dex/sdk';
+import {
+	mockVeloraCrossChainSwapResponse,
+	mockVeloraDeltaPrice,
+	mockVeloraOptimalRate
+} from '$tests/mocks/velora.mock';
+import { constructSimpleSDK, type DeltaPrice, type OptimalRate } from '@velora-dex/sdk';
 import { get } from 'svelte/store';
 
 vi.mock('$icp/api/icrc-ledger.api', () => ({
@@ -143,7 +147,12 @@ vi.mock('$sol/services/sol-send.services', () => ({
 }));
 
 vi.mock('@velora-dex/sdk', () => ({
-	constructSimpleSDK: vi.fn()
+	constructSimpleSDK: vi.fn(),
+	OrderHelpers: {
+		checks: {
+			isCompletedAuction: ({ status }: { status: string }) => status === 'COMPLETED'
+		}
+	}
 }));
 
 vi.mock('$eth/services/approve.services', () => ({
@@ -867,14 +876,13 @@ describe('swap.services', () => {
 		const mockReceiveAmount = 900000000n; // 0.9 DST
 		const mockSlippageValue = '0.5';
 		const mockSourceNetwork = ETHEREUM_NETWORK;
-		const mockDestinationNetwork = SEPOLIA_NETWORK;
 		const mockUserAddress = mockEthAddress;
 		const mockGas = '21000';
 		const mockMaxFeePerGas = '20000000000';
 		const mockMaxPriorityFeePerGas = '2000000000';
 
-		const mockSwapDetails: VeloraSwapDetails = {
-			...mockVeloraSwapDetails
+		const mockSwapDetails: DeltaPrice = {
+			...mockVeloraDeltaPrice
 		};
 
 		const mockProgress = vi.fn();
@@ -922,13 +930,11 @@ describe('swap.services', () => {
 			);
 			mockDeltaContractGetDeltaContract.mockResolvedValue(mockDeltaContract);
 			mockDeltaContractBuildDeltaOrder.mockResolvedValue({
-				data: { order: 'mock-order-data' }
+				toSign: { domain: {}, types: {}, value: { order: 'mock-order-data' } },
+				orderHash: 'mock-order-hash'
 			});
 			mockDeltaContractPostDeltaOrder.mockResolvedValue({ id: 'mock-auction-id' });
-			mockDeltaContractGetDeltaOrderById.mockResolvedValue({
-				status: 'EXECUTED',
-				order: { bridge: { destinationChainId: 0 } }
-			});
+			mockDeltaContractGetDeltaOrderById.mockResolvedValue({ status: 'COMPLETED' });
 
 			vi.mocked(createPermit).mockResolvedValue({
 				nonce: '0',
@@ -947,7 +953,6 @@ describe('swap.services', () => {
 				sourceNetwork: mockSourceNetwork,
 				receiveAmount: mockReceiveAmount,
 				slippageValue: mockSlippageValue,
-				destinationNetwork: mockDestinationNetwork,
 				userAddress: mockUserAddress,
 				gas: BigInt(mockGas),
 				isGasless: false,
@@ -977,7 +982,6 @@ describe('swap.services', () => {
 					sourceNetwork: mockSourceNetwork,
 					receiveAmount: mockReceiveAmount,
 					slippageValue: mockSlippageValue,
-					destinationNetwork: mockDestinationNetwork,
 					userAddress: mockUserAddress,
 					gas: BigInt(mockGas),
 					isGasless: false,
@@ -1000,7 +1004,6 @@ describe('swap.services', () => {
 				sourceNetwork: mockSourceNetwork,
 				receiveAmount: mockReceiveAmount,
 				slippageValue: mockSlippageValue,
-				destinationNetwork: mockDestinationNetwork,
 				userAddress: mockUserAddress,
 				gas: BigInt(mockGas),
 				isGasless: true,
@@ -1025,7 +1028,6 @@ describe('swap.services', () => {
 				sourceNetwork: mockSourceNetwork,
 				receiveAmount: mockReceiveAmount,
 				slippageValue: mockSlippageValue,
-				destinationNetwork: mockDestinationNetwork,
 				userAddress: mockUserAddress,
 				gas: BigInt(mockGas),
 				isGasless: false,
@@ -1038,11 +1040,12 @@ describe('swap.services', () => {
 			expect(mockDeltaContractPostDeltaOrder).not.toHaveBeenCalled();
 		});
 
-		it('should handle cross-chain bridge execution', async () => {
+		it('should treat a cross-chain order as settled only once it reports COMPLETED', async () => {
+			// A cross-chain order stays `BRIDGING` until the destination leg lands, so `COMPLETED`
+			// on its own means settled on every chain — no separate bridge check is needed.
 			mockDeltaContractGetDeltaOrderById.mockResolvedValue({
-				status: 'EXECUTED',
-				order: { bridge: { destinationChainId: 1 } },
-				bridgeStatus: 'filled'
+				status: 'COMPLETED',
+				transactions: [{ originTx: '0xorigin', destinationTx: '0xdestination' }]
 			});
 
 			await fetchVeloraDeltaSwap({
@@ -1054,7 +1057,6 @@ describe('swap.services', () => {
 				sourceNetwork: mockSourceNetwork,
 				receiveAmount: mockReceiveAmount,
 				slippageValue: mockSlippageValue,
-				destinationNetwork: mockDestinationNetwork,
 				userAddress: mockUserAddress,
 				gas: BigInt(mockGas),
 				isGasless: false,
@@ -1089,22 +1091,8 @@ describe('swap.services', () => {
 		const mockMaxFeePerGas = '20000000000';
 		const mockMaxPriorityFeePerGas = '2000000000';
 
-		const mockSwapDetails = {
-			srcToken: mockEthAddress,
-			destToken: '0xDestinationToken',
-			srcAmount: '1000000000000000000',
-			destAmount: '900000000',
-			destAmountBeforeFee: '920000000',
-			gasCost: '50000',
-			gasCostBeforeFee: '48000',
-			gasCostUSD: '15.5',
-			gasCostUSDBeforeFee: '14.8',
-			srcUSD: '1000.0',
-			destUSD: '895.5',
-			destUSDBeforeFee: '915.2',
-			partner: 'PartnerName',
-			partnerFee: 0.25,
-			hmac: 'abcd1234'
+		const mockSwapDetails: OptimalRate = {
+			...mockVeloraOptimalRate
 		};
 
 		const mockProgress = vi.fn();
@@ -1160,10 +1148,9 @@ describe('swap.services', () => {
 				gas: BigInt(mockGas),
 				maxFeePerGas: BigInt(mockMaxFeePerGas),
 				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
-				swapDetails: mockSwapDetails as VeloraSwapDetails,
+				swapDetails: mockSwapDetails,
 				receiveAmount: BigInt(1000),
-				isGasless: false,
-				destinationNetwork: SEPOLIA_NETWORK
+				isGasless: false
 			});
 
 			expect(mockProgress).toHaveBeenCalledTimes(2);
@@ -1188,10 +1175,9 @@ describe('swap.services', () => {
 				gas: BigInt(mockGas),
 				maxFeePerGas: BigInt(mockMaxFeePerGas),
 				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
-				swapDetails: mockSwapDetails as VeloraSwapDetails,
+				swapDetails: mockSwapDetails,
 				receiveAmount: BigInt(1000),
-				isGasless: false,
-				destinationNetwork: SEPOLIA_NETWORK
+				isGasless: false
 			});
 
 			expect(mockProgress).toHaveBeenCalledTimes(2);
@@ -1615,12 +1601,7 @@ describe('swap.services', () => {
 		});
 
 		it('should track SWAP_OFFER with delta event type on successful delta quote', async () => {
-			mockGetQuote.mockResolvedValue({
-				delta: {
-					destAmount: '123',
-					bridge: { scalingFactor: 0 }
-				}
-			});
+			mockGetQuote.mockResolvedValue({ delta: mockVeloraDeltaPrice });
 
 			await fetchVeloraSwapAmount({
 				sourceToken,
@@ -1692,13 +1673,8 @@ describe('swap.services', () => {
 			});
 		});
 
-		it('should track bridge info in delta swap', async () => {
-			mockGetQuote.mockResolvedValue({
-				delta: {
-					destAmount: '123',
-					bridgeInfo: { destAmountAfterBridge: '949920' }
-				}
-			});
+		it('should track a cross-chain delta swap', async () => {
+			mockGetQuote.mockResolvedValue(mockVeloraCrossChainSwapResponse);
 
 			await fetchVeloraSwapAmount({
 				sourceToken,

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -12,7 +12,9 @@ import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import { setCustomToken } from '$lib/api/backend.api';
 import * as icpSwapPool from '$lib/api/icp-swap-pool.api';
 import * as kongBackendApi from '$lib/api/kong_backend.api';
+import { signPrehash } from '$lib/api/signer.api';
 import { ZERO } from '$lib/constants/app.constants';
+import { SWAP_DELTA_INTERVAL_MS, SWAP_DELTA_TIMEOUT_MS } from '$lib/constants/swap.constants';
 import { PLAUSIBLE_EVENTS, PLAUSIBLE_EVENT_CONTEXTS } from '$lib/enums/plausible';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
@@ -146,14 +148,16 @@ vi.mock('$sol/services/sol-send.services', () => ({
 	sendSol: vi.fn()
 }));
 
-vi.mock('@velora-dex/sdk', () => ({
-	constructSimpleSDK: vi.fn(),
-	OrderHelpers: {
-		checks: {
-			isCompletedAuction: ({ status }: { status: string }) => status === 'COMPLETED'
-		}
-	}
-}));
+// `OrderHelpers` stays real: its status predicates are pure, and re-implementing them here would
+// let the test disagree with the SDK about which statuses are terminal failures.
+vi.mock('@velora-dex/sdk', async (importOriginal) => {
+	const actual = await importOriginal();
+
+	return {
+		...(actual as Record<string, unknown>),
+		constructSimpleSDK: vi.fn()
+	};
+});
 
 vi.mock('$eth/services/approve.services', () => ({
 	approve: vi.fn(),
@@ -929,8 +933,10 @@ describe('swap.services', () => {
 				mockSdk as unknown as ReturnType<typeof constructSimpleSDK>
 			);
 			mockDeltaContractGetDeltaContract.mockResolvedValue(mockDeltaContract);
+			// destAmount mirrors what the server would build from the mock quote's origin output
+			// (900000000) at the default 0.5% slippage.
 			mockDeltaContractBuildDeltaOrder.mockResolvedValue({
-				toSign: { domain: {}, types: {}, value: { order: 'mock-order-data' } },
+				toSign: { domain: {}, types: {}, value: { destAmount: '895500000' } },
 				orderHash: 'mock-order-hash'
 			});
 			mockDeltaContractPostDeltaOrder.mockResolvedValue({ id: 'mock-auction-id' });
@@ -1069,6 +1075,12 @@ describe('swap.services', () => {
 		});
 
 		it('rounds the slippage to integer basis points when building the order', async () => {
+			// 29 bps on the mock quote's origin output (900000000) → minimum 897390000.
+			mockDeltaContractBuildDeltaOrder.mockResolvedValue({
+				toSign: { domain: {}, types: {}, value: { destAmount: '897390000' } },
+				orderHash: 'mock-order-hash'
+			});
+
 			await fetchVeloraDeltaSwap({
 				identity: mockIdentity,
 				progress: mockProgress,
@@ -1090,6 +1102,150 @@ describe('swap.services', () => {
 			expect(mockDeltaContractBuildDeltaOrder).toHaveBeenCalledWith(
 				expect.objectContaining({ slippage: 29 })
 			);
+		});
+
+		it('refuses to sign an order whose destAmount is below the slippage minimum', async () => {
+			// The server-built minimum guarantees less than the quoted origin output (900000000)
+			// minus the 0.5% slippage the user accepted (895500000).
+			mockDeltaContractBuildDeltaOrder.mockResolvedValue({
+				toSign: { domain: {}, types: {}, value: { destAmount: '895499999' } },
+				orderHash: 'mock-order-hash'
+			});
+
+			await expect(
+				fetchVeloraDeltaSwap({
+					identity: mockIdentity,
+					progress: mockProgress,
+					sourceToken: mockSourceToken,
+					destinationToken: mockDestinationToken,
+					swapAmount: mockSwapAmount,
+					sourceNetwork: mockSourceNetwork,
+					receiveAmount: mockReceiveAmount,
+					slippageValue: mockSlippageValue,
+					userAddress: mockUserAddress,
+					gas: BigInt(mockGas),
+					isGasless: false,
+					maxFeePerGas: BigInt(mockMaxFeePerGas),
+					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+					swapDetails: mockSwapDetails
+				})
+			).rejects.toThrow(
+				// The `Slippage exceeded.` prefix is what the wizards match to show the slippage hint.
+				'Slippage exceeded. Velora returned 895499999, expected at least 895500000.'
+			);
+
+			expect(signPrehash).not.toHaveBeenCalled();
+			expect(mockDeltaContractPostDeltaOrder).not.toHaveBeenCalled();
+		});
+
+		it.each(['FAILED', 'EXPIRED', 'CANCELLED', 'REFUNDED', 'REFUNDING'])(
+			'throws instead of reporting success when the order ends up %s',
+			async (status) => {
+				mockDeltaContractGetDeltaOrderById.mockResolvedValue({ status });
+
+				await expect(
+					fetchVeloraDeltaSwap({
+						identity: mockIdentity,
+						progress: mockProgress,
+						sourceToken: mockSourceToken,
+						destinationToken: mockDestinationToken,
+						swapAmount: mockSwapAmount,
+						sourceNetwork: mockSourceNetwork,
+						receiveAmount: mockReceiveAmount,
+						slippageValue: mockSlippageValue,
+						userAddress: mockUserAddress,
+						gas: BigInt(mockGas),
+						isGasless: false,
+						maxFeePerGas: BigInt(mockMaxFeePerGas),
+						maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+						swapDetails: mockSwapDetails
+					})
+				).rejects.toThrow(`Velora Delta swap ${status.toLowerCase()} (order mock-auction-id)`);
+
+				// A terminal failure never recovers, so polling stops on the first read.
+				expect(mockDeltaContractGetDeltaOrderById).toHaveBeenCalledOnce();
+				expect(mockProgress).not.toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
+			}
+		);
+
+		it('keeps polling through transient statuses and surfaces the terminal failure', async () => {
+			vi.useFakeTimers();
+
+			mockDeltaContractGetDeltaOrderById
+				.mockResolvedValueOnce({ status: 'ACTIVE' })
+				.mockResolvedValueOnce({ status: 'BRIDGING' })
+				.mockResolvedValueOnce({ status: 'SUSPENDED' })
+				.mockResolvedValueOnce({ status: 'CANCELLING' })
+				.mockResolvedValueOnce({ status: 'FAILED' });
+
+			try {
+				// The rejection is captured rather than asserted with `expect().rejects` so that the
+				// assertion can happen *after* virtual time advances — awaiting it up front would
+				// deadlock, since nothing settles until the poll interval elapses.
+				const settled = fetchVeloraDeltaSwap({
+					identity: mockIdentity,
+					progress: mockProgress,
+					sourceToken: mockSourceToken,
+					destinationToken: mockDestinationToken,
+					swapAmount: mockSwapAmount,
+					sourceNetwork: mockSourceNetwork,
+					receiveAmount: mockReceiveAmount,
+					slippageValue: mockSlippageValue,
+					userAddress: mockUserAddress,
+					gas: BigInt(mockGas),
+					isGasless: false,
+					maxFeePerGas: BigInt(mockMaxFeePerGas),
+					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+					swapDetails: mockSwapDetails
+				}).catch((err: unknown) => err);
+
+				await vi.advanceTimersByTimeAsync(4 * SWAP_DELTA_INTERVAL_MS);
+
+				await expect(settled).resolves.toEqual(
+					new Error('Velora Delta swap failed (order mock-auction-id)')
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+
+			expect(mockDeltaContractGetDeltaOrderById).toHaveBeenCalledTimes(5);
+			expect(mockProgress).not.toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
+		});
+
+		it('throws instead of reporting success when the order never settles before the timeout', async () => {
+			vi.useFakeTimers();
+
+			mockDeltaContractGetDeltaOrderById.mockResolvedValue({ status: 'ACTIVE' });
+
+			try {
+				// See the note above on capturing the rejection instead of awaiting `expect().rejects`.
+				const settled = fetchVeloraDeltaSwap({
+					identity: mockIdentity,
+					progress: mockProgress,
+					sourceToken: mockSourceToken,
+					destinationToken: mockDestinationToken,
+					swapAmount: mockSwapAmount,
+					sourceNetwork: mockSourceNetwork,
+					receiveAmount: mockReceiveAmount,
+					slippageValue: mockSlippageValue,
+					userAddress: mockUserAddress,
+					gas: BigInt(mockGas),
+					isGasless: false,
+					maxFeePerGas: BigInt(mockMaxFeePerGas),
+					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+					swapDetails: mockSwapDetails
+				}).catch((err: unknown) => err);
+
+				await vi.advanceTimersByTimeAsync(SWAP_DELTA_TIMEOUT_MS + SWAP_DELTA_INTERVAL_MS);
+
+				await expect(settled).resolves.toEqual(
+					new Error('Velora Delta swap timed out (order mock-auction-id)')
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+
+			expect(mockProgress).not.toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -1067,6 +1067,30 @@ describe('swap.services', () => {
 
 			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
 		});
+
+		it('rounds the slippage to integer basis points when building the order', async () => {
+			await fetchVeloraDeltaSwap({
+				identity: mockIdentity,
+				progress: mockProgress,
+				sourceToken: mockSourceToken,
+				destinationToken: mockDestinationToken,
+				swapAmount: mockSwapAmount,
+				sourceNetwork: mockSourceNetwork,
+				receiveAmount: mockReceiveAmount,
+				// 0.29 * 100 === 28.999999999999996 in IEEE-754 — must reach the SDK as 29
+				slippageValue: '0.29',
+				userAddress: mockUserAddress,
+				gas: BigInt(mockGas),
+				isGasless: false,
+				maxFeePerGas: BigInt(mockMaxFeePerGas),
+				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+				swapDetails: mockSwapDetails
+			});
+
+			expect(mockDeltaContractBuildDeltaOrder).toHaveBeenCalledWith(
+				expect.objectContaining({ slippage: 29 })
+			);
+		});
 	});
 
 	describe('fetchVeloraMarketSwap', () => {
@@ -1186,6 +1210,28 @@ describe('swap.services', () => {
 
 			expect(mockSwapGetSpender).toHaveBeenCalled();
 			expect(mockSwapBuildTx).toHaveBeenCalled();
+		});
+
+		it('rounds the slippage to integer basis points when building the transaction', async () => {
+			await fetchVeloraMarketSwap({
+				identity: mockIdentity,
+				progress: mockProgress,
+				sourceToken: mockSourceToken,
+				destinationToken: mockDestinationToken,
+				swapAmount: mockSwapAmount,
+				sourceNetwork: mockSourceNetwork,
+				// 0.29 * 100 === 28.999999999999996 in IEEE-754 — must reach the SDK as 29
+				slippageValue: '0.29',
+				userAddress: mockUserAddress,
+				gas: BigInt(mockGas),
+				maxFeePerGas: BigInt(mockMaxFeePerGas),
+				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+				swapDetails: mockSwapDetails,
+				receiveAmount: BigInt(1000),
+				isGasless: false
+			});
+
+			expect(mockSwapBuildTx).toHaveBeenCalledWith(expect.objectContaining({ slippage: 29 }));
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -1,6 +1,6 @@
 import type { PoolMetadata } from '$declarations/icp_swap_pool/icp_swap_pool.did';
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
-import { ETHEREUM_NETWORK, SEPOLIA_NETWORK } from '$env/networks/networks.eth.env';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { createPermit } from '$eth/services/eip2612-permit.services';
 import { loadCustomTokens as loadCustomErc20Tokens } from '$eth/services/erc20.services';
 import { send as sendEvm } from '$eth/services/send.services';
@@ -39,7 +39,7 @@ import { exchangeStore } from '$lib/stores/exchange.store';
 import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
 import type { ICPSwapAmountReply } from '$lib/types/api';
 import type { NearIntentsQuoteResponse } from '$lib/types/near-intents';
-import { SwapErrorCodes, SwapProvider, type VeloraSwapDetails } from '$lib/types/swap';
+import { SwapErrorCodes, SwapProvider } from '$lib/types/swap';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { sendSol } from '$sol/services/sol-send.services';
 import { loadCustomTokens as loadCustomSplTokens } from '$sol/services/spl.services';
@@ -54,8 +54,12 @@ import { mockNearIntentsQuoteResponse } from '$tests/mocks/near-intents.mock';
 import { mockSolSignature } from '$tests/mocks/sol-signatures.mock';
 import { mockSolAddress } from '$tests/mocks/sol.mock';
 import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
-import { mockVeloraSwapDetails } from '$tests/mocks/velora.mock';
-import { constructSimpleSDK } from '@velora-dex/sdk';
+import {
+	mockVeloraCrossChainSwapResponse,
+	mockVeloraDeltaPrice,
+	mockVeloraOptimalRate
+} from '$tests/mocks/velora.mock';
+import { constructSimpleSDK, type DeltaPrice, type OptimalRate } from '@velora-dex/sdk';
 import { get } from 'svelte/store';
 
 vi.mock('$icp/api/icrc-ledger.api', () => ({
@@ -136,7 +140,12 @@ vi.mock('$sol/services/sol-send.services', () => ({
 }));
 
 vi.mock('@velora-dex/sdk', () => ({
-	constructSimpleSDK: vi.fn()
+	constructSimpleSDK: vi.fn(),
+	OrderHelpers: {
+		checks: {
+			isCompletedAuction: ({ status }: { status: string }) => status === 'COMPLETED'
+		}
+	}
 }));
 
 vi.mock('$eth/services/approve.services', () => ({
@@ -860,14 +869,13 @@ describe('swap.services', () => {
 		const mockReceiveAmount = 900000000n; // 0.9 DST
 		const mockSlippageValue = '0.5';
 		const mockSourceNetwork = ETHEREUM_NETWORK;
-		const mockDestinationNetwork = SEPOLIA_NETWORK;
 		const mockUserAddress = mockEthAddress;
 		const mockGas = '21000';
 		const mockMaxFeePerGas = '20000000000';
 		const mockMaxPriorityFeePerGas = '2000000000';
 
-		const mockSwapDetails: VeloraSwapDetails = {
-			...mockVeloraSwapDetails
+		const mockSwapDetails: DeltaPrice = {
+			...mockVeloraDeltaPrice
 		};
 
 		const mockProgress = vi.fn();
@@ -915,13 +923,11 @@ describe('swap.services', () => {
 			);
 			mockDeltaContractGetDeltaContract.mockResolvedValue(mockDeltaContract);
 			mockDeltaContractBuildDeltaOrder.mockResolvedValue({
-				data: { order: 'mock-order-data' }
+				toSign: { domain: {}, types: {}, value: { order: 'mock-order-data' } },
+				orderHash: 'mock-order-hash'
 			});
 			mockDeltaContractPostDeltaOrder.mockResolvedValue({ id: 'mock-auction-id' });
-			mockDeltaContractGetDeltaOrderById.mockResolvedValue({
-				status: 'EXECUTED',
-				order: { bridge: { destinationChainId: 0 } }
-			});
+			mockDeltaContractGetDeltaOrderById.mockResolvedValue({ status: 'COMPLETED' });
 
 			vi.mocked(createPermit).mockResolvedValue({
 				nonce: '0',
@@ -940,7 +946,6 @@ describe('swap.services', () => {
 				sourceNetwork: mockSourceNetwork,
 				receiveAmount: mockReceiveAmount,
 				slippageValue: mockSlippageValue,
-				destinationNetwork: mockDestinationNetwork,
 				userAddress: mockUserAddress,
 				gas: BigInt(mockGas),
 				isGasless: false,
@@ -970,7 +975,6 @@ describe('swap.services', () => {
 					sourceNetwork: mockSourceNetwork,
 					receiveAmount: mockReceiveAmount,
 					slippageValue: mockSlippageValue,
-					destinationNetwork: mockDestinationNetwork,
 					userAddress: mockUserAddress,
 					gas: BigInt(mockGas),
 					isGasless: false,
@@ -993,7 +997,6 @@ describe('swap.services', () => {
 				sourceNetwork: mockSourceNetwork,
 				receiveAmount: mockReceiveAmount,
 				slippageValue: mockSlippageValue,
-				destinationNetwork: mockDestinationNetwork,
 				userAddress: mockUserAddress,
 				gas: BigInt(mockGas),
 				isGasless: true,
@@ -1018,7 +1021,6 @@ describe('swap.services', () => {
 				sourceNetwork: mockSourceNetwork,
 				receiveAmount: mockReceiveAmount,
 				slippageValue: mockSlippageValue,
-				destinationNetwork: mockDestinationNetwork,
 				userAddress: mockUserAddress,
 				gas: BigInt(mockGas),
 				isGasless: false,
@@ -1031,11 +1033,12 @@ describe('swap.services', () => {
 			expect(mockDeltaContractPostDeltaOrder).not.toHaveBeenCalled();
 		});
 
-		it('should handle cross-chain bridge execution', async () => {
+		it('should treat a cross-chain order as settled only once it reports COMPLETED', async () => {
+			// A cross-chain order stays `BRIDGING` until the destination leg lands, so `COMPLETED`
+			// on its own means settled on every chain — no separate bridge check is needed.
 			mockDeltaContractGetDeltaOrderById.mockResolvedValue({
-				status: 'EXECUTED',
-				order: { bridge: { destinationChainId: 1 } },
-				bridgeStatus: 'filled'
+				status: 'COMPLETED',
+				transactions: [{ originTx: '0xorigin', destinationTx: '0xdestination' }]
 			});
 
 			await fetchVeloraDeltaSwap({
@@ -1047,7 +1050,6 @@ describe('swap.services', () => {
 				sourceNetwork: mockSourceNetwork,
 				receiveAmount: mockReceiveAmount,
 				slippageValue: mockSlippageValue,
-				destinationNetwork: mockDestinationNetwork,
 				userAddress: mockUserAddress,
 				gas: BigInt(mockGas),
 				isGasless: false,
@@ -1082,22 +1084,8 @@ describe('swap.services', () => {
 		const mockMaxFeePerGas = '20000000000';
 		const mockMaxPriorityFeePerGas = '2000000000';
 
-		const mockSwapDetails = {
-			srcToken: mockEthAddress,
-			destToken: '0xDestinationToken',
-			srcAmount: '1000000000000000000',
-			destAmount: '900000000',
-			destAmountBeforeFee: '920000000',
-			gasCost: '50000',
-			gasCostBeforeFee: '48000',
-			gasCostUSD: '15.5',
-			gasCostUSDBeforeFee: '14.8',
-			srcUSD: '1000.0',
-			destUSD: '895.5',
-			destUSDBeforeFee: '915.2',
-			partner: 'PartnerName',
-			partnerFee: 0.25,
-			hmac: 'abcd1234'
+		const mockSwapDetails: OptimalRate = {
+			...mockVeloraOptimalRate
 		};
 
 		const mockProgress = vi.fn();
@@ -1153,10 +1141,9 @@ describe('swap.services', () => {
 				gas: BigInt(mockGas),
 				maxFeePerGas: BigInt(mockMaxFeePerGas),
 				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
-				swapDetails: mockSwapDetails as VeloraSwapDetails,
+				swapDetails: mockSwapDetails,
 				receiveAmount: BigInt(1000),
-				isGasless: false,
-				destinationNetwork: SEPOLIA_NETWORK
+				isGasless: false
 			});
 
 			expect(mockProgress).toHaveBeenCalledTimes(2);
@@ -1181,10 +1168,9 @@ describe('swap.services', () => {
 				gas: BigInt(mockGas),
 				maxFeePerGas: BigInt(mockMaxFeePerGas),
 				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
-				swapDetails: mockSwapDetails as VeloraSwapDetails,
+				swapDetails: mockSwapDetails,
 				receiveAmount: BigInt(1000),
-				isGasless: false,
-				destinationNetwork: SEPOLIA_NETWORK
+				isGasless: false
 			});
 
 			expect(mockProgress).toHaveBeenCalledTimes(2);
@@ -1608,12 +1594,7 @@ describe('swap.services', () => {
 		});
 
 		it('should track SWAP_OFFER with delta event type on successful delta quote', async () => {
-			mockGetQuote.mockResolvedValue({
-				delta: {
-					destAmount: '123',
-					bridge: { scalingFactor: 0 }
-				}
-			});
+			mockGetQuote.mockResolvedValue({ delta: mockVeloraDeltaPrice });
 
 			await fetchVeloraSwapAmount({
 				sourceToken,
@@ -1685,13 +1666,8 @@ describe('swap.services', () => {
 			});
 		});
 
-		it('should track bridge info in delta swap', async () => {
-			mockGetQuote.mockResolvedValue({
-				delta: {
-					destAmount: '123',
-					bridgeInfo: { destAmountAfterBridge: '949920' }
-				}
-			});
+		it('should track a cross-chain delta swap', async () => {
+			mockGetQuote.mockResolvedValue(mockVeloraCrossChainSwapResponse);
 
 			await fetchVeloraSwapAmount({
 				sourceToken,

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -1060,6 +1060,30 @@ describe('swap.services', () => {
 
 			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
 		});
+
+		it('rounds the slippage to integer basis points when building the order', async () => {
+			await fetchVeloraDeltaSwap({
+				identity: mockIdentity,
+				progress: mockProgress,
+				sourceToken: mockSourceToken,
+				destinationToken: mockDestinationToken,
+				swapAmount: mockSwapAmount,
+				sourceNetwork: mockSourceNetwork,
+				receiveAmount: mockReceiveAmount,
+				// 0.29 * 100 === 28.999999999999996 in IEEE-754 — must reach the SDK as 29
+				slippageValue: '0.29',
+				userAddress: mockUserAddress,
+				gas: BigInt(mockGas),
+				isGasless: false,
+				maxFeePerGas: BigInt(mockMaxFeePerGas),
+				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+				swapDetails: mockSwapDetails
+			});
+
+			expect(mockDeltaContractBuildDeltaOrder).toHaveBeenCalledWith(
+				expect.objectContaining({ slippage: 29 })
+			);
+		});
 	});
 
 	describe('fetchVeloraMarketSwap', () => {
@@ -1179,6 +1203,28 @@ describe('swap.services', () => {
 
 			expect(mockSwapGetSpender).toHaveBeenCalled();
 			expect(mockSwapBuildTx).toHaveBeenCalled();
+		});
+
+		it('rounds the slippage to integer basis points when building the transaction', async () => {
+			await fetchVeloraMarketSwap({
+				identity: mockIdentity,
+				progress: mockProgress,
+				sourceToken: mockSourceToken,
+				destinationToken: mockDestinationToken,
+				swapAmount: mockSwapAmount,
+				sourceNetwork: mockSourceNetwork,
+				// 0.29 * 100 === 28.999999999999996 in IEEE-754 — must reach the SDK as 29
+				slippageValue: '0.29',
+				userAddress: mockUserAddress,
+				gas: BigInt(mockGas),
+				maxFeePerGas: BigInt(mockMaxFeePerGas),
+				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+				swapDetails: mockSwapDetails,
+				receiveAmount: BigInt(1000),
+				isGasless: false
+			});
+
+			expect(mockSwapBuildTx).toHaveBeenCalledWith(expect.objectContaining({ slippage: 29 }));
 		});
 	});
 

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -60,7 +60,7 @@ import {
 } from '$tests/mocks/near-intents.mock';
 import { mockTokens } from '$tests/mocks/tokens.mock';
 import {
-	mockVeloraBridgeSwapResponse,
+	mockVeloraCrossChainSwapResponse,
 	mockVeloraDeltaSwapResponse
 } from '$tests/mocks/velora.mock';
 import type { OptimalRate, SwapSide } from '@velora-dex/sdk';
@@ -406,7 +406,7 @@ describe('swap utils', () => {
 	});
 
 	describe('mapVeloraSwapResult', () => {
-		it('should map DeltaPrice swap result correctly (without bridgeInfo)', () => {
+		it('should map a same-chain DeltaPrice result correctly', () => {
 			const mockDeltaSwap: DeltaSwapResponse = {
 				...mockVeloraDeltaSwapResponse
 			};
@@ -414,21 +414,22 @@ describe('swap utils', () => {
 			const result = mapVeloraSwapResult(mockDeltaSwap);
 
 			expect(result.provider).toBe(SwapProvider.VELORA);
-			expect(result.receiveAmount).toBe(900n);
+			expect(result.receiveAmount).toBe(900000000n);
 			expect(result.swapDetails).toBe(mockDeltaSwap.delta);
 			expect(result.type).toBe(VeloraSwapTypes.DELTA);
 		});
 
-		it('should map BridgePrice swap result correctly (with bridgeInfo)', () => {
-			const mockBridgeSwap: DeltaSwapResponse = {
-				...mockVeloraBridgeSwapResponse
+		it('should read the destination step of a cross-chain route, not the origin one', () => {
+			const mockCrossChainSwap: DeltaSwapResponse = {
+				...mockVeloraCrossChainSwapResponse
 			};
 
-			const result = mapVeloraSwapResult(mockBridgeSwap);
+			const result = mapVeloraSwapResult(mockCrossChainSwap);
 
-			expect(result.provider).toBe(SwapProvider.VELORA);
-			expect(result.receiveAmount).toBe(800n);
-			expect(result.swapDetails).toBe(mockBridgeSwap.delta);
+			// The origin step is denominated in the 18-decimal source token; only the destination
+			// step carries the amount in the 6-decimal destination token.
+			expect(result.receiveAmount).toBe(99976241n);
+			expect(result.swapDetails).toBe(mockCrossChainSwap.delta);
 			expect(result.type).toBe(VeloraSwapTypes.DELTA);
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -354,6 +354,12 @@ describe('swap utils', () => {
 			expect(slippagePercentToBasisPoints('1.0099')).toBe(100);
 		});
 
+		it('floors values finer than the slippage input allows instead of rounding them up', () => {
+			// The invariant must hold even for a value that bypassed the input's decimal limit
+			expect(slippagePercentToBasisPoints('1.0051')).toBe(100);
+			expect(slippagePercentToBasisPoints(0.123456)).toBe(12);
+		});
+
 		it('survives IEEE-754 noise in the percent conversion', () => {
 			// 0.29 * 100 === 28.999999999999996 — a bare floor would drop a whole basis point
 			expect(slippagePercentToBasisPoints('0.29')).toBe(29);

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -47,7 +47,8 @@ import {
 	mapVeloraMarketSwapResult,
 	mapVeloraSwapResult,
 	resolveNearIntentsBlockchain,
-	resolveNearIntentsSwapAssets
+	resolveNearIntentsSwapAssets,
+	slippagePercentToBasisPoints
 } from '$lib/utils/swap.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
 import type { SplToken } from '$sol/types/spl';
@@ -338,6 +339,34 @@ describe('swap utils', () => {
 
 		it('returns 0 for full slippage (100%)', () => {
 			expect(calculateSlippage({ quoteAmount: 12345n, slippagePercentage: 100 })).toBe(ZERO);
+		});
+	});
+
+	describe('slippagePercentToBasisPoints', () => {
+		it('converts whole and fractional percentages to basis points', () => {
+			expect(slippagePercentToBasisPoints(1)).toBe(100);
+			expect(slippagePercentToBasisPoints('0.5')).toBe(50);
+			expect(slippagePercentToBasisPoints(1.5)).toBe(150);
+		});
+
+		it('floors fractional basis points instead of rounding them up', () => {
+			expect(slippagePercentToBasisPoints(1.005)).toBe(100);
+			expect(slippagePercentToBasisPoints('1.0099')).toBe(100);
+		});
+
+		it('survives IEEE-754 noise in the percent conversion', () => {
+			// 0.29 * 100 === 28.999999999999996 — a bare floor would drop a whole basis point
+			expect(slippagePercentToBasisPoints('0.29')).toBe(29);
+			expect(slippagePercentToBasisPoints(0.29)).toBe(29);
+		});
+
+		it('takes the absolute value of a negative slippage', () => {
+			expect(slippagePercentToBasisPoints(-1.005)).toBe(100);
+			expect(slippagePercentToBasisPoints('-0.29')).toBe(29);
+		});
+
+		it('returns 0 for zero slippage', () => {
+			expect(slippagePercentToBasisPoints(0)).toBe(0);
 		});
 	});
 

--- a/src/frontend/src/tests/mocks/swap.mocks.ts
+++ b/src/frontend/src/tests/mocks/swap.mocks.ts
@@ -3,7 +3,7 @@ import type { IcToken } from '$icp/types/ic-token';
 import type { NearIntentsQuoteResponse } from '$lib/types/near-intents';
 import { SwapProvider, VeloraSwapTypes, type SwapMappedResult } from '$lib/types/swap';
 import { mockNearIntentsQuoteResponse } from '$tests/mocks/near-intents.mock';
-import { mockVeloraSwapDetails } from '$tests/mocks/velora.mock';
+import { mockVeloraDeltaPrice, mockVeloraOptimalRate } from '$tests/mocks/velora.mock';
 
 export const mockSwapProviders: SwapMappedResult[] = [
 	{
@@ -35,7 +35,7 @@ export const mockVeloraMarketProvider: SwapMappedResult = {
 	provider: SwapProvider.VELORA,
 	receiveAmount: 900000000n,
 	receiveOutMinimum: 891000000n,
-	swapDetails: mockVeloraSwapDetails,
+	swapDetails: mockVeloraOptimalRate,
 	type: VeloraSwapTypes.MARKET
 };
 
@@ -43,7 +43,7 @@ export const mockVeloraDeltaProvider: SwapMappedResult = {
 	provider: SwapProvider.VELORA,
 	receiveAmount: 900000000n,
 	receiveOutMinimum: 891000000n,
-	swapDetails: mockVeloraSwapDetails,
+	swapDetails: mockVeloraDeltaPrice,
 	type: VeloraSwapTypes.DELTA
 };
 

--- a/src/frontend/src/tests/mocks/velora.mock.ts
+++ b/src/frontend/src/tests/mocks/velora.mock.ts
@@ -1,84 +1,122 @@
-import type { DeltaSwapResponse, VeloraSwapDetails } from '$lib/types/swap';
+import type { DeltaSwapResponse } from '$lib/types/swap';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { SwapSide } from '@paraswap/core/src/constants';
 import { ParaSwapVersion } from '@paraswap/core/src/types';
-import type { Bridge, BridgePrice, DeltaPrice, OptimalRate } from '@velora-dex/sdk';
+import type { DeltaPrice, DeltaRoute, OptimalRate } from '@velora-dex/sdk';
 
-const mockVeloraDeltaPrice: DeltaPrice = {
-	srcToken: mockEthAddress,
-	destToken: '0xDestinationToken',
-	srcAmount: '1000000000000000000',
-	destAmount: '900000000',
-	destAmountBeforeFee: '920000000',
-	receivedDestAmount: '890000000',
-	receivedDestUSD: '910000000',
-	gasCost: '50000',
-	gasCostBeforeFee: '48000',
-	gasCostUSD: '15.5',
-	gasCostUSDBeforeFee: '14.8',
-	srcUSD: '1000.0',
-	destUSD: '895.5',
-	destUSDBeforeFee: '915.2',
-	partner: 'PartnerName',
-	partnerFee: 0.25,
-	hmac: 'abcd1234',
-	bridge: {
-		destinationChainId: 1,
-		outputToken: '0xoutput456',
-		protocolSelector: 'bridge_protocol',
-		scalingFactor: 1000000,
-		protocolData: '0xprotocol_data'
+const ETHEREUM_CHAIN_ID = 1;
+const BSC_CHAIN_ID = 56;
+const BASE_CHAIN_ID = 8453;
+
+const mockDestinationToken = '0xDestinationToken';
+
+const mockVeloraSameChainRoute: DeltaRoute = {
+	origin: {
+		input: {
+			token: { chainId: ETHEREUM_CHAIN_ID, address: mockEthAddress },
+			amount: '1000000000000000000',
+			amountUSD: '1000.0'
+		},
+		output: {
+			token: { chainId: ETHEREUM_CHAIN_ID, address: mockDestinationToken },
+			amount: '900000000',
+			amountUSD: '895.5'
+		}
+	},
+	destination: {
+		input: {
+			token: { chainId: ETHEREUM_CHAIN_ID, address: mockDestinationToken },
+			amount: '900000000',
+			amountUSD: '895.5'
+		},
+		output: {
+			token: { chainId: ETHEREUM_CHAIN_ID, address: mockDestinationToken },
+			amount: '900000000',
+			amountUSD: '895.5'
+		}
+	},
+	bridge: null,
+	fees: {
+		gas: {
+			token: { chainId: ETHEREUM_CHAIN_ID, address: mockEthAddress },
+			amount: '50000',
+			amountUSD: '15.5'
+		},
+		bridge: []
 	}
 };
 
-const mockVeloraBridgePrice: BridgePrice = {
-	srcToken: mockEthAddress,
-	destToken: '0xDestinationToken',
-	srcAmount: '1000000000000000000',
-	destAmount: '900000000',
-	destAmountBeforeFee: '920000000',
-	receivedDestAmount: '890000000',
-	receivedDestUSD: '910000000',
-	gasCost: '50000',
-	gasCostBeforeFee: '48000',
-	gasCostUSD: '15.5',
-	gasCostUSDBeforeFee: '14.8',
-	srcUSD: '1000.0',
-	destUSD: '895.5',
-	destUSDBeforeFee: '915.2',
-	partner: 'PartnerName',
-	partnerFee: 0.25,
-	hmac: 'abcd1234',
+/**
+ * Cross-chain route whose two tokens have different decimals — USDC-BSC (18) to USDC-BASE (6).
+ * The origin step stays in source precision while the destination step is denominated in the
+ * destination token, which is what the quote mappers must read.
+ */
+const mockVeloraCrossChainRoute: DeltaRoute = {
+	origin: {
+		input: {
+			token: { chainId: BSC_CHAIN_ID, address: mockEthAddress },
+			amount: '100000000000000000000',
+			amountUSD: '99.97'
+		},
+		output: {
+			token: { chainId: BSC_CHAIN_ID, address: mockEthAddress },
+			amount: '99988851655496648995',
+			amountUSD: '99.958855'
+		}
+	},
+	destination: {
+		input: {
+			token: { chainId: BASE_CHAIN_ID, address: mockDestinationToken },
+			amount: '99976241',
+			amountUSD: '99.955845'
+		},
+		output: {
+			token: { chainId: BASE_CHAIN_ID, address: mockDestinationToken },
+			amount: '99976241',
+			amountUSD: '99.955845'
+		}
+	},
 	bridge: {
-		destinationChainId: 1,
-		outputToken: '0xoutput456',
-		protocolSelector: 'bridge_protocol',
-		scalingFactor: 1000000,
-		protocolData: '0xprotocol_data'
+		protocol: 'Across',
+		estimatedTimeMs: 2000,
+		tags: ['recommended'],
+		contractParams: {
+			protocolSelector: '0x2e09f389',
+			outputToken: mockDestinationToken,
+			scalingFactor: -12,
+			protocolData: '0xprotocol_data'
+		}
 	},
-	bridgeInfo: {
-		destAmountAfterBridge: '800000000',
-		destUSDAfterBridge: '795.0',
-		protocolName: 'Canonical',
-		fees: [
+	fees: {
+		gas: {
+			token: { chainId: BSC_CHAIN_ID, address: mockEthAddress },
+			amount: '355400',
+			amountUSD: '0.011145'
+		},
+		bridge: [
 			{
-				amount: '50',
-				feeToken: '0xoutput456',
-				amountInSrcToken: '50',
-				amountInUSD: '50.0'
+				token: { chainId: BASE_CHAIN_ID, address: mockEthAddress },
+				amount: '12602570924468607',
+				amountUSD: '0.0126'
 			}
-		],
-		estimatedTimeMs: 300000,
-		fastest: true,
-		bestReturn: true,
-		recommended: true
-	},
-	availableBridges: []
+		]
+	}
 };
 
-const mockVeloraOptimalRate: OptimalRate = {
+export const mockVeloraDeltaPrice: DeltaPrice = {
+	id: '204d3a61-693f-43ce-9658-6fe3a4c36c81',
+	side: 'SELL',
+	inputToken: { chainId: ETHEREUM_CHAIN_ID, address: mockEthAddress },
+	outputToken: { chainId: ETHEREUM_CHAIN_ID, address: mockDestinationToken },
+	route: mockVeloraSameChainRoute,
+	partner: { name: 'PartnerName', feePercent: 0.25 },
+	spender: '0xDeltaSpender',
+	alternatives: []
+};
+
+export const mockVeloraOptimalRate: OptimalRate = {
 	srcToken: mockEthAddress,
-	destToken: '0xDestinationToken',
+	destToken: mockDestinationToken,
 	srcAmount: '1000000000000000000',
 	destAmount: '900000000',
 	gasCost: '50000',
@@ -89,7 +127,7 @@ const mockVeloraOptimalRate: OptimalRate = {
 	partnerFee: 0.25,
 	hmac: 'abcd1234',
 	blockNumber: 12345,
-	network: 1,
+	network: ETHEREUM_CHAIN_ID,
 	srcDecimals: 18,
 	destDecimals: 6,
 	bestRoute: [
@@ -99,7 +137,7 @@ const mockVeloraOptimalRate: OptimalRate = {
 				{
 					srcToken: mockEthAddress,
 					srcDecimals: 18,
-					destToken: '0xDestinationToken',
+					destToken: mockDestinationToken,
 					destDecimals: 6,
 					swapExchanges: [
 						{
@@ -120,66 +158,15 @@ const mockVeloraOptimalRate: OptimalRate = {
 	contractAddress: '0xSwapContract'
 };
 
-export const mockVeloraSwapDetails: VeloraSwapDetails = {
-	...mockVeloraDeltaPrice,
-	...mockVeloraBridgePrice,
-	...mockVeloraOptimalRate
-} as VeloraSwapDetails;
-
 export const mockVeloraDeltaSwapResponse: DeltaSwapResponse = {
-	delta: {
-		srcToken: '0x123',
-		destToken: '0x456',
-		srcAmount: '1000',
-		destAmount: '900',
-		destAmountBeforeFee: '920',
-		receivedDestAmount: '890',
-		receivedDestUSD: '910',
-		gasCost: '50000',
-		gasCostBeforeFee: '48000',
-		gasCostUSD: '15.5',
-		gasCostUSDBeforeFee: '14.8',
-		srcUSD: '1000.0',
-		destUSD: '895.5',
-		destUSDBeforeFee: '915.2',
-		partner: 'PartnerName',
-		partnerFee: 0.25,
-		hmac: 'abcd1234',
-		bridge: {} as Bridge
-	},
-	deltaAddress: '0xdelta123'
+	delta: mockVeloraDeltaPrice
 };
 
-export const mockVeloraBridgeSwapResponse: DeltaSwapResponse = {
+export const mockVeloraCrossChainSwapResponse: DeltaSwapResponse = {
 	delta: {
-		srcToken: '0x123',
-		destToken: '0x456',
-		srcAmount: '1000',
-		destAmount: '900',
-		destAmountBeforeFee: '920',
-		receivedDestAmount: '890',
-		receivedDestUSD: '910',
-		gasCost: '50000',
-		gasCostBeforeFee: '48000',
-		gasCostUSD: '15.5',
-		gasCostUSDBeforeFee: '14.8',
-		srcUSD: '1000.0',
-		destUSD: '895.5',
-		destUSDBeforeFee: '915.2',
-		partner: 'PartnerName',
-		partnerFee: 0.25,
-		hmac: 'abcd1234',
-		bridge: {} as Bridge,
-		bridgeInfo: {
-			protocolName: 'Across',
-			destAmountAfterBridge: '800',
-			destUSDAfterBridge: '795.0',
-			fees: [],
-			estimatedTimeMs: 300000,
-			fastest: true,
-			bestReturn: true,
-			recommended: true
-		}
-	},
-	deltaAddress: '0xdelta123'
+		...mockVeloraDeltaPrice,
+		inputToken: { chainId: BSC_CHAIN_ID, address: mockEthAddress },
+		outputToken: { chainId: BASE_CHAIN_ID, address: mockDestinationToken },
+		route: mockVeloraCrossChainRoute
+	}
 };


### PR DESCRIPTION
# Motivation

`@velora-dex/sdk` v10 moves Delta swaps to Velora's route-based v2 API: order building is now server-side, cross-chain settlement is folded into the regular order lifecycle, and the v2 price response fixes the undocumented decimals scaling of bridged destination amounts that we previously worked around. Keeping up with the current major also keeps us on the API surface Velora actively maintains.


# Changes

- Bump `@velora-dex/sdk` `^9.5.3` → `^10.2.2`.
- **Delta order building** (`fetchVeloraDeltaSwap`): build orders from the quoted `route` + `side` + `slippage` (in bps) — the server computes the amounts. Removes the client-side `calculateSlippage` floor and the manual `srcAmount`/`destAmount`/`destChainId` parameters (the route already carries the destination chain).
- **Signing**: `SignableDeltaOrderData` → `BuiltDeltaOrder['toSign']` (`{ domain, types, value }`); `getSignParamsEIP712` re-derives the digest from the typed data as before, and `postDeltaOrder` submits `toSign.value` — the same flow as the SDK's own `submitDeltaOrder` orchestrator.
- **Order polling**: replace the custom `isExecutedDeltaAuction` (`EXECUTED` + `bridgeStatus === 'filled'`) with `OrderHelpers.checks.isCompletedAuction` — v10's `COMPLETED` status means settled on every chain, so cross-chain orders need no separate bridge check.
- **Receive amount**: read `route.destination.output.amount` (denominated in the destination token on the destination chain), replacing `destAmount` and the undocumented `bridgeInfo.destAmountAfterBridge` decimals workaround.
- **Types**: `VeloraSwapDetails` intersection → discriminated union (`DeltaPrice | OptimalRate` keyed by `VeloraSwapTypes`); split `SwapVeloraParams` into `SwapVeloraDeltaParams` / `SwapVeloraMarketParams`; `SwapEthWizard` narrows `swapDetails` per execution mode. Market flow is unchanged apart from the now-precise `OptimalRate` typing.
- Update tests and `velora.mock.ts` to the v10 quote/order/auction shapes.


# Tests

Updated.
