### PR TITLE
ci(devops): cache the dfx install across the config build matrix

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -196,6 +196,7 @@ jobs:
       contents: read
     outputs:
       network-matrix: ${{ steps.set-matrix.outputs.network-matrix }}
+      dfx-version: ${{ steps.set-dfx-version.outputs.dfx-version }}
 
     steps:
       - name: Checkout
@@ -209,6 +210,10 @@ jobs:
         run: |
           NETWORKS=$(scripts/build.ic-domains.test.list | jq -R . | jq -s -c .)
           echo "network-matrix=$NETWORKS" >> $GITHUB_OUTPUT
+      - name: Set dfx Version
+        id: set-dfx-version
+        run: |
+          echo "dfx-version=$(jq -er '.dfx' dfx.json)" >> $GITHUB_OUTPUT
 
   config-build:
     runs-on: ubuntu-24.04
@@ -226,8 +231,23 @@ jobs:
           persist-credentials: false
       - name: Prepare
         uses: ./.github/actions/prepare
+      # This job fans out over every network, so an uncached install would pull the same dfx
+      # release asset from github.com once per network. Those downloads are not retried by
+      # dfxvm, and a single one failing takes the whole config check down.
+      - name: Restore dfx
+        id: cache-dfx
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.local/share/dfx
+            ~/.cache/dfinity
+          key: ${{ runner.os }}-dfx-${{ needs.config-preparation.outputs.dfx-version }}
       - name: Install dfx
+        if: steps.cache-dfx.outputs.cache-hit != 'true'
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
+      - name: Set up dfx path
+        if: steps.cache-dfx.outputs.cache-hit == 'true'
+        run: echo "$HOME/.local/share/dfx/bin" >> "$GITHUB_PATH"
       - name: Check ic-domains
         # The build output is kept, so that a failure can be diagnosed from the job log.
         # Networks that serve no domain (local, old-backend, test_be_1) are expected to produce


### PR DESCRIPTION
# Motivation

This is the root cause of the flaky `config` check, captured on the first run of #13716 once the build output stopped being discarded:

```
info: downloading https://github.com/dfinity/sdk/releases/download/0.26.1/dfx-x86_64-unknown-linux-gnu.tar.gz.sha256
error: error sending request for url (https://github.com/dfinity/sdk/releases/download/0.26.1/dfx-x86_64-unknown-linux-gnu.tar.gz.sha256)
```

`config-build` fans out over 14 networks, and every one of those jobs installs dfx from scratch via `dfinity/setup-dfx`. That is 14 downloads of the exact same release asset from github.com per workflow run, and dfxvm does not retry the tarball download (the `--retry 10` in the action covers only `install.sh`, not the asset itself). One failed download out of 14 takes the whole check down, which is why the failing network looked random from run to run.

Frontend Checks went from roughly 2% failures between 10 and 12 August to 43% and then 86% in the 06:00 and 07:00 UTC hours of 13 August, tracking GitHub's release asset download reliability.

The fix is to stop making the request 14 times, not to retry it. With a warm cache the jobs make no release asset request at all.

# Changes

- `config-preparation` now also outputs the dfx version read from `dfx.json`.
- `config-build` restores `~/.local/share/dfx` and `~/.cache/dfinity` from a cache keyed on that version, and installs dfx only on a cache miss.

Frontend Checks runs on `main` too, so the cache is populated there and every PR and merge queue run reads it.

Residual exposure: a cold cache, for instance right after a dfx version bump. The 14 jobs of that one run still install dfx themselves, and every run after it is served from the cache.

Stacked on #13717. Base retargets to `main` automatically once the stack merges.

# Tests

- `jq -er '.dfx' dfx.json` returns `0.26.1` locally, which is the value the cache key is built from.
- Covered by the workflow itself: this PR runs `config-build` for all 14 networks, cold on the first run and warm afterwards. The `Restore dfx` step reports the hit or miss, and `Install dfx` is skipped on a hit.
