### PR TITLE
fix(frontend): mark the base amount, not the derived leg, on order errors

### DIFF
--- a/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
+++ b/src/frontend/src/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte
@@ -141,31 +141,17 @@
 		}).errorKind;
 	});
 
-	// Each amount error belongs to a specific leg: a balance shortfall is on the token
-	// being spent (buy → quote, sell → base), the lot grid is on the base amount, and
-	// the notional bounds are on the quote-denominated order value. Surface the message
-	// — and the red highlight — under the matching token box.
-	const amountErrorField = $derived.by((): 'base' | 'quote' | undefined => {
-		switch (amountErrorKind) {
-			case 'balance':
-				return side === 'buy' ? 'quote' : 'base';
-			case 'lot':
-				return 'base';
-			case 'min_notional':
-			case 'max_notional':
-				return 'quote';
-			default:
-				return undefined;
-		}
-	});
-
-	// Map the error onto the owning leg's `errorType` so only that shared input shows
-	// its red highlight. Routed through `TokenInputContent`'s `onCustomValidate` so the
-	// component owns (and does not clobber) its own `errorType` state.
+	// Every amount error lands on the base amount, whichever leg it is about. The quote
+	// row is a derived readout — `disabled` on both sides — so a red frame there marks a
+	// field the user cannot act on and says nothing about what to do; the base amount is
+	// the one input that can resolve any of these (the price below is the other lever,
+	// but raising it to clear a min-notional would push a resting order further from the
+	// book, so the amount is the fix worth pointing at).
+	//
+	// Routed through `TokenInputContent`'s `onCustomValidate` so the component owns —
+	// and does not clobber — its own `errorType` state.
 	const onBaseCustomValidate = (): TokenActionErrorType =>
-		amountErrorField === 'base' ? 'insufficient-funds' : undefined;
-	const onQuoteCustomValidate = (): TokenActionErrorType =>
-		amountErrorField === 'quote' ? 'insufficient-funds' : undefined;
+		nonNullish(amountErrorKind) ? 'insufficient-funds' : undefined;
 
 	const amountError = $derived.by((): string | undefined => {
 		const t = $i18n.trading.limit_order;
@@ -201,8 +187,7 @@
 		}
 	});
 
-	const baseAmountError = $derived(amountErrorField === 'base' ? amountError : undefined);
-	const quoteAmountError = $derived(amountErrorField === 'quote' ? amountError : undefined);
+	const baseAmountError = $derived(amountError);
 </script>
 
 <div class="rounded-lg border border-disabled bg-secondary px-3 py-1">
@@ -289,7 +274,6 @@
 			exchangeRate={quoteExchangeRate}
 			isSelectable={nonNullish(baseSymbol)}
 			onClick={onSelectQuoteGuarded}
-			onCustomValidate={onQuoteCustomValidate}
 			{selectTokenText}
 			showTokenNetwork
 			token={quoteToken}
@@ -334,10 +318,5 @@
 				{/if}
 			{/snippet}
 		</TokenInputContent>
