### PR TITLE
fix(frontend): show Harvest Autopilot data with disabled networks

### DIFF
--- a/src/frontend/src/eth/constants/harvest-autopilots.constants.ts
+++ b/src/frontend/src/eth/constants/harvest-autopilots.constants.ts
@@ -6,6 +6,10 @@ import { BAUTOPILOT_EURC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens
 import { BAUTOPILOT_USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_usdc.env';
 import { BAUTOPILOT_WETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.bautopilot_weth.env';
 import { MORPHOAUTOPILOT_USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc4626/tokens.morphoautopilot_usdc.env';
+import { ERC4626_TOKENS } from '$env/tokens/tokens.erc4626.env';
+import type { RequiredErc4626Token } from '$eth/types/erc4626';
+import type { RequiredEvmErc4626Token } from '$evm/types/erc4626';
+import { nonNullish } from '@dfinity/utils';
 
 export const HARVEST_AUTOPILOT_ADDRESSES = [
 	BAUTOPILOT_EURC_TOKEN.address.toLowerCase(),
@@ -19,3 +23,25 @@ export const HARVEST_AUTOPILOT_ADDRESSES = [
 ];
 
 export const HARVEST_AUTOPILOT_URL = 'https://app.harvest.finance/';
+
+// Every Autopilot vault the app ships with, unaffected by which networks the user enabled: the Earn
+// card advertises the opportunity, so it must describe Harvest even while its networks are off. The
+// address filter is inlined instead of reusing isTokenHarvestAutopilot to keep constants leaf-level.
+export const HARVEST_AUTOPILOT_TOKENS: (RequiredErc4626Token | RequiredEvmErc4626Token)[] =
+	ERC4626_TOKENS.filter(({ address }) =>
+		HARVEST_AUTOPILOT_ADDRESSES.includes(address.toLowerCase())
+	);
+
+export const HARVEST_AUTOPILOT_NETWORK_ICONS: string[] = [
+	...HARVEST_AUTOPILOT_TOKENS.reduce<Set<string>>(
+		(acc, { network: { icon } }) => (nonNullish(icon) ? acc.add(icon) : acc),
+		new Set()
+	)
+];
+
+export const HARVEST_AUTOPILOT_ASSET_ICONS: string[] = [
+	...HARVEST_AUTOPILOT_TOKENS.reduce<Set<string>>(
+		(acc, { assetIcon }) => (nonNullish(assetIcon) ? acc.add(assetIcon) : acc),
+		new Set()
+	)
+];

--- a/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
+++ b/src/frontend/src/eth/derived/harvest-autopilots.derived.ts
@@ -1,3 +1,4 @@
+import { HARVEST_AUTOPILOT_TOKENS } from '$eth/constants/harvest-autopilots.constants';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
@@ -49,13 +50,17 @@ export const harvestAutopilotsCurrentEarning: Readable<number> = derived(
 		)
 );
 
+// Deliberately sourced from the shipped vault list rather than from harvestAutopilots: the rate
+// Harvest offers does not depend on which networks the user enabled, and its only consumer is the
+// Earn card, which must keep advertising it when they are off.
 export const harvestAutopilotsMaxApy: Readable<string> = derived(
-	[harvestAutopilots],
-	([$harvestAutopilots]) =>
-		$harvestAutopilots.reduce<string>(
-			(acc, { apy }) => (nonNullish(apy) ? `${Math.max(Number(acc), Number(apy))}` : acc),
-			'0'
-		)
+	[harvestVaultsStore],
+	([$harvestVaultsStore]) =>
+		HARVEST_AUTOPILOT_TOKENS.reduce<string>((acc, { address }) => {
+			const apy = $harvestVaultsStore[address.toLowerCase()]?.estimatedApy;
+
+			return nonNullish(apy) ? `${Math.max(Number(acc), Number(apy))}` : acc;
+		}, '0')
 );
 
 export const harvestAutopilotsUsdBalance: Readable<number> = derived(

--- a/src/frontend/src/lib/derived/harvest-autopilot-earning.derived.ts
+++ b/src/frontend/src/lib/derived/harvest-autopilot-earning.derived.ts
@@ -1,8 +1,11 @@
 import { goto } from '$app/navigation';
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import {
+	HARVEST_AUTOPILOT_ASSET_ICONS,
+	HARVEST_AUTOPILOT_NETWORK_ICONS
+} from '$eth/constants/harvest-autopilots.constants';
+import {
 	enabledHarvestAutopilotsUsdBalance,
-	harvestAutopilots,
 	harvestAutopilotsCurrentEarning,
 	harvestAutopilotsMaxApy,
 	harvestAutopilotsUsdBalance
@@ -21,7 +24,6 @@ export const harvestAutopilotEarningData: Readable<EarningProviderData> = derive
 		harvestAutopilotsUsdBalance,
 		enabledHarvestAutopilotsUsdBalance,
 		harvestAutopilotsCurrentEarning,
-		harvestAutopilots,
 		harvestAutopilotsMaxApy
 	],
 	([
@@ -29,24 +31,13 @@ export const harvestAutopilotEarningData: Readable<EarningProviderData> = derive
 		$harvestAutopilotsUsdBalance,
 		$enabledHarvestAutopilotsUsdBalance,
 		$harvestAutopilotsCurrentEarning,
-		$harvestAutopilots,
 		$harvestAutopilotsMaxApy
 	]): EarningProviderData => ({
 		[EarningCardFields.APY]: $harvestAutopilotsMaxApy,
 		[EarningCardFields.CURRENT_EARNING]: $harvestAutopilotsCurrentEarning,
 		[EarningCardFields.CURRENT_STAKED]: $harvestAutopilotsUsdBalance,
-		[EarningCardFields.NETWORKS]: [
-			...$harvestAutopilots.reduce<Set<string>>(
-				(acc, { token: { network } }) => (nonNullish(network.icon) ? acc.add(network.icon) : acc),
-				new Set()
-			)
-		],
-		[EarningCardFields.ASSETS]: [
-			...$harvestAutopilots.reduce<Set<string>>(
-				(acc, { token: { assetIcon } }) => (nonNullish(assetIcon) ? acc.add(assetIcon) : acc),
-				new Set()
-			)
-		],
+		[EarningCardFields.NETWORKS]: HARVEST_AUTOPILOT_NETWORK_ICONS,
+		[EarningCardFields.ASSETS]: HARVEST_AUTOPILOT_ASSET_ICONS,
 		[EarningCardFields.EARNING_POTENTIAL]: nonNullish($enabledMainnetFungibleTokensUsdBalance)
 			? (($enabledMainnetFungibleTokensUsdBalance - $enabledHarvestAutopilotsUsdBalance) *
 					Number($harvestAutopilotsMaxApy)) /

--- a/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/harvest-autopilots.derived.spec.ts
@@ -133,10 +133,31 @@ describe('harvest-autopilots.derived', () => {
 	});
 
 	describe('harvestAutopilotsMaxApy', () => {
-		it('should return "0" when there are no autopilots', () => {
-			mockErc4626TokensStore([]);
+		it('should return "0" when no vault APY was loaded', () => {
+			mockErc4626TokensStore([mockHarvestToken]);
 
 			expect(get(harvestAutopilotsMaxApy)).toBe('0');
+		});
+
+		it('should return the highest APY across the shipped vaults', () => {
+			mockErc4626TokensStore([mockHarvestToken]);
+
+			harvestVaultsStore.set([
+				{ id: 'vault-1', vaultAddress: mockHarvestAddress, estimatedApy: '5.5' },
+				{ id: 'vault-2', vaultAddress: mockDisabledHarvestToken.address, estimatedApy: '12.25' }
+			]);
+
+			expect(get(harvestAutopilotsMaxApy)).toBe('12.3');
+		});
+
+		it('should return the APY even when no autopilot network is enabled', () => {
+			mockErc4626TokensStore([]);
+
+			harvestVaultsStore.set([
+				{ id: 'vault-1', vaultAddress: mockHarvestAddress, estimatedApy: '5.5' }
+			]);
+
+			expect(get(harvestAutopilotsMaxApy)).toBe('5.5');
 		});
 	});
 

--- a/src/frontend/src/tests/lib/components/earning/EarningsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningsList.spec.ts
@@ -20,9 +20,13 @@ import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
 import { render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 
-vi.mock('$eth/constants/harvest-autopilots.constants', () => ({
-	HARVEST_AUTOPILOT_ADDRESSES: ['0xautopilotaddress']
-}));
+vi.mock(import('$eth/constants/harvest-autopilots.constants'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		HARVEST_AUTOPILOT_ADDRESSES: ['0xautopilotaddress']
+	};
+});
 
 vi.mock('$app/navigation', () => ({
 	goto: vi.fn()

--- a/src/frontend/src/tests/lib/derived/harvest-autopilot-earning.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/harvest-autopilot-earning.derived.spec.ts
@@ -1,0 +1,94 @@
+import { EarningCardFields } from '$env/types/env.earning-cards';
+import {
+	HARVEST_AUTOPILOT_ASSET_ICONS,
+	HARVEST_AUTOPILOT_NETWORK_ICONS
+} from '$eth/constants/harvest-autopilots.constants';
+import { erc4626Tokens } from '$eth/derived/erc4626.derived';
+import { AppPath } from '$lib/constants/routes.constants';
+import { harvestAutopilotEarningData } from '$lib/derived/harvest-autopilot-earning.derived';
+import { enabledMainnetFungibleTokensUsdBalance } from '$lib/derived/tokens-ui.derived';
+import { harvestVaultsStore } from '$lib/stores/harvest.store';
+import { get } from 'svelte/store';
+
+const mockGoto = vi.fn();
+vi.mock('$app/navigation', () => ({ goto: (...args: unknown[]) => mockGoto(...args) }));
+
+describe('harvestAutopilotEarningData', () => {
+	// Base bAutopilot_USDC, one of the vaults the app ships with.
+	const mockVaultAddress = '0x0d877dc7c8fa3ad980dfdb18b48ec9f8768359c4';
+
+	const mockApy = 5.5;
+
+	// The ERC-4626 stores are filtered by the user-enabled networks, so turning every autopilot
+	// network off empties them — the state this card has to keep rendering through.
+	const mockAutopilotNetworksDisabled = () => {
+		vi.spyOn(erc4626Tokens, 'subscribe').mockImplementation((fn) => {
+			fn([]);
+			return () => {};
+		});
+	};
+
+	const mockUsdBalance = (balance: number) => {
+		vi.spyOn(enabledMainnetFungibleTokensUsdBalance, 'subscribe').mockImplementation((fn) => {
+			fn(balance);
+			return () => {};
+		});
+	};
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		mockGoto.mockClear();
+		harvestVaultsStore.reset();
+
+		mockAutopilotNetworksDisabled();
+	});
+
+	it('should expose the network and asset icons when no autopilot network is enabled', () => {
+		const data = get(harvestAutopilotEarningData);
+
+		expect(HARVEST_AUTOPILOT_NETWORK_ICONS.length).toBeGreaterThan(0);
+		expect(HARVEST_AUTOPILOT_ASSET_ICONS.length).toBeGreaterThan(0);
+
+		expect(data[EarningCardFields.NETWORKS]).toEqual(HARVEST_AUTOPILOT_NETWORK_ICONS);
+		expect(data[EarningCardFields.ASSETS]).toEqual(HARVEST_AUTOPILOT_ASSET_ICONS);
+	});
+
+	it('should expose the max APY when no autopilot network is enabled', () => {
+		harvestVaultsStore.set([
+			{ id: 'vault-1', vaultAddress: mockVaultAddress, estimatedApy: `${mockApy}` }
+		]);
+
+		expect(get(harvestAutopilotEarningData)[EarningCardFields.APY]).toBe(`${mockApy}`);
+	});
+
+	it('should derive the earning potential from the current balance when no autopilot network is enabled', () => {
+		const balance = 1000;
+
+		mockUsdBalance(balance);
+		harvestVaultsStore.set([
+			{ id: 'vault-1', vaultAddress: mockVaultAddress, estimatedApy: `${mockApy}` }
+		]);
+
+		expect(get(harvestAutopilotEarningData)[EarningCardFields.EARNING_POTENTIAL]).toBeCloseTo(
+			(balance * mockApy) / 100
+		);
+	});
+
+	it('should report no position when no autopilot network is enabled', () => {
+		mockUsdBalance(1000);
+		harvestVaultsStore.set([
+			{ id: 'vault-1', vaultAddress: mockVaultAddress, estimatedApy: `${mockApy}` }
+		]);
+
+		const data = get(harvestAutopilotEarningData);
+
+		expect(data[EarningCardFields.CURRENT_EARNING]).toBe(0);
+		expect(data[EarningCardFields.CURRENT_STAKED]).toBe(0);
+	});
+
+	it('should navigate to the autopilot page on action', async () => {
+		await get(harvestAutopilotEarningData).action();
+
+		expect(mockGoto).toHaveBeenCalledWith(AppPath.EarnAutopilot);
+	});
+});


### PR DESCRIPTION
# Motivation

On `/earn`, the Harvest Autopilot card breaks when Base / Arbitrum are toggled off: **Networks** and **Assets** stay stuck on skeletons, **Max APY** and **Earning potential** read `0`. The card advertises the opportunity, so it must describe Harvest regardless of which networks the user enabled.

Cause: every field flowed from `harvestAutopilots` → `erc4626Tokens`, which is filtered by the enabled ETH/EVM network ids. With those off the list is empty → icon arrays `[]` (`OverlappedLogos` renders `SkeletonText` on empty) → max APY `'0'` → earning potential (`balance × maxApy / 100`) `0`. The APY data itself was never network-dependent:  `harvestVaultsStore` is filled by a REST call from the globally mounted `LoaderHarvest`.


# Changes

 - `$eth/constants/harvest-autopilots.constants.ts`: add `HARVEST_AUTOPILOT_TOKENS` + deduped `HARVEST_AUTOPILOT_NETWORK_ICONS` / `HARVEST_AUTOPILOT_ASSET_ICONS`, sourced from `ERC4626_TOKENS` so the build-time mainnet flags still apply — we ignore *user-disabled* networks, not *unsupported* ones.
- `$eth/derived/harvest-autopilots.derived.ts`: `harvestAutopilotsMaxApy` reads `harvestVaultsStore` by shipped vault address instead of the network-filtered `harvestAutopilots`. Redefined in place — its only consumer is this card.
- `$lib/derived/harvest-autopilot-earning.derived.ts`: `networks` / `assets` use the new constants; `harvestAutopilots` dependency dropped. `earningPotential` unchanged — it starts working once APY is non-zero.


# Tests

Added.
