### PR TITLE
feat(frontend): NEAR Intents BTC swap groundwork behind a feature flag

### DIFF
--- a/src/frontend/src/env/rest/near-intents.env.ts
+++ b/src/frontend/src/env/rest/near-intents.env.ts
@@ -1,7 +1,13 @@
+import { LOCAL, STAGING } from '$lib/constants/app.constants';
 import { UrlSchema } from '$lib/validation/url.validation';
 import { safeParse } from '$lib/validation/utils.validation';
 
 export const NEAR_INTENTS_SWAP_ENABLED = true;
+
+// BTC via NEAR Intents rolls out on local and staging first; production stays off
+// until the flag is flipped deliberately. Intentionally unused for now; later PRs
+// consume it.
+export const NEAR_INTENTS_BTC_SWAP_ENABLED = LOCAL || STAGING;
 
 // Apparently we do not need any API keys for Near Intents; we can make unauthorised calls
 export const NEAR_INTENTS_API_KEY = import.meta.env.VITE_NEAR_INTENTS_API_KEY;

--- a/src/frontend/src/lib/constants/swap.constants.ts
+++ b/src/frontend/src/lib/constants/swap.constants.ts
@@ -38,7 +38,8 @@ export const NEAR_INTENTS_BLOCKCHAIN_MAP: Record<NetworkId, string> = {
 	[BASE_NETWORK_ID]: 'base',
 	[BSC_MAINNET_NETWORK_ID]: 'bsc',
 	[POLYGON_MAINNET_NETWORK_ID]: 'pol',
-	[SOLANA_MAINNET_NETWORK_ID]: 'sol'
+	[SOLANA_MAINNET_NETWORK_ID]: 'sol',
+	[BTC_MAINNET_NETWORK_ID]: 'btc'
 };
 
 export const NEAR_INTENTS_QUOTE_DEADLINE_MS = 3 * 60 * 1000;

--- a/src/frontend/src/lib/services/near-intents.services.ts
+++ b/src/frontend/src/lib/services/near-intents.services.ts
@@ -34,10 +34,15 @@ export const clearNearIntentsTokensCache = (): void => {
 	cachedTokens = undefined;
 };
 
