### PR TITLE
fix(frontend): render nothing for an empty OverlappedLogos

### DIFF
--- a/src/frontend/src/lib/components/ui/OverlappedLogos.svelte
+++ b/src/frontend/src/lib/components/ui/OverlappedLogos.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 	import Logo from '$lib/components/ui/Logo.svelte';
-	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { logoSizes } from '$lib/constants/components.constants';
 	import type { LogoSize } from '$lib/types/components';
 
@@ -16,22 +15,18 @@
 	let { icons, size = 'xxs', invertColor, color = 'off-white', styleClass = '' }: Props = $props();
 </script>
 
+<!-- An empty `icons` list renders nothing: absence of icons is not a loading state, so callers
+     that need a loading placeholder own that themselves rather than relying on this component. -->
 <div class={`${styleClass} flex items-center`}>
-	{#if icons.length > 0}
-		{#each icons as icon, i (icon)}
-			<div
-				style={`max-height: ${logoSizes[size]}; ${i < icons.length - 1 ? `margin-right: calc(-${logoSizes[size]} / 3);` : ''} z-index: ${i + 1};`}
-				class="relative rounded-full bg-primary ring ring-disabled"
-				in:fade
-			>
-				<span class="inline-flex" class:invert-on-dark-theme={invertColor}>
-					<Logo alt={`${icon}-${i}`} {color} {size} src={icon} />
-				</span>
-			</div>
-		{/each}
-	{:else}
-		<div class="w-12">
-			<SkeletonText />
+	{#each icons as icon, i (icon)}
+		<div
+			style={`max-height: ${logoSizes[size]}; ${i < icons.length - 1 ? `margin-right: calc(-${logoSizes[size]} / 3);` : ''} z-index: ${i + 1};`}
+			class="relative rounded-full bg-primary ring ring-disabled"
+			in:fade
+		>
+			<span class="inline-flex" class:invert-on-dark-theme={invertColor}>
+				<Logo alt={`${icon}-${i}`} {color} {size} src={icon} />
+			</span>
 		</div>
-	{/if}
+	{/each}
 </div>

--- a/src/frontend/src/lib/components/ui/OverlappedLogos.svelte
+++ b/src/frontend/src/lib/components/ui/OverlappedLogos.svelte
@@ -15,18 +15,21 @@
 	let { icons, size = 'xxs', invertColor, color = 'off-white', styleClass = '' }: Props = $props();
 </script>
 
-<!-- An empty `icons` list renders nothing: absence of icons is not a loading state, so callers
-     that need a loading placeholder own that themselves rather than relying on this component. -->
-<div class={`${styleClass} flex items-center`}>
-	{#each icons as icon, i (icon)}
-		<div
-			style={`max-height: ${logoSizes[size]}; ${i < icons.length - 1 ? `margin-right: calc(-${logoSizes[size]} / 3);` : ''} z-index: ${i + 1};`}
-			class="relative rounded-full bg-primary ring ring-disabled"
-			in:fade
-		>
-			<span class="inline-flex" class:invert-on-dark-theme={invertColor}>
-				<Logo alt={`${icon}-${i}`} {color} {size} src={icon} />
-			</span>
-		</div>
-	{/each}
-</div>
+<!-- An empty `icons` list renders no node at all — not even the wrapper — so a caller's `styleClass`
+     (e.g. spacing) adds nothing when there is nothing to show. Absence of icons is not a loading
+     state: callers that need a loading placeholder own that themselves rather than relying on this. -->
+{#if icons.length > 0}
+	<div class={`${styleClass} flex items-center`}>
+		{#each icons as icon, i (icon)}
+			<div
+				style={`max-height: ${logoSizes[size]}; ${i < icons.length - 1 ? `margin-right: calc(-${logoSizes[size]} / 3);` : ''} z-index: ${i + 1};`}
+				class="relative rounded-full bg-primary ring ring-disabled"
+				in:fade
+			>
+				<span class="inline-flex" class:invert-on-dark-theme={invertColor}>
+					<Logo alt={`${icon}-${i}`} {color} {size} src={icon} />
+				</span>
+			</div>
+		{/each}
+	</div>
+{/if}

--- a/src/frontend/src/tests/lib/components/ui/OverlappedLogos.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/OverlappedLogos.spec.ts
@@ -28,6 +28,10 @@ describe('OverlappedLogos.svelte', () => {
 		expect(skeleton).not.toBeInTheDocument();
 
 		expect(getIconWrappers(container)).toHaveLength(0);
+
+		// No element node renders at all (only Svelte's {#if} anchor comment), so a caller's
+		// styleClass adds no stray spacing when there is nothing to show.
+		expect(container.querySelector('*')).toBeNull();
 	});
 
 	it('applies z-index to each icon wrapper', () => {

--- a/src/frontend/src/tests/lib/components/ui/OverlappedLogos.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/OverlappedLogos.spec.ts
@@ -15,16 +15,19 @@ describe('OverlappedLogos.svelte', () => {
 		expect(images).toHaveLength(mockIcons.length);
 	});
 
-	it('renders a skeleton when icons array is empty', () => {
+	it('renders nothing when icons array is empty', () => {
 		const { container } = render(OverlappedLogos, { props: { icons: [] } });
 
 		const images = container.querySelectorAll('img');
 
 		expect(images).toHaveLength(0);
 
+		// No loading skeleton: an empty list is "no icons", not "loading".
 		const skeleton = container.querySelector('.w-12');
 
-		expect(skeleton).toBeInTheDocument();
+		expect(skeleton).not.toBeInTheDocument();
+
+		expect(getIconWrappers(container)).toHaveLength(0);
 	});
 
 	it('applies z-index to each icon wrapper', () => {


### PR DESCRIPTION
# Motivation

`OverlappedLogos` renders a loading skeleton whenever its `icons` array is empty, conflating "no icons to show" with "loading". Any caller that legitimately passes an empty list gets stuck on a permanent skeleton rather than degrading gracefully — for example a WalletConnect session on a chain with no mapped network icon (surfaced by the Bitcoin-icon case in #13653).

Loading is the caller's concern, not this presentational component's. The existing callers already reflect that: the Liquidium rows guard the component with `{#if networkIcons.length > 0}`, and the earning cards pass populated, config-driven arrays — none of them use the empty→skeleton path intentionally.

# Changes

- `OverlappedLogos.svelte`: render nothing when `icons` is empty (drop the `{:else}` skeleton branch and the now-unused `SkeletonText` import). Added a short comment noting that absence of icons is not a loading state.
- Following Copilot review: guard the whole block with `{#if icons.length > 0}` so an empty list renders no element at all — not even the wrapper `<div>` — so a caller's `styleClass` (e.g. `ml-2`) adds no stray spacing.

# Tests

- Updated `OverlappedLogos.spec.ts`: the empty-array case now asserts no skeleton, no icon wrappers, and no element node is rendered (previously asserted a skeleton).
- Ran the shared-component consumers to confirm none relied on the old behavior: `LiquidiumBorrowedRow`, `LiquidiumSuppliedRow`, `DefaultEarningOpportunityCard`, `WalletConnectSessionsModal` specs all pass (33 tests across them + OverlappedLogos).
- `prettier` and `eslint --max-warnings 0` clean on both changed files.

Independent of #13653 (that PR adds the Bitcoin icon mapping; this one makes an unmapped/empty list degrade gracefully). They touch different files and compose cleanly.

|Before|After|
|---|---|
|<img width="578" height="449" alt="image" src="https://github.com/user-attachments/assets/fdb117c5-5271-4de0-a8f8-52df1c8370c3" />|<img width="578" height="449" alt="image" src="https://github.com/user-attachments/assets/cf2e6c1f-3ee4-4f16-84ab-67d9884d7f93" />|


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Model: Claude Opus 4.8 (`claude-opus-4-8`)
