### PR TITLE
feat(frontend): thread recipientAddress through the swap quote fan-out

### DIFF
--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -343,14 +343,21 @@ export const loadKongSwapTokens = async ({
 	kongSwapTokensStore.setKongSwapTokens(supportedTokens);
 };
 
+type SwapRecipientResolution =
+	// The destination network has no cross-chain payout address (e.g. ICP, where
+	// providers credit the user's principal); quotes proceed without a recipient.
+	| { type: 'not-required' }
+	// The user's destination-chain address is known and becomes the quote's recipient.
+	| { type: 'resolved'; recipientAddress: string }
+	// The destination needs a payout address the user does not have (yet). Such a pair
+	// must not be quoted at all: a cross-chain quote request falls back to the
+	// source-chain user address as recipient, which would pay out to a wrong-chain
+	// address.
+	| { type: 'missing' };
+
 /**
  * A cross-chain swap pays out on the destination chain, so the quote's recipient is the
  * user's address for the destination token's network, never the source-chain address.
- *
- * Networks without a cross-chain payout address (e.g. ICP, where providers credit the
- * user's principal) resolve to `undefined`; a cross-chain quote request then falls back
- * to the source-chain user address, which is only reachable for same-address-space pairs
- * (EVM to EVM).
  */
 const resolveSwapRecipientAddress = ({
 	destinationToken,
@@ -360,24 +367,32 @@ const resolveSwapRecipientAddress = ({
 }: Pick<
 	FetchSwapAmountsParams,
 	'destinationToken' | 'userEthAddress' | 'userSolAddress' | 'userBtcAddress'
->): string | undefined => {
+>): SwapRecipientResolution => {
 	const {
 		network: { id: networkId }
 	} = destinationToken;
 
 	if (isNetworkIdSolana(networkId)) {
-		return userSolAddress ?? undefined;
+		return nonNullish(userSolAddress)
+			? { type: 'resolved', recipientAddress: userSolAddress }
+			: { type: 'missing' };
 	}
 
 	// Mainnet only: the address at hand is the user's mainnet address, and cross-chain
 	// providers do not serve BTC testnets.
 	if (isNetworkIdBTCMainnet(networkId)) {
-		return userBtcAddress ?? undefined;
+		return nonNullish(userBtcAddress)
+			? { type: 'resolved', recipientAddress: userBtcAddress }
+			: { type: 'missing' };
 	}
 
 	if (isNetworkIdEthereum(networkId) || isNetworkIdEvm(networkId)) {
-		return userEthAddress ?? undefined;
+		return nonNullish(userEthAddress)
+			? { type: 'resolved', recipientAddress: userEthAddress }
+			: { type: 'missing' };
 	}
+
+	return { type: 'not-required' };
 };
 
 export const fetchSwapAmounts = async ({
@@ -419,12 +434,19 @@ export const fetchSwapAmounts = async ({
 		});
 	}
 
-	const recipientAddress = resolveSwapRecipientAddress({
+	const recipientResolution = resolveSwapRecipientAddress({
 		destinationToken,
 		userEthAddress,
 		userSolAddress,
 		userBtcAddress
 	});
+
+	if (recipientResolution.type === 'missing') {
+		return [];
+	}
+
+	const recipientAddress =
+		recipientResolution.type === 'resolved' ? recipientResolution.recipientAddress : undefined;
 
 	// Ahead of the EVM fall-through, which would otherwise cast a Bitcoin token to
 	// `Erc20Token` and hand it to providers that cannot quote it.

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -99,7 +99,10 @@ import {
 	toNearIntentsExternalRefs
 } from '$lib/utils/near-intents-active-tx.utils';
 import {
+	isNetworkIdBTCMainnet,
 	isNetworkIdBitcoin,
+	isNetworkIdEthereum,
+	isNetworkIdEvm,
 	isNetworkIdICP,
 	isNetworkIdSOLDevnet,
 	isNetworkIdSolana
@@ -340,6 +343,43 @@ export const loadKongSwapTokens = async ({
 	kongSwapTokensStore.setKongSwapTokens(supportedTokens);
 };
 
+/**
+ * A cross-chain swap pays out on the destination chain, so the quote's recipient is the
+ * user's address for the destination token's network, never the source-chain address.
+ *
+ * Networks without a cross-chain payout address (e.g. ICP, where providers credit the
+ * user's principal) resolve to `undefined`; a cross-chain quote request then falls back
+ * to the source-chain user address, which is only reachable for same-address-space pairs
+ * (EVM to EVM).
+ */
+const resolveSwapRecipientAddress = ({
+	destinationToken,
+	userEthAddress,
+	userSolAddress,
+	userBtcAddress
+}: Pick<
+	FetchSwapAmountsParams,
+	'destinationToken' | 'userEthAddress' | 'userSolAddress' | 'userBtcAddress'
+>): string | undefined => {
+	const {
+		network: { id: networkId }
+	} = destinationToken;
+
+	if (isNetworkIdSolana(networkId)) {
+		return userSolAddress ?? undefined;
+	}
+
+	// Mainnet only: the address at hand is the user's mainnet address, and cross-chain
+	// providers do not serve BTC testnets.
+	if (isNetworkIdBTCMainnet(networkId)) {
+		return userBtcAddress ?? undefined;
+	}
+
+	if (isNetworkIdEthereum(networkId) || isNetworkIdEvm(networkId)) {
+		return userEthAddress ?? undefined;
+	}
+};
+
 export const fetchSwapAmounts = async ({
 	identity,
 	sourceToken,
@@ -379,6 +419,13 @@ export const fetchSwapAmounts = async ({
 		});
 	}
 
+	const recipientAddress = resolveSwapRecipientAddress({
+		destinationToken,
+		userEthAddress,
+		userSolAddress,
+		userBtcAddress
+	});
+
 	// Ahead of the EVM fall-through, which would otherwise cast a Bitcoin token to
 	// `Erc20Token` and hand it to providers that cannot quote it.
 	if (isNetworkIdBitcoin(sourceToken.network.id)) {
@@ -391,6 +438,7 @@ export const fetchSwapAmounts = async ({
 			destinationToken,
 			amount: sourceAmount,
 			userBtcAddress,
+			recipientAddress,
 			slippage
 		});
 	}
@@ -400,7 +448,6 @@ export const fetchSwapAmounts = async ({
 
 	if (isSourceSolana || isDestSolana) {
 		const sourceAddress = isSourceSolana ? userSolAddress : userEthAddress;
-		const destAddress = isDestSolana ? userSolAddress : userEthAddress;
 
 		if (isNullish(sourceAddress)) {
 			return [];
@@ -411,7 +458,7 @@ export const fetchSwapAmounts = async ({
 			destinationToken,
 			amount: sourceAmount,
 			userAddress: sourceAddress,
-			recipientAddress: destAddress ?? undefined,
+			recipientAddress,
 			slippage
 		});
 	}
@@ -421,6 +468,7 @@ export const fetchSwapAmounts = async ({
 		destinationToken: destinationToken as Erc20Token,
 		amount: sourceAmount,
 		userAddress: userEthAddress,
+		recipientAddress,
 		slippage
 	});
 };
@@ -1091,6 +1139,7 @@ export const fetchSwapAmountsEVM = async ({
 	destinationToken,
 	amount,
 	userAddress,
+	recipientAddress,
 	slippage
 }: EvmQuoteParams): Promise<SwapMappedResult[]> => {
 	if (isNullish(userAddress)) {
@@ -1101,7 +1150,7 @@ export const fetchSwapAmountsEVM = async ({
 
 	const settledResults = await Promise.allSettled(
 		enabledProviders.map(({ getQuote }) =>
-			getQuote({ sourceToken, destinationToken, amount, userAddress, slippage })
+			getQuote({ sourceToken, destinationToken, amount, userAddress, recipientAddress, slippage })
 		)
 	);
 
@@ -1125,13 +1174,21 @@ export const fetchSwapAmountsBTC = async ({
 	destinationToken,
 	amount,
 	userBtcAddress,
+	recipientAddress,
 	slippage
 }: BtcQuoteParams): Promise<SwapMappedResult[]> => {
 	const enabledProviders = btcSwapProviders.filter(({ isEnabled }) => isEnabled);
 
 	const settledResults = await Promise.allSettled(
 		enabledProviders.map(({ getQuote }) =>
-			getQuote({ sourceToken, destinationToken, amount, userBtcAddress, slippage })
+			getQuote({
+				sourceToken,
+				destinationToken,
+				amount,
+				userBtcAddress,
+				recipientAddress,
+				slippage
+			})
 		)
 	);
 

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -256,6 +256,9 @@ export interface EvmQuoteParams {
 	destinationToken: Erc20Token | IcToken;
 	amount: bigint;
 	userAddress: OptionEthAddress;
+	// The user's address on the destination chain, for cross-chain providers that pay out
+	// there. Absent, such providers fall back to `userAddress`.
+	recipientAddress?: string;
 	slippage: Slippage;
 }
 
@@ -388,6 +391,9 @@ export interface BtcQuoteParams {
 	amount: bigint;
 	// The user's own Bitcoin address, the source of the UTXOs a deposit spends.
 	userBtcAddress: BtcAddress;
+	// The user's address on the destination chain. Chain Fusion ignores it (a BTC → ckBTC
+	// deposit credits the user's own principal); cross-chain providers pay out to it.
+	recipientAddress?: string;
 	slippage: Slippage;
 }
 

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -770,6 +770,60 @@ describe('swap.services', () => {
 					})
 				);
 			});
+
+			// A missing destination-chain address must suppress the quote entirely: quoting
+			// anyway would let the request fall back to the source-chain address as the
+			// payout destination.
+			it('should not quote a Solana destination when the user Solana address is nullish', async () => {
+				const result = await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: evmDestToken,
+					destinationToken: solSourceToken,
+					amount: 100,
+					tokens: [evmDestToken, solSourceToken],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined,
+					userBtcAddress: undefined
+				});
+
+				expect(result).toEqual([]);
+				expect(mockSolGetQuote).not.toHaveBeenCalled();
+			});
+
+			it('should not quote an EVM destination when the user EVM address is nullish', async () => {
+				const result = await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: solSourceToken,
+					destinationToken: evmDestToken,
+					amount: 100,
+					tokens: [solSourceToken, evmDestToken],
+					slippage: 1,
+					userEthAddress: undefined,
+					userSolAddress: mockSolAddress,
+					userBtcAddress: undefined
+				});
+
+				expect(result).toEqual([]);
+				expect(mockSolGetQuote).not.toHaveBeenCalled();
+			});
+
+			it('should not quote a BTC destination when the user Bitcoin address is nullish', async () => {
+				const result = await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: solSourceToken,
+					destinationToken: BTC_MAINNET_TOKEN,
+					amount: 100,
+					tokens: [solSourceToken, BTC_MAINNET_TOKEN],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: mockSolAddress,
+					userBtcAddress: undefined
+				});
+
+				expect(result).toEqual([]);
+				expect(mockSolGetQuote).not.toHaveBeenCalled();
+			});
 		});
 
 		describe('with Bitcoin tokens', () => {
@@ -899,6 +953,23 @@ describe('swap.services', () => {
 				expect(mockSolGetQuote).not.toHaveBeenCalled();
 			});
 
+			it('should not quote a Solana destination when the user Solana address is nullish', async () => {
+				const result = await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: btcSourceToken,
+					destinationToken: mockValidSplToken,
+					amount: 1,
+					tokens: [btcSourceToken, mockValidSplToken],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined,
+					userBtcAddress: mockBtcAddress
+				});
+
+				expect(result).toEqual([]);
+				expect(mockBtcGetQuote).not.toHaveBeenCalled();
+			});
+
 			// Regression: BTC → ckBTC, today's only live BTC-source pair, keeps the exact
 			// quote payload it had before the recipient threading.
 			it('should quote an ICP destination without a recipient address', async () => {
@@ -956,6 +1027,25 @@ describe('swap.services', () => {
 					})
 				);
 				expect(mockBtcGetQuote).not.toHaveBeenCalled();
+			});
+
+			// The user's BTC payout address is not available yet: quoting anyway would let
+			// the request fall back to the EVM source address as the BTC recipient.
+			it('should not quote a BTC destination when the user Bitcoin address is nullish', async () => {
+				const result = await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: evmSourceToken,
+					destinationToken: BTC_MAINNET_TOKEN,
+					amount: 1000,
+					tokens: [evmSourceToken, BTC_MAINNET_TOKEN],
+					slippage: 0.5,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined,
+					userBtcAddress: undefined
+				});
+
+				expect(result).toEqual([]);
+				expect(mockVeloraGetQuote).not.toHaveBeenCalled();
 			});
 
 			// Regression: an EVM → EVM quote's recipient resolves to the user's own EVM

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -699,6 +699,77 @@ describe('swap.services', () => {
 					})
 				);
 			});
