### PR TITLE
fix(frontend): show ETH and EVM transaction history beyond the newest page

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactions.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactions.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import EthTokenModal from '$eth/components/tokens/EthTokenModal.svelte';
 	import EthTransactionModal from '$eth/components/transactions/EthTransactionModal.svelte';
+	import EthTransactionsScroll from '$eth/components/transactions/EthTransactionsScroll.svelte';
 	import EthTransactionsSkeletons from '$eth/components/transactions/EthTransactionsSkeletons.svelte';
 	import { sortedEthTransactions } from '$eth/derived/eth-transactions.derived';
 	import { nativeEthereumTokenId } from '$eth/derived/token.derived';
@@ -75,17 +76,19 @@
 <HiddenMicroTransactionsInfoBox />
 
 <EthTransactionsSkeletons>
-	{#if nonNullish(groupedTransactions) && Object.values(groupedTransactions).length > 0}
-		{#each Object.entries(groupedTransactions) as [formattedDate, transactions], index (formattedDate)}
-			<TransactionsDateGroup
-				{formattedDate}
-				testId={`${TRANSACTIONS_DATE_GROUP_PREFIX}-eth-${index}`}
-				{transactions}
-			/>
-		{/each}
-	{/if}
-
-	{#if isNullish(groupedTransactions) || Object.values(groupedTransactions).length === 0}
+	{#if filteredTransactions.length > 0}
+		<EthTransactionsScroll {token}>
+			{#if nonNullish(groupedTransactions) && Object.values(groupedTransactions).length > 0}
+				{#each Object.entries(groupedTransactions) as [formattedDate, transactions], index (formattedDate)}
+					<TransactionsDateGroup
+						{formattedDate}
+						testId={`${TRANSACTIONS_DATE_GROUP_PREFIX}-eth-${index}`}
+						{transactions}
+					/>
+				{/each}
+			{/if}
+		</EthTransactionsScroll>
+	{:else if isNullish(groupedTransactions) || Object.values(groupedTransactions).length === 0}
 		<TransactionsPlaceholder />
 	{/if}
 </EthTransactionsSkeletons>

--- a/src/frontend/src/eth/components/transactions/EthTransactionsScroll.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionsScroll.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { isNullish } from '@dfinity/utils';
+	import type { Snippet } from 'svelte';
+	import type { TokenId as BackendTokenId } from '$declarations/backend/backend.did';
+	import { sortedEthTransactions } from '$eth/derived/eth-transactions.derived';
+	import {
+		getEthBackendPaginationCursor,
+		loadNextEthUserTransactions
+	} from '$eth/services/eth-user-transactions.services';
+	import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
+	import InfiniteScroll from '$lib/components/ui/InfiniteScroll.svelte';
+	import { ethAddress } from '$lib/derived/address.derived';
+	import { authIdentity } from '$lib/derived/auth.derived';
+	import type { Token } from '$lib/types/token';
+	import { last } from '$lib/utils/array.utils';
+	import { isNetworkEthereum } from '$lib/utils/network.utils';
+
+	interface Props {
+		token: Token;
+		children: Snippet;
+	}
+
+	let { token, children }: Props = $props();
+
+	let disableInfiniteScroll = $state(false);
+
+	// Older history is fetched with `txlist`, which only answers for the chain's native asset. An ERC
+	// token's earlier transfers are not reachable this way, so its list stays where the loader left it.
+	let transactionTokenId: BackendTokenId | undefined = $derived(
+		isNetworkEthereum(token.network) && isTokenEthereumNative(token)
+			? { EvmNative: token.network.chainId }
+			: undefined
+	);
+
+	const onIntersect = async () => {
+		if (isNullish(transactionTokenId)) {
+			disableInfiniteScroll = true;
+
+			return;
+		}
+
+		// Sorted newest-first, so the last entry sits at the oldest block the UI has.
+		const oldestLoadedBlockNumber = last($sortedEthTransactions)?.data.blockNumber;
+
+		if (isNullish(oldestLoadedBlockNumber)) {
+			// Nothing loaded yet - the worker still owes us the first transactions.
+			return;
+		}
+
+		const { hasMore } = await loadNextEthUserTransactions({
+			identity: $authIdentity,
+			address: $ethAddress,
+			transactionTokenId,
+			tokenId: token.id,
+			networkId: token.network.id,
+			cursor: getEthBackendPaginationCursor(token.id),
+			oldestLoadedBlockNumber
+		});
+
+		if (!hasMore) {
+			disableInfiniteScroll = true;
+		}
+	};
+</script>
+
+<InfiniteScroll disabled={disableInfiniteScroll} {onIntersect}>
+	{@render children()}
+</InfiniteScroll>

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -10,7 +10,8 @@ import { etherscanProviders } from '$eth/providers/etherscan.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import {
 	loadEthUserTransactions,
-	saveEthFinalizedTransactions
+	saveEthFinalizedTransactions,
+	setEthBackendPaginationCursor
 } from '$eth/services/eth-user-transactions.services';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import type { EthAddress } from '$eth/types/address';
@@ -181,6 +182,11 @@ const loadEthTransactions = async ({
 		const stored = USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED
 			? await loadEthUserTransactions({ identity, tokenId: transactionTokenId })
 			: undefined;
+
+		// Left alone on a reload: the timer must not rewind pages the user has already scrolled past.
+		if (!updateOnly) {
+			setEthBackendPaginationCursor({ tokenId, nextStart: stored?.nextStart });
+		}
 
 		const startBlock = resolveEthIncrementalStartBlock({
 			newestStoredBlockIndex: stored?.newestBlockIndex,

--- a/src/frontend/src/eth/services/eth-user-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-user-transactions.services.ts
@@ -22,6 +22,34 @@ import type { ResultSuccess } from '$lib/types/utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 
 /**
+ * Where paging through the backend's stored history has got to, per token.
+ *
+ * The initial load reads the newest page and is handed the cursor to the one below it. Without
+ * keeping that cursor, scrolling back would skip the backend and ask Etherscan for history the
+ * backend already holds.
+ */
+const ethBackendPaginationCursors = new Map<TokenId, bigint>();
+
+export const setEthBackendPaginationCursor = ({
+	tokenId,
+	nextStart
+}: {
+	tokenId: TokenId;
+	nextStart: bigint | undefined;
+}) => {
+	if (nonNullish(nextStart)) {
+		ethBackendPaginationCursors.set(tokenId, nextStart);
+
+		return;
+	}
+
+	ethBackendPaginationCursors.delete(tokenId);
+};
+
+export const getEthBackendPaginationCursor = (tokenId: TokenId): bigint | undefined =>
+	ethBackendPaginationCursors.get(tokenId);
+
+/**
  * Loads a page of stored ETH transactions from the backend, mapping each
  * `UserTransaction` into a frontend `Transaction`.
  *
@@ -135,11 +163,16 @@ export const loadNextEthUserTransactions = async ({
 
 			ethTransactionsStore.append({ tokenId, transactions: certifiedTransactions });
 
+			setEthBackendPaginationCursor({ tokenId, nextStart: result.nextStart });
+
 			return {
 				hasMore: nonNullish(result.nextStart) || nonNullish(result.oldestBlockIndex)
 			};
 		}
 	}
+
+	// The backend has nothing more to give, so the next intersection must not ask it again.
+	setEthBackendPaginationCursor({ tokenId, nextStart: undefined });
 
 	return loadOlderFromEtherscan({
 		identity,

--- a/src/frontend/src/tests/eth/components/transactions/EthTransactionsScroll.spec.ts
+++ b/src/frontend/src/tests/eth/components/transactions/EthTransactionsScroll.spec.ts
@@ -1,0 +1,113 @@
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
+import EthTransactionsScroll from '$eth/components/transactions/EthTransactionsScroll.svelte';
+import * as ethUserTransactionsServices from '$eth/services/eth-user-transactions.services';
+import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
+import { token } from '$lib/stores/token.store';
+import type { Transaction } from '$lib/types/transaction';
+import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
+import {
+	IntersectionObserverActive,
+	IntersectionObserverPassive
+} from '$tests/mocks/infinite-scroll.mock';
+import { mockSnippet } from '$tests/mocks/snippet.mock';
+import { render } from '@testing-library/svelte';
+import type { MockInstance } from 'vitest';
+
+describe('EthTransactionsScroll', () => {
+	const mockToken = BASE_ETH_TOKEN;
+
+	// Descending block numbers: the oldest entry is the one the next page continues from.
+	const mockTransactions: Transaction[] = createMockEthTransactions(3).map(
+		(transaction, index) => ({
+			...transaction,
+			blockNumber: 300 - index * 100
+		})
+	);
+
+	const oldestLoadedBlockNumber = 100;
+
+	let loadNextSpy: MockInstance;
+
+	const setTransactions = ({ tokenId }: { tokenId: symbol }) => {
+		ethTransactionsStore.set({
+			tokenId,
+			transactions: mockTransactions.map((transaction) => ({
+				data: transaction,
+				certified: false
+			}))
+		});
+	};
+
+	beforeAll(() => {
+		Object.defineProperty(window, 'IntersectionObserver', {
+			writable: true,
+			configurable: true,
+			value: IntersectionObserverActive
+		});
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		ethTransactionsStore.reinitialize();
+
+		token.set(mockToken);
+
+		loadNextSpy = vi
+			.spyOn(ethUserTransactionsServices, 'loadNextEthUserTransactions')
+			.mockResolvedValue({ hasMore: true });
+
+		setTransactions({ tokenId: mockToken.id });
+	});
+
+	afterAll(() => (global.IntersectionObserver = IntersectionObserverPassive));
+
+	it('should ask for the page below the oldest transaction on screen', () => {
+		render(EthTransactionsScroll, { token: mockToken, children: mockSnippet });
+
+		expect(loadNextSpy).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({
+				transactionTokenId: { EvmNative: mockToken.network.chainId },
+				tokenId: mockToken.id,
+				networkId: mockToken.network.id,
+				oldestLoadedBlockNumber
+			})
+		);
+	});
+
+	it('should pass the stored backend cursor', () => {
+		ethUserTransactionsServices.setEthBackendPaginationCursor({
+			tokenId: mockToken.id,
+			nextStart: 77n
+		});
+
+		render(EthTransactionsScroll, { token: mockToken, children: mockSnippet });
+
+		expect(loadNextSpy).toHaveBeenCalledWith(expect.objectContaining({ cursor: 77n }));
+
+		ethUserTransactionsServices.setEthBackendPaginationCursor({
+			tokenId: mockToken.id,
+			nextStart: undefined
+		});
+	});
+
+	it('should not load anything while no transaction is on screen', () => {
+		ethTransactionsStore.reinitialize();
+
+		render(EthTransactionsScroll, { token: mockToken, children: mockSnippet });
+
+		expect(loadNextSpy).not.toHaveBeenCalled();
+	});
+
+	it('should not load anything for a token whose history is not the chain history', () => {
+		// Older ERC20 transfers come from `tokentx`, which this path does not query.
+		token.set(USDC_TOKEN);
+
+		setTransactions({ tokenId: USDC_TOKEN.id });
+
+		render(EthTransactionsScroll, { token: USDC_TOKEN, children: mockSnippet });
+
+		expect(loadNextSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/frontend/src/tests/eth/components/transactions/EthTransactionsScroll.spec.ts
+++ b/src/frontend/src/tests/eth/components/transactions/EthTransactionsScroll.spec.ts
@@ -1,9 +1,11 @@
+import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import EthTransactionsScroll from '$eth/components/transactions/EthTransactionsScroll.svelte';
 import * as ethUserTransactionsServices from '$eth/services/eth-user-transactions.services';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { token } from '$lib/stores/token.store';
+import type { TokenId } from '$lib/types/token';
 import type { Transaction } from '$lib/types/transaction';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
 import {
@@ -29,7 +31,7 @@ describe('EthTransactionsScroll', () => {
 
 	let loadNextSpy: MockInstance;
 
-	const setTransactions = ({ tokenId }: { tokenId: symbol }) => {
+	const setTransactions = ({ tokenId }: { tokenId: TokenId }) => {
 		ethTransactionsStore.set({
 			tokenId,
 			transactions: mockTransactions.map((transaction) => ({
@@ -68,7 +70,7 @@ describe('EthTransactionsScroll', () => {
 
 		expect(loadNextSpy).toHaveBeenCalledExactlyOnceWith(
 			expect.objectContaining({
-				transactionTokenId: { EvmNative: mockToken.network.chainId },
+				transactionTokenId: { EvmNative: BASE_NETWORK.chainId },
 				tokenId: mockToken.id,
 				networkId: mockToken.network.id,
 				oldestLoadedBlockNumber

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -12,7 +12,8 @@ import {
 } from '$eth/services/eth-transactions.services';
 import {
 	loadEthUserTransactions,
-	saveEthFinalizedTransactions
+	saveEthFinalizedTransactions,
+	setEthBackendPaginationCursor
 } from '$eth/services/eth-user-transactions.services';
 import { erc1155CustomTokensStore } from '$eth/stores/erc1155-custom-tokens.store';
 import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
@@ -45,7 +46,8 @@ vi.mock('$lib/services/analytics.services', () => ({
 
 vi.mock('$eth/services/eth-user-transactions.services', () => ({
 	loadEthUserTransactions: vi.fn(),
-	saveEthFinalizedTransactions: vi.fn()
+	saveEthFinalizedTransactions: vi.fn(),
+	setEthBackendPaginationCursor: vi.fn()
 }));
 
 vi.mock('$lib/utils/console.utils', () => ({
@@ -527,6 +529,56 @@ describe('eth-transactions.services', () => {
 						certified: false
 					}))
 				);
+			});
+
+			it('should keep the backend cursor of the page below the one it loaded', async () => {
+				vi.mocked(loadEthUserTransactions).mockResolvedValue({
+					transactions: createMockEthTransactions(2),
+					newestBlockIndex: 100n,
+					oldestBlockIndex: 50n,
+					nextStart: 60n,
+					totalStored: 30n
+				});
+
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(150);
+				mockEthTransactionsProvider.mockResolvedValueOnce([]);
+
+				await loadEthereumTransactions({
+					identity: mockIdentity,
+					networkId: mockNetworkId,
+					tokenId: mockTokenId,
+					chainId: mockChainId,
+					standard: mockStandard
+				});
+
+				expect(setEthBackendPaginationCursor).toHaveBeenCalledWith({
+					tokenId: mockTokenId,
+					nextStart: 60n
+				});
+			});
+
+			it('should leave the backend cursor alone on a reload', async () => {
+				vi.mocked(loadEthUserTransactions).mockResolvedValue({
+					transactions: createMockEthTransactions(2),
+					newestBlockIndex: 100n,
+					oldestBlockIndex: 50n,
+					nextStart: 60n,
+					totalStored: 30n
+				});
+
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(150);
+				mockEthTransactionsProvider.mockResolvedValueOnce([]);
+
+				await loadEthereumTransactions({
+					identity: mockIdentity,
+					networkId: mockNetworkId,
+					tokenId: mockTokenId,
+					chainId: mockChainId,
+					standard: mockStandard,
+					updateOnly: true
+				});
+
+				expect(setEthBackendPaginationCursor).not.toHaveBeenCalled();
 			});
 
 			it('should use update method when updateOnly is true', async () => {

--- a/src/frontend/src/tests/eth/services/eth-user-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-user-transactions.services.spec.ts
@@ -6,9 +6,11 @@ import * as etherscanProvidersModule from '$eth/providers/etherscan.providers';
 import type { InfuraProvider } from '$eth/providers/infura.providers';
 import * as infuraProvidersModule from '$eth/providers/infura.providers';
 import {
+	getEthBackendPaginationCursor,
 	loadEthUserTransactions,
 	loadNextEthUserTransactions,
-	saveEthFinalizedTransactions
+	saveEthFinalizedTransactions,
+	setEthBackendPaginationCursor
 } from '$eth/services/eth-user-transactions.services';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { ZERO } from '$lib/constants/app.constants';
@@ -482,6 +484,72 @@ describe('eth-user-transactions.services', () => {
 
 			// The store's append method deduplicates by hash
 			expect(store?.[mockTokenId]).toHaveLength(2);
+		});
+	});
+
+	describe('backend pagination cursor', () => {
+		beforeEach(() => {
+			setEthBackendPaginationCursor({ tokenId: mockTokenId, nextStart: undefined });
+		});
+
+		it('should keep and clear the cursor of a token', () => {
+			setEthBackendPaginationCursor({ tokenId: mockTokenId, nextStart: 42n });
+
+			expect(getEthBackendPaginationCursor(mockTokenId)).toBe(42n);
+
+			setEthBackendPaginationCursor({ tokenId: mockTokenId, nextStart: undefined });
+
+			expect(getEthBackendPaginationCursor(mockTokenId)).toBeUndefined();
+		});
+
+		it('should advance the cursor to the next page after loading one', async () => {
+			mockGetUserTransactions.mockResolvedValue(
+				makeBackendResponse({
+					overrides: {
+						transactions: [
+							createMockBackendUserTransaction({
+								hash: '0xhash1',
+								blockIndex: 100n,
+								timestamp: 1000n
+							})
+						],
+						newestBlockIndex: 500n,
+						oldestBlockIndex: 50n,
+						totalStored: 300n,
+						nextStart: 100n
+					}
+				})
+			);
+
+			await loadNextEthUserTransactions({
+				identity: mockIdentity,
+				address: mockEthAddress,
+				transactionTokenId: mockBackendTokenId,
+				tokenId: mockTokenId,
+				networkId: mockNetworkId,
+				cursor: 200n,
+				oldestLoadedBlockNumber: 300
+			});
+
+			expect(getEthBackendPaginationCursor(mockTokenId)).toBe(100n);
+		});
+
+		it('should clear the cursor once the backend has nothing left', async () => {
+			setEthBackendPaginationCursor({ tokenId: mockTokenId, nextStart: 200n });
+
+			mockGetUserTransactions.mockResolvedValue(makeBackendResponse({}));
+
+			await loadNextEthUserTransactions({
+				identity: mockIdentity,
+				address: mockEthAddress,
+				transactionTokenId: mockBackendTokenId,
+				tokenId: mockTokenId,
+				networkId: mockNetworkId,
+				cursor: 200n,
+				oldestLoadedBlockNumber: 300
+			});
+
+			expect(getEthBackendPaginationCursor(mockTokenId)).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The ETH token view of an EVM chain shows about ten transactions and stops. Opening ETH on Base lists nothing before the tenth-most-recent transaction, however far back the account's history goes — the cut-off looks like a date, but it is a page boundary.

The initial load asks the backend for one page of stored transactions (`WALLET_PAGINATION`, ten) and then asks Etherscan only for what is *newer* than the newest stored block, so the page it starts on is also the page it ends on. `loadNextEthUserTransactions` was written to page further back — through the backend first, then falling back to Etherscan with `endBlock: oldestLoadedBlockNumber - 1` and persisting what it finds — but nothing ever called it. The Solana and ICP views have had `SolTransactionsScroll` / `IcTransactionsScroll` for this; the ETH view had no equivalent.

# Changes

- Keep the backend pagination cursor per token, so paging back continues through stored history instead of re-fetching from Etherscan what the backend already holds. Set from the initial load's `nextStart`, advanced after each page, cleared once the backend is exhausted. A timer reload leaves it alone, so it cannot rewind pages the user has scrolled past.
- Add `EthTransactionsScroll.svelte` — `InfiniteScroll` over the date groups, taking the oldest loaded block from the store as the lower bound for the next page.
- Use it in `EthTransactions.svelte`, matching how the Solana view wraps its groups.

Scope: the chain's native asset on every EVM chain and Ethereum mainnet, not only Base. ERC token views are deliberately excluded and need nothing — `loadErcTransactions` does not go through the backend at all, so it has no page boundary to get stuck on: it asks `tokentx` for the whole history from block 0 on every load. Only the native path pages, which is why only the native path was capped.

Not visually verified — reproducing it needs an account with more than ten transactions on a chain. The wrapper is the same one the Solana and ICP views already use.

# Tests

- `EthTransactionsScroll.spec.ts` — asks for the page below the oldest transaction on screen; passes the stored cursor; loads nothing while the list is empty; loads nothing for an ERC token.
- `eth-user-transactions.services.spec.ts` — cursor kept and cleared; advanced to the next page after loading one; cleared once the backend has nothing left.
- `eth-transactions.services.spec.ts` — the initial load keeps the cursor of the page below it; a reload leaves it alone.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` all clean; touched specs pass (88 tests).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 5 (claude-opus-5)

