### PR TITLE
ci(devops): keep dfx build output in the frontend config check

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -230,10 +230,13 @@ jobs:
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
       - name: Check ic-domains
         continue-on-error: true
+        # The build output is kept, so that a failure can be diagnosed from the job log.
+        # Networks that serve no domain (local, old-backend, test_be_1) are expected to fail
+        # here and to leave the file empty; the `config` job asserts which ones those are.
         run: |
           FILE="ic-domain.$NETWORK.txt"
           echo "" > "$FILE"
-          dfx build frontend --network "$NETWORK" >/dev/null 2>/dev/null && \
+          dfx build frontend --network "$NETWORK" && \
             cat build/.well-known/ic-domains > "$FILE" && \
             echo " $NETWORK" >> "$FILE"
         env:

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -231,8 +231,9 @@ jobs:
       - name: Check ic-domains
         continue-on-error: true
         # The build output is kept, so that a failure can be diagnosed from the job log.
-        # Networks that serve no domain (local, old-backend, test_be_1) are expected to fail
-        # here and to leave the file empty; the `config` job asserts which ones those are.
+        # Networks that serve no domain (local, old-backend, test_be_1) are expected to produce
+        # no domain here, leaving the file with only its placeholder blank line, which the
+        # domain diff ignores.
         run: |
           FILE="ic-domain.$NETWORK.txt"
           echo "" > "$FILE"


### PR DESCRIPTION
# Motivation

The `config` job of Frontend Checks is currently flaky, and it is impossible to tell why from the logs.

`config-build` runs `dfx build frontend --network "$NETWORK"` for all 14 networks with both stdout and stderr sent to `/dev/null`. When that build fails, the `&&` chain short-circuits, the artifact silently keeps its blank placeholder line, and the job still reports green because of `continue-on-error`. The downstream `config` job then diffs the merged artifacts against `scripts/build.ic-domains.test.expected` and reports a missing domain, so a build crash surfaces as "Incorrect .well-known/ic-domains" for a random network.

Evidence that it is flaky rather than a real config regression: identical commits both pass and fail (`38344f93` on main: success at 06:55, failure at 06:59; `a437d1cd` on main: success at 06:13, failure at 06:34), and the missing network differs every run (`test_fe_5`, then `test_fe_3` + `test_fe_4`, then `audit` + `e2e`, then `test_fe_1`). The failure rate went from roughly 2% between 10 and 12 August to 43% and then 86% in the 06:00 and 07:00 UTC hours of 13 August.

All the job log says today is `Process completed with exit code 255`, which is dfx's generic error code. The actual message is discarded, so the root cause cannot be identified. This PR does not fix the flakiness, it makes the next occurrence diagnosable.

# Changes

- Drop `>/dev/null 2>/dev/null` from the `dfx build` invocation in the `config-build` job, so the failure is visible in the job log.
- Add a comment recording why some networks are expected to fail this step.

Behaviour is unchanged: the file written for the artifact is unaffected, since it is produced by a separate redirect.

# Tests

- Covered by the workflow itself: `config-build` runs on this PR for all 14 networks.
- Expect the job logs of `config-build (local)`, `config-build (old-backend)` and `config-build (test_be_1)` to now show the dfx error they always had, as those networks serve no domain.
