### PR TITLE
feat(frontend): signal the gated quote leg in the limit-order form

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
@@ -5,6 +5,10 @@
 		focused?: boolean;
 		error?: boolean;
 		readOnlyAmount?: boolean;
+		// The field can neither be typed into nor opened: it keeps its frame but
+		// drops the hover affordance, which would otherwise promise an interaction
+		// that isn't there.
+		inert?: boolean;
 		styleClass?: string;
 		children: Snippet;
 	}
@@ -13,6 +17,7 @@
 		focused = false,
 		error = false,
 		readOnlyAmount = false,
+		inert = false,
 		styleClass,
 		children
 	}: Props = $props();
@@ -26,8 +31,9 @@
 	class:border-error-solid={!readOnlyAmount && error}
 	class:border-solid={!readOnlyAmount}
 	class:border-tertiary={!readOnlyAmount && !error && !focused}
-	class:focus-within:border-2={!readOnlyAmount}
-	class:hover:border-brand-primary={!readOnlyAmount && !error}
+	class:cursor-not-allowed={inert}
+	class:focus-within:border-2={!readOnlyAmount && !inert}
+	class:hover:border-brand-primary={!readOnlyAmount && !error && !inert}
 	class:shadow-inner={!readOnlyAmount}
 >
 	{@render children()}

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -9,6 +9,7 @@
 	import TokenInputCurrencyToken from '$lib/components/tokens/TokenInputCurrencyToken.svelte';
 	import TokenLogo from '$lib/components/tokens/TokenLogo.svelte';
 	import { logoSizes } from '$lib/constants/components.constants';
+	import { TOKEN_INPUT_SELECT_TOKEN_BUTTON } from '$lib/constants/test-ids.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
@@ -202,6 +203,7 @@
 			class:hover:border-brand-primary={readOnlyAmount && isSelectable}
 			class:rounded-lg={readOnlyAmount}
 			class:shadow-inner={readOnlyAmount}
+			data-tid={TOKEN_INPUT_SELECT_TOKEN_BUTTON}
 			disabled={!isSelectable}
 			onclick={onClick}
 			type="button"

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -27,6 +27,9 @@
 		disabled?: boolean;
 		readOnlyAmount?: boolean;
 		placeholder?: string;
+		// Overrides the "Select token" prompt shown while no token is picked — e.g.
+		// to name what has to be chosen first when the picker is still gated.
+		selectTokenText?: string;
 		errorType?: TokenActionErrorType;
 		// TODO: We want to be able to reuse this component in the send forms. Unfortunately, the send forms work with errors instead of error types. For now, this component supports errors and error types but in the future the error handling in the send forms should be reworked.
 		error?: Error;
@@ -54,6 +57,7 @@
 		disabled = false,
 		readOnlyAmount = false,
 		placeholder = '0',
+		selectTokenText,
 		errorType = $bindable(),
 		error = $bindable(),
 		amountSetToMax = $bindable(false),
@@ -69,6 +73,10 @@
 		amountInfo,
 		balance
 	}: Props = $props();
+
+	// Nothing to type into and no picker to open: the field is inert, so it must
+	// not offer a hover border or a pointer cursor.
+	const inert = $derived(disabled && !isSelectable);
 
 	const onFocus = () => (focused = true);
 	const onBlur = () => (focused = false);
@@ -125,6 +133,7 @@
 <TokenInputContainer
 	error={nonNullish(errorType) || nonNullish(error)}
 	{focused}
+	{inert}
 	{readOnlyAmount}
 	styleClass="h-14 text-3xl"
 >
@@ -166,8 +175,15 @@
 		{:else if readOnlyAmount}
 			<div class="w-full pl-3 font-bold text-disabled">—</div>
 		{:else}
-			<button class="h-full w-full pl-3 text-base" onclick={onClick} type="button"
-				>{$i18n.tokens.text.select_token}</button
+			<!-- Muted and inert when the picker can't be opened yet (e.g. a pair's
+				 second leg before the first is chosen), so the field doesn't invite a
+				 click that does nothing. -->
+			<button
+				class="h-full w-full pl-3 text-base disabled:cursor-not-allowed"
+				class:text-tertiary={!isSelectable}
+				disabled={!isSelectable}
+				onclick={onClick}
+				type="button">{selectTokenText ?? $i18n.tokens.text.select_token}</button
 			>
 		{/if}
 	</div>
