### PR TITLE
fix(frontend): title Solana WalletConnect sign modal per requested method

### DIFF
--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "تم نسخ بيانات المعاملة الخام إلى الحافظة.",
 			"sign_message": "توقيع الرسالة",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Nezpracovaná data transakce zkopírována do schránky.",
 			"sign_message": "Podepsat zprávu",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Transaktions-Rohdaten in die Zwischenablage kopiert.",
 			"sign_message": "Nachricht signieren",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Raw transaction data copied to clipboard.",
 			"sign_message": "Sign Message",
 			"sign_psbt": "Sign Transaction",
+			"sign_transaction": "Sign Transaction",
+			"sign_and_send_transaction": "Sign and Send Transaction",
 			"signing_address": "Signing address",
 			"fee": "Fee",
 			"btc_symbol": "BTC",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Datos brutos de la transacción copiados al portapapeles.",
 			"sign_message": "Firmar Mensaje",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Données brutes de la transaction copiées dans le presse-papiers.",
 			"sign_message": "Signer le message",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "कच्चा लेनदेन डेटा क्लिपबोर्ड पर कॉपी किया गया।",
 			"sign_message": "संदेश पर हस्ताक्षर करें",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Dati transazione raw copiati negli appunti.",
 			"sign_message": "Firma messaggio",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "生のトランザクションデータをクリップボードにコピーしました。",
 			"sign_message": "メッセージに署名",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "원시 트랜잭션 데이터가 클립보드에 복사되었습니다.",
 			"sign_message": "메시지 서명",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Surowe dane transakcji skopiowane do schowka.",
 			"sign_message": "Podpisz wiadomość",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Dados da transação brutos copiados para a área de transferência.",
 			"sign_message": "Assinar Mensagem",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Необработанные данные транзакции скопированы в буфер обмена.",
 			"sign_message": "Подписать сообщение",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "Dữ liệu giao dịch thô đã được sao chép vào khay nhớ tạm.",
 			"sign_message": "Ký Tin Nhắn",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1604,6 +1604,8 @@
 			"raw_copied": "原始交易数据已复制到剪贴板。",
 			"sign_message": "签署消息",
 			"sign_psbt": "",
+			"sign_transaction": "",
+			"sign_and_send_transaction": "",
 			"signing_address": "",
 			"fee": "",
 			"btc_symbol": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1287,6 +1287,8 @@ interface I18nWallet_connect {
 		raw_copied: string;
 		sign_message: string;
 		sign_psbt: string;
+		sign_transaction: string;
+		sign_and_send_transaction: string;
 		signing_address: string;
 		fee: string;
 		btc_symbol: string;

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -169,7 +169,9 @@
 <WizardModal bind:this={modal} onClose={reject} {steps} bind:currentStep>
 	{#snippet title()}
 		<WalletConnectModalTitle>
-			{$i18n.wallet_connect.text.sign_message}
+			{signWithSending
+				? $i18n.wallet_connect.text.sign_and_send_transaction
+				: $i18n.wallet_connect.text.sign_transaction}
 		</WalletConnectModalTitle>
 	{/snippet}
 

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignModal.spec.ts
@@ -1,0 +1,87 @@
+import { SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
+import SolWalletConnectSignMessageModal from '$sol/components/wallet-connect/SolWalletConnectSignMessageModal.svelte';
+import SolWalletConnectSignModal from '$sol/components/wallet-connect/SolWalletConnectSignModal.svelte';
+import {
+	SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION,
+	SESSION_REQUEST_SOL_SIGN_MESSAGE,
+	SESSION_REQUEST_SOL_SIGN_TRANSACTION
+} from '$sol/constants/wallet-connect.constants';
+import en from '$tests/mocks/i18n.mock';
+import type { WalletKitTypes } from '@reown/walletkit';
+import { render, waitFor } from '@testing-library/svelte';
+
+vi.mock('$sol/services/wallet-connect.services', () => ({
+	decode: vi.fn().mockResolvedValue({
+		amount: undefined,
+		destination: undefined,
+		tokenAddress: undefined,
+		isApproval: false,
+		unreviewed: false
+	}),
+	decodeMessage: vi.fn().mockReturnValue('Sign in to Example'),
+	sign: vi.fn(),
+	signMessage: vi.fn()
+}));
+
+describe('SolWalletConnectSignModal', () => {
+	const mockRequest = (method: string): WalletKitTypes.SessionRequest =>
+		({
+			id: 1,
+			topic: 'mock-topic',
+			params: {
+				request: {
+					method,
+					params: { transaction: 'bW9jay10cmFuc2FjdGlvbg==', message: 'bW9jay1tZXNzYWdl' }
+				},
+				chainId: SOLANA_MAINNET_NETWORK.chainId
+			},
+			verifyContext: {
+				verified: {
+					verifyUrl: 'https://verify.walletconnect.org',
+					validation: 'VALID',
+					origin: 'https://dapp.example',
+					isScam: false
+				}
+			}
+		}) as unknown as WalletKitTypes.SessionRequest;
+
+	const props = (method: string) => ({
+		listener: undefined,
+		network: SOLANA_MAINNET_NETWORK,
+		request: mockRequest(method)
+	});
+
+	it('should title a sign-transaction request as a transaction', async () => {
+		const { getByText, queryByText } = render(SolWalletConnectSignModal, {
+			props: props(SESSION_REQUEST_SOL_SIGN_TRANSACTION)
+		});
+
+		await waitFor(() => {
+			expect(getByText(en.wallet_connect.text.sign_transaction)).toBeInTheDocument();
+		});
+
+		expect(queryByText(en.wallet_connect.text.sign_message)).not.toBeInTheDocument();
+	});
+
+	it('should title a sign-and-send-transaction request as sign and send', async () => {
+		const { getByText, queryByText } = render(SolWalletConnectSignModal, {
+			props: props(SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION)
+		});
+
+		await waitFor(() => {
+			expect(getByText(en.wallet_connect.text.sign_and_send_transaction)).toBeInTheDocument();
+		});
+
+		expect(queryByText(en.wallet_connect.text.sign_message)).not.toBeInTheDocument();
+	});
+
+	it('should keep the message title for a sign-message request', async () => {
+		const { getByText } = render(SolWalletConnectSignMessageModal, {
+			props: props(SESSION_REQUEST_SOL_SIGN_MESSAGE)
+		});
+
+		await waitFor(() => {
+			expect(getByText(en.wallet_connect.text.sign_message)).toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

`SolWalletConnectSignModal` hardcoded "Sign Message" as its title, but that modal only ever handles `solana_signTransaction` and `solana_signAndSendTransaction`. A transaction review was therefore labelled as a message, which reads as harmless when the user is actually authorising a transfer and a fee. `solana_signMessage` is routed to `SolWalletConnectSignMessageModal`, where "Sign Message" is correct and stays.

# Changes

The title now follows the requested method: `solana_signTransaction` shows "Sign Transaction", `solana_signAndSendTransaction` shows "Sign and Send Transaction". The two get distinct wording because they differ in outcome: one returns a signature to the dapp, the other also broadcasts it to the cluster, which is the irreversible part the user is approving. The component already derived `signWithSending` from the method, so no new plumbing was needed.

Two new i18n keys, `sign_transaction` and `sign_and_send_transaction`. The existing `sign_psbt` was left alone rather than reused, since a PSBT-named key on Solana would be misleading.

# Tests

New component spec asserting the rendered title per method, including that the message modal still says "Sign Message".
