### PR TITLE
feat(frontend): origin-aware NEAR Intents quote deadline for BTC

### DIFF
--- a/src/frontend/src/lib/constants/swap.constants.ts
+++ b/src/frontend/src/lib/constants/swap.constants.ts
@@ -44,6 +44,12 @@ export const NEAR_INTENTS_BLOCKCHAIN_MAP: Record<NetworkId, string> = {
 
 export const NEAR_INTENTS_QUOTE_DEADLINE_MS = 3 * 60 * 1000;
 
+// The 1Click deadline is the time by which the deposit must arrive; on expiry the swap
+// refunds minus a fee. BTC deposits confirm in tens of minutes, so the window must
+// comfortably cover slow blocks. EVM and SOL keep the short deadline above because their
+// deposits land in seconds and shorter deadlines mean fresher quotes.
+export const NEAR_INTENTS_BTC_QUOTE_DEADLINE_MS = 60 * 60 * 1000;
+
 export const OISY_DOCS_SWAP_WIDTHDRAW_FROM_ICPSWAP_LINK =
 	'https://docs.oisy.com/using-oisy-wallet/how-tos/swapping-tokens#manually-withdraw-funds-from-icpswap';
 

--- a/src/frontend/src/lib/services/near-intents.services.ts
+++ b/src/frontend/src/lib/services/near-intents.services.ts
@@ -1,6 +1,7 @@
 import { NEAR_INTENTS_SWAP_ENABLED } from '$env/rest/near-intents.env';
 import {
 	NEAR_INTENTS_BLOCKCHAIN_MAP,
+	NEAR_INTENTS_BTC_QUOTE_DEADLINE_MS,
 	NEAR_INTENTS_QUOTE_DEADLINE_MS
 } from '$lib/constants/swap.constants';
 import {
@@ -108,6 +109,13 @@ export const fetchNearIntentsSwapQuote = async ({
 		return;
 	}
 
+	// A BTC deposit needs a much longer window to confirm on-chain before the 1Click
+	// deadline triggers a refund; see the constants for the rationale.
+	const deadlineMs =
+		assets.srcAsset.blockchain === 'btc'
+			? NEAR_INTENTS_BTC_QUOTE_DEADLINE_MS
+			: NEAR_INTENTS_QUOTE_DEADLINE_MS;
+
 	const quoteResponse = await fetchNearIntentsQuote(
 		buildNearIntentsQuoteRequest({
 			slippageTolerance: Math.round(Number(slippage) * 100),
@@ -115,7 +123,7 @@ export const fetchNearIntentsSwapQuote = async ({
 			amount,
 			userAddress,
 			recipientAddress,
-			deadlineMs: NEAR_INTENTS_QUOTE_DEADLINE_MS
+			deadlineMs
 		})
 	);
 

--- a/src/frontend/src/tests/lib/services/near-intents.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/near-intents.services.spec.ts
@@ -5,7 +5,12 @@ import {
 import { BTC_MAINNET_NETWORK_ID } from '$env/networks/networks.btc.env';
 import { ETHEREUM_NETWORK, ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { SOLANA_MAINNET_NETWORK_ID } from '$env/networks/networks.sol.env';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import type { Erc20Token } from '$eth/types/erc20';
+import {
+	NEAR_INTENTS_BTC_QUOTE_DEADLINE_MS,
+	NEAR_INTENTS_QUOTE_DEADLINE_MS
+} from '$lib/constants/swap.constants';
 import * as nearIntentsApi from '$lib/rest/near-intents.rest';
 import {
 	clearNearIntentsTokensCache,
@@ -19,6 +24,7 @@ import { SwapProvider } from '$lib/types/swap';
 import { mapNearIntentsQuoteResult } from '$lib/utils/swap.utils';
 import { parseNetworkId } from '$lib/validation/network.validation';
 import type { SplToken } from '$sol/types/spl';
+import { mockBtcAddress } from '$tests/mocks/btc.mock';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
 import {
@@ -238,6 +244,76 @@ describe('near-intents.services', () => {
 			});
 
 			expect(result).toBeUndefined();
+		});
+
+		describe('quote deadline per origin chain', () => {
+			const now = new Date('2026-03-16T00:00:00.000Z');
+
+			const solSourceToken: SplToken = {
+				...mockValidSplToken,
+				address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+			};
+
+			beforeEach(() => {
+				vi.useFakeTimers();
+				vi.setSystemTime(now);
+
+				vi.mocked(nearIntentsApi.fetchNearIntentsQuote).mockResolvedValue(
+					mockNearIntentsQuoteResponse
+				);
+			});
+
+			afterEach(() => {
+				vi.useRealTimers();
+			});
+
+			const requestedDeadline = (): string => {
+				const [[request]] = vi.mocked(nearIntentsApi.fetchNearIntentsQuote).mock.calls;
+
+				return request.deadline;
+			};
+
+			it('should use the extended deadline for a BTC origin', async () => {
+				await fetchNearIntentsSwapQuote({
+					sourceToken: BTC_MAINNET_TOKEN,
+					destinationToken,
+					amount: 100_000n,
+					userAddress: mockBtcAddress,
+					slippage
+				});
+
+				expect(requestedDeadline()).toBe(
+					new Date(now.getTime() + NEAR_INTENTS_BTC_QUOTE_DEADLINE_MS).toISOString()
+				);
+			});
+
+			it('should keep the short deadline for an EVM origin', async () => {
+				await fetchNearIntentsSwapQuote({
+					sourceToken,
+					destinationToken,
+					amount: 1_000_000n,
+					userAddress: mockEthAddress,
+					slippage
+				});
+
+				expect(requestedDeadline()).toBe(
+					new Date(now.getTime() + NEAR_INTENTS_QUOTE_DEADLINE_MS).toISOString()
+				);
+			});
+
+			it('should keep the short deadline for a SOL origin', async () => {
+				await fetchNearIntentsSwapQuote({
+					sourceToken: solSourceToken,
+					destinationToken,
+					amount: 1_000_000n,
+					userAddress: mockSolAddress,
+					slippage
+				});
+
+				expect(requestedDeadline()).toBe(
+					new Date(now.getTime() + NEAR_INTENTS_QUOTE_DEADLINE_MS).toISOString()
+				);
+			});
 		});
 
 		describe('with Solana tokens', () => {


### PR DESCRIPTION
# Motivation

Carved out of the enable PR of the NEAR Intents BTC swap spec (docs/ai/spec-driven-development/specs/2026-08-25-feat-near-intents-btc-swap.md).

OISY sends `deadline = now + NEAR_INTENTS_QUOTE_DEADLINE_MS` (3 minutes) on every NEAR Intents quote. The 1Click deadline is the time by which the deposit must arrive; on expiry the swap refunds minus a refund fee. That is fine for EVM and SOL deposits, which land in seconds, but a BTC deposit confirms in tens of minutes (the live 1Click API estimates ~812 seconds, roughly 13.5 minutes, for BTC to ETH), so a 3-minute deadline would make every BTC-source swap expire into a refund.

This builds on the groundwork merged in #13788 (which added the `btc` entry to `NEAR_INTENTS_BLOCKCHAIN_MAP`) and is dead code until BTC quotes are enabled.

# Changes

- Add `NEAR_INTENTS_BTC_QUOTE_DEADLINE_MS` (1 hour) next to the existing constant, with a comment explaining why BTC needs a longer window while EVM and SOL keep the short one.
- In `fetchNearIntentsSwapQuote`, select the BTC deadline when the resolved origin asset's blockchain is `btc`, and keep the existing 3-minute deadline otherwise. EVM and SOL behavior is byte-identical.

# Tests

- New specs in `near-intents.services.spec.ts` (fake timers): a BTC origin produces a deadline exactly 1 hour out, and EVM and SOL origins keep the 3-minute deadline (regression).
- Locally: `npm run test -- run` on `near-intents.services.spec.ts`, `swap.utils.spec.ts`, and `swap.services.spec.ts` (225 tests, all passing, including tsc over tsconfig.spec.json), plus `npm run lint -- --max-warnings 0`, `npm run check`, and `npm run format`, all clean. Full `npm run test` is running and this section will be updated with the result.
