### PR TITLE
style(frontend): mute the derived amount input on the limit-order form

### DIFF
--- a/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContainer.svelte
@@ -9,6 +9,11 @@
 		// drops the hover affordance, which would otherwise promise an interaction
 		// that isn't there.
 		inert?: boolean;
+		// The amount is not editable. The frame keeps its neutral border on hover:
+		// lighting it up in brand would promise a field that takes a caret, which the
+		// tint inside is there to say it does not — even though the token selector on
+		// the far side is still pressable.
+		muted?: boolean;
 		styleClass?: string;
 		children: Snippet;
 	}
@@ -18,6 +23,7 @@
 		error = false,
 		readOnlyAmount = false,
 		inert = false,
+		muted = false,
 		styleClass,
 		children
 	}: Props = $props();
@@ -33,7 +39,7 @@
 	class:border-tertiary={!readOnlyAmount && !error && !focused}
 	class:cursor-not-allowed={inert}
 	class:focus-within:border-2={!readOnlyAmount && !inert}
-	class:hover:border-brand-primary={!readOnlyAmount && !error && !inert}
+	class:hover:border-brand-primary={!readOnlyAmount && !error && !inert && !muted}
 	class:shadow-inner={!readOnlyAmount}
 >
 	{@render children()}

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -29,7 +29,8 @@
 		readOnlyAmount?: boolean;
 		// Opt-in companion to `disabled`: tints the amount half of the field so a
 		// derived amount is legible as non-editable at a glance. Left off by default —
-		// the other disabled legs in the app keep the plain fill.
+		// the other disabled legs in the app keep the plain fill. Has no effect on its
+		// own, so it can never dress an editable field as dead.
 		muted?: boolean;
 		placeholder?: string;
 		// Overrides the "Select token" prompt shown while no token is picked — e.g.
@@ -84,9 +85,10 @@
 	// not offer a hover border or a pointer cursor.
 	const inert = $derived(disabled && !isSelectable);
 
-	// `readOnlyAmount` drops the frame and dresses the selector as its own pill, so
-	// there is no field left for the muted treatment to apply to.
-	const mutedAmount = $derived(muted && !readOnlyAmount);
+	// Gated on `disabled` so `muted` cannot produce a field that looks dead and still
+	// takes a caret; `readOnlyAmount` is excluded because it drops the frame and
+	// dresses the selector as its own pill, leaving nothing for the tint to fill.
+	const mutedAmount = $derived(muted && disabled && !readOnlyAmount);
 
 	// The selector joins the tint only while it cannot be opened. White is this
 	// field's promise that a region is pressable, and it is kept honest both ways.
@@ -148,7 +150,7 @@
 	error={nonNullish(errorType) || nonNullish(error)}
 	{focused}
 	{inert}
-	{muted}
+	muted={mutedAmount}
 	{readOnlyAmount}
 	styleClass="h-14 text-3xl"
 >
@@ -158,7 +160,7 @@
 		 input without a rule of its own and stops at the selector, which carries its
 		 own `cursor: pointer` for as long as it is enabled. -->
 	<div
-		style={readOnlyAmount || muted ? '--input-background: transparent;' : undefined}
+		style={readOnlyAmount || mutedAmount ? '--input-background: transparent;' : undefined}
 		class="flex h-full w-full items-center"
 		class:bg-disabled={mutedAmount}
 		class:cursor-not-allowed={mutedAmount}

--- a/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
+++ b/src/frontend/src/lib/components/tokens/TokenInputContent.svelte
@@ -27,6 +27,10 @@
 		exchangeRate?: number;
 		disabled?: boolean;
 		readOnlyAmount?: boolean;
+		// Opt-in companion to `disabled`: tints the amount half of the field so a
+		// derived amount is legible as non-editable at a glance. Left off by default —
+		// the other disabled legs in the app keep the plain fill.
+		muted?: boolean;
 		placeholder?: string;
 		// Overrides the "Select token" prompt shown while no token is picked — e.g.
 		// to name what has to be chosen first when the picker is still gated.
@@ -57,6 +61,7 @@
 		exchangeRate,
 		disabled = false,
 		readOnlyAmount = false,
