### PR TITLE
feat(frontend): map native Bitcoin tokens to their BE TokenId variants

### DIFF
--- a/src/frontend/src/lib/utils/token-id.utils.ts
+++ b/src/frontend/src/lib/utils/token-id.utils.ts
@@ -5,6 +5,8 @@ import { isTokenErc4626 } from '$eth/utils/erc4626.utils';
 import { isIcToken } from '$icp/validation/ic-token.validation';
 import type { Token } from '$lib/types/token';
 import {
+	isNetworkIdBTCMainnet,
+	isNetworkIdBTCTestnet,
 	isNetworkIdEthereum,
 	isNetworkIdEvm,
 	isNetworkIdSOLDevnet,
@@ -77,9 +79,10 @@ export const tokenIdKey = (id: TokenId): string | undefined => {
  * Transaction's `data` payload.
  *
  * Covers every asset the AUT consumers can swap: ERC-20 and ERC-4626 vault
- * tokens, native EVM coins, ICRC ledgers, and SPL / native Solana on both
- * mainnet and devnet. Returns `undefined` for anything else, which callers treat
- * as "do not track this operation" rather than as an error.
+ * tokens, native EVM coins, ICRC ledgers, SPL / native Solana on both mainnet
+ * and devnet, and native Bitcoin on mainnet and testnet. Returns `undefined` for
+ * anything else — including Bitcoin regtest, which has no backend variant —
+ * which callers treat as "do not track this operation" rather than as an error.
  *
  * An Internet Computer token maps to `Icrc` by ledger canister id — including
  * ICP itself, whose dedicated `IcpNative` variant is reserved for the
@@ -111,6 +114,16 @@ export const toBackendTokenId = (token: Token): TokenId | undefined => {
 	// Native tokens carry no contract address; disambiguate by network.
 	if (isNetworkIdSolana(networkId)) {
 		return isNetworkIdSOLDevnet(networkId) ? { SolNativeDevnet: null } : { SolNativeMainnet: null };
+	}
+
+	// Each Bitcoin network is matched on its own rather than via `isNetworkIdBitcoin`,
+	// so regtest — which has no backend `TokenId` variant — falls through to `undefined`.
+	if (isNetworkIdBTCMainnet(networkId)) {
+		return { BtcNativeMainnet: null };
+	}
+
+	if (isNetworkIdBTCTestnet(networkId)) {
+		return { BtcNativeTestnet: null };
 	}
 
 	// Native EVM coin (ETH, BNB, POL, …), identified by chain id.

--- a/src/frontend/src/tests/lib/utils/near-intents-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/near-intents-active-tx.utils.spec.ts
@@ -1,6 +1,6 @@
 import type { ActiveUserTransactionRef } from '$declarations/backend/backend.did';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
-import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { BTC_REGTEST_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import type { Erc20Token } from '$eth/types/erc20';
@@ -114,7 +114,7 @@ describe('near-intents-active-tx.utils', () => {
 			expect(
 				toNearIntentsData({
 					sourceToken: makeErc20Token(USDC_ETHEREUM),
-					destinationToken: BTC_MAINNET_TOKEN,
+					destinationToken: BTC_REGTEST_TOKEN,
 					amount: 1n
 				})
 			).toBeUndefined();

--- a/src/frontend/src/tests/lib/utils/token-id.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/token-id.utils.spec.ts
@@ -1,6 +1,10 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { SOLANA_DEVNET_NETWORK } from '$env/networks/networks.sol.env';
-import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import {
+	BTC_MAINNET_TOKEN,
+	BTC_REGTEST_TOKEN,
+	BTC_TESTNET_TOKEN
+} from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { SOLANA_DEVNET_TOKEN, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
@@ -81,8 +85,15 @@ describe('token-id.utils', () => {
 			});
 		});
 
+		it('maps native Bitcoin by network', () => {
+			expect(toBackendTokenId(BTC_MAINNET_TOKEN)).toEqual({ BtcNativeMainnet: null });
+			expect(toBackendTokenId(BTC_TESTNET_TOKEN)).toEqual({ BtcNativeTestnet: null });
+		});
+
+		// Bitcoin regtest is a local-development network with no `TokenId` variant
+		// on the backend, so it must stay untrackable rather than borrow testnet's.
 		it('returns undefined for a token with no backend representation', () => {
-			expect(toBackendTokenId(BTC_MAINNET_TOKEN)).toBeUndefined();
+			expect(toBackendTokenId(BTC_REGTEST_TOKEN)).toBeUndefined();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/velora-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/velora-active-tx.utils.spec.ts
@@ -1,6 +1,6 @@
 import type { ActiveUserTransactionRef } from '$declarations/backend/backend.did';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
-import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import { BTC_REGTEST_TOKEN } from '$env/tokens/tokens.btc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc4626Token } from '$eth/types/erc4626';
@@ -129,7 +129,7 @@ describe('velora-active-tx.utils', () => {
 				toVeloraData({
 					mode: { Delta: null },
 					sourceToken: makeErc20Token(USDC_ETHEREUM),
-					destinationToken: BTC_MAINNET_TOKEN,
+					destinationToken: BTC_REGTEST_TOKEN,
 					amount: 5n
 				})
 			).toBeUndefined();


### PR DESCRIPTION
# Motivation

`toBackendTokenId` is the mapper that turns an OISY token into the canonical backend `TokenId` used in an Active User Transaction's `data` payload. It covers ERC-20, ERC-4626, native EVM coins, ICRC ledgers and SPL / native Solana — but  returns `undefined` for Bitcoin, even though the backend enum has carried `BtcNativeMainnet` and `BtcNativeTestnet` since it was introduced, and `tokenIdKey` already reads them in the reverse direction.

Callers treat `undefined` as "do not track this operation", so as long as the forward mapper has this gap, no Bitcoin operation can ever be persisted as an Active User Transaction. This closes the gap, which is a prerequisite for tracking BTC↔ckBTC conversions as AUT rows.

