### PR TITLE
feat(frontend): track ck conversions as active user transactions

### DIFF
--- a/docs/ai/PRODUCT.md
+++ b/docs/ai/PRODUCT.md
@@ -303,6 +303,29 @@ The Bitcoin address scoped to a reservation is always **derived from the authent
 
 ---
 
+## Swap
+
+### Chain Fusion as a swap provider
+
+Turning ETH into ckETH, or a twinned ERC-20 into its ckERC-20 counterpart, is offered inside the Swap modal as an ordinary provider named **Chain Fusion**, competing on rate with ICPSwap, KongSwap, Velora, NEAR Intents and 1Sec. Selecting ETH as the pay token puts ckETH among the receive options; selecting ckETH puts ETH among them, and the same holds for every ck twin whose native side is on **Ethereum mainnet** — the only network where the ck helper contracts are deployed. USDC on Base or Arbitrum therefore gets no Chain Fusion offer, because a ckUSDC deposit made there could never be minted.
+
+The offer carries no slippage: a ck conversion is deterministic, so the rate is 1:1 apart from fees, and the provider sheet itemizes those fees one row at a time rather than as a single sum. A ckERC-20 withdrawal is the one case that charges in a **third token** — the minter's Ethereum gas is paid in ckETH — so the sheet names it separately and the form blocks Review when the user's ckETH balance cannot cover it.
+
+The pre-existing **Convert** flow is unchanged and still reachable from a token's own page. Both paths coexist; the two mechanisms are identical, only the entry point and the presentation differ.
+
+### Cross-session settlement
+
+A ck conversion outlives the modal. Once the user's funds have left their wallet the conversion becomes an **active user transaction**: a backend-persisted row that keeps settling with the modal closed, survives a tab close, a refresh and a logout, and resumes polling on next login from what it stored rather than from anything held in memory. This is a capability the Convert flow has never had — there, a conversion's progress dies with the modal.
+
+How settlement is observed differs by direction, because the minters answer different questions:
+
+- A **withdrawal** (ckETH → ETH, ckERC-20 → ERC-20) is exact. The minter is asked about the withdrawal directly, keyed on the ledger burn index it returned. Note that a freshly submitted withdrawal reads as "not found" until the minter indexes it, which is treated as "still in flight" and never as a failure — a terminal verdict cannot be taken back.
+- A **mint** (ETH → ckETH, ERC-20 → ckERC-20) has no per-deposit status endpoint, so it is followed the same way the Convert flow's pending "virtual" transaction is: the deposit counts as in flight for as long as the minter has not yet scanned past the Ethereum block it landed in, and the helper contract's deposit log is what confirms, once the minter has, that there was a deposit to mint at all. A transaction that reverted, or that mined without producing a deposit log for this user, is reported as failed rather than quietly counted as a success.
+
+When a row reaches a terminal state it refreshes the wallet and reports into the **swap** analytics funnel — not the convert one — exactly once, including when it finalizes across a page refresh.
+
+---
+
 ## Buy (OnRamper)
 
 Users can buy crypto with fiat through an embedded OnRamper widget. OnRamper requires the destination wallet addresses in the widget URL to be HMAC-signed so they cannot be tampered with in transit; OISY holds the signing secret in the backend canister (it never reaches the browser) and the frontend asks the backend to sign the URL before loading the widget.

--- a/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthWizard.svelte
@@ -65,6 +65,7 @@
 	import { SwapProvider, VeloraSwapTypes } from '$lib/types/swap';
 	import type { TokenId } from '$lib/types/token';
 	import type { WizardStep } from '$lib/types/wizard';
+	import { asCkTwinOf } from '$lib/utils/chain-fusion-swap.utils';
 	import { errorDetailToString } from '$lib/utils/error.utils';
 	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
 	import { replaceOisyPlaceholders, replacePlaceholders } from '$lib/utils/i18n.utils';
@@ -225,12 +226,13 @@
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.ONE_SEC
 	);
 
-	// Velora, OneSec and NEAR Intents all close the modal at initiation and settle
-	// in the background via the Active User Transactions store. Only the ICP-native
-	// providers still complete inside the modal.
+	// Velora, OneSec, NEAR Intents and Chain Fusion all close the modal at initiation
+	// and settle in the background via the Active User Transactions store. Only the
+	// ICP-native providers still complete inside the modal.
 	const isActiveTransactionSwap = $derived(
 		isNearIntentsProvider ||
 			isOneSecProvider ||
+			isChainFusionProvider ||
 			$swapAmountsStore?.selectedProvider?.provider === SwapProvider.VELORA
 	);
 
@@ -435,10 +437,30 @@
 					return;
 				}
 
