### PR TITLE
style(frontend): rework the limit-order price section

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
@@ -51,6 +51,11 @@
 		onPriceInput
 	}: Props = $props();
 
+	// The visible title names the field for screen readers: the input has no
+	// `<label>`, and a placeholder is not an accessible name.
+	const uid = $props.id();
+	const labelId = `limit-order-price-label-${uid}`;
+
 	// Drives the shared container's brand focus border, the same way
 	// `TokenInputContent` tracks it for the amount fields.
 	let focused = $state(false);
@@ -236,7 +241,7 @@
 >
 	<!-- Same shape as the token-input boxes above: `text-sm font-bold` title, the
 		 framed field, then the controls. Helper lines below all share `text-xs`. -->
-	<div class="mb-2 text-sm font-bold text-primary">{label}</div>
+	<div id={labelId} class="mb-2 text-sm font-bold text-primary">{label}</div>
 
 	<!-- The shared container, so the field carries the same frame, height and
 		 focus/hover behaviour as the amount inputs — the quote symbol sits where
@@ -245,6 +250,7 @@
 	<TokenInputContainer error={nonNullish(tickError)} {focused} styleClass="h-14 text-xl">
 		<input
 			class="h-full w-full min-w-0 border-none bg-transparent px-3 font-bold text-primary outline-none disabled:cursor-not-allowed disabled:text-tertiary"
+			aria-labelledby={labelId}
 			disabled={!active}
 			onblur={() => (focused = false)}
 			onfocus={() => (focused = true)}

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSection.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
+	import IconArrowDown from '$lib/components/icons/lucide/IconArrowDown.svelte';
+	import TokenInputContainer from '$lib/components/tokens/TokenInputContainer.svelte';
+	import PillButton from '$lib/components/ui/PillButton.svelte';
+	import ScrollableBar from '$lib/components/ui/ScrollableBar.svelte';
 	import ValueDifference from '$lib/components/ui/ValueDifference.svelte';
 	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -47,12 +51,18 @@
 		onPriceInput
 	}: Props = $props();
 
+	// Drives the shared container's brand focus border, the same way
+	// `TokenInputContent` tracks it for the amount fields.
+	let focused = $state(false);
+
 	const priceNum = $derived(parseFloat(price));
 	const active = $derived(nonNullish(pairView));
 
 	const crossing = $derived(active && crossesBook({ side, price: priceNum, bid, ask }));
 
 	const valueDiff = $derived(valueDifferencePercent({ side, price: priceNum, currentValue }));
+
+	const showValueDifference = $derived(priceNum > 0 && currentValue > 0);
 
 	// The book side we'd cross against (bid when selling, ask when buying). Null
 	// when that side is empty — without it crossing is indeterminate, so we can't
@@ -191,83 +201,115 @@
 	]);
 </script>
 
-<!-- Border marks the latched preset; it clears on a manual price edit
+<!-- The filled pill marks the latched preset; it clears on a manual price edit
 	 (which nulls `activePreset`) and follows the market while latched. -->
