### PR TITLE
feat(frontend): Velora active transactions

### DIFF
--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -187,10 +187,17 @@
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.NEAR_INTENTS
 	);
 
-	// OneSec and NEAR Intents both close the modal at initiation and settle in the
-	// background via the Active User Transactions store.
+	const isOneSecProvider = $derived(
+		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.ONE_SEC
+	);
+
+	// Velora, OneSec and NEAR Intents all close the modal at initiation and settle
+	// in the background via the Active User Transactions store. Only the ICP-native
+	// providers still complete inside the modal.
 	const isActiveTransactionSwap = $derived(
-		isNearIntentsProvider || $swapAmountsStore?.selectedProvider?.provider === SwapProvider.ONE_SEC
+		isNearIntentsProvider ||
+			isOneSecProvider ||
+			$swapAmountsStore?.selectedProvider?.provider === SwapProvider.VELORA
 	);
 
 	const isApproveNeeded = $derived(
@@ -382,11 +389,11 @@
 
 			progress(ProgressStepsSwap.DONE);
 
-			// For OneSec and NEAR Intents swaps, the foreground completes once the
-			// user's funds have left their wallet; success/failure of the background
-			// phase is tracked separately via the AUT store, so we fire `submitted`
-			// here. Velora still completes fully inside `await` and reaches this point
-			// only on success.
+			// For AUT-tracked swaps the foreground completes once the swap is
+			// committed — funds have left the wallet, or the order is live in the
+			// auction; success/failure of the background phase is tracked separately
+			// via the AUT store, so we fire `submitted` here. The ICP-native providers
+			// complete fully inside `await` and reach this point only on success.
 			trackEvent({
 				name: isActiveTransactionSwap ? TRACK_COUNT_SWAP_SUBMITTED : TRACK_COUNT_SWAP_SUCCESS,
 				metadata: swapTrackingMetadata
@@ -488,6 +495,7 @@
 					sendWithTransfer={isTransferNeeded}
 					{swapProgressStep}
 					swapWithActiveTransaction={isActiveTransactionSwap}
+					swapWithBridging={isOneSecProvider}
 				/>
 			{/if}
 		{/key}

--- a/src/frontend/src/eth/providers/infura.providers.ts
+++ b/src/frontend/src/eth/providers/infura.providers.ts
@@ -13,6 +13,7 @@ import {
 	InfuraProvider as InfuraProviderLib,
 	type FeeData,
 	type Networkish,
+	type TransactionReceipt,
 	type TransactionResponse
 } from 'ethers/providers';
 import { get } from 'svelte/store';
@@ -49,6 +50,11 @@ export class InfuraProvider {
 
 	sendTransaction = (signedTransaction: string): Promise<TransactionResponse> =>
 		this.provider.broadcastTransaction(signedTransaction);
+
+	// `null` while the transaction is unknown to the node or still unmined; the
+	// receipt's `status` is what distinguishes a successful tx from a reverted one.
+	getTransactionReceipt = (hash: string): Promise<TransactionReceipt | null> =>
+		this.provider.getTransactionReceipt(hash);
 
 	getTransactionCount = ({
 		address,

--- a/src/frontend/src/eth/services/swap.services.ts
+++ b/src/frontend/src/eth/services/swap.services.ts
@@ -92,6 +92,7 @@ export const swap = async ({
 	Omit<RequiredTransactionFeeData, 'gas'> &
 	SwapParams & { transaction: TransactionParams }): Promise<{
 	hash: string;
+	nonce: number;
 }> => {
 	progress(ProgressStepsSwap.SWAP);
 
@@ -112,5 +113,7 @@ export const swap = async ({
 
 	processTransactionSent({ identity, token, transaction: transactionSent });
 
-	return { hash: transactionSent.hash };
+	// The nonce is returned so callers can persist it: it is what later tells a
+	// transaction that is merely unmined from one that was replaced or dropped.
+	return { hash: transactionSent.hash, nonce };
 };

--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -96,6 +96,12 @@
 			: undefined
 	);
 
+	// 1Sec is the only provider on this wizard that settles in the background, and
+	// its background phase is a bridge.
+	let isOneSecProvider = $derived(
+		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.ONE_SEC
+	);
+
 	$effect(() => {
 		if (isNullish($sourceToken) || !isIcToken($sourceToken)) {
 			return;
@@ -308,8 +314,8 @@
 		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
 			<SwapProgress
 				{swapProgressStep}
-				swapWithActiveTransaction={$swapAmountsStore?.selectedProvider?.provider ===
-					SwapProvider.ONE_SEC}
+				swapWithActiveTransaction={isOneSecProvider}
+				swapWithBridging={isOneSecProvider}
 				swapWithWithdrawing={$swapAmountsStore?.selectedProvider?.provider ===
 					SwapProvider.ICP_SWAP}
 				bind:failedSteps={swapFailedProgressSteps}

--- a/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
+++ b/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
@@ -26,6 +26,7 @@
 		isOneSecActiveUserTransaction,
 		toOneSecExternalRefsMap
 	} from '$lib/utils/onesec-swap.utils';
+	import { isVeloraActiveUserTransaction } from '$lib/utils/velora-active-tx.utils';
 
 	interface Props {
 		tx: ActiveUserTransaction;
@@ -38,9 +39,11 @@
 
 	const isOneSec = $derived(isOneSecActiveUserTransaction(tx));
 	const isNearIntents = $derived(isNearIntentsActiveUserTransaction(tx));
-	// OneSec and NEAR Intents are both cross-chain swaps rendered identically
-	// (they share the same display-ref key names in `external_refs`).
-	const isSwap = $derived(isOneSec || isNearIntents);
+	const isVelora = $derived(isVeloraActiveUserTransaction(tx));
+	// Every swap provider is rendered identically — they share the same
+	// display-ref key names in `external_refs`. Velora's Delta/Market distinction
+	// is internal routing and deliberately not surfaced.
+	const isSwap = $derived(isOneSec || isNearIntents || isVelora);
 	const isLiquidium = $derived(isLiquidiumActiveUserTransaction(tx));
 	const refs = $derived(toOneSecExternalRefsMap(tx.external_refs));
 	const liquidiumRefs = $derived(toLiquidiumExternalRefsMap(tx.external_refs));
@@ -74,7 +77,9 @@
 				? (swapProvidersDetails[SwapProvider.NEAR_INTENTS]?.name ?? '')
 				: isOneSec
 					? (swapProvidersDetails[SwapProvider.ONE_SEC]?.name ?? '')
-					: undefined
+					: isVelora
+						? (swapProvidersDetails[SwapProvider.VELORA]?.name ?? '')
+						: undefined
 	);
 
 	const titleText = $derived(
@@ -100,6 +105,14 @@
 	const sourceNetwork = $derived(refs[ONESEC_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL] ?? '');
 	const destinationNetwork = $derived(
 		refs[ONESEC_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL] ?? ''
+	);
+
+	// A same-chain swap — always the case for a Velora Market swap — would
+	// otherwise read "Ethereum → Ethereum".
+	const networkText = $derived(
+		sourceNetwork === destinationNetwork
+			? sourceNetwork
+			: `${sourceNetwork} → ${destinationNetwork}`
 	);
 
 	const createdAgo = $derived(
@@ -166,8 +179,7 @@
 			{#if isLiquidium}
 				{providerName}
 			{:else}
-				{sourceNetwork} → {destinationNetwork}{#if nonNullish(providerName)}<Divider
-					/>{providerName}{/if}
+				{networkText}{#if nonNullish(providerName)}<Divider />{providerName}{/if}
 			{/if}
 		{/snippet}
 

--- a/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
@@ -17,6 +17,7 @@
 	import { loadLiquidium } from '$lib/services/liquidium.services';
 	import { pollNearIntentsActiveUserTransactions } from '$lib/services/near-intents-active-tx.services';
 	import { pollOneSecActiveUserTransactions } from '$lib/services/onesec-swap.services';
+	import { pollVeloraActiveUserTransactions } from '$lib/services/velora-active-tx.services';
 	import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
 	import { isTerminalActiveUserTransaction } from '$lib/utils/active-user-transactions.utils';
 	import { consoleError } from '$lib/utils/console.utils';
@@ -32,6 +33,10 @@
 		buildOneSecSwapTrackingMetadata,
 		isOneSecActiveUserTransaction
 	} from '$lib/utils/onesec-swap.utils';
+	import {
+		buildVeloraSwapTrackingMetadata,
+		isVeloraActiveUserTransaction
+	} from '$lib/utils/velora-active-tx.utils';
 	import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 
 	// `loadActiveUserTransactions` resets the store on nullish identity.
@@ -75,6 +80,16 @@
 
 			if (nearIntents.length > 0) {
 				await pollNearIntentsActiveUserTransactions({ identity, transactions: nearIntents });
+			}
+
+			const velora = $activeUserTransactionsPending.filter(isVeloraActiveUserTransaction);
+
+			if (velora.length > 0) {
+				await pollVeloraActiveUserTransactions({
+					identity,
+					transactions: velora,
+					userAddress: $ethAddress
+				});
 			}
 		} catch (err: unknown) {
 			consoleError(err);
@@ -154,6 +169,21 @@
 				trackEvent({
 					name: isSucceeded ? TRACK_COUNT_SWAP_SUCCESS : TRACK_COUNT_SWAP_ERROR,
 					metadata: buildNearIntentsSwapTrackingMetadata({ tx })
+				});
+
+				if (isSucceeded) {
+					shouldRefresh = true;
+				}
+			} else if (
+				isTerminalActiveUserTransaction(tx) &&
+				!alreadyApplied &&
+				isVeloraActiveUserTransaction(tx)
+			) {
+				newlyAppliedIds.push(tx.id);
+
+				trackEvent({
+					name: isSucceeded ? TRACK_COUNT_SWAP_SUCCESS : TRACK_COUNT_SWAP_ERROR,
+					metadata: buildVeloraSwapTrackingMetadata({ tx })
 				});
 
 				if (isSucceeded) {

--- a/src/frontend/src/lib/components/swap/SwapProgress.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProgress.svelte
@@ -10,6 +10,9 @@
 		sendWithTransfer?: boolean;
 		swapWithWithdrawing?: boolean;
 		swapWithActiveTransaction?: boolean;
+		// Only meaningful together with `swapWithActiveTransaction`: whether the
+		// background phase is a bridge (1Sec) rather than a plain swap settlement.
+		swapWithBridging?: boolean;
 		failedSteps?: string[];
 	}
 
@@ -19,7 +22,8 @@
 		sendWithApproval = false,
 		sendWithTransfer = false,
 		swapWithWithdrawing = false,
-		swapWithActiveTransaction = false
+		swapWithActiveTransaction = false,
+		swapWithBridging = false
 	}: Props = $props();
 
 	let steps = $derived<ProgressSteps>([
@@ -68,7 +72,9 @@
 		{
 			step: ProgressStepsSwap.UPDATE_UI,
 			text: swapWithActiveTransaction
-				? $i18n.swap.text.starting_to_bridge
+				? swapWithBridging
+					? $i18n.swap.text.starting_to_bridge
+					: $i18n.swap.text.finishing_in_background
 				: $i18n.swap.text.refreshing_ui,
 			state: 'next'
 		}

--- a/src/frontend/src/lib/constants/swap.constants.ts
+++ b/src/frontend/src/lib/constants/swap.constants.ts
@@ -26,8 +26,6 @@ export const ICP_SWAP_POOL_FEE = 3000n;
 
 export const SWAP_ETH_TOKEN_PLACEHOLDER = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
-export const SWAP_DELTA_TIMEOUT_MS = 5 * 60_000;
-export const SWAP_DELTA_INTERVAL_MS = 3_000;
 export const SWAP_AMOUNTS_PERIODIC_FETCH_INTERVAL_MS = 5_000;
 
 export const NEAR_INTENTS_BLOCKCHAIN_MAP: Record<NetworkId, string> = {

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1195,6 +1195,7 @@
 			"swapping": "جاري التبديل...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "جاري تحديث واجهة المستخدم",
 			"swap_provider": "مزود التبديل",
 			"swap_provider_website": "الموقع الإلكتروني",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Výměna...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "Aktualizace uživatelského rozhraní",
 			"swap_provider": "Poskytovatel výměny",
 			"swap_provider_website": "Webové stránky",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "Tokeny z vaší předchozí výměny byly úspěšně vybrány. Nyní můžete toto modální okno zavřít.",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Tausche...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "UI aktualisieren",
 			"swap_provider": "Tausch-Anbieter",
 			"swap_provider_website": "Website",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "Die Token deines vorherigen Tauschs wurden erfolgeich zurückgeholt. Die kannst dieses Fenster jetzt schliessen.",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Swapping...",
 			"starting_to_swap": "Submitting your swap...",
 			"starting_to_bridge": "Wrapping up. We'll keep bridging in the background.",
+			"finishing_in_background": "Wrapping up. We'll keep working on it in the background.",
 			"refreshing_ui": "Refreshing UI",
 			"swap_provider": "Swap provider",
 			"swap_provider_website": "Website",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "The tokens from your previous swap were successfully withdrawn. You can now close this modal.",
 			"swap_completed_close_failed": "The transaction completed successfully, but we failed to close the modal. Please refresh the page.",
 			"cannot_save_provider_agreement": "Failed to save the provider agreement. Please try again.",
-			"swap_refunded": "The swap transaction was refunded."
+			"swap_refunded": "The swap transaction was refunded.",
+			"swap_replaced_or_dropped": "This swap transaction was replaced or dropped before it was confirmed."
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Intercambiando...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "Actualizando UI",
 			"swap_provider": "Proveedor de intercambio",
 			"swap_provider_website": "sitio_web_del_proveedor_de_intercambio",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "Los tokens de tu intercambio anterior fueron retirados con éxito. Ahora puedes cerrar este modal.",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Échange en cours...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "Actualisation de l'interface",
 			"swap_provider": "Fournisseur d'échange",
 			"swap_provider_website": "Site web",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "Les tokens de votre précédent échange ont été retirés avec succès. Vous pouvez maintenant fermer cette fenêtre.",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1195,6 +1195,7 @@
 			"swapping": "स्वैप कर रहा है...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "UI रीफ्रेश कर रहा है",
 			"swap_provider": "स्वैप प्रदाता",
 			"swap_provider_website": "वेबसाइट",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "आपके पिछले स्वैप से टोकन सफलतापूर्वक वापस ले लिए गए थे। अब आप इस मोडल को बंद कर सकते हैं।",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Scambio...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "Aggiornamento UI",
 			"swap_provider": "Fornitore di scambio",
 			"swap_provider_website": "Sito web",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1195,6 +1195,7 @@
 			"swapping": "スワップ中...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "UIを更新中",
 			"swap_provider": "スワッププロバイダー",
 			"swap_provider_website": "ウェブサイト",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "前回のスワップのトークンは正常に出金されました。このモーダルを閉じることができます。",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1195,6 +1195,7 @@
 			"swapping": "스왑 중...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "UI 새로고침 중",
 			"swap_provider": "스왑 제공자",
 			"swap_provider_website": "웹사이트",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "이전 스왑의 토큰이 성공적으로 출금되었습니다. 이제 이 창을 닫을 수 있습니다.",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Wymiana...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "Odświeżanie interfejsu użytkownika",
 			"swap_provider": "Dostawca wymiany",
 			"swap_provider_website": "Strona internetowa",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "Tokeny z poprzedniej wymiany zostały pomyślnie wypłacone. Możesz teraz zamknąć to okno.",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Trocando...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "Atualizando UI",
 			"swap_provider": "Provedor de troca",
 			"swap_provider_website": "Site",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "A troca foi concluída, mas seus tokens não puderam ser retirados automaticamente. Clique no botão Retirar abaixo para retirá-los manualmente-<br> Ou siga",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Обмен...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "Обновление пользовательского интерфейса",
 			"swap_provider": "Поставщик обмена",
 			"swap_provider_website": "Веб-сайт",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "Обмен и вывод прошли успешно",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1195,6 +1195,7 @@
 			"swapping": "Đang hoán đổi...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "Đang làm mới giao diện người dùng",
 			"swap_provider": "Nhà cung cấp hoán đổi",
 			"swap_provider_website": "Trang web",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "Token từ giao dịch hoán đổi trước đó của bạn đã được rút thành công. Bây giờ bạn có thể đóng hộp thoại này.",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1195,6 +1195,7 @@
 			"swapping": "正在兑换...",
 			"starting_to_swap": "",
 			"starting_to_bridge": "",
+			"finishing_in_background": "",
 			"refreshing_ui": "刷新界面中",
 			"swap_provider": "兑换服务商",
 			"swap_provider_website": "官网",
@@ -1241,7 +1242,8 @@
 			"swap_sucess_manually_withdraw_success": "兑换成功，手动取款成功",
 			"swap_completed_close_failed": "",
 			"cannot_save_provider_agreement": "",
-			"swap_refunded": ""
+			"swap_refunded": "",
+			"swap_replaced_or_dropped": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -1,10 +1,13 @@
+import type { VeloraSwapMode } from '$declarations/backend/backend.did';
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
 import { approve as approveToken, erc20ContractAllowance } from '$eth/services/approve.services';
 import { createPermit } from '$eth/services/eip2612-permit.services';
 import { loadCustomTokens as loadCustomErc20Tokens } from '$eth/services/erc20.services';
 import { send as sendEvm } from '$eth/services/send.services';
 import { swap } from '$eth/services/swap.services';
+import type { ErcFungibleToken } from '$eth/types/erc-fungible';
 import type { Erc20Token } from '$eth/types/erc20';
+import type { EthereumNetwork } from '$eth/types/network';
 import { getCompactSignature, getSignParamsEIP712 } from '$eth/utils/eip712.utils';
 import { isTokenErc } from '$eth/utils/erc.utils';
 import { isDefaultEthereumToken, isNotDefaultEthereumToken } from '$eth/utils/eth.utils';
@@ -34,12 +37,7 @@ import {
 	ZERO
 } from '$lib/constants/app.constants';
 import { OISY_URL_HOSTNAME } from '$lib/constants/oisy.constants';
-import {
-	ICP_SWAP_POOL_FEE,
-	SWAP_DELTA_INTERVAL_MS,
-	SWAP_DELTA_TIMEOUT_MS,
-	SWAP_SIDE
-} from '$lib/constants/swap.constants';
+import { ICP_SWAP_POOL_FEE, SWAP_SIDE } from '$lib/constants/swap.constants';
 import { exchanges } from '$lib/derived/exchange.derived';
 import { PLAUSIBLE_EVENTS, PLAUSIBLE_EVENT_CONTEXTS } from '$lib/enums/plausible';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
@@ -71,7 +69,6 @@ import type { Amount } from '$lib/types/send';
 import {
 	SwapErrorCodes,
 	SwapProvider,
-	type CheckDeltaOrderStatusParams,
 	type EvmQuoteParams,
 	type FetchSwapAmountsParams,
 	type ICPSwapResult,
@@ -90,6 +87,7 @@ import {
 	type SwapVeloraMarketParams
 } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
+import { VELORA_EXTERNAL_REF_KEYS, type VeloraExternalRefKey } from '$lib/types/velora-swap';
 import { consoleError } from '$lib/utils/console.utils';
 import { toCustomToken } from '$lib/utils/custom-token.utils';
 import { formatToken } from '$lib/utils/format.utils';
@@ -108,6 +106,11 @@ import {
 	slippagePercentToBasisPoints
 } from '$lib/utils/swap.utils';
 import { isTokenToggleable } from '$lib/utils/token-toggleable.utils';
+import {
+	toVeloraData,
+	toVeloraDisplayRefs,
+	toVeloraExternalRefs
+} from '$lib/utils/velora-active-tx.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import { sendSol } from '$sol/services/sol-send.services';
 import { loadCustomTokens as loadCustomSplTokens } from '$sol/services/spl.services';
@@ -115,7 +118,7 @@ import { isTokenSpl } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish, nowInBigIntNanoSeconds } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
-import { OrderHelpers, constructSimpleSDK, type BuildDeltaOrderParams } from '@velora-dex/sdk';
+import { constructSimpleSDK, type BuildDeltaOrderParams } from '@velora-dex/sdk';
 import { get } from 'svelte/store';
 
 const checkNeedsApproval = async ({
@@ -1150,6 +1153,73 @@ export const withdrawUserUnusedBalance = async ({
 	}
 };
 
+/**
+ * Registers the Active User Transaction that carries a committed Velora swap to
+ * its terminal state, so the modal can close while settlement continues in the
+ * background.
+ *
+ * Best-effort, mirroring the other AUT providers: by the time this runs the
+ * order is live in the auction (Delta) or the transaction is broadcast
+ * (Market), so a failure here costs tracking, never funds.
+ */
+const createVeloraActiveUserTransaction = async ({
+	identity,
+	mode,
+	sourceToken,
+	destinationToken,
+	swapAmount,
+	parsedSwapAmount,
+	sourceNetwork,
+	pollRefs
+}: {
+	identity: Identity;
+	mode: VeloraSwapMode;
+	sourceToken: ErcFungibleToken;
+	destinationToken: ErcFungibleToken;
+	swapAmount: Amount;
+	parsedSwapAmount: bigint;
+	sourceNetwork: EthereumNetwork;
+	pollRefs: Partial<Record<VeloraExternalRefKey, string>>;
+}): Promise<void> => {
+	try {
+		const data = toVeloraData({
+			mode,
+			sourceToken,
+			destinationToken,
+			amount: parsedSwapAmount
+		});
+
+		if (isNullish(data)) {
+			return;
+		}
+
+		// Snapshotted rather than derived at settlement: the row's terminal
+		// analytics must report the value the user swapped at, and this is the same
+		// rate the wizard used for the `swap_submitted` event of this swap.
+		const sourceTokenExchangeRate = get(exchanges)?.[sourceToken.id]?.usd;
+
+		await createActiveUserTransaction({
+			identity,
+			id: crypto.randomUUID(),
+			data,
+			externalRefs: toVeloraExternalRefs({
+				...toVeloraDisplayRefs({
+					sourceToken,
+					destinationToken,
+					amount: `${swapAmount}`,
+					usdSourceValue: nonNullish(sourceTokenExchangeRate)
+						? `${Number(swapAmount) * sourceTokenExchangeRate}`
+						: undefined
+				}),
+				[VELORA_EXTERNAL_REF_KEYS.CHAIN_ID]: `${sourceNetwork.chainId}`,
+				...pollRefs
+			})
+		});
+	} catch (err: unknown) {
+		consoleError(err);
+	}
+};
+
 export const fetchVeloraDeltaSwap = async ({
 	identity,
 	progress,
@@ -1266,49 +1336,31 @@ export const fetchVeloraDeltaSwap = async ({
 
 	const compactSignature = getCompactSignature(signature);
 
+	// The order is live in the auction from here on — the point of no return.
 	const deltaAuction = await sdk.delta.postDeltaOrder({
 		order: builtOrder.toSign.value,
 		signature: compactSignature
 	});
 
-	await checkDeltaOrderStatus({
-		sdk,
-		auctionId: deltaAuction.id
+	await createVeloraActiveUserTransaction({
+		identity,
+		mode: { Delta: null },
+		sourceToken,
+		destinationToken,
+		swapAmount,
+		parsedSwapAmount,
+		sourceNetwork,
+		pollRefs: {
+			[VELORA_EXTERNAL_REF_KEYS.AUCTION_ID]: deltaAuction.id,
+			[VELORA_EXTERNAL_REF_KEYS.ORDER_HASH]: builtOrder.orderHash
+		}
 	});
 
 	progress(ProgressStepsSwap.UPDATE_UI);
 
+	// The destination token is enabled so it stays visible while the order
+	// settles; the balance refresh happens once the AUT row terminalizes.
 	await enableSwapDestinationToken({ destinationToken, identity });
-
-	await waitAndTriggerWallet();
-};
-
-const checkDeltaOrderStatus = async ({
-	sdk,
-	auctionId,
-	timeoutMs = SWAP_DELTA_TIMEOUT_MS,
-	intervalMs = SWAP_DELTA_INTERVAL_MS
-}: CheckDeltaOrderStatusParams): Promise<void> => {
-	const deadline = Date.now() + timeoutMs;
-
-	while (Date.now() < deadline) {
-		const auction = await sdk.delta.getDeltaOrderById(auctionId);
-
-		// `COMPLETED` means the order settled on every chain, so cross-chain orders need no
-		// separate bridge check — they stay `BRIDGING` until the destination leg lands.
-		if (OrderHelpers.checks.isCompletedAuction(auction)) {
-			return;
-		}
-
-		// Terminal failures (failed, expired, cancelled, refunding, refunded)
-		if (OrderHelpers.checks.isFailedAuction(auction)) {
-			throw new Error(`Velora Delta swap ${auction.status.toLowerCase()} (order ${auctionId})`);
-		}
-
-		await new Promise((r) => setTimeout(r, intervalMs));
-	}
-
-	throw new Error(`Velora Delta swap timed out (order ${auctionId})`);
 };
 
 export const fetchVeloraMarketSwap = async ({
@@ -1381,7 +1433,11 @@ export const fetchVeloraMarketSwap = async ({
 		partner: OISY_URL_HOSTNAME
 	});
 
-	await swap({
+	// The transaction is broadcast from here on — the point of no return. `swap`
+	// also kicks off `processTransactionSent`, which populates the pending row in
+	// the token's transaction list; the AUT row adds the durable, cross-session
+	// settlement record on top of it.
+	const { hash, nonce } = await swap({
 		from: userAddress,
 		to: txParams.to,
 		transaction: txParams,
@@ -1393,9 +1449,23 @@ export const fetchVeloraMarketSwap = async ({
 		progress
 	});
 
+	await createVeloraActiveUserTransaction({
+		identity,
+		mode: { Market: null },
+		sourceToken,
+		destinationToken,
+		swapAmount,
+		parsedSwapAmount,
+		sourceNetwork,
+		pollRefs: {
+			[VELORA_EXTERNAL_REF_KEYS.TX_HASH]: hash,
+			[VELORA_EXTERNAL_REF_KEYS.TX_NONCE]: `${nonce}`
+		}
+	});
+
 	progress(ProgressStepsSwap.UPDATE_UI);
 
+	// The destination token is enabled so it stays visible while the transaction
+	// confirms; the balance refresh happens once the AUT row terminalizes.
 	await enableSwapDestinationToken({ destinationToken, identity });
-
-	await waitAndTriggerWallet();
 };

--- a/src/frontend/src/lib/services/velora-active-tx.services.ts
+++ b/src/frontend/src/lib/services/velora-active-tx.services.ts
@@ -1,0 +1,277 @@
+import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import { infuraProviders } from '$eth/providers/infura.providers';
+import type { EthAddress, OptionEthAddress } from '$eth/types/address';
+import { applyActiveUserTransactionPollUpdate } from '$lib/services/active-user-transactions.services';
+import { VELORA_EXTERNAL_REF_KEYS, type VeloraExternalRefKey } from '$lib/types/velora-swap';
+import { advanceStatus } from '$lib/utils/active-user-transactions.utils';
+import { consoleError } from '$lib/utils/console.utils';
+import { findEvmNetworkByChainId } from '$lib/utils/network.utils';
+import {
+	toVeloraDeltaLearnedRefs,
+	toVeloraDeltaStatus,
+	toVeloraExternalRefs,
+	toVeloraExternalRefsMap,
+	toVeloraMarketOutcome,
+	veloraDeltaStatusError,
+	veloraMarketOutcomeError,
+	veloraMarketOutcomeToStatus,
+	type VeloraMarketOutcome
+} from '$lib/utils/velora-active-tx.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { constructSimpleSDK } from '@velora-dex/sdk';
+
+/**
+ * Counts how many consecutive polls have observed a Market row as
+ * replaced-or-dropped. A single observation is not trusted: the receipt read and
+ * the confirmed-nonce read are not atomic, so a transaction that has just
+ * confirmed can be seen with an advanced nonce while a lagging RPC node still
+ * answers `null` for its receipt. Writing `Failed` there would be a permanent
+ * wrong verdict on a successful swap.
+ *
+ * Deliberately in-memory: a refresh resets the count, which at worst delays
+ * terminalization by one tick and never produces a wrong verdict.
+ */
+const replacementObservations = new Map<string, number>();
+
+// Test seam — module-level state would otherwise leak between cases.
+export const resetVeloraReplacementObservations = (): void => {
+	replacementObservations.clear();
+};
+
+const REPLACEMENT_OBSERVATIONS_REQUIRED = 2;
+
+const recordReplacementObservation = (txId: string): number => {
+	const count = (replacementObservations.get(txId) ?? 0) + 1;
+	replacementObservations.set(txId, count);
+	return count;
+};
+
+const applyUpdate = async ({
+	identity,
+	tx,
+	candidate,
+	error,
+	learned,
+	refs
+}: {
+	identity: Identity;
+	tx: ActiveUserTransaction;
+	candidate: ReturnType<typeof toVeloraDeltaStatus>;
+	error: string | undefined;
+	learned: Partial<Record<VeloraExternalRefKey, string>>;
+	refs: Partial<Record<VeloraExternalRefKey, string>>;
+}): Promise<void> => {
+	const next = nonNullish(candidate) ? advanceStatus({ current: tx.status, candidate }) : undefined;
+
+	// Persist newly-learned hashes even when the status itself doesn't advance.
+	const hasNewRefs = (Object.keys(learned) as VeloraExternalRefKey[]).some(
+		(key) => refs[key] !== learned[key]
+	);
+	const externalRefs = hasNewRefs ? toVeloraExternalRefs({ ...refs, ...learned }) : undefined;
+
+	const update = {
+		...(nonNullish(next) ? { status: next } : {}),
+		...(nonNullish(next) && 'Failed' in next && nonNullish(error) ? { error } : {}),
+		...(nonNullish(externalRefs) ? { externalRefs } : {})
+	};
+
+	if (Object.keys(update).length === 0) {
+		return;
+	}
+
+	await applyActiveUserTransactionPollUpdate({ identity, tx, update });
+};
+
+// Velora's Delta v2 API is the source of truth: an unauthenticated, stateless
+// endpoint keyed by the auction id snapshotted in `external_refs` at creation
+// time, so the row resumes across refresh / logout.
+const pollVeloraDeltaTransaction = async ({
+	tx,
+	identity,
+	refs
+}: {
+	tx: ActiveUserTransaction;
+	identity: Identity;
+	refs: Partial<Record<VeloraExternalRefKey, string>>;
+}): Promise<void> => {
+	const auctionId = refs[VELORA_EXTERNAL_REF_KEYS.AUCTION_ID];
+	const chainId = refs[VELORA_EXTERNAL_REF_KEYS.CHAIN_ID];
+
+	// Not pollable without the auction id.
+	if (isNullish(auctionId) || isNullish(chainId)) {
+		return;
+	}
+
+	const sdk = constructSimpleSDK({ chainId: Number(chainId), fetch: window.fetch });
+
+	const auction = await sdk.delta.getDeltaOrderById(auctionId);
+
+	const candidate = toVeloraDeltaStatus(auction);
+
+	if (isNullish(candidate)) {
+		consoleError(`Unmapped Velora Delta order status: ${auction.status}`);
+	}
+
+	await applyUpdate({
+		identity,
+		tx,
+		candidate,
+		error: veloraDeltaStatusError(auction.status),
+		learned: toVeloraDeltaLearnedRefs(auction),
+		refs
+	});
+};
+
+// The source chain is the source of truth for a Market swap: the receipt's
+// `status` says whether it executed or reverted, and the sender's confirmed
+// nonce is what distinguishes a transaction still in the mempool from one that
+// was replaced or dropped.
+const pollVeloraMarketTransaction = async ({
+	tx,
+	identity,
+	refs,
+	userAddress,
+	confirmedNonceByChainId
+}: {
+	tx: ActiveUserTransaction;
+	identity: Identity;
+	refs: Partial<Record<VeloraExternalRefKey, string>>;
+	userAddress: EthAddress;
+	confirmedNonceByChainId: Map<string, Promise<number>>;
+}): Promise<void> => {
+	const hash = refs[VELORA_EXTERNAL_REF_KEYS.TX_HASH];
+	const nonce = refs[VELORA_EXTERNAL_REF_KEYS.TX_NONCE];
+	const chainId = refs[VELORA_EXTERNAL_REF_KEYS.CHAIN_ID];
+
+	// Not pollable without the transaction hash, its nonce, or the chain.
+	if (isNullish(hash) || isNullish(nonce) || isNullish(chainId)) {
+		return;
+	}
+
+	const network = findEvmNetworkByChainId(BigInt(chainId));
+
+	if (isNullish(network)) {
+		consoleError(`Unsupported Velora Market chain id: ${chainId}`);
+		return;
+	}
+
+	const txNonce = Number(nonce);
+
+	if (Number.isNaN(txNonce)) {
+		consoleError(`Unparsable Velora Market nonce for transaction ${hash}: ${nonce}`);
+		return;
+	}
+
+	const provider = infuraProviders(network.id);
+
+	const receipt = await provider.getTransactionReceipt(hash);
+
+	let outcome: VeloraMarketOutcome = toVeloraMarketOutcome({ receipt, txNonce });
+
+	// Only a missing receipt is ambiguous — it reads the same whether the
+	// transaction is still in the mempool or was replaced. The confirmed nonce
+	// tells the two apart.
+	if (isNullish(receipt)) {
+		// Several rows can share a chain within a tick; one nonce read serves all.
+		const confirmedNoncePromise =
+			confirmedNonceByChainId.get(chainId) ?? provider.getTransactionCountLatest(userAddress);
+		confirmedNonceByChainId.set(chainId, confirmedNoncePromise);
+
+		const confirmedNonce = await confirmedNoncePromise;
+
+		outcome = toVeloraMarketOutcome({ receipt, confirmedNonce, txNonce });
+
+		if (outcome === 'replaced') {
+			// The nonce read may have raced our own confirmation: re-read the receipt
+			// before counting this as evidence that the transaction can never mine.
+			outcome = toVeloraMarketOutcome({
+				receipt: await provider.getTransactionReceipt(hash),
+				confirmedNonce,
+				txNonce
+			});
+		}
+	}
+
+	if (
+		outcome === 'replaced' &&
+		recordReplacementObservation(tx.id) < REPLACEMENT_OBSERVATIONS_REQUIRED
+	) {
+		outcome = 'pending';
+	} else {
+		// The row either stopped looking replaced or terminalizes as Failed below;
+		// either way it is no longer under observation.
+		replacementObservations.delete(tx.id);
+	}
+
+	if (outcome === 'unknown') {
+		consoleError(`Unexpected Velora Market receipt for transaction ${hash}`);
+	}
+
+	await applyUpdate({
+		identity,
+		tx,
+		candidate: veloraMarketOutcomeToStatus(outcome),
+		error: veloraMarketOutcomeError(outcome),
+		learned: {},
+		refs
+	});
+};
+
+/**
+ * Advances the pending Velora rows, routed on the execution mode stored in the
+ * row's `data`.
+ *
+ * `userAddress` is the caller's EVM address. AUT rows are principal-scoped and
+ * OISY derives one EVM address per principal, so it is by construction the
+ * address that signed every Market row in the set; Market rows are skipped when
+ * it is unavailable, while Delta rows are unaffected.
+ */
+export const pollVeloraActiveUserTransactions = async ({
+	identity,
+	transactions,
+	userAddress
+}: {
+	identity: Identity;
+	transactions: ActiveUserTransaction[];
+	userAddress: OptionEthAddress;
+}): Promise<void> => {
+	if (transactions.length === 0) {
+		return;
+	}
+
+	const confirmedNonceByChainId = new Map<string, Promise<number>>();
+
+	await Promise.all(
+		transactions.map(async (tx) => {
+			try {
+				if (!('Velora' in tx.data)) {
+					return;
+				}
+
+				const refs = toVeloraExternalRefsMap(tx.external_refs);
+
+				if ('Delta' in tx.data.Velora.mode) {
+					await pollVeloraDeltaTransaction({ tx, identity, refs });
+					return;
+				}
+
+				if (isNullish(userAddress)) {
+					return;
+				}
+
+				await pollVeloraMarketTransaction({
+					tx,
+					identity,
+					refs,
+					userAddress,
+					confirmedNonceByChainId
+				});
+			} catch (err: unknown) {
+				// A transient RPC or API blip must leave the row pending so the next
+				// tick retries; one failing row never poisons the batch.
+				consoleError(err);
+			}
+		})
+	);
+};

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -921,6 +921,7 @@ interface I18nSwap {
 		swapping: string;
 		starting_to_swap: string;
 		starting_to_bridge: string;
+		finishing_in_background: string;
 		refreshing_ui: string;
 		swap_provider: string;
 		swap_provider_website: string;
@@ -968,6 +969,7 @@ interface I18nSwap {
 		swap_completed_close_failed: string;
 		cannot_save_provider_agreement: string;
 		swap_refunded: string;
+		swap_replaced_or_dropped: string;
 	};
 }
 

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -14,7 +14,7 @@ import type { Token } from '$lib/types/token';
 import type { RequiredTransactionFeeData } from '$lib/types/transaction';
 import type { OptionSolAddress, SolAddress } from '$sol/types/address';
 import type { Identity } from '@icp-sdk/core/agent';
-import type { DeltaPrice, OptimalRate, QuoteParams, SimpleFetchSDK } from '@velora-dex/sdk';
+import type { DeltaPrice, OptimalRate, QuoteParams } from '@velora-dex/sdk';
 
 export type SwapSelectTokenType = 'source' | 'destination';
 
@@ -364,14 +364,6 @@ export interface SwapNearIntentsEvmParams
 export interface SwapNearIntentsSolParams extends SwapNearIntentsParams {
 	destinationToken: Token;
 	userAddress: SolAddress;
-}
-
-export interface CheckDeltaOrderStatusParams {
-	sdk: SimpleFetchSDK;
-	auctionId: string;
-	onExecuted?: () => void;
-	timeoutMs?: number;
-	intervalMs?: number;
 }
 
 export interface DeltaSwapResponse {

--- a/src/frontend/src/lib/types/velora-swap.ts
+++ b/src/frontend/src/lib/types/velora-swap.ts
@@ -1,0 +1,36 @@
+export const VELORA_EXTERNAL_REF_KEYS = {
+	// Source chain id — both modes. `constructSimpleSDK` requires a chain id, and
+	// the Market poller needs it to pick the right EVM provider.
+	CHAIN_ID: 'velora_chain_id',
+	// Delta poll key: the auction id returned by `postDeltaOrder`. The order hash
+	// comes back from `buildDeltaOrder`, so it is snapshotted at creation too.
+	AUCTION_ID: 'velora_auction_id',
+	ORDER_HASH: 'velora_order_hash',
+	// Delta traceability, learned as the poller reads the order.
+	ORIGIN_TX_HASH: 'velora_origin_tx',
+	DEST_TX_HASH: 'velora_dest_tx',
+	REFUND_TX_HASH: 'velora_refund_tx',
+	// Market poll keys: the broadcast tx hash plus the nonce it was signed with.
+	// The nonce is what lets the poller tell "not mined yet" from "replaced or
+	// dropped" — see `toVeloraMarketOutcome`.
+	TX_HASH: 'velora_tx_hash',
+	TX_NONCE: 'velora_tx_nonce',
+	// Display + analytics metadata snapshotted at creation time. Reuses the same
+	// key names as OneSec (`$lib/types/onesec-swap`) and NEAR Intents so the AUT
+	// row rendering and analytics paths are shared rather than duplicated. Stay
+	// correct across page refresh / cross-session resume — even when the user has
+	// since disabled the underlying token.
+	AMOUNT: 'amount',
+	// The source amount in USD at commit time. Kept un-namespaced like the other
+	// display refs so OneSec and NEAR Intents can adopt the same key: it is what
+	// lets the terminal `swap_success` / `swap_error` carry the same
+	// `usdSourceValue` the wizard sent with `swap_submitted` for the same swap.
+	USD_SOURCE_VALUE: 'usd_source_value',
+	SOURCE_TOKEN_SYMBOL: 'source_token_symbol',
+	SOURCE_NETWORK_SYMBOL: 'source_network_symbol',
+	DESTINATION_TOKEN_SYMBOL: 'destination_token_symbol',
+	DESTINATION_NETWORK_SYMBOL: 'destination_network_symbol'
+} as const;
+
+export type VeloraExternalRefKey =
+	(typeof VELORA_EXTERNAL_REF_KEYS)[keyof typeof VELORA_EXTERNAL_REF_KEYS];

--- a/src/frontend/src/lib/utils/velora-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/velora-active-tx.utils.ts
@@ -124,15 +124,23 @@ export const toVeloraDeltaLearnedRefs = (
  * Maps a Velora Delta order to the AUT status enum.
  *
  * Built on the SDK's own partitions so that a patch release reclassifying a
- * status carries through here. `SUSPENDED` and `CANCELLING` sit in *neither*
- * partition and are handled explicitly as still-in-flight: `SUSPENDED` means the
- * order cannot currently be filled (insufficient balance or allowance) and still
- * resolves to `COMPLETED` or `EXPIRED` on its own, and `CANCELLING` resolves to
- * `CANCELLED`. An early `Failed` write could never be walked back, since AUT
- * terminal states are immutable on the backend.
+ * status carries through here, with three statuses handled explicitly in front
+ * of them because they read as terminal to the SDK — or to neither partition —
+ * while the order is still moving. AUT terminal states are immutable on the
+ * backend, and a terminalized row leaves `activeUserTransactionsPending`, so an
+ * early write is irreversible *and* stops the poller from learning anything
+ * else about the order:
  *
- * `REFUNDING` is safe to write as `Failed` even though it reads as in-flight:
- * its only continuation is `REFUNDED`, which is also `Failed`.
+ * - `SUSPENDED` (in neither partition) means the order cannot currently be
+ *   filled — insufficient balance or allowance — and still resolves to
+ *   `COMPLETED` or `EXPIRED` on its own.
+ * - `CANCELLING` (in neither partition) resolves to `CANCELLED`.
+ * - `REFUNDING` sits in the SDK's *failed* partition, and its verdict is indeed
+ *   already settled — its only continuation, `REFUNDED`, is also `Failed`. It is
+ *   still kept in flight, because terminalizing on the intent to refund buys
+ *   nothing and costs two things: the row would claim the swap "was refunded"
+ *   before any refund landed, and the poller could never persist the refund hash
+ *   that `refunds[]` reveals once it does. Terminalize on `REFUNDED`.
  *
  * Returns `undefined` for an unrecognised status so the poller leaves the row
  * untouched rather than guessing. Bumping `@velora-dex/sdk` requires reviewing
@@ -145,23 +153,26 @@ export const toVeloraDeltaStatus = (
 		return { Succeeded: null };
 	}
 
-	if (OrderHelpers.checks.isFailedAuction(auction)) {
-		return { Failed: null };
-	}
-
 	if (
 		OrderHelpers.checks.isPendingAuction(auction) ||
 		auction.status === 'SUSPENDED' ||
-		auction.status === 'CANCELLING'
+		auction.status === 'CANCELLING' ||
+		auction.status === 'REFUNDING'
 	) {
 		return { Executing: null };
+	}
+
+	if (OrderHelpers.checks.isFailedAuction(auction)) {
+		return { Failed: null };
 	}
 
 	return undefined;
 };
 
 export const veloraDeltaStatusError = (status: DeltaOrderStatus): string | undefined => {
-	if (status === 'REFUNDED' || status === 'REFUNDING') {
+	// `REFUNDING` is deliberately absent: it never reaches a `Failed` write, so it
+	// never carries an error — see `toVeloraDeltaStatus`.
+	if (status === 'REFUNDED') {
 		return get(i18n).swap.error.swap_refunded;
 	}
 

--- a/src/frontend/src/lib/utils/velora-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/velora-active-tx.utils.ts
@@ -1,0 +1,275 @@
+import type {
+	ActiveUserTransaction,
+	ActiveUserTransactionData,
+	ActiveUserTransactionRef,
+	ActiveUserTransactionStatus,
+	VeloraSwapMode
+} from '$declarations/backend/backend.did';
+import { i18n } from '$lib/stores/i18n.store';
+import { SwapProvider, VeloraSwapTypes } from '$lib/types/swap';
+import type { Token as AppToken } from '$lib/types/token';
+import { VELORA_EXTERNAL_REF_KEYS, type VeloraExternalRefKey } from '$lib/types/velora-swap';
+import { toBackendTokenId } from '$lib/utils/token-id.utils';
+import { nonNullish } from '@dfinity/utils';
+import { OrderHelpers, type DeltaAuction, type DeltaOrderStatus } from '@velora-dex/sdk';
+import { get } from 'svelte/store';
+
+export const isVeloraActiveUserTransaction = (tx: ActiveUserTransaction): boolean =>
+	'Velora' in tx.data;
+
+/**
+ * The stored execution mode as the string the analytics `swapType` field uses,
+ * so a row's terminal `swap_success` / `swap_error` lines up with the
+ * `swap_submitted` the wizard fired for the same swap.
+ */
+export const veloraSwapModeKey = (mode: VeloraSwapMode): VeloraSwapTypes =>
+	'Delta' in mode ? VeloraSwapTypes.DELTA : VeloraSwapTypes.MARKET;
+
+/**
+ * Builds the `Velora` AUT data variant carrying the mode plus the canonical
+ * immutable trio (source token, dest token, source amount in base units). The
+ * auction id / order hash / tx hash / nonce and display symbols ride in
+ * `external_refs`. Returns `undefined` when either token can't be mapped to a
+ * backend `TokenId`.
+ */
+export const toVeloraData = ({
+	mode,
+	sourceToken,
+	destinationToken,
+	amount
+}: {
+	mode: VeloraSwapMode;
+	sourceToken: AppToken;
+	destinationToken: AppToken;
+	amount: bigint;
+}): ActiveUserTransactionData | undefined => {
+	const source_token = toBackendTokenId(sourceToken);
+	const dest_token = toBackendTokenId(destinationToken);
+
+	if (nonNullish(source_token) && nonNullish(dest_token)) {
+		return { Velora: { mode, source_token, dest_token, amount } };
+	}
+};
+
+/**
+ * Builds a deterministic `(key, value)` external-ref array, dropping empties.
+ * Mirrors `toNearIntentsExternalRefs`.
+ */
+export const toVeloraExternalRefs = (
+	refs: Partial<Record<VeloraExternalRefKey, string>>
+): ActiveUserTransactionRef[] =>
+	(Object.keys(refs) as VeloraExternalRefKey[])
+		.filter((key) => refs[key] !== undefined && refs[key] !== '')
+		.sort()
+		.map((key) => ({ key, value: refs[key] as string }));
+
+// Wire-format `(key, value)` array → keyed lookup.
+export const toVeloraExternalRefsMap = (
+	refs: ActiveUserTransactionRef[]
+): Partial<Record<VeloraExternalRefKey, string>> => {
+	const map: Partial<Record<VeloraExternalRefKey, string>> = {};
+
+	for (const { key, value } of refs) {
+		map[key as VeloraExternalRefKey] = value;
+	}
+
+	return map;
+};
+
+/**
+ * Snapshots the user-facing fields needed to render an AUT row and to fire its
+ * terminal-state analytics events. Uses the same key names as OneSec and NEAR
+ * Intents so the UI and analytics code is shared.
+ */
+export const toVeloraDisplayRefs = ({
+	sourceToken,
+	destinationToken,
+	amount,
+	usdSourceValue
+}: {
+	sourceToken: AppToken;
+	destinationToken: AppToken;
+	amount: string;
+	usdSourceValue?: string;
+}): Partial<Record<VeloraExternalRefKey, string>> => ({
+	[VELORA_EXTERNAL_REF_KEYS.AMOUNT]: amount,
+	...(nonNullish(usdSourceValue)
+		? { [VELORA_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE]: usdSourceValue }
+		: {}),
+	[VELORA_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL]: sourceToken.symbol,
+	[VELORA_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL]: sourceToken.network.name,
+	[VELORA_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]: destinationToken.symbol,
+	[VELORA_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL]: destinationToken.network.name
+});
+
+/**
+ * Extracts the settlement / refund hashes a Delta order reveals as it
+ * progresses, so the poller can persist them for traceability.
+ */
+export const toVeloraDeltaLearnedRefs = (
+	auction: Pick<DeltaAuction, 'transactions' | 'refunds'>
+): Partial<Record<VeloraExternalRefKey, string>> => {
+	const origin = auction.transactions?.[0]?.originTx;
+	const destination = auction.transactions?.[0]?.destinationTx;
+	const refund = auction.refunds?.[0]?.tx;
+
+	return {
+		...(nonNullish(origin) ? { [VELORA_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH]: origin } : {}),
+		...(nonNullish(destination) ? { [VELORA_EXTERNAL_REF_KEYS.DEST_TX_HASH]: destination } : {}),
+		...(nonNullish(refund) ? { [VELORA_EXTERNAL_REF_KEYS.REFUND_TX_HASH]: refund } : {})
+	};
+};
+
+/**
+ * Maps a Velora Delta order to the AUT status enum.
+ *
+ * Built on the SDK's own partitions so that a patch release reclassifying a
+ * status carries through here. `SUSPENDED` and `CANCELLING` sit in *neither*
+ * partition and are handled explicitly as still-in-flight: `SUSPENDED` means the
+ * order cannot currently be filled (insufficient balance or allowance) and still
+ * resolves to `COMPLETED` or `EXPIRED` on its own, and `CANCELLING` resolves to
+ * `CANCELLED`. An early `Failed` write could never be walked back, since AUT
+ * terminal states are immutable on the backend.
+ *
+ * `REFUNDING` is safe to write as `Failed` even though it reads as in-flight:
+ * its only continuation is `REFUNDED`, which is also `Failed`.
+ *
+ * Returns `undefined` for an unrecognised status so the poller leaves the row
+ * untouched rather than guessing. Bumping `@velora-dex/sdk` requires reviewing
+ * this mapper against the current `DeltaOrderStatus` union.
+ */
+export const toVeloraDeltaStatus = (
+	auction: Pick<DeltaAuction, 'status'>
+): ActiveUserTransactionStatus | undefined => {
+	if (OrderHelpers.checks.isCompletedAuction(auction)) {
+		return { Succeeded: null };
+	}
+
+	if (OrderHelpers.checks.isFailedAuction(auction)) {
+		return { Failed: null };
+	}
+
+	if (
+		OrderHelpers.checks.isPendingAuction(auction) ||
+		auction.status === 'SUSPENDED' ||
+		auction.status === 'CANCELLING'
+	) {
+		return { Executing: null };
+	}
+
+	return undefined;
+};
+
+export const veloraDeltaStatusError = (status: DeltaOrderStatus): string | undefined => {
+	if (status === 'REFUNDED' || status === 'REFUNDING') {
+		return get(i18n).swap.error.swap_refunded;
+	}
+
+	if (status === 'FAILED' || status === 'EXPIRED' || status === 'CANCELLED') {
+		return get(i18n).swap.error.failed_unexpectedly;
+	}
+
+	return undefined;
+};
+
+/**
+ * What the source chain says about a Market swap transaction.
+ *
+ * `replaced` is a *candidate* verdict, not a conclusion: the receipt read and
+ * the nonce read are not atomic, so a successful swap can momentarily look
+ * replaced. The poller only terminalizes it after seeing it twice in a row.
+ */
+export type VeloraMarketOutcome = 'succeeded' | 'reverted' | 'pending' | 'replaced' | 'unknown';
+
+/**
+ * Reads a Market swap's outcome off the source chain.
+ *
+ * `getNonce` signs with the *pending* count, so the transaction owns nonce `N`,
+ * while `confirmedNonce` is the sender's next unused *confirmed* nonce. A null
+ * receipt with a confirmed count already past `N` means some other transaction
+ * consumed slot `N` — a speed-up, a cancel, or a re-broadcast — so ours can
+ * never mine.
+ */
+export const toVeloraMarketOutcome = ({
+	receipt,
+	confirmedNonce,
+	txNonce
+}: {
+	receipt: { status: number | null } | null;
+	confirmedNonce?: number;
+	txNonce: number;
+}): VeloraMarketOutcome => {
+	if (nonNullish(receipt)) {
+		if (receipt.status === 1) {
+			return 'succeeded';
+		}
+
+		if (receipt.status === 0) {
+			return 'reverted';
+		}
+
+		return 'unknown';
+	}
+
+	if (nonNullish(confirmedNonce) && confirmedNonce > txNonce) {
+		return 'replaced';
+	}
+
+	return 'pending';
+};
+
+export const veloraMarketOutcomeToStatus = (
+	outcome: VeloraMarketOutcome
+): ActiveUserTransactionStatus | undefined => {
+	switch (outcome) {
+		case 'succeeded':
+			return { Succeeded: null };
+		case 'reverted':
+		case 'replaced':
+			return { Failed: null };
+		case 'pending':
+			return { Executing: null };
+		default:
+			return undefined;
+	}
+};
+
+export const veloraMarketOutcomeError = (outcome: VeloraMarketOutcome): string | undefined => {
+	if (outcome === 'reverted') {
+		return get(i18n).swap.error.failed_unexpectedly;
+	}
+
+	if (outcome === 'replaced') {
+		return get(i18n).swap.error.swap_replaced_or_dropped;
+	}
+
+	return undefined;
+};
+
+/**
+ * Builds the analytics metadata for a Velora AUT row that has just reached a
+ * terminal status. Same shape as `buildNearIntentsSwapTrackingMetadata`, plus
+ * the execution mode, resolved entirely off the row's snapshot so it survives
+ * refresh/resume.
+ */
+export const buildVeloraSwapTrackingMetadata = ({
+	tx
+}: {
+	tx: ActiveUserTransaction;
+}): Record<string, string> => {
+	const refs = toVeloraExternalRefsMap(tx.external_refs);
+
+	return {
+		sourceToken: refs[VELORA_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL] ?? '',
+		destinationToken: refs[VELORA_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL] ?? '',
+		dApp: SwapProvider.VELORA,
+		tokenAmount: refs[VELORA_EXTERNAL_REF_KEYS.AMOUNT] ?? '',
+		// Snapshotted at commit time, so it matches the `swap_submitted` the wizard
+		// fired for the same swap rather than the rate at settlement.
+		usdSourceValue: refs[VELORA_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE] ?? '',
+		sourceNetwork: refs[VELORA_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL] ?? '',
+		destinationNetwork: refs[VELORA_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL] ?? '',
+		...('Velora' in tx.data ? { swapType: veloraSwapModeKey(tx.data.Velora.mode) } : {}),
+		...(nonNullish(tx.error[0]) ? { error: tx.error[0] } : {})
+	};
+};

--- a/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/swap/SwapEthWizard.spec.ts
@@ -9,6 +9,10 @@ import {
 	type EthFeeStore,
 	type FeeStoreData
 } from '$eth/stores/eth-fee.store';
+import {
+	TRACK_COUNT_SWAP_SUBMITTED,
+	TRACK_COUNT_SWAP_SUCCESS
+} from '$lib/constants/analytics.constants';
 import { ZERO } from '$lib/constants/app.constants';
 import * as addrDerived from '$lib/derived/address.derived';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
@@ -453,6 +457,27 @@ describe('SwapEthWizard', () => {
 			expect(swapServices.fetchVeloraMarketSwap).toHaveBeenCalledOnce();
 			expect(onClose).toHaveBeenCalledOnce();
 			expect(onBack).not.toHaveBeenCalled();
+		});
+
+		it('reports the swap as submitted, leaving success to the active-transaction poller', async () => {
+			const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+
+			const { getByRole, getByText, queryByRole } = renderExecution();
+
+			const valueDifferenceCheckbox = queryByRole('checkbox');
+			if (valueDifferenceCheckbox) {
+				await fireEvent.click(getByRole('checkbox'));
+			}
+
+			await fireEvent.click(getByText(en.swap.text.swap_button));
+			await vi.runOnlyPendingTimersAsync();
+
+			expect(trackEventSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ name: TRACK_COUNT_SWAP_SUBMITTED })
+			);
+			expect(trackEventSpy).not.toHaveBeenCalledWith(
+				expect.objectContaining({ name: TRACK_COUNT_SWAP_SUCCESS })
+			);
 		});
 
 		it('surfaces the failure on the review page when the swap fails', async () => {

--- a/src/frontend/src/tests/eth/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/swap.services.spec.ts
@@ -106,7 +106,7 @@ describe('swap.services', () => {
 		it('should perform swap successfully', async () => {
 			const result = await swap(mockSwapParams);
 
-			expect(result).toEqual({ hash: mockTransactionHash });
+			expect(result).toEqual({ hash: mockTransactionHash, nonce: mockNonce });
 
 			expect(infuraProviders).toHaveBeenCalled();
 			expect(mockGetTransactionCount).toHaveBeenCalledOnce();

--- a/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
@@ -2,7 +2,8 @@ import ActiveUserTransactionItem from '$lib/components/active-user-transactions/
 import en from '$lib/i18n/en.json';
 import {
 	mockLiquidiumActiveUserTransaction,
-	mockNearIntentsActiveUserTransaction
+	mockNearIntentsActiveUserTransaction,
+	mockVeloraActiveUserTransaction
 } from '$tests/mocks/active-user-transactions.mock';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 
@@ -20,6 +21,23 @@ describe('ActiveUserTransactionItem', () => {
 		expect(screen.getByText(`${en.swap.text.swap} 1 USDC → USDC`)).toBeInTheDocument();
 		expect(container).toHaveTextContent('Ethereum → Solana');
 		expect(container).toHaveTextContent('NEAR Intents');
+	});
+
+	it('renders Velora rows as a swap with the provider, collapsing a same-chain network line', () => {
+		const { container } = render(ActiveUserTransactionItem, {
+			props: {
+				tx: mockVeloraActiveUserTransaction,
+				isUnseen: false,
+				dismissing: false,
+				onDismiss: vi.fn()
+			}
+		});
+
+		expect(screen.getByText(`${en.swap.text.swap} 1 USDC → USDT`)).toBeInTheDocument();
+		expect(container).toHaveTextContent('Velora');
+		// Source and destination share a network, so it reads once, not "Ethereum → Ethereum".
+		expect(container).not.toHaveTextContent('Ethereum → Ethereum');
+		expect(container).toHaveTextContent('Ethereum');
 	});
 
 	it('renders Liquidium rows with the action, amount, asset and provider', () => {

--- a/src/frontend/src/tests/lib/components/loaders/LoaderActiveUserTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderActiveUserTransactions.spec.ts
@@ -15,13 +15,15 @@ import * as liquidiumPoller from '$lib/services/liquidium-active-tx.services';
 import * as liquidiumServices from '$lib/services/liquidium.services';
 import * as nearIntentsPoller from '$lib/services/near-intents-active-tx.services';
 import * as oneSecPoller from '$lib/services/onesec-swap.services';
+import * as veloraPoller from '$lib/services/velora-active-tx.services';
 import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
 import { SwapProvider } from '$lib/types/swap';
 import * as walletUtils from '$lib/utils/wallet.utils';
 import {
 	mockActiveUserTransaction,
 	mockLiquidiumActiveUserTransaction,
-	mockNearIntentsActiveUserTransaction
+	mockNearIntentsActiveUserTransaction,
+	mockVeloraActiveUserTransaction
 } from '$tests/mocks/active-user-transactions.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
@@ -63,6 +65,20 @@ const succeededNearIntents = (id: string) =>
 		id,
 		status: { Succeeded: null } as const
 	}) satisfies typeof mockNearIntentsActiveUserTransaction;
+
+const pendingVelora = (id: string) =>
+	({
+		...mockVeloraActiveUserTransaction,
+		id,
+		status: { Pending: null } as const
+	}) satisfies typeof mockVeloraActiveUserTransaction;
+
+const succeededVelora = (id: string) =>
+	({
+		...mockVeloraActiveUserTransaction,
+		id,
+		status: { Succeeded: null } as const
+	}) satisfies typeof mockVeloraActiveUserTransaction;
 
 const pendingLiquidium = (id: string) =>
 	({
@@ -220,6 +236,31 @@ describe('LoaderActiveUserTransactions', () => {
 			});
 		});
 
+		it('polls Velora rows on each tick when present, with the EVM address', async () => {
+			const oneSecSpy = vi
+				.spyOn(oneSecPoller, 'pollOneSecActiveUserTransactions')
+				.mockResolvedValue();
+			const veloraSpy = vi
+				.spyOn(veloraPoller, 'pollVeloraActiveUserTransactions')
+				.mockResolvedValue();
+			vi.spyOn(addressDerived, 'ethAddress', 'get').mockReturnValue(readable(mockEthAddress));
+			const tx = pendingVelora('velora-a');
+
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: tx });
+
+			render(LoaderActiveUserTransactions);
+
+			await vi.advanceTimersByTimeAsync(ACTIVE_USER_TRANSACTIONS_POLL_INTERVAL_MILLIS);
+
+			expect(oneSecSpy).not.toHaveBeenCalled();
+			expect(veloraSpy).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				transactions: [tx],
+				userAddress: mockEthAddress
+			});
+		});
+
 		it('stops polling once all rows reach a terminal state', async () => {
 			const spy = vi.spyOn(oneSecPoller, 'pollOneSecActiveUserTransactions').mockResolvedValue();
 
@@ -310,6 +351,27 @@ describe('LoaderActiveUserTransactions', () => {
 				metadata: expect.objectContaining({ dApp: SwapProvider.NEAR_INTENTS })
 			});
 			expect(appliedFlags()).toEqual({ 'near-a': true });
+		});
+
+		it('fires waitAndTriggerWallet and a swap_success event with the Velora dApp when a Velora row succeeds', async () => {
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: pendingVelora('velora-a') });
+
+			render(LoaderActiveUserTransactions);
+			await tick();
+
+			expect(refreshSpy).not.toHaveBeenCalled();
+			expect(trackEventSpy).not.toHaveBeenCalled();
+
+			activeUserTransactionsStore.upsert({ transaction: succeededVelora('velora-a') });
+			await tick();
+
+			expect(refreshSpy).toHaveBeenCalledOnce();
+			expect(trackEventSpy).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_SWAP_SUCCESS,
+				metadata: expect.objectContaining({ dApp: SwapProvider.VELORA })
+			});
+			expect(appliedFlags()).toEqual({ 'velora-a': true });
 		});
 
 		it('fires wallet and Liquidium refreshes plus analytics when a Liquidium row succeeds', async () => {

--- a/src/frontend/src/tests/lib/components/swap/SwapProgress.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapProgress.spec.ts
@@ -126,6 +126,37 @@ describe('SwapProgress', () => {
 		});
 	});
 
+	describe('swapWithActiveTransaction', () => {
+		it('replaces the swapping and refreshing copy with the background-settlement copy', () => {
+			const { container } = render(SwapProgress, {
+				props: { swapWithActiveTransaction: true }
+			});
+
+			expect(container).toHaveTextContent(en.swap.text.starting_to_swap);
+			expect(container).toHaveTextContent(en.swap.text.finishing_in_background);
+			expect(container).not.toHaveTextContent(baseStepTexts.swapping);
+			expect(container).not.toHaveTextContent(baseStepTexts.refreshingUi);
+		});
+
+		it('uses the bridging copy only when the background phase is a bridge', () => {
+			const { container } = render(SwapProgress, {
+				props: { swapWithActiveTransaction: true, swapWithBridging: true }
+			});
+
+			expect(container).toHaveTextContent(en.swap.text.starting_to_bridge);
+			expect(container).not.toHaveTextContent(en.swap.text.finishing_in_background);
+		});
+
+		it('ignores swapWithBridging when the swap is not tracked in the background', () => {
+			const { container } = render(SwapProgress, {
+				props: { swapWithBridging: true }
+			});
+
+			expect(container).toHaveTextContent(baseStepTexts.refreshingUi);
+			expect(container).not.toHaveTextContent(en.swap.text.starting_to_bridge);
+		});
+	});
+
 	describe('progress step highlighting', () => {
 		it('renders with INITIALIZATION step by default', () => {
 			const { container } = render(SwapProgress);

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -4,6 +4,7 @@ import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { createPermit } from '$eth/services/eip2612-permit.services';
 import { loadCustomTokens as loadCustomErc20Tokens } from '$eth/services/erc20.services';
 import { send as sendEvm } from '$eth/services/send.services';
+import { swap as sendEvmSwap } from '$eth/services/swap.services';
 import type { Erc20Token } from '$eth/types/erc20';
 import * as ethUtils from '$eth/utils/eth.utils';
 import * as icrcLedgerApi from '$icp/api/icrc-ledger.api';
@@ -14,7 +15,7 @@ import * as icpSwapPool from '$lib/api/icp-swap-pool.api';
 import * as kongBackendApi from '$lib/api/kong_backend.api';
 import { signPrehash } from '$lib/api/signer.api';
 import { ZERO } from '$lib/constants/app.constants';
-import { SWAP_DELTA_INTERVAL_MS, SWAP_DELTA_TIMEOUT_MS } from '$lib/constants/swap.constants';
+import * as exchangeDerived from '$lib/derived/exchange.derived';
 import { PLAUSIBLE_EVENTS, PLAUSIBLE_EVENT_CONTEXTS } from '$lib/enums/plausible';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
@@ -46,6 +47,7 @@ import {
 	type NearIntentsQuoteResponse
 } from '$lib/types/near-intents';
 import { SwapErrorCodes, SwapProvider } from '$lib/types/swap';
+import { VELORA_EXTERNAL_REF_KEYS } from '$lib/types/velora-swap';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { sendSol } from '$sol/services/sol-send.services';
 import { loadCustomTokens as loadCustomSplTokens } from '$sol/services/spl.services';
@@ -66,7 +68,7 @@ import {
 	mockVeloraOptimalRate
 } from '$tests/mocks/velora.mock';
 import { constructSimpleSDK, type DeltaPrice, type OptimalRate } from '@velora-dex/sdk';
-import { get } from 'svelte/store';
+import { get, readable } from 'svelte/store';
 
 vi.mock('$icp/api/icrc-ledger.api', () => ({
 	icrc1SupportedStandards: vi.fn()
@@ -940,7 +942,8 @@ describe('swap.services', () => {
 				orderHash: 'mock-order-hash'
 			});
 			mockDeltaContractPostDeltaOrder.mockResolvedValue({ id: 'mock-auction-id' });
-			mockDeltaContractGetDeltaOrderById.mockResolvedValue({ status: 'COMPLETED' });
+
+			vi.mocked(activeUserTransactionsServices.createActiveUserTransaction).mockResolvedValue();
 
 			vi.mocked(createPermit).mockResolvedValue({
 				nonce: '0',
@@ -1046,13 +1049,58 @@ describe('swap.services', () => {
 			expect(mockDeltaContractPostDeltaOrder).not.toHaveBeenCalled();
 		});
 
-		it('should treat a cross-chain order as settled only once it reports COMPLETED', async () => {
-			// A cross-chain order stays `BRIDGING` until the destination leg lands, so `COMPLETED`
-			// on its own means settled on every chain — no separate bridge check is needed.
-			mockDeltaContractGetDeltaOrderById.mockResolvedValue({
-				status: 'COMPLETED',
-				transactions: [{ originTx: '0xorigin', destinationTx: '0xdestination' }]
+		it('registers an active user transaction and leaves settlement to the poller', async () => {
+			await fetchVeloraDeltaSwap({
+				identity: mockIdentity,
+				progress: mockProgress,
+				sourceToken: mockSourceToken,
+				destinationToken: mockDestinationToken,
+				swapAmount: mockSwapAmount,
+				sourceNetwork: mockSourceNetwork,
+				receiveAmount: mockReceiveAmount,
+				slippageValue: mockSlippageValue,
+				userAddress: mockUserAddress,
+				gas: BigInt(mockGas),
+				isGasless: false,
+				maxFeePerGas: BigInt(mockMaxFeePerGas),
+				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+				swapDetails: mockSwapDetails
 			});
+
+			expect(
+				activeUserTransactionsServices.createActiveUserTransaction
+			).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					identity: mockIdentity,
+					data: {
+						Velora: expect.objectContaining({
+							mode: { Delta: null },
+							// The row stores base units: the 18-decimal source token scales the amount.
+							amount: BigInt(mockSwapAmount) * 10n ** 18n
+						})
+					},
+					externalRefs: expect.arrayContaining([
+						{ key: VELORA_EXTERNAL_REF_KEYS.AUCTION_ID, value: 'mock-auction-id' },
+						{ key: VELORA_EXTERNAL_REF_KEYS.ORDER_HASH, value: 'mock-order-hash' },
+						{
+							key: VELORA_EXTERNAL_REF_KEYS.CHAIN_ID,
+							value: `${mockSourceNetwork.chainId}`
+						}
+					])
+				})
+			);
+
+			// Settlement is the global AUT poller's job now — the modal must not block on it.
+			expect(mockDeltaContractGetDeltaOrderById).not.toHaveBeenCalled();
+			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
+		});
+
+		it('snapshots the USD value of the source amount at commit time', async () => {
+			// The row's terminal analytics must report the value the user swapped at,
+			// not the rate whenever the swap happens to settle.
+			vi.spyOn(exchangeDerived, 'exchanges', 'get').mockReturnValue(
+				readable({ [mockSourceToken.id]: { usd: 2 } })
+			);
 
 			await fetchVeloraDeltaSwap({
 				identity: mockIdentity,
@@ -1071,7 +1119,74 @@ describe('swap.services', () => {
 				swapDetails: mockSwapDetails
 			});
 
-			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
+			expect(
+				activeUserTransactionsServices.createActiveUserTransaction
+			).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					externalRefs: expect.arrayContaining([
+						{
+							key: VELORA_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE,
+							value: `${Number(mockSwapAmount) * 2}`
+						}
+					])
+				})
+			);
+		});
+
+		it('omits the USD value when the source token has no exchange rate', async () => {
+			vi.spyOn(exchangeDerived, 'exchanges', 'get').mockReturnValue(readable({}));
+
+			await fetchVeloraDeltaSwap({
+				identity: mockIdentity,
+				progress: mockProgress,
+				sourceToken: mockSourceToken,
+				destinationToken: mockDestinationToken,
+				swapAmount: mockSwapAmount,
+				sourceNetwork: mockSourceNetwork,
+				receiveAmount: mockReceiveAmount,
+				slippageValue: mockSlippageValue,
+				userAddress: mockUserAddress,
+				gas: BigInt(mockGas),
+				isGasless: false,
+				maxFeePerGas: BigInt(mockMaxFeePerGas),
+				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+				swapDetails: mockSwapDetails
+			});
+
+			const [[{ externalRefs }]] = vi.mocked(
+				activeUserTransactionsServices.createActiveUserTransaction
+			).mock.calls;
+
+			expect(externalRefs).not.toContainEqual(
+				expect.objectContaining({ key: VELORA_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE })
+			);
+		});
+
+		it('does not fail the swap when registering the active user transaction fails', async () => {
+			vi.mocked(activeUserTransactionsServices.createActiveUserTransaction).mockRejectedValueOnce(
+				new Error('backend down')
+			);
+
+			await expect(
+				fetchVeloraDeltaSwap({
+					identity: mockIdentity,
+					progress: mockProgress,
+					sourceToken: mockSourceToken,
+					destinationToken: mockDestinationToken,
+					swapAmount: mockSwapAmount,
+					sourceNetwork: mockSourceNetwork,
+					receiveAmount: mockReceiveAmount,
+					slippageValue: mockSlippageValue,
+					userAddress: mockUserAddress,
+					gas: BigInt(mockGas),
+					isGasless: false,
+					maxFeePerGas: BigInt(mockMaxFeePerGas),
+					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+					swapDetails: mockSwapDetails
+				})
+			).resolves.toBeUndefined();
+
+			expect(mockProgress).toHaveBeenLastCalledWith(ProgressStepsSwap.UPDATE_UI);
 		});
 
 		it('rounds the slippage to integer basis points when building the order', async () => {
@@ -1137,116 +1252,6 @@ describe('swap.services', () => {
 			expect(signPrehash).not.toHaveBeenCalled();
 			expect(mockDeltaContractPostDeltaOrder).not.toHaveBeenCalled();
 		});
-
-		it.each(['FAILED', 'EXPIRED', 'CANCELLED', 'REFUNDED', 'REFUNDING'])(
-			'throws instead of reporting success when the order ends up %s',
-			async (status) => {
-				mockDeltaContractGetDeltaOrderById.mockResolvedValue({ status });
-
-				await expect(
-					fetchVeloraDeltaSwap({
-						identity: mockIdentity,
-						progress: mockProgress,
-						sourceToken: mockSourceToken,
-						destinationToken: mockDestinationToken,
-						swapAmount: mockSwapAmount,
-						sourceNetwork: mockSourceNetwork,
-						receiveAmount: mockReceiveAmount,
-						slippageValue: mockSlippageValue,
-						userAddress: mockUserAddress,
-						gas: BigInt(mockGas),
-						isGasless: false,
-						maxFeePerGas: BigInt(mockMaxFeePerGas),
-						maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
-						swapDetails: mockSwapDetails
-					})
-				).rejects.toThrow(`Velora Delta swap ${status.toLowerCase()} (order mock-auction-id)`);
-
-				// A terminal failure never recovers, so polling stops on the first read.
-				expect(mockDeltaContractGetDeltaOrderById).toHaveBeenCalledOnce();
-				expect(mockProgress).not.toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
-			}
-		);
-
-		it('keeps polling through transient statuses and surfaces the terminal failure', async () => {
-			vi.useFakeTimers();
-
-			mockDeltaContractGetDeltaOrderById
-				.mockResolvedValueOnce({ status: 'ACTIVE' })
-				.mockResolvedValueOnce({ status: 'BRIDGING' })
-				.mockResolvedValueOnce({ status: 'SUSPENDED' })
-				.mockResolvedValueOnce({ status: 'CANCELLING' })
-				.mockResolvedValueOnce({ status: 'FAILED' });
-
-			try {
-				// The rejection is captured rather than asserted with `expect().rejects` so that the
-				// assertion can happen *after* virtual time advances — awaiting it up front would
-				// deadlock, since nothing settles until the poll interval elapses.
-				const settled = fetchVeloraDeltaSwap({
-					identity: mockIdentity,
-					progress: mockProgress,
-					sourceToken: mockSourceToken,
-					destinationToken: mockDestinationToken,
-					swapAmount: mockSwapAmount,
-					sourceNetwork: mockSourceNetwork,
-					receiveAmount: mockReceiveAmount,
-					slippageValue: mockSlippageValue,
-					userAddress: mockUserAddress,
-					gas: BigInt(mockGas),
-					isGasless: false,
-					maxFeePerGas: BigInt(mockMaxFeePerGas),
-					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
-					swapDetails: mockSwapDetails
-				}).catch((err: unknown) => err);
-
-				await vi.advanceTimersByTimeAsync(4 * SWAP_DELTA_INTERVAL_MS);
-
-				await expect(settled).resolves.toEqual(
-					new Error('Velora Delta swap failed (order mock-auction-id)')
-				);
-			} finally {
-				vi.useRealTimers();
-			}
-
-			expect(mockDeltaContractGetDeltaOrderById).toHaveBeenCalledTimes(5);
-			expect(mockProgress).not.toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
-		});
-
-		it('throws instead of reporting success when the order never settles before the timeout', async () => {
-			vi.useFakeTimers();
-
-			mockDeltaContractGetDeltaOrderById.mockResolvedValue({ status: 'ACTIVE' });
-
-			try {
-				// See the note above on capturing the rejection instead of awaiting `expect().rejects`.
-				const settled = fetchVeloraDeltaSwap({
-					identity: mockIdentity,
-					progress: mockProgress,
-					sourceToken: mockSourceToken,
-					destinationToken: mockDestinationToken,
-					swapAmount: mockSwapAmount,
-					sourceNetwork: mockSourceNetwork,
-					receiveAmount: mockReceiveAmount,
-					slippageValue: mockSlippageValue,
-					userAddress: mockUserAddress,
-					gas: BigInt(mockGas),
-					isGasless: false,
-					maxFeePerGas: BigInt(mockMaxFeePerGas),
-					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
-					swapDetails: mockSwapDetails
-				}).catch((err: unknown) => err);
-
-				await vi.advanceTimersByTimeAsync(SWAP_DELTA_TIMEOUT_MS + SWAP_DELTA_INTERVAL_MS);
-
-				await expect(settled).resolves.toEqual(
-					new Error('Velora Delta swap timed out (order mock-auction-id)')
-				);
-			} finally {
-				vi.useRealTimers();
-			}
-
-			expect(mockProgress).not.toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
-		});
 	});
 
 	describe('fetchVeloraMarketSwap', () => {
@@ -1290,6 +1295,9 @@ describe('swap.services', () => {
 		let mockSwapGetSpender: ReturnType<typeof vi.fn>;
 		let mockSwapBuildTx: ReturnType<typeof vi.fn>;
 
+		const mockTxHash = '0xMarketTxHash';
+		const mockTxNonce = 7;
+
 		beforeEach(() => {
 			vi.clearAllMocks();
 
@@ -1313,6 +1321,8 @@ describe('swap.services', () => {
 				to: '0xSwapContract',
 				data: '0xswapdata'
 			});
+			vi.mocked(sendEvmSwap).mockResolvedValue({ hash: mockTxHash, nonce: mockTxNonce });
+			vi.mocked(activeUserTransactionsServices.createActiveUserTransaction).mockResolvedValue();
 		});
 
 		it('should execute market swap successfully with non-default token', async () => {
@@ -1388,6 +1398,75 @@ describe('swap.services', () => {
 			});
 
 			expect(mockSwapBuildTx).toHaveBeenCalledWith(expect.objectContaining({ slippage: 29 }));
+		});
+
+		it('registers an active user transaction carrying the tx hash, nonce and chain id', async () => {
+			await fetchVeloraMarketSwap({
+				identity: mockIdentity,
+				progress: mockProgress,
+				sourceToken: mockSourceToken,
+				destinationToken: mockDestinationToken,
+				swapAmount: mockSwapAmount,
+				sourceNetwork: mockSourceNetwork,
+				slippageValue: mockSlippageValue,
+				userAddress: mockUserAddress,
+				gas: BigInt(mockGas),
+				maxFeePerGas: BigInt(mockMaxFeePerGas),
+				maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+				swapDetails: mockSwapDetails,
+				receiveAmount: BigInt(1000),
+				isGasless: false
+			});
+
+			expect(
+				activeUserTransactionsServices.createActiveUserTransaction
+			).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					identity: mockIdentity,
+					data: {
+						Velora: expect.objectContaining({
+							mode: { Market: null },
+							// The row stores base units: the 18-decimal source token scales the amount.
+							amount: BigInt(mockSwapAmount) * 10n ** 18n
+						})
+					},
+					externalRefs: expect.arrayContaining([
+						{ key: VELORA_EXTERNAL_REF_KEYS.TX_HASH, value: mockTxHash },
+						{ key: VELORA_EXTERNAL_REF_KEYS.TX_NONCE, value: `${mockTxNonce}` },
+						{
+							key: VELORA_EXTERNAL_REF_KEYS.CHAIN_ID,
+							value: `${mockSourceNetwork.chainId}`
+						}
+					])
+				})
+			);
+		});
+
+		it('does not fail the swap when registering the active user transaction fails', async () => {
+			vi.mocked(activeUserTransactionsServices.createActiveUserTransaction).mockRejectedValueOnce(
+				new Error('backend down')
+			);
+
+			await expect(
+				fetchVeloraMarketSwap({
+					identity: mockIdentity,
+					progress: mockProgress,
+					sourceToken: mockSourceToken,
+					destinationToken: mockDestinationToken,
+					swapAmount: mockSwapAmount,
+					sourceNetwork: mockSourceNetwork,
+					slippageValue: mockSlippageValue,
+					userAddress: mockUserAddress,
+					gas: BigInt(mockGas),
+					maxFeePerGas: BigInt(mockMaxFeePerGas),
+					maxPriorityFeePerGas: BigInt(mockMaxPriorityFeePerGas),
+					swapDetails: mockSwapDetails,
+					receiveAmount: BigInt(1000),
+					isGasless: false
+				})
+			).resolves.toBeUndefined();
+
+			expect(mockProgress).toHaveBeenLastCalledWith(ProgressStepsSwap.UPDATE_UI);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/velora-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/velora-active-tx.services.spec.ts
@@ -196,6 +196,54 @@ describe('velora-active-tx.services', () => {
 			);
 		});
 
+		// A row terminalized at REFUNDING would leave the pending set, so the refund
+		// hash the order only reveals once the refund lands could never be persisted.
+		it('keeps a refunding order in flight so the refund hash can still be learned', async () => {
+			getDeltaOrderById.mockResolvedValue({
+				status: 'REFUNDING',
+				transactions: [],
+				refunds: []
+			});
+
+			const tx = buildTx({ mode: 'Delta', refs: deltaRefs });
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [tx],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: { status: { Executing: null } }
+				})
+			);
+
+			getDeltaOrderById.mockResolvedValue({
+				status: 'REFUNDED',
+				transactions: [],
+				refunds: [{ tx: '0xrefund', chainId: 1, token: '0xtoken', amount: '1' }]
+			});
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [{ ...tx, status: { Executing: null } }],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						status: { Failed: null },
+						error: en.swap.error.swap_refunded,
+						externalRefs: expect.arrayContaining([
+							{ key: VELORA_EXTERNAL_REF_KEYS.REFUND_TX_HASH, value: '0xrefund' }
+						])
+					})
+				})
+			);
+		});
+
 		it('leaves the row untouched on an unrecognised status', async () => {
 			getDeltaOrderById.mockResolvedValue({
 				status: 'SOMETHING_NEW',

--- a/src/frontend/src/tests/lib/services/velora-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/velora-active-tx.services.spec.ts
@@ -1,0 +1,491 @@
+import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { infuraProviders } from '$eth/providers/infura.providers';
+import en from '$lib/i18n/en.json';
+import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
+import {
+	pollVeloraActiveUserTransactions,
+	resetVeloraReplacementObservations
+} from '$lib/services/velora-active-tx.services';
+import { VELORA_EXTERNAL_REF_KEYS, type VeloraExternalRefKey } from '$lib/types/velora-swap';
+import {
+	mockVeloraActiveUserTransaction,
+	mockVeloraData
+} from '$tests/mocks/active-user-transactions.mock';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import type * as VeloraSdk from '@velora-dex/sdk';
+import { constructSimpleSDK } from '@velora-dex/sdk';
+
+vi.mock('$eth/providers/infura.providers', () => ({
+	infuraProviders: vi.fn()
+}));
+
+// Only the SDK factory is faked — `OrderHelpers`, which the Delta status mapper
+// partitions on, must stay real.
+vi.mock('@velora-dex/sdk', async (importOriginal) => ({
+	...(await importOriginal<typeof VeloraSdk>()),
+	constructSimpleSDK: vi.fn()
+}));
+
+vi.mock('$lib/utils/console.utils', () => ({
+	consoleError: vi.fn()
+}));
+
+describe('velora-active-tx.services', () => {
+	const applySpy = vi.spyOn(activeUserTransactionsServices, 'applyActiveUserTransactionPollUpdate');
+
+	const buildTx = ({
+		mode,
+		refs,
+		status = { Pending: null },
+		id = mockVeloraActiveUserTransaction.id
+	}: {
+		mode: 'Delta' | 'Market';
+		refs: Partial<Record<VeloraExternalRefKey, string>>;
+		status?: ActiveUserTransaction['status'];
+		id?: string;
+	}): ActiveUserTransaction => ({
+		...mockVeloraActiveUserTransaction,
+		id,
+		status,
+		data: {
+			Velora: { ...mockVeloraData, mode: mode === 'Delta' ? { Delta: null } : { Market: null } }
+		},
+		external_refs: Object.entries(refs).map(([key, value]) => ({ key, value }))
+	});
+
+	const deltaRefs = {
+		[VELORA_EXTERNAL_REF_KEYS.AUCTION_ID]: 'auction-1',
+		[VELORA_EXTERNAL_REF_KEYS.CHAIN_ID]: '1'
+	};
+
+	const marketRefs = {
+		[VELORA_EXTERNAL_REF_KEYS.TX_HASH]: '0xhash',
+		[VELORA_EXTERNAL_REF_KEYS.TX_NONCE]: '5',
+		[VELORA_EXTERNAL_REF_KEYS.CHAIN_ID]: '1'
+	};
+
+	let getDeltaOrderById: ReturnType<typeof vi.fn>;
+	let getTransactionReceipt: ReturnType<typeof vi.fn>;
+	let getTransactionCountLatest: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetVeloraReplacementObservations();
+
+		applySpy.mockResolvedValue();
+
+		getDeltaOrderById = vi.fn();
+		vi.mocked(constructSimpleSDK).mockReturnValue({
+			delta: { getDeltaOrderById }
+		} as unknown as ReturnType<typeof constructSimpleSDK>);
+
+		getTransactionReceipt = vi.fn();
+		getTransactionCountLatest = vi.fn();
+		vi.mocked(infuraProviders).mockReturnValue({
+			getTransactionReceipt,
+			getTransactionCountLatest
+		} as unknown as ReturnType<typeof infuraProviders>);
+	});
+
+	it('does nothing for an empty list', async () => {
+		await pollVeloraActiveUserTransactions({
+			identity: mockIdentity,
+			transactions: [],
+			userAddress: mockEthAddress
+		});
+
+		expect(constructSimpleSDK).not.toHaveBeenCalled();
+		expect(infuraProviders).not.toHaveBeenCalled();
+		expect(applySpy).not.toHaveBeenCalled();
+	});
+
+	describe('Delta', () => {
+		it('skips a row without an auction id', async () => {
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [
+					buildTx({ mode: 'Delta', refs: { [VELORA_EXTERNAL_REF_KEYS.CHAIN_ID]: '1' } })
+				],
+				userAddress: mockEthAddress
+			});
+
+			expect(getDeltaOrderById).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('constructs the SDK for the stored chain and reads the stored auction', async () => {
+			getDeltaOrderById.mockResolvedValue({ status: 'ACTIVE', transactions: [], refunds: [] });
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Delta', refs: deltaRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(constructSimpleSDK).toHaveBeenCalledWith(expect.objectContaining({ chainId: 1 }));
+			expect(getDeltaOrderById).toHaveBeenCalledExactlyOnceWith('auction-1');
+		});
+
+		it('advances a pending row to Executing', async () => {
+			getDeltaOrderById.mockResolvedValue({ status: 'ACTIVE', transactions: [], refunds: [] });
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Delta', refs: deltaRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({ status: { Executing: null } })
+				})
+			);
+		});
+
+		it('terminalizes a completed order and persists the settlement hashes', async () => {
+			getDeltaOrderById.mockResolvedValue({
+				status: 'COMPLETED',
+				transactions: [{ originTx: '0xorigin', destinationTx: '0xdestination' }],
+				refunds: []
+			});
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Delta', refs: deltaRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						status: { Succeeded: null },
+						externalRefs: expect.arrayContaining([
+							{ key: VELORA_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH, value: '0xorigin' },
+							{ key: VELORA_EXTERNAL_REF_KEYS.DEST_TX_HASH, value: '0xdestination' }
+						])
+					})
+				})
+			);
+		});
+
+		it('terminalizes a refunded order with the refund error text', async () => {
+			getDeltaOrderById.mockResolvedValue({
+				status: 'REFUNDED',
+				transactions: [],
+				refunds: [{ tx: '0xrefund', chainId: 1, token: '0xtoken', amount: '1' }]
+			});
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Delta', refs: deltaRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						status: { Failed: null },
+						error: en.swap.error.swap_refunded,
+						externalRefs: expect.arrayContaining([
+							{ key: VELORA_EXTERNAL_REF_KEYS.REFUND_TX_HASH, value: '0xrefund' }
+						])
+					})
+				})
+			);
+		});
+
+		it('leaves the row untouched on an unrecognised status', async () => {
+			getDeltaOrderById.mockResolvedValue({
+				status: 'SOMETHING_NEW',
+				transactions: [],
+				refunds: []
+			});
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Delta', refs: deltaRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('writes newly-learned hashes even when the status does not advance', async () => {
+			getDeltaOrderById.mockResolvedValue({
+				status: 'ACTIVE',
+				transactions: [{ originTx: '0xorigin', destinationTx: null }],
+				refunds: []
+			});
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Delta', refs: deltaRefs, status: { Executing: null } })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						externalRefs: expect.arrayContaining([
+							{ key: VELORA_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH, value: '0xorigin' }
+						])
+					})
+				})
+			);
+			expect(applySpy.mock.calls[0][0].update).not.toHaveProperty('status');
+		});
+
+		it('does not write when nothing changed', async () => {
+			getDeltaOrderById.mockResolvedValue({ status: 'ACTIVE', transactions: [], refunds: [] });
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Delta', refs: deltaRefs, status: { Executing: null } })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('polls Delta rows even without an EVM address', async () => {
+			getDeltaOrderById.mockResolvedValue({ status: 'ACTIVE', transactions: [], refunds: [] });
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Delta', refs: deltaRefs })],
+				userAddress: undefined
+			});
+
+			expect(getDeltaOrderById).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('Market', () => {
+		it('skips a row without a hash or nonce', async () => {
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [
+					buildTx({ mode: 'Market', refs: { [VELORA_EXTERNAL_REF_KEYS.CHAIN_ID]: '1' } })
+				],
+				userAddress: mockEthAddress
+			});
+
+			expect(getTransactionReceipt).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('skips Market rows when the EVM address is unavailable', async () => {
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Market', refs: marketRefs })],
+				userAddress: null
+			});
+
+			expect(getTransactionReceipt).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('resolves the provider from the stored chain id', async () => {
+			getTransactionReceipt.mockResolvedValue({ status: 1 });
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Market', refs: marketRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(infuraProviders).toHaveBeenCalledWith(ETHEREUM_NETWORK_ID);
+		});
+
+		it('terminalizes a mined transaction as Succeeded', async () => {
+			getTransactionReceipt.mockResolvedValue({ status: 1 });
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Market', refs: marketRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({ status: { Succeeded: null } })
+				})
+			);
+			expect(getTransactionCountLatest).not.toHaveBeenCalled();
+		});
+
+		it('terminalizes a reverted transaction as Failed', async () => {
+			getTransactionReceipt.mockResolvedValue({ status: 0 });
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Market', refs: marketRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({
+						status: { Failed: null },
+						error: en.swap.error.failed_unexpectedly
+					})
+				})
+			);
+		});
+
+		it('keeps a still-unmined transaction Executing', async () => {
+			getTransactionReceipt.mockResolvedValue(null);
+			getTransactionCountLatest.mockResolvedValue(5);
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [buildTx({ mode: 'Market', refs: marketRefs })],
+				userAddress: mockEthAddress
+			});
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					update: expect.objectContaining({ status: { Executing: null } })
+				})
+			);
+		});
+
+		describe('replacement rule', () => {
+			it('does not terminalize on a single replaced observation', async () => {
+				getTransactionReceipt.mockResolvedValue(null);
+				getTransactionCountLatest.mockResolvedValue(6);
+
+				await pollVeloraActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [buildTx({ mode: 'Market', refs: marketRefs })],
+					userAddress: mockEthAddress
+				});
+
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: expect.objectContaining({ status: { Executing: null } })
+					})
+				);
+			});
+
+			it('terminalizes as Failed on the second consecutive replaced observation', async () => {
+				getTransactionReceipt.mockResolvedValue(null);
+				getTransactionCountLatest.mockResolvedValue(6);
+
+				const tx = buildTx({ mode: 'Market', refs: marketRefs, status: { Executing: null } });
+
+				await pollVeloraActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [tx],
+					userAddress: mockEthAddress
+				});
+				await pollVeloraActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [tx],
+					userAddress: mockEthAddress
+				});
+
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: expect.objectContaining({
+							status: { Failed: null },
+							error: en.swap.error.swap_replaced_or_dropped
+						})
+					})
+				);
+			});
+
+			it('does not produce a false Failed when the receipt merely lands late', async () => {
+				// The nonce read races our own confirmation: the re-read finds the receipt.
+				getTransactionReceipt.mockResolvedValueOnce(null).mockResolvedValueOnce({ status: 1 });
+				getTransactionCountLatest.mockResolvedValue(6);
+
+				await pollVeloraActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [buildTx({ mode: 'Market', refs: marketRefs })],
+					userAddress: mockEthAddress
+				});
+
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: expect.objectContaining({ status: { Succeeded: null } })
+					})
+				);
+			});
+
+			it('resets the count when the row stops looking replaced', async () => {
+				const tx = buildTx({ mode: 'Market', refs: marketRefs, status: { Executing: null } });
+
+				getTransactionReceipt.mockResolvedValue(null);
+				getTransactionCountLatest.mockResolvedValue(6);
+				await pollVeloraActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [tx],
+					userAddress: mockEthAddress
+				});
+
+				// A healthy tick in between must clear the evidence.
+				getTransactionCountLatest.mockResolvedValue(5);
+				await pollVeloraActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [tx],
+					userAddress: mockEthAddress
+				});
+
+				getTransactionCountLatest.mockResolvedValue(6);
+				await pollVeloraActiveUserTransactions({
+					identity: mockIdentity,
+					transactions: [tx],
+					userAddress: mockEthAddress
+				});
+
+				expect(applySpy).not.toHaveBeenCalled();
+			});
+		});
+
+		it('reads the confirmed nonce once for several rows on the same chain', async () => {
+			getTransactionReceipt.mockResolvedValue(null);
+			getTransactionCountLatest.mockResolvedValue(5);
+
+			await pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [
+					buildTx({ mode: 'Market', refs: marketRefs, id: 'row-a' }),
+					buildTx({
+						mode: 'Market',
+						refs: { ...marketRefs, [VELORA_EXTERNAL_REF_KEYS.TX_HASH]: '0xhash2' },
+						id: 'row-b'
+					})
+				],
+				userAddress: mockEthAddress
+			});
+
+			expect(getTransactionReceipt).toHaveBeenCalledTimes(2);
+			expect(getTransactionCountLatest).toHaveBeenCalledOnce();
+		});
+	});
+
+	it('isolates a failing row from the rest of the batch', async () => {
+		getDeltaOrderById.mockRejectedValue(new Error('velora down'));
+		getTransactionReceipt.mockResolvedValue({ status: 1 });
+
+		await expect(
+			pollVeloraActiveUserTransactions({
+				identity: mockIdentity,
+				transactions: [
+					buildTx({ mode: 'Delta', refs: deltaRefs, id: 'row-delta' }),
+					buildTx({ mode: 'Market', refs: marketRefs, id: 'row-market' })
+				],
+				userAddress: mockEthAddress
+			})
+		).resolves.toBeUndefined();
+
+		expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({
+				update: expect.objectContaining({ status: { Succeeded: null } })
+			})
+		);
+	});
+});

