### PR TITLE
test(backend): cover NearIntents active user transactions with BTC token ids

### DIFF
--- a/src/backend/src/active_user_transactions/model.rs
+++ b/src/backend/src/active_user_transactions/model.rs
@@ -544,6 +544,58 @@ mod tests {
         assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
     }
 
+    fn near_intents_btc_source_data(amount: u64) -> ActiveUserTransactionData {
+        ActiveUserTransactionData::NearIntents(NearIntentsData {
+            source_token: TokenId::BtcNativeMainnet,
+            dest_token: TokenId::EvmNative(8453),
+            amount: Nat::from(amount),
+        })
+    }
+
+    fn near_intents_btc_dest_data(amount: u64) -> ActiveUserTransactionData {
+        ActiveUserTransactionData::NearIntents(NearIntentsData {
+            source_token: TokenId::SolNativeMainnet,
+            dest_token: TokenId::BtcNativeMainnet,
+            amount: Nat::from(amount),
+        })
+    }
+
+    #[test]
+    fn near_intents_btc_create_roundtrip() {
+        // The BTC-via-NEAR-Intents swap relies on the chain-agnostic variant
+        // accepting BTC token ids in either position with no extra validation;
+        // pin both directions so a validation change cannot break it silently.
+        for (id, data) in [
+            ("near-btc-src", near_intents_btc_source_data(250_000)),
+            ("near-btc-dst", near_intents_btc_dest_data(250_000)),
+        ] {
+            let (mut map, _mm) = setup();
+            let mut req = create_req(id);
+            req.data = data.clone();
+            let tx = create(&mut map, principal(), req, 1).expect("create");
+            assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+            assert_eq!(tx.data, data);
+
+            let listed = list(&map, principal()).transactions;
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].data, data);
+        }
+    }
+
+    #[test]
+    fn near_intents_btc_zero_amount_rejected() {
+        for data in [
+            near_intents_btc_source_data(0),
+            near_intents_btc_dest_data(0),
+        ] {
+            let (mut map, _mm) = setup();
+            let mut req = create_req("near-btc-1");
+            req.data = data;
+            let err = create(&mut map, principal(), req, 1).unwrap_err();
+            assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+        }
+    }
+
     fn velora_data(amount: u64, mode: VeloraSwapMode) -> ActiveUserTransactionData {
         ActiveUserTransactionData::Velora(VeloraData {
             mode,

--- a/src/backend/tests/it/active_user_transactions.rs
+++ b/src/backend/tests/it/active_user_transactions.rs
@@ -220,6 +220,73 @@ fn create_near_intents_variant_roundtrip() {
 }
 
 #[test]
+fn create_near_intents_btc_variant_roundtrip() {
+    // The BTC-via-NEAR-Intents swap relies on the chain-agnostic NearIntents
+    // variant carrying BTC token ids in either position. Read back through the
+    // query path so the stored (not just echoed) representation is what the
+    // assertion sees.
+    let pic = setup();
+    let user = caller();
+    pic.ensure_user_profile(user);
+
+    let cases = [
+        (
+            "near-btc-src",
+            ActiveUserTransactionData::NearIntents(NearIntentsData {
+                source_token: TokenId::BtcNativeMainnet,
+                dest_token: TokenId::EvmNative(8453),
+                amount: Nat::from(250_000u64),
+            }),
+        ),
+        (
+            "near-btc-dst",
+            ActiveUserTransactionData::NearIntents(NearIntentsData {
+                source_token: TokenId::SolNativeMainnet,
+                dest_token: TokenId::BtcNativeMainnet,
+                amount: Nat::from(250_000u64),
+            }),
+        ),
+    ];
+
+    for (id, data) in &cases {
+        let created = pic
+            .update::<ActiveUserTransactionResult>(
+                user,
+                "create_active_user_transaction",
+                CreateActiveUserTransactionRequest {
+                    id: (*id).to_string(),
+                    data: data.clone(),
+                    progress_step: Some("initialization".to_string()),
+                    external_refs: vec![ActiveUserTransactionRef {
+                        key: "deposit_address".to_string(),
+                        value: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4".to_string(),
+                    }],
+                },
+            )
+            .expect("create_active_user_transaction call should succeed");
+
+        match created {
+            ActiveUserTransactionResult::Ok(tx) => {
+                assert_eq!(tx.id, *id);
+                assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+                assert_eq!(tx.data, *data);
+            }
+            ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
+        }
+    }
+
+    let listed = list_active(&pic, user);
+    assert_eq!(listed.len(), cases.len());
+    for (id, data) in &cases {
+        let row = listed
+            .iter()
+            .find(|tx| tx.id == *id)
+            .unwrap_or_else(|| panic!("row {id} should be listed"));
+        assert_eq!(row.data, *data);
+    }
+}
+
+#[test]
 fn create_velora_variant_roundtrip() {
     // Both Velora modes share one variant; the mode must survive the canister
     // round-trip untouched, since the FE poller routes on it.


### PR DESCRIPTION
# Motivation

The upcoming BTC swap via NEAR Intents (spec: `docs/ai/spec-driven-development/specs/2026-08-25-feat-near-intents-btc-swap.md`) relies on the existing chain-agnostic `NearIntents` active-user-transaction variant accepting BTC token ids (`TokenId::BtcNativeMainnet`) as source or destination. The backend already supports this (validation only requires a positive amount), but nothing pinned that guarantee. These tests make sure no backend change is needed for the feature and that none regresses it silently.

No production or candid code changes: `backend.did`, `src/declarations/` and all non-test code are untouched.

# Changes

- `src/backend/src/active_user_transactions/model.rs` (unit tests only): `near_intents_btc_create_roundtrip` covers `NearIntentsData` with `BtcNativeMainnet` as source (EVM dest) and as destination (SOL source), asserting create acceptance and list read-back; `near_intents_btc_zero_amount_rejected` pins that amount validation still applies to both directions.
- `src/backend/tests/it/active_user_transactions.rs`: `create_near_intents_btc_variant_roundtrip` performs a canister create/get roundtrip for both BTC directions and asserts the rows decode back from the query path with the same token ids.

# Tests

- `cargo test -p backend --lib active_user_transactions`: 32 passed, 0 failed (includes the 2 new unit tests).
- `./scripts/test.backend.sh -- active_user_transactions` (pocket-ic): unit run 32 passed, integration run 15 passed, 0 failed (includes the new `create_near_intents_btc_variant_roundtrip`). The full backend suite was not run; only the `active_user_transactions` filter.
- `./scripts/format.sh` and `./scripts/lint.rust.sh` pass with no warnings.
