### PR TITLE
fix(frontend): keep tabular figures from stretching spaces in order rows

### DIFF
--- a/src/frontend/src/lib/components/trading/OisyTradeOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeOrderRow.svelte
@@ -222,12 +222,14 @@
 		{#if $isPrivacyMode}
 			<IconDots variant="md" />
 		{:else}
-			<span class="text-base font-semibold text-primary"
-				><span class="tabular-nums">{baseAmountSigned}</span> {baseSymbol}</span
-			>
-			<span class="text-sm text-tertiary"
-				><span class="tabular-nums">{quoteAmountSigned}</span> {quoteSymbol}</span
-			>
+			<span class="text-base font-semibold text-primary">
+				<span class="tabular-nums">{baseAmountSigned}</span>
+				{baseSymbol}
+			</span>
+			<span class="text-sm text-tertiary">
+				<span class="tabular-nums">{quoteAmountSigned}</span>
+				{quoteSymbol}
+			</span>
 		{/if}
 	</div>
 </button>

--- a/src/frontend/src/lib/components/trading/OisyTradeOrderRow.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeOrderRow.svelte
@@ -63,13 +63,10 @@
 
 	// Signed legs on the right: the base leaves the account on a sell (−) and
 	// arrives on a buy (+); the quote is the mirror image. U+2212 is the typographic
-	// minus so the two signs align under tabular-nums.
-	let baseAmountSigned = $derived(
-		`${side === 'sell' ? '−' : '+'}${formattedQuantity} ${baseSymbol}`
-	);
-	let quoteAmountSigned = $derived(
-		`${side === 'sell' ? '+' : '−'}${formattedQuoteAmount} ${quoteSymbol}`
-	);
+	// minus so the two signs align under tabular-nums. Symbol-free: `tabular-nums`
+	// must wrap the figure only (see the render below).
+	let baseAmountSigned = $derived(`${side === 'sell' ? '−' : '+'}${formattedQuantity}`);
+	let quoteAmountSigned = $derived(`${side === 'sell' ? '+' : '−'}${formattedQuoteAmount}`);
 
 	let { labelKey, pillVariant } = $derived(orderStatusView(oisyTradeOrderDisplayStatus(order)));
 
@@ -200,11 +197,11 @@
 					{side === 'sell' ? $i18n.trading.orders.side_sell : $i18n.trading.orders.side_buy}
 				</span>
 				<span class="font-semibold">{baseSymbol}</span>
-				<span class="tabular-nums">{phrase}</span>
+				<span>{phrase}</span>
 			{/if}
 		</div>
 		{#if nonNullish(metaLine)}
-			<div class="mt-0.5 text-xs text-tertiary tabular-nums" transition:slide={SLIDE_PARAMS}>
+			<div class="mt-0.5 text-xs text-tertiary" transition:slide={SLIDE_PARAMS}>
 				{metaLine}
 			</div>
 		{/if}
@@ -225,8 +222,12 @@
 		{#if $isPrivacyMode}
 			<IconDots variant="md" />
 		{:else}
-			<span class="text-base font-semibold text-primary tabular-nums">{baseAmountSigned}</span>
-			<span class="text-sm text-tertiary tabular-nums">{quoteAmountSigned}</span>
+			<span class="text-base font-semibold text-primary"
+				><span class="tabular-nums">{baseAmountSigned}</span> {baseSymbol}</span
+			>
+			<span class="text-sm text-tertiary"
+				><span class="tabular-nums">{quoteAmountSigned}</span> {quoteSymbol}</span
+			>
 		{/if}
 	</div>
 </button>


### PR DESCRIPTION
# Motivation

Word spacing in the OISY TRADE order rows rendered far too wide — "Sell ICP for&nbsp;&nbsp;ckUSDT&nbsp;&nbsp;@&nbsp;&nbsp;0.25".

The cause is `tabular-nums`. In CircularXX the `tnum` OpenType feature remaps the **space** to the tabular figure advance, not just the digits. Measured in the running app:

| Text | Normal | With `tabular-nums` |
| --- | --- | --- |
| 10 spaces | 40.8px | **91.0px** |
| `0123456789` | 87.3px | 91.0px |

So each space goes from 4.08px to 9.10px, exactly one digit wide. The row applied the class to whole phrases, so every space inside them was set as if it were a numeral.

# Changes

- Drop `tabular-nums` from the intent phrase and the meta line. Both are prose, and neither aligns across rows anyway since they trail variable-width text.
- Keep it on the right-hand amounts but move the token symbol out of the tabular span, so the signs and figures still line up column-wise while the space before the symbol renders normally.

This component was the only user of `tabular-nums` in the codebase, so nothing else is affected.

# Tests

- `npm run check` — clean; `npx vitest run tests/lib/components/trading` — 218 passing.
- Measured the space advance with and without the feature in the running app to confirm the cause before changing anything.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| | |
| --- | --- |
| **Model** | Claude Opus 5 (`claude-opus-5`) |
| **Version** | Claude Code 2.1.202 |