### PR TITLE
style(frontend): drop the fiat lines from the limit-order intent hero

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapToken.svelte
+++ b/src/frontend/src/lib/components/swap/SwapToken.svelte
@@ -13,10 +13,14 @@
 		token?: Token;
 		amount: OptionAmount;
 		exchangeRate?: number;
+		// The fiat line under the amount. Opt out where the row is one leg of a
+		// price the screen already states in full — dropping `exchangeRate` is not
+		// the same thing, as that renders the "unavailable" fallback instead.
+		showExchangeValue?: boolean;
 		title: Snippet;
 	}
 
-	let { token, amount, exchangeRate, title }: Props = $props();
+	let { token, amount, exchangeRate, showExchangeValue = true, title }: Props = $props();
 
 	let formattedAmount = $derived(
 		nonNullish(token) && nonNullish(amount) && notEmptyString(`${amount}`)
@@ -42,9 +46,11 @@
 				{formattedAmount}
 				{getTokenDisplaySymbol(token)}
 			</span>
-			<span class="text-sm text-tertiary">
-				<TokenInputAmountExchange {amount} disabled {exchangeRate} />
-			</span>
+			{#if showExchangeValue}
+				<span class="text-sm text-tertiary">
+					<TokenInputAmountExchange {amount} disabled {exchangeRate} />
+				</span>
+			{/if}
 		</div>
 	</div>
 {/if}

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -102,8 +102,8 @@
 	// "Current value" anchors on the cross of the two legs' USD exchange-rate
 	// prices (base ÷ quote), NOT the DEX order-book mid — mirroring the reference
 	// the limit-order creation flow uses (see `referenceRate`). The book bid/ask
-	// still drive the crossing check below. The same two rates feed the hero's
-	// fiat lines, which it formats itself the way the Swap review does.
+	// still drive the crossing check below. Both rates stay in use here for that
+	// cross and for the analytics payload, and no longer reach the hero.
 	const baseUsdPrice = $derived($exchanges?.[base.id]?.usd);
 	const quoteUsdPrice = $derived($exchanges?.[quote.id]?.usd);
 	const currentValue = $derived(referenceRate({ baseUsd: baseUsdPrice, quoteUsd: quoteUsdPrice }));

--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -256,10 +256,8 @@
 
 		<LimitOrderIntentHero
 			baseAmount={baseAmountDisplay}
-			baseExchangeRate={baseUsdPrice}
 			baseToken={base}
 			quoteAmount={quoteAmountDisplay}
-			quoteExchangeRate={quoteUsdPrice}
 			quoteToken={quote}
 			{side}
 		/>

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderIntentHero.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderIntentHero.svelte
@@ -9,33 +9,24 @@
 	// Read-only two-leg intent hero shared by the limit-order Review and the
 	// order-detail modal: "You SELL/BUY <base>" on top, the derived quote bound
 	// below, with a centered direction arrow. Built from the same `SwapToken` rows
-	// and card as `TokensReview`, so it reads identically to the Swap review —
-	// logo, amount, fiat line — with the limit-order labels. Amounts are display
-	// strings so each caller rounds to the pair's decimals; the fiat line is
-	// derived from the exchange rate, and is omitted when no rate is known.
+	// and card as `TokensReview`, so it reads identically to the Swap review — with
+	// the limit-order labels and no fiat line: a swap review quotes a price the
+	// screen states nowhere else, whereas the rows below already spell this order's
+	// limit price and current value out in the quote token. Amounts are display
+	// strings so each caller rounds to the pair's decimals.
 	interface Props {
 		side: LimitOrderSide;
 		baseAmount: OptionAmount;
 		quoteAmount: OptionAmount;
 		baseToken?: Token;
 		quoteToken?: Token;
-		baseExchangeRate?: number;
-		quoteExchangeRate?: number;
 	}
 
-	let {
-		side,
-		baseAmount,
-		quoteAmount,
-		baseToken,
-		quoteToken,
-		baseExchangeRate,
-		quoteExchangeRate
-	}: Props = $props();
+	let { side, baseAmount, quoteAmount, baseToken, quoteToken }: Props = $props();
 </script>
 
 <div class="mb-6 rounded-lg border border-solid border-tertiary bg-primary p-4 shadow-sm">
-	<SwapToken amount={baseAmount} exchangeRate={baseExchangeRate} token={baseToken}>
+	<SwapToken amount={baseAmount} showExchangeValue={false} token={baseToken}>
 		{#snippet title()}
 			{$i18n.trading.limit_order.hero_prefix}
 			<!-- Red sell / green buy, as the order rows colour their side word. -->
@@ -61,7 +52,7 @@
 		<div class="h-[1px] w-[45%] bg-tertiary text-tertiary-inverted"></div>
 	</div>
 
-	<SwapToken amount={quoteAmount} exchangeRate={quoteExchangeRate} token={quoteToken}>
+	<SwapToken amount={quoteAmount} showExchangeValue={false} token={quoteToken}>
 		{#snippet title()}
 			{side === 'sell'
 				? $i18n.trading.limit_order.you_get_at_least

--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderReview.svelte
@@ -11,7 +11,6 @@
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
 	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
-	import { exchanges } from '$lib/derived/exchange.derived';
 	import { oisyTradeIcTokenBySymbol } from '$lib/derived/oisy-trade.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -78,15 +77,9 @@
 	);
 
 	// Resolved the same way the form does, so the hero can show each leg's logo
-	// and fiat value exactly as the Swap review does.
+	// exactly as the Swap review does.
 	const baseToken = $derived($oisyTradeIcTokenBySymbol[base]);
 	const quoteToken = $derived($oisyTradeIcTokenBySymbol[quote]);
-	const baseExchangeRate = $derived(
-		nonNullish(baseToken) ? $exchanges?.[baseToken.id]?.usd : undefined
-	);
-	const quoteExchangeRate = $derived(
-		nonNullish(quoteToken) ? $exchanges?.[quoteToken.id]?.usd : undefined
-	);
 	const priceDisplay = $derived(
 		formatTradeAmount({ amount: price, decimals: pairView?.quoteDecimals ?? 8 })
 	);
@@ -139,10 +132,8 @@
 <ContentWithToolbar>
 	<LimitOrderIntentHero
 		baseAmount={baseAmountDisplay}
-		{baseExchangeRate}
 		{baseToken}
 		quoteAmount={quoteAmountDisplay}
-		{quoteExchangeRate}
 		{quoteToken}
 		{side}
 	/>

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderIntentHero.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderIntentHero.svelte.spec.ts
@@ -1,5 +1,6 @@
 import type { IcToken } from '$icp/types/ic-token';
 import LimitOrderIntentHero from '$lib/components/trading/limit-order/LimitOrderIntentHero.svelte';
+import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
@@ -28,16 +29,12 @@ describe('LimitOrderIntentHero', () => {
 		expect(container).toHaveTextContent('Buy');
 	});
 
-	it('shows fiat lines only when an exchange rate is known', () => {
-		const { container, rerender } = render(LimitOrderIntentHero, {
-			props: { side: 'sell', ...baseProps }
-		});
+	// The order's price is spelled out by the rows under the hero, so neither leg
+	// carries a fiat line — and no "exchange rate unavailable" fallback in its place.
+	it('renders no fiat line on either leg', () => {
+		const { container } = render(LimitOrderIntentHero, { props: { side: 'sell', ...baseProps } });
 
-		expect(container).not.toHaveTextContent('$19.00');
-
-		rerender({ side: 'sell', ...baseProps, baseExchangeRate: 1.9, quoteExchangeRate: 0.756 });
-
-		expect(container).toHaveTextContent('$19.00');
-		expect(container).toHaveTextContent('$18.90');
+		expect(container).not.toHaveTextContent('$');
+		expect(container).not.toHaveTextContent(en.tokens.text.exchange_is_not_available);
 	});
 });


### PR DESCRIPTION
# Motivation

The limit-order intent hero borrowed `TokensReview`'s rows wholesale, fiat line included. A swap review needs that line, because it quotes a price the screen states nowhere else. A limit order already spells its limit price and current value out in the quote token immediately below the hero, so the two dollar figures only repeated the rows underneath.

# Changes

- `SwapToken` gains an optional `showExchangeValue`, defaulted to `true` — the Swap and Send reviews are untouched. Simply dropping `exchangeRate` would not have worked: `TokenInputAmountExchange` renders an "exchange rate unavailable" string in place of a missing rate, so the line has to be suppressed rather than starved.
- `LimitOrderIntentHero` opts out on both legs.
- That left the rate plumbing feeding nothing, so it goes too: the hero's `baseExchangeRate` / `quoteExchangeRate` props, and the derived rates plus the now-unused `exchanges` import in `LimitOrderReview`. `TradingOrderDetailModal` keeps its USD prices — it still needs them for the current value and for analytics — and just stops passing them down.

# Tests

- `npm run lint -- --max-warnings 0`, `npm run check` (0 errors / 0 warnings), and the `components/trading` + `components/swap` suites pass.
- The hero's spec asserted the opposite behaviour ("shows fiat lines only when an exchange rate is known"). It now guards that neither a fiat figure nor the unavailable fallback appears on either leg — the fallback being the trap that made this more than a prop removal.
- Checked by hand on the Review screen and the order-detail modal in the running app against staging, plus the Swap review to confirm its fiat lines are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code) v2.1.202
Model: Claude Opus 5 (`claude-opus-5`)
