### PR TITLE
fix(frontend): match ERC-20 selectors as bytes, not as text

### DIFF
--- a/src/frontend/src/eth/utils/transactions.utils.ts
+++ b/src/frontend/src/eth/utils/transactions.utils.ts
@@ -26,15 +26,34 @@ import { dataSlice } from 'ethers/utils';
 export const isTransactionPending = ({ blockNumber }: EthTransactionUi): boolean =>
 	isNullish(blockNumber);
 
+// `0x` and the four bytes of a function selector, as hex.
+const SELECTOR_LENGTH = 10;
+
+/**
+ * Whether calldata begins with a given function selector.
+ *
+ * Casing is not part of calldata: `0xA9059CBB` and `0xa9059cbb` are the same four bytes and the
+ * same call to the same contract. Comparing them as text therefore let a dApp miss every ERC-20
+ * check by changing nothing the EVM can see — the review described a native zero-value send, the
+ * fail-closed warning never fired because the calldata was never recognised as ERC-20 at all, and
+ * the transfer was signed and broadcast regardless.
+ *
+ * The comparison is on the selector alone. The calldata is passed on untouched, because what gets
+ * signed must be what was received.
+ */
+const hasSelector = ({ data, selector }: { data: string; selector: string }): boolean =>
+	data.slice(0, SELECTOR_LENGTH).toLowerCase() === selector.toLowerCase();
+
 export const isErc20TransactionApprove = (data: string | undefined): boolean =>
-	nonNullish(data) && data.startsWith(ERC20_APPROVE_HASH);
+	nonNullish(data) && hasSelector({ data, selector: ERC20_APPROVE_HASH });
 
 export const isErc20TransactionTransfer = (data: string | undefined): boolean =>
-	nonNullish(data) && data.startsWith(ERC20_TRANSFER_HASH);
+	nonNullish(data) && hasSelector({ data, selector: ERC20_TRANSFER_HASH });
 
 export const isErc20TransactionDeposit = (data: string | undefined): boolean =>
 	nonNullish(data) &&
-	(data.startsWith(ERC20_DEPOSIT_HASH) || data.startsWith(ERC20_DEPOSIT_ERC20_HASH));
+	(hasSelector({ data, selector: ERC20_DEPOSIT_HASH }) ||
+		hasSelector({ data, selector: ERC20_DEPOSIT_ERC20_HASH }));
 
 const abiCoder = AbiCoder.defaultAbiCoder();
 

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectSendReview.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectSendReview.spec.ts
@@ -12,6 +12,7 @@ import {
 	initEthFeeStore,
 	type EthFeeStore
 } from '$eth/stores/eth-fee.store';
+import { isErc20TransactionTransfer } from '$eth/utils/transactions.utils';
 import { ZERO } from '$lib/constants/app.constants';
 import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
 import en from '$tests/mocks/i18n.mock';
