### PR TITLE
style(frontend): align Solana WalletConnect network row with other rows

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import ReviewNetwork from '$lib/components/send/ReviewNetwork.svelte';
+	import NetworkWithLogo from '$lib/components/networks/NetworkWithLogo.svelte';
 	import SendData from '$lib/components/send/SendData.svelte';
 	import SendDataSpender from '$lib/components/send/SendDataSpender.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
 	import WalletConnectData from '$lib/components/wallet-connect/WalletConnectData.svelte';
+	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
@@ -61,7 +62,9 @@
 		<!-- TODO: add checks for insufficient funds if and when we are able to correctly parse the amount -->
 
 		{#snippet sourceNetwork()}
-			<ReviewNetwork sourceNetwork={token.network} />
+			<WalletConnectModalValue label={$i18n.send.text.network} ref="network">
+				<NetworkWithLogo network={token.network} />
+			</WalletConnectModalValue>
 		{/snippet}
 	</SendData>
 

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -1,4 +1,5 @@
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import SolWalletConnectSignReview from '$sol/components/wallet-connect/SolWalletConnectSignReview.svelte';
 import en from '$tests/mocks/i18n.mock';
 import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
@@ -48,5 +49,27 @@ describe('SolWalletConnectSignReview', () => {
 		});
 
 		expect(queryByText(en.wallet_connect.text.unreviewed_instructions)).not.toBeInTheDocument();
+	});
+
+	it('should render the network row with the same label-above-value shape as the other rows', () => {
+		const { container } = render(SolWalletConnectSignReview, { props });
+
+		const label = container.querySelector('label[for="network"]');
+		const value = container.querySelector('#network');
+
+		expect(label).toHaveTextContent(en.send.text.network);
+		expect(value).toHaveTextContent(SOLANA_TOKEN.network.name);
+	});
+
+	it('should render the network logo within the network row', () => {
+		const { container } = render(SolWalletConnectSignReview, { props });
+
+		const logo = container.querySelector(
+			`#network img[alt="${replacePlaceholders(en.core.alt.logo, {
+				$name: SOLANA_TOKEN.network.name
+			})}"]`
+		);
+
+		expect(logo).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

The Solana WalletConnect sign review modal mixed two row shapes. Application, Balance, Source and Destination render through `WalletConnectModalValue` (label above value), while the Network row went through `ReviewNetwork`, which uses the inline right-aligned `ModalValue`. There is no reason for the Network row to look different from its neighbours.

# Changes

- `SolWalletConnectSignReview.svelte`: the `sourceNetwork` snippet now renders `WalletConnectModalValue` wrapping `NetworkWithLogo`, matching the shape already used by `EthWalletConnectSendReview`. Label and network logo are unchanged, `ReviewNetwork` is no longer imported here.

No shared component is touched: `ReviewNetwork` and its other callers (BTC, ETH, IC, SOL send reviews, convert, harvest, AI assistant) keep the deliberate inline shape. The diff is limited to the Solana WalletConnect review component and its spec.

# Tests

- Extended `SolWalletConnectSignReview.spec.ts` with coverage for the new structure: the network label and value render in the label above value shape, and the network logo still renders inside the row.
- Gates run locally: format, lint with max-warnings 0, check, full vitest suite, tsc on `tsconfig.spec.json`.
