### PR TITLE
style(frontend): show the OISY Trade mark next to the provider label

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderRouting.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderRouting.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { slide } from 'svelte/transition';
 	import IconChevronRight from '$lib/components/icons/lucide/IconChevronRight.svelte';
+	import OisyTradeMark from '$lib/components/trading/OisyTradeMark.svelte';
 	import { OISY_TRADE_PROVIDER_NAME } from '$lib/constants/oisy-trade.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -41,7 +42,9 @@
 		onclick={() => (expanded = !expanded)}
 		type="button"
 	>
-		<span class="bg-success-subtle h-4 w-4 flex-shrink-0 rounded"></span>
+		<span class="flex flex-shrink-0 items-center">
+			<OisyTradeMark size="16" />
+		</span>
 		<span class="flex-1 text-xs text-secondary">
 			{replacePlaceholders($i18n.trading.limit_order.routing_name, { $provider: '' })}<strong
 				class="font-semibold text-primary">{OISY_TRADE_PROVIDER_NAME}</strong

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderRouting.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderRouting.svelte
@@ -42,7 +42,8 @@
 		onclick={() => (expanded = !expanded)}
 		type="button"
 	>
-		<span class="flex flex-shrink-0 items-center">
+		<!-- Decorative: the row's own text already names the provider. -->
+		<span class="flex flex-shrink-0 items-center" aria-hidden="true">
 			<OisyTradeMark size="16" />
 		</span>
 		<span class="flex-1 text-xs text-secondary">

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTermsList.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTermsList.svelte
@@ -28,9 +28,13 @@
 <ModalValue>
 	{#snippet label()}{$i18n.trading.limit_order.dex}{/snippet}
 	{#snippet mainValue()}
-		<!-- Marked like Swap's provider row, and matching the routing row on the form. -->
-		<span class="flex items-center gap-2">
-			<OisyTradeMark size="16" />
+		<!-- Marked like Swap's provider row, and matching the routing row on the form.
+			 Decorative: the mark carries its own `aria-label`, which would otherwise be
+			 announced on top of the provider name beside it (same as the deposit form). -->
+		<span class="inline-flex items-center gap-2">
+			<span class="flex" aria-hidden="true">
+				<OisyTradeMark size="16" />
+			</span>
 			{OISY_TRADE_PROVIDER_NAME}
 		</span>
 	{/snippet}

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTermsList.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTermsList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import OisyTradeMark from '$lib/components/trading/OisyTradeMark.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
 	import { OISY_TRADE_PROVIDER_NAME } from '$lib/constants/oisy-trade.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -26,7 +27,13 @@
 
 <ModalValue>
 	{#snippet label()}{$i18n.trading.limit_order.dex}{/snippet}
-	{#snippet mainValue()}{OISY_TRADE_PROVIDER_NAME}{/snippet}
+	{#snippet mainValue()}
+		<!-- Marked like Swap's provider row, and matching the routing row on the form. -->
+		<span class="flex items-center gap-2">
+			<OisyTradeMark size="16" />
+			{OISY_TRADE_PROVIDER_NAME}
+		</span>
+	{/snippet}
 </ModalValue>
 <ModalValue>
 	{#snippet label()}{$i18n.trading.limit_order.order_type}{/snippet}


### PR DESCRIPTION
# Motivation

Swap shows its provider's logo next to the provider name. OISY TRADE named itself with no mark in two places: the routing row on the limit-order form carried a literal placeholder — an empty `bg-success-subtle` square where an icon belonged — and the DEX row on the review had nothing at all.

# Changes

- `LimitOrderRouting` — replace the placeholder square with `OisyTradeMark` at 16px.
- `LimitOrderTermsList` — render the same mark before the provider name in the DEX row, with the `gap-2` swap uses between its provider logo and label.

`OisyTradeMark` is the existing mark the provider hero and info box already use at 64px and 42px.

# Tests

- `npm run check` — clean; `npx vitest run tests/lib/components/trading` — 218 passing.
- Checked in a local staging build on the form, the review and the order-detail modal (which shares the terms list).

One thing for reviewers to eyeball: the mark is drawn for large sizes (2.335 stroke on a 256 viewBox), so at 16px the fine detail is lost and it reads mostly as the blue disc. If that is too muddy, a simplified small variant would be the fix.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| | |
| --- | --- |
| **Model** | Claude Opus 5 (`claude-opus-5`) |
| **Version** | Claude Code 2.1.202 |