### PR TITLE
style(frontend): tighten the OISY TRADE provider page

### DIFF
--- a/src/frontend/src/lib/components/trading/OisyTradePositionRow.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradePositionRow.svelte
@@ -56,8 +56,11 @@
 {#snippet body()}
 	<TokenLogo badge={{ type: 'network' }} color="white" {data} logoSize="lg" />
 
-	<span class="flex min-w-0 flex-1 flex-col text-left">
-		<span class="font-bold">{symbol}</span>
+	<!-- `TokenNameAndNetwork` sets no size of its own, so the name and network lines
+		 inherit `text-sm` from here while the symbol keeps `text-base` — mirroring the
+		 amount / fiat pairing on the right of the same row. -->
+	<span class="flex min-w-0 flex-1 flex-col text-left text-sm">
+		<span class="text-base font-bold">{symbol}</span>
 		<TokenNameAndNetwork {data} />
 	</span>
 

--- a/src/frontend/src/lib/components/trading/OisyTradeProviderHero.svelte
+++ b/src/frontend/src/lib/components/trading/OisyTradeProviderHero.svelte
@@ -124,9 +124,13 @@
 						{depositable}
 					{/if}
 				</span>
-				<span class="text-xs text-tertiary">{$i18n.trading.page.trading_potential_hint}</span>
+				<!-- Breathing room above the action, carried by the hint rather than the
+					 button: the button's `mt-auto` (which keeps the two desktop cards' buttons
+					 level) would override any `mt-*` on it. 8px here plus the column's
+					 `gap-1.5` gives the same 14px on both breakpoints. -->
+				<span class="mb-2 text-xs text-tertiary">{$i18n.trading.page.trading_potential_hint}</span>
 
-				<Button colorStyle="success" fullWidth onclick={onDeposit} styleClass="mt-4 sm:mt-auto">
+				<Button colorStyle="success" fullWidth onclick={onDeposit} styleClass="sm:mt-auto">
 					{$i18n.trading.page.deposit}
 				</Button>
 			</div>
@@ -142,7 +146,7 @@
 						{deposited}
 					{/if}
 				</span>
-				<span class="text-xs text-tertiary">
+				<span class="mb-2 text-xs text-tertiary">
 					{#if $isPrivacyMode}
 						<IconDots variant="xs" />
 					{:else if hasReserved}
@@ -163,7 +167,7 @@
 					disabled={!hasDeposits}
 					fullWidth
 					onclick={onWithdraw}
-					styleClass="mt-4 sm:mt-auto"
+					styleClass="sm:mt-auto"
 				>
 					{$i18n.trading.page.withdraw}
 				</Button>


### PR DESCRIPTION
# Motivation

Two bits of polish on the OISY TRADE provider page: the position rows set the token name and network at the same 16px as the symbol above them, and the hero cards sat their actions tight against the hint line.

# Changes

Atomicity: both are spacing/typography on the same page.

- `OisyTradePositionRow` — the name and network drop to `text-sm` (14px), so the left of the row pairs a 16px symbol with 14px detail the way the amount and fiat value already do on the right. The size is inherited from the row's text column rather than set on `TokenNameAndNetwork`, which is shared with the token lists — and whose two spans have to stay separate flex children to keep stacking.
- `OisyTradeProviderHero` — 8px above each action. The buttons' `mt-auto` keeps the two desktop cards level but collapses to nothing once both are the same height, leaving only the column's `gap-1.5`; and a `mt-*` on the button would be overridden by that `auto`. Carrying the space on the hint instead gives both breakpoints the same 14px and leaves the bottom-alignment intact.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` — clean.
- `npx vitest run tests/lib/components/trading` — 218 passing.
- Checked at mobile and desktop widths in a local staging build.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| | |
| --- | --- |
| **Model** | Claude Opus 5 (`claude-opus-5`) |
| **Version** | Claude Code 2.1.202 |