### PR TITLE
fix(frontend): show only enabled tokens in Liquidium modal pickers

### DIFF
--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte
@@ -5,7 +5,7 @@
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import { liquidiumBorrowMarkets } from '$lib/derived/liquidium.derived';
-	import { tokens } from '$lib/derived/tokens.derived';
+	import { enabledFungibleTokens } from '$lib/derived/tokens.derived';
 	import {
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
@@ -25,15 +25,22 @@
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
+	let enabledTokenIds = $derived(new Set($enabledFungibleTokens.map(({ id }) => id)));
+
 	let entries = $derived(
 		$liquidiumBorrowMarkets
 			.map((market) => ({
 				market,
-				token: liquidiumMarketToken({ chain: market.chain, asset: market.asset, tokens: $tokens })
+				token: liquidiumMarketToken({
+					chain: market.chain,
+					asset: market.asset,
+					tokens: $enabledFungibleTokens
+				})
 			}))
 			.filter(
 				(entry): entry is { market: LiquidiumMarket; token: Token } =>
 					nonNullish(entry.token) &&
+					enabledTokenIds.has(entry.token.id) &&
 					!(
 						entry.market.poolId === selectedMarket?.poolId &&
 						entry.market.chain === selectedMarket?.chain

--- a/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte
@@ -12,7 +12,7 @@
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import type { Token } from '$lib/types/token';
-	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
+	import { liquidiumEnabledRailToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Omitted on a neutral (token-less) launch — then nothing is excluded.
@@ -25,22 +25,20 @@
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
-	let enabledTokenIds = $derived(new Set($enabledFungibleTokens.map(({ id }) => id)));
-
+	// Delivery rails whose token the user disabled resolve to `undefined` and drop out below.
 	let entries = $derived(
 		$liquidiumBorrowMarkets
 			.map((market) => ({
 				market,
-				token: liquidiumMarketToken({
+				token: liquidiumEnabledRailToken({
 					chain: market.chain,
 					asset: market.asset,
-					tokens: $enabledFungibleTokens
+					enabledTokens: $enabledFungibleTokens
 				})
 			}))
 			.filter(
 				(entry): entry is { market: LiquidiumMarket; token: Token } =>
 					nonNullish(entry.token) &&
-					enabledTokenIds.has(entry.token.id) &&
 					!(
 						entry.market.poolId === selectedMarket?.poolId &&
 						entry.market.chain === selectedMarket?.chain

--- a/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte
@@ -5,14 +5,14 @@
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import { liquidiumRepayReserves } from '$lib/derived/liquidium.derived';
-	import { tokens } from '$lib/derived/tokens.derived';
+	import { enabledFungibleTokens } from '$lib/derived/tokens.derived';
 	import {
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import type { Token } from '$lib/types/token';
-	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
+	import { liquidiumEnabledRailToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Omitted on a neutral (token-less) launch — then nothing is excluded.
@@ -25,11 +25,16 @@
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
+	// Transfer rails whose token the user disabled resolve to `undefined` and drop out below.
 	let entries = $derived(
 		$liquidiumRepayReserves
 			.map((reserve) => ({
 				reserve,
-				token: liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+				token: liquidiumEnabledRailToken({
+					chain: reserve.chain,
+					asset: reserve.asset,
+					enabledTokens: $enabledFungibleTokens
+				})
 			}))
 			.filter(
 				// Exclude only the currently-selected rail, keyed by (poolId, chain): a pool now

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte
@@ -12,7 +12,7 @@
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumMarket } from '$lib/types/liquidium';
 	import type { Token } from '$lib/types/token';
-	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
+	import { liquidiumEnabledRailToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Omitted on a neutral (token-less) launch — then nothing is excluded.
@@ -25,22 +25,20 @@
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
-	let enabledTokenIds = $derived(new Set($enabledFungibleTokens.map(({ id }) => id)));
-
+	// Rails whose token the user disabled resolve to `undefined` and drop out below.
 	let entries = $derived(
 		$liquidiumSupplyMarkets
 			.map((market) => ({
 				market,
-				token: liquidiumMarketToken({
+				token: liquidiumEnabledRailToken({
 					chain: market.chain,
 					asset: market.asset,
-					tokens: $enabledFungibleTokens
+					enabledTokens: $enabledFungibleTokens
 				})
 			}))
 			.filter(
 				(entry): entry is { market: LiquidiumMarket; token: Token } =>
 					nonNullish(entry.token) &&
-					enabledTokenIds.has(entry.token.id) &&
 					!(
 						entry.market.poolId === selectedMarket?.poolId &&
 						entry.market.chain === selectedMarket?.chain

--- a/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte
@@ -5,7 +5,7 @@
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import { liquidiumSupplyMarkets } from '$lib/derived/liquidium.derived';
-	import { tokens } from '$lib/derived/tokens.derived';
+	import { enabledFungibleTokens } from '$lib/derived/tokens.derived';
 	import {
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
@@ -25,15 +25,22 @@
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
+	let enabledTokenIds = $derived(new Set($enabledFungibleTokens.map(({ id }) => id)));
+
 	let entries = $derived(
 		$liquidiumSupplyMarkets
 			.map((market) => ({
 				market,
-				token: liquidiumMarketToken({ chain: market.chain, asset: market.asset, tokens: $tokens })
+				token: liquidiumMarketToken({
+					chain: market.chain,
+					asset: market.asset,
+					tokens: $enabledFungibleTokens
+				})
 			}))
 			.filter(
 				(entry): entry is { market: LiquidiumMarket; token: Token } =>
 					nonNullish(entry.token) &&
+					enabledTokenIds.has(entry.token.id) &&
 					!(
 						entry.market.poolId === selectedMarket?.poolId &&
 						entry.market.chain === selectedMarket?.chain

--- a/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte
+++ b/src/frontend/src/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte
@@ -5,14 +5,14 @@
 	import ModalTokensListItem from '$lib/components/tokens/ModalTokensListItem.svelte';
 	import ButtonCancel from '$lib/components/ui/ButtonCancel.svelte';
 	import { liquidiumWithdrawReserves } from '$lib/derived/liquidium.derived';
-	import { tokens } from '$lib/derived/tokens.derived';
+	import { enabledFungibleTokens } from '$lib/derived/tokens.derived';
 	import {
 		MODAL_TOKENS_LIST_CONTEXT_KEY,
 		type ModalTokensListContext
 	} from '$lib/stores/modal-tokens-list.store';
 	import type { LiquidiumReserve } from '$lib/types/liquidium';
 	import type { Token } from '$lib/types/token';
-	import { liquidiumMarketToken } from '$lib/utils/liquidium.utils';
+	import { liquidiumEnabledRailToken } from '$lib/utils/liquidium.utils';
 
 	interface Props {
 		// Omitted on a neutral (token-less) launch — then nothing is excluded.
@@ -25,11 +25,16 @@
 
 	const { setTokens } = getContext<ModalTokensListContext>(MODAL_TOKENS_LIST_CONTEXT_KEY);
 
+	// Delivery rails whose token the user disabled resolve to `undefined` and drop out below.
 	let entries = $derived(
 		$liquidiumWithdrawReserves
 			.map((reserve) => ({
 				reserve,
-				token: liquidiumMarketToken({ chain: reserve.chain, asset: reserve.asset, tokens: $tokens })
+				token: liquidiumEnabledRailToken({
+					chain: reserve.chain,
+					asset: reserve.asset,
+					enabledTokens: $enabledFungibleTokens
+				})
 			}))
 			.filter(
 				// Exclude only the currently-selected rail, keyed by (poolId, chain): a pool now

--- a/src/frontend/src/lib/utils/liquidium.utils.ts
+++ b/src/frontend/src/lib/utils/liquidium.utils.ts
@@ -16,7 +16,7 @@ import {
 import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
 import type { Token } from '$lib/types/token';
 import { findTwinToken } from '$lib/utils/token.utils';
-import { assertNonNullish, isNullish } from '@dfinity/utils';
+import { assertNonNullish, isNullish, nonNullish } from '@dfinity/utils';
 import { Principal } from '@icp-sdk/core/principal';
 import {
 	Chain,
@@ -81,6 +81,21 @@ export const liquidiumMarketToken = ({
 	}
 
 	return undefined;
+};
+
+// Display token for a rail the user can actually transact on, for the modal pickers.
+export const liquidiumEnabledRailToken = ({
+	chain,
+	asset,
+	enabledTokens
+}: {
+	chain: string;
+	asset: string;
+	enabledTokens: Token[];
+}): Token | undefined => {
+	const token = liquidiumMarketToken({ chain, asset, tokens: enabledTokens });
+
+	return nonNullish(token) && enabledTokens.some(({ id }) => id === token.id) ? token : undefined;
 };
 
 // Scaled protocol rate → percentage.

--- a/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.spec.ts
@@ -1,5 +1,10 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import LiquidiumBorrowTokensList from '$lib/components/liquidium/borrow/LiquidiumBorrowTokensList.svelte';
 import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
@@ -7,7 +12,15 @@ import {
 	initModalTokensListContext,
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { LiquidiumMarket } from '$lib/types/liquidium';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
+import {
+	mockNetworksSettings,
+	mockUserProfile,
+	mockUserSettings
+} from '$tests/mocks/user-profile.mock';
+import { toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 
 describe('LiquidiumBorrowTokensList', () => {
@@ -31,12 +44,40 @@ describe('LiquidiumBorrowTokensList', () => {
 		available: true
 	};
 
+	const ckBtcMarket: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'ICP',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
 	const context = new Map([
 		[MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] })]
 	]);
 
+	// The picker offers only rails whose token the user has enabled, so the ERC-20 rail needs its
+	// runtime token (suggested → enabled by default) and the ICP rail its ck twin.
 	beforeEach(() => {
 		liquidiumStore.reset();
+		userProfileStore.reset();
+		erc20DefaultTokensStore.reset();
+		icrcCustomTokensStore.resetAll();
+
+		erc20DefaultTokensStore.set([USDC_TOKEN]);
+		icrcCustomTokensStore.setAll([
+			{
+				data: {
+					...mockValidIcCkToken,
+					symbol: 'ckBTC',
+					network: ICP_TOKEN.network,
+					enabled: true
+				} as IcrcCustomToken,
+				certified: false
+			}
+		]);
 	});
 
 	it('lists the borrow-available tokens except the selected one', () => {
@@ -78,5 +119,40 @@ describe('LiquidiumBorrowTokensList', () => {
 
 		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
 		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+	});
+
+	it('omits the rails of the networks the user disabled, keeping their ck twins', () => {
+		userProfileStore.set({
+			certified: true,
+			profile: {
+				...mockUserProfile,
+				settings: toNullable({
+					...mockUserSettings,
+					networks: {
+						...mockNetworksSettings,
+						networks: [
+							[{ BitcoinMainnet: null }, { enabled: false, is_testnet: false }],
+							[{ EthereumMainnet: null }, { enabled: false, is_testnet: false }]
+						]
+					}
+				})
+			}
+		});
+
+		liquidiumStore.set({
+			markets: [btcMarket, usdcMarket, ckBtcMarket],
+			portfolio: null,
+			assetPrices: {}
+		});
+
+		const { getByText, queryByText } = render(LiquidiumBorrowTokensList, {
+			props: { onSelectMarket: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText('ckBTC')).toBeInTheDocument();
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+		expect(queryByText(USDC_TOKEN.symbol)).toBeNull();
+		expect(queryByText(ETHEREUM_TOKEN.symbol)).toBeNull();
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/borrow/LiquidiumBorrowTokensList.spec.ts
@@ -44,6 +44,16 @@ describe('LiquidiumBorrowTokensList', () => {
 		available: true
 	};
 
+	const ethMarket: LiquidiumMarket = {
+		poolId: 'pool-eth',
+		asset: 'ETH',
+		chain: 'ETH',
+		supplyApy: 2,
+		borrowApy: 6,
+		frozen: false,
+		available: true
+	};
+
 	const ckBtcMarket: LiquidiumMarket = {
 		poolId: 'pool-btc',
 		asset: 'BTC',
@@ -110,7 +120,11 @@ describe('LiquidiumBorrowTokensList', () => {
 	});
 
 	it('lists every available token when no market is selected (neutral launch)', () => {
-		liquidiumStore.set({ markets: [btcMarket, usdcMarket], portfolio: null, assetPrices: {} });
+		liquidiumStore.set({
+			markets: [btcMarket, usdcMarket, ethMarket],
+			portfolio: null,
+			assetPrices: {}
+		});
 
 		const { getByText } = render(LiquidiumBorrowTokensList, {
 			props: { onSelectMarket: () => {}, onClose: () => {} },
@@ -119,6 +133,7 @@ describe('LiquidiumBorrowTokensList', () => {
 
 		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
 		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+		expect(getByText(ETHEREUM_TOKEN.symbol)).toBeInTheDocument();
 	});
 
 	it('omits the rails of the networks the user disabled, keeping their ck twins', () => {
@@ -140,7 +155,7 @@ describe('LiquidiumBorrowTokensList', () => {
 		});
 
 		liquidiumStore.set({
-			markets: [btcMarket, usdcMarket, ckBtcMarket],
+			markets: [btcMarket, usdcMarket, ethMarket, ckBtcMarket],
 			portfolio: null,
 			assetPrices: {}
 		});

--- a/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayTokensList.spec.ts
@@ -1,5 +1,9 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import LiquidiumRepayTokensList from '$lib/components/liquidium/repay/LiquidiumRepayTokensList.svelte';
 import { ZERO } from '$lib/constants/app.constants';
 import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
@@ -8,24 +12,16 @@ import {
 	initModalTokensListContext,
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
+import {
+	mockNetworksSettings,
+	mockUserProfile,
+	mockUserSettings
+} from '$tests/mocks/user-profile.mock';
+import { toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
-
-// ck twins so the ICP (ck) rail resolves a display token in the picker; the native rails
-// resolve statically and need no token list.
-vi.mock('$lib/derived/tokens.derived', async (importOriginal) => {
-	const { readable } = await import('svelte/store');
-	const { mockValidIcCkToken } = await import('$tests/mocks/ic-tokens.mock');
-	const { parseTokenId } = await import('$lib/validation/token.validation');
-
-	return {
-		...(await importOriginal<Record<string, unknown>>()),
-		tokens: readable([
-			{ ...mockValidIcCkToken, id: parseTokenId('ckBTC'), symbol: 'ckBTC' },
-			{ ...mockValidIcCkToken, id: parseTokenId('ckUSDC'), symbol: 'ckUSDC' }
-		])
-	};
-});
 
 describe('LiquidiumRepayTokensList', () => {
 	const btcReserve: LiquidiumReserve = {
@@ -70,8 +66,26 @@ describe('LiquidiumRepayTokensList', () => {
 		[MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] })]
 	]);
 
+	// The picker offers only rails whose token the user has enabled, so the ERC-20 rail needs its
+	// runtime token (suggested → enabled by default) and the ICP rail its ck twin.
 	beforeEach(() => {
 		liquidiumStore.reset();
+		userProfileStore.reset();
+		erc20DefaultTokensStore.reset();
+		icrcCustomTokensStore.resetAll();
+
+		erc20DefaultTokensStore.set([USDC_TOKEN]);
+		icrcCustomTokensStore.setAll([
+			{
+				data: {
+					...mockValidIcCkToken,
+					symbol: 'ckBTC',
+					network: ICP_TOKEN.network,
+					enabled: true
+				} as IcrcCustomToken,
+				certified: false
+			}
+		]);
 	});
 
 	it('lists the positions with debt except the selected one', () => {
@@ -166,5 +180,41 @@ describe('LiquidiumRepayTokensList', () => {
 
 		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
 		expect(getByText('ckBTC')).toBeInTheDocument();
+	});
+
+	it('omits the transfer rails of the networks the user disabled, keeping their ck twins', () => {
+		userProfileStore.set({
+			certified: true,
+			profile: {
+				...mockUserProfile,
+				settings: toNullable({
+					...mockUserSettings,
+					networks: {
+						...mockNetworksSettings,
+						networks: [
+							[{ BitcoinMainnet: null }, { enabled: false, is_testnet: false }],
+							[{ EthereumMainnet: null }, { enabled: false, is_testnet: false }]
+						]
+					}
+				})
+			}
+		});
+
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, usdcReserve]),
+			assetPrices: {}
+		});
+
+		const { getByText, queryByText } = render(LiquidiumRepayTokensList, {
+			props: { onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		// Only the ck rail of the BTC debt survives; the ERC-20 rail of the USDC debt goes with the
+		// Ethereum network, and its ck twin is not enabled here.
+		expect(getByText('ckBTC')).toBeInTheDocument();
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+		expect(queryByText(USDC_TOKEN.symbol)).toBeNull();
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyTokensList.spec.ts
@@ -44,6 +44,16 @@ describe('LiquidiumSupplyTokensList', () => {
 		available: true
 	};
 
+	const ethMarket: LiquidiumMarket = {
+		poolId: 'pool-eth',
+		asset: 'ETH',
+		chain: 'ETH',
+		supplyApy: 2,
+		borrowApy: 6,
+		frozen: false,
+		available: true
+	};
+
 	const ckBtcMarket: LiquidiumMarket = {
 		poolId: 'pool-btc',
 		asset: 'BTC',
@@ -110,7 +120,11 @@ describe('LiquidiumSupplyTokensList', () => {
 	});
 
 	it('lists every available token when no market is selected (neutral launch)', () => {
-		liquidiumStore.set({ markets: [btcMarket, usdcMarket], portfolio: null, assetPrices: {} });
+		liquidiumStore.set({
+			markets: [btcMarket, usdcMarket, ethMarket],
+			portfolio: null,
+			assetPrices: {}
+		});
 
 		const { getByText } = render(LiquidiumSupplyTokensList, {
 			props: { onSelectMarket: () => {}, onClose: () => {} },
@@ -119,6 +133,7 @@ describe('LiquidiumSupplyTokensList', () => {
 
 		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
 		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+		expect(getByText(ETHEREUM_TOKEN.symbol)).toBeInTheDocument();
 	});
 
 	it('omits the rails of the networks the user disabled, keeping their ck twins', () => {
@@ -140,7 +155,7 @@ describe('LiquidiumSupplyTokensList', () => {
 		});
 
 		liquidiumStore.set({
-			markets: [btcMarket, usdcMarket, ckBtcMarket],
+			markets: [btcMarket, usdcMarket, ethMarket, ckBtcMarket],
 			portfolio: null,
 			assetPrices: {}
 		});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyTokensList.spec.ts
@@ -1,5 +1,10 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import LiquidiumSupplyTokensList from '$lib/components/liquidium/supply/LiquidiumSupplyTokensList.svelte';
 import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
@@ -7,7 +12,15 @@ import {
 	initModalTokensListContext,
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { LiquidiumMarket } from '$lib/types/liquidium';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
+import {
+	mockNetworksSettings,
+	mockUserProfile,
+	mockUserSettings
+} from '$tests/mocks/user-profile.mock';
+import { toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
 
 describe('LiquidiumSupplyTokensList', () => {
@@ -31,12 +44,40 @@ describe('LiquidiumSupplyTokensList', () => {
 		available: true
 	};
 
+	const ckBtcMarket: LiquidiumMarket = {
+		poolId: 'pool-btc',
+		asset: 'BTC',
+		chain: 'ICP',
+		supplyApy: 5,
+		borrowApy: 9,
+		frozen: false,
+		available: true
+	};
+
 	const context = new Map([
 		[MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] })]
 	]);
 
+	// The picker offers only rails whose token the user has enabled, so the ERC-20 rail needs its
+	// runtime token (suggested → enabled by default) and the ICP rail its ck twin.
 	beforeEach(() => {
 		liquidiumStore.reset();
+		userProfileStore.reset();
+		erc20DefaultTokensStore.reset();
+		icrcCustomTokensStore.resetAll();
+
+		erc20DefaultTokensStore.set([USDC_TOKEN]);
+		icrcCustomTokensStore.setAll([
+			{
+				data: {
+					...mockValidIcCkToken,
+					symbol: 'ckBTC',
+					network: ICP_TOKEN.network,
+					enabled: true
+				} as IcrcCustomToken,
+				certified: false
+			}
+		]);
 	});
 
 	it('lists the supply-available tokens except the selected one', () => {
@@ -78,5 +119,40 @@ describe('LiquidiumSupplyTokensList', () => {
 
 		expect(getByText(BTC_MAINNET_TOKEN.symbol)).toBeInTheDocument();
 		expect(getByText(USDC_TOKEN.symbol)).toBeInTheDocument();
+	});
+
+	it('omits the rails of the networks the user disabled, keeping their ck twins', () => {
+		userProfileStore.set({
+			certified: true,
+			profile: {
+				...mockUserProfile,
+				settings: toNullable({
+					...mockUserSettings,
+					networks: {
+						...mockNetworksSettings,
+						networks: [
+							[{ BitcoinMainnet: null }, { enabled: false, is_testnet: false }],
+							[{ EthereumMainnet: null }, { enabled: false, is_testnet: false }]
+						]
+					}
+				})
+			}
+		});
+
+		liquidiumStore.set({
+			markets: [btcMarket, usdcMarket, ckBtcMarket],
+			portfolio: null,
+			assetPrices: {}
+		});
+
+		const { getByText, queryByText } = render(LiquidiumSupplyTokensList, {
+			props: { onSelectMarket: () => {}, onClose: () => {} },
+			context
+		});
+
+		expect(getByText('ckBTC')).toBeInTheDocument();
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+		expect(queryByText(USDC_TOKEN.symbol)).toBeNull();
+		expect(queryByText(ETHEREUM_TOKEN.symbol)).toBeNull();
 	});
 });

--- a/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.spec.ts
@@ -1,5 +1,9 @@
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
+import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
+import type { IcrcCustomToken } from '$icp/types/icrc-custom-token';
 import LiquidiumWithdrawTokensList from '$lib/components/liquidium/withdraw/LiquidiumWithdrawTokensList.svelte';
 import { ZERO } from '$lib/constants/app.constants';
 import { MODAL_TOKENS_LIST } from '$lib/constants/test-ids.constants';
@@ -8,24 +12,16 @@ import {
 	initModalTokensListContext,
 	MODAL_TOKENS_LIST_CONTEXT_KEY
 } from '$lib/stores/modal-tokens-list.store';
+import { userProfileStore } from '$lib/stores/user-profile.store';
 import type { LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
+import {
+	mockNetworksSettings,
+	mockUserProfile,
+	mockUserSettings
+} from '$tests/mocks/user-profile.mock';
+import { toNullable } from '@dfinity/utils';
 import { fireEvent, render } from '@testing-library/svelte';
-
-// ck twins so the ICP (ck) rail resolves a display token in the picker; the native rails
-// resolve statically and need no token list.
-vi.mock('$lib/derived/tokens.derived', async (importOriginal) => {
-	const { readable } = await import('svelte/store');
-	const { mockValidIcCkToken } = await import('$tests/mocks/ic-tokens.mock');
-	const { parseTokenId } = await import('$lib/validation/token.validation');
-
-	return {
-		...(await importOriginal<Record<string, unknown>>()),
-		tokens: readable([
-			{ ...mockValidIcCkToken, id: parseTokenId('ckBTC'), symbol: 'ckBTC' },
-			{ ...mockValidIcCkToken, id: parseTokenId('ckUSDC'), symbol: 'ckUSDC' }
-		])
-	};
-});
 
 describe('LiquidiumWithdrawTokensList', () => {
 	const btcReserve: LiquidiumReserve = {
@@ -70,8 +66,26 @@ describe('LiquidiumWithdrawTokensList', () => {
 		[MODAL_TOKENS_LIST_CONTEXT_KEY, initModalTokensListContext({ tokens: [] })]
 	]);
 
+	// The picker offers only rails whose token the user has enabled, so the ERC-20 rail needs its
+	// runtime token (suggested → enabled by default) and the ICP rail its ck twin.
 	beforeEach(() => {
 		liquidiumStore.reset();
+		userProfileStore.reset();
+		erc20DefaultTokensStore.reset();
+		icrcCustomTokensStore.resetAll();
+
+		erc20DefaultTokensStore.set([USDC_TOKEN]);
+		icrcCustomTokensStore.setAll([
+			{
+				data: {
+					...mockValidIcCkToken,
+					symbol: 'ckBTC',
+					network: ICP_TOKEN.network,
+					enabled: true
+				} as IcrcCustomToken,
+				certified: false
+			}
+		]);
 	});
 
 	it('lists the supplied positions except the selected one', () => {
@@ -166,5 +180,41 @@ describe('LiquidiumWithdrawTokensList', () => {
 
 		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
 		expect(getByText('ckBTC')).toBeInTheDocument();
+	});
+
+	it('omits the delivery rails of the networks the user disabled, keeping their ck twins', () => {
+		userProfileStore.set({
+			certified: true,
+			profile: {
+				...mockUserProfile,
+				settings: toNullable({
+					...mockUserSettings,
+					networks: {
+						...mockNetworksSettings,
+						networks: [
+							[{ BitcoinMainnet: null }, { enabled: false, is_testnet: false }],
+							[{ EthereumMainnet: null }, { enabled: false, is_testnet: false }]
+						]
+					}
+				})
+			}
+		});
+
+		liquidiumStore.set({
+			markets: [],
+			portfolio: portfolio([btcReserve, usdcReserve]),
+			assetPrices: {}
+		});
+
+		const { getByText, queryByText } = render(LiquidiumWithdrawTokensList, {
+			props: { onSelectReserve: () => {}, onClose: () => {} },
+			context
+		});
+
+		// Only the ck rail of the BTC position survives; the ERC-20 rail of the USDC position goes
+		// with the Ethereum network, and its ck twin is not enabled here.
+		expect(getByText('ckBTC')).toBeInTheDocument();
+		expect(queryByText(BTC_MAINNET_TOKEN.symbol)).toBeNull();
+		expect(queryByText(USDC_TOKEN.symbol)).toBeNull();
 	});
 });

--- a/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/liquidium.utils.spec.ts
@@ -4,9 +4,11 @@ import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { ZERO } from '$lib/constants/app.constants';
 import type { LiquidiumMarket, LiquidiumPortfolio, LiquidiumReserve } from '$lib/types/liquidium';
+import type { Token } from '$lib/types/token';
 import {
 	liquidiumBorrowingPowerPotentialUsd,
 	liquidiumBorrowInterestUsd,
+	liquidiumEnabledRailToken,
 	liquidiumFreeCollateralUsd,
 	liquidiumHealthFactorPercent,
 	liquidiumHealthLevel,
@@ -28,6 +30,8 @@ import {
 	mapLiquidiumReserve,
 	orderLiquidiumRails
 } from '$lib/utils/liquidium.utils';
+import { parseTokenId } from '$lib/validation/token.validation';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import {
 	RATE_SCALE,
 	type Pool,
@@ -921,6 +925,76 @@ describe('liquidium.utils', () => {
 		it('returns undefined for an unsupported (chain, asset) pair', () => {
 			expect(liquidiumMarketToken({ chain: 'BTC', asset: 'USDC', tokens: [] })).toBeUndefined();
 			expect(liquidiumMarketToken({ chain: 'SOL', asset: 'SOL', tokens: [] })).toBeUndefined();
+		});
+	});
+
+	describe('liquidiumEnabledRailToken', () => {
+		const ckBtcToken = {
+			...mockValidIcCkToken,
+			id: parseTokenId('ckBTC'),
+			symbol: 'ckBTC',
+			network: ICP_TOKEN.network
+		} as Token;
+
+		it('resolves a native rail whose token is enabled', () => {
+			expect(
+				liquidiumEnabledRailToken({
+					chain: 'BTC',
+					asset: 'BTC',
+					enabledTokens: [BTC_MAINNET_TOKEN]
+				})
+			).toBe(BTC_MAINNET_TOKEN);
+		});
+
+		it('resolves a ck rail from the enabled twin', () => {
+			expect(
+				liquidiumEnabledRailToken({ chain: 'ICP', asset: 'BTC', enabledTokens: [ckBtcToken] })
+			).toBe(ckBtcToken);
+		});
+
+		it('resolves the ICP rail from the enabled list', () => {
+			// In the app ICP is always in that list: it is not toggleable, so `filterEnabledTokens`
+			// always keeps it and the ICP network cannot be switched off.
+			expect(
+				liquidiumEnabledRailToken({ chain: 'ICP', asset: 'ICP', enabledTokens: [ICP_TOKEN] })
+			).toBe(ICP_TOKEN);
+		});
+
+		it('rejects the rails that `liquidiumMarketToken` resolves statically', () => {
+			// The whole point of the id check: these come back from env config whatever list is passed,
+			// so membership is the only thing that can rule them out. Uniform — ICP included.
+			expect(
+				liquidiumEnabledRailToken({ chain: 'BTC', asset: 'BTC', enabledTokens: [] })
+			).toBeUndefined();
+			expect(
+				liquidiumEnabledRailToken({ chain: 'ETH', asset: 'USDC', enabledTokens: [] })
+			).toBeUndefined();
+			expect(
+				liquidiumEnabledRailToken({ chain: 'ETH', asset: 'USDT', enabledTokens: [] })
+			).toBeUndefined();
+			expect(
+				liquidiumEnabledRailToken({ chain: 'ICP', asset: 'ICP', enabledTokens: [] })
+			).toBeUndefined();
+		});
+
+		it('rejects a ck rail whose twin is not enabled', () => {
+			expect(
+				liquidiumEnabledRailToken({
+					chain: 'ICP',
+					asset: 'BTC',
+					enabledTokens: [BTC_MAINNET_TOKEN]
+				})
+			).toBeUndefined();
+		});
+
+		it('rejects an unsupported (chain, asset) pair', () => {
+			expect(
+				liquidiumEnabledRailToken({
+					chain: 'SOL',
+					asset: 'SOL',
+					enabledTokens: [BTC_MAINNET_TOKEN]
+				})
+			).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

With the Bitcoin, Ethereum and every EVM network switched off in settings, the Liquidium supply, borrow, repay and withdraw token pickers still offered the native BTC rail and the ERC-20 USDC/USDT rails. `liquidiumMarketToken` resolves those rails from static env config (`$env/tokens/...`) and only consults the runtime token list for the `chain: 'ICP'` ck twins, so the pickers listed rails the user has no address, balance or fee machinery for — and, for ERC-20, no loaded token at all. The list they read (`tokens`) also includes tokens the user disabled by design.


# Changes

- `LiquidiumSupplyTokensList`: resolve rail tokens from `enabledFungibleTokens` instead of `tokens`, and keep only entries whose resolved token is in that list. The enabled list serves as the lookup scope for the ck rails; the id check is what drops the statically-resolved native/ERC rails.
- `LiquidiumBorrowTokensList`, `LiquidiumRepayTokensList`, `LiquidiumWithdrawTokensList`: the same filter on the rest of the delivery rails.


# Tests

Added.
