### PR TITLE
style(frontend): tone down the limit-order review price rows

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSummary.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderPriceSummary.svelte
@@ -12,7 +12,7 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 
 	// Read-only price rows shared by the limit-order Review and the order-detail
-	// modal: the limit price plus current value, the value difference (green when
+	// modal: the limit price plus current value, the value difference (neutral while
 	// the order is favourable, amber/red as it gives value up — `valueDifference`
 	// is signed relative to the caller's side) and — for resting orders — the
 	// queue position. Rendered as `ModalValue` rows, the same key/value style the Swap
@@ -64,13 +64,18 @@
 		{/snippet}
 
 		{#snippet mainValue()}
-			{nonNullish(currentValueDisplay)
-				? replacePlaceholders($i18n.trading.limit_order.current_value_feed, {
-						$price: currentValueDisplay,
-						$quote: quoteSymbol,
-						$base: baseSymbol
-					})
-				: '-'}
+			<!-- `ModalValue` bolds every value it renders. These three read as context
+				 for the limit price above, not as figures in their own right, so they
+				 step back down to regular weight. -->
+			<span class="font-normal">
+				{nonNullish(currentValueDisplay)
+					? replacePlaceholders($i18n.trading.limit_order.current_value_feed, {
+							$price: currentValueDisplay,
+							$quote: quoteSymbol,
+							$base: baseSymbol
+						})
+					: '-'}
+			</span>
 		{/snippet}
 	</ModalValue>
 
@@ -82,16 +87,21 @@
 				{/snippet}
 
 				{#snippet mainValue()}
-					<!-- Same treatment as the Swap review: shared `ValueDifference`, swap's
-						 own thresholds, and neither `muted` nor `successNeutral` — so the
-						 figure is green when the order is favourable and amber/red with the
-						 warning icon when it gives value up. -->
-					<ValueDifference
-						errorLevel={SWAP_VALUE_DIFFERENCE_ERROR_VALUE}
-						iconPosition="left"
-						value={valueDifference}
-						warningLevel={SWAP_VALUE_DIFFERENCE_WARNING_VALUE}
-					/>
+					<!-- `successNeutral`, unlike the Swap review: a swap's difference is
+						 realized on the spot, so green means money made. A limit order has
+						 not executed yet — a favourable gap is the premium being asked for,
+						 not a gain — so the figure stays neutral until it turns amber/red for
+						 giving value up. `ValueDifference` bolds itself in those two states,
+						 which is why they keep their weight while this row loses it. -->
+					<span class="font-normal">
+						<ValueDifference
+							errorLevel={SWAP_VALUE_DIFFERENCE_ERROR_VALUE}
+							iconPosition="left"
+							successNeutral
+							value={valueDifference}
+							warningLevel={SWAP_VALUE_DIFFERENCE_WARNING_VALUE}
+						/>
+					</span>
 				{/snippet}
 			</ModalValue>
 		</div>
@@ -105,7 +115,7 @@
 				{/snippet}
 
 				{#snippet mainValue()}
-					{queueText}
+					<span class="font-normal">{queueText}</span>
 				{/snippet}
 			</ModalValue>
 		</div>


### PR DESCRIPTION
# Motivation

On the Review screen, `Current value`, `Value difference` and `Queue position` were rendered at the same bold weight as the limit price they describe, so four figures competed for attention when only one is the subject of the screen. The value difference also turned green on a favourable gap, which reads as money made — but a limit order has not executed yet.

# Changes

- The three context rows step down from `ModalValue`'s bold to regular weight. `ModalValue` is shared across many modals, so the weight is overridden per row rather than changed there. `Limit price` keeps its weight and size.
- `ValueDifference` gets `successNeutral`, so a favourable gap renders neutral instead of green. A swap's difference is realized the moment the trade goes through; here it is only the premium being asked for. Amber and red for giving value up are unchanged — as is the bold `ValueDifference` applies to itself in those two states, so an alert still carries weight while the neutral row does not.

Both rows are shared with the order-detail modal, which gets the same treatment.

# Tests

- `npm run lint -- --max-warnings 0`, `npm run check` (0 errors / 0 warnings), and the `components/trading` suite pass.
- No new tests: weight and colour only, with no behavioural branch added — `successNeutral` is an existing, already-tested `ValueDifference` mode.
- Checked by hand on the Review screen and the order-detail modal in the running app against staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code) v2.1.202
Model: Claude Opus 5 (`claude-opus-5`)