+		muted = false,
 		placeholder = '0',
 		selectTokenText,
 		errorType = $bindable(),
@@ -78,6 +83,14 @@
 	// Nothing to type into and no picker to open: the field is inert, so it must
 	// not offer a hover border or a pointer cursor.
 	const inert = $derived(disabled && !isSelectable);
+
+	// `readOnlyAmount` drops the frame and dresses the selector as its own pill, so
+	// there is no field left for the muted treatment to apply to.
+	const mutedAmount = $derived(muted && !readOnlyAmount);
+
+	// The selector joins the tint only while it cannot be opened. White is this
+	// field's promise that a region is pressable, and it is kept honest both ways.
+	const mutedSelector = $derived(mutedAmount && !isSelectable);
 
 	const onFocus = () => (focused = true);
 	const onBlur = () => (focused = false);
@@ -135,12 +148,21 @@
 	error={nonNullish(errorType) || nonNullish(error)}
 	{focused}
 	{inert}
+	{muted}
 	{readOnlyAmount}
 	styleClass="h-14 text-3xl"
 >
+	<!-- The gix input paints its own `--input-background`, cleared here so this
+		 wrapper's fill shows through, and `rounded-l-lg` keeps that fill inside the
+		 frame's corners. `cursor` is inherited, so not-allowed reaches the disabled
+		 input without a rule of its own and stops at the selector, which carries its
+		 own `cursor: pointer` for as long as it is enabled. -->
 	<div
-		style={readOnlyAmount ? '--input-background: transparent;' : undefined}
+		style={readOnlyAmount || muted ? '--input-background: transparent;' : undefined}
 		class="flex h-full w-full items-center"