--- a/src/frontend/src/tests/lib/utils/velora-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/velora-active-tx.utils.spec.ts
@@ -1,0 +1,387 @@
+import type { ActiveUserTransactionRef } from '$declarations/backend/backend.did';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import type { Erc20Token } from '$eth/types/erc20';
+import type { Erc4626Token } from '$eth/types/erc4626';
+import en from '$lib/i18n/en.json';
+import { SwapProvider, VeloraSwapTypes } from '$lib/types/swap';
+import { VELORA_EXTERNAL_REF_KEYS } from '$lib/types/velora-swap';
+import {
+	buildVeloraSwapTrackingMetadata,
+	isVeloraActiveUserTransaction,
+	toVeloraData,
+	toVeloraDeltaLearnedRefs,
+	toVeloraDeltaStatus,
+	toVeloraDisplayRefs,
+	toVeloraExternalRefs,
+	toVeloraExternalRefsMap,
+	toVeloraMarketOutcome,
+	veloraDeltaStatusError,
+	veloraMarketOutcomeError,
+	veloraMarketOutcomeToStatus,
+	veloraSwapModeKey
+} from '$lib/utils/velora-active-tx.utils';
+import { parseTokenId } from '$lib/validation/token.validation';
+import {
+	mockActiveUserTransaction,
+	mockVeloraActiveUserTransaction
+} from '$tests/mocks/active-user-transactions.mock';
+import { mockValidErc4626Token } from '$tests/mocks/erc4626-tokens.mock';
+import { mockValidToken } from '$tests/mocks/tokens.mock';
+import type { DeltaAuction, DeltaOrderStatus } from '@velora-dex/sdk';
+
+const USDC_ETHEREUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const USDT_ETHEREUM = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+
+const makeErc20Token = (address: string): Erc20Token => ({
+	...mockValidToken,
+	id: parseTokenId(`Erc20-${address}`),
+	standard: { code: 'erc20' },
+	address,
+	network: ETHEREUM_NETWORK
+});
+
+const makeErc4626Token = (address: string): Erc4626Token => ({
+	...mockValidErc4626Token,
+	id: parseTokenId(`Erc4626-${address}`),
+	address,
+	network: ETHEREUM_NETWORK
+});
+
+const auctionWithStatus = (status: DeltaOrderStatus): Pick<DeltaAuction, 'status'> => ({ status });
+
+describe('velora-active-tx.utils', () => {
+	describe('isVeloraActiveUserTransaction', () => {
+		it('is true for a Velora row', () => {
+			expect(isVeloraActiveUserTransaction(mockVeloraActiveUserTransaction)).toBeTruthy();
+		});
+
+		it('is false for another provider', () => {
+			expect(isVeloraActiveUserTransaction(mockActiveUserTransaction)).toBeFalsy();
+		});
+	});
+
+	describe('veloraSwapModeKey', () => {
+		it('maps the stored mode onto the analytics swap type', () => {
+			expect(veloraSwapModeKey({ Delta: null })).toBe(VeloraSwapTypes.DELTA);
+			expect(veloraSwapModeKey({ Market: null })).toBe(VeloraSwapTypes.MARKET);
+		});
+	});
+
+	describe('toVeloraData', () => {
+		it('builds the variant for an ERC-20 pair', () => {
+			expect(
+				toVeloraData({
+					mode: { Delta: null },
+					sourceToken: makeErc20Token(USDC_ETHEREUM),
+					destinationToken: makeErc20Token(USDT_ETHEREUM),
+					amount: 5n
+				})
+			).toEqual({
+				Velora: {
+					mode: { Delta: null },
+					source_token: { Erc20: [USDC_ETHEREUM, ETHEREUM_NETWORK.chainId] },
+					dest_token: { Erc20: [USDT_ETHEREUM, ETHEREUM_NETWORK.chainId] },
+					amount: 5n
+				}
+			});
+		});
+
+		it('builds the variant for an ERC-4626 vault token', () => {
+			expect(
+				toVeloraData({
+					mode: { Market: null },
+					sourceToken: makeErc4626Token(USDC_ETHEREUM),
+					destinationToken: makeErc20Token(USDT_ETHEREUM),
+					amount: 5n
+				})
+			).toEqual({
+				Velora: {
+					mode: { Market: null },
+					source_token: { Erc4626: [USDC_ETHEREUM, ETHEREUM_NETWORK.chainId] },
+					dest_token: { Erc20: [USDT_ETHEREUM, ETHEREUM_NETWORK.chainId] },
+					amount: 5n
+				}
+			});
+		});
+
+		it('builds the variant for a native EVM source', () => {
+			expect(
+				toVeloraData({
+					mode: { Market: null },
+					sourceToken: ETHEREUM_TOKEN,
+					destinationToken: makeErc20Token(USDT_ETHEREUM),
+					amount: 5n
+				})
+			).toEqual({
+				Velora: {
+					mode: { Market: null },
+					source_token: { EvmNative: ETHEREUM_NETWORK.chainId },
+					dest_token: { Erc20: [USDT_ETHEREUM, ETHEREUM_NETWORK.chainId] },
+					amount: 5n
+				}
+			});
+		});
+
+		it('returns undefined when a token cannot be mapped to a backend TokenId', () => {
+			expect(
+				toVeloraData({
+					mode: { Delta: null },
+					sourceToken: makeErc20Token(USDC_ETHEREUM),
+					destinationToken: BTC_MAINNET_TOKEN,
+					amount: 5n
+				})
+			).toBeUndefined();
+		});
+	});
+
+	describe('external refs', () => {
+		it('builds a deterministic sorted array and drops empties', () => {
+			expect(
+				toVeloraExternalRefs({
+					[VELORA_EXTERNAL_REF_KEYS.TX_HASH]: '0xhash',
+					[VELORA_EXTERNAL_REF_KEYS.CHAIN_ID]: '1',
+					[VELORA_EXTERNAL_REF_KEYS.ORDER_HASH]: '',
+					[VELORA_EXTERNAL_REF_KEYS.AUCTION_ID]: undefined
+				})
+			).toEqual([
+				{ key: VELORA_EXTERNAL_REF_KEYS.CHAIN_ID, value: '1' },
+				{ key: VELORA_EXTERNAL_REF_KEYS.TX_HASH, value: '0xhash' }
+			]);
+		});
+
+		it('round-trips through the keyed map', () => {
+			const refs: ActiveUserTransactionRef[] = [
+				{ key: VELORA_EXTERNAL_REF_KEYS.AUCTION_ID, value: 'auction-1' },
+				{ key: VELORA_EXTERNAL_REF_KEYS.TX_NONCE, value: '7' }
+			];
+
+			const map = toVeloraExternalRefsMap(refs);
+
+			expect(map[VELORA_EXTERNAL_REF_KEYS.AUCTION_ID]).toBe('auction-1');
+			expect(map[VELORA_EXTERNAL_REF_KEYS.TX_NONCE]).toBe('7');
+			expect(map[VELORA_EXTERNAL_REF_KEYS.TX_HASH]).toBeUndefined();
+		});
+
+		it('snapshots the display fields', () => {
+			expect(
+				toVeloraDisplayRefs({
+					sourceToken: makeErc20Token(USDC_ETHEREUM),
+					destinationToken: makeErc20Token(USDT_ETHEREUM),
+					amount: '1.5',
+					usdSourceValue: '1.5015'
+				})
+			).toEqual({
+				[VELORA_EXTERNAL_REF_KEYS.AMOUNT]: '1.5',
+				[VELORA_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE]: '1.5015',
+				[VELORA_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL]: mockValidToken.symbol,
+				[VELORA_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL]: ETHEREUM_NETWORK.name,
+				[VELORA_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]: mockValidToken.symbol,
+				[VELORA_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL]: ETHEREUM_NETWORK.name
+			});
+		});
+
+		it('omits the USD value when no exchange rate was available', () => {
+			expect(
+				toVeloraDisplayRefs({
+					sourceToken: makeErc20Token(USDC_ETHEREUM),
+					destinationToken: makeErc20Token(USDT_ETHEREUM),
+					amount: '1.5'
+				})
+			).not.toHaveProperty(VELORA_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE);
+		});
+	});
+
+	describe('toVeloraDeltaLearnedRefs', () => {
+		it('extracts the settlement and refund hashes', () => {
+			expect(
+				toVeloraDeltaLearnedRefs({
+					transactions: [
+						{
+							originTx: '0xorigin',
+							destinationTx: '0xdestination',
+							filledPercent: 100,
+							spentAmount: null,
+							receivedAmount: null
+						}
+					],
+					refunds: [{ tx: '0xrefund', chainId: 1, token: '0xtoken', amount: '1' }]
+				})
+			).toEqual({
+				[VELORA_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH]: '0xorigin',
+				[VELORA_EXTERNAL_REF_KEYS.DEST_TX_HASH]: '0xdestination',
+				[VELORA_EXTERNAL_REF_KEYS.REFUND_TX_HASH]: '0xrefund'
+			});
+		});
+
+		it('omits a destination hash that has not landed yet', () => {
+			expect(
+				toVeloraDeltaLearnedRefs({
+					transactions: [
+						{
+							originTx: '0xorigin',
+							destinationTx: null,
+							filledPercent: 50,
+							spentAmount: null,
+							receivedAmount: null
+						}
+					],
+					refunds: []
+				})
+			).toEqual({ [VELORA_EXTERNAL_REF_KEYS.ORIGIN_TX_HASH]: '0xorigin' });
+		});
+
+		it('returns nothing when the order has revealed no hashes', () => {
+			expect(toVeloraDeltaLearnedRefs({ transactions: [], refunds: [] })).toEqual({});
+		});
+	});
+
+	describe('toVeloraDeltaStatus', () => {
+		it.each<DeltaOrderStatus>(['PENDING', 'AWAITING_SIGNATURE', 'ACTIVE', 'BRIDGING'])(
+			'maps the in-flight status %s to Executing',
+			(status) => {
+				expect(toVeloraDeltaStatus(auctionWithStatus(status))).toEqual({ Executing: null });
+			}
+		);
+
+		// Neither SDK partition covers these, and both are recoverable — an early
+		// Failed write could never be walked back.
+		it.each<DeltaOrderStatus>(['SUSPENDED', 'CANCELLING'])(
+			'does NOT treat %s as terminal',
+			(status) => {
+				expect(toVeloraDeltaStatus(auctionWithStatus(status))).toEqual({ Executing: null });
+			}
+		);
+
+		it('maps COMPLETED to Succeeded', () => {
+			expect(toVeloraDeltaStatus(auctionWithStatus('COMPLETED'))).toEqual({ Succeeded: null });
+		});
+
+		it.each<DeltaOrderStatus>(['FAILED', 'EXPIRED', 'CANCELLED', 'REFUNDED', 'REFUNDING'])(
+			'maps the failed status %s to Failed',
+			(status) => {
+				expect(toVeloraDeltaStatus(auctionWithStatus(status))).toEqual({ Failed: null });
+			}
+		);
+
+		it('returns undefined for an unrecognised status so the row is left untouched', () => {
+			expect(
+				toVeloraDeltaStatus(auctionWithStatus('SOMETHING_NEW' as DeltaOrderStatus))
+			).toBeUndefined();
+		});
+	});
+
+	describe('veloraDeltaStatusError', () => {
+		it.each<DeltaOrderStatus>(['REFUNDED', 'REFUNDING'])('reports %s as a refund', (status) => {
+			expect(veloraDeltaStatusError(status)).toBe(en.swap.error.swap_refunded);
+		});
+
+		it.each<DeltaOrderStatus>(['FAILED', 'EXPIRED', 'CANCELLED'])(
+			'reports %s as a generic failure',
+			(status) => {
+				expect(veloraDeltaStatusError(status)).toBe(en.swap.error.failed_unexpectedly);
+			}
+		);
+
+		it('has no error text for a non-terminal status', () => {
+			expect(veloraDeltaStatusError('ACTIVE')).toBeUndefined();
+		});
+	});
+
+	describe('toVeloraMarketOutcome', () => {
+		it('reads a mined, executed transaction as succeeded', () => {
+			expect(toVeloraMarketOutcome({ receipt: { status: 1 }, txNonce: 5 })).toBe('succeeded');
+		});
+
+		it('reads a mined, reverted transaction as reverted', () => {
+			expect(toVeloraMarketOutcome({ receipt: { status: 0 }, txNonce: 5 })).toBe('reverted');
+		});
+
+		it('reads an unexpected receipt shape as unknown', () => {
+			expect(toVeloraMarketOutcome({ receipt: { status: null }, txNonce: 5 })).toBe('unknown');
+		});
+
+		it('reads a missing receipt with an unconsumed nonce as pending', () => {
+			expect(toVeloraMarketOutcome({ receipt: null, confirmedNonce: 5, txNonce: 5 })).toBe(
+				'pending'
+			);
+		});
+
+		it('reads a missing receipt with a consumed nonce as replaced', () => {
+			expect(toVeloraMarketOutcome({ receipt: null, confirmedNonce: 6, txNonce: 5 })).toBe(
+				'replaced'
+			);
+		});
+
+		it('stays pending when the confirmed nonce is unknown', () => {
+			expect(toVeloraMarketOutcome({ receipt: null, txNonce: 5 })).toBe('pending');
+		});
+	});
+
+	describe('veloraMarketOutcomeToStatus', () => {
+		it('maps every outcome onto its AUT status', () => {
+			expect(veloraMarketOutcomeToStatus('succeeded')).toEqual({ Succeeded: null });
+			expect(veloraMarketOutcomeToStatus('reverted')).toEqual({ Failed: null });
+			expect(veloraMarketOutcomeToStatus('replaced')).toEqual({ Failed: null });
+			expect(veloraMarketOutcomeToStatus('pending')).toEqual({ Executing: null });
+			expect(veloraMarketOutcomeToStatus('unknown')).toBeUndefined();
+		});
+	});
+
+	describe('veloraMarketOutcomeError', () => {
+		it('reports a reverted transaction as a generic failure', () => {
+			expect(veloraMarketOutcomeError('reverted')).toBe(en.swap.error.failed_unexpectedly);
+		});
+
+		it('reports a replaced transaction with its own copy', () => {
+			expect(veloraMarketOutcomeError('replaced')).toBe(en.swap.error.swap_replaced_or_dropped);
+		});
+
+		it('has no error text for a non-terminal outcome', () => {
+			expect(veloraMarketOutcomeError('pending')).toBeUndefined();
+		});
+	});
+
+	describe('buildVeloraSwapTrackingMetadata', () => {
+		it('reads the snapshot off the row', () => {
+			expect(
+				buildVeloraSwapTrackingMetadata({ tx: mockVeloraActiveUserTransaction })
+			).toStrictEqual({
+				sourceToken: 'USDC',
+				destinationToken: 'USDT',
+				dApp: SwapProvider.VELORA,
+				tokenAmount: '1',
+				usdSourceValue: '1.0002',
+				sourceNetwork: 'Ethereum',
+				destinationNetwork: 'Ethereum',
+				swapType: VeloraSwapTypes.DELTA
+			});
+		});
+
+		it('passes the row error through', () => {
+			expect(
+				buildVeloraSwapTrackingMetadata({
+					tx: { ...mockVeloraActiveUserTransaction, error: ['boom'] }
+				})
+			).toEqual(expect.objectContaining({ error: 'boom' }));
+		});
+
+		it('falls back to empty strings when the row carries no display refs', () => {
+			expect(
+				buildVeloraSwapTrackingMetadata({
+					tx: { ...mockVeloraActiveUserTransaction, external_refs: [] }
+				})
+			).toStrictEqual({
+				sourceToken: '',
+				destinationToken: '',
+				dApp: SwapProvider.VELORA,
+				tokenAmount: '',
+				usdSourceValue: '',
+				sourceNetwork: '',
+				destinationNetwork: '',
+				swapType: VeloraSwapTypes.DELTA
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/utils/velora-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/velora-active-tx.utils.spec.ts
@@ -254,11 +254,18 @@ describe('velora-active-tx.utils', () => {
 			}
 		);
 
+		// In the SDK's failed partition, but the refund has not landed yet:
+		// terminalizing here would claim the swap "was refunded" early and stop the
+		// poller before it can persist the refund hash.
+		it('does NOT treat REFUNDING as terminal, despite the SDK failed partition', () => {
+			expect(toVeloraDeltaStatus(auctionWithStatus('REFUNDING'))).toEqual({ Executing: null });
+		});
+
 		it('maps COMPLETED to Succeeded', () => {
 			expect(toVeloraDeltaStatus(auctionWithStatus('COMPLETED'))).toEqual({ Succeeded: null });
 		});
 
-		it.each<DeltaOrderStatus>(['FAILED', 'EXPIRED', 'CANCELLED', 'REFUNDED', 'REFUNDING'])(
+		it.each<DeltaOrderStatus>(['FAILED', 'EXPIRED', 'CANCELLED', 'REFUNDED'])(
 			'maps the failed status %s to Failed',
 			(status) => {
 				expect(toVeloraDeltaStatus(auctionWithStatus(status))).toEqual({ Failed: null });
@@ -273,8 +280,13 @@ describe('velora-active-tx.utils', () => {
 	});
 
 	describe('veloraDeltaStatusError', () => {
-		it.each<DeltaOrderStatus>(['REFUNDED', 'REFUNDING'])('reports %s as a refund', (status) => {
-			expect(veloraDeltaStatusError(status)).toBe(en.swap.error.swap_refunded);
+		it('reports REFUNDED as a refund', () => {
+			expect(veloraDeltaStatusError('REFUNDED')).toBe(en.swap.error.swap_refunded);
+		});
+
+		// It never reaches a Failed write, so it never carries an error.
+		it('has no error text for REFUNDING', () => {
+			expect(veloraDeltaStatusError('REFUNDING')).toBeUndefined();
 		});
 
 		it.each<DeltaOrderStatus>(['FAILED', 'EXPIRED', 'CANCELLED'])(

--- a/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
@@ -5,7 +5,8 @@ import type {
 	ActiveUserTransactionRef,
 	LiquidiumData,
 	NearIntentsData,
-	OneSecIcpToEvmData
+	OneSecIcpToEvmData,
+	VeloraData
 } from '$declarations/backend/backend.did';
 import { ZERO } from '$lib/constants/app.constants';
 import type {
@@ -14,6 +15,7 @@ import type {
 } from '$lib/types/api';
 import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
 import { NEAR_INTENTS_EXTERNAL_REF_KEYS } from '$lib/types/near-intents';
+import { VELORA_EXTERNAL_REF_KEYS } from '$lib/types/velora-swap';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 
 export const mockActiveUserTransactionId = '11111111-1111-4111-8111-111111111111';
@@ -49,6 +51,33 @@ export const mockNearIntentsActiveUserTransaction: ActiveUserTransaction = {
 		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL, value: 'Ethereum' },
 		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL, value: 'USDC' },
 		{ key: NEAR_INTENTS_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL, value: 'Solana' }
+	],
+	created_at_ns: ZERO,
+	updated_at_ns: ZERO,
+	error: []
+};
+
+export const mockVeloraData: VeloraData = {
+	mode: { Delta: null },
+	source_token: { Erc20: ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 1n] },
+	dest_token: { Erc20: ['0xdAC17F958D2ee523a2206206994597C13D831ec7', 1n] },
+	amount: 1_000_000n
+};
+
+export const mockVeloraActiveUserTransaction: ActiveUserTransaction = {
+	id: '44444444-4444-4444-8444-444444444444',
+	status: { Pending: null },
+	data: { Velora: mockVeloraData },
+	progress_step: [],
+	external_refs: [
+		{ key: VELORA_EXTERNAL_REF_KEYS.AUCTION_ID, value: 'auction-123' },
+		{ key: VELORA_EXTERNAL_REF_KEYS.CHAIN_ID, value: '1' },
+		{ key: VELORA_EXTERNAL_REF_KEYS.AMOUNT, value: '1' },
+		{ key: VELORA_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE, value: '1.0002' },
+		{ key: VELORA_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL, value: 'USDC' },
+		{ key: VELORA_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL, value: 'Ethereum' },
+		{ key: VELORA_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL, value: 'USDT' },
+		{ key: VELORA_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL, value: 'Ethereum' }
 	],
 	created_at_ns: ZERO,
 	updated_at_ns: ZERO,


### PR DESCRIPTION
# Motivation

This PR moves Velora provider onto the existing Active User Transactions mechanism, so a committed swap is driven to a terminal state by the global poller and survives modal close, tab close, refresh and logout — the same way 1Sec, Liquidium and NEAR Intents already work.

Final PR of three. Depends on `feat(backend)!: add Velora variant to active-user-transaction data` and `feat(frontend): upgrade Velora SDK to the latest version` (#13620), both merged.

# Changes

- **Execution:** both `fetchVelora*Swap` register an AUT row best-effort at commit and return; `checkDeltaOrderStatus` and its constants/types are deleted, and the balance refresh moves to the AUT terminal side-effect.
- **Poller** (new `velora-active-tx.services.ts` + `velora-active-tx.utils.ts`): Delta via `getDeltaOrderById`, Market via receipt + nonce reconciliation. Delta maps through the SDK's own partitions, with `SUSPENDED`/`CANCELLING` explicitly non-terminal; Market re-reads the receipt and needs two consecutive observations before calling a tx replaced, since terminal states are immutable.
- **Plumbing:** `InfuraProvider.getTransactionReceipt`; `swap()` returns `{ hash, nonce }`.
- **UI:** Velora joins `isActiveTransactionSwap` in `SwapEthWizard`; 4th branch and 4th terminal arm in `LoaderActiveUserTransactions`; Velora rows render as swaps, with the network line collapsed when source and destination match.
- **i18n:** new `swap.error.swap_replaced_or_dropped`, and `swap.text.finishing_in_background` for the non-bridging providers — `starting_to_bridge` is untouched and stays with 1Sec.

# Tests

Updated.
