### PR TITLE
feat(frontend): add a dev-only mock harness for the OISY TRADE flows

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -8,6 +8,7 @@ This document lists a couple of useful information for development and deploymen
   - [Signer Domains](#signer-domains)
 - [Internationalization](#internationalization)
 - [Faucets](#faucets)
+- [Mocking OISY Trade](#mocking-oisy-trade)
 - [Testing](#testing)
 - [Debugging Reactivity](#debugging-reactivity)
 - [Memory Benchmarking](#memory-benchmarking)
@@ -150,6 +151,40 @@ A list of useful faucets:
 - SOL: [Solana Foundation Faucet](https://faucet.solana.com/) or [Sol Faucet](https://solfaucet.com/)
 - TESTICP: [TESTICP Faucet](https://nqoci-rqaaa-aaaap-qp53q-cai.icp0.io/)
 - TICRC1: [TICRC1 Faucet](https://pwwqf-yaaaa-aaaap-qp5wq-cai.icp0.io/)
+
+## Mocking OISY Trade
+
+Clicking through the Trade flows normally needs a funded account: deposits,
+limit orders and withdrawals all move real tokens. To exercise the UI without
+that, start the dev server with the mock flag:
+
+```bash
+DFX_NETWORK=staging VITE_TRADE_MOCK=true npm run dev
+```
+
+A dev-only resolver in `vite.config.ts` then redirects two modules to mocks:
+
+| Real module                                 | Mock                                  |
+| ------------------------------------------- | ------------------------------------- |
+| `$lib/api/oisy-trade.api`                   | `oisy-trade.mock.api.ts`              |
+| `$lib/services/oisy-trade.deposit.services` | `oisy-trade.deposit.mock.services.ts` |
+
+What is faked and what is not:
+
+- **Faked** — your DEX balances and orders, and the four writes (`deposit`,
+  `withdraw`, `add_limit_order`, `cancel_limit_order`), which mutate in-memory
+  state instead of calling the canister. Balances move the way the canister
+  would move them: placing an order shifts free → reserved, cancelling releases
+  it, depositing and withdrawing adjust the free balance. A wallet balance is
+  also seeded for the depositable tokens, otherwise the Deposit picker has
+  nothing to offer.
+- **Real** — trading pairs, supported tokens, order-book ticker and depth. Those
+  reads need no funds, so the limit-order form still shows genuine prices and
+  crossing state.
+
+Nothing imports either mock without the flag, so a normal build cannot pick them
+up. The mocks are seeded from the tokens the DEX supports _and_ the wallet has
+enabled — if none overlap, they log a warning and the Trade tab stays empty.
 
 ## Testing
 

--- a/src/frontend/src/lib/api/oisy-trade.mock.api.ts
+++ b/src/frontend/src/lib/api/oisy-trade.mock.api.ts
@@ -1,0 +1,454 @@
+import type {
+	DepositRequest,
+	DepositResponse,
+	GetMyOrdersArgs,
+	LimitOrderRequest,
+	OrderId,
+	OrderRecord,
+	OrderStatus,
+	Side,
+	Token,
+	TradingPairInfo,
+	UserOrder,
+	UserTokenBalance,
+	WithdrawRequest,
+	WithdrawResponse
+} from '$declarations/oisy_trade/oisy_trade.did';
+// Resolves to the real module, not back to this one: the dev-only resolver in
+// `vite.config.ts` skips the redirect when the importer is the mock itself.
+import {
+	getTradingPairs as getTradingPairsApi,
+	listSupportedTokens as listSupportedTokensApi
+} from '$lib/api/oisy-trade.api';
+import { ZERO } from '$lib/constants/app.constants';
+import { enabledIcTokens } from '$lib/derived/tokens.derived';
+import { balancesStore } from '$lib/stores/balances.store';
+import type { CanisterApiFunctionParams } from '$lib/types/canister';
+import type { TokenId } from '$lib/types/token';
+import { consoleWarn } from '$lib/utils/console.utils';
+import { parseToken } from '$lib/utils/parse.utils';
+import { assertNonNullish, isNullish, nonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+// Dev-only stand-in for the caller-specific half of the OISY TRADE API, so the
+// Trade flows can be clicked through without funds and without submitting
+// anything on-chain. Activated by `VITE_TRADE_MOCK=true`, which makes the
+// resolver in `vite.config.ts` redirect `$lib/api/oisy-trade.api` onto this
+// module — nothing imports it otherwise, so it cannot reach a real build.
+//
+// Market data (pairs, supported tokens, ticker, depth) is re-exported untouched
+// from the real API: those reads need no funds, so the limit-order form still
+// shows genuine prices and crossing state. Only the caller's balances and orders
+// are fabricated, and the four writes mutate that in-memory state instead of
+// calling the canister.
+export {
+	getOrderBookDepth,
+	getOrderBookTicker,
+	getTradingPairs,
+	listSupportedTokens
+} from '$lib/api/oisy-trade.api';
+
+// Free balance seeded per token, in whole token units, keyed by symbol. Values
+// are arbitrary but chosen so the fiat totals on the provider page look
+// plausible for both mainnet and the testnet twins staging trades.
+const MOCK_FREE_UNITS: Record<string, string> = {
+	BTC: '0.42',
+	ckBTC: '0.42',
+	ckSepoliaBTC: '0.42',
+	ETH: '6.5',
+	ckETH: '6.5',
+	ckSepoliaETH: '6.5',
+	ICP: '3400',
+	TESTICP: '3400',
+	USDC: '12500',
+	ckUSDC: '12500',
+	ckSepoliaUSDC: '12500',
+	USDT: '12500',
+	ckUSDT: '12500'
+};
+
+const MOCK_DEFAULT_FREE_UNITS = '250';
+
+// Share of the seeded free balance that starts locked in open orders, so the
+// provider page's "$X free / $Y in orders" split is non-trivial.
+const MOCK_RESERVED_DIVISOR = 5n;
+
+// Wallet balance seeded per depositable token, in whole units — only so the
+// Deposit picker has something to offer. Deliberately smaller than the DEX
+// balances above: this is meant to read as "still in the wallet".
+const MOCK_WALLET_UNITS = '12';
+
+// Orders are minted against the first pairs the canister lists, cycling through
+// these shapes so Active and History both have content: a resting sell, a
+// partially filled buy (renders as "Partial"), a filled buy and a canceled sell.
+const MOCK_ORDER_SHAPES: { side: Side; status: OrderStatus; filledPercent: bigint }[] = [
+	{ side: { Sell: null }, status: { Open: null }, filledPercent: ZERO },
+	{ side: { Buy: null }, status: { Open: null }, filledPercent: 35n },
+	{ side: { Buy: null }, status: { Filled: null }, filledPercent: 100n },
+	{ side: { Sell: null }, status: { Canceled: null }, filledPercent: ZERO }
+];
+
+const MOCK_ORDER_QUANTITY_LOTS = 120n;
+const MOCK_ORDER_PRICE_TICKS = 250n;
+
+const NANO_SECONDS_IN_HOUR = 3_600_000_000_000n;
+
+const HUNDRED = 100n;
+
+interface MockBalance {
+	token: Token;
+	free: bigint;
+	reserved: bigint;
+}
+
+interface MockState {
+	// Keyed by ledger canister id text.
+	balances: Map<string, MockBalance>;
+	orders: UserOrder[];
+	nextOrderSeq: number;
+}
+
+let state: MockState | undefined;
+
+// Resolves once the first seed completes, so concurrent `getBalances` /
+// `getMyOrders` calls from `loadOisyTrade`'s `Promise.all` seed only once.
+let seeding: Promise<MockState> | undefined;
+
+const mockOrderId = (seq: number): OrderId => seq.toString(16).padStart(32, '0');
+
+// The real API asserts the identity before building the actor; mirror that so a
+// signed-out caller fails the same way instead of minting orders with no owner.
+const owner = ({
+	identity,
+	nullishIdentityErrorMessage
+}: CanisterApiFunctionParams): OrderRecord['owner'] => {
+	assertNonNullish(identity, nullishIdentityErrorMessage);
+
+	return identity.getPrincipal();
+};
+
+const scaled = ({ value, decimals }: { value: string; decimals: number }): bigint =>
+	parseToken({ value, unitName: decimals });
+
+const freeUnitsFor = (symbol: string): string => MOCK_FREE_UNITS[symbol] ?? MOCK_DEFAULT_FREE_UNITS;
+
+// The DEX tokens the wallet can actually render: `mapOisyTradeAssets` and
+// `mapOisyTradeOrders` join on ledger canister id against the user's enabled IC
+// tokens and silently drop anything unmatched, so seeding a token the wallet
+// doesn't know about would produce invisible rows.
+const walletKnownTokens = (supportedTokens: Token[]): Token[] => {
+	const walletLedgers = new Set(
+		get(enabledIcTokens).map(({ ledgerCanisterId }) => ledgerCanisterId)
+	);
+
+	return supportedTokens.filter(({ id }) => walletLedgers.has(id.ledger_id.toText()));
+};
+
+const seedBalances = (tokens: Token[]): Map<string, MockBalance> =>
+	tokens.reduce<Map<string, MockBalance>>((acc, token) => {
+		const {
+			id: { ledger_id },
+			metadata: { symbol, decimals }
+		} = token;
+
+		const free = scaled({ value: freeUnitsFor(symbol), decimals });
+
+		acc.set(ledger_id.toText(), {
+			token,
+			free,
+			reserved: free / MOCK_RESERVED_DIVISOR
+		});
+
+		return acc;
+	}, new Map());
+
+const seedOrders = ({
+	pairs,
+	balances,
+	owner
+}: {
+	pairs: TradingPairInfo[];
+	balances: Map<string, MockBalance>;
+	owner: OrderRecord['owner'];
+}): UserOrder[] => {
+	// Only pairs whose both legs were seeded — the same join the order mapper does.
+	const tradeable = pairs.filter(
+		({ base, quote }) =>
+			balances.has(base.id.ledger_id.toText()) && balances.has(quote.id.ledger_id.toText())
+	);
+
+	const now = nowInBigIntNanoSeconds();
+
+	return tradeable.slice(0, MOCK_ORDER_SHAPES.length).map((pair, index) => {
+		const { side, status, filledPercent } = MOCK_ORDER_SHAPES[index];
+
+		const quantity = pair.lot_size * MOCK_ORDER_QUANTITY_LOTS;
+
+		return {
+			id: mockOrderId(index),
+			pair: { base: pair.base.id.ledger_id, quote: pair.quote.id.ledger_id },
+			order: {
+				status,
+				owner,
+				side,
+				quantity,
+				filled_quantity: (quantity * filledPercent) / HUNDRED,
+				price: pair.tick_size * MOCK_ORDER_PRICE_TICKS,
+				created_at: now - BigInt(index + 1) * NANO_SECONDS_IN_HOUR,
+				last_updated_at: [],
+				time_in_force: { GoodTilCanceled: null }
+			}
+		};
+	});
+};
+
+// The Deposit picker only offers tokens whose *wallet* balance is above zero
+// (`oisyTradeDepositableTokens`), which an unfunded account never has. Seed one,
+// then re-assert it whenever something zeroes it — the wallet workers keep
+// publishing the real (empty) balance, and would otherwise empty the picker a
+// few seconds after it loads. Comparing before setting keeps this from looping
+// on its own writes.
+const seedWalletBalances = (tokens: Token[]) => {
+	const byLedger = get(enabledIcTokens).reduce<Record<string, { id: TokenId; decimals: number }>>(
+		(acc, { ledgerCanisterId, id, decimals }) => ({ ...acc, [ledgerCanisterId]: { id, decimals } }),
+		{}
+	);
+
+	const seeds = tokens
+		.map(({ id: { ledger_id } }) => byLedger[ledger_id.toText()])
+		.filter(nonNullish)
+		.map(({ id, decimals }) => ({
+			id,
+			data: scaled({ value: MOCK_WALLET_UNITS, decimals })
+		}));
+
+	const assert = () => {
+		seeds.forEach(({ id, data }) => {
+			if ((get(balancesStore)?.[id]?.data ?? ZERO) === data) {
+				return;
+			}
+
+			balancesStore.set({ id, data: { data, certified: false } });
+		});
+	};
+
+	assert();
+
+	balancesStore.subscribe(assert);
+};
+
+const seedState = async (params: CanisterApiFunctionParams): Promise<MockState> => {
+	const [supportedTokens, pairs] = await Promise.all([
+		listSupportedTokensApi(params),
+		getTradingPairsApi(params)
+	]);
+
+	const tokens = walletKnownTokens(supportedTokens);
+
+	if (tokens.length === 0) {
+		consoleWarn(
+			'VITE_TRADE_MOCK: none of the tokens OISY TRADE supports are enabled in this wallet, so the mocked balances and orders would not render. Enable them under Tokens → Manage.'
+		);
+	}
+
+	const balances = seedBalances(tokens);
+
+	seedWalletBalances(tokens);
+
+	return {
+		balances,
+		orders: seedOrders({ pairs, balances, owner: owner(params) }),
+		nextOrderSeq: MOCK_ORDER_SHAPES.length
+	};
+};
+
+const mockState = async (params: CanisterApiFunctionParams): Promise<MockState> => {
+	if (nonNullish(state)) {
+		return state;
+	}
+
+	seeding ??= seedState(params);
+
+	state = await seeding;
+
+	return state;
+};
+
+const balanceEntry = async ({
+	params,
+	ledgerId
+}: {
+	params: CanisterApiFunctionParams;
+	ledgerId: string;
+}): Promise<MockBalance> => {
+	const { balances } = await mockState(params);
+
+	const balance = balances.get(ledgerId);
+
+	if (nonNullish(balance)) {
+		return balance;
+	}
+
+	throw new Error(`VITE_TRADE_MOCK: no mocked balance for ledger ${ledgerId}`);
+};
+
+export const getBalances = async (
+	params: CanisterApiFunctionParams
+): Promise<UserTokenBalance[]> => {
+	const { balances } = await mockState(params);
+
+	return [...balances.values()].map(({ token, free, reserved }) => ({
+		token,
+		balance: { free, reserved }
+	}));
+};
+
+export const getMyOrders = async (
+	params: CanisterApiFunctionParams & { args: GetMyOrdersArgs }
+): Promise<UserOrder[]> => {
+	const { orders } = await mockState(params);
+
+	return [...orders].sort(({ order: a }, { order: b }) => Number(b.created_at - a.created_at));
+};
+
+export const deposit = async (
+	params: CanisterApiFunctionParams<{ request: DepositRequest }>
+): Promise<DepositResponse> => {
+	const {
+		request: { token_id, amount }
+	} = params;
+
+	const balance = await balanceEntry({ params, ledgerId: token_id.ledger_id.toText() });
+
+	balance.free += amount;
+
+	return { block_index: BigInt(Date.now()) };
+};
+
+export const withdraw = async (
+	params: CanisterApiFunctionParams<{ request: WithdrawRequest }>
+): Promise<WithdrawResponse> => {
+	const {
+		request: { token_id, amount }
+	} = params;
+
+	const balance = await balanceEntry({ params, ledgerId: token_id.ledger_id.toText() });
+
+	if (balance.free < amount) {
+		throw new Error('VITE_TRADE_MOCK: insufficient free balance to withdraw');
+	}
+
+	balance.free -= amount;
+
+	return { block_index: BigInt(Date.now()) };
+};
+
+// Mirrors what the canister reserves on submission: a buy locks quote
+// (`price × quantity / 10^base_decimals`), a sell locks the base quantity — so
+// the free/reserved split on the provider page moves the way it would live.
+const reserveFor = async ({
+	params,
+	request
+}: {
+	params: CanisterApiFunctionParams;
+	request: LimitOrderRequest;
+}): Promise<void> => {
+	const { pair, side, quantity, price } = request;
+
+	const isBuy = 'Buy' in side;
+
+	const ledgerId = (isBuy ? pair.quote : pair.base).toText();
+
+	const balance = await balanceEntry({ params, ledgerId });
+
+	const base = await balanceEntry({ params, ledgerId: pair.base.toText() });
+
+	const amount = isBuy
+		? (price * quantity) / 10n ** BigInt(base.token.metadata.decimals)
+		: quantity;
+
+	if (balance.free < amount) {
+		throw new Error('VITE_TRADE_MOCK: insufficient free balance for this order');
+	}
+
+	balance.free -= amount;
+	balance.reserved += amount;
+};
+
+export const addLimitOrder = async (
+	params: CanisterApiFunctionParams & { request: LimitOrderRequest }
+): Promise<OrderId> => {
+	const { request } = params;
+
+	const current = await mockState(params);
+
+	await reserveFor({ params, request });
+
+	const id = mockOrderId(current.nextOrderSeq);
+
+	current.nextOrderSeq += 1;
+
+	current.orders = [
+		...current.orders,
+		{
+			id,
+			pair: request.pair,
+			order: {
+				status: { Open: null },
+				owner: owner(params),
+				side: request.side,
+				quantity: request.quantity,
+				filled_quantity: ZERO,
+				price: request.price,
+				created_at: nowInBigIntNanoSeconds(),
+				last_updated_at: [],
+				time_in_force: request.time_in_force?.[0] ?? { GoodTilCanceled: null }
+			}
+		}
+	];
+
+	return id;
+};
+
+export const cancelLimitOrder = async (
+	params: CanisterApiFunctionParams & { orderId: OrderId }
+): Promise<OrderRecord> => {
+	const { orderId } = params;
+
+	const current = await mockState(params);
+
+	const target = current.orders.find(({ id }) => id === orderId);
+
+	if (isNullish(target)) {
+		throw new Error(`VITE_TRADE_MOCK: unknown order ${orderId}`);
+	}
+
+	const canceled: OrderRecord = {
+		...target.order,
+		status: { Canceled: null },
+		last_updated_at: [nowInBigIntNanoSeconds()]
+	};
+
+	current.orders = current.orders.map((order) =>
+		order.id === orderId ? { ...order, order: canceled } : order
+	);
+
+	// Release what the order had locked, so the freed funds show up again.
+	const isBuy = 'Buy' in target.order.side;
+	const ledgerId = (isBuy ? target.pair.quote : target.pair.base).toText();
+	const base = await balanceEntry({ params, ledgerId: target.pair.base.toText() });
+	const remaining = target.order.quantity - target.order.filled_quantity;
+
+	const amount = isBuy
+		? (target.order.price * remaining) / 10n ** BigInt(base.token.metadata.decimals)
+		: remaining;
+
+	const balance = await balanceEntry({ params, ledgerId });
+
+	const released = amount > balance.reserved ? balance.reserved : amount;
+
+	balance.reserved -= released;
+	balance.free += released;
+
+	return canceled;
+};

--- a/src/frontend/src/lib/services/oisy-trade.deposit.mock.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade.deposit.mock.services.ts
@@ -1,0 +1,66 @@
+import { deposit as depositApi } from '$lib/api/oisy-trade.api';
+import { ProgressStepsTradingDeposit } from '$lib/enums/progress-steps';
+// Resolves to the real module, not back to this one: the dev-only resolver in
+// `vite.config.ts` skips the redirect when the importer is the mock itself.
+import type { DepositOisyTradeParams } from '$lib/services/oisy-trade.deposit.services';
+import { loadOisyTrade } from '$lib/services/oisy-trade.services';
+import { i18n } from '$lib/stores/i18n.store';
+import { toastsError } from '$lib/stores/toasts.store';
+import { assertNonNullish } from '@dfinity/utils';
+import { Principal } from '@icp-sdk/core/principal';
+import { get } from 'svelte/store';
+
+// Dev-only stand-in for the deposit flow, activated by `VITE_TRADE_MOCK=true`
+// (see the resolver in `vite.config.ts`). The real service opens with an
+// `icrc2_approve` against the token ledger, which needs funds the mocked wallet
+// balance doesn't actually have — so the whole wizard would fail at the first
+// step. This walks the same progress steps and credits the in-memory DEX
+// balance instead, leaving nothing on-chain.
+//
+// Analytics are deliberately dropped: a mocked deposit is not a deposit, and
+// shouldn't show up in Plausible.
+const MOCK_STEP_DELAY_MS = 600;
+
+const pause = (): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, MOCK_STEP_DELAY_MS));
+
+export const depositOisyTrade = async ({
+	identity,
+	token,
+	amount,
+	progress
+}: DepositOisyTradeParams): Promise<boolean> => {
+	const { auth, trading } = get(i18n);
+
+	try {
+		assertNonNullish(identity, auth.error.no_internet_identity);
+
+		progress?.(ProgressStepsTradingDeposit.APPROVE);
+
+		await pause();
+
+		progress?.(ProgressStepsTradingDeposit.DEPOSIT);
+
+		await depositApi({
+			identity,
+			request: {
+				token_id: { ledger_id: Principal.fromText(token.ledgerCanisterId) },
+				amount
+			}
+		});
+
+		await pause();
+
+		progress?.(ProgressStepsTradingDeposit.UPDATE_UI);
+
+		await loadOisyTrade({ identity });
+
+		progress?.(ProgressStepsTradingDeposit.DONE);
+
+		return true;
+	} catch (err: unknown) {
+		toastsError({ msg: { text: trading.deposit.error.deposit_failed }, err });
+
+		return false;
+	}
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import inject from '@rollup/plugin-inject';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { defineConfig, loadEnv, type UserConfig } from 'vite';
+import { defineConfig, loadEnv, type PluginOption, type UserConfig } from 'vite';
 import { reactivityDebugPlugin } from './vite.plugin.reactivity-debug';
 import { defineViteReplacements, readCanisterIds } from './vite.utils';
 
@@ -16,18 +16,63 @@ const network = process.env.DFX_NETWORK ?? 'local';
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url));
 
+// Dev-only: swaps the caller-specific half of the OISY TRADE API — and the
+// deposit service, whose `icrc2_approve` needs real funds — for in-memory mocks,
+// so the Trade flows can be clicked through on an unfunded account without
+// submitting anything on-chain. Market data still comes from the real canister.
+// Opt-in via `VITE_TRADE_MOCK=true`; without it neither mock module is reachable
+// from any import, so a normal build cannot pick them up.
+const OISY_TRADE_MOCKS: [real: string, mock: string][] = [
+	['src/frontend/src/lib/api/oisy-trade.api', 'src/frontend/src/lib/api/oisy-trade.mock.api'],
+	[
+		'src/frontend/src/lib/services/oisy-trade.deposit.services',
+		'src/frontend/src/lib/services/oisy-trade.deposit.mock.services'
+	]
+];
+
+// Drops the `?v=…` / `?import` suffixes dev requests carry, and the extension,
+// so a module has one key however it was reached.
+const moduleKey = (id: string): string =>
+	resolve(projectRoot, id.split('?')[0]).replace(/\.ts$/, '');
+
+// A resolver rather than a `resolve.alias` entry: the mocks re-export the parts
+// of the real modules they don't fake, and they import them under the very
+// specifier being redirected. Skipping the redirect when the importer *is* the
+// mock lets those imports fall through to the real files, which an alias — which
+// only ever sees the specifier — could not do without relative paths. Keyed on
+// resolved paths because Vite's own alias plugin has already turned `$lib/…`
+// into an absolute path by the time this hook runs.
+const oisyTradeMockPlugin = (): PluginOption => ({
+	name: 'oisy-trade-mock',
+	enforce: 'pre',
+	// eslint-disable-next-line local-rules/prefer-object-params -- Rollup calls this hook positionally.
+	resolveId: (source: string, importer: string | undefined) => {
+		const key = moduleKey(source);
+
+		const entry = OISY_TRADE_MOCKS.find(([real]) => moduleKey(real) === key);
+
+		if (entry === undefined) {
+			return null;
+		}
+
+		const mock = `${moduleKey(entry[1])}.ts`;
+
+		return importer !== undefined && moduleKey(importer) === moduleKey(mock) ? null : mock;
+	}
+});
+
+const alias: Record<string, string> = {
+	$declarations: resolve('./src/declarations'),
+	// Rollup can fail to resolve "exports" subpaths in dynamic import(); pin the entry file.
+	'barcode-detector/ponyfill': resolve(
+		projectRoot,
+		'node_modules/barcode-detector/dist/es/ponyfill.js'
+	)
+};
+
 const config: UserConfig = {
 	plugins: [reactivityDebugPlugin(), sveltekit()],
-	resolve: {
-		alias: {
-			$declarations: resolve('./src/declarations'),
-			// Rollup can fail to resolve "exports" subpaths in dynamic import(); pin the entry file.
-			'barcode-detector/ponyfill': resolve(
-				projectRoot,
-				'node_modules/barcode-detector/dist/es/ponyfill.js'
-			)
-		}
-	},
+	resolve: { alias },
 	build: {
 		target: 'es2020',
 		rollupOptions: {
@@ -112,8 +157,13 @@ export default defineConfig((): UserConfig => {
 		...readCanisterIds({ prefix: 'VITE_' })
 	};
 
+	// Read after `loadEnv` so the flag can come either from the shell
+	// (`VITE_TRADE_MOCK=true npm run dev`) or from the network's `.env` file.
+	const mockOisyTrade = process.env.VITE_TRADE_MOCK === 'true';
+
 	return {
 		...config,
+		plugins: [...(mockOisyTrade ? [oisyTradeMockPlugin()] : []), ...(config.plugins ?? [])],
 		// Backwards compatibility for auto generated types of dfx that are meant for webpack and process.env
 		define: {
 			'process.env': {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,7 +79,10 @@ export default defineConfig((): UserConfig => ({
 			exclude: [
 				'src/frontend/src/routes/**/+page.ts',
 				'src/frontend/src/tests/**/*',
-				'src/frontend/src/**/*.d.ts'
+				'src/frontend/src/**/*.d.ts',
+				// Dev-only mocks, aliased in only behind an env flag and never built.
+				'src/frontend/src/**/*.mock.api.ts',
+				'src/frontend/src/**/*.mock.services.ts'
 			],
 			// TODO: increase the thresholds slowly up to an acceptable 90% at least
 			thresholds: {


### PR DESCRIPTION
# Motivation

Clicking through the OISY TRADE flows locally needs a funded account: deposits, limit orders and withdrawals all move real tokens, and the deposit flow opens with an `icrc2_approve` that fails outright on an empty wallet. That makes the whole Trade surface awkward to exercise while working on it.

# Changes

- `src/frontend/src/lib/api/oisy-trade.mock.api.ts` — in-memory stand-in for the caller-specific half of the API. It re-exports the market-data reads (pairs, supported tokens, ticker, depth) untouched from the real module, and fabricates only the caller's balances and orders. The four writes (`deposit`, `withdraw`, `add_limit_order`, `cancel_limit_order`) mutate that state the way the canister would: placing an order moves free → reserved, cancelling releases it.
- `src/frontend/src/lib/services/oisy-trade.deposit.mock.services.ts` — walks the same progress steps as the real deposit service without the ledger approve.
- `vite.config.ts` — a dev-only resolver redirects the two modules when `VITE_TRADE_MOCK=true`. It is a resolver rather than a `resolve.alias` entry because the mocks import the real modules under the very specifier being redirected; skipping the redirect when the importer *is* the mock lets those fall through, which an alias cannot do without relative paths.
- `vitest.config.ts` — excludes the mocks from coverage.
- `HACKING.md` — documents the flag and what is faked versus real.

Nothing imports either mock without the flag, so a normal build cannot reach them.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` — clean.
- Verified in a local staging dev server that the resolver rewires consumers to the mock and that the mock's own imports still resolve to the real module, and that without the flag both resolve to the real modules.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| | |
| --- | --- |
| **Model** | Claude Opus 5 (`claude-opus-5`) |
| **Version** | Claude Code 2.1.202 |