### PR TITLE
fix(frontend): sanitize consent message strictly and drop the approval form

### DIFF
--- a/docs/ai/frontend/stack-and-patterns.md
+++ b/docs/ai/frontend/stack-and-patterns.md
@@ -212,6 +212,10 @@ component uses. Never re-implement an icon that already exists.
   `$lib/services/auth.services` and `$lib/providers/auth-client.providers`.
 - Any HTML coming from backend / user input must be sanitized before
   `{@html …}`.
+- Text authored by a third party — e.g. a consent message built from data a
+  relying party supplies — goes through `sanitizeUntrusted` (`untrusted` prop
+  on `Html` / `Markdown`), which keeps only the markup Markdown can produce.
+  Never render it inside a `<form>` that drives a sensitive action.
 - External links: `target="_blank"` requires `rel="noopener noreferrer"`.
 - Threshold-signature operations are routed through the chain-fusion
   signer canister — not implemented here. See

--- a/src/frontend/src/lib/components/signer/SignerConsentMessage.svelte
+++ b/src/frontend/src/lib/components/signer/SignerConsentMessage.svelte
@@ -19,7 +19,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SIGNER_CONTEXT_KEY, type SignerContext } from '$lib/stores/signer.store';
 	import { toastsError } from '$lib/stores/toasts.store';