+// Blockchains whose addresses are not EVM hex: Solana (Base58, case-sensitive) and
+// Bitcoin (native asset only, no contract addresses). Only the remaining chains may
+// have their contract addresses lowercased.
+const NON_EVM_BLOCKCHAINS = new Set(['sol', 'btc']);
+
 const EVM_BLOCKCHAINS = new Set(
 	Object.getOwnPropertySymbols(NEAR_INTENTS_BLOCKCHAIN_MAP)
 		.map((s) => NEAR_INTENTS_BLOCKCHAIN_MAP[s as NetworkId])
-		.filter((b) => b !== 'sol')
+		.filter((b) => !NON_EVM_BLOCKCHAINS.has(b))
 );
 
 /**

--- a/src/frontend/src/lib/services/near-intents.services.ts
+++ b/src/frontend/src/lib/services/near-intents.services.ts
@@ -35,8 +35,9 @@ export const clearNearIntentsTokensCache = (): void => {
 };
 
 // Blockchains whose addresses are not EVM hex: Solana (Base58, case-sensitive) and
-// Bitcoin (native asset only, no contract addresses). Only the remaining chains may
-// have their contract addresses lowercased.
+// Bitcoin (1Click may list btc assets with a contractAddress, and those identifiers
+// are not case-insensitive hex). Only the remaining chains may have their contract
+// addresses lowercased.
 const NON_EVM_BLOCKCHAINS = new Set(['sol', 'btc']);
 
 const EVM_BLOCKCHAINS = new Set(

--- a/src/frontend/src/tests/lib/constants/swap.constants.spec.ts
+++ b/src/frontend/src/tests/lib/constants/swap.constants.spec.ts
@@ -1,6 +1,19 @@
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
+import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
+import { NEAR_INTENTS_BLOCKCHAIN_MAP } from '$lib/constants/swap.constants';
 import type { NetworkId } from '$lib/types/network';
 
 describe('swap.constants', () => {
+	describe('NEAR_INTENTS_BLOCKCHAIN_MAP', () => {
+		it('maps BTC mainnet to the btc blockchain code', () => {
+			expect(NEAR_INTENTS_BLOCKCHAIN_MAP[BTC_MAINNET_NETWORK_ID]).toBe('btc');
+		});
+
+		it('maps Solana mainnet to the sol blockchain code', () => {
+			expect(NEAR_INTENTS_BLOCKCHAIN_MAP[SOLANA_MAINNET_NETWORK_ID]).toBe('sol');
+		});
+	});
+
 	describe('SUPPORTED_CROSS_SWAP_NETWORKS', () => {
 		const loadMatrix = async ({
 			oneSec,

--- a/src/frontend/src/tests/lib/services/near-intents.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/near-intents.services.spec.ts
@@ -2,6 +2,7 @@ import {
 	ARBITRUM_MAINNET_NETWORK,
 	ARBITRUM_MAINNET_NETWORK_ID
 } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
+import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK, ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
 import type { Erc20Token } from '$eth/types/erc20';
@@ -449,6 +450,33 @@ describe('near-intents.services', () => {
 
 			expect(result.has('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeTruthy();
 			expect(result.has('0xA0b86991C6218B36C1D19D4a2E9eB0cE3606eB48')).toBeFalsy();
+		});
+
+		it('should use lowercased symbol for native BTC when filtering by BTC mainnet network', async () => {
+			vi.mocked(nearIntentsApi.fetchNearIntentsTokens).mockResolvedValue(mockNearIntentsTokens);
+
+			const result = await nearIntentsSupportedTokens({ networkIds: [BTC_MAINNET_NETWORK_ID] });
+
+			expect(result).toEqual(new Set(['btc']));
+		});
+
+		it('should not treat the btc blockchain as EVM when a contract address is present', async () => {
+			const btcTokenWithAddress: NearIntentsToken = {
+				assetId: 'nep141:btc-MixedCaseAddress.omft.near',
+				decimals: 8,
+				blockchain: 'btc',
+				symbol: 'WBTC',
+				price: 65000.0,
+				priceUpdatedAt: '2026-03-16T00:00:00.000Z',
+				contractAddress: 'MixedCaseAddress'
+			};
+
+			vi.mocked(nearIntentsApi.fetchNearIntentsTokens).mockResolvedValue([btcTokenWithAddress]);
+
+			const result = await nearIntentsSupportedTokens({ networkIds: [BTC_MAINNET_NETWORK_ID] });
+
+			expect(result.has('MixedCaseAddress')).toBeTruthy();
+			expect(result.has('mixedcaseaddress')).toBeFalsy();
 		});
 
 		it('should keep Solana contract addresses case-sensitive (Base58)', async () => {

--- a/src/frontend/src/tests/mocks/near-intents.mock.ts
+++ b/src/frontend/src/tests/mocks/near-intents.mock.ts
@@ -59,6 +59,15 @@ export const mockNearIntentsTokens: NearIntentsToken[] = [
 		price: 1.0,
 		priceUpdatedAt: '2026-03-16T00:00:00.000Z',
 		contractAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+	},
+	{
+		assetId: 'nep141:btc.omft.near',
+		decimals: 8,
+		blockchain: 'btc',
+		symbol: 'BTC',
+		price: 65000.0,
+		priceUpdatedAt: '2026-03-16T00:00:00.000Z',
+		contractAddress: null
 	}
 ];
 


### PR DESCRIPTION
# Motivation

First PR of the spec `docs/ai/spec-driven-development/specs/2026-08-25-feat-near-intents-btc-swap.md` (BTC swaps via NEAR Intents, flag enabled on local and staging only). It lays the groundwork for quoting and executing BTC swaps through the NEAR Intents 1Click provider. There is no user-visible change: the flag is intentionally unused for now, and the new blockchain map entry only affects code paths that later PRs will wire up. Flag, blockchain-map entry, and EVM-classification fix belong together because the map entry is only safe once the classification is fixed, and the flag names the rollout they serve.

# Changes

- Add `NEAR_INTENTS_BTC_SWAP_ENABLED` to `src/frontend/src/env/rest/near-intents.env.ts`, defined as `LOCAL || STAGING` (same idiom as `BACKEND_EXCHANGE_ENABLED`); production stays off until flipped deliberately.
- Add the BTC mainnet entry `[BTC_MAINNET_NETWORK_ID]: 'btc'` to `NEAR_INTENTS_BLOCKCHAIN_MAP` in `src/frontend/src/lib/constants/swap.constants.ts`.
- Fix the `EVM_BLOCKCHAINS` derivation in `src/frontend/src/lib/services/near-intents.services.ts`: it was "every map value except `sol`", which would have silently classified `btc` as an EVM chain; it now excludes an explicit `NON_EVM_BLOCKCHAINS` set (`sol`, `btc`), so BTC contract-address handling is never lowercased as EVM hex and native BTC keys by lowercased symbol like other native tokens.
- Extend `mockNearIntentsTokens` with a native BTC token and add unit tests covering the map entry and the `nearIntentsSupportedTokens` classification for the `btc` blockchain.

# Tests

- `npm run format` passes.
- `npm run lint -- --max-warnings 0` passes.
- `npm run check` passes (0 errors, 0 warnings).
- `npx vitest run` on `near-intents.services.spec.ts`, `swap.constants.spec.ts`, `swap.utils.spec.ts`, `near-intents.rest.spec.ts`: 131 tests pass.
- `npx tsc --noEmit --project tsconfig.spec.json` passes.
- Full `npm run test` (tsc on tsconfig.spec.json plus the whole vitest suite) passes locally: 1058 test files passed, 1 skipped; 17625 tests passed, 10 skipped, 1 todo.
