### PR TITLE
refactor(frontend): move Solana WalletConnect unreviewed-instructions warning to the top of the review

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -40,6 +40,10 @@
 </script>
 
 <ContentWithToolbar>
+	{#if unreviewed}
+		<MessageBox level="warning">{$i18n.wallet_connect.text.unreviewed_instructions}</MessageBox>
+	{/if}
+
 	<SendData
 		{amount}
 		{application}
@@ -50,10 +54,6 @@
 	>
 		{#if isApproval}
 			<SendDataSpender spender={destination} />
-		{/if}
-
-		{#if unreviewed}
-			<MessageBox level="warning">{$i18n.wallet_connect.text.unreviewed_instructions}</MessageBox>
 		{/if}
 
 		<WalletConnectData {data} label={$i18n.wallet_connect.text.hex_data} />

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -26,6 +26,22 @@ describe('SolWalletConnectSignReview', () => {
 		expect(getByText(en.wallet_connect.text.unreviewed_instructions)).toBeInTheDocument();
 	});
 
+	it('should render the unreviewed instructions warning above the application', () => {
+		const { getByText } = render(SolWalletConnectSignReview, {
+			props: {
+				...props,
+				unreviewed: true
+			}
+		});
+
+		const warning = getByText(en.wallet_connect.text.unreviewed_instructions);
+		const application = getByText(en.wallet_connect.text.application);
+
+		expect(warning.compareDocumentPosition(application) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING
+		);
+	});
+
 	it('should not render the unreviewed instructions warning by default', () => {
 		const { queryByText } = render(SolWalletConnectSignReview, {
 			props


### PR DESCRIPTION
# Motivation

In the Solana WalletConnect sign review, the warning that OISY could not decode some instructions was rendered below the transaction rows, just above the HEX data. A warning that the review may be incomplete belongs before the content it qualifies: the user reads top-down and should know the review is untrustworthy before reading any of its rows. The Ethereum review already places its invalid typed-data warning at the very top, so the two chains now behave the same.

# Changes

Moved the `MessageBox` with `unreviewed_instructions` out of `SendData` and up to the top of `SolWalletConnectSignReview`, above the Application row. Placement only: same i18n string, same `unreviewed` prop, same condition, no styling change.

# Tests

Added a component test asserting the warning renders before the Application row in document order. Ran format, lint, check, vitest and tsc on the spec project: all green.
