### PR TITLE
refactor(frontend): share toBackendTokenId and findEvmNetworkByChainId

### DIFF
--- a/docs/ai/frontend/reusability.md
+++ b/docs/ai/frontend/reusability.md
@@ -105,16 +105,17 @@ Add new feature folders only if your concern doesn't fit any of the above.
 
 ### Common utils
 
-| Util                                                        | Where                             | Purpose                           |
-| ----------------------------------------------------------- | --------------------------------- | --------------------------------- |
-| `format.utils`, `bigint.utils`, `array.utils`, `json.utils` | `$lib/utils/`                     | Generic formatting helpers.       |
-| `i18n.utils` (incl. `replacePlaceholders`)                  | `$lib/utils/`                     | i18n string interpolation.        |
-| `console.utils` (`consoleError`, `consoleWarn`)             | `$lib/utils/`                     | The only allowed console wrapper. |
-| `error.utils`, `assert-amount.utils`, `validation` helpers  | `$lib/utils/`, `$lib/validation/` | Error & input validation.         |
-| `network.utils`, `networks.utils`                           | `$lib/utils/`                     | Network ID predicates.            |
-| `nav.utils`, `before-navigate.utils`, `before-unload.utils` | `$lib/utils/`                     | Navigation hooks.                 |
-| `clipboard.utils`, `device.utils`, `events.utils`           | `$lib/utils/`                     | Browser plumbing.                 |
-| `derived-memo.utils`, `certified-store.utils`               | `$lib/utils/`                     | Store helpers.                    |
+| Util                                                        | Where                             | Purpose                                                           |
+| ----------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------- |
+| `format.utils`, `bigint.utils`, `array.utils`, `json.utils` | `$lib/utils/`                     | Generic formatting helpers.                                       |
+| `i18n.utils` (incl. `replacePlaceholders`)                  | `$lib/utils/`                     | i18n string interpolation.                                        |
+| `console.utils` (`consoleError`, `consoleWarn`)             | `$lib/utils/`                     | The only allowed console wrapper.                                 |
+| `error.utils`, `assert-amount.utils`, `validation` helpers  | `$lib/utils/`, `$lib/validation/` | Error & input validation.                                         |
+| `network.utils`, `networks.utils`                           | `$lib/utils/`                     | Network ID predicates, `findEvmNetworkByChainId`.                 |
+| `token-id.utils`                                            | `$lib/utils/`                     | Backend `TokenId` ↔ app token (`toBackendTokenId`, `tokenIdKey`). |
+| `nav.utils`, `before-navigate.utils`, `before-unload.utils` | `$lib/utils/`                     | Navigation hooks.                                                 |
+| `clipboard.utils`, `device.utils`, `events.utils`           | `$lib/utils/`                     | Browser plumbing.                                                 |
+| `derived-memo.utils`, `certified-store.utils`               | `$lib/utils/`                     | Store helpers.                                                    |
 
 ### REST + workers
 

--- a/src/frontend/src/lib/services/manage-tokens.services.ts
+++ b/src/frontend/src/lib/services/manage-tokens.services.ts
@@ -1,5 +1,3 @@
-import { SUPPORTED_EVM_NETWORKS } from '$env/networks/networks-evm/networks.evm.env';
-import { SUPPORTED_ETHEREUM_NETWORKS } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
@@ -40,6 +38,7 @@ import {
 	isVersionMismatchError,
 	mapIcErrorMetadata
 } from '$lib/utils/error.utils';
