### PR TITLE
feat(backend)!: add a ChainFusion active-user-transaction variant

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -29,6 +29,12 @@ type ActiveUserTransactionData = variant {
 	// source/destination leg (EVM and Solana); the deposit address, its
 	// optional memo, and origin/destination tx hashes ride in `external_refs`.
 	NearIntents : NearIntentsData;
+	// Chain Fusion ck conversion (BTC↔ckBTC, ETH↔ckETH, ERC20↔ckERC20). A
+	// single variant covers all six directions, discriminated by the
+	// `direction` field; the minter block indices, the BTC txid and deposit
+	// address, and the Ethereum deposit tx hash and block number ride in
+	// `external_refs`.
+	ChainFusion : ChainFusionData;
 	// Velora (`ParaSwap`) EVM swap. A single variant covers both execution
 	// modes, discriminated by the `mode` field; the auction id, order hash,
 	// transaction hash and nonce ride in `external_refs`.
@@ -377,6 +383,34 @@ type CanisterStatusType = variant {
 	stopping;
 	// The canister is running.
 	running
+};
+// Chain Fusion ck conversion payload. Every settlement pointer is learned
+// mid-flow — a minter block index, a BTC txid, an Ethereum deposit tx hash — so
+// those live in `external_refs`; only the canonical immutable fields are
+// captured here, which is why all six directions share one variant.
+//
+// `direction` is explicit rather than inferred from the token pair: the poller
+// selects its settlement oracle from it, and re-deriving "is this a mint or a
+// withdrawal?" from two token ids on every tick would rediscover something
+// known for certain at creation.
+type ChainFusionData = record {
+	direction : ChainFusionDirection;
+	source_token : TokenId;
+	// Source-token amount in base units.
+	amount : nat;
+	dest_token : TokenId
+};
+// Which ck conversion an active transaction tracks. Determines which minter the
+// frontend asks about settlement, and how: the three withdrawal directions have
+// an exact status keyed by the minter's burn block index, while the mint
+// directions are observed from the deposit side.
+type ChainFusionDirection = variant {
+	BtcToCkBtc;
+	CkBtcToBtc;
+	EthToCkEth;
+	CkErc20ToErc20;
+	Erc20ToCkErc20;
+	CkEthToEth
 };
 type Config = record {
 	// The derivation origin used for II authentication, ensuring users get a

--- a/src/backend/src/active_user_transactions/model.rs
+++ b/src/backend/src/active_user_transactions/model.rs
@@ -1,14 +1,20 @@
 use std::collections::HashSet;
 
 use candid::{Nat, Principal};
-use shared::types::active_user_transaction::{
-    ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
-    ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
-    GetActiveUserTransactionsResponse, UpdateActiveUserTransactionRequest,
-    MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_ACTIVE_USER_TRANSACTION_ERROR_LEN,
-    MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REFS, MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_KEY_LEN,
-    MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_VALUE_LEN, MAX_ACTIVE_USER_TRANSACTION_ID_LEN,
-    MAX_ACTIVE_USER_TRANSACTION_PROGRESS_STEP_LEN, MAX_EVM_ADDRESS_LEN, MAX_LIQUIDIUM_POOL_ID_LEN,
+use shared::types::{
+    active_user_transaction::{
+        ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
+        ActiveUserTransactionRef, ActiveUserTransactionStatus, ChainFusionData,
+        ChainFusionDirection, CreateActiveUserTransactionRequest,
+        GetActiveUserTransactionsResponse, UpdateActiveUserTransactionRequest,
+        MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_ACTIVE_USER_TRANSACTION_ERROR_LEN,
+        MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REFS,
+        MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_KEY_LEN,
+        MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_VALUE_LEN, MAX_ACTIVE_USER_TRANSACTION_ID_LEN,
+        MAX_ACTIVE_USER_TRANSACTION_PROGRESS_STEP_LEN, MAX_EVM_ADDRESS_LEN,
+        MAX_LIQUIDIUM_POOL_ID_LEN,
+    },
+    token_id::TokenId,
 };
 
 use crate::types::{ActiveUserTransactionKey, ActiveUserTransactionsMap, Candid, StoredPrincipal};
@@ -232,6 +238,10 @@ fn validate_data(data: &ActiveUserTransactionData) -> Result<(), ActiveUserTrans
         ActiveUserTransactionData::Velora(d) => {
             require_positive_amount(&d.amount)?;
         }
+        ActiveUserTransactionData::ChainFusion(d) => {
+            require_positive_amount(&d.amount)?;
+            require_chain_fusion_pair(d)?;
+        }
     }
     Ok(())
 }
@@ -252,6 +262,41 @@ fn require_pool_id(pool_id: &str) -> Result<(), ActiveUserTransactionError> {
         ));
     }
     Ok(())
