### PR TITLE
ci(devops): fail the config build when a network that serves a domain cannot build

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -229,16 +229,20 @@ jobs:
       - name: Install dfx
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
       - name: Check ic-domains
-        continue-on-error: true
         # The build output is kept, so that a failure can be diagnosed from the job log.
         # Networks that serve no domain (local, old-backend, test_be_1) are expected to fail
-        # here and to leave the file empty; the `config` job asserts which ones those are.
+        # to build and to leave the file empty. For every other network a build failure is a
+        # real failure, and must be reported as such instead of as a missing domain later on.
         run: |
           FILE="ic-domain.$NETWORK.txt"
           echo "" > "$FILE"
-          dfx build frontend --network "$NETWORK" && \
-            cat build/.well-known/ic-domains > "$FILE" && \
+          if dfx build frontend --network "$NETWORK"; then
+            cat build/.well-known/ic-domains > "$FILE"
             echo " $NETWORK" >> "$FILE"
+          elif grep -q " $NETWORK\$" scripts/build.ic-domains.test.expected; then
+            echo "ERROR: 'dfx build frontend --network $NETWORK' failed, but this network is expected to serve a domain."
+            exit 1
+          fi
         env:
           NETWORK: ${{ matrix.network }}
       - name: Upload Domain File


### PR DESCRIPTION
# Motivation

When `dfx build frontend --network X` fails in `config-build`, the job stays green thanks to `continue-on-error`, the uploaded artifact keeps its blank placeholder line, and the failure only surfaces one job later as `ERROR: Incorrect .well-known/ic-domains` with a domain missing from the diff. That is the wrong error, in the wrong job, and it reads like a configuration regression rather than a build failure.

The reason the step tolerates failures at all is that 3 of the 14 networks (`local`, `old-backend`, `test_be_1`) serve no domain and are expected to fail the build. Blanket tolerance for those 3 also hides real failures on the other 11.

# Changes

- Classify the network before deciding whether a build failure is acceptable: a network listed in `scripts/build.ic-domains.test.expected` must build, any other may fail and leaves the file empty as before.
- Fail `config-build` with an explicit message naming the network when a network that must build does not.
- Drop `continue-on-error: true`, which is no longer needed now that the tolerated case is expressed explicitly.

The `config` job keeps its diff as the second-level check, for the case where a build succeeds but emits the wrong domain.

Stacked on #13716, since both touch the same step. Base retargets to `main` automatically once that one merges.

# Tests

- Classification verified locally against `scripts/build.ic-domains.test.expected` for all 14 networks from `dfx.json`: the 11 networks with a domain resolve to "must build", and `local`, `old-backend` and `test_be_1` resolve to "may fail".
- Covered by the workflow itself: `config-build` runs on this PR for all 14 networks, and `config` still validates the merged result.
