### PR TITLE
feat(frontend): show fiat values and drop undecoded rows in the Solana WalletConnect review

### DIFF
--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -16,6 +16,10 @@
 		balance: OptionBalance;
 		source: string;
 		application: string;
+		// A caller whose decode produced no amount has nothing to say in the amount and balance rows,
+		// and a zero there would read as a figure the decode never produced. Both default to shown.
+		showAmount?: boolean;
+		showBalance?: boolean;
 		showNullishAmountLabel?: boolean;
 		showUnlimitedAmountLabel?: boolean;
 		sourceNetwork: Snippet;
@@ -31,6 +35,8 @@
 		balance,
 		source,
 		application,
+		showAmount = true,
+		showBalance = true,
 		showNullishAmountLabel = false,
 		showUnlimitedAmountLabel = false,
 		sourceNetwork,
@@ -45,15 +51,17 @@
 
 {@render destinationNetwork?.()}
 
-<SendDataAmount
-	{amount}
-	{exchangeRate}
-	showNullishLabel={showNullishAmountLabel}
-	showUnlimitedLabel={showUnlimitedAmountLabel}
-	{token}
-/>
+{#if showAmount}
+	<SendDataAmount
+		{amount}
+		{exchangeRate}
+		showNullishLabel={showNullishAmountLabel}
+		showUnlimitedLabel={showUnlimitedAmountLabel}
+		{token}
+	/>
+{/if}
 
-<SendSource {balance} {exchangeRate} {source} {token} />
+<SendSource {balance} {exchangeRate} {showBalance} {source} {token} />
 
 {#if nonNullish(destination)}
 	<SendDataDestination {destination} />

--- a/src/frontend/src/lib/components/send/SendSource.svelte
+++ b/src/frontend/src/lib/components/send/SendSource.svelte
@@ -13,23 +13,26 @@
 		balance: OptionBalance;
 		source: string;
 		exchangeRate?: number;
+		showBalance?: boolean;
 	}
 
-	let { token, balance, source, exchangeRate }: Props = $props();
+	let { token, balance, source, exchangeRate, showBalance = true }: Props = $props();
 </script>
 
-<WalletConnectModalValue label={$i18n.send.text.balance} ref="balance">
-	{#if nonNullish(token)}
-		<ExchangeAmountDisplay
-			amount={balance ?? ZERO}
-			decimals={token.decimals}
-			{exchangeRate}
-			symbol={token.symbol}
-		/>
-	{:else}
-		&ZeroWidthSpace;
-	{/if}
-</WalletConnectModalValue>
+{#if showBalance}
+	<WalletConnectModalValue label={$i18n.send.text.balance} ref="balance">
+		{#if nonNullish(token)}
+			<ExchangeAmountDisplay
+				amount={balance ?? ZERO}
+				decimals={token.decimals}
+				{exchangeRate}
+				symbol={token.symbol}
+			/>
+		{:else}
+			&ZeroWidthSpace;
+		{/if}
+	</WalletConnectModalValue>
+{/if}
 
 <WalletConnectModalValue label={$i18n.send.text.source} ref="source">
 	<div class="flex flex-col gap-1">

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -66,6 +66,11 @@
 
 	let balance = $derived($balancesStore?.[token.id]?.data);
 
+	// Instructions OISY cannot decode yield no amount, and with it no destination and no balance
+	// worth showing: what the transaction does is then told by the simulated changes alone. The
+	// rows are dropped rather than filled with a zero the decode never produced.
+	let decoded = $derived(nonNullish(amount));
+
 	let feeExchangeRate = $derived($exchanges?.[feeToken.id]?.usd);
 
 	let prioritizationFeeFloor = $derived(
@@ -131,7 +136,9 @@
 		{amount}
 		{application}
 		{balance}
-		destination={isApproval ? null : destination}
+		destination={isApproval || !decoded ? null : destination}
+		showAmount={decoded}
+		showBalance={decoded}
 		{source}
 		{token}
 	>

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -85,7 +85,7 @@
 	label={$i18n.wallet_connect.text.simulated_changes}
 	ref="simulated-changes"
 >
-	<div class="flex flex-col gap-2">
+	<div class="flex flex-col gap-1">
 		{#if nonNullish(solDelta)}
 			<div class="flex gap-4" data-tid="simulated-sol-delta">
 				{@render delta({

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
+	import ConvertAmountExchange from '$lib/components/convert/ConvertAmountExchange.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
+	import { exchanges } from '$lib/derived/exchange.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 	import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { enabledSplTokens } from '$sol/derived/spl.derived';
 	import type { SolSimulationControlField, SolSimulationPreview } from '$sol/types/sol-simulation';
 	import type { SplTokenAddress } from '$sol/types/spl';
+	import type { SplCustomToken } from '$sol/types/spl-custom-token';
 
 	interface Props {
 		preview: SolSimulationPreview;
@@ -21,17 +24,23 @@
 	let { solDelta, tokenDeltas, controlChanges } = $derived(preview);
 
 	// The same mint can exist on several clusters, so the network is matched too.
-	const symbol = (tokenAddress: SplTokenAddress): string =>
+	const splToken = (tokenAddress: SplTokenAddress): SplCustomToken | undefined =>
 		$enabledSplTokens.find(
 			({ address, network: { id } }) => address === tokenAddress && id === feeToken.network.id
-		)?.symbol ?? shortenWithMiddleEllipsis({ text: tokenAddress });
+		);
 
-	const signedAmount = ({ delta, decimals }: { delta: bigint; decimals: number }): string =>
-		`${delta > ZERO ? '+' : '-'}${formatToken({
-			value: delta > ZERO ? delta : -delta,
-			unitName: decimals,
-			displayDecimals: decimals
-		})}`;
+	const symbol = (tokenAddress: SplTokenAddress): string =>
+		splToken(tokenAddress)?.symbol ?? shortenWithMiddleEllipsis({ text: tokenAddress });
+
+	// A mint OISY does not know has no rate of its own, and no other token's rate describes it, so
+	// such a delta is left as a bare amount rather than priced against something it is not.
+	const splExchangeRate = (tokenAddress: SplTokenAddress): number | undefined => {
+		const token = splToken(tokenAddress);
+
+		return nonNullish(token) ? $exchanges?.[token.id]?.usd : undefined;
+	};
+
+	let feeExchangeRate = $derived($exchanges?.[feeToken.id]?.usd);
 
 	const controlLabels: Record<SolSimulationControlField, string> = $derived({
 		owner: $i18n.wallet_connect.text.simulation_new_owner,
@@ -40,6 +49,31 @@
 		program: $i18n.wallet_connect.text.simulation_new_program
 	});
 </script>
+
+{#snippet delta({
+	value,
+	decimals,
+	tokenSymbol,
+	exchangeRate
+}: {
+	value: bigint;
+	decimals: number;
+	tokenSymbol: string;
+	exchangeRate?: number;
+})}
+	{@const magnitude = formatToken({
+		value: value > ZERO ? value : -value,
+		unitName: decimals,
+		displayDecimals: decimals
+	})}
+
+	{`${value > ZERO ? '+' : '-'}${magnitude} ${tokenSymbol}`}
+
+	<!-- The sign is carried once, by the amount: the fiat figure prices the size of the change. -->
+	<div class="text-tertiary">
+		<ConvertAmountExchange amount={magnitude} {exchangeRate} />
+	</div>
+{/snippet}
 
 <!-- An authority change moves no funds at all, so it would be invisible among the amounts. It is
      named first, on its own, because it is the one that hands over the account itself. -->
@@ -53,15 +87,25 @@
 >
 	<div class="flex flex-col gap-2">
 		{#if nonNullish(solDelta)}
-			<span data-tid="simulated-sol-delta">
-				{`${signedAmount({ delta: solDelta, decimals: feeToken.decimals })} ${feeToken.symbol}`}
-			</span>
+			<div class="flex gap-4" data-tid="simulated-sol-delta">
+				{@render delta({
+					value: solDelta,
+					decimals: feeToken.decimals,
+					tokenSymbol: feeToken.symbol,
+					exchangeRate: feeExchangeRate
+				})}
+			</div>
 		{/if}
 
-		{#each tokenDeltas as { account, tokenAddress, decimals, delta } (`${account}-${tokenAddress}`)}
-			<span data-tid="simulated-token-delta">
-				{`${signedAmount({ delta, decimals })} ${symbol(tokenAddress)}`}
-			</span>
+		{#each tokenDeltas as { account, tokenAddress, decimals, delta: tokenDelta } (`${account}-${tokenAddress}`)}
+			<div class="flex gap-4" data-tid="simulated-token-delta">
+				{@render delta({
+					value: tokenDelta,
+					decimals,
+					tokenSymbol: symbol(tokenAddress),
+					exchangeRate: splExchangeRate(tokenAddress)
+				})}
+			</div>
 		{/each}
 
 		{#each controlChanges as { account, field, to } (`${account}-${field}`)}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -69,10 +69,14 @@
 
 	{`${value > ZERO ? '+' : '-'}${magnitude} ${tokenSymbol}`}
 
-	<!-- The sign is carried once, by the amount: the fiat figure prices the size of the change. -->
-	<div class="text-tertiary">
-		<ConvertAmountExchange amount={magnitude} {exchangeRate} />
-	</div>
+	<!-- The sign is carried once, by the amount: the fiat figure prices the size of the change.
+	     A mint we do not know has no rate, and the wrapper is skipped rather than left as an empty
+	     flex item, so such a row is a bare amount in the DOM as well as on screen. -->
+	{#if nonNullish(exchangeRate)}
+		<div class="text-tertiary">
+			<ConvertAmountExchange amount={magnitude} {exchangeRate} />
+		</div>
+	{/if}
 {/snippet}
 
 <!-- An authority change moves no funds at all, so it would be invisible among the amounts. It is

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -252,6 +252,66 @@ describe('SolWalletConnectSignReview', () => {
 		});
 	});
 
+	describe('when the decode produced no amount', () => {
+		const undecodedProps = { ...props, amount: undefined };
+
+		it('should render neither the amount, the balance nor the destination', () => {
+			const { queryByText } = render(SolWalletConnectSignReview, { props: undecodedProps });
+
+			expect(queryByText(en.core.text.amount)).not.toBeInTheDocument();
+			expect(queryByText(en.send.text.balance)).not.toBeInTheDocument();
+			expect(queryByText(en.send.text.destination)).not.toBeInTheDocument();
+		});
+
+		it('should not claim that the amount could not be retrieved', () => {
+			const { queryByText } = render(SolWalletConnectSignReview, { props: undecodedProps });
+
+			expect(queryByText(en.send.error.unable_to_retrieve_amount)).not.toBeInTheDocument();
+		});
+
+		it('should still render everything that does not depend on the decode', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: { ...undecodedProps, data: 'AQID', prioritizationFee: 238_217n }
+			});
+
+			expect(getByText(en.wallet_connect.text.application)).toBeInTheDocument();
+			expect(getByText(en.send.text.network)).toBeInTheDocument();
+			expect(getByText(en.send.text.source)).toBeInTheDocument();
+			expect(getByText(en.fee.text.network_fee)).toBeInTheDocument();
+			expect(getByText(en.fee.text.prioritization_fee)).toBeInTheDocument();
+			expect(getByText(en.wallet_connect.text.hex_data)).toBeInTheDocument();
+		});
+
+		it('should still render the simulated changes', () => {
+			const { getByText, getByTestId } = render(SolWalletConnectSignReview, {
+				props: {
+					...undecodedProps,
+					preview: { solDelta: -10_000_000n, tokenDeltas: [], controlChanges: [] }
+				}
+			});
+
+			expect(getByText(en.wallet_connect.text.simulated_changes)).toBeInTheDocument();
+			expect(getByTestId('simulated-sol-delta')).toHaveTextContent('-0.01 SOL');
+			expect(getByText(en.wallet_connect.text.simulation_note)).toBeInTheDocument();
+		});
+	});
+
+	// The three rows describe what will be signed, which the simulation only predicts.
+	it('should render the amount, the balance and the destination of a decoded transfer', () => {
+		balancesStore.set({ id: SOLANA_TOKEN.id, data: { data: 5_000_000_000n, certified: false } });
+
+		const { getByText, container } = render(SolWalletConnectSignReview, { props });
+
+		expect(getByText(en.core.text.amount)).toBeInTheDocument();
+		expect(container.querySelector('#amount')).toHaveTextContent('0.001 SOL');
+
+		expect(getByText(en.send.text.balance)).toBeInTheDocument();
+		expect(container.querySelector('#balance')).toHaveTextContent('5 SOL');
+
+		expect(getByText(en.send.text.destination)).toBeInTheDocument();
+		expect(container.querySelector('#destination')).toHaveTextContent(mockSolAddress2);
+	});
+
 	it('should render the network row with the same label-above-value shape as the other rows', () => {
 		const { container } = render(SolWalletConnectSignReview, { props });
 

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
@@ -1,14 +1,31 @@
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { CONVERT_AMOUNT_EXCHANGE_VALUE } from '$lib/constants/test-ids.constants';
+import { exchangeStore } from '$lib/stores/exchange.store';
 import SolWalletConnectSimulationPreview from '$sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte';
+import { splCustomTokensStore } from '$sol/stores/spl-custom-tokens.store';
 import type { SolSimulationPreview } from '$sol/types/sol-simulation';
 import en from '$tests/mocks/i18n.mock';
 import { mockAtaAddress, mockSolAddress2, mockSplAddress } from '$tests/mocks/sol.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('SolWalletConnectSimulationPreview', () => {
 	const props = (preview: SolSimulationPreview) => ({
 		preview,
 		feeToken: SOLANA_TOKEN
+	});
+
+	const solUsdPrice = 200;
+
+	const enableSplToken = () => {
+		splCustomTokensStore.setAll([
+			{ data: { ...mockValidSplToken, version: undefined, enabled: true }, certified: false }
+		]);
+	};
+
+	beforeEach(() => {
+		exchangeStore.reset();
+		splCustomTokensStore.resetAll();
 	});
 
 	it('should render an outgoing SOL delta as a negative amount', () => {
@@ -32,6 +49,69 @@ describe('SolWalletConnectSimulationPreview', () => {
 		);
 
 		expect(getByTestId('simulated-token-delta')).toHaveTextContent('+2.5');
+	});
+
+	it('should price the SOL delta with the native token rate', () => {
+		exchangeStore.set([{ solana: { usd: solUsdPrice } }]);
+
+		const { getByTestId } = render(
+			SolWalletConnectSimulationPreview,
+			props({ solDelta: -10_000_000n, tokenDeltas: [], controlChanges: [] })
+		);
+
+		expect(getByTestId('simulated-sol-delta')).toHaveTextContent('-0.01 SOL');
+		expect(getByTestId('simulated-sol-delta')).toHaveTextContent('~$2.00');
+	});
+
+	it('should price a known token delta with its own rate', () => {
+		enableSplToken();
+		exchangeStore.set([
+			{ solana: { usd: solUsdPrice }, [mockValidSplToken.address.toLowerCase()]: { usd: 4 } }
+		]);
+
+		const { getByTestId } = render(
+			SolWalletConnectSimulationPreview,
+			props({
+				tokenDeltas: [
+					{ account: mockAtaAddress, tokenAddress: mockSplAddress, decimals: 6, delta: 2_500_000n }
+				],
+				controlChanges: []
+			})
+		);
+
+		expect(getByTestId('simulated-token-delta')).toHaveTextContent(
+			`+2.5 ${mockValidSplToken.symbol}`
+		);
+		expect(getByTestId('simulated-token-delta')).toHaveTextContent('~$10.00');
+	});
+
+	it('should show a value below the display floor as a threshold', () => {
+		exchangeStore.set([{ solana: { usd: solUsdPrice } }]);
+
+		const { getByTestId } = render(
+			SolWalletConnectSimulationPreview,
+			props({ solDelta: -1_000n, tokenDeltas: [], controlChanges: [] })
+		);
+
+		expect(getByTestId('simulated-sol-delta')).toHaveTextContent('< $0.01');
+	});
+
+	// Pricing an unknown mint would mean borrowing a rate that describes a different token.
+	it('should render a delta of an unknown mint as an amount with no fiat value', () => {
+		exchangeStore.set([{ solana: { usd: solUsdPrice } }]);
+
+		const { getByTestId, queryByTestId } = render(
+			SolWalletConnectSimulationPreview,
+			props({
+				tokenDeltas: [
+					{ account: mockAtaAddress, tokenAddress: mockSplAddress, decimals: 6, delta: 2_500_000n }
+				],
+				controlChanges: []
+			})
+		);
+
+		expect(getByTestId('simulated-token-delta')).toHaveTextContent('+2.5');
+		expect(queryByTestId(CONVERT_AMOUNT_EXCHANGE_VALUE)).not.toBeInTheDocument();
 	});
 
 	// An authority change moves nothing, so it has to be named in its own right or it is invisible.


### PR DESCRIPTION
# Motivation

Three product approved follow-ups to the Solana WalletConnect simulation preview, which landed in #13695 while these were being written.

A simulated change told the user how much of a token moves but not what that is worth, while the two fee rows directly above it already carried a fiat figure. The rows also sat looser than the rest of the modal.

Separately, a transaction whose instructions OISY cannot decode still rendered `Amount 0 SOL`, a balance row and an empty destination. That zero is an artifact: `SendDataAmount` declares `amount = ZERO`, so a nullish amount rendered as a confident figure the decode never produced.

# Changes

- Every simulated change row now carries its fiat value beside the amount, in the shape the fee rows already use, including the below the floor form. The SOL delta uses the native token rate and each SPL delta the rate of the mint it resolves to on the same network. A mint OISY does not know has no rate of its own, and no other token's rate describes it, so its row stays a bare amount.
- The change rows sit at the gap `SendSource` uses between the address and the contact name.
- The Solana review omits the amount, balance and destination rows when the decode produced no amount. Everything else, the application, network, source, fee rows, simulated changes, notes and HEX data, is unchanged.

The last one needed a way to say "omit these" without touching the other caller of `SendData`. It gains `showAmount` and `showBalance`, both defaulting to true, and `SendSource` gains the matching `showBalance`; destination reuses the nullish gate `SendData` already had. `EthWalletConnectSendReview` is the only other caller and passes none of them, so its markup is identical. Omitting the rows is preferred over `showNullishAmountLabel`: the simulated changes below already answer the question, and an "unable to retrieve amount" row occupies the most prominent slot with no information.

Each change is its own commit.

# Tests

New component tests cover fiat beside the SOL delta and beside a known SPL delta, a delta for an unknown mint rendering the amount with no fiat, the threshold form, the three rows absent when the decode produced no amount, and the three rows present and unchanged for a decoded transfer. Gates run locally: format, lint, check, tsc on the spec project, and the full vitest suite.
