### PR TITLE
feat(frontend): support the btc category in the NEAR Intents destinations builder

### DIFF
--- a/src/frontend/src/lib/utils/near-intents-swap.utils.ts
+++ b/src/frontend/src/lib/utils/near-intents-swap.utils.ts
@@ -1,22 +1,30 @@
 import {
 	SwapProvider,
 	type GetSupportedDestinationsFn,
+	type SwapCategorizedTokenIds,
 	type SwapTokenCategory
 } from '$lib/types/swap';
 import { resolveSwapTokenLookup } from '$lib/utils/swap-tokens-filter.utils';
 import { nonNullish } from '@dfinity/utils';
 
+// NEAR Intents bridges across EVM, SOL, and BTC but not ICP, so the builder is
+// deliberately narrower than the full SwapTokenCategory.
+type NearIntentsCategory = Extract<SwapTokenCategory, 'evm' | 'sol' | 'btc'>;
+
+const NEAR_INTENTS_CATEGORIES: NearIntentsCategory[] = ['evm', 'sol', 'btc'];
+
 /**
  * Builds a `getSupportedDestinations` for a NEAR Intents provider entry registered
- * under `category` (either 'evm' or 'sol').
+ * under `category` ('evm', 'sol', or 'btc').
  *
- * NEAR Intents bridges across both EVM and SOL — but each provider entry only
+ * NEAR Intents bridges across all its categories, but each provider entry only
  * caches its own category's source set. We use `findProviderSourceTokens` to look
- * up the sibling NEAR Intents entry's set so the entry whose category matches the
- * source can advertise the union { evm, sol } as reachable destinations.
+ * up the sibling NEAR Intents entries' sets so the entry whose category matches the
+ * source can advertise the union of all registered categories as reachable
+ * destinations. Categories without a registered sibling entry are omitted.
  */
 export const buildNearIntentsSupportedDestinations =
-	(category: Extract<SwapTokenCategory, 'evm' | 'sol'>): GetSupportedDestinationsFn =>
+	(category: NearIntentsCategory): GetSupportedDestinationsFn =>
 	({ sourceToken, supportedSourceTokens, findProviderSourceTokens }) => {
 		const lookup = resolveSwapTokenLookup({ token: sourceToken });
 
@@ -24,22 +32,12 @@ export const buildNearIntentsSupportedDestinations =
 			return;
 		}
 
-		const evmSet =
-			category === 'evm'
-				? supportedSourceTokens
-				: findProviderSourceTokens({ key: SwapProvider.NEAR_INTENTS, category: 'evm' });
-		const solSet =
-			category === 'sol'
-				? supportedSourceTokens
-				: findProviderSourceTokens({ key: SwapProvider.NEAR_INTENTS, category: 'sol' });
+		return NEAR_INTENTS_CATEGORIES.reduce<SwapCategorizedTokenIds>((acc, destination) => {
+			const set =
+				destination === category
+					? supportedSourceTokens
+					: findProviderSourceTokens({ key: SwapProvider.NEAR_INTENTS, category: destination });
 
-		const result: { evm?: Set<string>; sol?: Set<string> } = {};
-		if (nonNullish(evmSet)) {
-			result.evm = evmSet;
-		}
-		if (nonNullish(solSet)) {
-			result.sol = solSet;
-		}
-
-		return result;
+			return nonNullish(set) ? { ...acc, [destination]: set } : acc;
+		}, {});
 	};

--- a/src/frontend/src/tests/lib/utils/near-intents-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/near-intents-swap.utils.spec.ts
@@ -1,4 +1,9 @@
-import { SwapProvider, type FindProviderSourceTokens } from '$lib/types/swap';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+import {
+	SwapProvider,
+	type FindProviderSourceTokens,
+	type SwapCategorizedTokenIds
+} from '$lib/types/swap';
 import { buildNearIntentsSupportedDestinations } from '$lib/utils/near-intents-swap.utils';
 import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