+				// Re-resolved through the same pair oracle the quote used, so the row the
+				// execution persists cannot disagree with the offer the user accepted about
+				// which twin this is.
+				const ckDestinationToken = asCkTwinOf({
+					ckToken: $destinationToken,
+					nativeToken: $sourceToken
+				});
+
+				if (isNullish(ckDestinationToken)) {
+					toastsError({
+						msg: { text: $i18n.swap.error.unexpected_missing_data }
+					});
+
+					onBack();
+					onStartTriggerAmount();
+
+					return;
+				}
+
 				await fetchChainFusionEvmSwap({
 					identity: $authIdentity,
 					progress,
 					sourceToken: $sourceToken as Erc20Token,
+					destinationToken: ckDestinationToken,
 					swapAmount,
 					userAddress: $ethAddress,
 					helperContractAddress: ckHelperContractAddress,
@@ -447,6 +469,8 @@
 					gas,
 					maxFeePerGas,
 					maxPriorityFeePerGas,
+					swapId: crypto.randomUUID(),
+					usdSourceValue: sourceTokenUsdValue,
 					enableDestinationToken: () =>
 						enableSwapDestinationToken({
 							destinationToken: $destinationToken,

--- a/src/frontend/src/eth/providers/infura-cketh.providers.ts
+++ b/src/frontend/src/eth/providers/infura-cketh.providers.ts
@@ -46,13 +46,19 @@ export class InfuraCkETHProvider implements Erc20Provider {
 		return ckEthContract.deposit.populateTransaction(to);
 	};
 
+	// `endBlock` defaults to `latest`, which is what the pending-transactions
+	// listener wants: every deposit the minter has not yet observed. A caller that
+	// already knows which block its deposit landed in passes both bounds instead,
+	// turning an open-ended scan into a single-block lookup.
 	getLogs = ({
 		contract: { address: contractAddress },
 		startBlock: fromBlock,
+		endBlock: toBlock = 'latest',
 		topics
 	}: {
 		contract: ContractAddress;
 		startBlock?: BlockTag;
+		endBlock?: BlockTag;
 		topics: (string | null)[];
 	}): Promise<Log[]> => {
 		try {
@@ -66,6 +72,7 @@ export class InfuraCkETHProvider implements Erc20Provider {
 					network: this.network.toString(),
 					contractAddress,
 					fromBlock: fromBlock?.toString() ?? 'latest',
+					toBlock: toBlock.toString(),
 					topics: topics.join(',')
 				}
 			});
@@ -75,7 +82,7 @@ export class InfuraCkETHProvider implements Erc20Provider {
 
 		return this.provider.getLogs({
 			fromBlock,
-			toBlock: 'latest',
+			toBlock,
 			address: contractAddress,
 			topics
 		});

--- a/src/frontend/src/icp/api/cketh-minter.api.ts
+++ b/src/frontend/src/icp/api/cketh-minter.api.ts
@@ -44,6 +44,30 @@ export const withdrawErc20 = async ({
 	});
 };
 
+/**
+ * Status of a ck withdrawal, keyed on the ckETH ledger burn index the minter
+ * returned when the withdrawal was submitted. Mirrors `withdrawalStatuses` in
+ * `ckbtc-minter.api.ts`: a thin pass-through over what the SDK already exposes.
+ *
+ * Serves ckERC20 withdrawals too — the minter's `withdrawal_id` for one *is* its
+ * `cketh_block_index`, and there is no `retrieve_erc20_status` counterpart.
+ */
+export const retrieveEthStatus = async ({
+	identity,
+	minterCanisterId,
+	blockIndex
+}: {
+	identity: NullishIdentity;
+	minterCanisterId: CanisterIdText;
+	blockIndex: bigint;
+}): Promise<CkEthMinterDid.RetrieveEthStatus> => {
+	assertNonNullish(identity);
+
+	const { retrieveEthStatus } = await ckEthMinterCanister({ identity, minterCanisterId });
+
+	return retrieveEthStatus(blockIndex);
+};
+
 export const eip1559TransactionPrice = async ({
 	identity,
 	minterCanisterId,

--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -101,11 +101,19 @@
 			: undefined
 	);
 
-	// 1Sec is the only provider on this wizard that settles in the background, and
-	// its background phase is a bridge.
+	// 1Sec's background phase is a bridge; Chain Fusion's is a ck minter settling a
+	// withdrawal, so it gets the plain background wording.
 	let isOneSecProvider = $derived(
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.ONE_SEC
 	);
+
+	let isChainFusionProvider = $derived(
+		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.CHAIN_FUSION
+	);
+
+	// Both close the modal once the funds have left the wallet and finish settling
+	// through the Active User Transactions store.
+	let isActiveTransactionSwap = $derived(isOneSecProvider || isChainFusionProvider);
 
 	$effect(() => {
 		if (isNullish($sourceToken) || !isIcToken($sourceToken)) {
@@ -213,6 +221,8 @@
 					destinationToken: $destinationToken,
 					swapAmount,
 					destinationAddress: $ethAddress,
+					swapId: crypto.randomUUID(),
+					usdSourceValue: sourceTokenUsdValue,
 					enableDestinationToken: () =>
 						enableSwapDestinationToken({
 							destinationToken: $destinationToken,
@@ -245,15 +255,12 @@
 
 			progress(ProgressStepsSwap.DONE);
 
-			// For OneSec swaps, the foreground completes once the user's funds have
-			// left their wallet; success/failure of the background phase is tracked
+			// For OneSec and Chain Fusion, the foreground completes once the user's funds
+			// have left their wallet; success/failure of the background phase is tracked
 			// separately via the AUT store. Other providers (ICPSwap, KongSwap) still
 			// complete fully inside `await` and reach this point only on success.
 			trackEvent({
-				name:
-					$swapAmountsStore.selectedProvider.provider === SwapProvider.ONE_SEC
-						? TRACK_COUNT_SWAP_SUBMITTED
-						: TRACK_COUNT_SWAP_SUCCESS,
+				name: isActiveTransactionSwap ? TRACK_COUNT_SWAP_SUBMITTED : TRACK_COUNT_SWAP_SUCCESS,
 				metadata: swapTrackingMetadata
 			});
 
@@ -341,7 +348,7 @@
 		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
 			<SwapProgress
 				{swapProgressStep}
-				swapWithActiveTransaction={isOneSecProvider}
+				swapWithActiveTransaction={isActiveTransactionSwap}
 				swapWithBridging={isOneSecProvider}
 				swapWithWithdrawing={$swapAmountsStore?.selectedProvider?.provider ===
 					SwapProvider.ICP_SWAP}

--- a/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
+++ b/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
@@ -15,6 +15,7 @@
 	import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
 	import { ONESEC_EXTERNAL_REF_KEYS } from '$lib/types/onesec-swap';
 	import { SwapProvider } from '$lib/types/swap';
+	import { isChainFusionActiveUserTransaction } from '$lib/utils/chain-fusion-swap-active-tx.utils';
 	import { formatNanosecondsToShortRelativeTime } from '$lib/utils/format.utils';
 	import {
 		isLiquidiumActiveUserTransaction,
@@ -40,10 +41,12 @@
 	const isOneSec = $derived(isOneSecActiveUserTransaction(tx));
 	const isNearIntents = $derived(isNearIntentsActiveUserTransaction(tx));
 	const isVelora = $derived(isVeloraActiveUserTransaction(tx));
+	const isChainFusion = $derived(isChainFusionActiveUserTransaction(tx));
 	// Every swap provider is rendered identically — they share the same
 	// display-ref key names in `external_refs`. Velora's Delta/Market distinction
-	// is internal routing and deliberately not surfaced.
-	const isSwap = $derived(isOneSec || isNearIntents || isVelora);
+	// and Chain Fusion's conversion direction are internal routing and deliberately
+	// not surfaced.
+	const isSwap = $derived(isOneSec || isNearIntents || isVelora || isChainFusion);
 	const isLiquidium = $derived(isLiquidiumActiveUserTransaction(tx));
 	const refs = $derived(toOneSecExternalRefsMap(tx.external_refs));
 	const liquidiumRefs = $derived(toLiquidiumExternalRefsMap(tx.external_refs));
@@ -79,7 +82,12 @@
 					? (swapProvidersDetails[SwapProvider.ONE_SEC]?.name ?? '')
 					: isVelora
 						? (swapProvidersDetails[SwapProvider.VELORA]?.name ?? '')
-						: undefined
+						: isChainFusion
+							? // Resolves even with `CHAIN_FUSION_SWAP_ENABLED` off: the entry is
+								// unconditional precisely so a row outliving a flag rollback keeps
+								// its provider name.
+								(swapProvidersDetails[SwapProvider.CHAIN_FUSION]?.name ?? '')
+							: undefined
 	);
 
 	const titleText = $derived(

--- a/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
@@ -13,6 +13,7 @@
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { loadActiveUserTransactions } from '$lib/services/active-user-transactions.services';
 	import { trackEvent } from '$lib/services/analytics.services';
+	import { pollChainFusionActiveUserTransactions } from '$lib/services/chain-fusion-swap-active-tx.services';
 	import { pollLiquidiumActiveUserTransactions } from '$lib/services/liquidium-active-tx.services';
 	import { loadLiquidium } from '$lib/services/liquidium.services';
 	import { pollNearIntentsActiveUserTransactions } from '$lib/services/near-intents-active-tx.services';
@@ -20,6 +21,10 @@
 	import { pollVeloraActiveUserTransactions } from '$lib/services/velora-active-tx.services';
 	import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
 	import { isTerminalActiveUserTransaction } from '$lib/utils/active-user-transactions.utils';
+	import {
+		buildChainFusionSwapTrackingMetadata,
+		isChainFusionActiveUserTransaction
+	} from '$lib/utils/chain-fusion-swap-active-tx.utils';
 	import { consoleError } from '$lib/utils/console.utils';
 	import {
 		buildLiquidiumTrackingMetadata,
@@ -90,6 +95,12 @@
 					transactions: velora,
 					userAddress: $ethAddress
 				});
+			}
+
+			const chainFusion = $activeUserTransactionsPending.filter(isChainFusionActiveUserTransaction);
+
+			if (chainFusion.length > 0) {
+				await pollChainFusionActiveUserTransactions({ identity, transactions: chainFusion });
 			}
 		} catch (err: unknown) {
 			consoleError(err);
@@ -184,6 +195,23 @@
 				trackEvent({
 					name: isSucceeded ? TRACK_COUNT_SWAP_SUCCESS : TRACK_COUNT_SWAP_ERROR,
 					metadata: buildVeloraSwapTrackingMetadata({ tx })
+				});
+
+				if (isSucceeded) {
+					shouldRefresh = true;
+				}
+			} else if (
+				isTerminalActiveUserTransaction(tx) &&
+				!alreadyApplied &&
+				isChainFusionActiveUserTransaction(tx)
+			) {
+				newlyAppliedIds.push(tx.id);
+
+				// A ck conversion started from the Swap modal reports into the swap funnel.
+				// The untouched Convert flow keeps firing its own `TRACK_COUNT_CONVERT_*`.
+				trackEvent({
+					name: isSucceeded ? TRACK_COUNT_SWAP_SUCCESS : TRACK_COUNT_SWAP_ERROR,
+					metadata: buildChainFusionSwapTrackingMetadata({ tx })
 				});
 
 				if (isSucceeded) {

--- a/src/frontend/src/lib/services/chain-fusion-swap-active-tx.services.ts
+++ b/src/frontend/src/lib/services/chain-fusion-swap-active-tx.services.ts
@@ -1,0 +1,343 @@
+import type {
+	ActiveUserTransaction,
+	ChainFusionData,
+	TokenId
+} from '$declarations/backend/backend.did';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
+import { infuraProviders } from '$eth/providers/infura.providers';
+import type { EthAddress } from '$eth/types/address';
+import { minterInfo } from '$icp-eth/api/cketh-minter.api';
+import { retrieveEthStatus } from '$icp/api/cketh-minter.api';
+import { applyActiveUserTransactionPollUpdate } from '$lib/services/active-user-transactions.services';
+import {
+	CHAIN_FUSION_EXTERNAL_REF_KEYS,
+	type ChainFusionExternalRefKey
+} from '$lib/types/chain-fusion-swap';
+import { advanceStatus } from '$lib/utils/active-user-transactions.utils';
+import {
+	chainFusionMintOutcomeError,
+	chainFusionMintOutcomeToStatus,
+	chainFusionWithdrawalStatusError,
+	isChainFusionEthWithdrawalDirection,
+	isChainFusionMintDirection,
+	toChainFusionDepositLogTopics,
+	toChainFusionExternalRefs,
+	toChainFusionExternalRefsMap,
+	toChainFusionWithdrawalLearnedRefs,
+	toChainFusionWithdrawalStatus,
+	type ChainFusionMintOutcome
+} from '$lib/utils/chain-fusion-swap-active-tx.utils';
+import { consoleError } from '$lib/utils/console.utils';
+import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+import type { CkEthMinterDid } from '@icp-sdk/canisters/cketh';
+import type { Identity } from '@icp-sdk/core/agent';
+
+/**
+ * Counts how many consecutive polls have found no deposit log in the block a ck
+ * deposit mined in, once the minter has already scanned past it.
+ *
+ * Only the *absence*-based verdict is guarded. `deposited` rests on positive
+ * evidence — the helper-contract log is there — while `notDeposited` rests on
+ * evidence not being there, which is also what a transiently lagging Infura node
+ * produces. Writing `Failed` on that would be a permanent wrong verdict on a
+ * conversion that actually settled.
+ *
+ * Deliberately in-memory, as in `velora-active-tx.services`: a refresh resets the
+ * count, which at worst delays terminalization by one tick and never produces a
+ * wrong verdict.
+ */
+const missingDepositLogObservations = new Map<string, number>();
+
+// Test seam — module-level state would otherwise leak between cases.
+export const resetChainFusionMissingDepositLogObservations = (): void => {
+	missingDepositLogObservations.clear();
+};
+
+const MISSING_DEPOSIT_LOG_OBSERVATIONS_REQUIRED = 2;
+
+const recordMissingDepositLogObservation = (txId: string): number => {
+	const count = (missingDepositLogObservations.get(txId) ?? 0) + 1;
+	missingDepositLogObservations.set(txId, count);
+	return count;
+};
+
+// One minter-info read serves every row sharing a minter within a tick.
+type MinterInfoCache = Map<string, Promise<CkEthMinterDid.MinterInfo>>;
+
+const applyUpdate = async ({
+	identity,
+	tx,
+	candidate,
+	error,
+	learned,
+	refs
+}: {
+	identity: Identity;
+	tx: ActiveUserTransaction;
+	candidate: ReturnType<typeof toChainFusionWithdrawalStatus>;
+	error: string | undefined;
+	learned: Partial<Record<ChainFusionExternalRefKey, string>>;
+	refs: Partial<Record<ChainFusionExternalRefKey, string>>;
+}): Promise<void> => {
+	const next = nonNullish(candidate) ? advanceStatus({ current: tx.status, candidate }) : undefined;
+
+	// Persist newly-learned pointers even when the status itself doesn't advance.
+	// `external_refs` replaces the stored list wholesale, so the merge is required.
+	const hasNewRefs = (Object.keys(learned) as ChainFusionExternalRefKey[]).some(
+		(key) => refs[key] !== learned[key]
+	);
+	const externalRefs = hasNewRefs ? toChainFusionExternalRefs({ ...refs, ...learned }) : undefined;
+
+	const update = {
+		...(nonNullish(next) ? { status: next } : {}),
+		...(nonNullish(next) && 'Failed' in next && nonNullish(error) ? { error } : {}),
+		...(nonNullish(externalRefs) ? { externalRefs } : {})
+	};
+
+	if (Object.keys(update).length === 0) {
+		return;
+	}
+
+	await applyActiveUserTransactionPollUpdate({ identity, tx, update });
+};
+
+/**
+ * ckETH → ETH and ckERC20 → ERC20. The minter answers exactly, keyed on the ckETH
+ * ledger burn index snapshotted at creation, so the row resumes across refresh /
+ * logout with nothing held in memory.
+ */
+const pollChainFusionWithdrawal = async ({
+	tx,
+	identity,
+	refs
+}: {
+	tx: ActiveUserTransaction;
+	identity: Identity;
+	refs: Partial<Record<ChainFusionExternalRefKey, string>>;
+}): Promise<void> => {
+	const minterCanisterId = refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID];
+	const blockIndex = refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.CKETH_BLOCK_INDEX];
+
+	// Not pollable without the minter or the burn index.
+	if (isNullish(minterCanisterId) || isNullish(blockIndex)) {
+		return;
+	}
+
+	const status = await retrieveEthStatus({
+		identity,
+		minterCanisterId,
+		blockIndex: BigInt(blockIndex)
+	});
+
+	await applyUpdate({
+		identity,
+		tx,
+		candidate: toChainFusionWithdrawalStatus(status),
+		error: chainFusionWithdrawalStatusError(status),
+		learned: toChainFusionWithdrawalLearnedRefs(status),
+		refs
+	});
+};
+
+// The ERC20 the deposit was made in, needed for the ckERC20 log topic. It is part
+// of the row's immutable `data`, so no ref carries it.
+const toErc20ContractAddress = (token: TokenId): EthAddress | undefined =>
+	'Erc20' in token ? token.Erc20[0] : undefined;
+
+/**
+ * Reads a ck deposit's state off the Ethereum side and the minter's scan
+ * progress, in the order that keeps the verdict honest.
+ *
+ * This is the durable form of the Convert flow's virtual transaction: while the
+ * minter has not scanned past the deposit's block the conversion is in flight,
+ * and once it has, the helper-contract log — the very log the virtual row is built
+ * from — says whether there was a deposit to mint.
+ *
+ * Returns the outcome plus anything worth persisting. The deposit's block number
+ * is read from the receipt once and then kept, which is what lets the settlement
+ * query be bounded to a single block instead of scanning to `latest`.
+ */
+const resolveChainFusionMintOutcome = async ({
+	identity,
+	data,
+	refs,
+	minterInfoCache
+}: {
+	identity: Identity;
+	data: ChainFusionData;
+	refs: Partial<Record<ChainFusionExternalRefKey, string>>;
+	minterInfoCache: MinterInfoCache;
+}): Promise<
+	| { outcome: ChainFusionMintOutcome; learned: Partial<Record<ChainFusionExternalRefKey, string>> }
+	| undefined
+> => {
+	const depositTxHash = refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_TX_HASH];
+	const helperContractAddress = refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.HELPER_CONTRACT_ADDRESS];
+	const minterCanisterId = refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID];
+
+	// Not pollable without the deposit, the contract it went to, or the minter.
+	if (isNullish(depositTxHash) || isNullish(helperContractAddress) || isNullish(minterCanisterId)) {
+		return;
+	}
+
+	const learned: Partial<Record<ChainFusionExternalRefKey, string>> = {};
+
+	// Chain Fusion mints are Ethereum-mainnet only by construction: the quote
+	// rejects any other source network, and the ck helper contracts exist nowhere
+	// else — `infuraCkETHProviders` is not even built for the other EVM chains.
+	let depositBlockNumber = refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER];
+
+	if (isNullish(depositBlockNumber)) {
+		const receipt = await infuraProviders(ETHEREUM_NETWORK_ID).getTransactionReceipt(depositTxHash);
+
+		if (isNullish(receipt)) {
+			// Still in the mempool. Nothing has been observed yet, either way.
+			return { outcome: 'notMined', learned };
+		}
+
+		if (receipt.status === 0) {
+			// The deposit reverted, so no funds ever reached the helper contract.
+			return { outcome: 'reverted', learned };
+		}
+
+		depositBlockNumber = `${receipt.blockNumber}`;
+		learned[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER] = depositBlockNumber;
+	}
+
+	const infoPromise =
+		minterInfoCache.get(minterCanisterId) ??
+		minterInfo({ identity, minterCanisterId, certified: false });
+	minterInfoCache.set(minterCanisterId, infoPromise);
+
+	const lastObservedBlockNumber = fromNullable((await infoPromise).last_observed_block_number);
+
+	// The minter has not reported a scan position yet; there is nothing to compare
+	// the deposit against, so leave the row where it is.
+	if (isNullish(lastObservedBlockNumber)) {
+		return { outcome: 'notObserved', learned };
+	}
+
+	// `<=`, not `<`: the Convert flow's virtual row survives while
+	// `getLogs(startBlock = last_observed_block_number)` — an *inclusive* bound —
+	// still returns the deposit's log, so the minter counts as past the block only
+	// once the deposit's block falls strictly behind its scan position.
+	if (lastObservedBlockNumber <= BigInt(depositBlockNumber)) {
+		return { outcome: 'notObserved', learned };
+	}
+
+	// The minter has consumed the deposit's block — the moment the Convert flow's
+	// virtual row is retired. Bounded to that single block, so an abandoned row
+	// picked up weeks later costs exactly the same query as a fresh one.
+	const logs = await infuraCkETHProviders(ETHEREUM_NETWORK_ID).getLogs({
+		contract: { address: helperContractAddress },
+		startBlock: Number(depositBlockNumber),
+		endBlock: Number(depositBlockNumber),
+		topics: toChainFusionDepositLogTopics({
+			principal: identity.getPrincipal(),
+			erc20ContractAddress: toErc20ContractAddress(data.source_token)
+		})
+	});
+
+	const deposited = logs.some(
+		({ transactionHash }) => transactionHash.toLowerCase() === depositTxHash.toLowerCase()
+	);
+
+	return { outcome: deposited ? 'deposited' : 'notDeposited', learned };
+};
+
+/**
+ * ETH → ckETH and ERC20 → ckERC20. The ckETH minter has no per-deposit status
+ * endpoint, so settlement is observed from the deposit side — see
+ * `resolveChainFusionMintOutcome`.
+ */
+const pollChainFusionMint = async ({
+	tx,
+	identity,
+	data,
+	refs,
+	minterInfoCache
+}: {
+	tx: ActiveUserTransaction;
+	identity: Identity;
+	data: ChainFusionData;
+	refs: Partial<Record<ChainFusionExternalRefKey, string>>;
+	minterInfoCache: MinterInfoCache;
+}): Promise<void> => {
+	const resolved = await resolveChainFusionMintOutcome({ identity, data, refs, minterInfoCache });
+
+	if (isNullish(resolved)) {
+		return;
+	}
+
+	const { learned } = resolved;
+	let { outcome } = resolved;
+
+	if (outcome === 'notDeposited') {
+		if (recordMissingDepositLogObservation(tx.id) < MISSING_DEPOSIT_LOG_OBSERVATIONS_REQUIRED) {
+			outcome = 'notObserved';
+		}
+	} else {
+		missingDepositLogObservations.delete(tx.id);
+	}
+
+	await applyUpdate({
+		identity,
+		tx,
+		candidate: chainFusionMintOutcomeToStatus(outcome),
+		error: chainFusionMintOutcomeError(outcome),
+		learned,
+		refs
+	});
+};
+
+/**
+ * Advances the pending Chain Fusion rows, routed on the direction stored in the
+ * row's immutable `data` — which is why the direction is captured at creation
+ * rather than re-derived from the token pair on every tick.
+ *
+ * The withdrawal directions ask the minter and get an exact answer; the mint
+ * directions are observed from the deposit side. Bitcoin's two directions are not
+ * handled yet: no code path can create such a row, since `enabledPairs` admits no
+ * Bitcoin twin.
+ */
+export const pollChainFusionActiveUserTransactions = async ({
+	identity,
+	transactions
+}: {
+	identity: Identity;
+	transactions: ActiveUserTransaction[];
+}): Promise<void> => {
+	if (transactions.length === 0) {
+		return;
+	}
+
+	const minterInfoCache: MinterInfoCache = new Map();
+
+	await Promise.all(
+		transactions.map(async (tx) => {
+			try {
+				if (!('ChainFusion' in tx.data)) {
+					return;
+				}
+
+				const { ChainFusion: data } = tx.data;
+
+				const refs = toChainFusionExternalRefsMap(tx.external_refs);
+
+				if (isChainFusionMintDirection(data.direction)) {
+					await pollChainFusionMint({ tx, identity, data, refs, minterInfoCache });
+					return;
+				}
+
+				if (isChainFusionEthWithdrawalDirection(data.direction)) {
+					await pollChainFusionWithdrawal({ tx, identity, refs });
+				}
+			} catch (err: unknown) {
+				// A transient RPC or canister blip must leave the row pending so the next
+				// tick retries; one failing row never poisons the batch.
+				consoleError(err);
+			}
+		})
+	);
+};

--- a/src/frontend/src/lib/services/chain-fusion-swap.services.ts
+++ b/src/frontend/src/lib/services/chain-fusion-swap.services.ts
@@ -1,3 +1,4 @@
+import type { ChainFusionDirection } from '$declarations/backend/backend.did';
 import { CHAIN_FUSION_SWAP_ENABLED } from '$env/chain-fusion-swap.env';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { ICP_NETWORK } from '$env/networks/networks.icp.env';
@@ -8,6 +9,7 @@ import type { Erc20Token } from '$eth/types/erc20';
 import type { EthereumNetwork } from '$eth/types/network';
 import type { ProgressStep } from '$eth/types/send';
 import { isTokenErcFungible } from '$eth/utils/erc-fungible.utils';
+import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 import type { OptionCertifiedMinterInfo } from '$icp-eth/types/cketh-minter';
 import {
@@ -26,7 +28,12 @@ import {
 	ProgressStepsSendIc,
 	ProgressStepsSwap
 } from '$lib/enums/progress-steps';
+import { createActiveUserTransaction } from '$lib/services/active-user-transactions.services';
 import type { CanisterIdText } from '$lib/types/canister';
+import {
+	CHAIN_FUSION_EXTERNAL_REF_KEYS,
+	type ChainFusionExternalRefKey
+} from '$lib/types/chain-fusion-swap';
 import type { Amount } from '$lib/types/send';
 import {
 	SwapProvider,
@@ -37,6 +44,11 @@ import {
 	type SwapMappedResult
 } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
+import {
+	toChainFusionData,
+	toChainFusionDisplayRefs,
+	toChainFusionExternalRefs
+} from '$lib/utils/chain-fusion-swap-active-tx.utils';
 import { asCkTwinOf, computeChainFusionReceiveAmount } from '$lib/utils/chain-fusion-swap.utils';
 import { consoleError } from '$lib/utils/console.utils';
 import { parseToken } from '$lib/utils/parse.utils';
@@ -273,6 +285,71 @@ const toSwapProgressStep = (step: ProgressStepsSendIc): ProgressStepsSwap =>
 	})[step];
 
 /**
+ * Persists the active user transaction that keeps a ck conversion settling after the
+ * modal closes. Called at the point of no return — the funds have already left the
+ * user's wallet — which is why every failure here is swallowed: an untracked
+ * conversion still completes, and surfacing a bookkeeping error as a swap failure
+ * would be a lie about the money. Same contract as `createAutAndDetachCloser`.
+ *
+ * Two prerequisites are checked rather than assumed, because a row that cannot be
+ * polled is worse than no row: it never terminalizes and occupies one of the user's
+ * slots for good. Both are unreachable for the pairs Chain Fusion offers — but
+ * `toBackendTokenId` is shared, and `minterCanisterId` is optional on `IcCkToken`.
+ * Either way the conversion degrades to untracked, which is the Convert flow's
+ * behaviour today, rather than to aborted.
+ */
+const createChainFusionActiveUserTransaction = async ({
+	identity,
+	swapId,
+	direction,
+	sourceToken,
+	destinationToken,
+	minterCanisterId,
+	amount,
+	swapAmount,
+	usdSourceValue,
+	extraRefs
+}: {
+	identity: Identity;
+	swapId: string;
+	direction: ChainFusionDirection;
+	sourceToken: Token;
+	destinationToken: Token;
+	minterCanisterId: CanisterIdText | undefined;
+	amount: bigint;
+	swapAmount: Amount;
+	usdSourceValue?: string;
+	extraRefs: Partial<Record<ChainFusionExternalRefKey, string>>;
+}): Promise<void> => {
+	try {
+		const data = toChainFusionData({ direction, sourceToken, destinationToken, amount });
+
+		if (isNullish(data) || isNullish(minterCanisterId)) {
+			consoleError('Skipping an untrackable Chain Fusion conversion', { swapId });
+			return;
+		}
+
+		await createActiveUserTransaction({
+			identity,
+			id: swapId,
+			data,
+			externalRefs: toChainFusionExternalRefs({
+				...toChainFusionDisplayRefs({
+					sourceToken,
+					destinationToken,
+					amount: `${swapAmount}`,
+					usdSourceValue
+				}),
+				[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: minterCanisterId,
+				...extraRefs
+			})
+		});
+	} catch (err: unknown) {
+		consoleError(err);
+	}
+};
+
+/**
  * Enabling the destination runs only after the funds have moved, so a swap the user
  * cancels on Review never leaves an enabled token behind. Failure is swallowed: the
  * conversion already succeeded and visibility is not worth surfacing as a swap error.
@@ -296,8 +373,8 @@ const enableDestination = async (
  * existing `sendIc`, which already owns the approve/withdraw choreography the Convert
  * flow uses. Nothing in `$icp` changes for this.
  *
- * Returns the minter block index `sendIc` now surfaces, so PR 5 can key an active user
- * transaction on it without re-deriving anything.
+ * Returns the minter block index `sendIc` surfaces — the same index the active user
+ * transaction created here is keyed on, so nothing is re-derived.
  */
 export const fetchChainFusionIcpSwap = async ({
 	identity,
@@ -306,6 +383,8 @@ export const fetchChainFusionIcpSwap = async ({
 	destinationToken,
 	swapAmount,
 	destinationAddress,
+	swapId,
+	usdSourceValue,
 	enableDestinationToken
 }: {
 	identity: Identity;
@@ -314,6 +393,8 @@ export const fetchChainFusionIcpSwap = async ({
 	destinationToken: Token;
 	swapAmount: Amount;
 	destinationAddress: EthAddress;
+	swapId: string;
+	usdSourceValue?: string;
 	enableDestinationToken?: () => Promise<void>;
 }): Promise<IcCkWithdrawalResult | undefined> => {
 	// The ckETH allowance a ckERC20 withdrawal grants the minter, resolved here — at the
@@ -337,10 +418,12 @@ export const fetchChainFusionIcpSwap = async ({
 		? (await resolveCkErc20WithdrawalDetails(sourceToken))?.externalFees[0]?.fee
 		: undefined;
 
+	const amount = parseToken({ value: `${swapAmount}`, unitName: sourceToken.decimals });
+
 	const result = await sendIc({
 		identity,
 		token: sourceToken,
-		amount: parseToken({ value: `${swapAmount}`, unitName: sourceToken.decimals }),
+		amount,
 		to: destinationAddress,
 		targetNetworkId: destinationToken.network.id,
 		ckErc20ToErc20MaxCkEthFees,
@@ -349,6 +432,35 @@ export const fetchChainFusionIcpSwap = async ({
 		// no separate completion hook to fire.
 		sendCompleted: () => undefined
 	});
+
+	// The withdrawal is irreversible from here, so the row is created regardless of what
+	// follows. The direction comes from the result rather than from a second look at the
+	// token pair: `sendIc` already decided which minter leg it ran.
+	if (nonNullish(result) && result.type !== 'ckBtcToBtc') {
+		await createChainFusionActiveUserTransaction({
+			identity,
+			swapId,
+			direction: result.type === 'ckEthToEth' ? { CkEthToEth: null } : { CkErc20ToErc20: null },
+			sourceToken,
+			destinationToken,
+			// The ck source is the token being burned, so its minter is the one to ask.
+			minterCanisterId: sourceToken.minterCanisterId,
+			amount,
+			swapAmount,
+			usdSourceValue,
+			extraRefs: {
+				// `retrieve_eth_status` is keyed on the ckETH burn index in both directions — a
+				// ckERC20 withdrawal's `withdrawal_id` *is* its `cketh_block_index`. The ckERC20
+				// index rides along as the only pointer back to that burn.
+				[CHAIN_FUSION_EXTERNAL_REF_KEYS.CKETH_BLOCK_INDEX]: `${
+					result.type === 'ckEthToEth' ? result.blockIndex : result.ckEthBlockIndex
+				}`,
+				...(result.type === 'ckErc20ToErc20' && {
+					[CHAIN_FUSION_EXTERNAL_REF_KEYS.CKERC20_BLOCK_INDEX]: `${result.ckErc20BlockIndex}`
+				})
+			}
+		});
+	}
 
 	await enableDestination(enableDestinationToken);
 
@@ -386,6 +498,7 @@ export const fetchChainFusionEvmSwap = async ({
 	identity,
 	progress,
 	sourceToken,
+	destinationToken,
 	swapAmount,
 	userAddress,
 	helperContractAddress,
@@ -394,11 +507,14 @@ export const fetchChainFusionEvmSwap = async ({
 	gas,
 	maxFeePerGas,
 	maxPriorityFeePerGas,
+	swapId,
+	usdSourceValue,
 	enableDestinationToken
 }: {
 	identity: Identity;
 	progress: (step: ProgressStepsSwap) => void;
 	sourceToken: Erc20Token;
+	destinationToken: IcCkToken;
 	swapAmount: Amount;
 	userAddress: EthAddress;
 	helperContractAddress: EthAddress;
@@ -407,9 +523,13 @@ export const fetchChainFusionEvmSwap = async ({
 	gas: bigint;
 	maxFeePerGas: bigint;
 	maxPriorityFeePerGas: bigint;
+	swapId: string;
+	usdSourceValue?: string;
 	enableDestinationToken?: () => Promise<void>;
 }): Promise<void> => {
-	await sendEth({
+	const amount = parseToken({ value: `${swapAmount}`, unitName: sourceToken.decimals });
+
+	const { hash } = await sendEth({
 		identity,
 		from: userAddress,
 		// The minter's helper contract, for both legs: `sendTransaction` recognises it as the
@@ -419,7 +539,7 @@ export const fetchChainFusionEvmSwap = async ({
 		// here, since the destination is always a contract address and ERC20 ICP has no ck twin.
 		to: mapAddressStartsWith0x(helperContractAddress),
 		token: sourceToken,
-		amount: parseToken({ value: `${swapAmount}`, unitName: sourceToken.decimals }),
+		amount,
 		sourceNetwork,
 		targetNetwork: ICP_NETWORK,
 		minterInfo,
@@ -432,6 +552,31 @@ export const fetchChainFusionEvmSwap = async ({
 			if (nonNullish(mapped)) {
 				progress(mapped);
 			}
+		}
+	});
+
+	// The deposit is broadcast, so the row is created regardless of what follows. It
+	// carries what the poller needs to follow the mint without any store: the deposit's
+	// hash, the helper contract the log to look for lives at, and the minter to ask how
+	// far it has scanned. The helper contract is snapshotted rather than re-read later,
+	// because a minter upgrade moves the address while the log stays at the old one.
+	await createChainFusionActiveUserTransaction({
+		identity,
+		swapId,
+		// `isTokenErc20`, not `isTokenErcFungible`: the direction must agree with how
+		// `toBackendTokenId` classifies the source, and only its `Erc20` arm carries
+		// the contract address the mint poller's ckERC20 log topic is built from.
+		direction: isTokenErc20(sourceToken) ? { Erc20ToCkErc20: null } : { EthToCkEth: null },
+		sourceToken,
+		destinationToken,
+		// The ck destination is the token being minted, so its minter is the one to ask.
+		minterCanisterId: destinationToken.minterCanisterId,
+		amount,
+		swapAmount,
+		usdSourceValue,
+		extraRefs: {
+			[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_TX_HASH]: hash,
+			[CHAIN_FUSION_EXTERNAL_REF_KEYS.HELPER_CONTRACT_ADDRESS]: helperContractAddress
 		}
 	});
 

--- a/src/frontend/src/lib/types/chain-fusion-swap.ts
+++ b/src/frontend/src/lib/types/chain-fusion-swap.ts
@@ -1,0 +1,40 @@
+export const CHAIN_FUSION_EXTERNAL_REF_KEYS = {
+	// The ck minter a row asks about settlement. Snapshotted rather than resolved
+	// from the ck token at poll time, so a row keeps settling after the user
+	// disables the token — or never enabled it in the first place.
+	MINTER_CANISTER_ID: 'chain_fusion_minter_id',
+	// Withdrawal poll key: the ckETH ledger burn index `withdraw_eth` /
+	// `withdraw_erc20` returns. The minter keys `retrieve_eth_status` on it for
+	// both directions — a ckERC20 withdrawal's `withdrawal_id` *is* its
+	// `cketh_block_index`.
+	CKETH_BLOCK_INDEX: 'chain_fusion_cketh_index',
+	// The ckERC20 ledger burn index, carried for traceability only: nothing polls
+	// it, but it is the only pointer back to the ckERC20 burn.
+	CKERC20_BLOCK_INDEX: 'chain_fusion_ckerc20_index',
+	// The Ethereum transaction the minter sent on the user's behalf, learned from
+	// `TxSent` / `TxFinalized` as the withdrawal progresses.
+	WITHDRAWAL_TX_HASH: 'chain_fusion_eth_tx',
+	// Mint poll keys. The deposit's transaction hash comes back from the Ethereum
+	// send; its block number is learned from the receipt on the first tick that
+	// finds one, and pins the block the settlement log query is bounded to.
+	DEPOSIT_TX_HASH: 'chain_fusion_deposit_tx',
+	DEPOSIT_BLOCK_NUMBER: 'chain_fusion_deposit_block',
+	// The helper contract the deposit was actually sent to. Snapshotted rather
+	// than re-read from minter info at poll time: a minter upgrade moves the
+	// address, and the log being looked for lives at the old one.
+	HELPER_CONTRACT_ADDRESS: 'chain_fusion_helper',
+	// Display + analytics metadata snapshotted at creation time. These reuse
+	// OneSec's exact key strings — `ActiveUserTransactionItem` reads *every* row's
+	// refs through `toOneSecExternalRefsMap`, so a fourth swap provider renders
+	// for free only by speaking the same vocabulary. They stay correct across
+	// refresh / cross-session resume, and after the token is disabled.
+	AMOUNT: 'amount',
+	USD_SOURCE_VALUE: 'usd_source_value',
+	SOURCE_TOKEN_SYMBOL: 'source_token_symbol',
+	SOURCE_NETWORK_SYMBOL: 'source_network_symbol',
+	DESTINATION_TOKEN_SYMBOL: 'destination_token_symbol',
+	DESTINATION_NETWORK_SYMBOL: 'destination_network_symbol'
+} as const;
+
+export type ChainFusionExternalRefKey =
+	(typeof CHAIN_FUSION_EXTERNAL_REF_KEYS)[keyof typeof CHAIN_FUSION_EXTERNAL_REF_KEYS];

--- a/src/frontend/src/lib/utils/chain-fusion-swap-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/chain-fusion-swap-active-tx.utils.ts
@@ -1,0 +1,296 @@
+import type {
+	ActiveUserTransaction,
+	ActiveUserTransactionData,
+	ActiveUserTransactionRef,
+	ActiveUserTransactionStatus,
+	ChainFusionDirection
+} from '$declarations/backend/backend.did';
+import {
+	CKERC20_HELPER_CONTRACT_SIGNATURE,
+	CKETH_HELPER_CONTRACT_SIGNATURE
+} from '$env/networks/networks.cketh.env';
+import type { EthAddress } from '$eth/types/address';
+import { tokenAddressToHex } from '$eth/utils/token.utils';
+import { i18n } from '$lib/stores/i18n.store';
+import {
+	CHAIN_FUSION_EXTERNAL_REF_KEYS,
+	type ChainFusionExternalRefKey
+} from '$lib/types/chain-fusion-swap';
+import { SwapProvider } from '$lib/types/swap';
+import type { Token } from '$lib/types/token';
+import { toBackendTokenId } from '$lib/utils/token-id.utils';
+import { nonNullish } from '@dfinity/utils';
+import { encodePrincipalToEthAddress, type CkEthMinterDid } from '@icp-sdk/canisters/cketh';
+import type { Principal } from '@icp-sdk/core/principal';
+import { get } from 'svelte/store';
+
+export const isChainFusionActiveUserTransaction = (tx: ActiveUserTransaction): boolean =>
+	'ChainFusion' in tx.data;
+
+/**
+ * The two directions whose settlement is observed from the *deposit* side rather
+ * than asked of the minter: the ckETH minter has no per-deposit status endpoint,
+ * so a mint is followed exactly as the Convert flow's virtual transaction is —
+ * see `toChainFusionMintStatus`.
+ */
+export const isChainFusionMintDirection = (direction: ChainFusionDirection): boolean =>
+	'EthToCkEth' in direction || 'Erc20ToCkErc20' in direction;
+
+/**
+ * The two directions the ckETH minter answers exactly, keyed on a ledger burn
+ * index. `CkBtcToBtc` is deliberately excluded: it is also a withdrawal, but it
+ * is a different minter answering a different question, and asking the ckETH
+ * minter about it would be nonsense. Its arm arrives with the Bitcoin family.
+ */
+export const isChainFusionEthWithdrawalDirection = (direction: ChainFusionDirection): boolean =>
+	'CkEthToEth' in direction || 'CkErc20ToErc20' in direction;
+
+/**
+ * Builds the `ChainFusion` AUT data variant: the direction discriminant plus the
+ * canonical immutable trio (source token, destination token, source amount in
+ * base units). Every settlement pointer — block indices, the deposit tx hash and
+ * block number, the minter and helper-contract addresses — rides in
+ * `external_refs`, which need no Candid change to extend.
+ *
+ * Returns `undefined` when either token has no backend `TokenId`, which callers
+ * treat as "do not track this conversion" rather than as a failure.
+ */
+export const toChainFusionData = ({
+	direction,
+	sourceToken,
+	destinationToken,
+	amount
+}: {
+	direction: ChainFusionDirection;
+	sourceToken: Token;
+	destinationToken: Token;
+	amount: bigint;
+}): ActiveUserTransactionData | undefined => {
+	const source_token = toBackendTokenId(sourceToken);
+	const dest_token = toBackendTokenId(destinationToken);
+
+	if (nonNullish(source_token) && nonNullish(dest_token)) {
+		return { ChainFusion: { direction, source_token, dest_token, amount } };
+	}
+};
+
+/**
+ * Builds a deterministic `(key, value)` external-ref array, dropping empties.
+ * Mirrors `toVeloraExternalRefs`.
+ */
+export const toChainFusionExternalRefs = (
+	refs: Partial<Record<ChainFusionExternalRefKey, string>>
+): ActiveUserTransactionRef[] =>
+	(Object.keys(refs) as ChainFusionExternalRefKey[])
+		.filter((key) => refs[key] !== undefined && refs[key] !== '')
+		.sort()
+		.map((key) => ({ key, value: refs[key] as string }));
+
+// Wire-format `(key, value)` array → keyed lookup.
+export const toChainFusionExternalRefsMap = (
+	refs: ActiveUserTransactionRef[]
+): Partial<Record<ChainFusionExternalRefKey, string>> => {
+	const map: Partial<Record<ChainFusionExternalRefKey, string>> = {};
+
+	for (const { key, value } of refs) {
+		map[key as ChainFusionExternalRefKey] = value;
+	}
+
+	return map;
+};
+
+/**
+ * Snapshots the user-facing fields needed to render an AUT row and to fire its
+ * terminal-state analytics. Uses OneSec's key names, which is what lets
+ * `ActiveUserTransactionItem` render a Chain Fusion row without a new layout.
+ */
+export const toChainFusionDisplayRefs = ({
+	sourceToken,
+	destinationToken,
+	amount,
+	usdSourceValue
+}: {
+	sourceToken: Token;
+	destinationToken: Token;
+	amount: string;
+	usdSourceValue?: string;
+}): Partial<Record<ChainFusionExternalRefKey, string>> => ({
+	[CHAIN_FUSION_EXTERNAL_REF_KEYS.AMOUNT]: amount,
+	...(nonNullish(usdSourceValue)
+		? { [CHAIN_FUSION_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE]: usdSourceValue }
+		: {}),
+	[CHAIN_FUSION_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL]: sourceToken.symbol,
+	[CHAIN_FUSION_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL]: sourceToken.network.name,
+	[CHAIN_FUSION_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]: destinationToken.symbol,
+	[CHAIN_FUSION_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL]: destinationToken.network.name
+});
+
+/**
+ * Maps the ckETH minter's withdrawal status to the AUT status enum.
+ *
+ * `NotFound` is deliberately **not** a failure: a withdrawal reads as `NotFound`
+ * in the window between the ledger burn and the minter indexing the request, so
+ * mapping it to `Failed` would terminalize nearly every withdrawal wrongly — and
+ * terminal states are immutable, so there is no recovery from that.
+ *
+ * `TxFinalized` splits on its own payload: `Success` succeeded, while
+ * `Reimbursed` and `PendingReimbursement` mean the Ethereum transaction failed
+ * and the user is getting their ckETH back. `PendingReimbursement` is terminal
+ * for our purposes — the verdict is settled even though the refund has not
+ * landed yet, and unlike Velora's `REFUNDING` there is no later hash to learn.
+ */
+export const toChainFusionWithdrawalStatus = (
+	status: CkEthMinterDid.RetrieveEthStatus
+): ActiveUserTransactionStatus | undefined => {
+	if ('TxFinalized' in status) {
+		return 'Success' in status.TxFinalized ? { Succeeded: null } : { Failed: null };
+	}
+
+	if ('TxSent' in status || 'TxCreated' in status || 'Pending' in status) {
+		return { Executing: null };
+	}
+
+	// `NotFound` — the minter has not indexed the burn yet. Leave the row alone.
+	return undefined;
+};
+
+export const chainFusionWithdrawalStatusError = (
+	status: CkEthMinterDid.RetrieveEthStatus
+): string | undefined => {
+	if ('TxFinalized' in status && !('Success' in status.TxFinalized)) {
+		return get(i18n).swap.error.swap_refunded;
+	}
+
+	return undefined;
+};
+
+// The Ethereum transaction the minter sent, revealed as soon as it is broadcast.
+export const toChainFusionWithdrawalLearnedRefs = (
+	status: CkEthMinterDid.RetrieveEthStatus
+): Partial<Record<ChainFusionExternalRefKey, string>> => {
+	if ('TxSent' in status) {
+		return {
+			[CHAIN_FUSION_EXTERNAL_REF_KEYS.WITHDRAWAL_TX_HASH]: status.TxSent.transaction_hash
+		};
+	}
+
+	if ('TxFinalized' in status) {
+		const { TxFinalized } = status;
+
+		const hash =
+			'Success' in TxFinalized
+				? TxFinalized.Success.transaction_hash
+				: 'PendingReimbursement' in TxFinalized
+					? TxFinalized.PendingReimbursement.transaction_hash
+					: TxFinalized.Reimbursed.transaction_hash;
+
+		return { [CHAIN_FUSION_EXTERNAL_REF_KEYS.WITHDRAWAL_TX_HASH]: hash };
+	}
+
+	return {};
+};
+
+/**
+ * What the Ethereum side plus the minter's scan progress say about a ck deposit.
+ *
+ * `notMined` and `notObserved` are the two in-flight shapes; `deposited` and
+ * `notDeposited` are the verdict, and are only ever reached once the minter has
+ * scanned past the deposit's block.
+ */
+export type ChainFusionMintOutcome =
+	'notMined' | 'reverted' | 'notObserved' | 'deposited' | 'notDeposited';
+
+/**
+ * Maps a ck deposit's observed state to the AUT status enum.
+ *
+ * This is the durable form of the Convert flow's virtual transaction. There, a
+ * deposit is synthesized into a pending `IcTransactionUi` for as long as
+ * `getLogs(startBlock = last_observed_block_number)` still returns its log —
+ * i.e. for as long as the minter has not consumed the block — and the row is
+ * retired once the minter passes it and the real minted ICRC transaction arrives
+ * from the index canister (`icp-eth/services/eth.services.ts:150`).
+ *
+ * The same two signals decide the verdict here, in the order that keeps it
+ * honest: while the minter has not reached the deposit's block the row is
+ * `Executing`, and once it has, the helper-contract log is what says whether
+ * there was a deposit to mint at all. That last check is why this is not the
+ * bare block-number heuristic: a transaction that mined but emitted no log for
+ * this principal — wrong contract, malformed calldata, a quarantined deposit —
+ * terminalizes as `Failed` instead of claiming a mint that never happened.
+ */
+export const chainFusionMintOutcomeToStatus = (
+	outcome: ChainFusionMintOutcome
+): ActiveUserTransactionStatus | undefined => {
+	switch (outcome) {
+		case 'deposited':
+			return { Succeeded: null };
+		case 'reverted':
+		case 'notDeposited':
+			return { Failed: null };
+		case 'notMined':
+		case 'notObserved':
+			return { Executing: null };
+	}
+};
+
+export const chainFusionMintOutcomeError = (
+	outcome: ChainFusionMintOutcome
+): string | undefined => {
+	if (outcome === 'reverted' || outcome === 'notDeposited') {
+		return get(i18n).swap.error.failed_unexpectedly;
+	}
+
+	return undefined;
+};
+
+/**
+ * The `getLogs` topic filter that identifies *this user's* deposits at a ck
+ * helper contract, byte for byte the filter
+ * `loadCkEthereumPendingTransactions` builds for the virtual transaction.
+ *
+ * ckETH: `[signature, <any sender>, principal]`. ckERC20 inserts the ERC20
+ * contract the deposit was made in: `[signature, erc20, <any sender>, principal]`.
+ */
+export const toChainFusionDepositLogTopics = ({
+	principal,
+	erc20ContractAddress
+}: {
+	principal: Principal;
+	erc20ContractAddress?: EthAddress;
+}): (string | null)[] => {
+	const to = encodePrincipalToEthAddress(principal);
+
+	return nonNullish(erc20ContractAddress)
+		? [CKERC20_HELPER_CONTRACT_SIGNATURE, tokenAddressToHex(erc20ContractAddress), null, to]
+		: [CKETH_HELPER_CONTRACT_SIGNATURE, null, to];
+};
+
+/**
+ * Builds the analytics metadata for a Chain Fusion AUT row that has just reached
+ * a terminal status. Same shape as `buildVeloraSwapTrackingMetadata`, resolved
+ * entirely off the row's snapshot so it survives refresh / cross-session resume.
+ *
+ * `dApp` is the provider, not the direction: a ck conversion started from the
+ * Swap modal belongs in the swap funnel, and the Convert flow keeps firing its
+ * own `TRACK_COUNT_CONVERT_*` events untouched.
+ */
+export const buildChainFusionSwapTrackingMetadata = ({
+	tx
+}: {
+	tx: ActiveUserTransaction;
+}): Record<string, string> => {
+	const refs = toChainFusionExternalRefsMap(tx.external_refs);
+
+	return {
+		sourceToken: refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL] ?? '',
+		destinationToken: refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL] ?? '',
+		dApp: SwapProvider.CHAIN_FUSION,
+		tokenAmount: refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.AMOUNT] ?? '',
+		// Snapshotted at commit time, so it matches the `swap_submitted` the wizard
+		// fired for the same conversion rather than the rate at settlement.
+		usdSourceValue: refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE] ?? '',
+		sourceNetwork: refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL] ?? '',
+		destinationNetwork: refs[CHAIN_FUSION_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL] ?? '',
+		...(nonNullish(tx.error[0]) ? { error: tx.error[0] } : {})
+	};
+};

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
@@ -1,6 +1,10 @@
 import SwapIcpWizard from '$icp/components/swap/SwapIcpWizard.svelte';
 import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 import type { IcToken } from '$icp/types/ic-token';
+import {
+	TRACK_COUNT_SWAP_SUBMITTED,
+	TRACK_COUNT_SWAP_SUCCESS
+} from '$lib/constants/analytics.constants';
 import * as addrDerived from '$lib/derived/address.derived';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import { WizardStepsSwap } from '$lib/enums/wizard-steps';
@@ -8,7 +12,7 @@ import * as analytics from '$lib/services/analytics.services';
 import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
 import * as toasts from '$lib/stores/toasts.store';
-import type { ChainFusionSwapDetails } from '$lib/types/swap';
+import { SwapProvider, type ChainFusionSwapDetails } from '$lib/types/swap';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
@@ -418,6 +422,41 @@ describe('SwapIcpWizard', () => {
 						destinationAddress: mockEthAddress,
 						sourceToken: ckErc20SourceToken
 					})
+				);
+			});
+
+			// The id the active user transaction is created under, so the row and the
+			// `swap_submitted` event describe the same conversion.
+			it('passes a swap id and the USD value the row is snapshotted with', async () => {
+				setChainFusionContext({ sourceFees: [], externalFees: [] });
+
+				await submit();
+
+				expect(mockChainFusionFn).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({ swapId: expect.any(String) })
+				);
+
+				expect(mockChainFusionFn.mock.lastCall?.[0].swapId).not.toBe('');
+			});
+
+			// The foreground ends when the funds leave the wallet; the minter settles
+			// afterwards, and the AUT row is what reports success or failure.
+			it('reports the conversion as submitted rather than succeeded', async () => {
+				const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+
+				setChainFusionContext({ sourceFees: [], externalFees: [] });
+
+				await submit();
+
+				expect(trackEventSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						name: TRACK_COUNT_SWAP_SUBMITTED,
+						metadata: expect.objectContaining({ dApp: SwapProvider.CHAIN_FUSION })
+					})
+				);
+
+				expect(trackEventSpy).not.toHaveBeenCalledWith(
+					expect.objectContaining({ name: TRACK_COUNT_SWAP_SUCCESS })
 				);
 			});
 		});

--- a/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
@@ -1,6 +1,7 @@
 import ActiveUserTransactionItem from '$lib/components/active-user-transactions/ActiveUserTransactionItem.svelte';
 import en from '$lib/i18n/en.json';
 import {
+	mockChainFusionActiveUserTransaction,
 	mockLiquidiumActiveUserTransaction,
 	mockNearIntentsActiveUserTransaction,
 	mockVeloraActiveUserTransaction
@@ -38,6 +39,23 @@ describe('ActiveUserTransactionItem', () => {
 		// Source and destination share a network, so it reads once, not "Ethereum → Ethereum".
 		expect(container).not.toHaveTextContent('Ethereum → Ethereum');
 		expect(container).toHaveTextContent('Ethereum');
+	});
+
+	// A ck conversion joins the swap union and reuses the shared display refs, so it
+	// needs no row layout of its own.
+	it('renders Chain Fusion rows as a swap with the provider and the cross-chain networks', () => {
+		const { container } = render(ActiveUserTransactionItem, {
+			props: {
+				tx: mockChainFusionActiveUserTransaction,
+				isUnseen: false,
+				dismissing: false,
+				onDismiss: vi.fn()
+			}
+		});
+
+		expect(screen.getByText(`${en.swap.text.swap} 1 ckETH → ETH`)).toBeInTheDocument();
+		expect(container).toHaveTextContent('Internet Computer → Ethereum');
+		expect(container).toHaveTextContent('Chain Fusion');
 	});
 
 	it('renders Liquidium rows with the action, amount, asset and provider', () => {

--- a/src/frontend/src/tests/lib/components/loaders/LoaderActiveUserTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderActiveUserTransactions.spec.ts
@@ -11,6 +11,7 @@ import * as addressDerived from '$lib/derived/address.derived';
 import * as authDerived from '$lib/derived/auth.derived';
 import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
 import * as analyticsServices from '$lib/services/analytics.services';
+import * as chainFusionPoller from '$lib/services/chain-fusion-swap-active-tx.services';
 import * as liquidiumPoller from '$lib/services/liquidium-active-tx.services';
 import * as liquidiumServices from '$lib/services/liquidium.services';
 import * as nearIntentsPoller from '$lib/services/near-intents-active-tx.services';
@@ -21,6 +22,7 @@ import { SwapProvider } from '$lib/types/swap';
 import * as walletUtils from '$lib/utils/wallet.utils';
 import {
 	mockActiveUserTransaction,
+	mockChainFusionActiveUserTransaction,
 	mockLiquidiumActiveUserTransaction,
 	mockNearIntentsActiveUserTransaction,
 	mockVeloraActiveUserTransaction
@@ -79,6 +81,20 @@ const succeededVelora = (id: string) =>
 		id,
 		status: { Succeeded: null } as const
 	}) satisfies typeof mockVeloraActiveUserTransaction;
+
+const pendingChainFusion = (id: string) =>
+	({
+		...mockChainFusionActiveUserTransaction,
+		id,
+		status: { Pending: null } as const
+	}) satisfies typeof mockChainFusionActiveUserTransaction;
+
+const succeededChainFusion = (id: string) =>
+	({
+		...mockChainFusionActiveUserTransaction,
+		id,
+		status: { Succeeded: null } as const
+	}) satisfies typeof mockChainFusionActiveUserTransaction;
 
 const pendingLiquidium = (id: string) =>
 	({
@@ -261,6 +277,29 @@ describe('LoaderActiveUserTransactions', () => {
 			});
 		});
 
+		it('polls Chain Fusion rows on each tick when present', async () => {
+			const oneSecSpy = vi
+				.spyOn(oneSecPoller, 'pollOneSecActiveUserTransactions')
+				.mockResolvedValue();
+			const chainFusionSpy = vi
+				.spyOn(chainFusionPoller, 'pollChainFusionActiveUserTransactions')
+				.mockResolvedValue();
+			const tx = pendingChainFusion('chain-fusion-a');
+
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: tx });
+
+			render(LoaderActiveUserTransactions);
+
+			await vi.advanceTimersByTimeAsync(ACTIVE_USER_TRANSACTIONS_POLL_INTERVAL_MILLIS);
+
+			expect(oneSecSpy).not.toHaveBeenCalled();
+			expect(chainFusionSpy).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				transactions: [tx]
+			});
+		});
+
 		it('stops polling once all rows reach a terminal state', async () => {
 			const spy = vi.spyOn(oneSecPoller, 'pollOneSecActiveUserTransactions').mockResolvedValue();
 
@@ -372,6 +411,47 @@ describe('LoaderActiveUserTransactions', () => {
 				metadata: expect.objectContaining({ dApp: SwapProvider.VELORA })
 			});
 			expect(appliedFlags()).toEqual({ 'velora-a': true });
+		});
+
+		it('fires waitAndTriggerWallet and a swap_success event with the Chain Fusion dApp when a ck row succeeds', async () => {
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: pendingChainFusion('chain-fusion-a') });
+
+			render(LoaderActiveUserTransactions);
+			await tick();
+
+			expect(refreshSpy).not.toHaveBeenCalled();
+			expect(trackEventSpy).not.toHaveBeenCalled();
+
+			activeUserTransactionsStore.upsert({ transaction: succeededChainFusion('chain-fusion-a') });
+			await tick();
+
+			expect(refreshSpy).toHaveBeenCalledOnce();
+			// A ck conversion reports into the swap funnel, not the convert one.
+			expect(trackEventSpy).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_SWAP_SUCCESS,
+				metadata: expect.objectContaining({ dApp: SwapProvider.CHAIN_FUSION })
+			});
+			expect(appliedFlags()).toEqual({ 'chain-fusion-a': true });
+		});
+
+		it('fires a swap_error event without a wallet refresh when a ck row fails', async () => {
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: pendingChainFusion('chain-fusion-a') });
+
+			render(LoaderActiveUserTransactions);
+			await tick();
+
+			activeUserTransactionsStore.upsert({
+				transaction: { ...pendingChainFusion('chain-fusion-a'), status: { Failed: null } }
+			});
+			await tick();
+
+			expect(refreshSpy).not.toHaveBeenCalled();
+			expect(trackEventSpy).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_SWAP_ERROR,
+				metadata: expect.objectContaining({ dApp: SwapProvider.CHAIN_FUSION })
+			});
 		});
 
 		it('fires wallet and Liquidium refreshes plus analytics when a Liquidium row succeeds', async () => {

--- a/src/frontend/src/tests/lib/services/chain-fusion-swap-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/chain-fusion-swap-active-tx.services.spec.ts
@@ -1,0 +1,498 @@
+import type {
+	ActiveUserTransaction,
+	ActiveUserTransactionStatus,
+	ChainFusionDirection
+} from '$declarations/backend/backend.did';
+import { CKERC20_HELPER_CONTRACT_SIGNATURE } from '$env/networks/networks.cketh.env';
+import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
+import { infuraProviders } from '$eth/providers/infura.providers';
+import { tokenAddressToHex } from '$eth/utils/token.utils';
+import { minterInfo } from '$icp-eth/api/cketh-minter.api';
+import { retrieveEthStatus } from '$icp/api/cketh-minter.api';
+import { applyActiveUserTransactionPollUpdate } from '$lib/services/active-user-transactions.services';
+import {
+	pollChainFusionActiveUserTransactions,
+	resetChainFusionMissingDepositLogObservations
+} from '$lib/services/chain-fusion-swap-active-tx.services';
+import { CHAIN_FUSION_EXTERNAL_REF_KEYS } from '$lib/types/chain-fusion-swap';
+import { toChainFusionExternalRefs } from '$lib/utils/chain-fusion-swap-active-tx.utils';
+import { mockCkMinterInfo } from '$tests/mocks/ck-minter.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { toNullable } from '@dfinity/utils';
+import { encodePrincipalToEthAddress } from '@icp-sdk/canisters/cketh';
+import { Principal } from '@icp-sdk/core/principal';
+
+vi.mock('$icp/api/cketh-minter.api', () => ({
+	retrieveEthStatus: vi.fn()
+}));
+
+vi.mock('$icp-eth/api/cketh-minter.api', () => ({
+	minterInfo: vi.fn()
+}));
+
+vi.mock('$eth/providers/infura.providers', () => ({
+	infuraProviders: vi.fn()
+}));
+
+vi.mock('$eth/providers/infura-cketh.providers', () => ({
+	infuraCkETHProviders: vi.fn()
+}));
+
+vi.mock('$lib/services/active-user-transactions.services', () => ({
+	applyActiveUserTransactionPollUpdate: vi.fn()
+}));
+
+const CKETH_LEDGER = 'ss2fx-dyaaa-aaaar-qacoq-cai';
+const MINTER_CANISTER_ID = 'sv3dd-oaaaa-aaaar-qacoa-cai';
+
+const DEPOSIT_TX_HASH = '0xDEADBEEF';
+const HELPER_CONTRACT = '0x7574eB42cA208A4f6960ECCAfDF186D627dCC175';
+const DEPOSIT_BLOCK = 1_000;
+
+const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+const getTransactionReceipt = vi.fn();
+const getLogs = vi.fn();
+
+const toTx = ({
+	id = 'tx-id',
+	status = { Pending: null },
+	direction,
+	source_token = { Icrc: Principal.fromText(CKETH_LEDGER) },
+	refs
+}: {
+	id?: string;
+	status?: ActiveUserTransactionStatus;
+	direction: ChainFusionDirection;
+	source_token?: ActiveUserTransaction['data'] extends never ? never : { Icrc: Principal } | object;
+	refs: Partial<Record<string, string>>;
+}): ActiveUserTransaction =>
+	({
+		id,
+		status,
+		data: {
+			ChainFusion: {
+				direction,
+				source_token,
+				dest_token: { EvmNative: 1n },
+				amount: 1_000n
+			}
+		},
+		progress_step: [],
+		external_refs: toChainFusionExternalRefs(refs),
+		created_at_ns: 1n,
+		updated_at_ns: 1n,
+		error: []
+	}) as ActiveUserTransaction;
+
+const withdrawalTx = (refs?: Partial<Record<string, string>>) =>
+	toTx({
+		direction: { CkEthToEth: null },
+		refs: {
+			[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: MINTER_CANISTER_ID,
+			[CHAIN_FUSION_EXTERNAL_REF_KEYS.CKETH_BLOCK_INDEX]: '7',
+			...refs
+		}
+	});
+
+const mintTx = ({ id, refs }: { id?: string; refs?: Partial<Record<string, string>> } = {}) =>
+	toTx({
+		id,
+		direction: { EthToCkEth: null },
+		source_token: { EvmNative: 1n },
+		refs: {
+			[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: MINTER_CANISTER_ID,
+			[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_TX_HASH]: DEPOSIT_TX_HASH,
+			[CHAIN_FUSION_EXTERNAL_REF_KEYS.HELPER_CONTRACT_ADDRESS]: HELPER_CONTRACT,
+			...refs
+		}
+	});
+
+const setLastObservedBlock = (blockNumber: number | undefined) =>
+	vi.mocked(minterInfo).mockResolvedValue({
+		...mockCkMinterInfo,
+		last_observed_block_number: toNullable(
+			blockNumber === undefined ? undefined : BigInt(blockNumber)
+		)
+	});
+
+const poll = (transactions: ActiveUserTransaction[]) =>
+	pollChainFusionActiveUserTransactions({ identity: mockIdentity, transactions });
+
+const lastUpdate = () => vi.mocked(applyActiveUserTransactionPollUpdate).mock.lastCall?.[0].update;
+
+describe('chain-fusion-swap-active-tx.services', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetChainFusionMissingDepositLogObservations();
+
+		vi.mocked(infuraProviders).mockReturnValue({
+			getTransactionReceipt
+		} as unknown as ReturnType<typeof infuraProviders>);
+
+		vi.mocked(infuraCkETHProviders).mockReturnValue({ getLogs } as unknown as ReturnType<
+			typeof infuraCkETHProviders
+		>);
+	});
+
+	it('should do nothing for an empty batch', async () => {
+		await poll([]);
+
+		expect(retrieveEthStatus).not.toHaveBeenCalled();
+		expect(minterInfo).not.toHaveBeenCalled();
+	});
+
+	describe('withdrawal directions', () => {
+		it('should advance a finalized withdrawal to Succeeded and learn its transaction hash', async () => {
+			vi.mocked(retrieveEthStatus).mockResolvedValue({
+				TxFinalized: { Success: { transaction_hash: '0xok', effective_transaction_fee: [] } }
+			});
+
+			await poll([withdrawalTx()]);
+
+			expect(retrieveEthStatus).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				minterCanisterId: MINTER_CANISTER_ID,
+				blockIndex: 7n
+			});
+
+			expect(lastUpdate()).toStrictEqual({
+				status: { Succeeded: null },
+				externalRefs: expect.arrayContaining([{ key: 'chain_fusion_eth_tx', value: '0xok' }])
+			});
+		});
+
+		it('should fail a reimbursed withdrawal with an error message', async () => {
+			vi.mocked(retrieveEthStatus).mockResolvedValue({
+				TxFinalized: {
+					Reimbursed: {
+						transaction_hash: '0xrefund',
+						reimbursed_amount: 1n,
+						reimbursed_in_block: 2n
+					}
+				}
+			});
+
+			await poll([withdrawalTx()]);
+
+			expect(lastUpdate()).toStrictEqual(
+				expect.objectContaining({ status: { Failed: null }, error: expect.any(String) })
+			);
+		});
+
+		// Acceptance criterion 17: the window between the burn and the minter indexing
+		// it must never terminalize the row.
+		it('should leave a NotFound withdrawal untouched', async () => {
+			vi.mocked(retrieveEthStatus).mockResolvedValue({ NotFound: null });
+
+			await poll([withdrawalTx()]);
+
+			expect(applyActiveUserTransactionPollUpdate).not.toHaveBeenCalled();
+		});
+
+		it('should not regress a row whose status is already ahead of the candidate', async () => {
+			vi.mocked(retrieveEthStatus).mockResolvedValue({ TxSent: { transaction_hash: '0xsent' } });
+
+			const tx = withdrawalTx();
+
+			await poll([
+				{
+					...tx,
+					status: { Succeeded: null },
+					external_refs: toChainFusionExternalRefs({
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: MINTER_CANISTER_ID,
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.CKETH_BLOCK_INDEX]: '7',
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.WITHDRAWAL_TX_HASH]: '0xsent'
+					})
+				}
+			]);
+
+			// Neither a status nor a ref changed, so there is nothing to write.
+			expect(applyActiveUserTransactionPollUpdate).not.toHaveBeenCalled();
+		});
+
+		it('should persist a newly learned hash even when the status does not advance', async () => {
+			vi.mocked(retrieveEthStatus).mockResolvedValue({ TxSent: { transaction_hash: '0xsent' } });
+
+			await poll([{ ...withdrawalTx(), status: { Executing: null } }]);
+
+			expect(lastUpdate()).toStrictEqual({
+				externalRefs: expect.arrayContaining([{ key: 'chain_fusion_eth_tx', value: '0xsent' }])
+			});
+		});
+
+		it('should skip a row missing its burn index', async () => {
+			await poll([
+				toTx({
+					direction: { CkEthToEth: null },
+					refs: { [CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: MINTER_CANISTER_ID }
+				})
+			]);
+
+			expect(retrieveEthStatus).not.toHaveBeenCalled();
+		});
+
+		it('should leave the row pending when the minter query throws', async () => {
+			vi.mocked(retrieveEthStatus).mockRejectedValue(new Error('replica unavailable'));
+
+			await expect(poll([withdrawalTx()])).resolves.toBeUndefined();
+
+			expect(applyActiveUserTransactionPollUpdate).not.toHaveBeenCalled();
+		});
+
+		// PR 10's arm. Until then a ckBTC row cannot exist, and must certainly not be
+		// asked of the ckETH minter.
+		it('should not route a ckBTC withdrawal to the ckETH minter', async () => {
+			await poll([
+				toTx({
+					direction: { CkBtcToBtc: null },
+					refs: {
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: MINTER_CANISTER_ID,
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.CKETH_BLOCK_INDEX]: '7'
+					}
+				})
+			]);
+
+			expect(retrieveEthStatus).not.toHaveBeenCalled();
+			expect(applyActiveUserTransactionPollUpdate).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('mint directions', () => {
+		it('should keep a deposit still in the mempool executing, without asking the minter', async () => {
+			getTransactionReceipt.mockResolvedValue(null);
+
+			await poll([mintTx()]);
+
+			expect(minterInfo).not.toHaveBeenCalled();
+			expect(lastUpdate()).toStrictEqual({ status: { Executing: null } });
+		});
+
+		it('should fail a deposit whose transaction reverted', async () => {
+			getTransactionReceipt.mockResolvedValue({ status: 0, blockNumber: DEPOSIT_BLOCK });
+
+			await poll([mintTx()]);
+
+			expect(lastUpdate()).toStrictEqual(
+				expect.objectContaining({ status: { Failed: null }, error: expect.any(String) })
+			);
+		});
+
+		it('should learn the deposit block from the receipt and keep it for later ticks', async () => {
+			getTransactionReceipt.mockResolvedValue({ status: 1, blockNumber: DEPOSIT_BLOCK });
+			setLastObservedBlock(DEPOSIT_BLOCK - 1);
+
+			await poll([mintTx()]);
+
+			expect(lastUpdate()).toStrictEqual({
+				status: { Executing: null },
+				externalRefs: expect.arrayContaining([
+					{ key: 'chain_fusion_deposit_block', value: `${DEPOSIT_BLOCK}` }
+				])
+			});
+
+			// Nothing to look for yet: the minter has not reached the block.
+			expect(getLogs).not.toHaveBeenCalled();
+		});
+
+		it('should not re-read the receipt once the deposit block is known', async () => {
+			setLastObservedBlock(DEPOSIT_BLOCK - 1);
+
+			await poll([
+				mintTx({
+					refs: {
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}`
+					}
+				})
+			]);
+
+			expect(getTransactionReceipt).not.toHaveBeenCalled();
+		});
+
+		it('should succeed once the minter has passed the block and the deposit log is there', async () => {
+			setLastObservedBlock(DEPOSIT_BLOCK + 1);
+			// Lower-cased by the node, as Infura returns it — the comparison must not care.
+			getLogs.mockResolvedValue([{ transactionHash: DEPOSIT_TX_HASH.toLowerCase() }]);
+
+			await poll([
+				mintTx({
+					refs: {
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}`
+					}
+				})
+			]);
+
+			// Bounded to the single block the deposit mined in, so an abandoned row costs
+			// the same query as a fresh one.
+			expect(getLogs).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					contract: { address: HELPER_CONTRACT },
+					startBlock: DEPOSIT_BLOCK,
+					endBlock: DEPOSIT_BLOCK
+				})
+			);
+
+			expect(lastUpdate()).toStrictEqual({ status: { Succeeded: null } });
+		});
+
+		it('should keep the row executing until the minter has scanned strictly past the block', async () => {
+			// Equality is still in flight: the Convert flow's virtual row survives while
+			// `getLogs(startBlock = last_observed)` — an inclusive bound — returns the log.
+			setLastObservedBlock(DEPOSIT_BLOCK);
+
+			await poll([
+				mintTx({
+					refs: {
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}`
+					}
+				})
+			]);
+
+			expect(getLogs).not.toHaveBeenCalled();
+			expect(lastUpdate()).toStrictEqual({ status: { Executing: null } });
+		});
+
+		it('should keep the row executing when the minter reports no scan position', async () => {
+			setLastObservedBlock(undefined);
+
+			await poll([
+				mintTx({
+					refs: {
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}`
+					}
+				})
+			]);
+
+			expect(lastUpdate()).toStrictEqual({ status: { Executing: null } });
+		});
+
+		// A missing log is also what a transiently lagging node returns, and `Failed` is
+		// irreversible — so it takes two consecutive observations.
+		it('should require two consecutive missing-log observations before failing', async () => {
+			setLastObservedBlock(DEPOSIT_BLOCK + 1);
+			getLogs.mockResolvedValue([]);
+
+			const tx = mintTx({
+				refs: { [CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}` }
+			});
+
+			await poll([tx]);
+
+			expect(lastUpdate()).toStrictEqual({ status: { Executing: null } });
+
+			await poll([tx]);
+
+			expect(lastUpdate()).toStrictEqual(
+				expect.objectContaining({ status: { Failed: null }, error: expect.any(String) })
+			);
+		});
+
+		it('should forget the observation once the log shows up after all', async () => {
+			setLastObservedBlock(DEPOSIT_BLOCK + 1);
+
+			const tx = mintTx({
+				refs: { [CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}` }
+			});
+
+			getLogs.mockResolvedValue([]);
+			await poll([tx]);
+
+			getLogs.mockResolvedValue([{ transactionHash: DEPOSIT_TX_HASH }]);
+			await poll([tx]);
+
+			expect(lastUpdate()).toStrictEqual({ status: { Succeeded: null } });
+
+			// The counter was cleared, so a later miss starts from scratch.
+			getLogs.mockResolvedValue([]);
+			await poll([tx]);
+
+			expect(lastUpdate()).toStrictEqual({ status: { Executing: null } });
+		});
+
+		it('should read the minter once per tick for rows sharing it', async () => {
+			setLastObservedBlock(DEPOSIT_BLOCK - 1);
+
+			const refs = {
+				[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}`
+			};
+
+			await poll([mintTx({ id: 'a', refs }), mintTx({ id: 'b', refs })]);
+
+			expect(minterInfo).toHaveBeenCalledOnce();
+		});
+
+		it('should skip a row missing the helper contract it deposited to', async () => {
+			await poll([
+				toTx({
+					direction: { EthToCkEth: null },
+					source_token: { EvmNative: 1n },
+					refs: {
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: MINTER_CANISTER_ID,
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_TX_HASH]: DEPOSIT_TX_HASH
+					}
+				})
+			]);
+
+			expect(getTransactionReceipt).not.toHaveBeenCalled();
+			expect(applyActiveUserTransactionPollUpdate).not.toHaveBeenCalled();
+		});
+
+		it('should filter an ERC20 deposit on its contract address', async () => {
+			setLastObservedBlock(DEPOSIT_BLOCK + 1);
+			getLogs.mockResolvedValue([{ transactionHash: DEPOSIT_TX_HASH }]);
+
+			await poll([
+				toTx({
+					direction: { Erc20ToCkErc20: null },
+					source_token: { Erc20: [USDC_ADDRESS, 1n] },
+					refs: {
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: MINTER_CANISTER_ID,
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_TX_HASH]: DEPOSIT_TX_HASH,
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.HELPER_CONTRACT_ADDRESS]: HELPER_CONTRACT,
+						[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}`
+					}
+				})
+			]);
+
+			// Four topics for ckERC20 against three for ckETH: the ERC20 contract sits in
+			// the extra slot, so a deposit of a *different* ERC20 cannot match this row.
+			expect(getLogs).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					topics: [
+						CKERC20_HELPER_CONTRACT_SIGNATURE,
+						tokenAddressToHex(USDC_ADDRESS),
+						null,
+						encodePrincipalToEthAddress(mockIdentity.getPrincipal())
+					]
+				})
+			);
+		});
+
+		it('should leave the row pending when the log query throws', async () => {
+			setLastObservedBlock(DEPOSIT_BLOCK + 1);
+			getLogs.mockRejectedValue(new Error('infura down'));
+
+			await expect(
+				poll([
+					mintTx({
+						refs: { [CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: `${DEPOSIT_BLOCK}` }
+					})
+				])
+			).resolves.toBeUndefined();
+
+			expect(applyActiveUserTransactionPollUpdate).not.toHaveBeenCalled();
+		});
+	});
+
+	it('should not let one failing row poison the batch', async () => {
+		vi.mocked(retrieveEthStatus)
+			.mockRejectedValueOnce(new Error('boom'))
+			.mockResolvedValueOnce({
+				TxFinalized: { Success: { transaction_hash: '0xok', effective_transaction_fee: [] } }
+			});
+
+		await poll([withdrawalTx(), withdrawalTx()]);
+
+		expect(applyActiveUserTransactionPollUpdate).toHaveBeenCalledOnce();
+	});
+});