+		class:bg-disabled={mutedAmount}
+		class:cursor-not-allowed={mutedAmount}
+		class:rounded-l-lg={mutedAmount}
 	>
 		{#if token}
 			{#if displayUnit === 'token'}
@@ -190,17 +212,29 @@
 	</div>
 
 	{#if !readOnlyAmount}
-		<div class="h-3/4 w-[1px] bg-disabled"></div>
+		<!-- Full height when muted: the inset rule leaves the container's white showing
+			 above and below it, invisible on a white field but two slivers once the
+			 halves either side are tinted. -->
+		<div class={`w-[1px] bg-disabled ${mutedAmount ? 'h-full' : 'h-3/4'}`}></div>
 	{/if}
 
 	{#if !readOnlyAmount || isSelectable}
+		<!-- `muted-selector` squares off the edge facing the divider. Every `button` is
+			 rounded by the global stylesheet at `--border-radius-md` (16px, twice this
+			 frame's), which goes unnoticed while the button has no fill of its own but
+			 cuts two white notches out of the tint. A `rounded-*` utility cannot undo
+			 it — utilities are emitted inside `@layer`, and the unlayered global rule
+			 wins the cascade whatever its specificity — so the override is a scoped
+			 rule, which is unlayered too. -->
 		<button
 			class="flex h-full items-center gap-1 px-3 transition-colors disabled:cursor-not-allowed"
+			class:bg-disabled={mutedSelector}
 			class:bg-primary={readOnlyAmount}
 			class:border={readOnlyAmount}
 			class:border-solid={readOnlyAmount}
 			class:border-tertiary={readOnlyAmount}
 			class:hover:border-brand-primary={readOnlyAmount && isSelectable}
+			class:muted-selector={mutedSelector}
 			class:rounded-lg={readOnlyAmount}
 			class:shadow-inner={readOnlyAmount}
 			data-tid={TOKEN_INPUT_SELECT_TOKEN_BUTTON}
@@ -213,12 +247,14 @@
 				<div class="ml-2 text-sm font-semibold">{getTokenDisplaySymbol(token)}</div>
 			{:else}
 				<!-- Grey rather than brand while the picker is unavailable: the plus is
-					 the field's only affordance, so leaving it blue reads as actionable. -->
+					 the field's only affordance, so leaving it blue reads as actionable. The
+					 disc is dropped on a muted field — the same tint over itself makes a
+					 darker circle that draws the eye to the one control that does nothing. -->
 				<span
 					style={`width: ${logoSizes['xs']}; height: ${logoSizes['xs']};`}
 					class="flex items-center justify-center rounded-full"
 					class:bg-brand-primary={isSelectable}
-					class:bg-disabled={!isSelectable}
+					class:bg-disabled={!isSelectable && !mutedSelector}
 					class:text-primary-inverted={isSelectable}
 					class:text-tertiary={!isSelectable}
 				>
@@ -238,3 +274,11 @@
 
 	{@render balance()}
 </div>
+
+<style lang="scss">
+	// Only the outer edge stays round; the edge against the divider is squared so the
+	// muted fill meets the amount half without a notch of the frame showing through.
+	.muted-selector {
+		border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+	}
+</style>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -277,10 +277,12 @@
 		<span class="h-px flex-1 bg-disabled"></span>
 	</div>
 
-	<!-- Quote row: the derived amount in a disabled input. Deliberately not
+	<!-- Quote row: the derived amount in a disabled, muted input. Deliberately not
 		 `readOnlyAmount` — that strips the input's frame and turns the selector into
-		 a pill, whereas Swap renders its computed "You receive" leg as a plain
-		 disabled input. Same shape here keeps the two modals consistent. -->
+		 a pill, and the quote token still has to be pickable here. The muted fill does
+		 the job the dropped frame would have: it says "computed", before the caret has
+		 to refuse the click — and it stops at the divider, so the still-pickable token
+		 selector is not dressed as disabled too. -->
 	<div class="py-2">
 		<TokenInputContent
 			amount={quoteAmountValue}
@@ -288,6 +290,7 @@
 			displayUnit={inputUnit}
 			exchangeRate={quoteExchangeRate}
 			isSelectable={nonNullish(baseSymbol)}
+			muted
 			onClick={onSelectQuoteGuarded}
 			onCustomValidate={onQuoteCustomValidate}
 			{selectTokenText}


### PR DESCRIPTION
# Motivation

The limit order's quote leg is computed from the base amount and the price, so its input has always been `disabled` — but it looked identical to the editable leg above it, and only refused the caret once clicked. It should read as non-editable before you try.

# Changes

Adds an opt-in `muted` prop to the shared token input, used here by the quote row alone. Every other disabled leg in the app (Swap's "You receive", Convert's destination) is untouched — `muted` defaults to `false`, and has no effect unless the field is also `disabled`.

Muted splits the field in two:

- The **amount** half takes the disabled tint and a `not-allowed` cursor. `cursor` is inherited, so it reaches the disabled input without a rule of its own.
- The **token selector** keeps the container's white while it is pressable, and joins the tint only while the picker is gated on the other leg (`Select token to sell first`). White stays a reliable promise that a region can be pressed.
- The frame drops its brand hover border either way: lighting up in brand would promise a field that takes a caret.

Three details the tint made visible, each fixed in the same pass:

- The divider goes full height when muted. Its `h-3/4` version leaves the container's white showing above and below it — invisible on a white field, two slivers between tinted halves.
- The `+` disc drops its own background rather than compositing the same tint over itself into a darker circle.
- The selector squares off the edge facing the divider. The global stylesheet rounds every `button` at `--border-radius-md` (16px, twice this frame's), which cut two white notches out of the tint. A `rounded-*` utility cannot undo it — utilities are emitted inside `@layer` and the unlayered global rule wins the cascade regardless of specificity — so the override is a scoped rule, which is unlayered too.

A follow-up commit acts on review feedback: `muted` is now gated on `disabled` so it cannot dress an editable field as dead, and the derived `mutedAmount` (rather than the raw prop) drives the container's hover suppression and the `--input-background` reset, so all three follow one condition.

# Tests

- `npm run lint -- --max-warnings 0`, `npm run check` (0 errors / 0 warnings), and the `components/tokens` + `components/trading` suites pass.
- No new tests: this is presentation only, and both new props default to today's rendering, so Swap, Send and Convert are byte-identical.
- Verified by hand in the running app against staging, in the gated state (no sell token yet) and after picking one, plus hover over both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code) v2.1.202
Model: Claude Opus 5 (`claude-opus-5`)