### PR TITLE
feat(frontend): enable BTC WalletConnect on beta and production

### DIFF
--- a/src/frontend/src/env/btc-wallet-connect.env.ts
+++ b/src/frontend/src/env/btc-wallet-connect.env.ts
@@ -1,13 +1,12 @@
-import { LOCAL, STAGING } from '$lib/constants/app.constants';
+import { BETA, LOCAL, PROD, STAGING } from '$lib/constants/app.constants';
 
 // Gate for the Bitcoin (bip122) WalletConnect surface (namespace advertisement, `getAccountAddresses`
 // session property/method, `signMessage` and `signPsbt`).
 //
-// Enabled on local and staging only, for testing — not on beta nor production (ic). `STAGING` already
-// covers the test_fe / audit / e2e environments. Signing goes through the signer's `btc_sign_prehash`,
-// which signs under the BTC key matching the advertised P2WPKH address (unlike
-// `generic_sign_with_ecdsa`, whose generic key does not). That endpoint ships in chain-fusion-signer
-// v0.5.1 — the release pinned for local deploys — and is live on the staging signer, but the
-// production signer has not been upgraded to it yet. Enable on beta and production once it is;
-// until then a `signMessage` there would hit a missing method.
-export const BTC_WALLET_CONNECT_ENABLED = LOCAL || STAGING;
+// Signing goes through the signer's `btc_sign_prehash`, which signs under the BTC key matching the
+// advertised P2WPKH address (unlike `generic_sign_with_ecdsa`, whose generic key does not). That
+// endpoint is now live on every signer, including production, so the surface is enabled everywhere.
+// Kept as an explicit kill-switch for the initial production rollout: drop `|| BETA || PROD` to turn
+// it off on beta/production while keeping local and staging for debugging. Remove this gate once BTC
+// WalletConnect is confirmed stable on production.
+export const BTC_WALLET_CONNECT_ENABLED = LOCAL || STAGING || BETA || PROD;


### PR DESCRIPTION
# Motivation

OISY's Bitcoin (`bip122`) WalletConnect surface has been gated off on beta and production via `BTC_WALLET_CONNECT_ENABLED = LOCAL || STAGING` (introduced in #13522). BTC WalletConnect signing routes through the chain-fusion-signer's `btc_sign_prehash` endpoint, which at the time was only live on the local/staging signer.

As a result, connecting a Bitcoin dApp via WalletConnect on production fails with:

> Unexpected error while communicating with WalletConnect. — approve(), namespaces should be an object with data

When the flag is off, the provider constructor forces `#btcAddressMainnet` to `undefined`, so the `bip122` namespace is never added. For a Bitcoin-only dApp this leaves `approveSession()` with an empty `namespaces` object, which the WalletConnect SDK rejects with the error above. (Staging/test instances work because `STAGING` covers `test_fe_*`, so the flag is on there.)

The production signer `grghe-syaaa-aaaar-qabyq-cai` (shared by the `ic` and `beta` targets) now exposes `btc_sign_prehash` — verified against its live Candid interface, with a signature identical to the staging signer. The original reason for gating the surface off on beta/production therefore no longer holds.

# Changes

- Extend `BTC_WALLET_CONNECT_ENABLED` to every environment (`LOCAL || STAGING || BETA || PROD`), enabling the BTC WalletConnect surface on beta and production.
- Keep the gate as an explicit kill-switch for the initial production rollout — dropping `|| BETA || PROD` disables it on beta/production while retaining local/staging for debugging — rather than removing it outright. A follow-up should remove the gate once BTC WalletConnect is confirmed stable on production.
- Update the comment to reflect that `btc_sign_prehash` is now live on every signer.

# Tests

- `wallet-connect.providers.spec.ts` and `wallet-connect-handlers.services.spec.ts` pass (30 tests). Both specs mock the flag on/off, so the enabled and disabled paths remain covered regardless of the constant's value.
- `prettier` and `eslint --max-warnings 0` clean on the changed file.

Recommended manual verification after deploy: connect a Bitcoin dApp via WalletConnect on production and exercise `signMessage` / `signPsbt`. The production signer is a different canister than the staging one this feature was originally exercised against, so it is worth confirming end-to-end signing there.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Model: Claude Opus 4.8 (`claude-opus-4-8`)
