### PR TITLE
feat(frontend): Earning tab loading state

### DIFF
--- a/src/frontend/src/eth/derived/erc4626.derived.ts
+++ b/src/frontend/src/eth/derived/erc4626.derived.ts
@@ -138,6 +138,13 @@ export const erc4626CustomTokensNotInitialized: Readable<boolean> = derived(
 	([$erc4626CustomTokensInitialized]) => !$erc4626CustomTokensInitialized
 );
 
+export const erc4626CustomTokensLoading: Readable<boolean> = derived(
+	[erc4626CustomTokensNotInitialized, enabledEthereumNetworksIds, enabledEvmNetworksIds],
+	([$erc4626CustomTokensNotInitialized, $enabledEthereumNetworksIds, $enabledEvmNetworksIds]) =>
+		$erc4626CustomTokensNotInitialized &&
+		$enabledEthereumNetworksIds.length + $enabledEvmNetworksIds.length > 0
+);
+
 export const erc4626AssetAddresses: Readable<Erc4626ContractAddressWithNetwork[]> = derived(
 	[erc4626Tokens],
 	([$erc4626Tokens]) =>

--- a/src/frontend/src/lib/components/earning/EarningsList.svelte
+++ b/src/frontend/src/lib/components/earning/EarningsList.svelte
@@ -2,7 +2,7 @@
 	import { fade } from 'svelte/transition';
 	import { goto } from '$app/navigation';
 	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
-	import { erc4626CustomTokensNotInitialized } from '$eth/derived/erc4626.derived';
+	import { erc4626CustomTokensLoading } from '$eth/derived/erc4626.derived';
 	import { allVaults } from '$eth/derived/vaults.derived';
 	import { isTokenHarvestAutopilot } from '$eth/utils/harvest-autopilots.utils';
 	import EarningsListSkeletons from '$lib/components/earning/EarningsListSkeletons.svelte';
@@ -11,7 +11,7 @@
 	import VaultCard from '$lib/components/vaults/VaultCard.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { AppPath, VAULT_PARAM } from '$lib/constants/routes.constants';
-	import { liquidiumPortfolio } from '$lib/derived/liquidium.derived';
+	import { liquidiumPortfolio, liquidiumPortfolioLoading } from '$lib/derived/liquidium.derived';
 	import { pseudoNetworkChainFusion, selectedNetwork } from '$lib/derived/network.derived';
 	import { tokenListStore } from '$lib/stores/token-list.store';
 	import { transactionsUrl } from '$lib/utils/nav.utils';
@@ -19,7 +19,7 @@
 	import { getFilteredTokenGroup } from '$lib/utils/token-list.utils';
 	import { filterEnabledToken } from '$lib/utils/token.utils';
 
-	let loading = $derived($erc4626CustomTokensNotInitialized);
+	let loading = $derived($erc4626CustomTokensLoading || $liquidiumPortfolioLoading);
 
 	let filteredVaults = $derived(
 		$allVaults.filter(

--- a/src/frontend/src/lib/derived/liquidium.derived.ts
+++ b/src/frontend/src/lib/derived/liquidium.derived.ts
@@ -1,4 +1,5 @@
 import { goto } from '$app/navigation';
+import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 import { EarningCardFields } from '$env/types/env.earning-cards';
 import { ZERO } from '$lib/constants/app.constants';
 import { LIQUIDIUM_ADVERTISED_TOKENS } from '$lib/constants/liquidium.constants';
@@ -33,6 +34,11 @@ export const liquidiumMarkets: Readable<LiquidiumMarket[]> = derived(
 export const liquidiumPortfolio: Readable<LiquidiumPortfolio | null> = derived(
 	liquidiumStore,
 	({ portfolio }) => portfolio
+);
+
+export const liquidiumPortfolioLoading: Readable<boolean> = derived(
+	liquidiumStore,
+	({ loaded }) => anyLendBorrowProviderEnabled && !loaded
 );
 
 export const liquidiumSupplyMarkets: Readable<LiquidiumMarket[]> = derived(

--- a/src/frontend/src/lib/services/liquidium.services.ts
+++ b/src/frontend/src/lib/services/liquidium.services.ts
@@ -74,5 +74,7 @@ export const loadLiquidium = async ({
 		liquidiumStore.set({ markets, portfolio, assetPrices });
 	} catch (err: unknown) {
 		consoleError(err);
+	} finally {
+		liquidiumStore.setLoaded(true);
 	}
 };

--- a/src/frontend/src/lib/stores/liquidium.store.ts
+++ b/src/frontend/src/lib/stores/liquidium.store.ts
@@ -1,22 +1,30 @@
 import type { LiquidiumStoreData } from '$lib/types/liquidium';
 import { writable, type Readable } from 'svelte/store';
 
-export interface LiquidiumStore extends Readable<LiquidiumStoreData> {
+// `loaded` cannot be inferred from the payload: empty markets and `portfolio: null` are the
+// legitimate settled values for an address without a Liquidium profile, so a loading gate reading
+// the payload alone would take "nothing there" for "still fetching".
+type LiquidiumStoreState = LiquidiumStoreData & { loaded: boolean };
+
+export interface LiquidiumStore extends Readable<LiquidiumStoreState> {
 	set: (data: LiquidiumStoreData) => void;
+	setLoaded: (loaded: boolean) => void;
 	reset: () => void;
 }
 
 const initLiquidiumStore = (): LiquidiumStore => {
-	const defaultStoreValue: LiquidiumStoreData = {
+	const defaultStoreValue: LiquidiumStoreState = {
 		markets: [],
 		portfolio: null,
-		assetPrices: {}
+		assetPrices: {},
+		loaded: false
 	};
-	const { subscribe, set } = writable<LiquidiumStoreData>(defaultStoreValue);
+	const { subscribe, set, update } = writable<LiquidiumStoreState>(defaultStoreValue);
 
 	return {
 		subscribe,
-		set,
+		set: (data: LiquidiumStoreData) => update(({ loaded }) => ({ ...data, loaded })),
+		setLoaded: (loaded: boolean) => update((state) => ({ ...state, loaded })),
 		reset: () => set(defaultStoreValue)
 	};
 };

--- a/src/frontend/src/tests/eth/derived/erc4626.derived.spec.ts
+++ b/src/frontend/src/tests/eth/derived/erc4626.derived.spec.ts
@@ -5,6 +5,7 @@ import {
 	erc4626AssetAddresses,
 	erc4626CustomTokens,
 	erc4626CustomTokensInitialized,
+	erc4626CustomTokensLoading,
 	erc4626CustomTokensNotInitialized,
 	erc4626Tokens,
 	erc4626TokensExchangeData
@@ -246,6 +247,47 @@ describe('erc4626.derived', () => {
 			erc4626CustomTokensStore.setAll([]);
 
 			expect(get(erc4626CustomTokensNotInitialized)).toBeFalsy();
+		});
+	});
+
+	describe('erc4626CustomTokensLoading', () => {
+		const mockStoreUninitialized = () => {
+			vi.spyOn(erc4626CustomTokensStore, 'subscribe').mockImplementation((fn) => {
+				fn(undefined);
+				return () => {};
+			});
+		};
+
+		const mockNetworksEnabled = (enabled: boolean) => {
+			vi.spyOn(userNetworks, 'subscribe').mockImplementation((fn) => {
+				fn({
+					[ETHEREUM_NETWORK_ID]: { enabled, isTestnet: false },
+					[BASE_NETWORK_ID]: { enabled, isTestnet: false }
+				});
+				return () => {};
+			});
+		};
+
+		it('should return true while the store is not initialized and a network is enabled', () => {
+			mockStoreUninitialized();
+			mockNetworksEnabled(true);
+
+			expect(get(erc4626CustomTokensLoading)).toBeTruthy();
+		});
+
+		it('should return false when the store is not initialized but no network is enabled', () => {
+			mockStoreUninitialized();
+			mockNetworksEnabled(false);
+
+			expect(get(erc4626CustomTokensLoading)).toBeFalsy();
+		});
+
+		it('should return false once the store has been set', () => {
+			mockNetworksEnabled(true);
+
+			erc4626CustomTokensStore.setAll([]);
+
+			expect(get(erc4626CustomTokensLoading)).toBeFalsy();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/components/earning/EarningsList.spec.ts
+++ b/src/frontend/src/tests/lib/components/earning/EarningsList.spec.ts
@@ -2,6 +2,7 @@ import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import * as erc4626Derived from '$eth/derived/erc4626.derived';
 import { allVaults } from '$eth/derived/vaults.derived';
+import { erc4626CustomTokensStore } from '$eth/stores/erc4626-custom-tokens.store';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import EarningsList from '$lib/components/earning/EarningsList.svelte';
 import { lendBorrowProvidersConfig } from '$lib/config/lend-borrow.config';
@@ -11,6 +12,7 @@ import {
 	EARNING_NO_POSITION_PLACEHOLDER
 } from '$lib/constants/test-ids.constants';
 import * as networkDerived from '$lib/derived/network.derived';
+import { userNetworks } from '$lib/derived/user-networks.derived';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
 import { tokenListStore } from '$lib/stores/token-list.store';
 import { LendBorrowProvider } from '$lib/types/lend-borrow';
@@ -80,16 +82,12 @@ describe('EarningsList', () => {
 		});
 	};
 
-	const mockCustomTokensInitialized = () => {
-		vi.spyOn(erc4626Derived, 'erc4626CustomTokensNotInitialized', 'get').mockReturnValue(
-			readable(false)
-		);
+	const mockNotLoading = () => {
+		vi.spyOn(erc4626Derived, 'erc4626CustomTokensLoading', 'get').mockReturnValue(readable(false));
 	};
 
-	const mockCustomTokensNotInitialized = () => {
-		vi.spyOn(erc4626Derived, 'erc4626CustomTokensNotInitialized', 'get').mockReturnValue(
-			readable(true)
-		);
+	const mockLoading = () => {
+		vi.spyOn(erc4626Derived, 'erc4626CustomTokensLoading', 'get').mockReturnValue(readable(true));
 	};
 
 	const supplyReserve: LiquidiumReserve = {
@@ -120,7 +118,10 @@ describe('EarningsList', () => {
 		vi.restoreAllMocks();
 		tokenListStore.set({ filter: '' });
 		liquidiumStore.reset();
-		mockCustomTokensInitialized();
+		// Liquidium gates the skeleton too, so every case below starts from a settled-but-empty
+		// portfolio unless it says otherwise.
+		liquidiumStore.setLoaded(true);
+		mockNotLoading();
 	});
 
 	it('should render the placeholder when there are no vaults', () => {
@@ -354,8 +355,8 @@ describe('EarningsList', () => {
 		expect(text.indexOf('Autopilot Vault')).toBeLessThan(text.indexOf(providerName));
 	});
 
-	it('should show skeletons when custom tokens are not initialized', () => {
-		mockCustomTokensNotInitialized();
+	it('should show skeletons while custom tokens are loading', () => {
+		mockLoading();
 		mockAllVaultsStore([]);
 
 		const { getAllByTestId, queryByTestId } = render(EarningsList);
@@ -366,7 +367,43 @@ describe('EarningsList', () => {
 		expect(queryByTestId(EARNING_NO_POSITION_PLACEHOLDER)).not.toBeInTheDocument();
 	});
 
-	it('should not show skeletons when custom tokens are initialized', () => {
+	it('should show skeletons while the Liquidium portfolio is still loading', () => {
+		// ERC-4626 is settled via beforeEach, so this pins the other half of the union gate: a source
+		// that can still contribute positions must hold the skeleton on its own.
+		liquidiumStore.reset();
+		mockAllVaultsStore([]);
+
+		const { getAllByTestId, queryByTestId } = render(EarningsList);
+
+		const skeletons = getAllByTestId(new RegExp(`^${EARNING_CARD_SKELETON}`));
+
+		expect(skeletons.length).toBeGreaterThan(0);
+		expect(queryByTestId(EARNING_NO_POSITION_PLACEHOLDER)).not.toBeInTheDocument();
+	});
+
+	it('should not show skeletons once custom tokens have loaded', () => {
+		mockAllVaultsStore([]);
+
+		const { getByTestId, queryByTestId } = render(EarningsList);
+
+		expect(queryByTestId(new RegExp(`^${EARNING_CARD_SKELETON}`))).not.toBeInTheDocument();
+		expect(getByTestId(EARNING_NO_POSITION_PLACEHOLDER)).toBeInTheDocument();
+	});
+
+	it('should not show skeletons when no Ethereum or EVM network is enabled', () => {
+		// Runs against the real derived, unlike the two cases above: with every Ethereum/EVM network
+		// off, LoaderTokens never fetches the ERC-4626 custom tokens, so the store stays uninitialized
+		// and the tab has to settle rather than wait for it.
+		vi.restoreAllMocks();
+
+		vi.spyOn(erc4626CustomTokensStore, 'subscribe').mockImplementation((fn) => {
+			fn(undefined);
+			return () => {};
+		});
+		vi.spyOn(userNetworks, 'subscribe').mockImplementation((fn) => {
+			fn({});
+			return () => {};
+		});
 		mockAllVaultsStore([]);
 
 		const { getByTestId, queryByTestId } = render(EarningsList);

--- a/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/liquidium.derived.spec.ts
@@ -22,6 +22,7 @@ import {
 	liquidiumMinBorrowApy,
 	liquidiumNetValueUsd,
 	liquidiumPortfolio,
+	liquidiumPortfolioLoading,
 	liquidiumRepayReserves,
 	liquidiumSupplyMarkets,
 	liquidiumTotalBorrowedUsd,
@@ -352,6 +353,37 @@ describe('liquidium derived stores', () => {
 
 		it('is null by default', () => {
 			expect(get(liquidiumPortfolio)).toBeNull();
+		});
+	});
+
+	describe('liquidiumPortfolioLoading', () => {
+		it('is true before the first load settles', () => {
+			expect(get(liquidiumPortfolioLoading)).toBeTruthy();
+		});
+
+		it('is false once the load settles, even with nothing to show', () => {
+			liquidiumStore.setLoaded(true);
+
+			expect(get(liquidiumPortfolioLoading)).toBeFalsy();
+		});
+
+		it('is true again after a reset', () => {
+			liquidiumStore.setLoaded(true);
+			liquidiumStore.reset();
+
+			expect(get(liquidiumPortfolioLoading)).toBeTruthy();
+		});
+
+		it('is false when the lend & borrow provider is off, however unsettled the store', async () => {
+			vi.resetModules();
+			vi.doMock('$env/lend-borrow', () => ({ anyLendBorrowProviderEnabled: false }));
+
+			const { liquidiumPortfolioLoading: gated } = await import('$lib/derived/liquidium.derived');
+
+			expect(get(gated)).toBeFalsy();
+
+			vi.doUnmock('$env/lend-borrow');
+			vi.resetModules();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/liquidium.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/liquidium.services.spec.ts
@@ -84,7 +84,8 @@ describe('liquidium.services', () => {
 			expect(get(liquidiumStore)).toEqual({
 				markets: [],
 				portfolio: null,
-				assetPrices: {}
+				assetPrices: {},
+				loaded: false
 			});
 			expect(liquidiumApi.liquidiumClient).not.toHaveBeenCalled();
 		});
@@ -98,7 +99,8 @@ describe('liquidium.services', () => {
 			expect(get(liquidiumStore)).toEqual({
 				markets: [market],
 				portfolio: null,
-				assetPrices: {}
+				assetPrices: {},
+				loaded: true
 			});
 			expect(getUserReserves).not.toHaveBeenCalled();
 			expect(getUserPositionSummary).not.toHaveBeenCalled();
@@ -126,7 +128,8 @@ describe('liquidium.services', () => {
 			expect(get(liquidiumStore)).toEqual({
 				markets: [market],
 				portfolio,
-				assetPrices: {}
+				assetPrices: {},
+				loaded: true
 			});
 		});
 
@@ -142,11 +145,12 @@ describe('liquidium.services', () => {
 			expect(get(liquidiumStore)).toEqual({
 				markets: [market],
 				portfolio,
-				assetPrices: {}
+				assetPrices: {},
+				loaded: true
 			});
 		});
 
-		it('swallows SDK errors and leaves the store unchanged', async () => {
+		it('swallows SDK errors and leaves the data unchanged, but settles the loaded flag', async () => {
 			listPools.mockRejectedValue(new Error('rpc down'));
 
 			await expect(loadLiquidium({ identity: mockIdentity, ethAddress })).resolves.toBeUndefined();
@@ -154,7 +158,28 @@ describe('liquidium.services', () => {
 			expect(get(liquidiumStore)).toEqual({
 				markets: [],
 				portfolio: null,
-				assetPrices: {}
+				assetPrices: {},
+				loaded: true
+			});
+		});
+
+		it('keeps already-loaded positions when a refresh fails', async () => {
+			listPools.mockResolvedValue([{ id: 'pool-btc' }]);
+			getProfileId.mockResolvedValue(profileId);
+			getUserReserves.mockResolvedValue([]);
+			getUserPositionSummary.mockResolvedValue({});
+
+			await loadLiquidium({ identity: mockIdentity, ethAddress });
+
+			listPools.mockRejectedValue(new Error('rpc down'));
+
+			await loadLiquidium({ identity: mockIdentity, ethAddress });
+
+			expect(get(liquidiumStore)).toEqual({
+				markets: [market],
+				portfolio,
+				assetPrices: {},
+				loaded: true
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/stores/liquidium.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/liquidium.store.spec.ts
@@ -23,28 +23,45 @@ describe('liquidium.store', () => {
 		liquidiumStore.reset();
 	});
 
-	it('initializes with empty markets and no portfolio', () => {
+	it('initializes with empty markets, no portfolio and not loaded', () => {
 		expect(get(liquidiumStore)).toEqual({
 			markets: [],
 			portfolio: null,
-			assetPrices: {}
+			assetPrices: {},
+			loaded: false
 		});
 	});
 
 	it('replaces the store data on set', () => {
 		liquidiumStore.set(data);
 
-		expect(get(liquidiumStore)).toEqual(data);
+		expect(get(liquidiumStore)).toEqual({ ...data, loaded: false });
+	});
+
+	it('keeps the loaded flag across a set', () => {
+		liquidiumStore.setLoaded(true);
+		liquidiumStore.set(data);
+
+		expect(get(liquidiumStore)).toEqual({ ...data, loaded: true });
+	});
+
+	it('flips the loaded flag without touching the data', () => {
+		liquidiumStore.set(data);
+		liquidiumStore.setLoaded(true);
+
+		expect(get(liquidiumStore)).toEqual({ ...data, loaded: true });
 	});
 
 	it('restores the default value on reset', () => {
 		liquidiumStore.set(data);
+		liquidiumStore.setLoaded(true);
 		liquidiumStore.reset();
 
 		expect(get(liquidiumStore)).toEqual({
 			markets: [],
 			portfolio: null,
-			assetPrices: {}
+			assetPrices: {},
+			loaded: false
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The Earning tab skeletons were gated solely on the ERC-4626 custom-token store being initialized. In this PR, we extend `loading` flag with the Liquidium counter-part.

# Changes

- Add `erc4626CustomTokensLoading`: true only while the store is uninitialized *and* at least one Ethereum/EVM network is enabled — mirroring the condition under which `LoaderTokens` actually fetches. (The ETH-address half of that loader gate is driven by the same network condition in `Loader.svelte`, so the derived needs no extra address check.)
- Add a `loaded` flag to `liquidiumStore` (`setLoaded`; preserved across `set`, cleared on `reset`). It cannot be inferred from the payload: empty markets and a `null` portfolio are the legitimate settled values for an address without a Liquidium profile.
- Settle the flag in a `finally` in `loadLiquidium`, so consumers gating on it don't wait forever on a swallowed error. The failure path deliberately keeps existing data: the service also runs as a post-action refresh, where clearing the portfolio would read as "no positions" to the user who just changed them.
- Add `liquidiumPortfolioLoading`, gated off entirely when no lend & borrow provider is enabled.
- `EarningsList` now holds its skeletons on the union of both loading states.

# Tests

Added.