+
+			// Regression: the two live cross-chain directions keep the recipient they had
+			// before the recipient resolution was shared across the fan-out branches.
+			it('should keep passing the Solana address as recipient when the destination is Solana', async () => {
+				mockSolGetQuote.mockResolvedValue(undefined);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: evmDestToken,
+					destinationToken: solSourceToken,
+					amount: 100,
+					tokens: [evmDestToken, solSourceToken],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: mockSolAddress,
+					userBtcAddress: undefined
+				});
+
+				expect(mockSolGetQuote).toHaveBeenCalledWith(
+					expect.objectContaining({
+						userAddress: mockEthAddress,
+						recipientAddress: mockSolAddress
+					})
+				);
+			});
+
+			it('should keep passing the EVM address as recipient when the destination is EVM', async () => {
+				mockSolGetQuote.mockResolvedValue(undefined);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: solSourceToken,
+					destinationToken: evmDestToken,
+					amount: 100,
+					tokens: [solSourceToken, evmDestToken],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: mockSolAddress,
+					userBtcAddress: undefined
+				});
+
+				expect(mockSolGetQuote).toHaveBeenCalledWith(
+					expect.objectContaining({
+						userAddress: mockSolAddress,
+						recipientAddress: mockEthAddress
+					})
+				);
+			});
+
+			it('should pass the user Bitcoin address as recipient when the destination is BTC mainnet', async () => {
+				mockSolGetQuote.mockResolvedValue(undefined);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: solSourceToken,
+					destinationToken: BTC_MAINNET_TOKEN,
+					amount: 100,
+					tokens: [solSourceToken, BTC_MAINNET_TOKEN],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: mockSolAddress,
+					userBtcAddress: mockBtcAddress
+				});
+
+				expect(mockSolGetQuote).toHaveBeenCalledWith(
+					expect.objectContaining({
+						userAddress: mockSolAddress,
+						recipientAddress: mockBtcAddress
+					})
+				);
+			});
 		});
 
 		describe('with Bitcoin tokens', () => {
@@ -777,6 +848,167 @@ describe('swap.services', () => {
 				expect(result).toHaveLength(1);
 				expect(mockIcpBridgeGetQuote).toHaveBeenCalledOnce();
 				expect(mockBtcGetQuote).not.toHaveBeenCalled();
+			});
+
+			it('should pass the EVM address as recipient for an EVM destination', async () => {
+				mockBtcGetQuote.mockResolvedValue(undefined);
+
+				const evmDest = { ...mockValidErc20Token, network: ETHEREUM_NETWORK } as Erc20Token;
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: btcSourceToken,
+					destinationToken: evmDest,
+					amount: 1,
+					tokens: [btcSourceToken, evmDest],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined,
+					userBtcAddress: mockBtcAddress
+				});
+
+				expect(mockBtcGetQuote).toHaveBeenCalledWith(
+					expect.objectContaining({
+						userBtcAddress: mockBtcAddress,
+						recipientAddress: mockEthAddress
+					})
+				);
+			});
+
+			it('should pass the Solana address as recipient for a Solana destination', async () => {
+				mockBtcGetQuote.mockResolvedValue(undefined);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: btcSourceToken,
+					destinationToken: mockValidSplToken,
+					amount: 1,
+					tokens: [btcSourceToken, mockValidSplToken],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: mockSolAddress,
+					userBtcAddress: mockBtcAddress
+				});
+
+				expect(mockBtcGetQuote).toHaveBeenCalledWith(
+					expect.objectContaining({
+						userBtcAddress: mockBtcAddress,
+						recipientAddress: mockSolAddress
+					})
+				);
+				expect(mockSolGetQuote).not.toHaveBeenCalled();
+			});
+
+			// Regression: BTC → ckBTC, today's only live BTC-source pair, keeps the exact
+			// quote payload it had before the recipient threading.
+			it('should quote an ICP destination without a recipient address', async () => {
+				mockBtcGetQuote.mockResolvedValue(undefined);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: btcSourceToken,
+					destinationToken: mockValidIcCkToken as IcToken,
+					amount: 1,
+					tokens: [btcSourceToken],
+					slippage: 1,
+					userEthAddress: mockEthAddress,
+					userSolAddress: mockSolAddress,
+					userBtcAddress: mockBtcAddress
+				});
+
+				expect(mockBtcGetQuote).toHaveBeenCalledWith({
+					sourceToken: btcSourceToken,
+					destinationToken: mockValidIcCkToken,
+					amount: 100_000_000n,
+					userBtcAddress: mockBtcAddress,
+					recipientAddress: undefined,
+					slippage: 1
+				});
+			});
+		});
+
+		describe('with an EVM source and a non-EVM, non-Solana destination', () => {
+			const evmSourceToken = { ...mockValidErc20Token, network: ETHEREUM_NETWORK } as Erc20Token;
+
+			beforeEach(() => {
+				vi.clearAllMocks();
+			});
+
+			it('should pass the user Bitcoin address as recipient when the destination is BTC mainnet', async () => {
+				mockVeloraGetQuote.mockResolvedValue(undefined);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: evmSourceToken,
+					destinationToken: BTC_MAINNET_TOKEN,
+					amount: 1000,
+					tokens: [evmSourceToken, BTC_MAINNET_TOKEN],
+					slippage: 0.5,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined,
+					userBtcAddress: mockBtcAddress
+				});
+
+				expect(mockVeloraGetQuote).toHaveBeenCalledWith(
+					expect.objectContaining({
+						userAddress: mockEthAddress,
+						recipientAddress: mockBtcAddress
+					})
+				);
+				expect(mockBtcGetQuote).not.toHaveBeenCalled();
+			});
+
+			// Regression: an EVM → EVM quote's recipient resolves to the user's own EVM
+			// address, the value the quote request builder already fell back to when no
+			// recipient was passed, so the request payload is unchanged.
+			it('should mirror the user EVM address as recipient for an EVM destination', async () => {
+				mockVeloraGetQuote.mockResolvedValue(undefined);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: evmSourceToken,
+					destinationToken: mockValidErc20Token,
+					amount: 1000,
+					tokens: [evmSourceToken, mockValidErc20Token],
+					slippage: 0.5,
+					userEthAddress: mockEthAddress,
+					userSolAddress: undefined,
+					userBtcAddress: undefined
+				});
+
+				expect(mockVeloraGetQuote).toHaveBeenCalledWith(
+					expect.objectContaining({
+						userAddress: mockEthAddress,
+						recipientAddress: mockEthAddress
+					})
+				);
+			});
+
+			// Regression: an ICP destination has no cross-chain payout address, so the quote
+			// payload stays exactly what it was before the recipient threading.
+			it('should not pass a recipient for an ICP destination', async () => {
+				mockVeloraGetQuote.mockResolvedValue(undefined);
+
+				await fetchSwapAmounts({
+					identity: mockIdentity,
+					sourceToken: evmSourceToken,
+					destinationToken: mockValidIcrcToken as IcToken,
+					amount: 1000,
+					tokens: [evmSourceToken, mockValidIcrcToken as IcToken],
+					slippage: 0.5,
+					userEthAddress: mockEthAddress,
+					userSolAddress: mockSolAddress,
+					userBtcAddress: mockBtcAddress
+				});
+
+				expect(mockVeloraGetQuote).toHaveBeenCalledWith({
+					sourceToken: evmSourceToken,
+					destinationToken: mockValidIcrcToken,
+					amount: expect.any(BigInt),
+					userAddress: mockEthAddress,
+					recipientAddress: undefined,
+					slippage: 0.5
+				});
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/swap.utils.spec.ts
@@ -1080,6 +1080,31 @@ describe('swap utils', () => {
 			expect(result.refundTo).toBe(mockEthAddress);
 		});
 
+		// Regression: threading a recipient equal to the user's own address is a no-op at
+		// the request level, so pre-existing same-address-space pairs keep their exact
+		// payload now that the fan-out always resolves a recipient.
+		it('should build the same request whether the user address is passed as recipient or omitted', () => {
+			const params = {
+				slippageTolerance: 150,
+				srcAsset,
+				destAsset,
+				amount: 1_000_000n,
+				userAddress: mockEthAddress,
+				deadlineMs: 180_000
+			};
+
+			const withoutRecipient = buildNearIntentsQuoteRequest(params);
+			const withRecipient = buildNearIntentsQuoteRequest({
+				...params,
+				recipientAddress: mockEthAddress
+			});
+
+			// The deadline is clock-dependent, so it is pinned before comparing.
+			expect({ ...withRecipient, deadline: withoutRecipient.deadline }).toStrictEqual(
+				withoutRecipient
+			);
+		});
+
 		it('should set deadline as ISO string in the future', () => {
 			const before = Date.now();
 


### PR DESCRIPTION
# Motivation

Groundwork for BTC swaps via NEAR Intents, per `docs/ai/spec-driven-development/specs/2026-08-25-feat-near-intents-btc-swap.md` (PR 2 of the plan). A NEAR Intents quote pays out on the destination chain, so its recipient must be the user's address for the destination token's network. Today only the Solana branch of `fetchSwapAmounts` resolves and passes a `recipientAddress`; the BTC and EVM branches pass none. Once BTC becomes a NEAR Intents source or destination, those branches would quote with the wrong (source-chain) recipient. No user-visible change today.

# Changes

- New `resolveSwapRecipientAddress` helper in `swap.services.ts`: maps the destination token's network to the user's address there (Solana, BTC mainnet, Ethereum/EVM) as a discriminated result: `resolved` with the address, `missing` when the destination needs a payout address the user does not have yet, or `not-required` for networks without a cross-chain payout address (e.g. ICP).
- When the resolution is `missing`, `fetchSwapAmounts` returns no quotes for the pair: quoting anyway would let the quote request fall back to the source-chain user address as the destination-chain payout recipient. This also closes the pre-existing hazard on the Solana branch, where an EVM to Solana (or Solana to EVM) quote with the destination-chain address still nullish fell back to the wrong-chain address as recipient.
- All three cross-chain branches of `fetchSwapAmounts` (BTC, Solana, EVM fall-through) now resolve the recipient through that single helper; the Solana branch previously had its own inline resolution, which the helper mirrors and extends with BTC.
- `BtcQuoteParams` and `EvmQuoteParams` gain an optional `recipientAddress`, forwarded by `fetchSwapAmountsBTC` and `fetchSwapAmountsEVM` to their providers, matching what `fetchSwapAmountsSOL` already does.

No currently live pair changes its quote request payload:

- EVM to EVM: the resolved recipient is the user's own EVM address, exactly the value `buildNearIntentsQuoteRequest` already falls back to (`recipient: recipientAddress ?? userAddress`), so the request is byte-identical. A new builder test pins this.
- EVM or Solana to ICP: the recipient resolves to `undefined` (before, the Solana branch passed the user's ETH address for any non-Solana destination). This is unobservable: ICP is not in `NEAR_INTENTS_BLOCKCHAIN_MAP`, so `resolveNearIntentsSwapAssets` bails out and no quote request is ever built for ICP destinations.
- BTC to ckBTC (Chain Fusion, the only live BTC-source pair): `recipientAddress` arrives as `undefined` and `fetchChainFusionBtcQuote` does not read it. A regression test asserts the exact quote params.

# Tests

- `swap.services.spec.ts`: BTC-source quotes receive the destination-chain recipient per destination network (EVM and Solana destinations); quotes toward a BTC mainnet destination receive the user's BTC address from EVM and Solana sources; regression assertions that BTC to ckBTC and EVM to ICP quote payloads are unchanged, and that the live EVM/Solana cross-chain directions keep their previous recipients.
- `swap.utils.spec.ts`: `buildNearIntentsQuoteRequest` builds the same request whether the user address is passed as recipient or omitted.

- Suppression tests: a BTC mainnet destination with a nullish `userBtcAddress` produces no quote from EVM or Solana sources; likewise for Solana and EVM destinations whose user address is nullish (from EVM, Solana, and BTC sources); ICP destinations keep quoting without a recipient.

Gates run locally: prettier, `eslint --max-warnings 0` on touched files, `npm run check` (0 errors, 0 warnings), `npx vitest run` on the touched and related swap/provider/near-intents specs, `tsc --noEmit --project tsconfig.spec.json`, and the full `npm run test` suite: 1058 test files passed (1 skipped), 17636 tests passed (10 skipped, 1 todo), exit code 0.