+}
+
+/// Each direction fixes which side of the conversion is the ck (ICRC) token and
+/// what kind the other side must be. `data` is immutable after creation and the
+/// FE poller picks its settlement oracle from `direction`, so a pair that
+/// contradicts the direction could never settle and would occupy one of the
+/// user's slots forever — reject it up front. Kinds only, deliberately: any
+/// EVM chain id and any ICRC ledger stay valid so testnets need no special
+/// casing here.
+fn require_chain_fusion_pair(data: &ChainFusionData) -> Result<(), ActiveUserTransactionError> {
+    let is_btc = |t: &TokenId| matches!(t, TokenId::BtcNativeMainnet | TokenId::BtcNativeTestnet);
+    let is_eth = |t: &TokenId| matches!(t, TokenId::EvmNative(_));
+    let is_erc20 = |t: &TokenId| matches!(t, TokenId::Erc20(..));
+    let is_ck = |t: &TokenId| matches!(t, TokenId::Icrc(_));
+
+    let ok = match data.direction {
+        ChainFusionDirection::BtcToCkBtc => is_btc(&data.source_token) && is_ck(&data.dest_token),
+        ChainFusionDirection::CkBtcToBtc => is_ck(&data.source_token) && is_btc(&data.dest_token),
+        ChainFusionDirection::EthToCkEth => is_eth(&data.source_token) && is_ck(&data.dest_token),
+        ChainFusionDirection::CkEthToEth => is_ck(&data.source_token) && is_eth(&data.dest_token),
+        ChainFusionDirection::Erc20ToCkErc20 => {
+            is_erc20(&data.source_token) && is_ck(&data.dest_token)
+        }
+        ChainFusionDirection::CkErc20ToErc20 => {
+            is_ck(&data.source_token) && is_erc20(&data.dest_token)
+        }
+    };
+
+    if ok {
+        Ok(())
+    } else {
+        Err(ActiveUserTransactionError::InvalidData(
+            "token pair does not match chain-fusion direction".to_string(),
+        ))
+    }
 }
 
 fn require_evm_address(addr: &str) -> Result<(), ActiveUserTransactionError> {
@@ -307,10 +352,10 @@ mod tests {
     use shared::types::{
         active_user_transaction::{
             ActiveUserTransactionData, ActiveUserTransactionError, ActiveUserTransactionRef,
-            ActiveUserTransactionStatus, CreateActiveUserTransactionRequest, LiquidiumAction,
-            LiquidiumData, NearIntentsData, OneSecEvmToIcpData, OneSecIcpToEvmData,
-            UpdateActiveUserTransactionRequest, VeloraData, VeloraSwapMode,
-            MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_LIQUIDIUM_POOL_ID_LEN,
+            ActiveUserTransactionStatus, ChainFusionData, ChainFusionDirection,
+            CreateActiveUserTransactionRequest, LiquidiumAction, LiquidiumData, NearIntentsData,
+            OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData,
+            VeloraSwapMode, MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_LIQUIDIUM_POOL_ID_LEN,
         },
         custom_token::ErcTokenId,
         token_id::TokenId,
@@ -534,6 +579,95 @@ mod tests {
             let (mut map, _mm) = setup();
             let mut req = create_req("velora-1");
             req.data = velora_data(0, mode);
+            let err = create(&mut map, principal(), req, 1).unwrap_err();
+            assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+        }
+    }
+
+    const CKBTC_LEDGER: &str = "mxzaz-hqaaa-aaaar-qaada-cai";
+    const CKETH_LEDGER: &str = "ss2fx-dyaaa-aaaar-qacoq-cai";
+    const CKUSDC_LEDGER: &str = "xevnm-gaaaa-aaaar-qafnq-cai";
+    const USDC_ETHEREUM: &str = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+
+    fn icrc(ledger: &str) -> TokenId {
+        TokenId::Icrc(Principal::from_text(ledger).unwrap())
+    }
+
+    fn chain_fusion_data(
+        amount: u64,
+        direction: ChainFusionDirection,
+    ) -> ActiveUserTransactionData {
+        // Mirrors `chain_fusion_leg` in the shared-crate tests: each direction
+        // carries the token pair it can actually settle, since `validate_data`
+        // rejects a pair that contradicts the direction.
+        let (source_token, dest_token) = match &direction {
+            ChainFusionDirection::BtcToCkBtc => (TokenId::BtcNativeMainnet, icrc(CKBTC_LEDGER)),
+            ChainFusionDirection::CkBtcToBtc => (icrc(CKBTC_LEDGER), TokenId::BtcNativeMainnet),
+            ChainFusionDirection::EthToCkEth => (TokenId::EvmNative(1), icrc(CKETH_LEDGER)),
+            ChainFusionDirection::CkEthToEth => (icrc(CKETH_LEDGER), TokenId::EvmNative(1)),
+            ChainFusionDirection::Erc20ToCkErc20 => (
+                TokenId::Erc20(ErcTokenId(USDC_ETHEREUM.to_string()), 1),
+                icrc(CKUSDC_LEDGER),
+            ),
+            ChainFusionDirection::CkErc20ToErc20 => (
+                icrc(CKUSDC_LEDGER),
+                TokenId::Erc20(ErcTokenId(USDC_ETHEREUM.to_string()), 1),
+            ),
+        };
+        ActiveUserTransactionData::ChainFusion(ChainFusionData {
+            direction,
+            source_token,
+            dest_token,
+            amount: Nat::from(amount),
+        })
+    }
+
+    #[test]
+    fn chain_fusion_create_roundtrip() {
+        // All six directions share one variant, so each must survive create —
+        // and the stable-memory read path — unchanged; the direction is what
+        // the FE poller routes on.
+        for direction in ChainFusionDirection::ALL {
+            let (mut map, _mm) = setup();
+            let mut req = create_req("ck-1");
+            req.data = chain_fusion_data(1_000, direction.clone());
+            let tx = create(&mut map, principal(), req, 1).expect("create");
+            assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+
+            let listed = list(&map, principal()).transactions;
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].data, chain_fusion_data(1_000, direction));
+        }
+    }
+
+    #[test]
+    fn chain_fusion_zero_amount_rejected() {
+        for direction in ChainFusionDirection::ALL {
+            let (mut map, _mm) = setup();
+            let mut req = create_req("ck-1");
+            req.data = chain_fusion_data(0, direction);
+            let err = create(&mut map, principal(), req, 1).unwrap_err();
+            assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+        }
+    }
+
+    #[test]
+    fn chain_fusion_mismatched_token_pair_rejected() {
+        // The BtcToCkBtc pair submitted under every other direction: `data` is
+        // immutable after creation, so a row whose tokens contradict its
+        // direction could never settle and must be rejected up front.
+        for direction in ChainFusionDirection::ALL {
+            if direction == ChainFusionDirection::BtcToCkBtc {
+                continue;
+            }
+            let (mut map, _mm) = setup();
+            let mut req = create_req("ck-1");
+            req.data = ActiveUserTransactionData::ChainFusion(ChainFusionData {
+                direction,
+                source_token: TokenId::BtcNativeMainnet,
+                dest_token: icrc(CKBTC_LEDGER),
+                amount: Nat::from(1_000u64),
+            });
             let err = create(&mut map, principal(), req, 1).unwrap_err();
             assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
         }

--- a/src/backend/tests/it/active_user_transactions.rs
+++ b/src/backend/tests/it/active_user_transactions.rs
@@ -5,9 +5,9 @@ use pretty_assertions::assert_eq;
 use shared::types::{
     active_user_transaction::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
-        ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
-        NearIntentsData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData,
-        VeloraSwapMode,
+        ActiveUserTransactionRef, ActiveUserTransactionStatus, ChainFusionData,
+        ChainFusionDirection, CreateActiveUserTransactionRequest, NearIntentsData,
+        OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData, VeloraSwapMode,
     },
     custom_token::ErcTokenId,
     result_types::{
@@ -270,6 +270,55 @@ fn create_velora_variant_roundtrip() {
             ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
         }
     }
+}
+
+#[test]
+fn create_chain_fusion_variant_roundtrip() {
+    // Per-direction candid fidelity is covered in-process by the shared-crate
+    // round-trip tests, so one canister round-trip proves the end-to-end wiring.
+    // `BtcToCkBtc` keeps `BtcNativeMainnet` on the wire — no other AUT variant
+    // can carry it.
+    let pic = setup();
+    let user = caller();
+    pic.ensure_user_profile(user);
+
+    let data = ActiveUserTransactionData::ChainFusion(ChainFusionData {
+        direction: ChainFusionDirection::BtcToCkBtc,
+        source_token: TokenId::BtcNativeMainnet,
+        dest_token: TokenId::Icrc(Principal::from_text("mxzaz-hqaaa-aaaar-qaada-cai").unwrap()),
+        amount: Nat::from(1_000u64),
+    });
+
+    let created = pic
+        .update::<ActiveUserTransactionResult>(
+            user,
+            "create_active_user_transaction",
+            CreateActiveUserTransactionRequest {
+                data: data.clone(),
+                external_refs: vec![ActiveUserTransactionRef {
+                    key: "btc_txid".to_string(),
+                    value: "aa".repeat(32),
+                }],
+                ..create_req(TX_ID)
+            },
+        )
+        .expect("create_active_user_transaction call should succeed");
+
+    match created {
+        ActiveUserTransactionResult::Ok(tx) => {
+            assert_eq!(tx.id, TX_ID);
+            assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+            assert_eq!(tx.data, data);
+            assert_eq!(tx.external_refs.len(), 1);
+        }
+        ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+
+    // Read back through the query path so the stored (not just echoed)
+    // representation is what the assertion sees.
+    let listed = list_active(&pic, user);
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].data, data);
 }
 
 #[test]

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -29,6 +29,12 @@ type ActiveUserTransactionData = variant {
 	// source/destination leg (EVM and Solana); the deposit address, its
 	// optional memo, and origin/destination tx hashes ride in `external_refs`.
 	NearIntents : NearIntentsData;
+	// Chain Fusion ck conversion (BTC↔ckBTC, ETH↔ckETH, ERC20↔ckERC20). A
+	// single variant covers all six directions, discriminated by the
+	// `direction` field; the minter block indices, the BTC txid and deposit
+	// address, and the Ethereum deposit tx hash and block number ride in
+	// `external_refs`.
+	ChainFusion : ChainFusionData;
 	// Velora (`ParaSwap`) EVM swap. A single variant covers both execution
 	// modes, discriminated by the `mode` field; the auction id, order hash,
 	// transaction hash and nonce ride in `external_refs`.
@@ -377,6 +383,34 @@ type CanisterStatusType = variant {
 	stopping;
 	// The canister is running.
 	running
+};
+// Chain Fusion ck conversion payload. Every settlement pointer is learned
+// mid-flow — a minter block index, a BTC txid, an Ethereum deposit tx hash — so
+// those live in `external_refs`; only the canonical immutable fields are
+// captured here, which is why all six directions share one variant.
+//
+// `direction` is explicit rather than inferred from the token pair: the poller
+// selects its settlement oracle from it, and re-deriving "is this a mint or a
+// withdrawal?" from two token ids on every tick would rediscover something
+// known for certain at creation.
+type ChainFusionData = record {
+	direction : ChainFusionDirection;
+	source_token : TokenId;
+	// Source-token amount in base units.
+	amount : nat;
+	dest_token : TokenId
+};
+// Which ck conversion an active transaction tracks. Determines which minter the
+// frontend asks about settlement, and how: the three withdrawal directions have
+// an exact status keyed by the minter's burn block index, while the mint
+// directions are observed from the deposit side.
+type ChainFusionDirection = variant {
+	BtcToCkBtc;
+	CkBtcToBtc;
+	EthToCkEth;
+	CkErc20ToErc20;
+	Erc20ToCkErc20;
+	CkEthToEth
 };
 type Config = record {
 	// The derivation origin used for II authentication, ensuring users get a

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -61,6 +61,16 @@ export type ActiveUserTransactionData =
 	  }
 	| {
 			/**
+			 * Chain Fusion ck conversion (BTC↔ckBTC, ETH↔ckETH, ERC20↔ckERC20). A
+			 * single variant covers all six directions, discriminated by the
+			 * `direction` field; the minter block indices, the BTC txid and deposit
+			 * address, and the Ethereum deposit tx hash and block number ride in
+			 * `external_refs`.
+			 */
+			ChainFusion: ChainFusionData;
+	  }
+	| {
+			/**
 			 * Velora (`ParaSwap`) EVM swap. A single variant covers both execution
 			 * modes, discriminated by the `mode` field; the auction id, order hash,
 			 * transaction hash and nonce ride in `external_refs`.
@@ -553,6 +563,39 @@ export type CanisterStatusType =
 			 */
 			running: null;
 	  };
+/**
+ * Chain Fusion ck conversion payload. Every settlement pointer is learned
+ * mid-flow — a minter block index, a BTC txid, an Ethereum deposit tx hash — so
+ * those live in `external_refs`; only the canonical immutable fields are
+ * captured here, which is why all six directions share one variant.
+ *
+ * `direction` is explicit rather than inferred from the token pair: the poller
+ * selects its settlement oracle from it, and re-deriving "is this a mint or a
+ * withdrawal?" from two token ids on every tick would rediscover something
+ * known for certain at creation.
+ */
+export interface ChainFusionData {
+	direction: ChainFusionDirection;
+	source_token: TokenId;
+	/**
+	 * Source-token amount in base units.
+	 */
+	amount: bigint;
+	dest_token: TokenId;
+}
+/**
+ * Which ck conversion an active transaction tracks. Determines which minter the
+ * frontend asks about settlement, and how: the three withdrawal directions have
+ * an exact status keyed by the minter's burn block index, while the mint
+ * directions are observed from the deposit side.
+ */
+export type ChainFusionDirection =
+	| { BtcToCkBtc: null }
+	| { CkBtcToBtc: null }
+	| { EthToCkEth: null }
+	| { CkErc20ToErc20: null }
+	| { Erc20ToCkErc20: null }
+	| { CkEthToEth: null };
 export interface Config {
 	/**
 	 * The derivation origin used for II authentication, ensuring users get a

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -251,6 +251,20 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const ChainFusionDirection = IDL.Variant({
+		BtcToCkBtc: IDL.Null,
+		CkBtcToBtc: IDL.Null,
+		EthToCkEth: IDL.Null,
+		CkErc20ToErc20: IDL.Null,
+		Erc20ToCkErc20: IDL.Null,
+		CkEthToEth: IDL.Null
+	});
+	const ChainFusionData = IDL.Record({
+		direction: ChainFusionDirection,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
 	const VeloraSwapMode = IDL.Variant({
 		Delta: IDL.Null,
 		Market: IDL.Null
@@ -277,6 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		OneSecEvmToIcp: OneSecEvmToIcpData,
 		OneSecIcpToEvm: OneSecIcpToEvmData,
 		NearIntents: NearIntentsData,
+		ChainFusion: ChainFusionData,
 		Velora: VeloraData,
 		Liquidium: LiquidiumData
 	});

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -251,6 +251,20 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const ChainFusionDirection = IDL.Variant({
+		BtcToCkBtc: IDL.Null,
+		CkBtcToBtc: IDL.Null,
+		EthToCkEth: IDL.Null,
+		CkErc20ToErc20: IDL.Null,
+		Erc20ToCkErc20: IDL.Null,
+		CkEthToEth: IDL.Null
+	});
+	const ChainFusionData = IDL.Record({
+		direction: ChainFusionDirection,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
 	const VeloraSwapMode = IDL.Variant({
 		Delta: IDL.Null,
 		Market: IDL.Null
@@ -277,6 +291,7 @@ export const idlFactory = ({ IDL }) => {
 		OneSecEvmToIcp: OneSecEvmToIcpData,
 		OneSecIcpToEvm: OneSecIcpToEvmData,
 		NearIntents: NearIntentsData,
+		ChainFusion: ChainFusionData,
 		Velora: VeloraData,
 		Liquidium: LiquidiumData
 	});

--- a/src/shared/src/types/active_user_transaction.rs
+++ b/src/shared/src/types/active_user_transaction.rs
@@ -85,6 +85,12 @@ pub enum ActiveUserTransactionData {
     /// modes, discriminated by the `mode` field; the auction id, order hash,
     /// transaction hash and nonce ride in `external_refs`.
     Velora(VeloraData),
+    /// Chain Fusion ck conversion (BTC↔ckBTC, ETH↔ckETH, ERC20↔ckERC20). A
+    /// single variant covers all six directions, discriminated by the
+    /// `direction` field; the minter block indices, the BTC txid and deposit
+    /// address, and the Ethereum deposit tx hash and block number ride in
+    /// `external_refs`.
+    ChainFusion(ChainFusionData),
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -158,6 +164,51 @@ pub struct VeloraData {
     pub amount: Nat,
 }
 
+/// Which ck conversion an active transaction tracks. Determines which minter the
+/// frontend asks about settlement, and how: the three withdrawal directions have
+/// an exact status keyed by the minter's burn block index, while the mint
+/// directions are observed from the deposit side.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum ChainFusionDirection {
+    BtcToCkBtc,
+    CkBtcToBtc,
+    EthToCkEth,
+    CkEthToEth,
+    Erc20ToCkErc20,
+    CkErc20ToErc20,
+}
+
+impl ChainFusionDirection {
+    /// Every direction, in declaration order. Tests iterate this instead of
+    /// hand-spelling the list, so a new direction is added in one place.
+    pub const ALL: [Self; 6] = [
+        Self::BtcToCkBtc,
+        Self::CkBtcToBtc,
+        Self::EthToCkEth,
+        Self::CkEthToEth,
+        Self::Erc20ToCkErc20,
+        Self::CkErc20ToErc20,
+    ];
+}
+
+/// Chain Fusion ck conversion payload. Every settlement pointer is learned
+/// mid-flow — a minter block index, a BTC txid, an Ethereum deposit tx hash — so
+/// those live in `external_refs`; only the canonical immutable fields are
+/// captured here, which is why all six directions share one variant.
+///
+/// `direction` is explicit rather than inferred from the token pair: the poller
+/// selects its settlement oracle from it, and re-deriving "is this a mint or a
+/// withdrawal?" from two token ids on every tick would rediscover something
+/// known for certain at creation.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct ChainFusionData {
+    pub direction: ChainFusionDirection,
+    pub source_token: TokenId,
+    pub dest_token: TokenId,
+    /// Source-token amount in base units.
+    pub amount: Nat,
+}
+
 /// In-flight high-level user operation, persisted so the FE can resume polling
 /// across logout / tab close.
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -223,7 +274,8 @@ mod tests {
 
     use super::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
-        ActiveUserTransactionRef, ActiveUserTransactionStatus, CreateActiveUserTransactionRequest,
+        ActiveUserTransactionRef, ActiveUserTransactionStatus, ChainFusionData,
+        ChainFusionDirection, CreateActiveUserTransactionRequest,
         GetActiveUserTransactionsResponse, LiquidiumAction, LiquidiumData, NearIntentsData,
         OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData,
         VeloraSwapMode,
@@ -332,6 +384,53 @@ mod tests {
     fn velora_swap_mode_roundtrips() {
         for mode in [VeloraSwapMode::Delta, VeloraSwapMode::Market] {
             assert_eq!(roundtrip(&mode), mode);
+        }
+    }
+
+    const CKBTC_LEDGER: &str = "mxzaz-hqaaa-aaaar-qaada-cai";
+    const CKETH_LEDGER: &str = "ss2fx-dyaaa-aaaar-qacoq-cai";
+    const CKUSDC_LEDGER: &str = "xevnm-gaaaa-aaaar-qafnq-cai";
+    const USDC_ETHEREUM: &str = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+
+    fn icrc(ledger: &str) -> TokenId {
+        TokenId::Icrc(Principal::from_text(ledger).unwrap())
+    }
+
+    /// The token pair each direction actually carries, so the round-trip also
+    /// covers `BtcNativeMainnet` — which no other `ActiveUserTransactionData`
+    /// variant can reach. The match is exhaustive, so a new direction cannot
+    /// ship without declaring its legs here.
+    fn chain_fusion_leg(direction: &ChainFusionDirection) -> (TokenId, TokenId) {
+        match direction {
+            ChainFusionDirection::BtcToCkBtc => (TokenId::BtcNativeMainnet, icrc(CKBTC_LEDGER)),
+            ChainFusionDirection::CkBtcToBtc => (icrc(CKBTC_LEDGER), TokenId::BtcNativeMainnet),
+            ChainFusionDirection::EthToCkEth => (TokenId::EvmNative(1), icrc(CKETH_LEDGER)),
+            ChainFusionDirection::CkEthToEth => (icrc(CKETH_LEDGER), TokenId::EvmNative(1)),
+            ChainFusionDirection::Erc20ToCkErc20 => (erc20(USDC_ETHEREUM, 1), icrc(CKUSDC_LEDGER)),
+            ChainFusionDirection::CkErc20ToErc20 => (icrc(CKUSDC_LEDGER), erc20(USDC_ETHEREUM, 1)),
+        }
+    }
+
+    #[test]
+    fn chain_fusion_variant_roundtrips() {
+        // All six directions share one variant, so each must survive the
+        // round-trip untouched — the direction is what the FE poller routes on.
+        for direction in ChainFusionDirection::ALL {
+            let (source_token, dest_token) = chain_fusion_leg(&direction);
+            let original = ActiveUserTransactionData::ChainFusion(ChainFusionData {
+                direction,
+                source_token,
+                dest_token,
+                amount: Nat::from(1_000u64),
+            });
+            assert_eq!(roundtrip(&original), original);
+        }
+    }
+
+    #[test]
+    fn chain_fusion_direction_roundtrips() {
+        for direction in ChainFusionDirection::ALL {
+            assert_eq!(roundtrip(&direction), direction);
         }
     }
 


### PR DESCRIPTION
# Motivation

Chain Fusion ck conversions (BTC↔ckBTC, ETH↔ckETH, ERC20↔ckERC20) are long-running and today lose all feedback when the modal or tab closes. To let them register as Active User Transactions and be driven by the existing global poller — as OneSec, Liquidium, NearIntents and Velora already are — `ActiveUserTransactionData` needs a ChainFusion variant. This PR lands only that backend prerequisite; no frontend creates such rows yet.

BREAKING CHANGE: `ActiveUserTransactionData` gains a `ChainFusion` variant. Because this type is returned by `create_active_user_transaction`, `update_active_user_transaction`, and `get_active_user_transactions`, a client built against the previous candid interface cannot decode an active transaction whose `data` is `ChainFusion`. Only newer frontends create such rows; deploy the backend ahead of (or together with) the frontend that starts writing them.


# Changes

- `ChainFusionData` (direction + source/dest `TokenId` + amount) and `ChainFusionDirection` (six directions), modelled on `VeloraData`/`VeloraSwapMode`; the variant is appended **last** per the evolution rule. Settlement pointers ride in `external_refs`.
- `validate_data` gains the `ChainFusion` arm: positive amount plus a direction↔token-pair kind check. `data` is immutable after creation and the poller routes on `direction`, so a contradictory pair is rejected up front.
- `backend.did` + `src/declarations/backend/*` regenerated, not hand-edited.
- Spec updated: PR 0 is wire-breaking in return position, and the pair check is documented.


# Tests

Added.
