### PR TITLE
style(frontend): frost the sticky header fill so the app artwork shows through

### DIFF
--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -34,21 +34,23 @@
 <svelte:window onscroll={handleScroll} />
 
 <!--
-	The pinned fill is frosted rather than solid. The app background is a
-	fixed artwork (`oisy_bg_light.webp`) whose base color is exactly
-	`--color-background-page`, so a solid `bg-page` was invisible over the
-	flat areas but stamped a hard-edged rectangle over the artwork's
-	blobs. It shows worst on the `Assets` tab bar, which pins right on top
-	of the upper-left blob. A translucent fill plus `backdrop-blur` still
-	masks the content scrolling underneath while letting the artwork
-	through. Same treatment as the lock screen (see `LockPage`).
+	The pinned header masks the content underneath with blur alone, and
+	deliberately paints no fill. The app background is a fixed artwork
+	(`oisy_bg_light.webp`) whose base color is exactly
+	`--color-background-page`, so the previous solid `bg-page` was
+	invisible over the artwork's flat areas but stamped a hard-edged
+	rectangle wherever one of its soft blobs sat underneath, worst on the
+	`Assets` tab bar which pins on top of the upper-left blob. Any fill or
+	color-shifting backdrop filter redraws that edge, since the step is
+	proportional to how far the blob is from the base color. Blurring a
+	smooth gradient is close to a no-op, so blur on its own leaves the
+	artwork intact while still smearing the rows scrolling beneath.
 -->
 <div bind:this={rootElement}>
 	<div
 		style:z-index={zIndex}
 		class="sticky top-0 px-1 whitespace-nowrap"
-		class:backdrop-blur-md={scrolledSoon}
-		class:bg-overlay-page-30={scrolledSoon}
+		class:backdrop-blur-xl={scrolledSoon}
 		class:pt-6={scrolledSoon}
 	>
 		{@render header()}

--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -38,7 +38,7 @@
 	fixed artwork (`oisy_bg_light.webp`) whose base color is exactly
 	`--color-background-page`, so a solid `bg-page` was invisible over the
 	flat areas but stamped a hard-edged rectangle over the artwork's
-	blobs — most visible on the `Assets` tab bar, which pins right on top
+	blobs. It shows worst on the `Assets` tab bar, which pins right on top
 	of the upper-left blob. A translucent fill plus `backdrop-blur` still
 	masks the content scrolling underneath while letting the artwork
 	through. Same treatment as the lock screen (see `LockPage`).

--- a/src/frontend/src/lib/components/ui/StickyHeader.svelte
+++ b/src/frontend/src/lib/components/ui/StickyHeader.svelte
@@ -33,11 +33,22 @@
 
 <svelte:window onscroll={handleScroll} />
 
+<!--
+	The pinned fill is frosted rather than solid. The app background is a
+	fixed artwork (`oisy_bg_light.webp`) whose base color is exactly
+	`--color-background-page`, so a solid `bg-page` was invisible over the
+	flat areas but stamped a hard-edged rectangle over the artwork's
+	blobs — most visible on the `Assets` tab bar, which pins right on top
+	of the upper-left blob. A translucent fill plus `backdrop-blur` still
+	masks the content scrolling underneath while letting the artwork
+	through. Same treatment as the lock screen (see `LockPage`).
+-->
 <div bind:this={rootElement}>
 	<div
 		style:z-index={zIndex}
 		class="sticky top-0 px-1 whitespace-nowrap"
-		class:bg-page={scrolledSoon}
+		class:backdrop-blur-md={scrolledSoon}
+		class:bg-overlay-page-30={scrolledSoon}
 		class:pt-6={scrolledSoon}
 	>
 		{@render header()}


### PR DESCRIPTION
# Motivation

When the sticky header pins, it paints a solid `bg-page` fill. The app background is a fixed artwork (`oisy_bg_light.webp`) whose base color is exactly `--color-background-page` (`#e8f1ff`), so that fill is invisible over the artwork's flat areas, but it stamps a hard-edged opaque rectangle wherever the artwork has one of its soft blobs.

The `Assets` tab bar (`Tokens` / `Trading` / `Earning` / `Borrowing`) pins right on top of the artwork's upper-left blob, so scrolling there visibly erases the blob and leaves a flat colored band.

This is not new: `bg-page` has been on `StickyHeader` unchanged since #7535. The Activity date headers use the same component and the same solid fill, and they just happen to pin over a flat region of the artwork, so the fill is undetectable there.

# Changes

`StickyHeader`: drop the `bg-page` fill entirely and mask the content underneath with `backdrop-blur-xl` alone.

A translucent fill is not enough. The blob differs from the base color by up to roughly 25 to 40 per channel, so a 30% overlay still leaves a step of 8 to 12 per channel at the rectangle's edge, which stays clearly visible. The same is true of any color-shifting backdrop filter such as `backdrop-brightness` or `backdrop-saturate`. Blurring a smooth gradient is close to a no-op, so blur on its own is the one treatment that leaves no edge over the artwork while still smearing the rows that scroll beneath the header.

Applied in the shared component rather than behind a prop, so all call sites (`Assets`, `TransactionsDateGroup`, `TokensList`) stay consistent.

# Tests

- `npm run lint -- --max-warnings 0` and `npx prettier`: pass.
- `npx vitest run` over the `StickyHeader` consumers (`tokens`, `transactions`, `ui`): 92 files / 573 tests pass.
- Deployed to `test_fe_2` for visual review of the pinned header on the `Assets` tabs.

Note: `npm run check` and `npm run test` currently fail on `main` with 14 pre-existing `@liquidium/client` type errors, unrelated to this change. Verified identical counts with this diff stashed.
