### PR TITLE
fix(frontend): render Bitcoin network icon for WalletConnect sessions

### DIFF
--- a/src/frontend/src/lib/components/wallet-connect/WalletConnectSessionsModal.svelte
+++ b/src/frontend/src/lib/components/wallet-connect/WalletConnectSessionsModal.svelte
@@ -2,8 +2,10 @@
 	import { nonNullish } from '@dfinity/utils';
 	import type { SessionTypes } from '@walletconnect/types';
 	import { onMount } from 'svelte';
+	import { BIP122_CHAINS } from '$env/bip122-chains.env';
 	import { CAIP10_CHAINS } from '$env/caip10-chains.env';
 	import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
+	import { SUPPORTED_BITCOIN_NETWORKS } from '$env/networks/networks.btc.env';
 	import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 	import { SOLANA_DEVNET_NETWORK, SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
 	import IconLinkOff from '$lib/components/icons/IconLinkOff.svelte';
@@ -37,6 +39,10 @@
 		...Object.entries(CAIP10_CHAINS).reduce<Record<string, string>>((acc, [key, { network }]) => {
 			const { icon } =
 				network === SolanaNetworks.mainnet ? SOLANA_MAINNET_NETWORK : SOLANA_DEVNET_NETWORK;
+			return nonNullish(icon) ? { ...acc, [key]: icon } : acc;
+		}, {}),
+		...Object.entries(BIP122_CHAINS).reduce<Record<string, string>>((acc, [key, { networkId }]) => {
+			const icon = SUPPORTED_BITCOIN_NETWORKS.find(({ id }) => id === networkId)?.icon;
 			return nonNullish(icon) ? { ...acc, [key]: icon } : acc;
 		}, {})
 	};

--- a/src/frontend/src/tests/lib/components/wallet-connect/WalletConnectSessionsModal.spec.ts
+++ b/src/frontend/src/tests/lib/components/wallet-connect/WalletConnectSessionsModal.spec.ts
@@ -13,10 +13,12 @@ import type { SessionTypes } from '@walletconnect/types';
 describe('WalletConnectSessionsModal', () => {
 	const mockSession = ({
 		accounts,
+		namespace = 'eip155',
 		name = 'Test dApp',
 		url = 'https://test-dapp.com'
 	}: {
 		accounts: string[];
+		namespace?: string;
 		name?: string;
 		url?: string;
 	}): SessionTypes.Struct =>
@@ -31,7 +33,7 @@ describe('WalletConnectSessionsModal', () => {
 				}
 			},
 			namespaces: {
-				eip155: {
+				[namespace]: {
 					accounts,
 					methods: [],
 					events: []
@@ -128,6 +130,29 @@ describe('WalletConnectSessionsModal', () => {
 		const overlappedLogos = container.querySelectorAll('[style*="z-index"]');
 
 		expect(overlappedLogos.length).toBeGreaterThan(0);
+	});
+
+	it('should render the Bitcoin network icon for a bip122 session', () => {
+		// Regression: the bip122 chain had no entry in the icon map, so the Bitcoin icon never
+		// resolved and OverlappedLogos showed its loading skeleton indefinitely.
+		const session = mockSession({
+			namespace: 'bip122',
+			// bip122 account: `bip122:<first 32 hex chars of the mainnet genesis hash>:<address>`.
+			accounts: [
+				'bip122:000000000019d6689c085ae165831e93:bc1qexampleaddressxxxxxxxxxxxxxxxxxxxxxxx'
+			]
+		});
+
+		walletConnectListenerStore.set({
+			...mockListener,
+			getActiveSessions: vi.fn().mockReturnValue({ 'test-topic': session })
+		} as unknown as WalletConnectListener);
+
+		const { container } = render(WalletConnectSessionsModal);
+
+		const overlappedLogos = container.querySelectorAll('[style*="z-index"]');
+
+		expect(overlappedLogos).toHaveLength(1);
 	});
 
 	it('should deduplicate network icons for same chain', () => {


### PR DESCRIPTION
# Motivation

In the WalletConnect **Connected Apps** modal, a Bitcoin connection never renders its network icon — it shows the loading skeleton indefinitely. EVM connections (e.g. 1inch) render their network icons correctly.

Root cause: `WalletConnectSessionsModal` maps each session's CAIP-2 chains to network icons via `chainIconMap`, which is built only from `eip155` (Ethereum + EVM) and Solana chains. A `bip122` (Bitcoin) account has no entry, so `getSessionDetails` returns an empty `networkIcons` array. `OverlappedLogos` renders its `SkeletonText` fallback whenever `icons` is empty, so the Bitcoin row is stuck on the skeleton rather than showing the Bitcoin icon.

# Changes

- Extend `chainIconMap` in `WalletConnectSessionsModal.svelte` with the `bip122` chains, keyed by their CAIP-2 id (`bip122:<genesis>`, from `BIP122_CHAINS`) and mapped to the corresponding Bitcoin network's icon (from `SUPPORTED_BITCOIN_NETWORKS`). Mirrors the existing Solana reducer.

# Tests

- Added a regression test to `WalletConnectSessionsModal.spec.ts`: a `bip122` session now renders one network icon (previously zero → skeleton). Generalized the `mockSession` helper to accept a namespace so the existing `eip155` tests are unchanged.
- Verified the new test **fails without the component change** (`expected length 1, got 0`) and passes with it.
- `prettier` and `eslint --max-warnings 0` clean on both changed files; full modal spec passes (14 tests).

Note: verified via the component regression test rather than a live WalletConnect pairing (standing up a real BTC dApp session locally is impractical). The test asserts the rendered logo count, which is exactly what the skeleton fallback replaced.

|Before|After|
|---|---|
|<img width="578" height="449" alt="image" src="https://github.com/user-attachments/assets/a0d2813f-932d-49fa-9ca9-4e173ef583c3" />|<img width="578" height="449" alt="image" src="https://github.com/user-attachments/assets/f1566ca6-c365-4057-91a7-7898a67e5ce2" />|

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Model: Claude Opus 4.8 (`claude-opus-4-8`)
