### PR TITLE
style(frontend): drop the em dash from the fill-or-kill help copy

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1867,7 +1867,7 @@
 			"error_min_notional": "Order value must be at least $amount $symbol",
 			"error_max_notional": "Order value can't exceed $amount $symbol",
 			"fok_title": "Fill or kill",
-			"fok_help": "Fill the whole order now at your price or better, or cancel it — nothing rests. The price must cross the order book for the order to fill, and the order always executes as a taker (taker fee applies).",
+			"fok_help": "Fill the whole order now at your price or better, or cancel it. Nothing rests. The price must cross the order book for the order to fill, and the order always executes as a taker (taker fee applies).",
 			"routing_name": "Routed via $provider",
 			"routing_tag": "best execution",
 			"best_ask": "Best ask",


### PR DESCRIPTION
# Motivation

The fill-or-kill help copy used an em dash, which the voice avoids.

# Changes

- `fok_help` becomes two sentences: "…or cancel it. Nothing rests." — the full stop carries the emphasis the dash was doing, rather than swapping in a comma that would flatten it.

No key rename, so no other files change.

# Tests

- `npm run i18n`, `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` — clean.
- Copy-only change; the string renders in the Fill-or-kill help panel on the limit-order form.

Note for a follow-up: 19 em dashes remain elsewhere in `en.json`. If the rule is general rather than a one-off here, that is worth its own sweep.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| | |
| --- | --- |
| **Model** | Claude Opus 5 (`claude-opus-5`) |
| **Version** | Claude Code 2.1.202 |