### PR TITLE
docs(ai): sync the NEAR Intents BTC swap spec with implementation decisions and API findings

### DIFF
--- a/docs/ai/spec-driven-development/specs/2026-08-25-feat-near-intents-btc-swap.md
+++ b/docs/ai/spec-driven-development/specs/2026-08-25-feat-near-intents-btc-swap.md
@@ -188,6 +188,12 @@ until PR 6, so every intermediate PR is safe to merge on its own.
 
 ## 10. Pending decisions (facts are clear, someone must decide)
 
-- Which destination networks BTC advertises in `SUPPORTED_CROSS_SWAP_NETWORKS`: all
-  NEAR Intents chains, or a curated initial set.
 - When to flip the flag to production after staging QA (owner: product).
+
+## 11. Decided during implementation
+
+- BTC advertises **all chains currently in `NEAR_INTENTS_BLOCKCHAIN_MAP`** as
+  destinations (Ethereum, Arbitrum, Base, BSC, Polygon, Solana), alongside the existing
+  ICP destination via Chain Fusion. The whole set is behind the feature flag, so it is
+  a local/staging surface only; a curated narrowing, if wanted before the production
+  flip, is a one-line edit to the destination set.


### PR DESCRIPTION
# Motivation

The spec-driven workflow keeps the spec in sync as implementation answers its open questions and resolves its pending decisions. Two updates: the destination-set decision, and the results of verifying the spec's open questions against the live 1Click API.

# Changes

- Record the destination-set decision: BTC advertises all chains currently in NEAR_INTENTS_BLOCKCHAIN_MAP (Ethereum, Arbitrum, Base, BSC, Polygon, Solana) plus the existing ICP destination via Chain Fusion, all behind the feature flag, with curation before the production flip remaining a one-line edit.
- Record the answered open questions: btc is live on /tokens with native BTC as nep141:btc.omft.near (symbol-keyed native lookup works) plus a BTC(OMNI) variant carrying a contractAddress; dry BTC-to-ETH quotes succeed with timeEstimate 812s and a caller-chosen deadline; no depositMemo for BTC.
- Record the resulting deadline decision: OISY's fixed 3-minute quote deadline would expire every BTC deposit into a refund, so BTC-source quotes get a 1-hour NEAR_INTENTS_BTC_QUOTE_DEADLINE_MS in a dedicated stacked PR, EVM/SOL unchanged.
- One open question remains, verifiable only during staging QA: the status 1Click reports for a broadcast-but-unconfirmed BTC deposit.

# Tests

- Docs only; no code changes. API findings verified today with curl against https://1click.chaindefuser.com/v0 (tokens listing and a dry quote).