### PR TITLE
fix(frontend): resolve NFT media URIs per EIP-1155 and non-HTTP schemes

### DIFF
--- a/src/frontend/src/eth/providers/infura-erc1155.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc1155.providers.ts
@@ -5,6 +5,7 @@ import { ERC1155_ABI } from '$eth/constants/erc1155.constants';
 import { InfuraErc165Provider } from '$eth/providers/infura-erc165.providers';
 import { fetchMetadataFromUri } from '$eth/services/erc.services';
 import type { Erc1155ContractAddress, Erc1155Metadata } from '$eth/types/erc1155';
+import { replaceErc1155UriTokenId } from '$eth/utils/erc1155.utils';
 import { i18n } from '$lib/stores/i18n.store';
 import type { Address } from '$lib/types/address';
 import type { NetworkId } from '$lib/types/network';
@@ -128,7 +129,7 @@ export class InfuraErc1155Provider extends InfuraErc165Provider {
 		const tokenUri = await erc1155Contract.uri(tokenId);
 
 		const { metadata, imageUrl } = await fetchMetadataFromUri({
-			metadataUrl: tokenUri.replace(/{id}/g, tokenId.toString()),
+			metadataUrl: replaceErc1155UriTokenId({ uri: tokenUri, tokenId }),
 			contractAddress,
 			tokenId
 		});

--- a/src/frontend/src/eth/services/erc.services.ts
+++ b/src/frontend/src/eth/services/erc.services.ts
@@ -3,25 +3,42 @@ import type { Erc721ContractAddress, Erc721UriJson } from '$eth/types/erc721';
 import { InvalidMetadataImageUrl, InvalidTokenUri } from '$lib/types/errors';
 import type { NftId } from '$lib/types/nft';
 import { parseMetadataResourceUrl } from '$lib/utils/nfts.utils';
-import { isNullish } from '@dfinity/utils';
+import { isNullish, notEmptyString } from '@dfinity/utils';
+
+// `image_data` carries the media inline as raw SVG markup instead of by
+// reference, so it has to be wrapped into a data URI to become displayable.
+const toImageDataUrl = (imageData: string): string =>
+	`data:image/svg+xml;utf8,${encodeURIComponent(imageData)}`;
 
 const extractImageUrl = ({
-	imageUrl,
+	metadata: { image, image_url: imageUrl, image_data: imageData },
+	metadataUrl,
 	contractAddress,
 	tokenId
 }: {
-	imageUrl: string | undefined;
+	metadata: Erc721UriJson | Erc1155UriJson;
+	metadataUrl: URL;
 	contractAddress: Erc721ContractAddress['address'] | Erc1155ContractAddress['address'];
 	tokenId: NftId;
 }): URL | undefined => {
-	if (isNullish(imageUrl)) {
-		return undefined;
+	const source =
+		[image, imageUrl].find(notEmptyString) ??
+		(notEmptyString(imageData) ? toImageDataUrl(imageData) : undefined);
+
+	if (isNullish(source)) {
+		return;
 	}
 
-	return parseMetadataResourceUrl({
-		url: imageUrl,
-		error: new InvalidMetadataImageUrl(tokenId, contractAddress)
-	});
+	try {
+		return parseMetadataResourceUrl({
+			url: source,
+			base: metadataUrl,
+			error: new InvalidMetadataImageUrl(tokenId, contractAddress)
+		});
+	} catch (_: unknown) {
+		// An unusable image reference must not discard the rest of the document:
+		// name, description and attributes remain worth displaying.
+	}
 };
 
 export const fetchMetadataFromUri = async ({
@@ -46,17 +63,20 @@ export const fetchMetadataFromUri = async ({
 	});
 
 	const response = await fetch(metadataUrl);
-	const metadata = await response.json();
+
+	// A gateway that 404s still resolves the promise, and parsing its error page
+	// as JSON would surface as an opaque syntax error instead of a token URI one.
+	if (!response.ok) {
+		throw new InvalidTokenUri(tokenId, contractAddress);
+	}
+
+	const metadata: Erc721UriJson | Erc1155UriJson | undefined = await response.json();
 
 	if (isNullish(metadata)) {
 		return { metadata: undefined, imageUrl: undefined };
 	}
 
-	const imageUrl = extractImageUrl({
-		imageUrl: metadata.image ?? metadata.image_url,
-		contractAddress,
-		tokenId
-	});
+	const imageUrl = extractImageUrl({ metadata, metadataUrl, contractAddress, tokenId });
 
 	return { metadata, imageUrl };
 };

--- a/src/frontend/src/eth/types/erc1155.ts
+++ b/src/frontend/src/eth/types/erc1155.ts
@@ -26,6 +26,8 @@ export interface Erc1155UriJson {
 	decimals?: number;
 	description?: string;
 	image?: string;
+	image_url?: string;
+	image_data?: string;
 	attributes?: { trait_type: string; value: UriJsonPrimitive }[];
 	properties?: Record<string, NestedUriJsonValue>;
 }

--- a/src/frontend/src/eth/types/erc721.ts
+++ b/src/frontend/src/eth/types/erc721.ts
@@ -25,6 +25,9 @@ export interface Erc721UriJson {
 	name?: string;
 	image?: string;
 	image_url?: string;
+	// Inline SVG markup, as popularized by the OpenSea metadata standard for
+	// fully on-chain collections.
+	image_data?: string;
 	description?: string;
 	attributes?: {
 		trait_type: string;

--- a/src/frontend/src/eth/utils/erc1155.utils.ts
+++ b/src/frontend/src/eth/utils/erc1155.utils.ts
@@ -1,6 +1,6 @@
 import type { Erc1155Token } from '$eth/types/erc1155';
 import type { Erc1155CustomToken } from '$eth/types/erc1155-custom-token';
-import type { NftCollection } from '$lib/types/nft';
+import type { NftCollection, NftId } from '$lib/types/nft';
 import type { Token } from '$lib/types/token';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
 
@@ -12,3 +12,38 @@ export const isCollectionErc1155 = (collection: NftCollection) =>
 
 export const isTokenErc1155CustomToken = (token: Token): token is Erc1155CustomToken =>
 	isTokenErc1155(token) && isTokenToggleable(token);
+
+const ERC1155_URI_ID_PLACEHOLDER = '{id}';
+
+// https://eips.ethereum.org/EIPS/eip-1155#metadata
+const ERC1155_URI_ID_HEX_LENGTH = 64;
+
+const toUriTokenId = (tokenId: NftId): string | undefined => {
+	try {
+		return BigInt(tokenId).toString(16).padStart(ERC1155_URI_ID_HEX_LENGTH, '0');
+	} catch (_: unknown) {
+		// A token id that is not a number cannot follow the EIP-1155 rule; the caller
+		// falls back to the raw id rather than dropping the collection's media.
+	}
+};
+
+/**
+ * Applies the EIP-1155 `{id}` substitution rule to a collection metadata URI.
+ *
+ * The standard mandates the id to be lowercase hexadecimal, zero-padded to 64
+ * characters and without the `0x` prefix — a decimal id resolves to a path that
+ * does not exist on the collection's metadata host.
+ */
+export const replaceErc1155UriTokenId = ({
+	uri,
+	tokenId
+}: {
+	uri: string;
+	tokenId: NftId;
+}): string => {
+	if (!uri.includes(ERC1155_URI_ID_PLACEHOLDER)) {
+		return uri;
+	}
+
+	return uri.replaceAll(ERC1155_URI_ID_PLACEHOLDER, toUriTokenId(tokenId) ?? tokenId.toString());
+};

--- a/src/frontend/src/lib/utils/nfts.utils.ts
+++ b/src/frontend/src/lib/utils/nfts.utils.ts
@@ -81,15 +81,35 @@ export const getNftCountsByNetwork = (
 	};
 };
 
-const adaptMetadataResourceUrl = (url: URL): URL | undefined => {
-	const IPFS_PROTOCOL = 'ipfs:';
-	const IPFS_GATEWAY = 'https://ipfs.io/ipfs/';
+const DATA_PROTOCOL = 'data:';
 
-	if (url.protocol !== IPFS_PROTOCOL) {
+// Content-addressed schemes are not fetchable by the browser; they have to be
+// rewritten to an HTTP gateway that serves the same content.
+const CONTENT_ADDRESSED_GATEWAYS: Record<string, string> = {
+	'ipfs:': 'https://ipfs.io/ipfs/',
+	'ipns:': 'https://ipfs.io/ipns/',
+	'ar:': 'https://arweave.net/'
+};
+
+// `ipfs://ipfs/<cid>` and its `ipns`/`ar` equivalents are widespread in NFT
+// metadata; the gateway already carries that segment, so keeping it would build
+// a path that does not exist.
+const DUPLICATED_GATEWAY_SEGMENT = /^(?:ipfs|ipns|ar)\//;
+
+const adaptMetadataResourceUrl = (url: URL): URL | undefined => {
+	const gateway = CONTENT_ADDRESSED_GATEWAYS[url.protocol];
+
+	if (isNullish(gateway)) {
 		return url;
 	}
 
-	const newUrl = url.href.replace(`${IPFS_PROTOCOL}//`, IPFS_GATEWAY);
+	const prefix = `${url.protocol}//`;
+
+	const href = url.href.startsWith(prefix)
+		? `${prefix}${url.href.slice(prefix.length).replace(DUPLICATED_GATEWAY_SEGMENT, '')}`
+		: url.href;
+
+	const newUrl = href.replace(prefix, gateway);
 
 	const parsedNewUrl = UrlSchema.safeParse(newUrl);
 
@@ -101,7 +121,7 @@ const adaptMetadataResourceUrl = (url: URL): URL | undefined => {
 };
 
 const dataUrlMediaStatus = ({ url }: { url: URL }): MediaStatusEnum | undefined => {
-	if (url.protocol !== 'data:') {
+	if (url.protocol !== DATA_PROTOCOL) {
 		return;
 	}
 
@@ -129,16 +149,43 @@ const base64ByteLength = ({ data }: { data: string }): number => {
 	return Math.floor((sanitizedData.length * 3) / 4) - padding;
 };
 
-export const parseMetadataResourceUrl = ({ url, error }: { url: string; error: NftError }): URL => {
-	const parsedUrl = UrlSchema.safeParse(url);
+// A metadata document routinely references its media with a path relative to
+// itself, so the document URL has to be used as base for those to resolve.
+const resolveResourceUrl = ({ url, base }: { url: string; base?: URL }): URL | undefined => {
+	try {
+		return nonNullish(base) ? new URL(url, base) : new URL(url);
+	} catch (_: unknown) {
+		// A reference the URL parser rejects is simply not resolvable media.
+	}
+};
 
-	if (!parsedUrl.success) {
+export const parseMetadataResourceUrl = ({
+	url,
+	error,
+	base
+}: {
+	url: string;
+	error: NftError;
+	base?: URL;
+}): URL => {
+	const resolvedUrl = resolveResourceUrl({ url, base });
+
+	if (isNullish(resolvedUrl)) {
 		throw error;
 	}
 
-	const adaptedUrl = adaptMetadataResourceUrl(new URL(parsedUrl.data));
+	// Fully on-chain collections inline their token URI and their media as a
+	// `data:` URI. Those are not network resources, so they bypass `UrlSchema`
+	// — `dataUrlMediaStatus` is what vets them further down the pipeline.
+	if (resolvedUrl.protocol === DATA_PROTOCOL) {
+		return resolvedUrl;
+	}
 
-	if (isNullish(adaptedUrl)) {
+	const adaptedUrl = adaptMetadataResourceUrl(resolvedUrl);
+
+	// Validation runs on the adapted URL: content-addressed schemes are only
+	// fetchable once rewritten to their gateway.
+	if (isNullish(adaptedUrl) || !UrlSchema.safeParse(adaptedUrl.href).success) {
 		throw error;
 	}
 

--- a/src/frontend/src/tests/eth/providers/infura-erc1155.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/infura-erc1155.providers.spec.ts
@@ -162,6 +162,7 @@ describe('infura-erc1155.providers', () => {
 				vi.spyOn(SvelteMap.prototype, 'get').mockReturnValue(undefined); // invalidate cache
 
 				global.fetch = vi.fn().mockResolvedValue({
+					ok: true,
 					json: () => Promise.resolve(mockMetadata)
 				});
 
@@ -181,6 +182,20 @@ describe('infura-erc1155.providers', () => {
 				expect(global.fetch).toHaveBeenCalledOnce();
 
 				expect(result).toEqual(expected);
+			});
+
+			it('should substitute the {id} placeholder of the contract URI per EIP-1155', async () => {
+				mockUri.mockResolvedValueOnce('https://example.com/metadata/{id}.json');
+
+				const provider = new InfuraErc1155Provider(infura);
+
+				await provider.getNftMetadata(mockParams);
+
+				expect(global.fetch).toHaveBeenCalledExactlyOnceWith(
+					new URL(
+						'https://example.com/metadata/0000000000000000000000000000000000000000000000000000000000003039.json'
+					)
+				);
 			});
 
 			it('should handle metadata gracefully if the contract does not support IERC1155MetadataURI', async () => {
@@ -237,6 +252,7 @@ describe('infura-erc1155.providers', () => {
 
 			it('should handle nullish metadata gracefully', async () => {
 				global.fetch = vi.fn().mockResolvedValueOnce({
+					ok: true,
 					json: () => Promise.resolve(undefined)
 				});
 

--- a/src/frontend/src/tests/eth/providers/infura-erc721.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/infura-erc721.providers.spec.ts
@@ -146,6 +146,7 @@ describe('infura-erc721.providers', () => {
 				vi.spyOn(SvelteMap.prototype, 'get').mockReturnValue(undefined); // invalidate cache
 
 				global.fetch = vi.fn().mockResolvedValue({
+					ok: true,
 					json: () => Promise.resolve(mockMetadata)
 				});
 

--- a/src/frontend/src/tests/eth/services/erc.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc.services.spec.ts
@@ -143,8 +143,82 @@ describe('erc.services', () => {
 			});
 			expect(parseMetadataResourceUrl).toHaveBeenNthCalledWith(2, {
 				url: mockMetadataResponse.image,
+				base: expectedMetadataUrl,
 				error: new InvalidMetadataImageUrl(tokenId, contractAddress)
 			});
+		});
+
+		it('should throw if the metadata URL responds with an error status', async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				json: () => mockMetadataResponse
+			} as unknown as Response);
+
+			await expect(fetchMetadataFromUri(mockParams)).rejects.toThrow(
+				new InvalidTokenUri(tokenId, contractAddress)
+			);
+		});
+
+		it('should resolve an image referenced relatively to the metadata document', async () => {
+			const metadata = { ...mockMetadataResponse, image: `images/${tokenId}.png` };
+
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () => metadata
+			} as unknown as Response);
+
+			const result = await fetchMetadataFromUri({
+				...mockParams,
+				metadataUrl: 'https://example.com/collection/metadata.json'
+			});
+
+			expect(result).toEqual({
+				metadata,
+				imageUrl: new URL(`https://example.com/collection/images/${tokenId}.png`)
+			});
+		});
+
+		it('should build a data URL out of inline SVG image data', async () => {
+			const imageData = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+			const metadata = { ...mockMetadataResponse, image: undefined, image_data: imageData };
+
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () => metadata
+			} as unknown as Response);
+
+			const result = await fetchMetadataFromUri(mockParams);
+
+			expect(result).toEqual({
+				metadata,
+				imageUrl: new URL(`data:image/svg+xml;utf8,${encodeURIComponent(imageData)}`)
+			});
+		});
+
+		it('should prefer a referenced image over inline SVG image data', async () => {
+			const metadata = { ...mockMetadataResponse, image_data: '<svg />' };
+
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () => metadata
+			} as unknown as Response);
+
+			const result = await fetchMetadataFromUri(mockParams);
+
+			expect(result).toEqual({ metadata, imageUrl: new URL(mockMetadataResponse.image) });
+		});
+
+		it('should keep the metadata when the image URL is unusable', async () => {
+			const metadata = { ...mockMetadataResponse, image: 'http://localhost:3000/image.png' };
+
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				json: () => metadata
+			} as unknown as Response);
+
+			const result = await fetchMetadataFromUri(mockParams);
+
+			expect(result).toEqual({ metadata, imageUrl: undefined });
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/utils/erc1155.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/erc1155.utils.spec.ts
@@ -6,7 +6,12 @@ import { SUPPORTED_ETHEREUM_TOKENS } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SUPPORTED_SOLANA_TOKENS } from '$env/tokens/tokens.sol.env';
 import { SPL_TOKENS } from '$env/tokens/tokens.spl.env';
-import { isTokenErc1155, isTokenErc1155CustomToken } from '$eth/utils/erc1155.utils';
+import {
+	isTokenErc1155,
+	isTokenErc1155CustomToken,
+	replaceErc1155UriTokenId
+} from '$eth/utils/erc1155.utils';
+import { parseNftId } from '$lib/validation/nft.validation';
 import { MOCK_ERC1155_TOKENS } from '$tests/mocks/erc1155-tokens.mock';
 import { MOCK_ERC721_TOKENS } from '$tests/mocks/erc721-tokens.mock';
 
@@ -60,6 +65,47 @@ describe('erc1155.utils', () => {
 			...MOCK_ERC721_TOKENS
 		])('should return false for token $name', (token) => {
 			expect(isTokenErc1155CustomToken(token)).toBeFalsy();
+		});
+	});
+
+	describe('replaceErc1155UriTokenId', () => {
+		const uri = 'ipfs://bafybeibtnykuscihteucyu5zv5ccmzsnt57tfpyv43zurafe2ghh6xo44i/{id}.json';
+
+		it('should substitute the id as 64-char zero-padded lowercase hexadecimal', () => {
+			expect(replaceErc1155UriTokenId({ uri, tokenId: parseNftId('1') })).toBe(
+				'ipfs://bafybeibtnykuscihteucyu5zv5ccmzsnt57tfpyv43zurafe2ghh6xo44i/0000000000000000000000000000000000000000000000000000000000000001.json'
+			);
+		});
+
+		it('should substitute a large id in lowercase hexadecimal', () => {
+			expect(replaceErc1155UriTokenId({ uri, tokenId: parseNftId('305') })).toBe(
+				'ipfs://bafybeibtnykuscihteucyu5zv5ccmzsnt57tfpyv43zurafe2ghh6xo44i/0000000000000000000000000000000000000000000000000000000000000131.json'
+			);
+		});
+
+		it('should substitute every occurrence of the placeholder', () => {
+			expect(
+				replaceErc1155UriTokenId({
+					uri: 'https://example.com/{id}/meta/{id}.json',
+					tokenId: parseNftId('16')
+				})
+			).toBe(
+				'https://example.com/0000000000000000000000000000000000000000000000000000000000000010/meta/0000000000000000000000000000000000000000000000000000000000000010.json'
+			);
+		});
+
+		it('should return the URI untouched when it has no placeholder', () => {
+			const staticUri = 'https://example.com/meta/1.json';
+
+			expect(replaceErc1155UriTokenId({ uri: staticUri, tokenId: parseNftId('1') })).toBe(
+				staticUri
+			);
+		});
+
+		it('should fall back to the raw id when it is not a number', () => {
+			expect(replaceErc1155UriTokenId({ uri, tokenId: parseNftId('abc') })).toBe(
+				'ipfs://bafybeibtnykuscihteucyu5zv5ccmzsnt57tfpyv43zurafe2ghh6xo44i/abc.json'
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/nfts.utils.spec.ts
@@ -383,6 +383,67 @@ describe('nfts.utils', () => {
 
 			expect(() => parseMetadataResourceUrl({ url, error: mockError })).toThrow(mockError);
 		});
+
+		it('should not duplicate the ipfs segment of the gateway', () => {
+			const url = 'ipfs://ipfs/Qm12345abcde/metadata.json';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result?.href).toBe('https://ipfs.io/ipfs/Qm12345abcde/metadata.json');
+		});
+
+		it('should transform a valid ipns:// URL to the IPNS gateway', () => {
+			const url = 'ipns://example.eth/metadata.json';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result?.href).toBe('https://ipfs.io/ipns/example.eth/metadata.json');
+		});
+
+		it('should transform a valid ar:// URL to the Arweave gateway', () => {
+			const url = 'ar://ZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmY';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result?.href).toBe('https://arweave.net/ZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmY');
+		});
+
+		it('should return a data URL untouched', () => {
+			const url = 'data:image/svg+xml;utf8,%3Csvg%2F%3E';
+			const result = parseMetadataResourceUrl({ url, error: mockError });
+
+			expect(result?.href).toBe(url);
+		});
+
+		it('should resolve a relative URL against the provided base', () => {
+			const url = '../images/27.png';
+			const base = new URL('https://example.com/collection/metadata/27.json');
+
+			const result = parseMetadataResourceUrl({ url, base, error: mockError });
+
+			expect(result?.href).toBe('https://example.com/collection/images/27.png');
+		});
+
+		it('should resolve a relative URL against an IPFS base', () => {
+			const url = '27.png';
+			const base = new URL('https://ipfs.io/ipfs/Qm12345abcde/metadata/27.json');
+
+			const result = parseMetadataResourceUrl({ url, base, error: mockError });
+
+			expect(result?.href).toBe('https://ipfs.io/ipfs/Qm12345abcde/metadata/27.png');
+		});
+
+		it('should keep an absolute URL when a base is provided', () => {
+			const url = 'ipfs://Qm12345abcde/27.png';
+			const base = new URL('https://example.com/metadata/27.json');
+
+			const result = parseMetadataResourceUrl({ url, base, error: mockError });
+
+			expect(result?.href).toBe('https://ipfs.io/ipfs/Qm12345abcde/27.png');
+		});
+
+		it('should raise an error for a relative URL without a base', () => {
+			const url = '27.png';
+
+			expect(() => parseMetadataResourceUrl({ url, error: mockError })).toThrow(mockError);
+		});
 	});
 
 	describe('mapTokenToCollection', () => {


### PR DESCRIPTION
# Motivation

NFT media often fails to render because the metadata resolution layer understands only a fraction of what collections actually publish. `feat(frontend): fixes the loading of erc1155 tokens metadata` (468cb2ae81) substitutes the ERC-1155 `{id}` placeholder with the *decimal* token id, while EIP-1155 mandates a 64-character zero-padded lowercase hex id — so every collection using the canonical `{id}` template resolves to a path that 404s and ends up with no media at all. On top of that, `feat(frontend): Util to parse NFT metadata URLs` (9c198eb0f6) validates every token URI and image reference against `UrlSchema`, which accepts only `https:`/`wss:`/`ipfs:`: `data:` URIs (fully on-chain SVG collections), `ar://` and `ipns://` are rejected outright, the widespread `ipfs://ipfs/<cid>` form is rewritten to a doubled gateway path, and image paths expressed relative to the metadata document cannot resolve. The display layer already handles `data:` media (c820467fda), but resolution discards those references before they ever reach it — and a single unusable image reference throws away the document's name, description and attributes with it.

# Changes

- Apply the EIP-1155 `{id}` substitution rule (64-char zero-padded lowercase hex, no `0x`) through a new `replaceErc1155UriTokenId` in `$eth/utils/erc1155.utils`, falling back to the raw id for non-numeric ids.
- Extend the resolver in `$lib/utils/nfts.utils`: `ipns://` and `ar://` now map to their gateways, a duplicated `ipfs/`/`ipns/`/`ar/` segment is dropped instead of producing a missing path, `data:` URIs pass through (`dataUrlMediaStatus` already vets them downstream), and `parseMetadataResourceUrl` takes an optional `base` so relative references resolve against the metadata document. Validation now runs on the adapted URL rather than on the raw string.
- Harden `fetchMetadataFromUri`: reject a non-`ok` response with `InvalidTokenUri` instead of parsing an error page as JSON, fall back `image` → `image_url` → `image_data` (inline SVG wrapped into a data URI), and keep the rest of the document when the image reference is unusable.
- Type the fetched metadata as `Erc721UriJson | Erc1155UriJson` (it was implicitly `any`) and add the missing `image_url` / `image_data` fields.

# Tests

- New unit tests for `replaceErc1155UriTokenId`: padding, large id, multiple placeholders, no placeholder, non-numeric id.
- New `parseMetadataResourceUrl` cases: `ipfs://ipfs/…`, `ipns://`, `ar://`, `data:`, relative-to-base, absolute-wins-over-base, relative without base.
- New `fetchMetadataFromUri` cases: error status, relative image, `image_data`, referenced image taking precedence over `image_data`, unusable image keeping the metadata.
- Regression test on `InfuraErc1155Provider.getNftMetadata` asserting the fetched URL carries the hex-padded id.
- Gates: `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` (0 errors / 0 warnings), `npx tsc --project tsconfig.spec.json`, and `vitest run` (1031 files, 16802 tests) all green locally.

# Overlap

The open draft PR #12917 (`fix(frontend): gate NFT media consent by URL`) touches the same two files — `src/frontend/src/lib/utils/nfts.utils.ts` and its spec — but different regions: it appends `getAllowedExternalContentSourceUrls` / `isNftMediaConsentEnabled` after `filterSortByCollection`, whereas this PR reworks `adaptMetadataResourceUrl` / `parseMetadataResourceUrl` further up. No semantic conflict, but whoever merges second should expect to reconcile that file. Flagging it rather than reconciling here.

# Follow-ups

- `animation_url` is still ignored. NFT media is painted as a CSS `background-image` (`BgImg`), so animated/video media needs a real media element in the UI before resolving it is useful.
- No gateway fallback: everything content-addressed goes through `ipfs.io` / `arweave.net`, with no retry against a second gateway.
- ERC-721 contracts that also template `{id}` in `tokenURI` are not covered.
- Media type and size are still probed client-side and are routinely defeated by CORS (pre-existing TODOs in `getMediaStatus`).
