### PR TITLE
feat(frontend): derive ETH address when Liquidium provider is on

### DIFF
--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -6,6 +6,8 @@
 		loadBtcAddressRegtest,
 		loadBtcAddressTestnet
 	} from '$btc/services/btc-address.services';
+	import { LEND_BORROW_ENABLED } from '$env/lend-borrow';
+	import { LIQUIDIUM_ENABLED } from '$env/liquidium';
 	import { loadEthAddress } from '$eth/services/eth-address.services';
 	import { LOCAL } from '$lib/constants/app.constants';
 	import {
@@ -73,9 +75,14 @@
 	const debounceLoadSolAddressDevnet = debounce(loadSolAddressDevnet);
 	const debounceLoadSolAddressLocal = debounce(loadSolAddressLocal);
 
+	const isLiquidiumProviderEnabled = LEND_BORROW_ENABLED && LIQUIDIUM_ENABLED;
+
 	$effect(() => {
 		if (progressDone) {
-			if (($networkEthereumEnabled || $networkEvmMainnetEnabled) && isNullish($ethAddress)) {
+			if (
+				($networkEthereumEnabled || $networkEvmMainnetEnabled || isLiquidiumProviderEnabled) &&
+				isNullish($ethAddress)
+			) {
 				debounceLoadEthAddress();
 			}
 

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -3,6 +3,7 @@ import {
 	loadBtcAddressRegtest,
 	loadBtcAddressTestnet
 } from '$btc/services/btc-address.services';
+import type * as LendBorrowEnv from '$env/lend-borrow';
 import { loadEthAddress } from '$eth/services/eth-address.services';
 import Loader from '$lib/components/loaders/Loader.svelte';
 import * as appConstants from '$lib/constants/app.constants';
@@ -36,6 +37,24 @@ import { setupTestnetsStore } from '$tests/utils/testnets.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { toNullable } from '@dfinity/utils';
 import { render, waitFor } from '@testing-library/svelte';
+
+const { mockLendBorrowEnabled, mockLiquidiumEnabled } = vi.hoisted(() => ({
+	mockLendBorrowEnabled: { value: true },
+	mockLiquidiumEnabled: { value: true }
+}));
+
+vi.mock('$env/lend-borrow', async (importOriginal) => ({
+	...(await importOriginal<typeof LendBorrowEnv>()),
+	get LEND_BORROW_ENABLED() {
+		return mockLendBorrowEnabled.value;
+	}
+}));
+
+vi.mock('$env/liquidium', () => ({
+	get LIQUIDIUM_ENABLED() {
+		return mockLiquidiumEnabled.value;
+	}
+}));
 
 vi.mock('@dfinity/utils', async () => {
 	const mod = await vi.importActual<object>('@dfinity/utils');
@@ -106,6 +125,48 @@ describe('Loader', () => {
 
 		await waitFor(() => {
 			expect(initLoader).toHaveBeenCalledOnce();
+		});
+	});
+
+	// Liquidium profiles are keyed by the ETH address and its writes are signature-gated, so the
+	// address is required even for a user who shows no ETH/EVM network at all.
+	describe('handling the lend & borrow ETH address', () => {
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			setupTestnetsStore('disabled');
+
+			ethAddressStore.reset();
+
+			mockLendBorrowEnabled.value = true;
+			mockLiquidiumEnabled.value = true;
+		});
+
+		it('should load the ETH address when every ETH/EVM network is disabled', async () => {
+			setupUserNetworksStore('allDisabled');
+
+			render(Loader, { children: mockSnippet });
+
+			await waitFor(() => {
+				expect(loadEthAddress).toHaveBeenCalledOnce();
+			});
+		});
+
+		it.each([
+			{ flag: 'the lend & borrow feature', disable: () => (mockLendBorrowEnabled.value = false) },
+			{ flag: 'the Liquidium provider', disable: () => (mockLiquidiumEnabled.value = false) }
+		])('should not load the ETH address when $flag is disabled', async ({ disable }) => {
+			disable();
+
+			setupUserNetworksStore('allDisabled');
+
+			render(Loader, { children: mockSnippet });
+
+			await waitFor(() => {
+				expect(initLoader).toHaveBeenCalledOnce();
+			});
+
+			expect(loadEthAddress).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

Liquidium keys profiles by the user's ETH address and signature-gates writes with it, but `Loader.svelte` only derived that address when an ETH/EVM mainnet network was enabled. With those networks off, `loadLiquidium` resolved no `profileId`, the portfolio stayed `null`, and Earn / Borrow had nothing to show — even with the provider fully enabled. Lend & borrow is network-agnostic to the user, so gating it behind an Ethereum toggle is the wrong coupling.

# Changes

- `Loader.svelte`: also derive the ETH address when the Liquidium provider is active. Computed once outside the `$effect` (both flags are build-time constants).
- Uses `LEND_BORROW_ENABLED && LIQUIDIUM_ENABLED` rather than `anyLendBorrowProviderEnabled`: the address is needed because *Liquidium* keys profiles by it. Equivalent today, but diverges once a second, non-ETH-keyed provider exists.
- `Loader.spec.ts`: covers both directions — address loads with every ETH/EVM network disabled, and is not loaded when either flag is off (table-driven).


# Tests

Added.
