### PR TITLE
chore(rust): bump rust-toolchain from 1.96.1 to 1.97.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"
 targets = ["wasm32-unknown-unknown"]

--- a/src/backend/src/exchange/mod.rs
+++ b/src/backend/src/exchange/mod.rs
@@ -607,7 +607,7 @@ mod tests {
 
         let second = try_acquire_refresh_lock_at(start + REFRESH_LOCK_TIMEOUT_NS + 1).unwrap();
 
-        assert!(first.generation != second.generation);
+        assert_ne!(first.generation, second.generation);
     }
 
     #[test]


### PR DESCRIPTION
> Same change as #13567, plus the adaptations needed to make CI green.

### Added on top of the Dependabot bump

- Replaced `assert!(a != b)` with `assert_ne!(a, b)` in `src/backend/src/exchange/mod.rs`, which the new `clippy::manual_assert_eq` lint (introduced in Rust 1.97) rejects under `warnings = "deny"`.

---

Bumps [rust-toolchain](https://github.com/rust-lang/rust) from 1.96.1 to 1.97.1.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/rust-lang/rust/releases">rust-toolchain's releases</a>.</em></p>
<blockquote>
<h2>Rust 1.97.1</h2>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<ul>
<li><a href="https://redirect.github.com/rust-lang/rust/issues/159035">rustc: Fix miscompilation in LLVM optimization</a> This backports an LLVM submodule bump to include the LLVM-side fix and a revert of the rustc change that is one known trigger for the bug. The rustc side revert should not be strictly necessary but is done out of abundance of caution.</li>
</ul>
<h2>Rust 1.97.0</h2>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2>Language</h2>
<ul>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/148214">Consider <code>Result&lt;T, Uninhabited&gt;</code> and <code>ControlFlow&lt;Uninhabited, T&gt;</code> to be equivalent to <code>T</code> for must use lint</a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/149509">Add allow-by-default <code>dead_code_pub_in_binary</code> lint for unused pub items in binary crates</a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/154510">Stabilize the <code>div32</code>, <code>lam-bh</code>, <code>lamcas</code>, <code>ld-seq-sa</code> and <code>scq</code> target features</a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/155006">Stabilize <code>cfg(target_has_atomic_primitive_alignment)</code></a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/155137">Allow trailing <code>self</code> in imports in more cases</a></li>
</ul>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2>Platform Support</h2>
<ul>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/152443">nvptx64-nvidia-cuda: drop support for old architectures and old ISAs</a></li>
</ul>
<p>Refer to Rust's <a href="https://doc.rust-lang.org/rustc/platform-support.html">platform support page</a> for more information on Rust's tiered platform support.</p>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2>Stabilized APIs</h2>
<ul>
<li><a href="https://doc.rust-lang.org/stable/std/iter/struct.RepeatN.html#impl-Default-for-RepeatN%3CA%3E"><code>Default for RepeatN</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/ffi/struct.FromBytesUntilNulError.html#impl-Copy-for-FromBytesUntilNulError"><code>Copy for ffi::FromBytesUntilNulError</code></a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/154003"><code>Send for std::fs::File</code> on UEFI</a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.isolate_highest_one"><code>&lt;{integer}&gt;::isolate_highest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.isolate_lowest_one"><code>&lt;{integer}&gt;::isolate_lowest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.highest_one"><code>&lt;{integer}&gt;::highest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.lowest_one"><code>&lt;{integer}&gt;::lowest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.bit_width"><code>&lt;{integer}&gt;::bit_width</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/num/struct.NonZero.html#method.isolate_highest_one"><code>NonZero&lt;{integer}&gt;::isolate_highest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/num/struct.NonZero.html#method.isolate_lowest_one"><code>NonZero&lt;{integer}&gt;::isolate_lowest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/num/struct.NonZero.html#method.highest_one"><code>NonZero&lt;{integer}&gt;::highest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/num/struct.NonZero.html#method.lowest_one"><code>NonZero&lt;{integer}&gt;::lowest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/num/struct.NonZero.html#method.bit_width"><code>NonZero&lt;{integer}&gt;::bit_width</code></a></li>
</ul>
<p>These previously stable APIs are now stable in const contexts:</p>
<ul>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.char.html#method.is_control"><code>char::is_control</code></a></li>
</ul>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2>Cargo</h2>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rust-lang/rust/blob/main/RELEASES.md">rust-toolchain's changelog</a>.</em></p>
<blockquote>
<h1>Version 1.97.1 (2026-07-16)</h1>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<ul>
<li><a href="https://redirect.github.com/rust-lang/rust/issues/159035">rustc: Fix miscompilation in LLVM optimization</a>
This backports an LLVM submodule bump to include the LLVM-side fix and a
revert of the rustc change that is one known trigger for the bug. The rustc
side revert should not be strictly necessary but is done out of abundance of caution.</li>
</ul>
<h1>Version 1.97.0 (2026-07-09)</h1>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2>Language</h2>
<ul>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/148214">Consider <code>Result&lt;T, Uninhabited&gt;</code> and <code>ControlFlow&lt;Uninhabited, T&gt;</code> to be equivalent to <code>T</code> for must use lint</a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/149509">Add allow-by-default <code>dead_code_pub_in_binary</code> lint for unused pub items in binary crates</a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/154510">Stabilize the <code>div32</code>, <code>lam-bh</code>, <code>lamcas</code>, <code>ld-seq-sa</code> and <code>scq</code> target features</a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/155006">Stabilize <code>cfg(target_has_atomic_primitive_alignment)</code></a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/155137">Allow trailing <code>self</code> in imports in more cases</a></li>
</ul>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2>Platform Support</h2>
<ul>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/152443">nvptx64-nvidia-cuda: drop support for old architectures and old ISAs</a></li>
</ul>
<p>Refer to Rust's <a href="https://doc.rust-lang.org/rustc/platform-support.html">platform support page</a>
for more information on Rust's tiered platform support.</p>
<p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
<h2>Stabilized APIs</h2>
<ul>
<li><a href="https://doc.rust-lang.org/stable/std/iter/struct.RepeatN.html#impl-Default-for-RepeatN%3CA%3E"><code>Default for RepeatN</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/ffi/struct.FromBytesUntilNulError.html#impl-Copy-for-FromBytesUntilNulError"><code>Copy for ffi::FromBytesUntilNulError</code></a></li>
<li><a href="https://redirect.github.com/rust-lang/rust/pull/154003"><code>Send for std::fs::File</code> on UEFI</a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.isolate_highest_one"><code>&lt;{integer}&gt;::isolate_highest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.isolate_lowest_one"><code>&lt;{integer}&gt;::isolate_lowest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.highest_one"><code>&lt;{integer}&gt;::highest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.lowest_one"><code>&lt;{integer}&gt;::lowest_one</code></a></li>
<li><a href="https://doc.rust-lang.org/stable/std/primitive.u32.html#method.bit_width"><code>&lt;{integer}&gt;::bit_width</code></a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rust-lang/rust/commit/8bab26f4f68e0e26f0bb7960be334d5b520ea452"><code>8bab26f</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/rust/issues/159288">#159288</a> - Mark-Simulacrum:stable-next, r=Mark-Simulacrum</li>
<li><a href="https://github.com/rust-lang/rust/commit/979b2d35681d832e25e09ae839be320755d9cf42"><code>979b2d3</code></a> Backport fix for 159035</li>
<li><a href="https://github.com/rust-lang/rust/commit/e641feae5ee2a3c393d78546fc056c60c9e623fa"><code>e641fea</code></a> Revert &quot;Only exclude the 155473 change for 1-byte bool-likes&quot;</li>
<li><a href="https://github.com/rust-lang/rust/commit/eabe5e433d90c301e0c7bbfa701582e498a9ea0b"><code>eabe5e4</code></a> Add regression test for enum miscompilation</li>
<li><a href="https://github.com/rust-lang/rust/commit/9b8be8a0dc11bdbcad507329f1b3f24613824e17"><code>9b8be8a</code></a> 1.97.1 release</li>
<li><a href="https://github.com/rust-lang/rust/commit/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3"><code>2d8144b</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/rust/issues/158832">#158832</a> - Mark-Simulacrum:stable-next, r=Mark-Simulacrum</li>
<li><a href="https://github.com/rust-lang/rust/commit/1417dc76bbb9355480513eae23b27d0279932837"><code>1417dc7</code></a> Cherry pick mirroring kernel archives in <code>ci-mirrors</code></li>
<li><a href="https://github.com/rust-lang/rust/commit/e6ccfb3a4f922060b0b32e79895b15387b2d5b6f"><code>e6ccfb3</code></a> Fetch latest relnotes</li>
<li><a href="https://github.com/rust-lang/rust/commit/701e4718e758ce51540163517be0b8c2983d4467"><code>701e471</code></a> Bump stable channel</li>
<li><a href="https://github.com/rust-lang/rust/commit/b2282dd5646a57d570fc86fbe8df0e8826665ef6"><code>b2282dd</code></a> Auto merge of <a href="https://redirect.github.com/rust-lang/rust/issues/158630">#158630</a> - weihanglo:beta-cargo-backport, r=weihanglo</li>
<li>Additional commits viewable in <a href="https://github.com/rust-lang/rust/compare/1.96.1...1.97.1">compare view</a></li>
</ul>
</details>
<br />