-		{#if nonNullish(quoteAmountError)}
-			<p class="mt-1 mb-0 text-xs text-error-primary" transition:slide={SLIDE_DURATION}>
-				{quoteAmountError}
-			</p>
-		{/if}
 	</div>
 </div>

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
@@ -128,7 +128,10 @@ describe('LimitOrderTradePairBox', () => {
 		expect(quoteInput.closest('div.py-2')).not.toHaveTextContent(expected);
 	});
 
-	it('shows the buy balance error under the quote (second) token box, not the base box', () => {
+	// The quote row is a derived readout, disabled on both sides, so no amount error
+	// belongs to it — even the ones denominated in the quote token. Each of these
+	// asserts the error lands on the base amount, the only input that can clear it.
+	it('shows the buy balance error under the base (first) token box, not the quote box', () => {
 		// Buy 100 ICP at 12 ckUSDC each costs 1200 ckUSDC, above the 1000 free quote.
 		const { getAllByTestId } = render(LimitOrderTradePairBox, {
 			props: { ...baseProps, side: 'buy', baseAmount: '100', price: '12', freeQuote: 1000 }
@@ -142,11 +145,11 @@ describe('LimitOrderTradePairBox', () => {
 
 		const [baseInput, quoteInput] = getAllByTestId(TOKEN_INPUT_CURRENCY_TOKEN);
 
-		expect(quoteInput.closest('div.py-2')).toHaveTextContent(expected);
-		expect(baseInput.closest('div.py-2')).not.toHaveTextContent(expected);
+		expect(baseInput.closest('div.py-2')).toHaveTextContent(expected);
+		expect(quoteInput.closest('div.py-2')).not.toHaveTextContent(expected);
 	});
 
-	it('shows the min-notional error under the quote (second) token box', () => {
+	it('shows the min-notional error under the base (first) token box, not the quote box', () => {
 		// 0.25 ICP at 1 ckUSDC is a 0.25 notional, below the pair's min notional of 1.
 		const { getAllByTestId } = render(LimitOrderTradePairBox, {
 			props: { ...baseProps, side: 'buy', baseAmount: '0.25', price: '1' }
@@ -159,8 +162,24 @@ describe('LimitOrderTradePairBox', () => {
 
 		const [baseInput, quoteInput] = getAllByTestId(TOKEN_INPUT_CURRENCY_TOKEN);
 
-		expect(quoteInput.closest('div.py-2')).toHaveTextContent(expected);
-		expect(baseInput.closest('div.py-2')).not.toHaveTextContent(expected);
+		expect(baseInput.closest('div.py-2')).toHaveTextContent(expected);
+		expect(quoteInput.closest('div.py-2')).not.toHaveTextContent(expected);
+	});
+
+	it('leaves the derived quote input unmarked when a quote-denominated error fires', () => {
+		const { getAllByTestId } = render(LimitOrderTradePairBox, {
+			props: { ...baseProps, side: 'sell', baseAmount: '0.25', price: '1' }
+		});
+
+		const [baseInput, quoteInput] = getAllByTestId(TOKEN_INPUT_CURRENCY_TOKEN);
+
+		expect(quoteInput).toBeDisabled();
+		expect(quoteInput.closest('div.py-2')).not.toHaveTextContent(
+			en.trading.limit_order.error_min_notional.split(' $')[0]
+		);
+		expect(baseInput.closest('div.py-2')).toHaveTextContent(
+			en.trading.limit_order.error_min_notional.split(' $')[0]
+		);
 	});
 
 	it('shows the lot-multiple error when the amount is not a multiple of the lot size', () => {

--- a/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/limit-order/LimitOrderTradePairBox.svelte.spec.ts
@@ -166,20 +166,43 @@ describe('LimitOrderTradePairBox', () => {
 		expect(quoteInput.closest('div.py-2')).not.toHaveTextContent(expected);
 	});
 
-	it('leaves the derived quote input unmarked when a quote-denominated error fires', () => {
-		const { getAllByTestId } = render(LimitOrderTradePairBox, {
-			props: { ...baseProps, side: 'sell', baseAmount: '0.25', price: '1' }
-		});
+	// The red mark is the subject of this fix, so it is asserted directly rather than
+	// through the message beside it — a regression could drop one and keep the other.
+	// There is no semantic equivalent to assert instead: nothing in this tree sets
+	// `aria-invalid`, so the class `TokenInputCurrency` toggles is the observable.
+	//
+	// Fake timers rather than `waitFor`: the mark arrives on `TokenInputContent`'s
+	// 300ms validation debounce, and both rows run their own. Waiting on the base row
+	// alone resolves while the quote row's debounce is still pending, so the negative
+	// assertion would pass against a marked quote row simply by reading it too early.
+	// Advancing past both leaves nothing in flight for either to be judged on.
+	it('marks the base amount and leaves the derived quote input unmarked', async () => {
+		vi.useFakeTimers();
 
-		const [baseInput, quoteInput] = getAllByTestId(TOKEN_INPUT_CURRENCY_TOKEN);
+		try {
+			const { getAllByTestId } = render(LimitOrderTradePairBox, {
+				props: { ...baseProps, side: 'sell', baseAmount: '0.25', price: '1' }
+			});
 
-		expect(quoteInput).toBeDisabled();
-		expect(quoteInput.closest('div.py-2')).not.toHaveTextContent(
-			en.trading.limit_order.error_min_notional.split(' $')[0]
-		);
-		expect(baseInput.closest('div.py-2')).toHaveTextContent(
-			en.trading.limit_order.error_min_notional.split(' $')[0]
-		);
+			const expected = replacePlaceholders(en.trading.limit_order.error_min_notional, {
+				$amount: '1',
+				$symbol: 'ckUSDC'
+			});
+
+			const [baseInput, quoteInput] = getAllByTestId(TOKEN_INPUT_CURRENCY_TOKEN);
+
+			expect(quoteInput).toBeDisabled();
+
+			// `TokenInputContent` debounces its validation by 300ms.
+			await vi.advanceTimersByTimeAsync(400);
+
+			expect(baseInput.closest('.token-input-currency')).toHaveClass('text-error-primary');
+			expect(quoteInput.closest('.token-input-currency')).not.toHaveClass('text-error-primary');
+			expect(baseInput.closest('div.py-2')).toHaveTextContent(expected);
+			expect(quoteInput.closest('div.py-2')).not.toHaveTextContent(expected);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it('shows the lot-multiple error when the amount is not a multiple of the lot size', () => {


### PR DESCRIPTION
# Motivation

An order below the pair's minimum notional reddened the **You get at least** input:

> Order value must be at least 1 ckUSDT

That row is the derived leg — `disabled` on both sides, a readout of `base × price`. Marking it points the user at a field they cannot act on, and says nothing about what to change. The same held for a buy whose cost exceeded the free quote balance, which reddened **You pay at most**.

The only inputs a user can adjust are the base amount and the price.

# Changes

Every amount error now marks the base amount, the one input that can clear any of them:

| Error | Was | Now |
| --- | --- | --- |
| `balance` (sell) | base | base |
| `balance` (buy) | **quote** | base |
| `lot` | base | base |
| `min_notional` / `max_notional` | **quote** | base |

The messages travel with the mark rather than staying next to the figure they are denominated in, so the mark and the explanation agree — a red message under an unmarked field, or a marked field with no message, reads worse than either. The copy holds up: *"Costs 1200 ckUSDC, only 1000 free"* sits under the amount you would reduce, and *"Order value must be at least 1 ckUSDT"* under the amount you would raise.

The price is the other lever for a notional error, but raising it to clear a min-notional pushes a resting order further from the book — a worse fix than adjusting size — so the amount is the one worth pointing at.

Drops the now-dead quote-side plumbing: `onQuoteCustomValidate`, `quoteAmountError`, and its message line.

# Tests

`validateAmount` returns at most one `errorKind`, so exactly one field is ever marked — the edge cases are about which one, and each is covered:

- Two existing specs asserted the old placement (buy balance and min-notional under the quote box); both now assert the base box, with the negative assertion kept so a regression cannot pass silently.
- Added a spec that the derived quote input stays unmarked while a quote-denominated error fires, asserting `toBeDisabled()` alongside it so the reason is recorded next to the expectation.
- Sell balance and lot-multiple specs already asserted the base box and are unchanged.
- No amount error can fire before an amount is entered (`validateAmount` returns early on `!(baseAmount > 0)`) or before a price is set for the notional bounds, so neither produces an unexplained mark.
- The generic parse error still takes precedence over the amount error under the base row.

`npm run lint -- --max-warnings 0`, `npm run check` (0 errors / 0 warnings) and the `components/trading` suite (219 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code) v2.1.202
Model: Claude Opus 5 (`claude-opus-5`)