-	import { preventDefault } from '$lib/utils/event-modifiers.utils';
 	import { mapSignerOriginHost } from '$lib/utils/signer.utils';
 
 	const {
@@ -160,7 +159,8 @@
 {:else if nonNullish(text)}
 	{@const { title, content } = text}
 
-	<form method="POST" onsubmit={preventDefault(onApprove)} in:fade>
+	<!-- The consent message is authored by the relying party. It is rendered outside of any form, and approving is a click on our own button rather than a form submission, so that no markup coming from that text can ever reach the approval handler. -->
+	<div in:fade>
 		<h2 class="mb-4 text-center">{title}</h2>
 
 		<SignerOrigin payload={$payload} />
@@ -168,18 +168,18 @@
 		<SignerConsentMessageWarning {consentInfo} />
 
 		<div class="msg mb-6 rounded-lg border border-off-white px-8 py-4 break-all">
-			<Markdown text={content} />
+			<Markdown text={content} untrusted />
 		</div>
 
 		<ButtonGroup>
-			<Button colorStyle="error" onclick={onReject}>
+			<Button colorStyle="error" onclick={onReject} type="button">
 				{$i18n.core.text.reject}
 			</Button>
-			<Button colorStyle="success" type="submit">
+			<Button colorStyle="success" onclick={onApprove} type="button">
 				{$i18n.core.text.approve}
 			</Button>
 		</ButtonGroup>
-	</form>
+	</div>
 {/if}
 
 <style lang="scss">

--- a/src/frontend/src/lib/components/ui/Html.svelte
+++ b/src/frontend/src/lib/components/ui/Html.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { onMount } from 'svelte';
-	import { sanitize } from '$lib/utils/html.utils';
+	import { sanitize, sanitizeUntrusted } from '$lib/utils/html.utils';
 
 	interface Props {
 		text?: string;
+		untrusted?: boolean;
 	}
 
-	let { text }: Props = $props();
+	let { text, untrusted = false }: Props = $props();
 
 	// force to rerender after SSR
 	let mounted = $state(false);
@@ -16,5 +17,5 @@
 
 {#if mounted && nonNullish(text)}
 	<!-- eslint-disable svelte/no-at-html-tags -->
-	{@html sanitize(text)}
+	{@html untrusted ? sanitizeUntrusted(text) : sanitize(text)}
 {/if}

--- a/src/frontend/src/lib/components/ui/Markdown.svelte
+++ b/src/frontend/src/lib/components/ui/Markdown.svelte
@@ -6,9 +6,10 @@
 
 	interface Props {
 		text: string | undefined;
+		untrusted?: boolean;
 	}
 
-	let { text }: Props = $props();
+	let { text, untrusted = false }: Props = $props();
 
 	let html = $state<string | undefined>();
 	let error = $state(false);
@@ -44,5 +45,5 @@
 {:else if html === undefined}
 	<LoaderSpinner inline />
 {:else}
-	<Html text={html} />
+	<Html text={html} {untrusted} />
 {/if}

--- a/src/frontend/src/lib/utils/html.utils.ts
+++ b/src/frontend/src/lib/utils/html.utils.ts
@@ -1,8 +1,51 @@
 import { consoleError } from '$lib/utils/console.utils';
-import { isNullish } from '@dfinity/utils';
-import DOMPurify from 'dompurify';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import DOMPurify, { type Config } from 'dompurify';
 
 let domPurify: typeof DOMPurify | undefined = undefined;
+
+/**
+ * Markup a text authored by a third party is allowed to produce.
+ *
+ * It covers what Markdown can render and nothing else. Notably, form controls are excluded so that
+ * such a text can never contribute a control to one of our flows, and `style` is excluded - both as
+ * a tag and as an attribute - so that it can never hide or repaint what we display next to it.
+ */
+const UNTRUSTED_CONFIG: Config = {
+	ALLOWED_TAGS: [
+		'a',
+		'b',
+		'blockquote',
+		'br',
+		'code',
+		'del',
+		'em',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'hr',
+		'i',
+		'li',
+		'ol',
+		'p',
+		'pre',
+		's',
+		'strong',
+		'sub',
+		'sup',
+		'table',
+		'tbody',
+		'td',
+		'th',
+		'thead',
+		'tr',
+		'ul'
+	],
+	ALLOWED_ATTR: ['align', 'colspan', 'href', 'lang', 'rowspan', 'title']
+};
 
 /**
  * A workaround to preserve target="_blank" attribute from sanitizer.
@@ -37,10 +80,7 @@ const flagTargetAttributeHook = (node: Element) => {
 	return node;
 };
 
-/**
- * Sanitize a text with DOMPurify.
- */
-export const sanitize = (text: string): string => {
+const sanitizeWithConfig = ({ text, config }: { text: string; config?: Config }): string => {
 	try {
 		// DOMPurify initialization
 		if (isNullish(domPurify)) {
@@ -51,13 +91,27 @@ export const sanitize = (text: string): string => {
 			domPurify.addHook('afterSanitizeAttributes', restoreTargetAttributeHook);
 		}
 
-		return domPurify.sanitize(text);
+		return nonNullish(config) ? domPurify.sanitize(text, config) : domPurify.sanitize(text);
 	} catch (err: unknown) {
 		consoleError('Failed to sanitize HTML content', err);
 	}
 
 	return '';
 };
+
+/**
+ * Sanitize a text with DOMPurify.
+ *
+ * For a text we do not author ourselves - e.g. anything derived from data a third party supplies -
+ * use `sanitizeUntrusted` instead.
+ */
+export const sanitize = (text: string): string => sanitizeWithConfig({ text });
+
+/**
+ * Sanitize a text authored by a third party, keeping only the markup listed in `UNTRUSTED_CONFIG`.
+ */
+export const sanitizeUntrusted = (text: string): string =>
+	sanitizeWithConfig({ text, config: UNTRUSTED_CONFIG });
 
 let elementsCounters: Record<string, number> = {};
 

--- a/src/frontend/src/lib/utils/html.utils.ts
+++ b/src/frontend/src/lib/utils/html.utils.ts
@@ -56,11 +56,16 @@ const UNTRUSTED_CONFIG: Config = {
 const restoreTargetAttributeHook = (node: Element) => {
 	if (node.getAttribute('data-target') === 'blank') {
 		// Use provided "rel" value if it contains "noopener" or "noreferrer" (https://web.dev/external-anchors-use-rel-noopener/)
-		// otherwise add "noopener".
+		// otherwise fall back to the pair we require on external links everywhere else.
+		// `sanitizeUntrusted` drops "rel" as an unlisted attribute, so a third-party link always
+		// lands on that fallback rather than on a value its author picked.
 		// split() to avoid invalid values (e.g. "noopenernoreferrer")
 		const originRel = node.getAttribute('rel') ?? '';
 		const parts = originRel.split(/\s+/);
-		const rel = parts.includes('noopener') || parts.includes('noreferrer') ? originRel : 'noopener';
+		const rel =
+			parts.includes('noopener') || parts.includes('noreferrer')
+				? originRel
+				: 'noopener noreferrer';
 
 		node.setAttribute('target', '_blank');
 		node.setAttribute('rel', rel);

--- a/src/frontend/src/tests/lib/components/signer/SignerConsentMessage.spec.ts
+++ b/src/frontend/src/tests/lib/components/signer/SignerConsentMessage.spec.ts
@@ -1,0 +1,120 @@
+import SignerConsentMessage from '$lib/components/signer/SignerConsentMessage.svelte';
+import { SIGNER_CONTEXT_KEY } from '$lib/stores/signer.store';
+import en from '$tests/mocks/i18n.mock';
+import type { ConsentMessagePromptPayload } from '@dfinity/oisy-wallet-signer';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+
+vi.mock('$lib/services/analytics.services', () => ({
+	trackEvent: vi.fn()
+}));
+
+describe('SignerConsentMessage', () => {
+	const approve = vi.fn();
+	const reject = vi.fn();
+	const resetConsentMessagePrompt = vi.fn();
+	const resetCallCanisterPrompt = vi.fn();
+
+	const renderComponent = (message: string) => {
+		const payload: ConsentMessagePromptPayload = {
+			origin: 'https://relying.party',
+			status: 'result',
+			consentInfo: {
+				Ok: {
+					metadata: { language: 'en', utc_offset_minutes: [] },
+					consent_message: { GenericDisplayMessage: message }
+				}
+			},
+			approve,
+			reject
+		};
+
+		return render(SignerConsentMessage, {
+			context: new Map([
+				[
+					SIGNER_CONTEXT_KEY,
+					{
+						consentMessagePrompt: {
+							payload: writable<ConsentMessagePromptPayload>(payload),
+							reset: resetConsentMessagePrompt
+						},
+						callCanisterPrompt: {
+							payload: writable(undefined),
+							reset: resetCallCanisterPrompt
+						}
+					}
+				]
+			])
+		});
+	};
+
+	// The memo of an ICRC-1 transfer is decoded verbatim into the consent message when the target
+	// ledger does not implement ICRC-21, so its content is authored by the relying party.
+	const buildMessageWithMemo = (memo: string): string =>
+		`# Approve the transfer of funds\n\n**Amount:**\n1 ICP\n\n**Memo:**\n${memo}`;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should approve when our own approve button is activated', async () => {
+		const { getByText } = renderComponent(buildMessageWithMemo('Invoice 42'));
+
+		await fireEvent.click(getByText(en.core.text.approve));
+
+		expect(approve).toHaveBeenCalledOnce();
+	});
+
+	it('should not render the dialog within a form', async () => {
+		const { container } = renderComponent(buildMessageWithMemo('Invoice 42'));
+
+		await waitFor(() => expect(container.querySelector('.msg p')).not.toBeNull());
+
+		expect(container.querySelector('form')).toBeNull();
+	});
+
+	it('should not render an interactive control originating from the consent message', async () => {
+		const { container } = renderComponent(
+			buildMessageWithMemo('<button style=zoom:99>Approve</button>')
+		);
+
+		await waitFor(() => expect(container.querySelector('.msg p')).not.toBeNull());
+
+		expect(container.querySelector('.msg button')).toBeNull();
+		// The label of the injected control remains, as inert text.
+		expect(container.querySelector('.msg')?.textContent).toContain(en.core.text.approve);
+
+		const buttons = container.querySelectorAll('button');
+
+		expect(buttons).toHaveLength(2);
+		expect(buttons[0].textContent?.trim()).toBe(en.core.text.reject);
+		expect(buttons[1].textContent?.trim()).toBe(en.core.text.approve);
+	});
+
+	it('should not approve when any element originating from the consent message is activated', async () => {
+		const { container } = renderComponent(
+			buildMessageWithMemo('<button style=zoom:99>Approve</button>')
+		);
+
+		await waitFor(() => expect(container.querySelector('.msg p')).not.toBeNull());
+
+		const consentMessage = container.querySelector('.msg');
+
+		for (const element of consentMessage?.querySelectorAll('*') ?? []) {
+			await fireEvent.click(element);
+		}
+
+		expect(approve).not.toHaveBeenCalled();
+	});
+
+	it('should not let the consent message style the dialog', async () => {
+		const { container } = renderComponent(
+			buildMessageWithMemo('<style>p{display:none}</style>Invoice 42')
+		);
+
+		await waitFor(() => expect(container.querySelector('.msg p')).not.toBeNull());
+
+		expect(container.querySelector('style')).toBeNull();
+		expect(container.innerHTML).not.toContain('display:none');
+	});
+});

--- a/src/frontend/src/tests/lib/utils/html.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/html.utils.spec.ts
@@ -1,4 +1,4 @@
-import { nextElementId, sanitize } from '$lib/utils/html.utils';
+import { nextElementId, sanitize, sanitizeUntrusted } from '$lib/utils/html.utils';
 
 const parseHtml = (html: string): HTMLElement => {
 	const container = document.createElement('div');
@@ -38,6 +38,66 @@ describe('html.utils', () => {
 
 			expect(link?.getAttribute('target')).toBe('_blank');
 			expect(link?.getAttribute('rel')).toBe('noreferrer external');
+		});
+	});
+
+	describe('sanitizeUntrusted', () => {
+		it('should keep the markup markdown can produce', () => {
+			const result = sanitizeUntrusted(
+				'<h1>Title</h1><p><strong>Amount:</strong> 1 ICP</p><ul><li>item</li></ul>'
+			);
+			const container = parseHtml(result);
+
+			expect(container.querySelector('h1')?.textContent).toBe('Title');
+			expect(container.querySelector('strong')?.textContent).toBe('Amount:');
+			expect(container.querySelector('li')?.textContent).toBe('item');
+		});
+
+		it('should preserve target blank links with noopener rel', () => {
+			const result = sanitizeUntrusted('<a href="https://oisy.com" target="_blank">OISY</a>');
+			const link = parseHtml(result).querySelector('a');
+
+			expect(link?.getAttribute('href')).toBe('https://oisy.com');
+			expect(link?.getAttribute('target')).toBe('_blank');
+			expect(link?.getAttribute('rel')).toBe('noopener');
+			expect(link?.getAttribute('data-target')).toBeNull();
+		});
+
+		it('should remove buttons and other form controls', () => {
+			const result = sanitizeUntrusted(
+				'<button style=zoom:99>Approve</button><input type="submit"><select></select><textarea></textarea>'
+			);
+			const container = parseHtml(result);
+
+			expect(container.querySelector('button')).toBeNull();
+			expect(container.querySelector('input')).toBeNull();
+			expect(container.querySelector('select')).toBeNull();
+			expect(container.querySelector('textarea')).toBeNull();
+		});
+
+		it('should remove style tags and inline styles', () => {
+			const result = sanitizeUntrusted('<style>p{display:none}</style><p style="zoom:99">Fee</p>');
+			const container = parseHtml(result);
+
+			expect(container.querySelector('style')).toBeNull();
+			expect(container.querySelector('p')?.getAttribute('style')).toBeNull();
+			expect(result).not.toContain('display:none');
+		});
+
+		it('should remove elements carrying event handlers', () => {
+			const result = sanitizeUntrusted('<p onclick="alert(1)">Fee</p><img src="x" onerror="1">');
+			const container = parseHtml(result);
+
+			expect(container.querySelector('p')?.getAttribute('onclick')).toBeNull();
+			expect(container.querySelector('img')).toBeNull();
+		});
+
+		it('should not let the default sanitizer configuration leak into a subsequent call', () => {
+			sanitizeUntrusted('<button>Approve</button>');
+
+			const result = sanitize('<button>Approve</button>');
+
+			expect(parseHtml(result).querySelector('button')).not.toBeNull();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/utils/html.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/html.utils.spec.ts
@@ -20,13 +20,13 @@ describe('html.utils', () => {
 			expect(container.textContent).toBe('Hello');
 		});
 
-		it('should preserve target blank links with noopener rel', () => {
+		it('should preserve target blank links with noopener noreferrer rel', () => {
 			const result = sanitize('<a href="https://oisy.com" target="_blank">OISY</a>');
 			const link = parseHtml(result).querySelector('a');
 
 			expect(link?.getAttribute('href')).toBe('https://oisy.com');
 			expect(link?.getAttribute('target')).toBe('_blank');
-			expect(link?.getAttribute('rel')).toBe('noopener');
+			expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
 			expect(link?.getAttribute('data-target')).toBeNull();
 		});
 
@@ -53,13 +53,13 @@ describe('html.utils', () => {
 			expect(container.querySelector('li')?.textContent).toBe('item');
 		});
 
-		it('should preserve target blank links with noopener rel', () => {
+		it('should preserve target blank links with noopener noreferrer rel', () => {
 			const result = sanitizeUntrusted('<a href="https://oisy.com" target="_blank">OISY</a>');
 			const link = parseHtml(result).querySelector('a');
 
 			expect(link?.getAttribute('href')).toBe('https://oisy.com');
 			expect(link?.getAttribute('target')).toBe('_blank');
-			expect(link?.getAttribute('rel')).toBe('noopener');
+			expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
 			expect(link?.getAttribute('data-target')).toBeNull();
 		});
 


### PR DESCRIPTION
# Motivation

When a target ledger exposes no ICRC-21 endpoint, `@dfinity/oisy-wallet-signer` builds the consent message itself and embeds the relying party's ICRC-1 `memo`, UTF-8 decoded verbatim, into the markdown handed to OISY. That text reached the approval dialog through `sanitize()` in `$lib/utils/html.utils`, which called DOMPurify with no configuration: its two hooks only restore `target="_blank"` and constrain nothing, so `<button>` and `<style>` survived. It was then rendered inside `<form method="POST" onsubmit={preventDefault(onApprove)}>`. A `<button>` without a `type` defaults to `submit` and adopts that form as its owner, so a 22 byte memo, well within the 32 byte floor every conforming ICRC-1 ledger accepts, could ship both the transfer and a control that approves it. A `<style>` rule in the same memo could hide the origin line and the transfer facts.

Root cause from history: `sanitize()` was vendored verbatim from `@dfinity/gix-components` in 8d85f2f63b (#13193), whose stated goal was no behavioral change, so the unconfigured DOMPurify call came along. The `<form>` wrapper dates to 43afad5cf4 (#2955), when the consent text always came from a canister. 1691f023ff (#4082) later routed locally built, relying-party-influenced text onto that same trusted surface without revisiting either.

# Changes

- `html.utils`: add `sanitizeUntrusted`, an allowlist limited to the markup markdown can produce. Form controls, `<style>` and `style` attributes are dropped. `sanitize` keeps its current behaviour, so the 34 `Html` consumers rendering our own i18n copy are unaffected.
- `Html` and `Markdown` gain an `untrusted` prop selecting that sanitizer. `SignerConsentMessage` is the only caller passing it, so `MarkdownWithSidebar` and `AiAssistantBotMessage` keep today's behaviour.
- `SignerConsentMessage`: drop the `<form>` and approve on a click of our own button. With no form in the dialog, nothing rendered from consent text can reach the approval handler even if something interactive were to survive sanitisation. This also removes a latent bug where Reject, a default `submit` button, additionally submitted the form.

# Tests

- `html.utils.spec`: buttons, inputs, selects, textareas, `<style>`, inline styles and event handlers are stripped, markdown markup and `target="_blank"` links still pass, and the strict config does not leak into later `sanitize` calls.
- New `SignerConsentMessage.spec`: a memo carrying `<button style=zoom:99>` renders no interactive control and leaves only our two buttons, clicking every element rendered from the consent text never invokes the approve callback, a `<style>` memo never reaches the DOM, the dialog contains no form, and our own approve button still approves. Four of the five fail without the fix.
- `format`, `lint --max-warnings 0`, `check` (0 errors, 0 warnings), `tsc --project tsconfig.spec.json`, `vitest run` (16939 passed).
