### PR TITLE
feat(frontend): show pending Solana transactions in the transactions list

### DIFF
--- a/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
+++ b/src/frontend/src/sol/components/send/SolSendTokenWizard.svelte
@@ -38,6 +38,7 @@
 		isNetworkIdSOLLocal
 	} from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
+	import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 	import SolFeeContext from '$sol/components/fee/SolFeeContext.svelte';
 	import SolSendForm from '$sol/components/send/SolSendForm.svelte';
 	import SolSendReview from '$sol/components/send/SolSendReview.svelte';
@@ -203,6 +204,11 @@
 			});
 
 			setTimeout(() => close(), 750);
+
+			// The Solana wallet worker only polls once a minute, so without an explicit trigger the
+			// transaction that was just sent - and is not finalized yet - would stay out of the list for
+			// up to that long.
+			await waitAndTriggerWallet();
 		} catch (err: unknown) {
 			trackEvent({
 				name: TRACK_COUNT_SOL_SEND_ERROR,

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import { isNullish, nonNullish } from '@dfinity/utils';
+	import { nonNullish } from '@dfinity/utils';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { modalStore } from '$lib/stores/modal.store';
 	import type { Token } from '$lib/types/token';
 	import type { TransactionStatus } from '$lib/types/transaction';
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
+	import { mapSolTransactionStatus } from '$sol/utils/sol-transactions.utils';
 
 	interface Props {
 		transaction: SolTransactionUi;
@@ -15,13 +16,11 @@
 
 	let { transaction, token, iconType = 'transaction' }: Props = $props();
 
-	let { type, value, timestamp, status, to, from, toOwner, fromOwner } = $derived(transaction);
+	let { type, value, timestamp, to, from, toOwner, fromOwner } = $derived(transaction);
 
 	let label = $derived(type === 'send' ? $i18n.send.text.send : $i18n.receive.text.receive);
 
-	let pending = $derived(status === 'processed' || isNullish(status));
-
-	let transactionStatus: TransactionStatus = $derived(pending ? 'pending' : 'confirmed');
+	let transactionStatus: TransactionStatus = $derived(mapSolTransactionStatus(transaction));
 
 	let displayAmount = $derived(nonNullish(value) ? (type === 'send' ? value * -1n : value) : value);
 

--- a/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
+++ b/src/frontend/src/sol/schedulers/sol-wallet.scheduler.ts
@@ -202,10 +202,18 @@ export class SolWalletScheduler implements Scheduler<PostMessageDataRequestSol> 
 			);
 		}
 
-		const newRpcTransactions = rpcCertified.filter(
-			({ data: { id, signature } }) =>
-				refreshedSignatures.has(String(signature)) || isNullish(this.store.transactions[`${id}`])
-		);
+		const newRpcTransactions = rpcCertified.filter(({ data: { id, signature, status } }) => {
+			const knownTransaction = this.store.transactions[`${id}`];
+
+			return (
+				refreshedSignatures.has(String(signature)) ||
+				isNullish(knownTransaction) ||
+				// A transaction first seen below the `finalized` commitment is emitted as pending. It keeps
+				// the same id once the cluster advances its commitment, so without re-emitting it on a
+				// commitment change the UI would show it as pending forever.
+				knownTransaction.data.status !== status
+			);
+		});
 
 		if (USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED && newRpcTransactions.length > 0) {
 			const backendTokenId = solBackendTokenId({ network, tokenAddress });

--- a/src/frontend/src/sol/utils/sol-transactions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transactions.utils.ts
@@ -1,8 +1,10 @@
 import { ZERO } from '$lib/constants/app.constants';
+import type { TransactionStatus } from '$lib/types/transaction';
 import type { OptionSolAddress } from '$sol/types/address';
-import type { MappedSolTransaction } from '$sol/types/sol-transaction';
+import type { MappedSolTransaction, SolTransactionUi } from '$sol/types/sol-transaction';
 import type { CompilableTransactionMessage } from '$sol/types/sol-transaction-message';
 import { mapSolInstruction } from '$sol/utils/sol-instructions.utils';
+import { isSolTransactionFinalized } from '$sol/utils/user-transactions.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import {
 	decompileTransactionMessageFetchingLookupTables,
@@ -14,6 +16,16 @@ import {
 	type Transaction,
 	type TransactionMessage
 } from '@solana/kit';
+
+/**
+ * Maps the Solana commitment of a transaction to the cross-chain UI status.
+ *
+ * A Solana transaction is only irreversible once the cluster has rooted it, so anything below the
+ * `finalized` commitment - including a signature whose commitment the RPC has not reported yet - is
+ * still revertible and must be surfaced as pending, the same way the other chains do.
+ */
+export const mapSolTransactionStatus = (transaction: SolTransactionUi): TransactionStatus =>
+	isSolTransactionFinalized(transaction) ? 'confirmed' : 'pending';
 
 export const decodeTransactionMessage = (transactionMessage: string): Transaction => {
 	const transactionBytes = getBase64Encoder().encode(transactionMessage);

--- a/src/frontend/src/tests/sol/components/send/SolSendTokenWizard.spec.ts
+++ b/src/frontend/src/tests/sol/components/send/SolSendTokenWizard.spec.ts
@@ -1,0 +1,90 @@
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { ZERO } from '$lib/constants/app.constants';
+import { REVIEW_FORM_SEND_BUTTON } from '$lib/constants/test-ids.constants';
+import * as addressDerived from '$lib/derived/address.derived';
+import { ProgressStepsSendSol } from '$lib/enums/progress-steps';
+import { WizardStepsSend } from '$lib/enums/wizard-steps';
+import * as walletUtils from '$lib/utils/wallet.utils';
+import * as solanaApi from '$sol/api/solana.api';
+import SolSendTokenWizard from '$sol/components/send/SolSendTokenWizard.svelte';
+import * as solSendServices from '$sol/services/sol-send.services';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
+import { mockSignature } from '$tests/mocks/sol-transactions.mock';
+import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
+import { mockContextMap } from '$tests/utils/context.test-utils';
+import { mockSendContextEntry } from '$tests/utils/send.context.test-utils';
+import { signature } from '@solana/kit';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+
+describe('SolSendTokenWizard', () => {
+	const props = {
+		currentStep: { name: WizardStepsSend.REVIEW, title: 'title' },
+		sendProgressStep: ProgressStepsSendSol.INITIALIZATION,
+		amount: 0.001,
+		destination: mockSolAddress2,
+		onBack: vi.fn(),
+		onClose: vi.fn(),
+		onNext: vi.fn(),
+		onSendBack: vi.fn(),
+		onTokensList: vi.fn()
+	};
+
+	const renderWizard = () =>
+		render(SolSendTokenWizard, {
+			props,
+			context: mockContextMap([mockSendContextEntry({ token: SOLANA_TOKEN })])
+		});
+
+	const clickSend = async (container: HTMLElement) => {
+		const button = container.querySelector<HTMLButtonElement>(
+			`[data-tid="${REVIEW_FORM_SEND_BUTTON}"]`
+		);
+
+		await fireEvent.click(button as HTMLButtonElement);
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		mockAuthStore();
+
+		vi.spyOn(addressDerived, 'solAddressMainnet', 'get').mockImplementation(() =>
+			readable(mockSolAddress)
+		);
+		vi.spyOn(solanaApi, 'estimatePriorityFee').mockResolvedValue(ZERO);
+		vi.spyOn(walletUtils, 'waitAndTriggerWallet').mockResolvedValue(undefined);
+	});
+
+	it('should trigger the wallet after a successful send, so the pending transaction shows up', async () => {
+		const spySendSol = vi
+			.spyOn(solSendServices, 'sendSol')
+			.mockResolvedValue(signature(mockSignature));
+
+		const { container } = renderWizard();
+
+		await clickSend(container);
+
+		await waitFor(() => {
+			expect(spySendSol).toHaveBeenCalledOnce();
+		});
+
+		await waitFor(() => {
+			expect(walletUtils.waitAndTriggerWallet).toHaveBeenCalledOnce();
+		});
+	});
+
+	it('should not trigger the wallet when the send fails', async () => {
+		vi.spyOn(solSendServices, 'sendSol').mockRejectedValue(new Error('send failed'));
+
+		const { container } = renderWizard();
+
+		await clickSend(container);
+
+		await waitFor(() => {
+			expect(props.onBack).toHaveBeenCalled();
+		});
+
+		expect(walletUtils.waitAndTriggerWallet).not.toHaveBeenCalled();
+	});
+});

--- a/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
@@ -1,5 +1,6 @@
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
+import en from '$lib/i18n/en.json';
 import { formatToken } from '$lib/utils/format.utils';
 import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 import SolTransaction from '$sol/components/transactions/SolTransaction.svelte';
@@ -52,5 +53,32 @@ describe('SolTransaction', () => {
 				showPlusSign: true
 			})} ${getTokenDisplaySymbol(SOLANA_TOKEN)}`
 		);
+	});
+
+	it.each(['confirmed', 'processed'] as const)(
+		'should mark a %s transaction as pending',
+		(status) => {
+			const { getByText } = render(SolTransaction, {
+				props: { transaction: { ...mockTrx, status }, token: SOLANA_TOKEN }
+			});
+
+			expect(getByText(en.transaction.status.pending)).toBeInTheDocument();
+		}
+	);
+
+	it('should mark a transaction without commitment as pending', () => {
+		const { getByText } = render(SolTransaction, {
+			props: { transaction: { ...mockTrx, status: null }, token: SOLANA_TOKEN }
+		});
+
+		expect(getByText(en.transaction.status.pending)).toBeInTheDocument();
+	});
+
+	it('should not mark a finalized transaction as pending', () => {
+		const { queryByText } = render(SolTransaction, {
+			props: { transaction: { ...mockTrx, status: 'finalized' }, token: SOLANA_TOKEN }
+		});
+
+		expect(queryByText(en.transaction.status.pending)).toBeNull();
 	});
 });

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -489,6 +489,66 @@ describe('sol-wallet.scheduler', () => {
 			expect(saveSolFinalizedTransactions).not.toHaveBeenCalled();
 		});
 
+		it('should re-emit a known transaction when its commitment advances to finalized', async () => {
+			const [pendingTransaction] = createMockSolTransactionsUi(1).map((transaction) => ({
+				...transaction,
+				status: 'confirmed' as const
+			}));
+			const finalizedTransaction: SolTransactionUi = {
+				...pendingTransaction,
+				status: 'finalized'
+			};
+
+			spyLoadTransactions.mockResolvedValue([pendingTransaction]);
+
+			await scheduler.trigger(startData);
+
+			expect(scheduler['store'].transactions).toEqual({
+				[pendingTransaction.id]: { data: pendingTransaction, certified: false }
+			});
+
+			postMessageMock.mockClear();
+			spyLoadTransactions.mockResolvedValue([finalizedTransaction]);
+
+			await scheduler.trigger(startData);
+
+			expect(scheduler['store'].transactions).toEqual({
+				[finalizedTransaction.id]: { data: finalizedTransaction, certified: false }
+			});
+			expect(postMessageMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					msg: 'syncSolWallet',
+					data: expect.objectContaining({
+						wallet: expect.objectContaining({
+							newTransactions: JSON.stringify(
+								[{ data: finalizedTransaction, certified: false }],
+								jsonReplacer
+							)
+						})
+					})
+				})
+			);
+		});
+
+		it('should not re-emit a known transaction when its commitment did not change', async () => {
+			const [pendingTransaction] = createMockSolTransactionsUi(1).map((transaction) => ({
+				...transaction,
+				status: 'confirmed' as const
+			}));
+
+			spyLoadTransactions.mockResolvedValue([pendingTransaction]);
+
+			await scheduler.trigger(startData);
+
+			postMessageMock.mockClear();
+
+			await scheduler.trigger(startData);
+
+			expect(postMessageMock).not.toHaveBeenCalledWith(
+				expect.objectContaining({ msg: 'syncSolWallet' })
+			);
+		});
+
 		it('should load backend stored transactions and include them in the response', async () => {
 			const storedTransactions = createMockSolTransactionsUi(2).map((tx, i) => ({
 				...tx,

--- a/src/frontend/src/tests/sol/utils/sol-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transactions.utils.spec.ts
@@ -1,9 +1,15 @@
 import { ZERO } from '$lib/constants/app.constants';
 import type { MappedSolTransaction } from '$sol/types/sol-transaction';
 import * as solInstructionsUtils from '$sol/utils/sol-instructions.utils';
-import { mapSolTransactionMessage } from '$sol/utils/sol-transactions.utils';
+import {
+	mapSolTransactionMessage,
+	mapSolTransactionStatus
+} from '$sol/utils/sol-transactions.utils';
 import { bn1Bi, bn3Bi } from '$tests/mocks/balances.mock';
-import { mockSolParsedTransactionMessage } from '$tests/mocks/sol-transactions.mock';
+import {
+	createMockSolTransactionUi,
+	mockSolParsedTransactionMessage
+} from '$tests/mocks/sol-transactions.mock';
 import {
 	mockAtaAddress,
 	mockSolAddress,
@@ -14,6 +20,27 @@ import type { TransactionMessage } from '@solana/kit';
 import type { MockInstance } from 'vitest';
 
 describe('sol-transactions.utils', () => {
+	describe('mapSolTransactionStatus', () => {
+		const mockTransaction = createMockSolTransactionUi('tx');
+
+		it('should map a finalized transaction to confirmed', () => {
+			expect(mapSolTransactionStatus({ ...mockTransaction, status: 'finalized' })).toBe(
+				'confirmed'
+			);
+		});
+
+		it.each(['confirmed', 'processed'] as const)(
+			'should map a %s transaction to pending',
+			(status) => {
+				expect(mapSolTransactionStatus({ ...mockTransaction, status })).toBe('pending');
+			}
+		);
+
+		it('should map a transaction without commitment to pending', () => {
+			expect(mapSolTransactionStatus({ ...mockTransaction, status: null })).toBe('pending');
+		});
+	});
+
 	describe('mapSolTransactionMessage', () => {
 		const [instruction1, instruction2, instruction3] = mockSolParsedTransactionMessage.instructions;
 		const mockParams: TransactionMessage = {


### PR DESCRIPTION
# Motivation

Solana transactions never showed as pending. `@solana/kit`'s `createSolanaRpc` already applies a `confirmed` default commitment, so `getSignaturesForAddress` / `getTransaction` do return transactions the cluster has confirmed but not finalized — but `SolTransaction.svelte` (unchanged in that respect since b40ecdf1fc) only treated `processed` or a missing commitment as pending, and `getSignaturesForAddress` can never return `processed` (the RPC type excludes it). The pending branch was therefore unreachable and every Solana transaction rendered as settled.

On top of that, the SOL wallet worker polls only once a minute (`SOL_WALLET_TIMER_INTERVAL_MILLIS`) and the send wizard — unlike the swap flows, which call `waitAndTriggerWallet` — never triggered a wallet refresh after a send, so a transaction the user had just sent stayed out of the list for up to a minute and then appeared already marked as settled.

# Changes

- Add `mapSolTransactionStatus` in `$sol/utils/sol-transactions.utils.ts`: anything below the `finalized` commitment maps to the shared `'pending'` status, reusing the existing `isSolTransactionFinalized` helper.
- `SolTransaction.svelte` uses it, so pending Solana rows get the same `TransactionStatus` badge and dimmed icon as BTC / ETH / IC.
- `SolWalletScheduler` re-emits a known transaction when its commitment changes. Without it a transaction first seen as `confirmed` keeps its id and would never be re-sent, leaving the pending badge on forever. The transactions store already replaces by id on `prepend`, and `saveSolFinalizedTransactions` still persists only finalized ones to the backend cache.
- `SolSendTokenWizard` triggers the wallet after a successful send, so the pending transaction shows up right away instead of on the next minute-long poll.

No new i18n keys: `transaction.status.pending` already exists and the transaction modal keeps showing the exact commitment (`Processed` / `Confirmed` / `Finalised`).

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npx tsc --project tsconfig.spec.json`, `npx vitest run` (1032 files / 16795 tests passed).
- New: `mapSolTransactionStatus` unit tests; `SolTransaction` renders the pending badge for `confirmed` / `processed` / no commitment and not for `finalized`; scheduler re-emits on a commitment change and stays quiet when it does not; new `SolSendTokenWizard` spec covering the wallet trigger on success and its absence on failure.

# Follow-ups

- Failed Solana transactions are still filtered out at the signature level (`fetchSignatures` drops signatures with `err`), so a pending row disappears instead of showing as failed.
- The IndexedDB transaction cache stores the commitment as-is, so a reload can briefly show a stale pending badge until the first worker sync replaces the entry.
