### PR TITLE
style(frontend): align network and fee rows in the Solana WalletConnect sign review

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -1,18 +1,20 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
-	import ReviewNetwork from '$lib/components/send/ReviewNetwork.svelte';
+	import ConvertAmountExchange from '$lib/components/convert/ConvertAmountExchange.svelte';
+	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
 	import SendData from '$lib/components/send/SendData.svelte';
 	import SendDataSpender from '$lib/components/send/SendDataSpender.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
 	import WalletConnectData from '$lib/components/wallet-connect/WalletConnectData.svelte';
+	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { exchanges } from '$lib/derived/exchange.derived';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
+	import { formatToken } from '$lib/utils/format.utils';
 	import {
 		SOLANA_HIGH_PRIORITIZATION_FEE_BALANCE_DIVISOR,
 		SOLANA_HIGH_PRIORITIZATION_FEE_IN_LAMPORTS,
@@ -69,6 +71,22 @@
 	);
 </script>
 
+{#snippet feeValue(feeAmount: bigint)}
+	{@const formattedFee = formatToken({
+		value: feeAmount,
+		unitName: feeToken.decimals,
+		displayDecimals: feeToken.decimals
+	})}
+
+	<div class="flex gap-4">
+		{`${formattedFee} ${feeToken.symbol}`}
+
+		<div class="text-tertiary">
+			<ConvertAmountExchange amount={formattedFee} exchangeRate={feeExchangeRate} />
+		</div>
+	</div>
+{/snippet}
+
 <ContentWithToolbar>
 	<SendData
 		{amount}
@@ -82,28 +100,14 @@
 			<SendDataSpender spender={destination} />
 		{/if}
 
-		<FeeDisplay
-			decimals={feeToken.decimals}
-			exchangeRate={feeExchangeRate}
-			feeAmount={SOLANA_TRANSACTION_FEE_IN_LAMPORTS}
-			symbol={feeToken.symbol}
-		>
-			{#snippet label()}
-				<span>{$i18n.fee.text.network_fee}</span>
-			{/snippet}
-		</FeeDisplay>
+		<WalletConnectModalValue label={$i18n.fee.text.network_fee} ref="network-fee">
+			{@render feeValue(SOLANA_TRANSACTION_FEE_IN_LAMPORTS)}
+		</WalletConnectModalValue>
 
 		{#if nonNullish(prioritizationFee)}
-			<FeeDisplay
-				decimals={feeToken.decimals}
-				exchangeRate={feeExchangeRate}
-				feeAmount={prioritizationFee}
-				symbol={feeToken.symbol}
-			>
-				{#snippet label()}
-					<span>{$i18n.fee.text.prioritization_fee}</span>
-				{/snippet}
-			</FeeDisplay>
+			<WalletConnectModalValue label={$i18n.fee.text.prioritization_fee} ref="prioritization-fee">
+				{@render feeValue(prioritizationFee)}
+			</WalletConnectModalValue>
 		{/if}
 
 		{#if unreviewed}
@@ -121,7 +125,9 @@
 		<!-- TODO: add checks for insufficient funds if and when we are able to correctly parse the amount -->
 
 		{#snippet sourceNetwork()}
-			<ReviewNetwork sourceNetwork={token.network} />
+			<WalletConnectModalValue label={$i18n.send.text.network} ref="network">
+				<NetworkWithLogo network={token.network} />
+			</WalletConnectModalValue>
 		{/snippet}
 	</SendData>
 

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -1,5 +1,6 @@
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { balancesStore } from '$lib/stores/balances.store';
+import { exchangeStore } from '$lib/stores/exchange.store';
 import SolWalletConnectSignReview from '$sol/components/wallet-connect/SolWalletConnectSignReview.svelte';
 import en from '$tests/mocks/i18n.mock';
 import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
@@ -19,6 +20,39 @@ describe('SolWalletConnectSignReview', () => {
 
 	beforeEach(() => {
 		balancesStore.reset(SOLANA_TOKEN.id);
+		exchangeStore.reset();
+	});
+
+	it('should render the network and the fees as title/value pairs, like every other row', () => {
+		const { container, getByText } = render(SolWalletConnectSignReview, {
+			props: {
+				...props,
+				prioritizationFee: 238_217n
+			}
+		});
+
+		expect(getByText(en.send.text.network)).toHaveAttribute('for', 'network');
+		expect(container.querySelector('#network')).toHaveTextContent(SOLANA_TOKEN.network.name);
+
+		expect(getByText(en.fee.text.network_fee)).toHaveAttribute('for', 'network-fee');
+		expect(container.querySelector('#network-fee')).toHaveTextContent('0.000005 SOL');
+
+		expect(getByText(en.fee.text.prioritization_fee)).toHaveAttribute('for', 'prioritization-fee');
+		expect(container.querySelector('#prioritization-fee')).toHaveTextContent('0.000238217 SOL');
+	});
+
+	it('should keep the fiat approximation next to each fee', () => {
+		exchangeStore.set([{ solana: { usd: 30 } }]);
+
+		const { getByText } = render(SolWalletConnectSignReview, {
+			props: {
+				...props,
+				prioritizationFee: 5_000_000n
+			}
+		});
+
+		expect(getByText('< $0.01')).toBeInTheDocument();
+		expect(getByText('~$0.15')).toBeInTheDocument();
 	});
 
 	it('should render the unreviewed instructions warning', () => {


### PR DESCRIPTION
# Motivation

Stacks on #13672.

The Solana WalletConnect sign review mixed two row shapes. Application, Amount, Balance, Source and Destination render through `Value` (bold label above, value below), while Network and the two fee rows rendered through `ModalValue` (small grey label left, value right). The modal read as two lists instead of one.

# Changes

Only `SolWalletConnectSignReview.svelte` composes differently, no shared component was touched:

- Network: renders `NetworkWithLogo` inside `WalletConnectModalValue` instead of `ReviewNetwork`. Logo unchanged.
- Network fee and Priority fee: render inside `WalletConnectModalValue`, via a local snippet that reuses `ConvertAmountExchange` for the fiat approximation, instead of `FeeDisplay`.

`FeeDisplay` is used by roughly 35 send, swap, convert, Liquidium, trading and AI assistant surfaces across BTC, ETH, ICP and SOL. `ReviewNetwork` is used by `BtcSendReview`, `EthSendReview`, `IcSendReview`, `SolSendReview`, `ConvertReview`, the Harvest reviews and `AiAssistantReviewSendTokenTool`. An inline fee line is the deliberate norm in those flows, so both components are left exactly as they are and every other caller is untouched.

Layout only. Amount formatting keeps the token's full decimals, so the fiat values (`< $0.01`, `~$0.15`) are unchanged.

# Tests

Extended `SolWalletConnectSignReview.spec.ts`: one case asserts every row is now a label plus value pair, another asserts the fiat approximation still sits next to each fee.

Gates: `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npx vitest run`, `npx tsc --project tsconfig.spec.json`.