-{#snippet presetButton({ preset, label }: { preset: PricePreset; label: string })}
-	<button
-		class="rounded border px-1 py-0.5 transition-colors"
-		class:border-brand-primary={activePreset === preset}
-		class:border-transparent={activePreset !== preset}
-		class:font-semibold={activePreset === preset}
-		class:text-brand-primary={activePreset !== preset}
-		class:text-primary={activePreset === preset}
-		class:underline={activePreset !== preset}
-		aria-pressed={activePreset === preset}
-		onclick={() => setPreset(preset)}
-		type="button">{label}</button
-	>
+{#snippet presetButton({
+	preset,
+	label,
+	arrow = false
+}: {
+	preset: PricePreset;
+	label: string;
+	arrow?: boolean;
+})}
+	<PillButton onClick={() => setPreset(preset)} selected={activePreset === preset}>
+		<span class="flex items-center gap-1">
+			{label}
+
+			<!-- Which way the offset moves the price: up for a sell, down for a buy.
+				 Rotating `IconArrowDown` is how `LimitOrderSideControl` draws its own
+				 up arrow — there is no `IconArrowUp` in the set. -->
+			{#if arrow}
+				<span class="flex" class:rotate-180={side === 'sell'}>
+					<IconArrowDown size="14" />
+				</span>
+			{/if}
+		</span>
+	</PillButton>
 {/snippet}
 
 <div
-	class="rounded-lg border bg-secondary px-3 py-2.5"
+	class="rounded-lg border bg-secondary px-3 py-3"
 	class:border-disabled={isNullish(warningText)}
 	class:border-error-primary={nonNullish(warningText) && warningText.danger}
 	class:border-warning-primary={nonNullish(warningText) && !warningText.danger}
 >
-	<div class="flex items-center justify-between gap-2">
-		<span class="text-xs text-secondary">{label}</span>
-		<div class="flex items-center gap-1.5 text-xs">
-			{@render presetButton({ preset: 'book', label: bidAskLabel })}
-			<span class="text-tertiary" aria-hidden="true">|</span>
-			<div class="flex items-center gap-0.5">
-				{#each pricePresets as { preset, label }, i (preset)}
-					{#if i > 0}
-						<span class="text-tertiary" aria-hidden="true">·</span>
-					{/if}
-					{@render presetButton({ preset, label })}
-				{/each}
-			</div>
-		</div>
-	</div>
+	<!-- Same shape as the token-input boxes above: `text-sm font-bold` title, the
+		 framed field, then the controls. Helper lines below all share `text-xs`. -->
+	<div class="mb-2 text-sm font-bold text-primary">{label}</div>
 
-	<div class="mt-2 flex items-baseline justify-between gap-2">
-		<div class="flex items-baseline gap-1">
-			<input
-				class="w-32 rounded-md border border-secondary bg-primary px-2 py-1 text-xl text-primary outline-none focus:border-brand-primary"
-				class:border-error-primary={nonNullish(tickError)}
-				disabled={!active}
-				oninput={(e) => onPriceInput(e.currentTarget.value)}
-				placeholder={$i18n.trading.limit_order.price_placeholder}
-				type="text"
-				value={price}
-			/>
-			<span class="text-xs text-secondary">{pairView?.quoteSymbol ?? ''}</span>
+	<!-- The shared container, so the field carries the same frame, height and
+		 focus/hover behaviour as the amount inputs — the quote symbol sits where
+		 those put their token selector. The inner input mirrors what
+		 `TokenInputCurrency` renders: borderless, full-height, bold, px-3. -->
+	<TokenInputContainer error={nonNullish(tickError)} {focused} styleClass="h-14 text-xl">
+		<input
+			class="h-full w-full min-w-0 border-none bg-transparent px-3 font-bold text-primary outline-none disabled:cursor-not-allowed disabled:text-tertiary"
+			disabled={!active}
+			onblur={() => (focused = false)}
+			onfocus={() => (focused = true)}
+			oninput={(e) => onPriceInput(e.currentTarget.value)}
+			placeholder={$i18n.trading.limit_order.price_placeholder}
+			type="text"
+			value={price}
+		/>
+
+		<div class="h-3/4 w-[1px] bg-disabled"></div>
+
+		<span class="flex h-full shrink-0 items-center px-3 text-sm font-semibold text-primary">
+			{pairView?.quoteSymbol ?? ''}
+		</span>
+	</TokenInputContainer>
+
+	<!-- The value difference shares the presets' row rather than taking one of its
+		 own: it is a single short figure, and on a crossing price the warning below
+		 already carries the same colour. `pb-1` matches `ScrollableBar`'s, so the
+		 figure sits on the pills' centre line. -->
+	<div class="mt-2 flex items-center gap-2">
+		<div class="min-w-0 flex-1">
+			<ScrollableBar>
+				{@render presetButton({ preset: 'book', label: bidAskLabel })}
+
+				<!-- Keeps the book price set apart from the three value-derived presets,
+					 as the `|` did when these were links. -->
+				<span class="h-4 w-px shrink-0 bg-disabled" aria-hidden="true"></span>
+
+				{#each pricePresets as { preset, label } (preset)}
+					{@render presetButton({ preset, label, arrow: preset !== 0 })}
+				{/each}
+			</ScrollableBar>
 		</div>
-		{#if priceNum > 0 && currentValue > 0}
-			<ValueDifference
-				errorLevel={-5}
-				iconPosition="left"
-				muted={!(crossing || fillOrKill)}
-				successNeutral
-				value={valueDiff}
-				warningLevel={0}
-			/>
+
+		{#if showValueDifference}
+			<!-- `ValueDifference` sets no size of its own; without `text-sm` it
+				 inherits the base 16px and ends up the largest text in the box. -->
+			<span class="shrink-0 pb-1 text-sm">
+				<ValueDifference
+					errorLevel={-5}
+					iconPosition="left"
+					muted={!(crossing || fillOrKill)}
+					successNeutral
+					value={valueDiff}
+					warningLevel={0}
+				/>
+			</span>
 		{/if}
 	</div>
 
-	{#if nonNullish(tickError)}
-		<p class="mt-1 text-xs text-error-primary" transition:slide={SLIDE_PARAMS}>{tickError}</p>
+	{#if nonNullish(queueText)}
+		<p class="mt-1 mb-0 text-xs text-tertiary" transition:slide={SLIDE_PARAMS}>{queueText}</p>
 	{/if}
 
-	{#if nonNullish(queueText)}
-		<p class="mt-1.5 text-xs text-tertiary" transition:slide={SLIDE_PARAMS}>{queueText}</p>
+	{#if nonNullish(tickError)}
+		<p class="mt-1 mb-0 text-xs text-error-primary" transition:slide={SLIDE_PARAMS}>{tickError}</p>
 	{/if}
 
 	{#if nonNullish(warningText)}
+		<!-- Plain line rather than a tinted chip: its own `px-2.5` indented the copy
+			 past the title and field, and the subtle fill barely reads on the box's
+			 own background. The section border already carries the alert colour. -->
 		<p
-			class="mt-2 rounded-md px-2.5 py-2 text-xs"
-			class:bg-error-subtle={warningText.danger}
-			class:bg-warning-subtle={!warningText.danger}
+			class="mt-2 mb-0 text-xs"
 			class:text-error-primary={warningText.danger}
 			class:text-warning-primary={!warningText.danger}
 			transition:slide={SLIDE_PARAMS}

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderPriceSection.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderPriceSection.svelte.spec.ts
@@ -1,6 +1,7 @@
 import LimitOrderPriceSection from '$lib/components/trading/limit-order/LimitOrderPriceSection.svelte';
 import type { LimitOrderPairView, LimitOrderSide, PricePreset } from '$lib/utils/oisy-trade.utils';
 import en from '$tests/mocks/i18n.mock';
+import type { Nullish } from '@dfinity/zod-schemas';
 import { fireEvent, render } from '@testing-library/svelte';
 
 describe('LimitOrderPriceSection', () => {

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderPriceSection.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderPriceSection.svelte.spec.ts
@@ -113,22 +113,28 @@ describe('LimitOrderPriceSection', () => {
 		expect(parseFloat(props.price)).toBeGreaterThan(0);
 	});
 
-	it('borders the latched preset and no other', () => {
+	// The presets are `PillButton`s, so the latched one is marked by `aria-pressed`
+	// rather than a class of this component's own — assert the semantics, not the
+	// pill's styling.
+	const pressed = (element: HTMLElement): Nullish<string> =>
+		element.closest('button')?.getAttribute('aria-pressed');
+
+	it('marks the latched preset and no other', () => {
 		const { getByText } = render(LimitOrderPriceSection, {
 			props: { ...baseProps, activePreset: 1 as PricePreset | null }
 		});
 
-		expect(getByText(en.trading.limit_order.preset_sell_1)).toHaveClass('border-brand-primary');
-		expect(getByText(en.trading.limit_order.preset_market)).not.toHaveClass('border-brand-primary');
+		expect(pressed(getByText(en.trading.limit_order.preset_sell_1))).toBe('true');
+		expect(pressed(getByText(en.trading.limit_order.preset_market))).toBe('false');
 	});
 
-	it('borders no preset when none is latched', () => {
+	it('marks no preset when none is latched', () => {
 		const { getByText } = render(LimitOrderPriceSection, {
 			props: { ...baseProps, activePreset: null as PricePreset | null }
 		});
 
-		expect(getByText(en.trading.limit_order.preset_market)).not.toHaveClass('border-brand-primary');
-		expect(getByText(en.trading.limit_order.preset_sell_1)).not.toHaveClass('border-brand-primary');
+		expect(pressed(getByText(en.trading.limit_order.preset_market))).toBe('false');
+		expect(pressed(getByText(en.trading.limit_order.preset_sell_1))).toBe('false');
 	});
 
 	it('renders the value difference when price and current value are positive', () => {


### PR DESCRIPTION
# Motivation

The limit-order price section was built from one-off markup and ran on a type scale that matched nothing else in the modal: a 12px label, a 20px figure in a narrow bespoke frame, and a value-difference percentage that inherited the 16px base — making the least important number the largest text in the box. The field also looked nothing like the two token inputs directly above it.

Atomicity: every item below is the same box, restyled in one pass.

# Changes

- Reuse `TokenInputContainer` for the price field, so it carries the same frame, height, shadow and focus/hover behaviour as the amount inputs above. The inner input mirrors what `TokenInputCurrency` renders (borderless, full-height, bold), and the quote symbol sits behind a divider where those boxes put their token selector.
- Move the presets from underlined links onto `PillButton` inside a `ScrollableBar` — the pair the token filter bar already uses. A 1px rule keeps the book price grouped apart from the three value-derived offsets, and each offset carries a direction arrow (up for a sell, down for a buy), drawn the same way `LimitOrderSideControl` draws its own.
- One type scale: label, controls and figures on `text-sm`, helper lines on `text-xs`.
- The value difference shares the presets' row instead of taking one of its own, and the row is dropped entirely until there is something to show — before a price is entered it reserved an empty band.
- The crossing warning becomes a plain line: its own `px-2.5` indented the copy past everything else while its subtle fill barely registered. The section border already carries the alert colour.
- Zero the bottom margin the global `p` rule adds, which was leaving dead space at the bottom of the box.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` — clean.
- `npx vitest run tests/lib/components/trading` — 218 passing. Two preset assertions moved from a class check to `aria-pressed`, which `PillButton` exposes: the previous assertion targeted the element `getByText` returns, which is now the inner span, and one of the two had quietly become vacuous.
- Visual states (resting, crossing, fill-or-kill, tick error) checked in a local staging build.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| | |
| --- | --- |
| **Model** | Claude Opus 5 (`claude-opus-5`) |
| **Version** | Claude Code 2.1.202 |