@@ -178,7 +194,7 @@
 
 	{#if !readOnlyAmount || isSelectable}
 		<button
-			class="flex h-full items-center gap-1 px-3 transition-colors"
+			class="flex h-full items-center gap-1 px-3 transition-colors disabled:cursor-not-allowed"
 			class:bg-primary={readOnlyAmount}
 			class:border={readOnlyAmount}
 			class:border-solid={readOnlyAmount}
@@ -194,9 +210,15 @@
 				<TokenLogo data={token} logoSize="xs" />
 				<div class="ml-2 text-sm font-semibold">{getTokenDisplaySymbol(token)}</div>
 			{:else}
+				<!-- Grey rather than brand while the picker is unavailable: the plus is
+					 the field's only affordance, so leaving it blue reads as actionable. -->
 				<span
 					style={`width: ${logoSizes['xs']}; height: ${logoSizes['xs']};`}
-					class="flex items-center justify-center rounded-full bg-brand-primary text-primary-inverted"
+					class="flex items-center justify-center rounded-full"
+					class:bg-brand-primary={isSelectable}
+					class:bg-disabled={!isSelectable}
+					class:text-primary-inverted={isSelectable}
+					class:text-tertiary={!isSelectable}
 				>
 					<IconPlus />
 				</span>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -85,6 +85,17 @@
 			: undefined
 	);
 
