### PR TITLE
ci(devops): fail the ic-domains check instead of uploading a blank file

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -229,13 +229,35 @@ jobs:
       - name: Install dfx
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
       - name: Check ic-domains
-        continue-on-error: true
         run: |
           FILE="ic-domain.$NETWORK.txt"
+          DOMAINS="build/.well-known/ic-domains"
           echo "" > "$FILE"
-          dfx build frontend --network "$NETWORK" >/dev/null 2>/dev/null && \
-            cat build/.well-known/ic-domains > "$FILE" && \
+
+          # `dfx build` downloads dependency artifacts from GitHub releases, which
+          # fails intermittently. Retry before giving up, and keep the output so a
+          # genuine build error is diagnosable from the job log.
+          for attempt in 1 2 3; do
+            if dfx build frontend --network "$NETWORK" >dfx-build.log 2>&1; then
+              break
+            fi
+            if [[ "$attempt" == 3 ]]; then
+              echo "::error::dfx build frontend --network $NETWORK failed after $attempt attempts"
+              cat dfx-build.log
+              exit 1
+            fi
+            echo "dfx build failed (attempt $attempt), retrying..."
+            sleep $((attempt * 15))
+          done
+
+          # Networks without a custom domain produce no ic-domains file. That is
+          # expected, and leaves the placeholder blank line the validation ignores.
+          if [[ -f "$DOMAINS" ]]; then
+            cat "$DOMAINS" > "$FILE"
             echo " $NETWORK" >> "$FILE"
+          else
+            echo "No $DOMAINS for $NETWORK; leaving the domain file blank."
+          fi
         env:
           NETWORK: ${{ matrix.network }}
       - name: Upload Domain File

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -216,6 +216,9 @@ jobs:
     permissions:
       contents: read
     strategy:
+      # One network failing should not hide the state of the others: `config`
+      # needs every domain file to produce a meaningful comparison.
+      fail-fast: false
       matrix:
         network: ${{ fromJson(needs.config-preparation.outputs.network-matrix) }}
 
@@ -233,6 +236,14 @@ jobs:
           FILE="ic-domain.$NETWORK.txt"
           DOMAINS="build/.well-known/ic-domains"
           echo "" > "$FILE"
+
+          # Some networks (e.g. old-backend) have no frontend canister, so the
+          # build cannot run there at all. That is not a failure: leave the
+          # placeholder blank line, which the validation ignores.
+          if ! dfx canister id frontend --network "$NETWORK" >/dev/null 2>&1; then
+            echo "No frontend canister for $NETWORK; leaving the domain file blank."
+            exit 0
+          fi
 
           # `dfx build` downloads dependency artifacts from GitHub releases, which
           # fails intermittently. Retry before giving up, and keep the output so a


### PR DESCRIPTION
# Motivation

The `config` check has been failing across the repo, on `main`, on the merge queue, and on unrelated branches. The reported diff looks like domain line-ordering noise, which is misleading: the real comparison in `scripts/build.ic-domains.test` is `diff --ignore-all-space --ignore-blank-lines` over sorted input, so the only genuine difference is a missing domain.

The cause is that `Check ic-domains` cannot fail. It writes a blank placeholder, runs `dfx build` with all output discarded, and carries `continue-on-error: true`:

```bash
echo "" > "$FILE"
dfx build frontend --network "$NETWORK" >/dev/null 2>/dev/null && \
  cat build/.well-known/ic-domains > "$FILE" && \
  echo " $NETWORK" >> "$FILE"
```

When `dfx build` fails, the `&&` chain short-circuits, the blank placeholder is uploaded as the artifact, and the job is still reported green. The failure only surfaces one job later in `config`, as a diff that points at the wrong thing. Downloading the artifacts from a failing run confirms it: the `ic` and `test_fe_5` files contained a single newline while both jobs reported success.

`dfx build` downloads dependency artifacts from GitHub releases, which has been failing intermittently (`http2 error: refused stream before processing any application logic`), so a different network goes blank on each run.

`continue-on-error` could not simply be dropped, because `local`, `old-backend` and `test_be_1` have no custom domain and therefore produce no `build/.well-known/ic-domains`. For those, `cat` fails and short-circuits the same chain, so the flag was masking a legitimate case and a real failure with equal silence.

# Changes

- Removed `continue-on-error: true` from `Check ic-domains`.
- Separated the two cases the `&&` chain conflated: a failing `dfx build` now fails the step explicitly, while a missing `ic-domains` file is treated as the expected outcome for networks without a custom domain and leaves the blank placeholder the validation already ignores.
- Retry `dfx build` up to 3 times with backoff, since the failures are transient GitHub release downloads.
- Keep `dfx build` output in a log and print it when the build ultimately fails, instead of discarding it, so a genuine build error is diagnosable from the job log.
- Skip networks that have no frontend canister. The first run of this PR proved the point of the change: `old-backend` failed instantly and identically on all three attempts with `Cannot find canister id. Please issue 'dfx canister create frontend --network old-backend'`. That is a permanent property of the network, not a build error, and it was previously invisible because the blank artifact looked the same as every other blank one. It is now detected up front with `dfx canister id` rather than by letting the build fail.
- Set `fail-fast: false` on the matrix, so one network going red no longer cancels the other thirteen. `config` needs every domain file to produce a meaningful comparison.

Not touched: `scripts/build.ic-domains.test` has the same short-circuit pattern in its local `dfx_network_domains()` path. It is only used when the script runs without an argument, which CI never does, so it is left for a separate change.

# Tests

- `shellcheck` clean on the extracted step body, and `bash -n` parses it.
- `prettier --check` clean on the workflow.
- The behavioural check is CI itself: `config-build` must stay green for `local`, `old-backend` and `test_be_1` (no domains file, blank artifact by design), and `config` must pass with the full domain list. A `dfx build` failure should now turn its own job red with the dfx output attached, rather than surfacing as a domain diff.
