### PR TITLE
fix(frontend): sign personal_sign / eth_sign as raw messages, never as EIP-712

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -6,7 +6,8 @@
 	import { erc721Tokens } from '$eth/derived/erc721.derived';
 	import {
 		getSignParamsMessageTypedDataV4,
-		getSignParamsMessageUtf8
+		getSignParamsMessageUtf8,
+		isEthSignTypedDataMethod
 	} from '$eth/utils/wallet-connect.utils';
 	import Json from '$lib/components/ui/Json.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
@@ -27,7 +28,14 @@
 
 	let method = $derived(request.params.request.method);
 
+	// Only a typed-data method is previewed as typed data. A raw-message request
+	// whose payload happens to parse as EIP-712 is signed as a plain message, so
+	// previewing it as a permit would describe something that is not signed.
 	let json = $derived.by(() => {
+		if (!isEthSignTypedDataMethod(method)) {
+			return undefined;
+		}
+
 		try {
 			return getSignParamsMessageTypedDataV4(request.params.request.params);
 		} catch (_: unknown) {

--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -33,7 +33,7 @@
 	// previewing it as a permit would describe something that is not signed.
 	let json = $derived.by(() => {
 		if (!isEthSignTypedDataMethod(method)) {
-			return undefined;
+			return;
 		}
 
 		try {

--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSignModal.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSignModal.svelte
@@ -4,12 +4,11 @@
 	import { onDestroy } from 'svelte';
 	import WalletConnectSignReview from '$eth/components/wallet-connect/WalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$eth/constants/steps.constants';
-	import {
-		SESSION_REQUEST_ETH_SIGN_LEGACY,
-		SESSION_REQUEST_ETH_SIGN_V4
-	} from '$eth/constants/wallet-connect.constants';
 	import { signMessage } from '$eth/services/wallet-connect.services';
-	import { getSignParamsMessageTypedDataV4 } from '$eth/utils/wallet-connect.utils';
+	import {
+		getSignParamsMessageTypedDataV4,
+		isEthSignTypedDataMethod
+	} from '$eth/utils/wallet-connect.utils';
 	import InProgressWizard from '$lib/components/ui/InProgressWizard.svelte';
 	import WizardModal from '$lib/components/ui/WizardModal.svelte';
 	import WalletConnectModalTitle from '$lib/components/wallet-connect/WalletConnectModalTitle.svelte';
@@ -31,7 +30,7 @@
 	let method = $derived(request.params.request.method);
 
 	let domainName = $derived.by(() => {
-		if (method === SESSION_REQUEST_ETH_SIGN_V4 || method === SESSION_REQUEST_ETH_SIGN_LEGACY) {
+		if (isEthSignTypedDataMethod(method)) {
 			const {
 				domain: { name }
 			} = getSignParamsMessageTypedDataV4(request.params.request.params);

--- a/src/frontend/src/eth/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/eth/constants/wallet-connect.constants.ts
@@ -4,3 +4,10 @@ export const SESSION_REQUEST_ETH_SIGN = 'eth_sign';
 export const SESSION_REQUEST_PERSONAL_SIGN = 'personal_sign';
 export const SESSION_REQUEST_ETH_SIGN_V4 = 'eth_signTypedData_v4';
 export const SESSION_REQUEST_ETH_SIGN_LEGACY = 'eth_signTypedData';
+
+// Only these methods carry EIP-712 typed data. Any other signing method signs
+// the raw message, whatever its payload happens to look like.
+export const SESSION_REQUEST_ETH_SIGN_TYPED_DATA_METHODS: string[] = [
+	SESSION_REQUEST_ETH_SIGN_V4,
+	SESSION_REQUEST_ETH_SIGN_LEGACY
+];

--- a/src/frontend/src/eth/constants/wallet-connect.constants.ts
+++ b/src/frontend/src/eth/constants/wallet-connect.constants.ts
@@ -7,7 +7,7 @@ export const SESSION_REQUEST_ETH_SIGN_LEGACY = 'eth_signTypedData';
 
 // Only these methods carry EIP-712 typed data. Any other signing method signs
 // the raw message, whatever its payload happens to look like.
-export const SESSION_REQUEST_ETH_SIGN_TYPED_DATA_METHODS: string[] = [
+export const SESSION_REQUEST_ETH_SIGN_TYPED_DATA_METHODS: readonly string[] = [
 	SESSION_REQUEST_ETH_SIGN_V4,
 	SESSION_REQUEST_ETH_SIGN_LEGACY
 ];

--- a/src/frontend/src/eth/services/wallet-connect.services.ts
+++ b/src/frontend/src/eth/services/wallet-connect.services.ts
@@ -1,11 +1,11 @@
-import { SESSION_REQUEST_ETH_SIGN_V4 } from '$eth/constants/wallet-connect.constants';
 import { send as executeSend } from '$eth/services/send.services';
 import type { FeeStoreData } from '$eth/stores/eth-fee.store';
 import type { OptionEthAddress } from '$eth/types/address';
 import type { SendParams } from '$eth/types/send';
 import {
 	getSignParamsMessageHex,
-	getSignParamsMessageTypedDataV4Hash
+	getSignParamsMessageTypedDataV4Hash,
+	isEthSignTypedDataMethod
 } from '$eth/utils/wallet-connect.utils';
 import { assertCkEthMinterInfoLoaded } from '$icp-eth/services/cketh.services';
 import { signMessage as signMessageApi, signPrehash } from '$lib/api/signer.api';
@@ -219,33 +219,26 @@ export const signMessage = ({
 				const sign = (params: string[]): Promise<string> => {
 					const { identity } = get(authStore);
 
-					const signTypedDataHash = (): Promise<string> =>
-						signPrehash({
+					// The signature scheme is decided by the requested method alone. A
+					// payload that parses as EIP-712 must not turn `personal_sign` /
+					// `eth_sign` into a typed-data signature: the user approves those as
+					// plain messages, and an EIP-712 signature over them would be an
+					// executable authorization (e.g. an ERC-2612 permit) they never saw.
+					if (isEthSignTypedDataMethod(request.params.request.method)) {
+						// Typed-data methods reject on any parse/validate/hash failure, never
+						// downgrading to a raw message signature.
+						return signPrehash({
 							hash: getSignParamsMessageTypedDataV4Hash(params),
 							identity,
 							nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 						});
-
-					// `eth_signTypedData_v4` must be valid EIP-712 typed data: it always goes
-					// through the typed-data path and rejects on any parse/validate/hash
-					// failure, never downgrading to a raw message signature.
-					if (request.params.request.method === SESSION_REQUEST_ETH_SIGN_V4) {
-						return signTypedDataHash();
 					}
 
-					// personal_sign / eth_sign / legacy eth_signTypedData: attempt the
-					// typed-data hash, falling back to signing the raw message when the
-					// payload is not typed data.
-					try {
-						return signTypedDataHash();
-					} catch (_err: unknown) {
-						const message = getSignParamsMessageHex(params);
-						return signMessageApi({
-							message,
-							identity,
-							nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
-						});
-					}
+					return signMessageApi({
+						message: getSignParamsMessageHex(params),
+						identity,
+						nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+					});
 				};
 
 				const signedMessage = await sign(params);

--- a/src/frontend/src/eth/utils/wallet-connect.utils.ts
+++ b/src/frontend/src/eth/utils/wallet-connect.utils.ts
@@ -1,4 +1,4 @@
-import { SESSION_REQUEST_ETH_SIGN_V4 } from '$eth/constants/wallet-connect.constants';
+import { SESSION_REQUEST_ETH_SIGN_TYPED_DATA_METHODS } from '$eth/constants/wallet-connect.constants';
 import type { WalletConnectEthSignTypedDataV4 } from '$eth/types/wallet-connect';
 import { isEthAddress } from '$eth/utils/account.utils';
 import { ZERO } from '$lib/constants/app.constants';
@@ -265,13 +265,22 @@ export const getSignParamsMessageTypedDataV4Hash = (params: string[]): string =>
 };
 
 /**
- * Whether an `eth_signTypedData_v4` request would fail to sign — i.e. its typed
- * data cannot be parsed, validated, and hashed. Used by the confirmation UI to
- * warn and disable approval, so the preview mirrors what the signer would do
- * (which rejects any such v4 request).
+ * Whether a request carries EIP-712 typed data, i.e. whether its payload is
+ * interpreted as typed data rather than as a raw message. This is decided by the
+ * method alone, never by the shape of the payload: a `personal_sign` payload
+ * that happens to parse as typed data is still only ever a raw message.
+ */
+export const isEthSignTypedDataMethod = (method: string): boolean =>
+	SESSION_REQUEST_ETH_SIGN_TYPED_DATA_METHODS.includes(method);
+
+/**
+ * Whether a typed-data request would fail to sign — i.e. its typed data cannot
+ * be parsed, validated, and hashed. Used by the confirmation UI to warn and
+ * disable approval, so the preview mirrors what the signer would do (which
+ * rejects any such typed-data request).
  *
- * Returns `false` for non-v4 methods (e.g. `personal_sign`), which are signed
- * differently and stay approvable.
+ * Returns `false` for raw-message methods (e.g. `personal_sign`), which are
+ * signed differently and stay approvable.
  */
 export const hasInvalidTypedData = ({
 	method,
@@ -280,7 +289,7 @@ export const hasInvalidTypedData = ({
 	method: string;
 	params: string[];
 }): boolean => {
-	if (method !== SESSION_REQUEST_ETH_SIGN_V4) {
+	if (!isEthSignTypedDataMethod(method)) {
 		return false;
 	}
 

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
@@ -1,7 +1,10 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import EthWalletConnectMessage from '$eth/components/wallet-connect/EthWalletConnectMessage.svelte';
-import { SESSION_REQUEST_ETH_SIGN_V4 } from '$eth/constants/wallet-connect.constants';
+import {
+	SESSION_REQUEST_ETH_SIGN_V4,
+	SESSION_REQUEST_PERSONAL_SIGN
+} from '$eth/constants/wallet-connect.constants';
 import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
 import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
 import * as walletConnectUtils from '$eth/utils/wallet-connect.utils';
@@ -372,5 +375,34 @@ describe('EthWalletConnectMessage', () => {
 
 		expect(getByTestId('wallet-connect-invalid-typed-data-warning')).toBeInTheDocument();
 		expect(getByText(en.wallet_connect.text.invalid_typed_data)).toBeInTheDocument();
+	});
+
+	it('should render a typed-data payload sent through personal_sign as a raw message', () => {
+		// Such a request is signed as a plain message, so previewing it as a permit
+		// would describe an authorization that is not the one being signed.
+		const newRequest: WalletKitTypes.SessionRequest = {
+			...request,
+			params: {
+				...request.params,
+				request: {
+					...request.params.request,
+					method: SESSION_REQUEST_PERSONAL_SIGN
+				}
+			}
+		} as WalletKitTypes.SessionRequest;
+
+		const { getByText, queryByText } = render(EthWalletConnectMessage, {
+			props: {
+				request: newRequest
+			}
+		});
+
+		expect(queryByText('{ ... }')).not.toBeInTheDocument();
+		expect(queryByText(`${en.wallet_connect.text.token}:`)).not.toBeInTheDocument();
+		expect(queryByText(USDC_TOKEN.symbol)).not.toBeInTheDocument();
+
+		expect(
+			getByText(getSignParamsMessageUtf8(newRequest.params.request.params))
+		).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/eth/services/wallet-connect.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/wallet-connect.services.spec.ts
@@ -1,4 +1,6 @@
 import {
+	SESSION_REQUEST_ETH_SIGN,
+	SESSION_REQUEST_ETH_SIGN_LEGACY,
 	SESSION_REQUEST_ETH_SIGN_V4,
 	SESSION_REQUEST_PERSONAL_SIGN
 } from '$eth/constants/wallet-connect.constants';
@@ -139,7 +141,20 @@ describe('eth wallet-connect.services', () => {
 			});
 		});
 
-		it('falls back to raw message signing for a plain (non-typed-data) message', async () => {
+		it('signs a valid typed-data permit via signPrehash for the legacy typed-data method', async () => {
+			const request = buildRequest({
+				method: SESSION_REQUEST_ETH_SIGN_LEGACY,
+				params: [HOLDER, daiPermitJson(true)]
+			});
+
+			const result = await signMessage(buildParams(request));
+
+			expect(result).toStrictEqual({ success: true });
+			expect(signPrehash).toHaveBeenCalledOnce();
+			expect(signMessageApi).not.toHaveBeenCalled();
+		});
+
+		it('signs a plain (non-typed-data) message as a raw message', async () => {
 			const message = '0x48656c6c6f'; // "Hello"
 			const request = buildRequest({
 				method: SESSION_REQUEST_PERSONAL_SIGN,
@@ -158,5 +173,27 @@ describe('eth wallet-connect.services', () => {
 				message: '0xRAW_SIGNATURE'
 			});
 		});
+
+		it.each([SESSION_REQUEST_PERSONAL_SIGN, SESSION_REQUEST_ETH_SIGN])(
+			'signs a valid typed-data permit sent through %s as a raw message, never as EIP-712',
+			async (method) => {
+				// A dApp can dress an executable EIP-712 authorization as a plain message
+				// request. It is approved as a plain message, so it must be signed as one.
+				const message = daiPermitJson(true);
+				const request = buildRequest({ method, params: [message, HOLDER] });
+
+				const result = await signMessage(buildParams(request));
+
+				expect(result).toStrictEqual({ success: true });
+				expect(signPrehash).not.toHaveBeenCalled();
+				expect(signMessageApi).toHaveBeenCalledOnce();
+				expect(vi.mocked(signMessageApi).mock.calls[0][0]).toMatchObject({ message });
+				expect(mockListener.approveRequest).toHaveBeenCalledExactlyOnceWith({
+					id: request.id,
+					topic: request.topic,
+					message: '0xRAW_SIGNATURE'
+				});
+			}
+		);
 	});
 });

--- a/src/frontend/src/tests/eth/services/wallet-connect.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/wallet-connect.services.spec.ts
@@ -180,7 +180,11 @@ describe('eth wallet-connect.services', () => {
 				// A dApp can dress an executable EIP-712 authorization as a plain message
 				// request. It is approved as a plain message, so it must be signed as one.
 				const message = daiPermitJson(true);
-				const request = buildRequest({ method, params: [message, HOLDER] });
+				// `eth_sign` takes [address, data] while `personal_sign` takes [data, address].
+				const request = buildRequest({
+					method,
+					params: method === SESSION_REQUEST_ETH_SIGN ? [HOLDER, message] : [message, HOLDER]
+				});
 
 				const result = await signMessage(buildParams(request));
 

--- a/src/frontend/src/tests/eth/utils/wallet-connect.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/wallet-connect.utils.spec.ts
@@ -1,4 +1,6 @@
 import {
+	SESSION_REQUEST_ETH_SIGN,
+	SESSION_REQUEST_ETH_SIGN_LEGACY,
 	SESSION_REQUEST_ETH_SIGN_V4,
 	SESSION_REQUEST_PERSONAL_SIGN
 } from '$eth/constants/wallet-connect.constants';
@@ -7,6 +9,7 @@ import {
 	assertValidEthTypedData,
 	getSignParamsMessageTypedDataV4Hash,
 	hasInvalidTypedData,
+	isEthSignTypedDataMethod,
 	WalletConnectEthTypedDataError
 } from '$eth/utils/wallet-connect.utils';
 import { TypedDataEncoder, type TypedDataField } from 'ethers/hash';
@@ -132,9 +135,8 @@ describe('wallet-connect.utils', () => {
 		});
 
 		it('throws a non-typed-data error for a plain (non-JSON) message', () => {
-			// personal_sign / eth_sign carry a hex string, not typed-data JSON. The
-			// caller relies on this NOT being a WalletConnectEthTypedDataError so it
-			// can fall back to raw message signing.
+			// A typed-data method whose payload is not typed-data JSON fails to hash,
+			// and the request is rejected rather than signed.
 			let caught: unknown;
 			try {
 				getSignParamsMessageTypedDataV4Hash(['0xdeadbeef']);
@@ -175,11 +177,38 @@ describe('wallet-connect.utils', () => {
 			).toBeFalsy();
 		});
 
-		it('is false for a non-v4 method', () => {
-			// personal_sign is signed differently and must stay approvable.
+		it('is true for a type-invalid legacy typed-data permit', () => {
+			expect(
+				hasInvalidTypedData({
+					method: SESSION_REQUEST_ETH_SIGN_LEGACY,
+					params: toParams(daiPermit('false'))
+				})
+			).toBeTruthy();
+		});
+
+		it('is false for a raw-message method, even with a typed-data payload', () => {
+			// personal_sign is signed as a raw message and must stay approvable.
 			expect(
 				hasInvalidTypedData({ method: SESSION_REQUEST_PERSONAL_SIGN, params: ['0xdeadbeef'] })
 			).toBeFalsy();
+			expect(
+				hasInvalidTypedData({
+					method: SESSION_REQUEST_PERSONAL_SIGN,
+					params: toParams(daiPermit('false'))
+				})
+			).toBeFalsy();
+		});
+	});
+
+	describe('isEthSignTypedDataMethod', () => {
+		it('is true for the typed-data methods', () => {
+			expect(isEthSignTypedDataMethod(SESSION_REQUEST_ETH_SIGN_V4)).toBeTruthy();
+			expect(isEthSignTypedDataMethod(SESSION_REQUEST_ETH_SIGN_LEGACY)).toBeTruthy();
+		});
+
+		it('is false for the raw-message methods', () => {
+			expect(isEthSignTypedDataMethod(SESSION_REQUEST_PERSONAL_SIGN)).toBeFalsy();
+			expect(isEthSignTypedDataMethod(SESSION_REQUEST_ETH_SIGN)).toBeFalsy();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The WalletConnect ETH signing path picked the signature scheme from the shape of the payload rather than from the requested method. `signMessage` tried the EIP-712 typed-data hash first and only signed the raw message when that threw. A dApp could therefore send well-formed typed data (e.g. an ERC-2612 permit authorising a token transfer) through `personal_sign` or `eth_sign`: OISY showed a plain message-signing request and returned a genuine, executable typed-data signature.

The fallback dates to `b033aaa4a9` (Sep 2023), which added v4 hashing to a handler shared by all four ETH sign methods and used `JSON.parse` throwing as the "this is a plain message" signal, a payload sniff rather than a method check. `564ee5d2f9` carved out v4 so it never downgrades, but left the sniffing in place for the rest.

# Changes

- Decide the scheme from the method alone: `eth_signTypedData_v4` and legacy `eth_signTypedData` sign typed data; `personal_sign` and `eth_sign` always sign the raw message, whatever the payload looks like.
- Add `SESSION_REQUEST_ETH_SIGN_TYPED_DATA_METHODS` and the `isEthSignTypedDataMethod` predicate, reused by the service, `hasInvalidTypedData` and the sign modal, so one definition drives signing, warning and preview.
- Preview typed data only for typed-data methods, so a `personal_sign` payload that happens to parse as EIP-712 is shown as the raw message it is signed as, not as a permit.

Deliberate behaviour change: legacy `eth_signTypedData` no longer downgrades to a raw signature when its payload is not v4-shaped. It is rejected, with the existing warning and Approve disabled. Such a signature was unverifiable by the dApp anyway, and the modal already parsed legacy requests as typed data.

# Tests

- Service: a valid permit sent via `personal_sign` and via `eth_sign` is signed raw and never via `signPrehash`. Both cases fail against the previous code. Legacy and v4 paths unchanged.
- Utils and component: predicate coverage, `hasInvalidTypedData` across methods, and a typed-data payload under `personal_sign` rendering as a raw message.