+import { findEvmNetworkByChainId } from '$lib/utils/network.utils';
 import type { SaveSplCustomToken } from '$sol/types/spl-custom-token';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -112,11 +111,7 @@ const mapTokenManageNetwork = <T extends SaveTokensToken>({
 		return;
 	}
 
-	const evmNetwork = [...SUPPORTED_ETHEREUM_NETWORKS, ...SUPPORTED_EVM_NETWORKS].find(
-		({ chainId }) => chainId === token.chainId
-	);
-
-	return evmNetwork?.id.description;
+	return findEvmNetworkByChainId(token.chainId)?.id.description;
 };
 
 const mapTokenManageToken = <T extends SaveTokensToken>({

--- a/src/frontend/src/lib/services/onesec-swap.services.ts
+++ b/src/frontend/src/lib/services/onesec-swap.services.ts
@@ -295,12 +295,6 @@ const createAutAndDetachCloser = async ({
 	extraRefs: Partial<Record<OneSecExternalRefKey, string>>;
 	plan: BridgingPlan;
 }): Promise<void> => {
-	// Unreachable for the ERC-20 / ICRC pair OneSec supports, but the token
-	// mapper is shared: an unmappable token degrades to an untracked swap.
-	if (isNullish(data)) {
-		return;
-	}
-
 	const initialRefs: Partial<Record<OneSecExternalRefKey, string>> = {
 		...toOneSecDisplayRefs({
 			sourceToken,
@@ -310,19 +304,24 @@ const createAutAndDetachCloser = async ({
 		...extraRefs
 	};
 
-	// AUT persistence is best-effort: a failed `createActiveUserTransaction`
-	// must NOT abort the plan. The user has already committed funds (point of
-	// no return), so the closer is the only path that completes the bridge —
-	// it always runs, persisted row or not.
-	try {
-		await createActiveUserTransaction({
-			identity,
-			id: swapId,
-			data,
-			externalRefs: toOneSecExternalRefs(initialRefs)
-		});
-	} catch (err: unknown) {
-		consoleError(err);
+	// AUT persistence is best-effort: neither a failed
+	// `createActiveUserTransaction` nor an unmappable token may abort the plan.
+	// The user has already committed funds (point of no return), so the closer is
+	// the only path that completes the bridge — it always runs, persisted row or
+	// not. Nullish `data` is unreachable for the ERC-20 / ICRC pair OneSec
+	// supports, but the token mapper is shared, so it must degrade to an
+	// untracked bridge rather than a stranded one.
+	if (nonNullish(data)) {
+		try {
+			await createActiveUserTransaction({
+				identity,
+				id: swapId,
+				data,
+				externalRefs: toOneSecExternalRefs(initialRefs)
+			});
+		} catch (err: unknown) {
+			consoleError(err);
+		}
 	}
 
 	finishOneSecBridgingInSession({ identity, id: swapId, plan, initialRefs });

--- a/src/frontend/src/lib/services/onesec-swap.services.ts
+++ b/src/frontend/src/lib/services/onesec-swap.services.ts
@@ -288,13 +288,19 @@ const createAutAndDetachCloser = async ({
 }: {
 	identity: Identity;
 	swapId: string;
-	data: ActiveUserTransactionData;
+	data: ActiveUserTransactionData | undefined;
 	sourceToken: Token;
 	destinationToken: Token;
 	swapAmount: string | number;
 	extraRefs: Partial<Record<OneSecExternalRefKey, string>>;
 	plan: BridgingPlan;
 }): Promise<void> => {
+	// Unreachable for the ERC-20 / ICRC pair OneSec supports, but the token
+	// mapper is shared: an unmappable token degrades to an untracked swap.
+	if (isNullish(data)) {
+		return;
+	}
+
 	const initialRefs: Partial<Record<OneSecExternalRefKey, string>> = {
 		...toOneSecDisplayRefs({
 			sourceToken,

--- a/src/frontend/src/lib/utils/near-intents-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/near-intents-active-tx.utils.ts
@@ -2,11 +2,8 @@ import type {
 	ActiveUserTransaction,
 	ActiveUserTransactionData,
 	ActiveUserTransactionRef,
-	ActiveUserTransactionStatus,
-	TokenId as BackendTokenId
+	ActiveUserTransactionStatus
 } from '$declarations/backend/backend.did';
-import type { EthereumNetwork } from '$eth/types/network';
-import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { i18n } from '$lib/stores/i18n.store';
 import {
 	NEAR_INTENTS_EXTERNAL_REF_KEYS,
@@ -16,53 +13,12 @@ import {
 } from '$lib/types/near-intents';
 import { SwapProvider } from '$lib/types/swap';
 import type { Token as AppToken } from '$lib/types/token';
-import {
-	isNetworkIdEthereum,
-	isNetworkIdEvm,
-	isNetworkIdSOLDevnet,
-	isNetworkIdSolana
-} from '$lib/utils/network.utils';
-import { isTokenSpl } from '$sol/utils/spl.utils';
+import { toBackendTokenId } from '$lib/utils/token-id.utils';
 import { nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
 export const isNearIntentsActiveUserTransaction = (tx: ActiveUserTransaction): boolean =>
 	'NearIntents' in tx.data;
-
-/**
- * Maps an OISY app token to its canonical backend `TokenId` variant. NEAR
- * Intents spans EVM (native + ERC-20) and Solana (native + SPL) as both source
- * and destination, so — unlike OneSec's `Erc20`/`Icrc`-only mapper — this covers
- * all four. Returns `undefined` for an unmappable token (should not happen for a
- * NEAR-Intents-supported asset).
- */
-const appTokenToBackendTokenId = (token: AppToken): BackendTokenId | undefined => {
-	const {
-		network: { id: networkId }
-	} = token;
-
-	if (isTokenErc20(token)) {
-		return { Erc20: [token.address, BigInt(token.network.chainId)] };
-	}
-
-	if (isTokenSpl(token)) {
-		return isNetworkIdSOLDevnet(networkId)
-			? { SplDevnet: token.address }
-			: { SplMainnet: token.address };
-	}
-
-	// Native tokens carry no contract address; disambiguate by network.
-	if (isNetworkIdSolana(networkId)) {
-		return isNetworkIdSOLDevnet(networkId) ? { SolNativeDevnet: null } : { SolNativeMainnet: null };
-	}
-
-	// Native EVM coin (ETH, BNB, POL, …), identified by chain id.
-	if (isNetworkIdEthereum(networkId) || isNetworkIdEvm(networkId)) {
-		return { EvmNative: BigInt((token.network as EthereumNetwork).chainId) };
-	}
-
-	return undefined;
-};
 
 /**
  * Builds the `NearIntents` AUT data variant carrying the canonical immutable
@@ -79,8 +35,8 @@ export const toNearIntentsData = ({
 	destinationToken: AppToken;
 	amount: bigint;
 }): ActiveUserTransactionData | undefined => {
-	const source_token = appTokenToBackendTokenId(sourceToken);
-	const dest_token = appTokenToBackendTokenId(destinationToken);
+	const source_token = toBackendTokenId(sourceToken);
+	const dest_token = toBackendTokenId(destinationToken);
 
 	if (nonNullish(source_token) && nonNullish(dest_token)) {
 		return { NearIntents: { source_token, dest_token, amount } };

--- a/src/frontend/src/lib/utils/network.utils.ts
+++ b/src/frontend/src/lib/utils/network.utils.ts
@@ -3,7 +3,10 @@ import type { Network as SignerBitcoinNetwork } from '$declarations/signer/signe
 import { SUPPORTED_ARBITRUM_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { SUPPORTED_BASE_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.base.env';
 import { SUPPORTED_BSC_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.bsc.env';
-import { SUPPORTED_EVM_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.env';
+import {
+	SUPPORTED_EVM_NETWORK_IDS,
+	SUPPORTED_EVM_NETWORKS
+} from '$env/networks/networks-evm/networks.evm.env';
 import { SUPPORTED_POLYGON_NETWORK_IDS } from '$env/networks/networks-evm/networks.evm.polygon.env';
 import {
 	BTC_MAINNET_NETWORK_ID,
@@ -11,7 +14,11 @@ import {
 	BTC_TESTNET_NETWORK_ID,
 	SUPPORTED_BITCOIN_NETWORK_IDS
 } from '$env/networks/networks.btc.env';
-import { SEPOLIA_NETWORK_ID, SUPPORTED_ETHEREUM_NETWORK_IDS } from '$env/networks/networks.eth.env';
+import {
+	SEPOLIA_NETWORK_ID,
+	SUPPORTED_ETHEREUM_NETWORK_IDS,
+	SUPPORTED_ETHEREUM_NETWORKS
+} from '$env/networks/networks.eth.env';
 import { ICP_NETWORK_ID, ICP_PSEUDO_TESTNET_NETWORK_ID } from '$env/networks/networks.icp.env';
 import {
 	SOLANA_DEVNET_NETWORK_ID,
@@ -41,6 +48,16 @@ export const assertIsNetworkEthereum: (
 };
 
 export const isNetworkICP = (network: Network | undefined): boolean => isNetworkIdICP(network?.id);
+
+/**
+ * Resolves an EVM chain id back to the network OISY knows it by, across both the
+ * Ethereum and the EVM network sets. Returns `undefined` for a chain OISY does
+ * not support.
+ */
+export const findEvmNetworkByChainId = (chainId: bigint): EthereumNetwork | undefined =>
+	[...SUPPORTED_ETHEREUM_NETWORKS, ...SUPPORTED_EVM_NETWORKS].find(
+		({ chainId: networkChainId }) => networkChainId === chainId
+	);
 
 export const isNetworkSolana = (network: Network | undefined): network is SolanaNetwork =>
 	isNetworkIdSolana(network?.id);

--- a/src/frontend/src/lib/utils/onesec-swap.utils.ts
+++ b/src/frontend/src/lib/utils/onesec-swap.utils.ts
@@ -2,8 +2,7 @@ import type {
 	ActiveUserTransaction,
 	ActiveUserTransactionData,
 	ActiveUserTransactionRef,
-	ActiveUserTransactionStatus,
-	TokenId as BackendTokenId
+	ActiveUserTransactionStatus
 } from '$declarations/backend/backend.did';
 import { ARBITRUM_MAINNET_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import { BASE_NETWORK_ID } from '$env/networks/networks-evm/networks.evm.base.env';
@@ -22,8 +21,9 @@ import {
 } from '$lib/types/onesec-swap';
 import { SwapProvider } from '$lib/types/swap';
 import type { Token as AppToken } from '$lib/types/token';
+import { toBackendTokenId } from '$lib/utils/token-id.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import { Principal } from '@icp-sdk/core/principal';
+import type { Principal } from '@icp-sdk/core/principal';
 import { DEFAULT_CONFIG, type TokenConfig, type Transfer } from 'onesec-bridge';
 import { get } from 'svelte/store';
 
@@ -238,20 +238,6 @@ export const findMatchingOneSecTransfer = ({
 	});
 };
 
-/**
- * Maps an Erc20Token to the canister-side `TokenId` variant. Native EVM tokens
- * are not currently supported by OneSec swaps in OISY, so this helper assumes
- * an ERC-20 source/destination. The chain id is required (and present on the
- * `Erc20Token`'s network).
- */
-const erc20ToBackendTokenId = (token: Erc20Token): BackendTokenId => ({
-	Erc20: [token.address, BigInt(token.network.chainId)]
-});
-
-const icrcToBackendTokenId = (token: IcToken): BackendTokenId => ({
-	Icrc: Principal.fromText(token.ledgerCanisterId)
-});
-
 interface OneSecIcpToEvmInput {
 	sourceToken: IcToken;
 	destinationToken: Erc20Token;
@@ -271,28 +257,42 @@ export const toOneSecIcpToEvmData = ({
 	destinationToken,
 	amount,
 	recipientEvmAddress
-}: OneSecIcpToEvmInput): ActiveUserTransactionData => ({
-	OneSecIcpToEvm: {
-		source_token: icrcToBackendTokenId(sourceToken),
-		dest_token: erc20ToBackendTokenId(destinationToken),
-		amount,
-		recipient_evm_address: recipientEvmAddress
+}: OneSecIcpToEvmInput): ActiveUserTransactionData | undefined => {
+	const source_token = toBackendTokenId(sourceToken);
+	const dest_token = toBackendTokenId(destinationToken);
+
+	if (nonNullish(source_token) && nonNullish(dest_token)) {
+		return {
+			OneSecIcpToEvm: {
+				source_token,
+				dest_token,
+				amount,
+				recipient_evm_address: recipientEvmAddress
+			}
+		};
 	}
-});
+};
 
 export const toOneSecEvmToIcpData = ({
 	sourceToken,
 	destinationToken,
 	amount,
 	recipientPrincipal
-}: OneSecEvmToIcpInput): ActiveUserTransactionData => ({
-	OneSecEvmToIcp: {
-		source_token: erc20ToBackendTokenId(sourceToken),
-		dest_token: icrcToBackendTokenId(destinationToken),
-		amount,
-		recipient_principal: recipientPrincipal
+}: OneSecEvmToIcpInput): ActiveUserTransactionData | undefined => {
+	const source_token = toBackendTokenId(sourceToken);
+	const dest_token = toBackendTokenId(destinationToken);
+
+	if (nonNullish(source_token) && nonNullish(dest_token)) {
+		return {
+			OneSecEvmToIcp: {
+				source_token,
+				dest_token,
+				amount,
+				recipient_principal: recipientPrincipal
+			}
+		};
 	}
-});
+};
 
 /**
  * Builds a `(key, value)` external-ref array for a OneSec record. Keys are

--- a/src/frontend/src/lib/utils/token-id.utils.ts
+++ b/src/frontend/src/lib/utils/token-id.utils.ts
@@ -1,5 +1,18 @@
 import type { TokenId } from '$declarations/backend/backend.did';
+import type { EthereumNetwork } from '$eth/types/network';
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
+import { isTokenErc4626 } from '$eth/utils/erc4626.utils';
+import { isIcToken } from '$icp/validation/ic-token.validation';
+import type { Token } from '$lib/types/token';
+import {
+	isNetworkIdEthereum,
+	isNetworkIdEvm,
+	isNetworkIdSOLDevnet,
+	isNetworkIdSolana
+} from '$lib/utils/network.utils';
+import { isTokenSpl } from '$sol/utils/spl.utils';
 import { assertNever } from '@dfinity/utils';
+import { Principal } from '@icp-sdk/core/principal';
 
 /**
  * Serializes a {@link TokenId} Candid variant into a deterministic string key.
@@ -56,4 +69,54 @@ export const tokenIdKey = (id: TokenId): string | undefined => {
 	}
 
 	assertNever(id, `Unknown TokenId variant: ${id}`);
+};
+
+/**
+ * Maps an OISY app token to its canonical backend {@link TokenId} variant — the
+ * inverse direction of {@link tokenIdKey}, used when persisting an Active User
+ * Transaction's `data` payload.
+ *
+ * Covers every asset the AUT consumers can swap: ERC-20 and ERC-4626 vault
+ * tokens, native EVM coins, ICRC ledgers, and SPL / native Solana on both
+ * mainnet and devnet. Returns `undefined` for anything else, which callers treat
+ * as "do not track this operation" rather than as an error.
+ *
+ * An Internet Computer token maps to `Icrc` by ledger canister id — including
+ * ICP itself, whose dedicated `IcpNative` variant is reserved for the
+ * exchange-rate path.
+ */
+export const toBackendTokenId = (token: Token): TokenId | undefined => {
+	const {
+		network: { id: networkId }
+	} = token;
+
+	if (isTokenErc20(token)) {
+		return { Erc20: [token.address, BigInt(token.network.chainId)] };
+	}
+
+	if (isTokenErc4626(token)) {
+		return { Erc4626: [token.address, BigInt(token.network.chainId)] };
+	}
+
+	if (isTokenSpl(token)) {
+		return isNetworkIdSOLDevnet(networkId)
+			? { SplDevnet: token.address }
+			: { SplMainnet: token.address };
+	}
+
+	if (isIcToken(token)) {
+		return { Icrc: Principal.fromText(token.ledgerCanisterId) };
+	}
+
+	// Native tokens carry no contract address; disambiguate by network.
+	if (isNetworkIdSolana(networkId)) {
+		return isNetworkIdSOLDevnet(networkId) ? { SolNativeDevnet: null } : { SolNativeMainnet: null };
+	}
+
+	// Native EVM coin (ETH, BNB, POL, …), identified by chain id.
+	if (isNetworkIdEthereum(networkId) || isNetworkIdEvm(networkId)) {
+		return { EvmNative: BigInt((token.network as EthereumNetwork).chainId) };
+	}
+
+	return undefined;
 };

--- a/src/frontend/src/tests/lib/services/onesec-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/onesec-swap.services.spec.ts
@@ -17,6 +17,7 @@ import { activeUserTransactionsStore } from '$lib/stores/active-user-transaction
 import { ONESEC_EXTERNAL_REF_KEYS } from '$lib/types/onesec-swap';
 import { SwapProvider } from '$lib/types/swap';
 import { consoleError } from '$lib/utils/console.utils';
+import * as oneSecUtils from '$lib/utils/onesec-swap.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
 import {
 	mockActiveUserTransaction,
@@ -452,6 +453,35 @@ describe('onesec-swap.services', () => {
 						])
 					})
 				);
+			});
+
+			it('still runs the in-session closer when the row payload cannot be built', async () => {
+				const dataSpy = vi.spyOn(oneSecUtils, 'toOneSecIcpToEvmData').mockReturnValue(undefined);
+
+				try {
+					mockPlan.nextStepToRun
+						.mockReturnValueOnce(mockStep)
+						.mockReturnValueOnce(mockStep)
+						.mockReturnValue(undefined);
+					mockStep.index.mockReturnValueOnce(0).mockReturnValueOnce(1);
+					mockStep.run
+						.mockResolvedValueOnce({ state: 'succeeded' })
+						.mockResolvedValueOnce({ state: 'succeeded' });
+					mockStep.getTransferId.mockReturnValueOnce(undefined).mockReturnValueOnce({ id: 42n });
+
+					await executeOneSecIcpToEvmBridge({ ...baseIcpToEvmParams, swapId });
+
+					expect(createSpy).not.toHaveBeenCalled();
+
+					await vi.waitFor(() => {
+						expect(updateSpy.mock.calls.at(-1)?.[0]).toMatchObject({
+							id: swapId,
+							status: { Succeeded: null }
+						});
+					});
+				} finally {
+					dataSpy.mockRestore();
+				}
 			});
 
 			it('does not create a row when a foreground step fails', async () => {

--- a/src/frontend/src/tests/lib/utils/near-intents-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/near-intents-active-tx.utils.spec.ts
@@ -1,5 +1,6 @@
 import type { ActiveUserTransactionRef } from '$declarations/backend/backend.did';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import type { Erc20Token } from '$eth/types/erc20';
@@ -30,6 +31,7 @@ import {
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { mockValidToken } from '$tests/mocks/tokens.mock';
+import { Principal } from '@icp-sdk/core/principal';
 
 const USDC_ETHEREUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const USDC_SOLANA = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
@@ -92,11 +94,27 @@ describe('near-intents-active-tx.utils', () => {
 			});
 		});
 
-		it('returns undefined when a token cannot be mapped to a backend TokenId', () => {
+		it('maps an ICP-side destination to its ICRC ledger', () => {
 			expect(
 				toNearIntentsData({
 					sourceToken: makeErc20Token(USDC_ETHEREUM),
 					destinationToken: mockValidIcToken,
+					amount: 1n
+				})
+			).toEqual({
+				NearIntents: {
+					source_token: { Erc20: [USDC_ETHEREUM, ETHEREUM_NETWORK.chainId] },
+					dest_token: { Icrc: Principal.fromText(mockValidIcToken.ledgerCanisterId) },
+					amount: 1n
+				}
+			});
+		});
+
+		it('returns undefined when a token cannot be mapped to a backend TokenId', () => {
+			expect(
+				toNearIntentsData({
+					sourceToken: makeErc20Token(USDC_ETHEREUM),
+					destinationToken: BTC_MAINNET_TOKEN,
 					amount: 1n
 				})
 			).toBeUndefined();

--- a/src/frontend/src/tests/lib/utils/token-id.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-id.utils.spec.ts
@@ -1,0 +1,88 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { SOLANA_DEVNET_NETWORK } from '$env/networks/networks.sol.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import { SOLANA_DEVNET_TOKEN, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import type { Erc20Token } from '$eth/types/erc20';
+import type { Erc4626Token } from '$eth/types/erc4626';
+import { toBackendTokenId } from '$lib/utils/token-id.utils';
+import { parseTokenId } from '$lib/validation/token.validation';
+import type { SplToken } from '$sol/types/spl';
+import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
+import { Principal } from '@icp-sdk/core/principal';
+
+const USDC_ETHEREUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const USDC_SOLANA = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+describe('token-id.utils', () => {
+	describe('toBackendTokenId', () => {
+		it('maps an ERC-20 token to its address and chain id', () => {
+			const token: Erc20Token = {
+				...mockValidToken,
+				id: parseTokenId(`Erc20-${USDC_ETHEREUM}`),
+				standard: { code: 'erc20' },
+				address: USDC_ETHEREUM,
+				network: ETHEREUM_NETWORK
+			};
+
+			expect(toBackendTokenId(token)).toEqual({
+				Erc20: [USDC_ETHEREUM, ETHEREUM_NETWORK.chainId]
+			});
+		});
+
+		it('maps an ERC-4626 vault token to its address and chain id', () => {
+			const token: Erc4626Token = {
+				...mockValidErc4626Token,
+				address: USDC_ETHEREUM,
+				network: ETHEREUM_NETWORK
+			};
+
+			expect(toBackendTokenId(token)).toEqual({
+				Erc4626: [USDC_ETHEREUM, ETHEREUM_NETWORK.chainId]
+			});
+		});
+
+		it('maps a native EVM coin to its chain id', () => {
+			expect(toBackendTokenId(ETHEREUM_TOKEN)).toEqual({ EvmNative: ETHEREUM_NETWORK.chainId });
+		});
+
+		it('maps an SPL token by network', () => {
+			const mainnet: SplToken = { ...mockValidSplToken, address: USDC_SOLANA };
+			const devnet: SplToken = {
+				...mockValidSplToken,
+				address: USDC_SOLANA,
+				network: SOLANA_DEVNET_NETWORK
+			};
+
+			expect(toBackendTokenId(mainnet)).toEqual({ SplMainnet: USDC_SOLANA });
+			expect(toBackendTokenId(devnet)).toEqual({ SplDevnet: USDC_SOLANA });
+		});
+
+		it('maps native Solana by network', () => {
+			expect(toBackendTokenId(SOLANA_TOKEN)).toEqual({ SolNativeMainnet: null });
+			expect(toBackendTokenId(SOLANA_DEVNET_TOKEN)).toEqual({ SolNativeDevnet: null });
+		});
+
+		it('maps an Internet Computer token to its ICRC ledger', () => {
+			expect(toBackendTokenId(mockValidIcToken)).toEqual({
+				Icrc: Principal.fromText(mockValidIcToken.ledgerCanisterId)
+			});
+		});
+
+		// ICP has a dedicated `IcpNative` variant, reserved for the exchange-rate
+		// path; as an AUT payload it stays addressable by its ledger like any ICRC.
+		it('maps ICP itself to its ledger rather than IcpNative', () => {
+			expect(toBackendTokenId(ICP_TOKEN)).toEqual({
+				Icrc: Principal.fromText(ICP_TOKEN.ledgerCanisterId)
+			});
+		});
+
+		it('returns undefined for a token with no backend representation', () => {
+			expect(toBackendTokenId(BTC_MAINNET_TOKEN)).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Three provider integrations are now going to persist Active User Transaction rows, and each grew its own copy of the same "app token → backend TokenId" mapping:

  - OneSec has private erc20ToBackendTokenId / icrcToBackendTokenId helpers (Erc20 + Icrc, both total).
  - NEAR Intents added a private appTokenToBackendTokenId (Erc20, EvmNative, SPL and SOL-native on mainnet + devnet; partial).

The Velora Active-Transactions work needs the union of both plus Erc4626, which would have made this a third copy of the same switch. Consolidating first keeps that PR to its own concern.

Same story, smaller, for chain-id lookups: resolving an EVM chain id back to the network OISY knows it by was an inline [...SUPPORTED_ETHEREUM_NETWORKS, ...SUPPORTED_EVM_NETWORKS].find(…) in manage-tokens.services.ts, and the Velora Market poller needs exactly that lookup.


# Changes

- $lib/utils/token-id.utils.ts gains toBackendTokenId(token) — the inverse direction of the tokenIdKey serializer that module already owns, so no new file or bucket. Covers Erc20, Erc4626, EvmNative, Icrc, SplMainnet / SplDevnet and SolNativeMainnet / SolNativeDevnet, returning undefined for anything else — which callers treat as "do not track this operation" rather than as an error.
- Deleted NEAR Intents' private appTokenToBackendTokenId and OneSec's private erc20ToBackendTokenId / icrcToBackendTokenId in favour of it. NEAR's Solana devnet coverage is preserved deliberately, so nothing regresses there.
- toOneSecIcpToEvmData / toOneSecEvmToIcpData now return ActiveUserTransactionData | undefined, matching toNearIntentsData, because the shared mapper is partial where OneSec's private helpers were total. createAutAndDetachCloser skips row creation when the data is nullish.
- $lib/utils/network.utils.ts gains findEvmNetworkByChainId(chainId), with the manage-tokens.services.ts call site switched to it.
- docs/ai/frontend/reusability.md: catalog rows for both, per the meta-update rule.


# Tests

Updated.
