### PR TITLE
fix(frontend): make gasless Velora Delta swaps pass v2 order validation

### DIFF
--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -158,7 +158,8 @@
 			const { isErc20SupportsPermit } = infuraErc20Providers($sourceToken.network.id);
 			const isPermitSupported = await isErc20SupportsPermit({
 				contractAddress: $sourceToken.address,
-				userAddress: $ethAddress
+				userAddress: $ethAddress,
+				chainId: $sourceToken.network.chainId
 			});
 			setIsTokenPermitSupported({
 				address: $sourceToken.address,

--- a/src/frontend/src/eth/constants/erc20.constants.ts
+++ b/src/frontend/src/eth/constants/erc20.constants.ts
@@ -17,6 +17,7 @@ export const ERC20_ABI = [
 // Not all ERC-20 tokens implement it, so this ABI is kept separate to avoid breaking logic.
 // Spec: https://eips.ethereum.org/EIPS/eip-2612
 export const ERC20_PERMIT_ABI = [
+	'function name() view returns (string)',
 	'function nonces(address owner) view returns (uint256)',
 	'function version() view returns (string)',
 	'function DOMAIN_SEPARATOR() view returns (bytes32)'

--- a/src/frontend/src/eth/providers/infura-erc20.providers.ts
+++ b/src/frontend/src/eth/providers/infura-erc20.providers.ts
@@ -11,6 +11,7 @@ import type { NetworkId } from '$lib/types/network';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { assertNonNullish } from '@dfinity/utils';
 import { Contract, type ContractTransaction } from 'ethers/contract';
+import { TypedDataEncoder } from 'ethers/hash';
 import { InfuraProvider, type Networkish } from 'ethers/providers';
 import { get } from 'svelte/store';
 
@@ -130,21 +131,40 @@ export class InfuraErc20Provider implements Erc20Provider {
 
 	isErc20SupportsPermit = async ({
 		contractAddress,
-		userAddress
+		userAddress,
+		chainId
 	}: {
 		contractAddress: string;
 		userAddress: EthAddress;
+		chainId: bigint;
 	}): Promise<boolean> => {
-		const { nonces, DOMAIN_SEPARATOR, version } = new Contract(
+		const { nonces, DOMAIN_SEPARATOR, version, name } = new Contract(
 			contractAddress,
 			ERC20_PERMIT_ABI,
 			this.provider
 		);
 
 		try {
-			await Promise.all([nonces(userAddress), DOMAIN_SEPARATOR(), version()]);
+			const [, domainSeparator, tokenVersion, tokenName] = await Promise.all([
+				nonces(userAddress),
+				DOMAIN_SEPARATOR(),
+				version(),
+				name()
+			]);
 
-			return true;
+			// Probing for the getters is not enough: a token can expose all of them yet hash a
+			// different domain shape (salt-based domains without chainId, DAI-style permits), and a
+			// permit signed over the wrong domain can never be verified by the token. Only report
+			// support when the standard EIP-2612 domain reproduces the token's DOMAIN_SEPARATOR;
+			// everything else must go through the on-chain approval flow.
+			return (
+				TypedDataEncoder.hashDomain({
+					name: tokenName,
+					version: tokenVersion,
+					chainId,
+					verifyingContract: contractAddress
+				}).toLowerCase() === domainSeparator.toLowerCase()
+			);
 		} catch (_: unknown) {
 			return false;
 		}

--- a/src/frontend/src/eth/services/eip2612-permit.services.ts
+++ b/src/frontend/src/eth/services/eip2612-permit.services.ts
@@ -24,19 +24,25 @@ const createDeadline = ({
 const fetchPermitMetadata = async ({
 	tokenContract,
 	userAddress,
-	customDeadline,
-	tokenName
+	customDeadline
 }: FetchPermitMetadataParams): Promise<PermitMetadata> => {
-	const [nonce, version] = await Promise.all([
+	// The EIP-712 domain must reproduce the token's DOMAIN_SEPARATOR bit for bit, so the name
+	// comes from the contract, not from our token metadata — display names drift (e.g.
+	// "Euro Coin" vs the on-chain "EURC"), and a drifted name yields a signature the token
+	// can never verify.
+	const [nonce, version, name, domainSeparator] = await Promise.all([
 		tokenContract.nonces(userAddress),
-		tokenContract.version()
+		tokenContract.version(),
+		tokenContract.name(),
+		tokenContract.DOMAIN_SEPARATOR()
 	]);
 
 	return {
-		name: tokenName,
+		name,
 		version,
 		nonce: nonce.toString(),
-		deadline: customDeadline ?? createDeadline()
+		deadline: customDeadline ?? createDeadline(),
+		domainSeparator
 	};
 };
 
@@ -89,8 +95,7 @@ const createPermitHash = async ({
 	const metadata = await fetchPermitMetadata({
 		tokenContract,
 		userAddress,
-		customDeadline: deadline,
-		tokenName: token.name
+		customDeadline: deadline
 	});
 
 	const { domain, types, values } = createEIP2612TypedData({
@@ -100,6 +105,17 @@ const createPermitHash = async ({
 		value,
 		metadata
 	});
+
+	// Some permit-capable tokens hash a different domain shape (e.g. salt-based domains
+	// without chainId, or DAI-style permits): signing would succeed but the token could never
+	// verify the result. Fail here rather than hand a dead permit to a counterparty.
+	if (
+		TypedDataEncoder.hashDomain(domain).toLowerCase() !== metadata.domainSeparator.toLowerCase()
+	) {
+		throw new Error(
+			`The EIP-2612 domain of token ${token.symbol} (${token.address}) does not match its on-chain DOMAIN_SEPARATOR; the token cannot be used with a permit.`
+		);
+	}
 
 	const hash = TypedDataEncoder.hash(domain, types, values);
 

--- a/src/frontend/src/eth/types/eip2612-permit.ts
+++ b/src/frontend/src/eth/types/eip2612-permit.ts
@@ -17,6 +17,7 @@ export interface PermitMetadata {
 	name: string;
 	version: string;
 	deadline: number;
+	domainSeparator: string;
 }
 
 export interface EIP2612Domain {
@@ -44,7 +45,6 @@ export interface FetchPermitMetadataParams {
 	tokenContract: Contract;
 	userAddress: EthAddress;
 	customDeadline?: number;
-	tokenName: string;
 }
 
 export interface CreateEIP2612TypedDataParams {

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -1276,7 +1276,7 @@ export const fetchVeloraDeltaSwap = async ({
 	if (isGasless) {
 		progress(ProgressStepsSwap.APPROVE);
 
-		const { nonce, deadline, encodedPermit } = await createPermit({
+		const { deadline, encodedPermit } = await createPermit({
 			token: sourceToken,
 			userAddress,
 			spender: deltaContract,
@@ -1286,10 +1286,13 @@ export const fetchVeloraDeltaSwap = async ({
 
 		progress(ProgressStepsSwap.SWAP);
 
+		// The order nonce is deliberately not set: the permit nonce is already embedded in the
+		// signature inside `encodedPermit`, while the order nonce is a separate per-address replay
+		// guard that the server randomizes when omitted. Reusing the per-token, counter-based
+		// permit nonce here collides on /v2/delta/orders ("Nonce has already been used").
 		builtOrder = await sdk.delta.buildDeltaOrder({
 			...deltaOrderBaseParams,
 			deadline,
-			nonce,
 			permit: encodedPermit
 		});
 	} else {

--- a/src/frontend/src/tests/eth/providers/infura-erc20.providers.spec.ts
+++ b/src/frontend/src/tests/eth/providers/infura-erc20.providers.spec.ts
@@ -11,6 +11,7 @@ import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { mockEthAddress, mockEthAddress2 } from '$tests/mocks/eth.mock';
 import en from '$tests/mocks/i18n.mock';
 import { Contract, type ContractTransaction } from 'ethers/contract';
+import { TypedDataEncoder } from 'ethers/hash';
 import { InfuraProvider, InfuraProvider as InfuraProviderLib } from 'ethers/providers';
 
 vi.mock('$env/rest/infura.env', () => ({
@@ -533,11 +534,26 @@ describe('infura-erc20.providers', () => {
 		describe('isErc20SupportsPermit', () => {
 			const mockUserAddress = '0x1234567890123456789012345678901234567890' as EthAddress;
 			const mockContractAddress = '0x0987654321098765432109876543210987654321';
+			const mockChainId = 11155111n;
+			const mockTokenName = 'Test Token';
+			const mockTokenVersion = '2';
 
-			it('should return true when contract supports permit (both nonces and DOMAIN_SEPARATOR succeed)', async () => {
+			// The real domain hash of the mocked getters: what a standard EIP-2612 token would
+			// store as its DOMAIN_SEPARATOR.
+			const matchingDomainSeparator = TypedDataEncoder.hashDomain({
+				name: mockTokenName,
+				version: mockTokenVersion,
+				chainId: mockChainId,
+				verifyingContract: mockContractAddress
+			});
+
+			const mockPermitGetters = ({
+				domainSeparator = matchingDomainSeparator
+			}: { domainSeparator?: string } = {}) => {
 				const mockNonces = vi.fn().mockResolvedValue(BigInt(0));
-				const mockDomainSeparator = vi.fn().mockResolvedValue('0xabcd...');
-				const mockVersion = vi.fn().mockResolvedValue('2');
+				const mockDomainSeparator = vi.fn().mockResolvedValue(domainSeparator);
+				const mockVersion = vi.fn().mockResolvedValue(mockTokenVersion);
+				const mockName = vi.fn().mockResolvedValue(mockTokenName);
 
 				mockContract.prototype.nonces =
 					mockNonces as unknown as typeof mockContract.prototype.nonces;
@@ -545,11 +561,19 @@ describe('infura-erc20.providers', () => {
 					mockDomainSeparator as unknown as typeof mockContract.prototype.DOMAIN_SEPARATOR;
 				mockContract.prototype.version =
 					mockVersion as unknown as typeof mockContract.prototype.version;
+				mockContract.prototype.name = mockName as unknown as typeof mockContract.prototype.name;
+
+				return { mockNonces, mockDomainSeparator, mockVersion, mockName };
+			};
+
+			it('should return true when the EIP-2612 domain reproduces the DOMAIN_SEPARATOR', async () => {
+				const { mockNonces, mockDomainSeparator } = mockPermitGetters();
 
 				const provider = new InfuraErc20Provider('sepolia');
 				const result = await provider.isErc20SupportsPermit({
 					contractAddress: mockContractAddress,
-					userAddress: mockUserAddress
+					userAddress: mockUserAddress,
+					chainId: mockChainId
 				});
 
 				expect(result).toBeTruthy();
@@ -557,22 +581,41 @@ describe('infura-erc20.providers', () => {
 				expect(mockDomainSeparator).toHaveBeenCalled();
 			});
 
-			it('should return false when nonces method throws error', async () => {
-				const mockNonces = vi.fn().mockRejectedValue(new Error('Method not found'));
-				const mockDomainSeparator = vi.fn().mockResolvedValue('0xabcd...');
-				const mockVersion = vi.fn().mockResolvedValue('2');
-
-				mockContract.prototype.nonces =
-					mockNonces as unknown as typeof mockContract.prototype.nonces;
-				mockContract.prototype.DOMAIN_SEPARATOR =
-					mockDomainSeparator as unknown as typeof mockContract.prototype.DOMAIN_SEPARATOR;
-				mockContract.prototype.version =
-					mockVersion as unknown as typeof mockContract.prototype.version;
+			it('should return false when the domain does not reproduce the DOMAIN_SEPARATOR', async () => {
+				mockPermitGetters({ domainSeparator: `0x${'cd'.repeat(32)}` });
 
 				const provider = new InfuraErc20Provider('sepolia');
 				const result = await provider.isErc20SupportsPermit({
 					contractAddress: mockContractAddress,
-					userAddress: mockUserAddress
+					userAddress: mockUserAddress,
+					chainId: mockChainId
+				});
+
+				expect(result).toBeFalsy();
+			});
+
+			it('should return false for a matching domain on the wrong chain', async () => {
+				mockPermitGetters();
+
+				const provider = new InfuraErc20Provider('sepolia');
+				const result = await provider.isErc20SupportsPermit({
+					contractAddress: mockContractAddress,
+					userAddress: mockUserAddress,
+					chainId: 1n
+				});
+
+				expect(result).toBeFalsy();
+			});
+
+			it('should return false when nonces method throws error', async () => {
+				const { mockNonces } = mockPermitGetters();
+				mockNonces.mockRejectedValue(new Error('Method not found'));
+
+				const provider = new InfuraErc20Provider('sepolia');
+				const result = await provider.isErc20SupportsPermit({
+					contractAddress: mockContractAddress,
+					userAddress: mockUserAddress,
+					chainId: mockChainId
 				});
 
 				expect(result).toBeFalsy();
@@ -580,66 +623,59 @@ describe('infura-erc20.providers', () => {
 			});
 
 			it('should return false when DOMAIN_SEPARATOR method throws error', async () => {
-				const mockNonces = vi.fn().mockResolvedValue(BigInt(0));
-				const mockDomainSeparator = vi.fn().mockRejectedValue(new Error('Method not found'));
-				const mockVersion = vi.fn().mockResolvedValue('2');
-
-				mockContract.prototype.nonces =
-					mockNonces as unknown as typeof mockContract.prototype.nonces;
-				mockContract.prototype.DOMAIN_SEPARATOR =
-					mockDomainSeparator as unknown as typeof mockContract.prototype.DOMAIN_SEPARATOR;
-				mockContract.prototype.version =
-					mockVersion as unknown as typeof mockContract.prototype.version;
+				const { mockDomainSeparator } = mockPermitGetters();
+				mockDomainSeparator.mockRejectedValue(new Error('Method not found'));
 
 				const provider = new InfuraErc20Provider('sepolia');
 				const result = await provider.isErc20SupportsPermit({
 					contractAddress: mockContractAddress,
-					userAddress: mockUserAddress
+					userAddress: mockUserAddress,
+					chainId: mockChainId
 				});
 
 				expect(result).toBeFalsy();
 				expect(mockDomainSeparator).toHaveBeenCalled();
 			});
 
-			it('should return false when both methods throw errors', async () => {
-				const mockNonces = vi.fn().mockRejectedValue(new Error('nonces not found'));
-				const mockDomainSeparator = vi
-					.fn()
-					.mockRejectedValue(new Error('DOMAIN_SEPARATOR not found'));
-				const mockVersion = vi.fn().mockResolvedValue('2');
-
-				mockContract.prototype.nonces =
-					mockNonces as unknown as typeof mockContract.prototype.nonces;
-				mockContract.prototype.DOMAIN_SEPARATOR =
-					mockDomainSeparator as unknown as typeof mockContract.prototype.DOMAIN_SEPARATOR;
-				mockContract.prototype.version =
-					mockVersion as unknown as typeof mockContract.prototype.version;
+			it('should return false when name method throws error', async () => {
+				const { mockName } = mockPermitGetters();
+				mockName.mockRejectedValue(new Error('Method not found'));
 
 				const provider = new InfuraErc20Provider('sepolia');
 				const result = await provider.isErc20SupportsPermit({
 					contractAddress: mockContractAddress,
-					userAddress: mockUserAddress
+					userAddress: mockUserAddress,
+					chainId: mockChainId
+				});
+
+				expect(result).toBeFalsy();
+			});
+
+			it('should return false when all methods throw errors', async () => {
+				const { mockNonces, mockDomainSeparator, mockVersion, mockName } = mockPermitGetters();
+				mockNonces.mockRejectedValue(new Error('nonces not found'));
+				mockDomainSeparator.mockRejectedValue(new Error('DOMAIN_SEPARATOR not found'));
+				mockVersion.mockRejectedValue(new Error('version not found'));
+				mockName.mockRejectedValue(new Error('name not found'));
+
+				const provider = new InfuraErc20Provider('sepolia');
+				const result = await provider.isErc20SupportsPermit({
+					contractAddress: mockContractAddress,
+					userAddress: mockUserAddress,
+					chainId: mockChainId
 				});
 
 				expect(result).toBeFalsy();
 			});
 
 			it('should use ERC20_PERMIT_ABI for contract instantiation', async () => {
-				const mockNonces = vi.fn().mockResolvedValue(BigInt(0));
-				const mockDomainSeparator = vi.fn().mockResolvedValue('0xabcd...');
-				const mockVersion = vi.fn().mockResolvedValue('2');
-
-				mockContract.prototype.nonces =
-					mockNonces as unknown as typeof mockContract.prototype.nonces;
-				mockContract.prototype.DOMAIN_SEPARATOR =
-					mockDomainSeparator as unknown as typeof mockContract.prototype.DOMAIN_SEPARATOR;
-				mockContract.prototype.version =
-					mockVersion as unknown as typeof mockContract.prototype.version;
+				mockPermitGetters();
 
 				const provider = new InfuraErc20Provider('sepolia');
 				await provider.isErc20SupportsPermit({
 					contractAddress: mockContractAddress,
-					userAddress: mockUserAddress
+					userAddress: mockUserAddress,
+					chainId: mockChainId
 				});
 
 				expect(Contract).toHaveBeenCalledWith(

--- a/src/frontend/src/tests/eth/services/eip2612-permit.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eip2612-permit.services.spec.ts
@@ -24,7 +24,8 @@ vi.mock('ethers/crypto', () => ({
 
 vi.mock('ethers/hash', () => ({
 	TypedDataEncoder: {
-		hash: vi.fn()
+		hash: vi.fn(),
+		hashDomain: vi.fn()
 	}
 }));
 
@@ -54,10 +55,26 @@ describe('EIP2612 Permit Services', () => {
 
 	const mockContract = vi.mocked(Contract);
 
+	// The on-chain domain name deliberately differs from the token metadata name: the domain
+	// must be built from the contract's name(), not from what we display.
+	const mockOnChainName = 'EURC';
+	const mockDomainSeparator = `0x${'ab'.repeat(32)}`;
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+
+		mockContract.prototype.name = vi
+			.fn()
+			.mockResolvedValue(mockOnChainName) as unknown as typeof mockContract.prototype.name;
+		mockContract.prototype.DOMAIN_SEPARATOR = vi
+			.fn()
+			.mockResolvedValue(
+				mockDomainSeparator
+			) as unknown as typeof mockContract.prototype.DOMAIN_SEPARATOR;
+
+		vi.mocked(TypedDataEncoder.hashDomain).mockReturnValue(mockDomainSeparator);
 	});
 
 	afterEach(() => {
@@ -195,7 +212,7 @@ describe('EIP2612 Permit Services', () => {
 
 			expect(TypedDataEncoder.hash).toHaveBeenCalledWith(
 				expect.objectContaining({
-					name: mockValidErc20Token.name,
+					name: mockOnChainName,
 					version: '2',
 					chainId: mockChainId,
 					verifyingContract: mockValidErc20Token.address
@@ -203,6 +220,66 @@ describe('EIP2612 Permit Services', () => {
 				EIP2612_TYPES,
 				expect.any(Object)
 			);
+		});
+
+		it('should verify the domain against the on-chain DOMAIN_SEPARATOR', async () => {
+			const mockNonces = vi.fn().mockResolvedValue(mockNonce);
+			const mockVersionFn = vi.fn().mockResolvedValue('2');
+
+			mockContract.prototype.nonces = mockNonces as unknown as typeof mockContract.prototype.nonces;
+			mockContract.prototype.version =
+				mockVersionFn as unknown as typeof mockContract.prototype.version;
+
+			vi.mocked(TypedDataEncoder.hash).mockReturnValue(mockHash);
+			vi.mocked(signerApi.signPrehash).mockResolvedValue(mockSignatureData);
+			vi.mocked(Signature.from).mockReturnValue({
+				v: 27,
+				r: `0x${'a'.repeat(64)}`,
+				s: `0x${'b'.repeat(64)}`
+			} as unknown as Signature);
+			vi.mocked(concat).mockReturnValue(mockEncodedPermit);
+
+			await createPermit({
+				token: mockValidErc20Token,
+				userAddress: mockUserAddress,
+				spender: mockSpenderAddress,
+				value: mockValue,
+				identity: mockIdentity
+			});
+
+			expect(TypedDataEncoder.hashDomain).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: mockOnChainName,
+					version: '2',
+					chainId: mockChainId,
+					verifyingContract: mockValidErc20Token.address
+				})
+			);
+		});
+
+		it('should throw without signing when the domain does not reproduce the DOMAIN_SEPARATOR', async () => {
+			const mockNonces = vi.fn().mockResolvedValue(mockNonce);
+			const mockVersionFn = vi.fn().mockResolvedValue('2');
+
+			mockContract.prototype.nonces = mockNonces as unknown as typeof mockContract.prototype.nonces;
+			mockContract.prototype.version =
+				mockVersionFn as unknown as typeof mockContract.prototype.version;
+
+			vi.mocked(TypedDataEncoder.hashDomain).mockReturnValue(`0x${'cd'.repeat(32)}`);
+
+			await expect(
+				createPermit({
+					token: mockValidErc20Token,
+					userAddress: mockUserAddress,
+					spender: mockSpenderAddress,
+					value: mockValue,
+					identity: mockIdentity
+				})
+			).rejects.toThrow(
+				`The EIP-2612 domain of token ${mockValidErc20Token.symbol} (${mockValidErc20Token.address}) does not match its on-chain DOMAIN_SEPARATOR; the token cannot be used with a permit.`
+			);
+
+			expect(signerApi.signPrehash).not.toHaveBeenCalled();
 		});
 
 		it('should create correct values structure', async () => {

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -1023,6 +1023,16 @@ describe('swap.services', () => {
 
 			expect(mockProgress).toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
 			expect(createPermit).toHaveBeenCalled();
+
+			// The permit rides along, but the order nonce must stay unset: the server randomizes
+			// it, and the per-token permit counter would collide per address on /v2/delta/orders.
+			const [[buildParams]] = mockDeltaContractBuildDeltaOrder.mock.calls;
+
+			expect(buildParams).toMatchObject({
+				deadline: 1234567890,
+				permit: '0xpermitdata'
+			});
+			expect(buildParams).not.toHaveProperty('nonce');
 		});
 
 		it('should handle delta contract not found', async () => {


### PR DESCRIPTION
# Motivation

Since the Velora SDK v9→v10 upgrade (#13620), gasless Delta swaps fail at POST /v2/delta/orders:

`OrderValidationError: Nonce "0" has already been used for address 0x…`
`OrderValidationError: Invalid order permit`

The v10 SDK moved from the v1 API (client-built orders, no submission-time checks) to the v2 API, which validates orders at post time. That unmasked two latent bugs in the gasless flow, present since it was introduced (#10038):

1. Nonce collision. The ERC-2612 permit nonce (a per-(token, owner) counter starting at 0) was passed as the Delta order nonce, which must be unique per owner address across all orders. Any address that ever posted an order with nonce 0 collided on its next gasless swap with a fresh token, or whenever a prior order expired without consuming the permit.
2. Unverifiable permit signature. The permit's EIP-712 domain was built from OISY's display token name instead of the contract's name(). For EURC on Base, OISY signs with "Euro Coin" while the contract's DOMAIN_SEPARATOR is derived from "EURC" — verified on-chain: the signed digest can never be validated by the token, so Velora's recovery yields an address ≠ order owner.

Both belong in one PR: they are the two halves of "a gasless Delta order that the v2 API accepts" — fixing either alone still leaves every gasless swap failing.