--- a/src/frontend/src/tests/lib/services/chain-fusion-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/chain-fusion-swap.services.spec.ts
@@ -2,13 +2,18 @@ import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { USDC_TOKEN as BASE_USDC_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens-erc20/tokens.usdc.env';
 import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
+import { send as sendEth } from '$eth/services/send.services';
+import type { Erc20Token } from '$eth/types/erc20';
+import type { EthereumNetwork } from '$eth/types/network';
 import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 import { eip1559TransactionPrice } from '$icp/api/cketh-minter.api';
 import { sendIc } from '$icp/services/ic-send.services';
 import { icrcDefaultTokensStore } from '$icp/stores/icrc-default-tokens.store';
 import type { IcCkToken, IcToken } from '$icp/types/ic-token';
+import { createActiveUserTransaction } from '$lib/services/active-user-transactions.services';
 import {
 	fetchChainFusionEvmQuote,
+	fetchChainFusionEvmSwap,
 	fetchChainFusionIcpQuote,
 	fetchChainFusionIcpSwap
 } from '$lib/services/chain-fusion-swap.services';
@@ -24,6 +29,7 @@ import {
 } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
+import { Principal } from '@icp-sdk/core/principal';
 
 let mockEnabled = true;
 
@@ -41,6 +47,14 @@ vi.mock('$icp/services/ic-send.services', () => ({
 	sendIc: vi.fn()
 }));
 
+vi.mock('$eth/services/send.services', () => ({
+	send: vi.fn()
+}));
+
+vi.mock('$lib/services/active-user-transactions.services', () => ({
+	createActiveUserTransaction: vi.fn()
+}));
+
 const IC_CKETH_LEDGER = 'ss2fx-dyaaa-aaaar-qacoq-cai';
 const IC_CKUSDC_LEDGER = 'xevnm-gaaaa-aaaar-qafnq-cai';
 const LOCAL_CKUSDC_LEDGER = 'yfumr-cyaaa-aaaar-qaela-cai';
@@ -50,6 +64,17 @@ const CKETH_LEDGER_FEE = 2_000n;
 const CK_LEDGER_FEE = 123n;
 
 const AMOUNT = 1_000_000n;
+
+const SWAP_ID = '11111111-1111-4111-8111-111111111111';
+const MINTER_CANISTER_ID = 'sv3dd-oaaaa-aaaar-qacoa-cai';
+
+// The wire format is a sorted `(key, value)` array; assertions read better keyed.
+const refsOfLastCreate = (): Record<string, string> =>
+	Object.fromEntries(
+		(vi.mocked(createActiveUserTransaction).mock.lastCall?.[0].externalRefs ?? []).map(
+			({ key, value }) => [key, value]
+		)
+	);
 
 const makeCkToken = ({
 	ledgerCanisterId,
@@ -404,7 +429,8 @@ describe('chain-fusion-swap.services', () => {
 			identity: mockIdentity,
 			progress,
 			swapAmount: '1',
-			destinationAddress: mockEthAddress
+			destinationAddress: mockEthAddress,
+			swapId: SWAP_ID
 		};
 
 		beforeEach(() => {
@@ -470,6 +496,213 @@ describe('chain-fusion-swap.services', () => {
 					destinationToken: ETHEREUM_TOKEN
 				})
 			).resolves.toStrictEqual(result);
+		});
+
+		it('should create an active user transaction keyed on the ckETH burn index', async () => {
+			vi.mocked(sendIc).mockResolvedValue({ type: 'ckEthToEth', blockIndex: 7n });
+
+			await fetchChainFusionIcpSwap({
+				...swapParams,
+				sourceToken: { ...ckEthSource, minterCanisterId: MINTER_CANISTER_ID },
+				destinationToken: ETHEREUM_TOKEN,
+				usdSourceValue: '3000'
+			});
+
+			expect(createActiveUserTransaction).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					id: SWAP_ID,
+					data: {
+						ChainFusion: {
+							direction: { CkEthToEth: null },
+							source_token: { Icrc: Principal.fromText(IC_CKETH_LEDGER) },
+							dest_token: { EvmNative: 1n },
+							// `swapAmount: '1'` in the *source* token's base units.
+							amount: 10n ** BigInt(ckEthSource.decimals)
+						}
+					}
+				})
+			);
+
+			expect(refsOfLastCreate()).toStrictEqual(
+				expect.objectContaining({
+					chain_fusion_cketh_index: '7',
+					chain_fusion_minter_id: MINTER_CANISTER_ID,
+					amount: '1',
+					usd_source_value: '3000',
+					source_token_symbol: 'ckETH-swap-source',
+					destination_token_symbol: ETHEREUM_TOKEN.symbol
+				})
+			);
+
+			expect(refsOfLastCreate()).not.toHaveProperty('chain_fusion_ckerc20_index');
+		});
+
+		it('should key a ckERC20 withdrawal on its ckETH burn index and carry the ckERC20 one', async () => {
+			vi.mocked(sendIc).mockResolvedValue({
+				type: 'ckErc20ToErc20',
+				ckEthBlockIndex: 11n,
+				ckErc20BlockIndex: 12n
+			});
+
+			await fetchChainFusionIcpSwap({
+				...swapParams,
+				sourceToken: { ...ckUsdcSource, minterCanisterId: MINTER_CANISTER_ID },
+				destinationToken: USDC_TOKEN
+			});
+
+			expect(createActiveUserTransaction).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						ChainFusion: expect.objectContaining({ direction: { CkErc20ToErc20: null } })
+					})
+				})
+			);
+
+			expect(refsOfLastCreate()).toStrictEqual(
+				expect.objectContaining({
+					chain_fusion_cketh_index: '11',
+					chain_fusion_ckerc20_index: '12'
+				})
+			);
+		});
+
+		it('should not surface a failed active-user-transaction creation as a swap failure', async () => {
+			const result = { type: 'ckEthToEth', blockIndex: 7n } as const;
+
+			vi.mocked(sendIc).mockResolvedValue(result);
+			vi.mocked(createActiveUserTransaction).mockRejectedValue(new Error('backend down'));
+
+			// The funds have already left the wallet — a bookkeeping failure must not read
+			// as the conversion having failed.
+			await expect(
+				fetchChainFusionIcpSwap({
+					...swapParams,
+					sourceToken: ckEthSource,
+					destinationToken: ETHEREUM_TOKEN
+				})
+			).resolves.toStrictEqual(result);
+		});
+	});
+
+	describe('fetchChainFusionEvmSwap', () => {
+		const progress = vi.fn();
+
+		const DEPOSIT_TX_HASH = '0xdeadbeef';
+		const HELPER_CONTRACT = '0x7574eB42cA208A4f6960ECCAfDF186D627dCC175';
+
+		const ckEthDestination: IcCkToken = {
+			...makeCkToken({
+				ledgerCanisterId: IC_CKETH_LEDGER,
+				twinToken: ETHEREUM_TOKEN,
+				symbol: 'ckETH-mint-destination'
+			}),
+			minterCanisterId: MINTER_CANISTER_ID
+		};
+
+		const ckUsdcDestination: IcCkToken = {
+			...makeCkToken({
+				ledgerCanisterId: IC_CKUSDC_LEDGER,
+				twinToken: USDC_TOKEN,
+				symbol: 'ckUSDC-mint-destination'
+			}),
+			minterCanisterId: MINTER_CANISTER_ID
+		};
+
+		const swapParams = {
+			identity: mockIdentity,
+			progress,
+			swapAmount: '1',
+			userAddress: mockEthAddress,
+			helperContractAddress: HELPER_CONTRACT,
+			sourceNetwork: ETHEREUM_TOKEN.network as EthereumNetwork,
+			minterInfo: undefined,
+			gas: 1n,
+			maxFeePerGas: 1n,
+			maxPriorityFeePerGas: 1n,
+			swapId: SWAP_ID
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.mocked(sendEth).mockResolvedValue({ hash: DEPOSIT_TX_HASH });
+		});
+
+		it('should create an active user transaction carrying what the mint poller needs', async () => {
+			await fetchChainFusionEvmSwap({
+				...swapParams,
+				sourceToken: ETHEREUM_TOKEN as unknown as Erc20Token,
+				destinationToken: ckEthDestination
+			});
+
+			expect(createActiveUserTransaction).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					id: SWAP_ID,
+					data: {
+						ChainFusion: {
+							direction: { EthToCkEth: null },
+							source_token: { EvmNative: 1n },
+							dest_token: { Icrc: Principal.fromText(IC_CKETH_LEDGER) },
+							amount: 1_000_000_000_000_000_000n
+						}
+					}
+				})
+			);
+
+			expect(refsOfLastCreate()).toStrictEqual(
+				expect.objectContaining({
+					chain_fusion_deposit_tx: DEPOSIT_TX_HASH,
+					chain_fusion_helper: HELPER_CONTRACT,
+					chain_fusion_minter_id: MINTER_CANISTER_ID
+				})
+			);
+
+			// Learned only once the deposit mines; nothing to snapshot at creation.
+			expect(refsOfLastCreate()).not.toHaveProperty('chain_fusion_deposit_block');
+		});
+
+		it('should record an ERC20 deposit as the Erc20ToCkErc20 direction', async () => {
+			await fetchChainFusionEvmSwap({
+				...swapParams,
+				sourceToken: USDC_TOKEN,
+				destinationToken: ckUsdcDestination
+			});
+
+			expect(createActiveUserTransaction).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						ChainFusion: expect.objectContaining({
+							direction: { Erc20ToCkErc20: null },
+							source_token: { Erc20: [USDC_TOKEN.address, 1n] }
+						})
+					})
+				})
+			);
+		});
+
+		it('should not surface a failed active-user-transaction creation as a swap failure', async () => {
+			vi.mocked(createActiveUserTransaction).mockRejectedValue(new Error('backend down'));
+
+			await expect(
+				fetchChainFusionEvmSwap({
+					...swapParams,
+					sourceToken: ETHEREUM_TOKEN as unknown as Erc20Token,
+					destinationToken: ckEthDestination
+				})
+			).resolves.toBeUndefined();
+		});
+
+		// A row with no minter to ask could never terminalize, and would hold one of the
+		// user's slots for good. Not tracking it at all is the lesser evil.
+		it('should create no row when the ck token names no minter', async () => {
+			await fetchChainFusionEvmSwap({
+				...swapParams,
+				sourceToken: ETHEREUM_TOKEN as unknown as Erc20Token,
+				destinationToken: { ...ckEthDestination, minterCanisterId: undefined }
+			});
+
+			expect(sendEth).toHaveBeenCalledOnce();
+			expect(createActiveUserTransaction).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/utils/chain-fusion-swap-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/chain-fusion-swap-active-tx.utils.spec.ts
@@ -1,0 +1,441 @@
+import type {
+	ActiveUserTransaction,
+	ActiveUserTransactionRef,
+	ActiveUserTransactionStatus
+} from '$declarations/backend/backend.did';
+import {
+	CKERC20_HELPER_CONTRACT_SIGNATURE,
+	CKETH_HELPER_CONTRACT_SIGNATURE
+} from '$env/networks/networks.cketh.env';
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BTC_MAINNET_TOKEN, BTC_REGTEST_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import { tokenAddressToHex } from '$eth/utils/token.utils';
+import { CHAIN_FUSION_EXTERNAL_REF_KEYS } from '$lib/types/chain-fusion-swap';
+import { SwapProvider } from '$lib/types/swap';
+import {
+	buildChainFusionSwapTrackingMetadata,
+	chainFusionMintOutcomeError,
+	chainFusionMintOutcomeToStatus,
+	chainFusionWithdrawalStatusError,
+	isChainFusionActiveUserTransaction,
+	isChainFusionEthWithdrawalDirection,
+	isChainFusionMintDirection,
+	toChainFusionData,
+	toChainFusionDepositLogTopics,
+	toChainFusionDisplayRefs,
+	toChainFusionExternalRefs,
+	toChainFusionExternalRefsMap,
+	toChainFusionWithdrawalLearnedRefs,
+	toChainFusionWithdrawalStatus,
+	type ChainFusionMintOutcome
+} from '$lib/utils/chain-fusion-swap-active-tx.utils';
+import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
+import { mockPrincipal } from '$tests/mocks/identity.mock';
+import { encodePrincipalToEthAddress, type CkEthMinterDid } from '@icp-sdk/canisters/cketh';
+import { Principal } from '@icp-sdk/core/principal';
+
+const CKETH_LEDGER = 'ss2fx-dyaaa-aaaar-qacoq-cai';
+
+const ckEthToken = {
+	...mockValidIcCkToken,
+	symbol: 'ckETH',
+	ledgerCanisterId: CKETH_LEDGER,
+	twinToken: ETHEREUM_TOKEN
+};
+
+const toTx = ({
+	external_refs = [],
+	error = [],
+	data
+}: {
+	external_refs?: ActiveUserTransactionRef[];
+	error?: [] | [string];
+	data: ActiveUserTransaction['data'];
+}): ActiveUserTransaction => ({
+	id: 'tx-id',
+	status: { Pending: null },
+	data,
+	progress_step: [],
+	external_refs,
+	created_at_ns: 1n,
+	updated_at_ns: 1n,
+	error
+});
+
+const chainFusionTx = (
+	rest: Omit<Parameters<typeof toTx>[0], 'data'> = {}
+): ActiveUserTransaction =>
+	toTx({
+		data: {
+			ChainFusion: {
+				direction: { CkEthToEth: null },
+				source_token: { Icrc: Principal.fromText(CKETH_LEDGER) },
+				dest_token: { EvmNative: 1n },
+				amount: 1_000n
+			}
+		},
+		...rest
+	});
+
+describe('chain-fusion-swap-active-tx.utils', () => {
+	describe('isChainFusionActiveUserTransaction', () => {
+		it('should match a ChainFusion row', () => {
+			expect(isChainFusionActiveUserTransaction(chainFusionTx())).toBeTruthy();
+		});
+
+		it('should not match another provider', () => {
+			expect(
+				isChainFusionActiveUserTransaction(
+					toTx({
+						data: {
+							NearIntents: {
+								source_token: { EvmNative: 1n },
+								dest_token: { EvmNative: 1n },
+								amount: 1n
+							}
+						}
+					})
+				)
+			).toBeFalsy();
+		});
+	});
+
+	describe('direction predicates', () => {
+		it('should classify the two mint directions', () => {
+			expect(isChainFusionMintDirection({ EthToCkEth: null })).toBeTruthy();
+			expect(isChainFusionMintDirection({ Erc20ToCkErc20: null })).toBeTruthy();
+
+			expect(isChainFusionMintDirection({ CkEthToEth: null })).toBeFalsy();
+			expect(isChainFusionMintDirection({ BtcToCkBtc: null })).toBeFalsy();
+		});
+
+		it('should classify the two Ethereum-family withdrawal directions', () => {
+			expect(isChainFusionEthWithdrawalDirection({ CkEthToEth: null })).toBeTruthy();
+			expect(isChainFusionEthWithdrawalDirection({ CkErc20ToErc20: null })).toBeTruthy();
+		});
+
+		// `CkBtcToBtc` is a withdrawal too, but of a different minter — routing it to
+		// `retrieve_eth_status` would be nonsense.
+		it('should exclude ckBTC → BTC from the Ethereum withdrawal family', () => {
+			expect(isChainFusionEthWithdrawalDirection({ CkBtcToBtc: null })).toBeFalsy();
+			expect(isChainFusionMintDirection({ CkBtcToBtc: null })).toBeFalsy();
+		});
+	});
+
+	describe('toChainFusionData', () => {
+		it('should build the variant with the direction and the immutable trio', () => {
+			expect(
+				toChainFusionData({
+					direction: { CkEthToEth: null },
+					sourceToken: ckEthToken,
+					destinationToken: ETHEREUM_TOKEN,
+					amount: 5_000n
+				})
+			).toStrictEqual({
+				ChainFusion: {
+					direction: { CkEthToEth: null },
+					source_token: { Icrc: Principal.fromText(CKETH_LEDGER) },
+					dest_token: { EvmNative: 1n },
+					amount: 5_000n
+				}
+			});
+		});
+
+		it('should map an ERC20 source by contract address and chain id', () => {
+			expect(
+				toChainFusionData({
+					direction: { Erc20ToCkErc20: null },
+					sourceToken: USDC_TOKEN,
+					destinationToken: ckEthToken,
+					amount: 1n
+				})
+			).toStrictEqual(
+				expect.objectContaining({
+					ChainFusion: expect.objectContaining({
+						source_token: { Erc20: [USDC_TOKEN.address, 1n] }
+					})
+				})
+			);
+		});
+
+		// The mapper is shared, so an unmappable token must degrade to "do not track"
+		// rather than throw at the point of no return.
+		it('should return undefined when a token has no backend TokenId', () => {
+			expect(
+				toChainFusionData({
+					direction: { BtcToCkBtc: null },
+					sourceToken: BTC_REGTEST_TOKEN,
+					destinationToken: ckEthToken,
+					amount: 1n
+				})
+			).toBeUndefined();
+		});
+
+		it('should map a Bitcoin mainnet source, which does have a variant', () => {
+			expect(
+				toChainFusionData({
+					direction: { BtcToCkBtc: null },
+					sourceToken: BTC_MAINNET_TOKEN,
+					destinationToken: ckEthToken,
+					amount: 1n
+				})
+			).toStrictEqual(
+				expect.objectContaining({
+					ChainFusion: expect.objectContaining({ source_token: { BtcNativeMainnet: null } })
+				})
+			);
+		});
+	});
+
+	describe('external refs round-trip', () => {
+		it('should drop empty and undefined values and sort by key', () => {
+			expect(
+				toChainFusionExternalRefs({
+					[CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID]: 'minter',
+					[CHAIN_FUSION_EXTERNAL_REF_KEYS.AMOUNT]: '1',
+					[CHAIN_FUSION_EXTERNAL_REF_KEYS.CKETH_BLOCK_INDEX]: '',
+					[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_TX_HASH]: undefined
+				})
+			).toStrictEqual([
+				{ key: 'amount', value: '1' },
+				{ key: 'chain_fusion_minter_id', value: 'minter' }
+			]);
+		});
+
+		it('should round-trip through the keyed map', () => {
+			const refs = {
+				[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_TX_HASH]: '0xabc',
+				[CHAIN_FUSION_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_NUMBER]: '42'
+			};
+
+			expect(toChainFusionExternalRefsMap(toChainFusionExternalRefs(refs))).toStrictEqual(refs);
+		});
+
+		// The backend caps a row at 16 refs; the widest Phase A row must stay under it.
+		it('should keep every key within the backend length limit', () => {
+			Object.values(CHAIN_FUSION_EXTERNAL_REF_KEYS).forEach((key) => {
+				expect(key.length).toBeLessThanOrEqual(32);
+			});
+		});
+	});
+
+	describe('toChainFusionDisplayRefs', () => {
+		it('should snapshot the fields the row is rendered from', () => {
+			expect(
+				toChainFusionDisplayRefs({
+					sourceToken: ckEthToken,
+					destinationToken: ETHEREUM_TOKEN,
+					amount: '1.5',
+					usdSourceValue: '4500'
+				})
+			).toStrictEqual({
+				amount: '1.5',
+				usd_source_value: '4500',
+				source_token_symbol: 'ckETH',
+				source_network_symbol: ckEthToken.network.name,
+				destination_token_symbol: ETHEREUM_TOKEN.symbol,
+				destination_network_symbol: ETHEREUM_TOKEN.network.name
+			});
+		});
+
+		it('should omit the USD value when it is unknown', () => {
+			expect(
+				toChainFusionDisplayRefs({
+					sourceToken: ckEthToken,
+					destinationToken: ETHEREUM_TOKEN,
+					amount: '1'
+				})
+			).not.toHaveProperty('usd_source_value');
+		});
+	});
+
+	describe('toChainFusionWithdrawalStatus', () => {
+		it('should succeed on a finalized successful transaction', () => {
+			expect(
+				toChainFusionWithdrawalStatus({
+					TxFinalized: { Success: { transaction_hash: '0xabc', effective_transaction_fee: [] } }
+				})
+			).toStrictEqual({ Succeeded: null });
+		});
+
+		it('should fail on a reimbursement, which is what a failed withdrawal looks like', () => {
+			expect(
+				toChainFusionWithdrawalStatus({
+					TxFinalized: {
+						Reimbursed: {
+							transaction_hash: '0xabc',
+							reimbursed_amount: 1n,
+							reimbursed_in_block: 2n
+						}
+					}
+				})
+			).toStrictEqual({ Failed: null });
+
+			expect(
+				toChainFusionWithdrawalStatus({
+					TxFinalized: { PendingReimbursement: { transaction_hash: '0xabc' } }
+				})
+			).toStrictEqual({ Failed: null });
+		});
+
+		it.each<{ name: string; status: CkEthMinterDid.RetrieveEthStatus }>([
+			{ name: 'TxSent', status: { TxSent: { transaction_hash: '0xabc' } } },
+			{ name: 'TxCreated', status: { TxCreated: null } },
+			{ name: 'Pending', status: { Pending: null } }
+		])('should keep the row executing on $name', ({ status }) => {
+			expect(toChainFusionWithdrawalStatus(status)).toStrictEqual({ Executing: null });
+		});
+
+		// The window between the ledger burn and the minter indexing it reads as
+		// `NotFound`. Terminalizing there would wrongly fail nearly every withdrawal,
+		// irreversibly.
+		it('should no-op on NotFound rather than fail', () => {
+			expect(toChainFusionWithdrawalStatus({ NotFound: null })).toBeUndefined();
+		});
+	});
+
+	describe('chainFusionWithdrawalStatusError', () => {
+		it('should describe a reimbursed withdrawal', () => {
+			expect(
+				chainFusionWithdrawalStatusError({
+					TxFinalized: { PendingReimbursement: { transaction_hash: '0xabc' } }
+				})
+			).toBeDefined();
+		});
+
+		it('should carry no error for a success or an in-flight status', () => {
+			expect(
+				chainFusionWithdrawalStatusError({
+					TxFinalized: { Success: { transaction_hash: '0xabc', effective_transaction_fee: [] } }
+				})
+			).toBeUndefined();
+
+			expect(chainFusionWithdrawalStatusError({ NotFound: null })).toBeUndefined();
+		});
+	});
+
+	describe('toChainFusionWithdrawalLearnedRefs', () => {
+		it.each<{ name: string; status: CkEthMinterDid.RetrieveEthStatus; hash: string }>([
+			{ name: 'TxSent', status: { TxSent: { transaction_hash: '0xsent' } }, hash: '0xsent' },
+			{
+				name: 'TxFinalized Success',
+				status: {
+					TxFinalized: { Success: { transaction_hash: '0xok', effective_transaction_fee: [] } }
+				},
+				hash: '0xok'
+			},
+			{
+				name: 'TxFinalized Reimbursed',
+				status: {
+					TxFinalized: {
+						Reimbursed: {
+							transaction_hash: '0xrefund',
+							reimbursed_amount: 1n,
+							reimbursed_in_block: 2n
+						}
+					}
+				},
+				hash: '0xrefund'
+			},
+			{
+				name: 'TxFinalized PendingReimbursement',
+				status: { TxFinalized: { PendingReimbursement: { transaction_hash: '0xpending' } } },
+				hash: '0xpending'
+			}
+		])('should learn the minter transaction hash from $name', ({ status, hash }) => {
+			expect(toChainFusionWithdrawalLearnedRefs(status)).toStrictEqual({
+				chain_fusion_eth_tx: hash
+			});
+		});
+
+		it('should learn nothing before the minter has created a transaction', () => {
+			expect(toChainFusionWithdrawalLearnedRefs({ Pending: null })).toStrictEqual({});
+			expect(toChainFusionWithdrawalLearnedRefs({ NotFound: null })).toStrictEqual({});
+		});
+	});
+
+	describe('chainFusionMintOutcomeToStatus', () => {
+		it.each<{ outcome: ChainFusionMintOutcome; expected: ActiveUserTransactionStatus }>([
+			{ outcome: 'deposited', expected: { Succeeded: null } },
+			{ outcome: 'reverted', expected: { Failed: null } },
+			{ outcome: 'notDeposited', expected: { Failed: null } },
+			{ outcome: 'notMined', expected: { Executing: null } },
+			{ outcome: 'notObserved', expected: { Executing: null } }
+		])('should map $outcome', ({ outcome, expected }) => {
+			expect(chainFusionMintOutcomeToStatus(outcome)).toStrictEqual(expected);
+		});
+
+		it('should describe only the failing outcomes', () => {
+			expect(chainFusionMintOutcomeError('reverted')).toBeDefined();
+			expect(chainFusionMintOutcomeError('notDeposited')).toBeDefined();
+
+			expect(chainFusionMintOutcomeError('deposited')).toBeUndefined();
+			expect(chainFusionMintOutcomeError('notObserved')).toBeUndefined();
+		});
+	});
+
+	describe('toChainFusionDepositLogTopics', () => {
+		it('should filter ckETH deposits on the signature and the principal', () => {
+			expect(toChainFusionDepositLogTopics({ principal: mockPrincipal })).toStrictEqual([
+				CKETH_HELPER_CONTRACT_SIGNATURE,
+				null,
+				encodePrincipalToEthAddress(mockPrincipal)
+			]);
+		});
+
+		it('should insert the ERC20 contract for a ckERC20 deposit', () => {
+			expect(
+				toChainFusionDepositLogTopics({
+					principal: mockPrincipal,
+					erc20ContractAddress: USDC_TOKEN.address
+				})
+			).toStrictEqual([
+				CKERC20_HELPER_CONTRACT_SIGNATURE,
+				tokenAddressToHex(USDC_TOKEN.address),
+				null,
+				encodePrincipalToEthAddress(mockPrincipal)
+			]);
+		});
+	});
+
+	describe('buildChainFusionSwapTrackingMetadata', () => {
+		it('should resolve the metadata entirely from the row snapshot', () => {
+			const tx = chainFusionTx({
+				external_refs: toChainFusionExternalRefs({
+					...toChainFusionDisplayRefs({
+						sourceToken: ckEthToken,
+						destinationToken: ETHEREUM_TOKEN,
+						amount: '2',
+						usdSourceValue: '6000'
+					})
+				})
+			});
+
+			expect(buildChainFusionSwapTrackingMetadata({ tx })).toStrictEqual({
+				sourceToken: 'ckETH',
+				destinationToken: ETHEREUM_TOKEN.symbol,
+				dApp: SwapProvider.CHAIN_FUSION,
+				tokenAmount: '2',
+				usdSourceValue: '6000',
+				sourceNetwork: ckEthToken.network.name,
+				destinationNetwork: ETHEREUM_TOKEN.network.name
+			});
+		});
+
+		it('should include the stored error and tolerate missing refs', () => {
+			expect(
+				buildChainFusionSwapTrackingMetadata({ tx: chainFusionTx({ error: ['boom'] }) })
+			).toStrictEqual({
+				sourceToken: '',
+				destinationToken: '',
+				dApp: SwapProvider.CHAIN_FUSION,
+				tokenAmount: '',
+				usdSourceValue: '',
+				sourceNetwork: '',
+				destinationNetwork: '',
+				error: 'boom'
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
@@ -3,6 +3,7 @@ import type {
 	ActiveUserTransactionData,
 	ActiveUserTransactionError,
 	ActiveUserTransactionRef,
+	ChainFusionData,
 	LiquidiumData,
 	NearIntentsData,
 	OneSecIcpToEvmData,
@@ -13,6 +14,7 @@ import type {
 	CreateActiveUserTransactionParams,
 	UpdateActiveUserTransactionParams
 } from '$lib/types/api';
+import { CHAIN_FUSION_EXTERNAL_REF_KEYS } from '$lib/types/chain-fusion-swap';
 import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
 import { NEAR_INTENTS_EXTERNAL_REF_KEYS } from '$lib/types/near-intents';
 import { VELORA_EXTERNAL_REF_KEYS } from '$lib/types/velora-swap';
@@ -78,6 +80,36 @@ export const mockVeloraActiveUserTransaction: ActiveUserTransaction = {
 		{ key: VELORA_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL, value: 'Ethereum' },
 		{ key: VELORA_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL, value: 'USDT' },
 		{ key: VELORA_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL, value: 'Ethereum' }
+	],
+	created_at_ns: ZERO,
+	updated_at_ns: ZERO,
+	error: []
+};
+
+export const mockChainFusionData: ChainFusionData = {
+	direction: { CkEthToEth: null },
+	source_token: { Icrc: mockPrincipal },
+	dest_token: { EvmNative: 1n },
+	amount: 1_000_000n
+};
+
+export const mockChainFusionActiveUserTransaction: ActiveUserTransaction = {
+	id: '66666666-6666-4666-8666-666666666666',
+	status: { Pending: null },
+	data: { ChainFusion: mockChainFusionData },
+	progress_step: [],
+	external_refs: [
+		{
+			key: CHAIN_FUSION_EXTERNAL_REF_KEYS.MINTER_CANISTER_ID,
+			value: 'sv3dd-oaaaa-aaaar-qacoa-cai'
+		},
+		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.CKETH_BLOCK_INDEX, value: '7' },
+		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.AMOUNT, value: '1' },
+		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE, value: '3000' },
+		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL, value: 'ckETH' },
+		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL, value: 'Internet Computer' },
+		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL, value: 'ETH' },
+		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL, value: 'Ethereum' }
 	],
 	created_at_ns: ZERO,
 	updated_at_ns: ZERO,


### PR DESCRIPTION
# Motivation

Chain Fusion landed as a swap provider in the previous PR, but only in the foreground: a ck conversion's progress died with the modal, exactly as it does in the Convert flow. Close the tab, refresh, or log out, and the user lost all visibility of a conversion that was still settling.

This PR makes settlement durable for the Ethereum family (ETH ↔ ckETH, ERC-20 ↔ ckERC-20). A conversion becomes a backend-persisted active user transaction the moment the user's funds leave their wallet, keeps settling with the modal closed, survives a refresh and a logout, and resumes polling on next login from what the row stored rather than from anything held in memory — a capability the Convert flow has never had.