@@ -7,6 +12,7 @@ import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 describe('buildNearIntentsSupportedDestinations', () => {
 	const evmId = mockValidErc20Token.address.toLowerCase();
 	const solId = mockValidSplToken.address;
+	const btcId = BTC_MAINNET_TOKEN.symbol.toLowerCase();
 
 	const noLookup: FindProviderSourceTokens = () => undefined;
 
@@ -69,7 +75,7 @@ describe('buildNearIntentsSupportedDestinations', () => {
 			expect(result).toEqual({ evm: supportedSourceTokens, sol: sisterSol });
 		});
 
-		it('omits sol when sibling lookup returns undefined', () => {
+		it('omits sol and btc when sibling lookups return undefined', () => {
 			const supportedSourceTokens = new Set([evmId]);
 
 			const result = evmFn({
@@ -79,6 +85,22 @@ describe('buildNearIntentsSupportedDestinations', () => {
 			});
 
 			expect(result).toEqual({ evm: supportedSourceTokens });
+		});
+
+		it('includes btc when a NEAR Intents btc sibling is registered', () => {
+			const supportedSourceTokens = new Set([evmId]);
+			const sisterBtc = new Set([btcId]);
+
+			const findProviderSourceTokens: FindProviderSourceTokens = ({ key, category }) =>
+				key === SwapProvider.NEAR_INTENTS && category === 'btc' ? sisterBtc : undefined;
+
+			const result = evmFn({
+				sourceToken: mockValidErc20Token,
+				supportedSourceTokens,
+				findProviderSourceTokens
+			});
+
+			expect(result).toEqual({ evm: supportedSourceTokens, btc: sisterBtc });
 		});
 	});
 
@@ -131,7 +153,7 @@ describe('buildNearIntentsSupportedDestinations', () => {
 			expect(result).toEqual({ sol: supportedSourceTokens, evm: sisterEvm });
 		});
 
-		it('omits evm when sibling lookup returns undefined', () => {
+		it('omits evm and btc when sibling lookups return undefined', () => {
 			const supportedSourceTokens = new Set([solId]);
 
 			const result = solFn({
@@ -143,12 +165,12 @@ describe('buildNearIntentsSupportedDestinations', () => {
 			expect(result).toEqual({ sol: supportedSourceTokens });
 		});
 
-		it('only queries the NEAR Intents sibling, ignoring other providers', () => {
+		it('only queries NEAR Intents siblings, ignoring other providers', () => {
 			const supportedSourceTokens = new Set([solId]);
 			const wrongProviderSet = new Set(['ignored']);
 
-			const findProviderSourceTokens: FindProviderSourceTokens = ({ key, category }) =>
-				key === SwapProvider.NEAR_INTENTS && category === 'evm' ? undefined : wrongProviderSet;
+			const findProviderSourceTokens: FindProviderSourceTokens = ({ key }) =>
+				key === SwapProvider.NEAR_INTENTS ? undefined : wrongProviderSet;
 
 			const result = solFn({
 				sourceToken: mockValidSplToken,
@@ -157,6 +179,93 @@ describe('buildNearIntentsSupportedDestinations', () => {
 			});
 
 			expect(result).toEqual({ sol: supportedSourceTokens });
+		});
+	});
+
+	describe('category = btc', () => {
+		const btcFn = buildNearIntentsSupportedDestinations('btc');
+
+		it('returns undefined when source token category does not match (ICP source)', () => {
+			const result = btcFn({
+				sourceToken: mockValidIcToken,
+				supportedSourceTokens: new Set([btcId]),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when source token category does not match (EVM source)', () => {
+			const result = btcFn({
+				sourceToken: mockValidErc20Token,
+				supportedSourceTokens: new Set([btcId]),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when source identifier is not in supportedSourceTokens', () => {
+			const result = btcFn({
+				sourceToken: BTC_MAINNET_TOKEN,
+				supportedSourceTokens: new Set(['not-btc']),
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('returns undefined when supportedSourceTokens is undefined', () => {
+			const result = btcFn({
+				sourceToken: BTC_MAINNET_TOKEN,
+				supportedSourceTokens: undefined,
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it('matches the BTC source on its lowercased symbol', () => {
+			const supportedSourceTokens = new Set([BTC_MAINNET_TOKEN.symbol.toLowerCase()]);
+
+			const result = btcFn({
+				sourceToken: BTC_MAINNET_TOKEN,
+				supportedSourceTokens,
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toEqual({ btc: supportedSourceTokens });
+		});
+
+		it('returns the supported set as btc and looks up sibling evm and sol sets', () => {
+			const supportedSourceTokens = new Set([btcId]);
+			const sisterEvm = new Set([evmId]);
+			const sisterSol = new Set([solId]);
+
+			const siblings: SwapCategorizedTokenIds = { evm: sisterEvm, sol: sisterSol };
+
+			const findProviderSourceTokens: FindProviderSourceTokens = ({ key, category }) =>
+				key === SwapProvider.NEAR_INTENTS ? siblings[category] : undefined;
+
+			const result = btcFn({
+				sourceToken: BTC_MAINNET_TOKEN,
+				supportedSourceTokens,
+				findProviderSourceTokens
+			});
+
+			expect(result).toEqual({ btc: supportedSourceTokens, evm: sisterEvm, sol: sisterSol });
+		});
+
+		it('omits evm and sol when sibling lookups return undefined', () => {
+			const supportedSourceTokens = new Set([btcId]);
+
+			const result = btcFn({
+				sourceToken: BTC_MAINNET_TOKEN,
+				supportedSourceTokens,
+				findProviderSourceTokens: noLookup
+			});
+
+			expect(result).toEqual({ btc: supportedSourceTokens });
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Carved out of the enable PR of the merged spec docs/ai/spec-driven-development/specs/2026-08-25-feat-near-intents-btc-swap.md (section 5), so that the final enable PR stays small. NEAR Intents will bridge to BTC in addition to EVM and SOL, so the destinations builder must treat `btc` as a first-class category.

# Changes

- Generalize `buildNearIntentsSupportedDestinations` in `near-intents-swap.utils.ts`: instead of hardcoding a two-sided union of the `evm` and `sol` sibling source sets, the builder derives the destination map by iterating a `NearIntentsCategory` list (`'evm' | 'sol' | 'btc'`, kept narrower than the full `SwapTokenCategory` since NEAR Intents does not bridge to ICP).
- The existing `'evm'` and `'sol'` callers in `evm-swap.providers.ts` and `sol-swap.providers.ts` keep byte-identical behavior: no NEAR Intents `btc` provider entry is registered yet, so the `btc` sibling lookup returns `undefined` and the category is omitted, exactly as before. The `'btc'` category has no caller and stays dead code until the provider-registration enable PR.
- No call sites change, no provider registrations, no feature flag or `SUPPORTED_CROSS_SWAP_NETWORKS` changes.
- Extend `near-intents-swap.utils.spec.ts`: regression coverage that evm/sol behavior is unchanged, a new `category = btc` block mirroring the per-category edge cases (category mismatch, unsupported identifier, undefined source set, sibling unions, symbol-keyed native BTC lookup), and evm coverage that a registered btc sibling is advertised.

# Tests

- `npx vitest run` on `near-intents-swap.utils.spec.ts` and `swap-tokens-filter.utils.spec.ts`: 2 files, 46 tests, all passing.
- `npx tsc --noEmit --project tsconfig.spec.json`: clean.
- `npm run check` (svelte-check): 5914 files, 0 errors, 0 warnings.
- `npm run lint -- --max-warnings 0` (prettier + eslint) and `npm run format`: clean, no diffs.
- Full `npm run test`: 17628 passed, 10 skipped, 1 todo, 1 failed. The single failure is `Busy.spec.ts`, a 300ms `waitFor` timing flake under heavy parallel machine load, untouched by this PR; it passes when rerun in isolation.