+	// Until a base is picked the quote field says which leg is blocking it, in
+	// place of the generic "Select token" prompt — the picker it points at carries
+	// the same wording, minus the "first".
+	const selectTokenText = $derived(
+		nonNullish(baseSymbol)
+			? undefined
+			: side === 'sell'
+				? $i18n.trading.limit_order.select_sell_token_first
+				: $i18n.trading.limit_order.select_buy_token_first
+	);
+
 	// The quote can only be chosen once a base is set (the quote list is filtered
 	// by the base's markets), mirroring the previous disabled-pill behaviour.
 	const onSelectQuoteGuarded = () => {
@@ -266,7 +277,10 @@
 		<span class="h-px flex-1 bg-disabled"></span>
 	</div>
 
-	<!-- Quote row: shared token selector with a read-only, non-editable derived amount -->
+	<!-- Quote row: the derived amount in a disabled input. Deliberately not
+		 `readOnlyAmount` — that strips the input's frame and turns the selector into
+		 a pill, whereas Swap renders its computed "You receive" leg as a plain
+		 disabled input. Same shape here keeps the two modals consistent. -->
 	<div class="py-2">
 		<TokenInputContent
 			amount={quoteAmountValue}
@@ -276,7 +290,7 @@
 			isSelectable={nonNullish(baseSymbol)}
 			onClick={onSelectQuoteGuarded}
 			onCustomValidate={onQuoteCustomValidate}
-			readOnlyAmount={true}
+			{selectTokenText}
 			showTokenNetwork
 			token={quoteToken}
 		>

--- a/src/frontend/src/lib/constants/test-ids.constants.ts
+++ b/src/frontend/src/lib/constants/test-ids.constants.ts
@@ -164,6 +164,7 @@ export const REFERRAL_CODE_LEARN_MORE = 'referral-code-learn-more';
 
 export const SOL_TRANSACTION_SKELETON_PREFIX = 'sol-txn';
 
+export const TOKEN_INPUT_SELECT_TOKEN_BUTTON = 'token-input-select-token-button';
 export const TOKEN_INPUT_CURRENCY_TOKEN = 'token-input-currency-token';
 export const TOKEN_INPUT_CURRENCY_FIAT = 'token-input-currency-fiat';
 export const TOKEN_INPUT_CURRENCY_FIAT_SYMBOL = 'token-input-currency-fiat-symbol';

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1817,6 +1817,8 @@
 			"buy": "Buy",
 			"select_sell_token": "Select token to sell",
 			"select_buy_token": "Select token to buy",
+			"select_sell_token_first": "Select token to sell first",
+			"select_buy_token_first": "Select token to buy first",
 			"you_sell": "You sell",
 			"you_buy": "You buy",
 			"hero_prefix": "You",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1817,6 +1817,8 @@
 			"buy": "",
 			"select_sell_token": "",
 			"select_buy_token": "",
+			"select_sell_token_first": "",
+			"select_buy_token_first": "",
 			"you_sell": "",
 			"you_buy": "",
 			"hero_prefix": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1490,6 +1490,8 @@ interface I18nTrading {
 		buy: string;
 		select_sell_token: string;
 		select_buy_token: string;
+		select_sell_token_first: string;
+		select_buy_token_first: string;
 		you_sell: string;
 		you_buy: string;
 		hero_prefix: string;

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
@@ -185,12 +185,12 @@ describe('LimitOrderTradePairBox', () => {
 		expect(onSelectQuote).toHaveBeenCalledOnce();
 	});
 
-	it('does not render the quote selector until a base token is picked', () => {
+	it('disables the quote selector until a base token is picked', async () => {
 		const onSelectQuote = vi.fn();
 
-		// No base yet: the quote list is filtered by the base's markets, so the
-		// quote leg shows only the dash placeholder and its selector is not
-		// rendered until a base is chosen — there is nothing to open the picker.
+		// No base yet: the quote list is filtered by the base's markets. The quote
+		// leg keeps Swap's shape — the selector still renders — but it is disabled,
+		// so there is no way to open the picker.
 		const { getAllByRole } = render(LimitOrderTradePairBox, {
 			props: {
 				...baseProps,
@@ -202,10 +202,12 @@ describe('LimitOrderTradePairBox', () => {
 			}
 		});
 
-		// The quote selector was the sole disabled button; without a base it is gone.
 		const disabledSelect = getAllByRole('button').find((button) => button.hasAttribute('disabled'));
 
-		expect(disabledSelect).toBeUndefined();
+		expect(disabledSelect).toBeDefined();
+
+		await fireEvent.click(disabledSelect as HTMLElement);
+
 		expect(onSelectQuote).not.toHaveBeenCalled();
 	});
 });

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
@@ -1,5 +1,8 @@
 import LimitOrderTradePairBox from '$lib/components/trading/limit-order/LimitOrderTradePairBox.svelte';
-import { TOKEN_INPUT_CURRENCY_TOKEN } from '$lib/constants/test-ids.constants';
+import {
+	TOKEN_INPUT_CURRENCY_TOKEN,
+	TOKEN_INPUT_SELECT_TOKEN_BUTTON
+} from '$lib/constants/test-ids.constants';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import {
 	formatTradeAmount,
@@ -191,7 +194,7 @@ describe('LimitOrderTradePairBox', () => {
 		// No base yet: the quote list is filtered by the base's markets. The quote
 		// leg keeps Swap's shape — the selector still renders — but it is disabled,
 		// so there is no way to open the picker.
-		const { getAllByRole } = render(LimitOrderTradePairBox, {
+		const { getAllByTestId } = render(LimitOrderTradePairBox, {
 			props: {
 				...baseProps,
 				baseSymbol: undefined,
@@ -202,11 +205,15 @@ describe('LimitOrderTradePairBox', () => {
 			}
 		});
 
-		const disabledSelect = getAllByRole('button').find((button) => button.hasAttribute('disabled'));
+		// Both legs' selectors, base first: the previous lookup took the first
+		// disabled button in the tree, which is the gated leg's prompt, not its
+		// selector. Asserting the pair also pins that only the quote leg is gated.
+		const [baseSelect, quoteSelect] = getAllByTestId(TOKEN_INPUT_SELECT_TOKEN_BUTTON);
 
-		expect(disabledSelect).toBeDefined();
+		expect(baseSelect).toBeEnabled();
+		expect(quoteSelect).toBeDisabled();
 
-		await fireEvent.click(disabledSelect as HTMLElement);
+		await fireEvent.click(quoteSelect);
 
 		expect(onSelectQuote).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
# Motivation

On the limit-order form the quote token can only be picked once a base is set — the quote list is filtered by the base's markets. The field gave no sign of that: a brand-blue plus, a brand hover border on the frame, and a "Select token" prompt that looked clickable and quietly did nothing.

# Changes

Atomicity: all three files exist to make that one field honest about its state.

- `TokenInputContainer` gains `inert` — no hover border, no focus ring, `cursor-not-allowed` — for a field that can neither be typed into nor opened. Swap's disabled "You receive" leg keeps its hover, because its picker does work; `TokenInputContent` derives the flag as `disabled && !isSelectable`.
- `TokenInputContent` greys the plus badge and disables the prompt when the picker is unavailable, and takes an optional `selectTokenText` so a caller can name what has to be chosen first.
- The limit-order quote leg uses it to read "Select token to sell first" (or buy) in the field itself, and drops `readOnlyAmount` so it keeps the framed shape Swap gives its computed leg rather than a bare pill with a transparent value.
- Two i18n keys, alongside the existing `select_sell_token` / `select_buy_token` the base picker already titles itself with. Non-`en` locales are structurally synced with empty placeholders by `npm run i18n` — no translations authored.

One behaviour note for review: before a base is picked the quote selector used to be absent from the DOM; it now renders disabled, matching Swap. It still cannot open the picker, and the test asserts that by clicking it.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run i18n` — clean.
- `npx vitest run tests/lib/components/trading tests/lib/components/tokens` — 377 passing.
- Both sides (sell and buy) and both states (no base picked, base picked) checked in a local staging build.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| | |
| --- | --- |
| **Model** | Claude Opus 5 (`claude-opus-5`) |
| **Version** | Claude Code 2.1.202 |