### PR TITLE
style(frontend): match the limit-order review to the swap review

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -17,9 +17,7 @@
 	import { OISY_TRADE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
 	import { TRADING_ORDER_DETAIL_CANCEL_BUTTON } from '$lib/constants/test-ids.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
-	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
-	import { currentLanguage } from '$lib/derived/i18n.derived';
 	import { oisyTradePairs } from '$lib/derived/oisy-trade.derived';
 	import { PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
 	import {
@@ -31,13 +29,11 @@
 		trackLimitOrder,
 		type TrackLimitOrderParams
 	} from '$lib/services/trading-analytics.services';
-	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import { toastsError } from '$lib/stores/toasts.store';
 	import type { OisyTradeOrderBook, OisyTradeOrderView } from '$lib/types/oisy-trade';
 	import { replaceIcErrorFields } from '$lib/utils/error.utils';
-	import { formatCurrency } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import {
 		crossesBook,
@@ -54,7 +50,7 @@
 		toTradingPair,
 		valueDifferencePercent
 	} from '$lib/utils/oisy-trade.utils';
-	import { calculateTokenUsdAmount, getTokenDisplaySymbol } from '$lib/utils/token.utils';
+	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
 		order: OisyTradeOrderView;
@@ -76,25 +72,6 @@
 		formatTradeAmount({ amount: quoteAmount, decimals: quote.decimals })
 	);
 	const priceDisplay = $derived(formatTradeAmount({ amount: price, decimals: quote.decimals }));
-
-	// --- Fiat ($) values, recomputed against the live exchange feed. -----------
-	const fiat = ({ amount, token }: { amount: number; token: typeof base }): string | undefined => {
-		const value = calculateTokenUsdAmount({
-			amount: BigInt(Math.round(amount * 10 ** token.decimals)),
-			token,
-			$exchanges
-		});
-		return nonNullish(value)
-			? formatCurrency({
-					value,
-					currency: $currentCurrency,
-					exchangeRate: $currencyExchangeStore,
-					language: $currentLanguage
-				})
-			: undefined;
-	};
-	const baseFiat = $derived(fiat({ amount: quantity, token: base }));
-	const quoteFiat = $derived(fiat({ amount: quoteAmount, token: quote }));
 
 	// --- Live valuation from the pair's order book. ----------------------------
 	let orderBook = $state<OisyTradeOrderBook | undefined>();
@@ -125,7 +102,8 @@
 	// "Current value" anchors on the cross of the two legs' USD exchange-rate
 	// prices (base ÷ quote), NOT the DEX order-book mid — mirroring the reference
 	// the limit-order creation flow uses (see `referenceRate`). The book bid/ask
-	// still drive the crossing check below.
+	// still drive the crossing check below. The same two rates feed the hero's
+	// fiat lines, which it formats itself the way the Swap review does.
 	const baseUsdPrice = $derived($exchanges?.[base.id]?.usd);
 	const quoteUsdPrice = $derived($exchanges?.[quote.id]?.usd);
 	const currentValue = $derived(referenceRate({ baseUsd: baseUsdPrice, quoteUsd: quoteUsdPrice }));
@@ -278,18 +256,17 @@
 
 		<LimitOrderIntentHero
 			baseAmount={baseAmountDisplay}
-			{baseFiat}
-			{baseSymbol}
+			baseExchangeRate={baseUsdPrice}
+			baseToken={base}
 			quoteAmount={quoteAmountDisplay}
-			{quoteFiat}
-			{quoteSymbol}
+			quoteExchangeRate={quoteUsdPrice}
+			quoteToken={quote}
 			{side}
 		/>
 
 		<LimitOrderPriceSummary
 			{baseSymbol}
 			{currentValueDisplay}
-			muted
 			{priceDisplay}
 			{queueText}
 			{quoteSymbol}
@@ -310,9 +287,8 @@
 
 		{#snippet outerContent()}
 			{#if active}
-				<div class="flex justify-start px-3 py-2 sm:px-6 sm:py-3">
+				<div class="flex justify-center px-3 py-2 sm:px-6 sm:py-3">
 					<Button
-						alignLeft
 						ariaLabel={$i18n.trading.order_detail.cancel_order}
 						colorStyle="error"
 						onclick={() => (showCancelConfirm = true)}

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderIntentHero.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderIntentHero.svelte
@@ -1,58 +1,71 @@
 <script lang="ts">
-	import { nonNullish } from '@dfinity/utils';
-	import IconArrowDown from '$lib/components/icons/lucide/IconArrowDown.svelte';
+	import IconCircleArrowDown from '$lib/components/icons/lucide/IconCircleArrowDown.svelte';
+	import SwapToken from '$lib/components/swap/SwapToken.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { OptionAmount } from '$lib/types/send';
+	import type { Token } from '$lib/types/token';
 	import type { LimitOrderSide } from '$lib/utils/oisy-trade.utils';
 
-	// Read-only two-box intent hero shared by the limit-order Review and the
+	// Read-only two-leg intent hero shared by the limit-order Review and the
 	// order-detail modal: "You SELL/BUY <base>" on top, the derived quote bound
-	// below, with a centered direction arrow. Amounts are display strings so each
-	// caller formats them consistently; fiat lines are optional (detail only).
+	// below, with a centered direction arrow. Built from the same `SwapToken` rows
+	// and card as `TokensReview`, so it reads identically to the Swap review —
+	// logo, amount, fiat line — with the limit-order labels. Amounts are display
+	// strings so each caller rounds to the pair's decimals; the fiat line is
+	// derived from the exchange rate, and is omitted when no rate is known.
 	interface Props {
 		side: LimitOrderSide;
-		baseAmount: string;
-		baseSymbol: string;
-		quoteAmount: string;
-		quoteSymbol: string;
-		baseFiat?: string;
-		quoteFiat?: string;
+		baseAmount: OptionAmount;
+		quoteAmount: OptionAmount;
+		baseToken?: Token;
+		quoteToken?: Token;
+		baseExchangeRate?: number;
+		quoteExchangeRate?: number;
 	}
 
-	let { side, baseAmount, baseSymbol, quoteAmount, quoteSymbol, baseFiat, quoteFiat }: Props =
-		$props();
+	let {
+		side,
+		baseAmount,
+		quoteAmount,
+		baseToken,
+		quoteToken,
+		baseExchangeRate,
+		quoteExchangeRate
+	}: Props = $props();
 </script>
 
-<div class="relative mb-4 rounded-lg border border-disabled">
-	<div class="px-3.5 py-3">
-		<div class="mb-1 text-xs text-secondary">
+<div class="mb-6 rounded-lg border border-solid border-tertiary bg-primary p-4 shadow-sm">
+	<SwapToken amount={baseAmount} exchangeRate={baseExchangeRate} token={baseToken}>
+		{#snippet title()}
 			{$i18n.trading.limit_order.hero_prefix}
-			<strong class="font-bold text-primary uppercase">
+			<!-- Red sell / green buy, as the order rows colour their side word. -->
+			<strong
+				class="font-bold"
+				class:text-error-primary={side === 'sell'}
+				class:text-success-primary={side === 'buy'}
+			>
 				{side === 'sell' ? $i18n.trading.limit_order.sell : $i18n.trading.limit_order.buy}
 			</strong>
-		</div>
-		<div class="text-xl font-medium text-primary">{baseAmount} {baseSymbol}</div>
-		{#if nonNullish(baseFiat)}
-			<div class="text-xs text-tertiary">{baseFiat}</div>
+		{/snippet}
+	</SwapToken>
+
+	<!-- Same divider as `TokensReview`; only the arrow flips, because a buy reads
+		 bottom-up (you pay the quote to get the base). -->
+	<div class="my-2 flex w-full items-center justify-between text-tertiary-inverted">
+		<div class="h-[1px] w-[45%] bg-tertiary text-tertiary-inverted"></div>
+		{#if side === 'sell'}
+			<IconCircleArrowDown />
+		{:else}
+			<span class="flex rotate-180"><IconCircleArrowDown /></span>
 		{/if}
+		<div class="h-[1px] w-[45%] bg-tertiary text-tertiary-inverted"></div>
 	</div>
-	<div class="border-t border-disabled px-3.5 py-3">
-		<div class="mb-1 text-xs text-secondary">
+
+	<SwapToken amount={quoteAmount} exchangeRate={quoteExchangeRate} token={quoteToken}>
+		{#snippet title()}
 			{side === 'sell'
 				? $i18n.trading.limit_order.you_get_at_least
 				: $i18n.trading.limit_order.you_pay_at_most}
-		</div>
-		<div class="text-xl font-medium text-primary">{quoteAmount} {quoteSymbol}</div>
-		{#if nonNullish(quoteFiat)}
-			<div class="text-xs text-tertiary">{quoteFiat}</div>
-		{/if}
-	</div>
-	<span
-		class="absolute top-1/2 left-1/2 flex h-7 w-7 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-secondary bg-primary text-tertiary"
-	>
-		{#if side === 'sell'}
-			<IconArrowDown size="16" />
-		{:else}
-			<span class="rotate-180"><IconArrowDown size="16" /></span>
-		{/if}
-	</span>
+		{/snippet}
+	</SwapToken>
 </div>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSummary.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSummary.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
+	import Hr from '$lib/components/ui/Hr.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import ValueDifference from '$lib/components/ui/ValueDifference.svelte';
+	import {
+		SWAP_VALUE_DIFFERENCE_ERROR_VALUE,
+		SWAP_VALUE_DIFFERENCE_WARNING_VALUE
+	} from '$lib/constants/swap.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
-	// Read-only price card shared by the limit-order Review and the order-detail
-	// modal: the limit-price headline plus current value, the value-difference
-	// (crossing gate: neutral/amber/red, no green) and — for resting orders — the
-	// queue position. Values are display strings so both callers format alike.
+	// Read-only price rows shared by the limit-order Review and the order-detail
+	// modal: the limit price plus current value, the value-difference (crossing
+	// gate: neutral/amber/red, no green) and — for resting orders — the queue
+	// position. Rendered as `ModalValue` rows, the same key/value style the Swap
+	// review uses and that `LimitOrderTermsList` already uses right below.
+	// Values are display strings so both callers format alike.
 	interface Props {
 		priceDisplay: string;
 		baseSymbol: string;
@@ -16,8 +24,6 @@
 		// Formatted current value; `undefined` renders "-".
 		currentValueDisplay?: string;
 		valueDifference: number;
-		// Neutral (informational) while resting; false surfaces the amber/red gate.
-		muted: boolean;
 		queueText?: string;
 	}
 
@@ -27,53 +33,84 @@
 		quoteSymbol,
 		currentValueDisplay,
 		valueDifference,
-		muted,
 		queueText
 	}: Props = $props();
 </script>
 
-<div class="mb-3 rounded-lg border border-disabled px-3.5 py-3">
-	<div class="flex items-baseline justify-between">
-		<span class="text-sm text-secondary">{$i18n.trading.limit_order.limit_price}</span>
-		<span class="text-lg font-semibold text-primary">
-			{replacePlaceholders($i18n.trading.limit_order.limit_price_value, {
-				$price: priceDisplay,
-				$quote: quoteSymbol,
-				$base: baseSymbol
-			})}
-		</span>
-	</div>
-	<div class="mt-2.5 flex flex-col gap-1.5 border-t border-disabled pt-2.5">
-		<div class="flex items-center justify-between text-xs">
-			<span class="text-tertiary">{$i18n.trading.limit_order.current_value}</span>
-			<span class="font-medium text-secondary">
-				{nonNullish(currentValueDisplay)
-					? replacePlaceholders($i18n.trading.limit_order.current_value_feed, {
-							$price: currentValueDisplay,
-							$quote: quoteSymbol,
-							$base: baseSymbol
-						})
-					: '-'}
+<div>
+	<ModalValue>
+		{#snippet label()}
+			{$i18n.trading.limit_order.limit_price}
+		{/snippet}
+
+		{#snippet mainValue()}
+			<!-- The one figure the whole screen is about, so it outranks the rows it
+				 sits above — the `ModalValue` row structure is shared, the type scale
+				 is not. -->
+			<span class="text-lg">
+				{replacePlaceholders($i18n.trading.limit_order.limit_price_value, {
+					$price: priceDisplay,
+					$quote: quoteSymbol,
+					$base: baseSymbol
+				})}
 			</span>
+		{/snippet}
+	</ModalValue>
+
+	<ModalValue>
+		{#snippet label()}
+			{$i18n.trading.limit_order.current_value}
+		{/snippet}
+
+		{#snippet mainValue()}
+			{nonNullish(currentValueDisplay)
+				? replacePlaceholders($i18n.trading.limit_order.current_value_feed, {
+						$price: currentValueDisplay,
+						$quote: quoteSymbol,
+						$base: baseSymbol
+					})
+				: '-'}
+		{/snippet}
+	</ModalValue>
+
+	{#if nonNullish(currentValueDisplay)}
+		<div class="mb-2" transition:slide>
+			<ModalValue>
+				{#snippet label()}
+					{$i18n.trading.limit_order.value_difference_label}
+				{/snippet}
+
+				{#snippet mainValue()}
+					<!-- Same treatment as the Swap review: shared `ValueDifference`, swap's
+						 own thresholds, and neither `muted` nor `successNeutral` — so the
+						 figure is green when the order is favourable and amber/red with the
+						 warning icon when it gives value up. -->
+					<ValueDifference
+						errorLevel={SWAP_VALUE_DIFFERENCE_ERROR_VALUE}
+						iconPosition="left"
+						value={valueDifference}
+						warningLevel={SWAP_VALUE_DIFFERENCE_WARNING_VALUE}
+					/>
+				{/snippet}
+			</ModalValue>
 		</div>
-		{#if nonNullish(currentValueDisplay)}
-			<div class="flex items-center justify-between text-xs" transition:slide>
-				<span class="text-tertiary">{$i18n.trading.limit_order.value_difference_label}</span>
-				<ValueDifference
-					errorLevel={-5}
-					iconPosition="left"
-					{muted}
-					successNeutral
-					value={valueDifference}
-					warningLevel={0}
-				/>
-			</div>
-		{/if}
-		{#if nonNullish(queueText)}
-			<div class="flex items-center justify-between text-xs" transition:slide>
-				<span class="text-tertiary">{$i18n.trading.limit_order.queue_position_row}</span>
-				<span class="font-medium text-secondary">{queueText}</span>
-			</div>
-		{/if}
-	</div>
+	{/if}
+
+	{#if nonNullish(queueText)}
+		<div class="mb-2" transition:slide>
+			<ModalValue>
+				{#snippet label()}
+					{$i18n.trading.limit_order.queue_position_row}
+				{/snippet}
+
+				{#snippet mainValue()}
+					{queueText}
+				{/snippet}
+			</ModalValue>
+		</div>
+	{/if}
 </div>
+
+<!-- Splits the order's price terms from its execution terms, the grouping the
+	 two cards had before both became `ModalValue` rows. -->
+<Hr spacing="md" />

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSummary.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSummary.svelte
@@ -12,9 +12,10 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	// Read-only price rows shared by the limit-order Review and the order-detail
-	// modal: the limit price plus current value, the value-difference (crossing
-	// gate: neutral/amber/red, no green) and — for resting orders — the queue
-	// position. Rendered as `ModalValue` rows, the same key/value style the Swap
+	// modal: the limit price plus current value, the value difference (green when
+	// the order is favourable, amber/red as it gives value up — `valueDifference`
+	// is signed relative to the caller's side) and — for resting orders — the
+	// queue position. Rendered as `ModalValue` rows, the same key/value style the Swap
 	// review uses and that `LimitOrderTermsList` already uses right below.
 	// Values are display strings so both callers format alike.
 	interface Props {

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
@@ -11,6 +11,8 @@
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { oisyTradeIcTokenBySymbol } from '$lib/derived/oisy-trade.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import {
@@ -67,10 +69,23 @@
 	const baseAmountDisplay = $derived(
 		formatTradeAmount({ amount: baseAmount, decimals: pairView?.baseDecimals ?? 8 })
 	);
+	// Undefined rather than a dash below the min notional: the hero's shared
+	// `SwapToken` row parses the amount, so a placeholder string would throw.
 	const quoteAmountDisplay = $derived(
 		quoteAmount > 0
 			? formatTradeAmount({ amount: quoteAmount, decimals: pairView?.quoteDecimals ?? 8 })
-			: '-'
+			: undefined
+	);
+
+	// Resolved the same way the form does, so the hero can show each leg's logo
+	// and fiat value exactly as the Swap review does.
+	const baseToken = $derived($oisyTradeIcTokenBySymbol[base]);
+	const quoteToken = $derived($oisyTradeIcTokenBySymbol[quote]);
+	const baseExchangeRate = $derived(
+		nonNullish(baseToken) ? $exchanges?.[baseToken.id]?.usd : undefined
+	);
+	const quoteExchangeRate = $derived(
+		nonNullish(quoteToken) ? $exchanges?.[quoteToken.id]?.usd : undefined
 	);
 	const priceDisplay = $derived(
 		formatTradeAmount({ amount: price, decimals: pairView?.quoteDecimals ?? 8 })
@@ -124,16 +139,17 @@
 <ContentWithToolbar>
 	<LimitOrderIntentHero
 		baseAmount={baseAmountDisplay}
-		baseSymbol={base}
+		{baseExchangeRate}
+		{baseToken}
 		quoteAmount={quoteAmountDisplay}
-		quoteSymbol={quote}
+		{quoteExchangeRate}
+		{quoteToken}
 		{side}
 	/>
 
 	<LimitOrderPriceSummary
 		baseSymbol={base}
 		{currentValueDisplay}
-		muted={!(crossing || fillOrKill)}
 		{priceDisplay}
 		{queueText}
 		quoteSymbol={quote}

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderIntentHero.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderIntentHero.svelte.spec.ts
@@ -1,12 +1,17 @@
+import type { IcToken } from '$icp/types/ic-token';
 import LimitOrderIntentHero from '$lib/components/trading/limit-order/LimitOrderIntentHero.svelte';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('LimitOrderIntentHero', () => {
+	const baseToken: IcToken = { ...mockValidIcToken, symbol: 'ICP', decimals: 8 };
+	const quoteToken: IcToken = { ...mockValidIcToken, symbol: 'ckUSDC', decimals: 6 };
+
 	const baseProps = {
 		baseAmount: '10',
-		baseSymbol: 'ICP',
+		baseToken,
 		quoteAmount: '25',
-		quoteSymbol: 'ckUSDC'
+		quoteToken
 	};
 
 	it('renders a sell intent with both legs', () => {
@@ -23,14 +28,14 @@ describe('LimitOrderIntentHero', () => {
 		expect(container).toHaveTextContent('Buy');
 	});
 
-	it('shows fiat lines only when provided', () => {
+	it('shows fiat lines only when an exchange rate is known', () => {
 		const { container, rerender } = render(LimitOrderIntentHero, {
 			props: { side: 'sell', ...baseProps }
 		});
 
 		expect(container).not.toHaveTextContent('$19.00');
 
-		rerender({ side: 'sell', ...baseProps, baseFiat: '$19.00', quoteFiat: '$18.90' });
+		rerender({ side: 'sell', ...baseProps, baseExchangeRate: 1.9, quoteExchangeRate: 0.756 });
 
 		expect(container).toHaveTextContent('$19.00');
 		expect(container).toHaveTextContent('$18.90');

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderPriceSummary.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderPriceSummary.svelte.spec.ts
@@ -6,8 +6,7 @@ describe('LimitOrderPriceSummary', () => {
 		priceDisplay: '2.5',
 		baseSymbol: 'ICP',
 		quoteSymbol: 'ckUSDC',
-		valueDifference: -2,
-		muted: false
+		valueDifference: -2
 	};
 
 	it('renders the limit price and a resolved current value', () => {

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderReview.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderReview.svelte.spec.ts
@@ -1,10 +1,31 @@
+import type { IcToken } from '$icp/types/ic-token';
 import LimitOrderReview from '$lib/components/trading/limit-order/LimitOrderReview.svelte';
 import { OISY_TRADE_PROVIDER_NAME } from '$lib/constants/oisy-trade.constants';
 import type { LimitOrderPairView, LimitOrderSide } from '$lib/utils/oisy-trade.utils';
 import en from '$tests/mocks/i18n.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { fireEvent, render } from '@testing-library/svelte';
 
+// The hero resolves each leg to its wallet token to render the logo and fiat
+// line, so the review needs the symbol → token map the wizard would have loaded.
+const { mockIcTokenBySymbol } = vi.hoisted(() => {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const { writable } = require('svelte/store');
+	return { mockIcTokenBySymbol: writable({}) };
+});
+
+vi.mock('$lib/derived/oisy-trade.derived', () => ({
+	oisyTradeIcTokenBySymbol: mockIcTokenBySymbol
+}));
+
 describe('LimitOrderReview', () => {
+	beforeEach(() => {
+		mockIcTokenBySymbol.set({
+			ICP: { ...mockValidIcToken, symbol: 'ICP', decimals: 8 } as IcToken,
+			ckUSDC: { ...mockValidIcToken, symbol: 'ckUSDC', decimals: 6 } as IcToken
+		});
+	});
+
 	const pairView: LimitOrderPairView = {
 		baseSymbol: 'ICP',
 		quoteSymbol: 'ckUSDC',


### PR DESCRIPTION
# Motivation

The limit-order review and the swap review present the same kind of information in different clothes: swap draws each leg with a token logo, amount and fiat line inside a shared card, then lists its terms as `ModalValue` rows. The limit-order review had a bespoke two-box hero with no logos or fiat, and a bordered price card sitting directly above `LimitOrderTermsList`, which already used `ModalValue`. The price card was the only thing on that screen not following the pattern.

# Changes

Atomicity: one screen, brought onto the shared review styles. The detail modal shares all three components, so it follows along.

- Rebuild `LimitOrderIntentHero` on `SwapToken` inside `TokensReview`'s card, so each leg gets the logo, amount and fiat line exactly as swap draws them. It takes tokens and exchange rates now instead of pre-formatted strings; the fiat is rendered by the same `TokenInputAmountExchange` swap uses.
- Render the price terms as `ModalValue` rows with a rule splitting price terms from execution terms. The limit price keeps a size above the rows it heads — the row structure is shared, the type scale is not.
- Give the value difference swap's own thresholds (`SWAP_VALUE_DIFFERENCE_*`) and treatment: it colours and carries the warning icon instead of staying muted. `valueDifferencePercent` is signed relative to the caller's side, so positive is always favourable and the colours read correctly. The now-unused `muted` prop is gone from the component and both call sites.
- Colour the side word red for sell / green for buy, matching the order rows, and drop its uppercase.
- Centre the cancel action in the detail modal. `Button` carries `flex-1`, so it already spanned the row; the left alignment came from its own `alignLeft`.
- The detail modal's duplicated `fiat()` helper and five now-unused imports are removed, since the shared row computes the same value from the rate.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` — clean.
- `npx vitest run tests/lib/components/trading` — 218 passing. The hero spec now builds tokens and rates; the review spec mocks `oisyTradeIcTokenBySymbol`, which the hero needs to resolve each leg.
- Review and order-detail screens checked in a local staging build, both sides, crossing and resting.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| | |
| --- | --- |
| **Model** | Claude Opus 5 (`claude-opus-5`) |
| **Version** | Claude Code 2.1.202 |