@@ -122,6 +123,55 @@ describe('EthWalletConnectSendReview', () => {
 
 		expect(queryByText(`0 ${ETHEREUM_TOKEN.symbol}`)).not.toBeInTheDocument();
 		expect(queryByText(USDC_TOKEN.address)).not.toBeInTheDocument();
+	});
+
+	// The classifier decides whether the review enters its ERC20 branch at all, so it is wired in
+	// here rather than assumed: a selector that differs only in casing is the same call to the same
+	// contract, and used to leave every protection below dormant.
+	it.each([ERC20_TRANSFER_HASH, ERC20_TRANSFER_HASH.toUpperCase().replace('0X', '0x')])(
+		'should describe a transfer sent with selector %s',
+		(selector) => {
+			const data = encodeCall({ selector, to: RECIPIENT, value: 1_500_000n });
+
+			const { getByText, queryByText, queryByTestId, getByRole } = render(
+				EthWalletConnectSendReview,
+				{
+					props: {
+						...props,
+						data,
+						destination: USDC_TOKEN.address,
+						erc20Transfer: isErc20TransactionTransfer(data)
+					},
+					context: mockContext
+				}
+			);
+
+			expect(getByText(`1.5 ${USDC_SYMBOL}`)).toBeInTheDocument();
+			expect(getByText(RECIPIENT)).toBeInTheDocument();
+
+			// The shape the report described: a token transfer wearing a native zero-value send.
+			expect(queryByText(`0 ${ETHEREUM_TOKEN.symbol}`)).not.toBeInTheDocument();
+
+			expect(queryByTestId(warningTestId)).not.toBeInTheDocument();
+			expect(getByRole('button', { name: en.core.text.approve })).not.toBeDisabled();
+		}
+	);
+
+	it('should warn and disable approval for a mixed-case transfer whose arguments do not decode', () => {
+		const data = `${ERC20_TRANSFER_HASH.toUpperCase().replace('0X', '0x')}deadbeef`;
+
+		const { getByTestId, getByRole } = render(EthWalletConnectSendReview, {
+			props: {
+				...props,
+				data,
+				destination: USDC_TOKEN.address,
+				erc20Transfer: isErc20TransactionTransfer(data)
+			},
+			context: mockContext
+		});
+
+		expect(getByTestId(warningTestId)).toBeInTheDocument();
+		expect(getByRole('button', { name: en.core.text.approve })).toBeDisabled();
 	});
 
 	it('should warn and disable approval for an ERC20 transfer of an unknown token', () => {

--- a/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/transactions.utils.spec.ts
@@ -13,6 +13,8 @@ import {
 	findErcTransfers,
 	formatErcTransferAsset,
 	groupEthTransactionsByNetworkAndHash,
+	isErc20TransactionApprove,
+	isErc20TransactionDeposit,
 	isErc20TransactionTransfer,
 	isMaxUint256,
 	mapAddressToName,
@@ -471,6 +473,42 @@ describe('transactions.utils', () => {
 
 		it('should return false for nullish calldata', () => {
 			expect(isErc20TransactionTransfer(undefined)).toBeFalsy();
+		});
+	});
+
+	// Casing is not part of calldata: the EVM sees the same four bytes either way, so a classifier
+	// that reads the text can be stepped around without changing the call that executes. That let a
+	// token transfer reach the review as a native zero-value send, with the fail-closed warning
+	// silent because the calldata was never recognised as ERC-20 in the first place.
+	describe('ERC20 selectors are matched as bytes, not as text', () => {
+		const args =
+			'000000000000000000000000ca11bde05977b3631167028862be2a173976ca110000000000000000000000000000000000000000000000000de0b6b3a7640000';
+
+		it.each(['0xA9059CBB', '0xa9059CBB', '0xA9059cbb'])(
+			'should recognise %s as a transfer',
+			(selector) => {
+				expect(isErc20TransactionTransfer(`${selector}${args}`)).toBeTruthy();
+			}
+		);
+
+		it.each(['0x095EA7B3', '0x095eA7B3'])('should recognise %s as an approve', (selector) => {
+			expect(isErc20TransactionApprove(`${selector}${args}`)).toBeTruthy();
+		});
+
+		it.each(['0x26B3293F', '0xDB9751AF'])('should recognise %s as a deposit', (selector) => {
+			expect(isErc20TransactionDeposit(`${selector}${args}`)).toBeTruthy();
+		});
+
+		// The selector is four bytes and no more: a longer prefix that merely starts the same way is
+		// a different call.
+		it('should not mistake one selector for another that shares a prefix', () => {
+			expect(isErc20TransactionTransfer(`${ERC20_APPROVE_HASH}${args}`)).toBeFalsy();
+			expect(isErc20TransactionApprove(`${ERC20_TRANSFER_HASH}${args}`)).toBeFalsy();
+		});
+
+		it('should return false for calldata too short to carry a selector', () => {
+			expect(isErc20TransactionTransfer('0xa905')).toBeFalsy();
+			expect(isErc20TransactionApprove('0x')).toBeFalsy();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

ERC-20 calldata was classified by comparing its selector as text against lowercase constants. Casing is not part of calldata: `0xA9059CBB` and `0xa9059cbb` are the same four bytes and the same call to the same contract. A dApp could therefore miss every ERC-20 check by changing nothing the EVM can see.

What that cost is the whole review. With neither flag set, the request never entered the ERC-20 branch, so it was not decoded, the recipient and amount encoded in the calldata were never shown, and the fail-closed warning stayed silent because nothing recognised the calldata as ERC-20 in the first place. The screen described a native zero-value send to the token contract, Approve stayed enabled, and the transfer was signed and broadcast unchanged.

This is the same review the earlier work hardened. That work decoded transfers, showed the real recipient, and disabled Approve when the token or the arguments could not be read — but every one of those protections hangs off the classifier, so the door was reinforced and the gap beside it left open.

# Changes

The three ERC-20 classifiers compare the selector as bytes: the first four, lowercased on both sides. Comparing a fixed-length slice rather than a prefix also means a selector is matched as four bytes and not as the start of something longer.

Done in the classifier rather than at each call site, so nothing downstream can reintroduce it. The calldata itself is passed on untouched, because what gets signed must be what was received; only the comparison is canonicalised.

Decoding needed no change: it goes through ethers, which reads hex without regard to case. So a recognised mixed-case transfer decodes and renders exactly like a lowercase one.

# Tests

Mixed-case variants of all three selectors, in every casing shape. Two negative cases the fix must not break: a selector is not mistaken for a different one sharing a prefix, and calldata too short to carry one is still refused.

At the review, the classifier is now wired into the render rather than assumed, since it is the seam that decides whether the ERC-20 branch is entered at all. A mixed-case transfer is asserted to show its token, recipient and amount, to never render as a native zero-value send, and to keep Approve enabled; a mixed-case transfer whose arguments do not decode warns and disables Approve.

Reverting only the classifier fails nine of these.

Gates pass: format, lint, check, check:tests, and the full frontend suite at 17633 tests.
