### PR TITLE
style(frontend): align MessageBox slide with the shared transition params

### DIFF
--- a/src/frontend/src/lib/components/ui/MessageBox.svelte
+++ b/src/frontend/src/lib/components/ui/MessageBox.svelte
@@ -4,7 +4,7 @@
 	import { slide } from 'svelte/transition';
 	import IconClose from '$lib/components/icons/lucide/IconClose.svelte';
 	import IconInfo from '$lib/components/icons/lucide/IconInfo.svelte';
-	import { SLIDE_EASING } from '$lib/constants/transition.constants';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { type HideInfoKey, saveHideInfo, shouldHideInfo } from '$lib/utils/info.utils';
 
@@ -55,7 +55,7 @@
 		class:bg-success-light={level === 'success'}
 		class:bg-warning-light={level === 'warning'}
 		data-tid={testId}
-		transition:slide={SLIDE_EASING}
+		transition:slide={SLIDE_PARAMS}
 	>
 		{#if nonNullish(icon)}
 			{@render icon()}

--- a/src/frontend/src/tests/lib/components/ui/MessageBox.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/MessageBox.spec.ts
@@ -1,4 +1,5 @@
 import MessageBox from '$lib/components/ui/MessageBox.svelte';
+import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
 import en from '$tests/mocks/i18n.mock';
 import { createMockSnippet } from '$tests/mocks/snippet.mock';
 import { assertNonNullish } from '@dfinity/utils';
@@ -173,6 +174,46 @@ describe('MessageBox', () => {
 			expect(queryByTestId('msg-box')).not.toBeInTheDocument();
 
 			vi.restoreAllMocks();
+		});
+	});
+
+	describe('slide transition', () => {
+		const renderClosable = () =>
+			render(MessageBox, {
+				props: { children: childrenSnippet, testId: 'msg-box', onDismiss: vi.fn() }
+			});
+
+		it('should stay mounted and animate while sliding out', async () => {
+			const { getByRole, queryByTestId } = renderClosable();
+
+			await fireEvent.click(getByRole('button', { name: en.core.text.close }));
+
+			// `overflow: hidden` is the inline style Svelte's slide sets for the duration of the
+			// transition, so its presence proves the box animates out instead of vanishing.
+			await waitFor(() => {
+				const box = queryByTestId('msg-box');
+
+				assertNonNullish(box);
+
+				expect(box.style.overflow).toBe('hidden');
+			});
+		});
+
+		it('should be removed within the shared slide duration', async () => {
+			const { getByRole, queryByTestId } = renderClosable();
+
+			await fireEvent.click(getByRole('button', { name: en.core.text.close }));
+
+			const { duration } = SLIDE_PARAMS;
+
+			assertNonNullish(duration);
+
+			await waitFor(
+				() => {
+					expect(queryByTestId('msg-box')).not.toBeInTheDocument();
+				},
+				{ timeout: duration + 100 }
+			);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

`MessageBox` already slides in and out, so the transition itself was not missing. What was off is the timing: it used `SLIDE_EASING`, which only carries `easing` and `axis`. With no `duration`, the slide fell back to Svelte's implicit 400ms default rather than the 250ms `SLIDE_DURATION` that every other animated component in the app shares. Message boxes therefore animated noticeably slower than the surrounding UI, which is most visible in signing and review flows where a box appears in reaction to something the user just did.

Eight components render `MessageBox` inside an element that carries its own transition, and most of those wrappers already use the shared 250ms. Those cases were animating an outer 250ms slide against an inner 400ms one, so this also removes an existing mismatch.

# Changes

- `MessageBox.svelte`: use the existing `SLIDE_PARAMS` constant (`delay: 0`, `duration: 250`, `easing: quintOut`, `axis: 'y'`) instead of `SLIDE_EASING`. No new constant, no magic number, no markup or styling change.

Out of scope, listed as follow-ups: `InfoBox.svelte` and `NetworkSwitcherList.svelte` are the only other components still on bare `SLIDE_EASING` and deserve the same alignment.

There is no `prefers-reduced-motion` convention in this repo. It appears only inside two decorative Halloween icons, so there is no shared helper to reuse. Introducing a global motion policy is deliberately not done here.

# Tests

Two tests added to `MessageBox.spec.ts`, asserting the transition is applied rather than intermediate visual state:

- the box stays mounted and carries the `overflow: hidden` inline style Svelte's `slide` sets while animating out
- the box is removed within the shared slide duration, with the bound derived from `SLIDE_PARAMS.duration` rather than hardcoded

The second test is a genuine regression test: verified it fails against the previous `SLIDE_EASING` version (400ms default) and passes with `SLIDE_PARAMS`.

Gates: `format`, `lint --max-warnings 0`, `check` (0 errors), `vitest run` (16971 passed), `tsc --project tsconfig.spec.json` all pass.
