### PR TITLE
style(frontend): hide network label on top-level assets list rows

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenCard.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import Divider from '$lib/components/common/Divider.svelte';
 	import ExchangeRateChange from '$lib/components/exchange/ExchangeRateChange.svelte';
 	import ExchangeTokenValue from '$lib/components/exchange/ExchangeTokenValue.svelte';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
@@ -21,13 +20,14 @@
 	import { formatCurrency } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils.js';
 	import { isCardDataTogglableToken } from '$lib/utils/token-card.utils';
-	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
+	import { getTokenDisplayName, getTokenDisplaySymbol } from '$lib/utils/token.utils';
 
 	interface Props {
 		data: CardData;
 		testIdPrefix?: typeof TOKEN_CARD | typeof TOKEN_GROUP;
 		asNetwork?: boolean;
 		hover?: boolean;
+		showNetwork?: boolean;
 		onClick?: () => void;
 		onToggle?: (t: Token) => void;
 	}
@@ -37,6 +37,7 @@
 		testIdPrefix = TOKEN_CARD,
 		asNetwork = false,
 		hover = false,
+		showNetwork = true,
 		onClick,
 		onToggle
 	}: Props = $props();
@@ -120,17 +121,13 @@
 		{#snippet description()}
 			<span class:text-sm={asNetwork}>
 				{#if data?.networks}
-					{@const networks = [...new Set(data.networks.map((n) => n.name))]}
-
 					<span class="text-primary">{data.name}</span>
-					{replacePlaceholders($i18n.tokens.text.on_network, { $network: '' })}
-					{#each networks as network, index (network)}
-						{#if index !== 0}
-							<Divider />
-						{/if}{network}
-					{/each}
 				{:else if !asNetwork}
-					<TokenNameAndNetwork {data} />
+					{#if showNetwork}
+						<TokenNameAndNetwork {data} />
+					{:else}
+						<span class="text-primary">{getTokenDisplayName(data)}</span>
+					{/if}
 				{/if}
 			</span>
 		{/snippet}

--- a/src/frontend/src/lib/components/tokens/TokensList.svelte
+++ b/src/frontend/src/lib/components/tokens/TokensList.svelte
@@ -166,7 +166,11 @@
 						{@const { token } = tokenOrGroup}
 
 						<div class="transition-colors duration-300 hover:bg-primary">
-							<TokenCard data={token} onClick={() => goto(transactionsUrl({ token }))} />
+							<TokenCard
+								data={token}
+								onClick={() => goto(transactionsUrl({ token }))}
+								showNetwork={false}
+							/>
 						</div>
 					{/if}
 				</div>

--- a/src/frontend/src/tests/lib/components/tokens/TokenCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenCard.spec.ts
@@ -1,0 +1,45 @@
+import { ICP_NETWORK } from '$env/networks/networks.icp.env';
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import TokenCard from '$lib/components/tokens/TokenCard.svelte';
+import type { CardData } from '$lib/types/token-card';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import en from '$tests/mocks/i18n.mock';
+import { render, screen } from '@testing-library/svelte';
+
+describe('TokenCard', () => {
+	const onNetworkText = (network: string) =>
+		replacePlaceholders(en.tokens.text.on_network, { $network: network }).trim();
+
+	it('should show the network for a token group header without listing member networks', () => {
+		const data: CardData = {
+			...USDC_TOKEN,
+			networks: [USDC_TOKEN.network, ICP_NETWORK]
+		};
+
+		render(TokenCard, { props: { data } });
+
+		expect(screen.getByText(USDC_TOKEN.name)).toBeInTheDocument();
+		expect(screen.queryByText(onNetworkText(USDC_TOKEN.network.name))).not.toBeInTheDocument();
+		expect(screen.queryByText(ICP_NETWORK.name)).not.toBeInTheDocument();
+	});
+
+	it('should show the network suffix for a top-level token by default', () => {
+		render(TokenCard, { props: { data: USDC_TOKEN } });
+
+		expect(screen.getByText(onNetworkText(USDC_TOKEN.network.name))).toBeInTheDocument();
+	});
+
+	it('should hide the network suffix for a top-level token when showNetwork is false', () => {
+		render(TokenCard, { props: { data: USDC_TOKEN, showNetwork: false } });
+
+		expect(screen.getByText(USDC_TOKEN.name)).toBeInTheDocument();
+		expect(screen.queryByText(onNetworkText(USDC_TOKEN.network.name))).not.toBeInTheDocument();
+	});
+
+	it('should still show the network for a token rendered inside an expanded group (asNetwork)', () => {
+		render(TokenCard, { props: { data: ETHEREUM_TOKEN, asNetwork: true, showNetwork: false } });
+
+		expect(screen.getByText(onNetworkText(ETHEREUM_TOKEN.network.name))).toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/components/tokens/TokenCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenCard.spec.ts
@@ -11,7 +11,7 @@ describe('TokenCard', () => {
 	const onNetworkText = (network: string) =>
 		replacePlaceholders(en.tokens.text.on_network, { $network: network }).trim();
 
-	it('should show the network for a token group header without listing member networks', () => {
+	it('should show the group name for a token group header without listing member networks', () => {
 		const data: CardData = {
 			...USDC_TOKEN,
 			networks: [USDC_TOKEN.network, ICP_NETWORK]

--- a/src/frontend/src/tests/lib/components/tokens/TokenGroupCard.spec.ts
+++ b/src/frontend/src/tests/lib/components/tokens/TokenGroupCard.spec.ts
@@ -3,6 +3,7 @@ import { ICP_NETWORK } from '$env/networks/networks.icp.env';
 import TokenGroupCard from '$lib/components/tokens/TokenGroupCard.svelte';
 import { TokenCategoryTagValue, TokenTagType } from '$lib/enums/token-tag';
 import { hideTokenCategoryFilterStore, tokenCategoryFilterStore } from '$lib/stores/settings.store';
+import { tokenGroupStore } from '$lib/stores/token-group.store';
 import { tokenListStore } from '$lib/stores/token-list.store';
 import type { TokenUi } from '$lib/types/token-ui';
 import type { TokenUiGroup } from '$lib/types/token-ui-group';
@@ -81,6 +82,7 @@ describe('TokenGroupCard', () => {
 		hideTokenCategoryFilterStore.reset({ key: 'hide-token-category-filter' });
 		tokenCategoryFilterStore.reset({ key: 'token-category-filter' });
 		tokenListStore.set({ filter: '' });
+		tokenGroupStore.reset(groupId);
 	});
 
 	const getTokenCountBadge = (container: HTMLElement): HTMLElement | null =>
@@ -194,6 +196,14 @@ describe('TokenGroupCard', () => {
 		expect(cryptoCardA).toBeInTheDocument();
 		expect(cryptoCardB).toBeInTheDocument();
 		expect(stableCard).not.toBeInTheDocument();
+	});
+
+	it('should show the group name in the collapsed header without listing member networks', () => {
+		const { container } = render(TokenGroupCard, { props: { tokenGroup } });
+
+		expect(container).toHaveTextContent(tokenGroup.groupData.name);
+		expect(container).not.toHaveTextContent(ICP_NETWORK.name);
+		expect(container).not.toHaveTextContent(ETHEREUM_NETWORK.name);
 	});
 
 	it('should render all tokens when expanded without category filter', async () => {


### PR DESCRIPTION
# Motivation

The main token list on the Assets page repeats " on <network>" for every row, including collapsed token groups and single-network tokens. That's redundant at the top level: a collapsed group already implies "multiple networks", and a standalone token only has one network anyway. The label is only informative once a group is expanded and each row needs to say which network it represents.

# Changes

- `TokenCard`: add a `showNetwork` prop (default `true`, preserving existing behavior everywhere else). The token-group header branch no longer appends the network list after the group name.
- `TokensList`: pass `showNetwork={false}` for the main list's plain (ungrouped) token rows. The "enable more assets" search list keeps the network label, since it's a flat cross-network list where the network is the only disambiguator.
- Rows inside an expanded token group (`asNetwork`) are unchanged and still show "on <network>".

# Tests

- Added `TokenCard.spec.ts` covering: group header hides the network list, top-level token hides/shows the network suffix via `showNetwork`, and the expanded-group (`asNetwork`) row still shows it.
- Added a `TokenGroupCard.spec.ts` case asserting the collapsed header no longer renders member network names.
- Also reset `tokenGroupStore` between `TokenGroupCard` tests (state was leaking across tests via the shared store), which was necessary for the new test to run deterministically regardless of order.
- Verified visually in a throwaway local route rendering `TokenCard`/`TokenGroupCard` with real token fixtures (removed before pushing) — collapsed rows hide the network, expanded rows keep it.

|Before / After|
|---|
|<img width="1280" height="1153" alt="telegram-cloud-photo-size-4-6025902918487183154-y" src="https://github.com/user-attachments/assets/922605b4-7a57-435e-baf6-7fa5967ce215" />|

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Sonnet 5 (claude-sonnet-5)