### PR TITLE
feat(backend)!: add an OisyTrade active-user-transaction variant

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -25,6 +25,11 @@ type ActiveUserTransaction = record {
 type ActiveUserTransactionData = variant {
 	OneSecEvmToIcp : OneSecEvmToIcpData;
 	OneSecIcpToEvm : OneSecIcpToEvmData;
+	// OISY Trade order-book swap. Both legs are Internet Computer ledgers, and
+	// the row is opened *before* the deposit — it is the record that tells a
+	// later session which token to pull back out of the DEX's custody: the
+	// destination token on a fill, the source token on a kill.
+	OisyTrade : OisyTradeData;
 	// NEAR Intents (1Click) cross-chain swap. A single variant covers every
 	// source/destination leg (EVM and Solana); the deposit address, its
 	// optional memo, and origin/destination tx hashes ride in `external_refs`.
@@ -865,6 +870,27 @@ type NetworksSettings = record {
 type NotificationSettings = record {
 	dismissed_notifications : vec DismissedNotification
 };
+// OISY Trade order-book swap payload. The order id, the deposit and withdrawal
+// block indices and the submitted price/quantity all ride in `external_refs`;
+// only the fields fixed at creation are captured here.
+//
+// `side` is explicit rather than left to the poll. `get_my_orders` does return
+// the side and the pair, but only once an order exists — and the two recovery
+// paths this row is opened early for (a deposit that landed with no order, and
+// a row abandoned before either) have no order to read, while still needing to
+// know which token to pull back out. It also fixes the base/quote orientation,
+// which `source_token` / `dest_token` alone cannot express.
+type OisyTradeData = record {
+	side : OisyTradeSide;
+	source_token : TokenId;
+	// Source-token amount in base units.
+	amount : nat;
+	dest_token : TokenId
+};
+// Which side of the pair a swap-placed order takes. Equivalently, which leg of
+// the pair the source token is: `Sell` spends the base token, `Buy` spends the
+// quote token.
+type OisyTradeSide = variant { Buy; Sell };
 type OneSecEvmToIcpData = record {
 	recipient_principal : principal;
 	source_token : TokenId;

--- a/src/backend/src/active_user_transactions/model.rs
+++ b/src/backend/src/active_user_transactions/model.rs
@@ -6,7 +6,7 @@ use shared::types::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
         ActiveUserTransactionRef, ActiveUserTransactionStatus, ChainFusionData,
         ChainFusionDirection, CreateActiveUserTransactionRequest,
-        GetActiveUserTransactionsResponse, UpdateActiveUserTransactionRequest,
+        GetActiveUserTransactionsResponse, OisyTradeData, UpdateActiveUserTransactionRequest,
         MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_ACTIVE_USER_TRANSACTION_ERROR_LEN,
         MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REFS,
         MAX_ACTIVE_USER_TRANSACTION_EXTERNAL_REF_KEY_LEN,
@@ -242,6 +242,10 @@ fn validate_data(data: &ActiveUserTransactionData) -> Result<(), ActiveUserTrans
             require_positive_amount(&d.amount)?;
             require_chain_fusion_pair(d)?;
         }
+        ActiveUserTransactionData::OisyTrade(d) => {
+            require_positive_amount(&d.amount)?;
+            require_oisy_trade_pair(d)?;
+        }
     }
     Ok(())
 }
@@ -295,6 +299,24 @@ fn require_chain_fusion_pair(data: &ChainFusionData) -> Result<(), ActiveUserTra
     } else {
         Err(ActiveUserTransactionError::InvalidData(
             "token pair does not match chain-fusion direction".to_string(),
+        ))
+    }
+}
+
+/// An OISY Trade pair is two ledger principals on the Internet Computer, so a
+/// row naming an EVM or Solana token is unsatisfiable by construction. `data` is
+/// immutable after creation, so such a row could never settle and would occupy
+/// one of the user's slots forever — reject it up front. Kinds only,
+/// deliberately: any ICRC ledger stays valid, so a newly listed pair needs no
+/// change here.
+fn require_oisy_trade_pair(data: &OisyTradeData) -> Result<(), ActiveUserTransactionError> {
+    let is_ic = |t: &TokenId| matches!(t, TokenId::Icrc(_) | TokenId::IcpNative);
+
+    if is_ic(&data.source_token) && is_ic(&data.dest_token) {
+        Ok(())
+    } else {
+        Err(ActiveUserTransactionError::InvalidData(
+            "oisy-trade tokens must both be Internet Computer ledgers".to_string(),
         ))
     }
 }
@@ -354,8 +376,9 @@ mod tests {
             ActiveUserTransactionData, ActiveUserTransactionError, ActiveUserTransactionRef,
             ActiveUserTransactionStatus, ChainFusionData, ChainFusionDirection,
             CreateActiveUserTransactionRequest, LiquidiumAction, LiquidiumData, NearIntentsData,
-            OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData,
-            VeloraSwapMode, MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_LIQUIDIUM_POOL_ID_LEN,
+            OisyTradeData, OisyTradeSide, OneSecEvmToIcpData, OneSecIcpToEvmData,
+            UpdateActiveUserTransactionRequest, VeloraData, VeloraSwapMode,
+            MAX_ACTIVE_USER_TRANSACTIONS_PER_USER, MAX_LIQUIDIUM_POOL_ID_LEN,
         },
         custom_token::ErcTokenId,
         token_id::TokenId,
@@ -722,6 +745,99 @@ mod tests {
             });
             let err = create(&mut map, principal(), req, 1).unwrap_err();
             assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+        }
+    }
+
+    fn oisy_trade_data(
+        amount: u64,
+        side: OisyTradeSide,
+        source_token: TokenId,
+        dest_token: TokenId,
+    ) -> ActiveUserTransactionData {
+        ActiveUserTransactionData::OisyTrade(OisyTradeData {
+            side,
+            source_token,
+            dest_token,
+            amount: Nat::from(amount),
+        })
+    }
+
+    #[test]
+    fn oisy_trade_create_roundtrip() {
+        // The ICP ledger reaches the wallet as `IcpNative` rather than `Icrc`,
+        // so both spellings of an IC leg must survive create — and the
+        // stable-memory read path — in either position. `side` fixes the
+        // base/quote orientation the token pair alone cannot express, and the
+        // recovery paths route on it, so both sides must survive too.
+        for (side, source_token, dest_token) in [
+            (OisyTradeSide::Sell, icrc(CKBTC_LEDGER), icrc(CKUSDC_LEDGER)),
+            (OisyTradeSide::Buy, icrc(CKUSDC_LEDGER), icrc(CKBTC_LEDGER)),
+            (OisyTradeSide::Sell, TokenId::IcpNative, icrc(CKUSDC_LEDGER)),
+            (OisyTradeSide::Buy, icrc(CKUSDC_LEDGER), TokenId::IcpNative),
+        ] {
+            let (mut map, _mm) = setup();
+            let mut req = create_req("trade-1");
+            req.data = oisy_trade_data(
+                1_000_000,
+                side.clone(),
+                source_token.clone(),
+                dest_token.clone(),
+            );
+            let tx = create(&mut map, principal(), req, 1).expect("create");
+            assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+
+            let listed = list(&map, principal()).transactions;
+            assert_eq!(listed.len(), 1);
+            assert_eq!(
+                listed[0].data,
+                oisy_trade_data(1_000_000, side, source_token, dest_token)
+            );
+        }
+    }
+
+    #[test]
+    fn oisy_trade_zero_amount_rejected() {
+        let (mut map, _mm) = setup();
+        let mut req = create_req("trade-1");
+        req.data = oisy_trade_data(
+            0,
+            OisyTradeSide::Sell,
+            icrc(CKBTC_LEDGER),
+            icrc(CKUSDC_LEDGER),
+        );
+        let err = create(&mut map, principal(), req, 1).unwrap_err();
+        assert!(matches!(err, ActiveUserTransactionError::InvalidData(_)));
+    }
+
+    #[test]
+    fn oisy_trade_non_ic_token_rejected() {
+        // OISY Trade pairs are ledger principals, so a non-IC leg in either
+        // position is unsatisfiable by construction — and `data` is immutable
+        // after creation, so the row could never settle.
+        let non_ic = [
+            TokenId::EvmNative(1),
+            TokenId::Erc20(ErcTokenId(USDC_ETHEREUM.to_string()), 1),
+            TokenId::BtcNativeMainnet,
+            TokenId::SolNativeMainnet,
+        ];
+
+        for token in non_ic {
+            for (source_token, dest_token) in [
+                (token.clone(), icrc(CKUSDC_LEDGER)),
+                (icrc(CKUSDC_LEDGER), token.clone()),
+            ] {
+                let (mut map, _mm) = setup();
+                let mut req = create_req("trade-1");
+                req.data =
+                    oisy_trade_data(1_000_000, OisyTradeSide::Sell, source_token, dest_token);
+                let err = create(&mut map, principal(), req, 1).unwrap_err();
+                assert_eq!(
+                    err,
+                    ActiveUserTransactionError::InvalidData(
+                        "oisy-trade tokens must both be Internet Computer ledgers".to_string()
+                    )
+                );
+            }
         }
     }
 

--- a/src/backend/tests/it/active_user_transactions.rs
+++ b/src/backend/tests/it/active_user_transactions.rs
@@ -6,8 +6,9 @@ use shared::types::{
     active_user_transaction::{
         ActiveUserTransaction, ActiveUserTransactionData, ActiveUserTransactionError,
         ActiveUserTransactionRef, ActiveUserTransactionStatus, ChainFusionData,
-        ChainFusionDirection, CreateActiveUserTransactionRequest, NearIntentsData,
-        OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData, VeloraSwapMode,
+        ChainFusionDirection, CreateActiveUserTransactionRequest, NearIntentsData, OisyTradeData,
+        OisyTradeSide, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData,
+        VeloraSwapMode,
     },
     custom_token::ErcTokenId,
     result_types::{
@@ -365,6 +366,54 @@ fn create_chain_fusion_variant_roundtrip() {
                 external_refs: vec![ActiveUserTransactionRef {
                     key: "btc_txid".to_string(),
                     value: "aa".repeat(32),
+                }],
+                ..create_req(TX_ID)
+            },
+        )
+        .expect("create_active_user_transaction call should succeed");
+
+    match created {
+        ActiveUserTransactionResult::Ok(tx) => {
+            assert_eq!(tx.id, TX_ID);
+            assert_eq!(tx.status, ActiveUserTransactionStatus::Pending);
+            assert_eq!(tx.data, data);
+            assert_eq!(tx.external_refs.len(), 1);
+        }
+        ActiveUserTransactionResult::Err(err) => panic!("expected Ok, got {err:?}"),
+    }
+
+    // Read back through the query path so the stored (not just echoed)
+    // representation is what the assertion sees.
+    let listed = list_active(&pic, user);
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].data, data);
+}
+
+#[test]
+fn create_oisy_trade_variant_roundtrip() {
+    // Both legs are Internet Computer ledgers, and `IcpNative` is how the ICP
+    // ledger reaches the wallet — so the source leg here is the spelling the
+    // pair table cannot express as a principal.
+    let pic = setup();
+    let user = caller();
+    pic.ensure_user_profile(user);
+
+    let data = ActiveUserTransactionData::OisyTrade(OisyTradeData {
+        side: OisyTradeSide::Sell,
+        source_token: TokenId::IcpNative,
+        dest_token: TokenId::Icrc(Principal::from_text("xevnm-gaaaa-aaaar-qafnq-cai").unwrap()),
+        amount: Nat::from(1_000_000u64),
+    });
+
+    let created = pic
+        .update::<ActiveUserTransactionResult>(
+            user,
+            "create_active_user_transaction",
+            CreateActiveUserTransactionRequest {
+                data: data.clone(),
+                external_refs: vec![ActiveUserTransactionRef {
+                    key: "order_id".to_string(),
+                    value: "ab".repeat(16),
                 }],
                 ..create_req(TX_ID)
             },

--- a/src/declarations/backend/backend.did
+++ b/src/declarations/backend/backend.did
@@ -25,6 +25,11 @@ type ActiveUserTransaction = record {
 type ActiveUserTransactionData = variant {
 	OneSecEvmToIcp : OneSecEvmToIcpData;
 	OneSecIcpToEvm : OneSecIcpToEvmData;
+	// OISY Trade order-book swap. Both legs are Internet Computer ledgers, and
+	// the row is opened *before* the deposit — it is the record that tells a
+	// later session which token to pull back out of the DEX's custody: the
+	// destination token on a fill, the source token on a kill.
+	OisyTrade : OisyTradeData;
 	// NEAR Intents (1Click) cross-chain swap. A single variant covers every
 	// source/destination leg (EVM and Solana); the deposit address, its
 	// optional memo, and origin/destination tx hashes ride in `external_refs`.
@@ -865,6 +870,27 @@ type NetworksSettings = record {
 type NotificationSettings = record {
 	dismissed_notifications : vec DismissedNotification
 };
+// OISY Trade order-book swap payload. The order id, the deposit and withdrawal
+// block indices and the submitted price/quantity all ride in `external_refs`;
+// only the fields fixed at creation are captured here.
+//
+// `side` is explicit rather than left to the poll. `get_my_orders` does return
+// the side and the pair, but only once an order exists — and the two recovery
+// paths this row is opened early for (a deposit that landed with no order, and
+// a row abandoned before either) have no order to read, while still needing to
+// know which token to pull back out. It also fixes the base/quote orientation,
+// which `source_token` / `dest_token` alone cannot express.
+type OisyTradeData = record {
+	side : OisyTradeSide;
+	source_token : TokenId;
+	// Source-token amount in base units.
+	amount : nat;
+	dest_token : TokenId
+};
+// Which side of the pair a swap-placed order takes. Equivalently, which leg of
+// the pair the source token is: `Sell` spends the base token, `Buy` spends the
+// quote token.
+type OisyTradeSide = variant { Buy; Sell };
 type OneSecEvmToIcpData = record {
 	recipient_principal : principal;
 	source_token : TokenId;

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -53,6 +53,15 @@ export type ActiveUserTransactionData =
 	| { OneSecIcpToEvm: OneSecIcpToEvmData }
 	| {
 			/**
+			 * OISY Trade order-book swap. Both legs are Internet Computer ledgers, and
+			 * the row is opened *before* the deposit — it is the record that tells a
+			 * later session which token to pull back out of the DEX's custody: the
+			 * destination token on a fill, the source token on a kill.
+			 */
+			OisyTrade: OisyTradeData;
+	  }
+	| {
+			/**
 			 * NEAR Intents (1Click) cross-chain swap. A single variant covers every
 			 * source/destination leg (EVM and Solana); the deposit address, its
 			 * optional memo, and origin/destination tx hashes ride in `external_refs`.
@@ -1273,6 +1282,33 @@ export interface NetworksSettings {
 export interface NotificationSettings {
 	dismissed_notifications: Array<DismissedNotification>;
 }
+/**
+ * OISY Trade order-book swap payload. The order id, the deposit and withdrawal
+ * block indices and the submitted price/quantity all ride in `external_refs`;
+ * only the fields fixed at creation are captured here.
+ *
+ * `side` is explicit rather than left to the poll. `get_my_orders` does return
+ * the side and the pair, but only once an order exists — and the two recovery
+ * paths this row is opened early for (a deposit that landed with no order, and
+ * a row abandoned before either) have no order to read, while still needing to
+ * know which token to pull back out. It also fixes the base/quote orientation,
+ * which `source_token` / `dest_token` alone cannot express.
+ */
+export interface OisyTradeData {
+	side: OisyTradeSide;
+	source_token: TokenId;
+	/**
+	 * Source-token amount in base units.
+	 */
+	amount: bigint;
+	dest_token: TokenId;
+}
+/**
+ * Which side of the pair a swap-placed order takes. Equivalently, which leg of
+ * the pair the source token is: `Sell` spends the base token, `Buy` spends the
+ * quote token.
+ */
+export type OisyTradeSide = { Buy: null } | { Sell: null };
 export interface OneSecEvmToIcpData {
 	recipient_principal: Principal;
 	source_token: TokenId;

--- a/src/declarations/backend/backend.factory.certified.did.js
+++ b/src/declarations/backend/backend.factory.certified.did.js
@@ -246,6 +246,13 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const OisyTradeSide = IDL.Variant({ Buy: IDL.Null, Sell: IDL.Null });
+	const OisyTradeData = IDL.Record({
+		side: OisyTradeSide,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
 	const NearIntentsData = IDL.Record({
 		source_token: TokenId,
 		amount: IDL.Nat,
@@ -290,6 +297,7 @@ export const idlFactory = ({ IDL }) => {
 	const ActiveUserTransactionData = IDL.Variant({
 		OneSecEvmToIcp: OneSecEvmToIcpData,
 		OneSecIcpToEvm: OneSecIcpToEvmData,
+		OisyTrade: OisyTradeData,
 		NearIntents: NearIntentsData,
 		ChainFusion: ChainFusionData,
 		Velora: VeloraData,

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -246,6 +246,13 @@ export const idlFactory = ({ IDL }) => {
 		amount: IDL.Nat,
 		dest_token: TokenId
 	});
+	const OisyTradeSide = IDL.Variant({ Buy: IDL.Null, Sell: IDL.Null });
+	const OisyTradeData = IDL.Record({
+		side: OisyTradeSide,
+		source_token: TokenId,
+		amount: IDL.Nat,
+		dest_token: TokenId
+	});
 	const NearIntentsData = IDL.Record({
 		source_token: TokenId,
 		amount: IDL.Nat,
@@ -290,6 +297,7 @@ export const idlFactory = ({ IDL }) => {
 	const ActiveUserTransactionData = IDL.Variant({
 		OneSecEvmToIcp: OneSecEvmToIcpData,
 		OneSecIcpToEvm: OneSecIcpToEvmData,
+		OisyTrade: OisyTradeData,
 		NearIntents: NearIntentsData,
 		ChainFusion: ChainFusionData,
 		Velora: VeloraData,

--- a/src/shared/src/types/active_user_transaction.rs
+++ b/src/shared/src/types/active_user_transaction.rs
@@ -91,6 +91,11 @@ pub enum ActiveUserTransactionData {
     /// address, and the Ethereum deposit tx hash and block number ride in
     /// `external_refs`.
     ChainFusion(ChainFusionData),
+    /// OISY Trade order-book swap. Both legs are Internet Computer ledgers, and
+    /// the row is opened *before* the deposit — it is the record that tells a
+    /// later session which token to pull back out of the DEX's custody: the
+    /// destination token on a fill, the source token on a kill.
+    OisyTrade(OisyTradeData),
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -209,6 +214,34 @@ pub struct ChainFusionData {
     pub amount: Nat,
 }
 
+/// Which side of the pair a swap-placed order takes. Equivalently, which leg of
+/// the pair the source token is: `Sell` spends the base token, `Buy` spends the
+/// quote token.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum OisyTradeSide {
+    Buy,
+    Sell,
+}
+
+/// OISY Trade order-book swap payload. The order id, the deposit and withdrawal
+/// block indices and the submitted price/quantity all ride in `external_refs`;
+/// only the fields fixed at creation are captured here.
+///
+/// `side` is explicit rather than left to the poll. `get_my_orders` does return
+/// the side and the pair, but only once an order exists — and the two recovery
+/// paths this row is opened early for (a deposit that landed with no order, and
+/// a row abandoned before either) have no order to read, while still needing to
+/// know which token to pull back out. It also fixes the base/quote orientation,
+/// which `source_token` / `dest_token` alone cannot express.
+#[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct OisyTradeData {
+    pub side: OisyTradeSide,
+    pub source_token: TokenId,
+    pub dest_token: TokenId,
+    /// Source-token amount in base units.
+    pub amount: Nat,
+}
+
 /// In-flight high-level user operation, persisted so the FE can resume polling
 /// across logout / tab close.
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -277,8 +310,8 @@ mod tests {
         ActiveUserTransactionRef, ActiveUserTransactionStatus, ChainFusionData,
         ChainFusionDirection, CreateActiveUserTransactionRequest,
         GetActiveUserTransactionsResponse, LiquidiumAction, LiquidiumData, NearIntentsData,
-        OneSecEvmToIcpData, OneSecIcpToEvmData, UpdateActiveUserTransactionRequest, VeloraData,
-        VeloraSwapMode,
+        OisyTradeData, OisyTradeSide, OneSecEvmToIcpData, OneSecIcpToEvmData,
+        UpdateActiveUserTransactionRequest, VeloraData, VeloraSwapMode,
     };
     use crate::types::{custom_token::ErcTokenId, token_id::TokenId};
 
@@ -431,6 +464,36 @@ mod tests {
     fn chain_fusion_direction_roundtrips() {
         for direction in ChainFusionDirection::ALL {
             assert_eq!(roundtrip(&direction), direction);
+        }
+    }
+
+    #[test]
+    fn oisy_trade_variant_roundtrips() {
+        // Both legs are always Internet Computer ledgers, and the ICP ledger
+        // reaches the wallet as `IcpNative` rather than `Icrc` — so both
+        // spellings of an IC leg must survive, in either position. `side` fixes
+        // the base/quote orientation the token pair alone cannot express, so
+        // both sides must survive too.
+        for (side, source_token, dest_token) in [
+            (OisyTradeSide::Sell, icrc(CKBTC_LEDGER), icrc(CKUSDC_LEDGER)),
+            (OisyTradeSide::Buy, icrc(CKUSDC_LEDGER), icrc(CKBTC_LEDGER)),
+            (OisyTradeSide::Sell, TokenId::IcpNative, icrc(CKUSDC_LEDGER)),
+            (OisyTradeSide::Buy, icrc(CKUSDC_LEDGER), TokenId::IcpNative),
+        ] {
+            let original = ActiveUserTransactionData::OisyTrade(OisyTradeData {
+                side,
+                source_token,
+                dest_token,
+                amount: Nat::from(1_000_000u64),
+            });
+            assert_eq!(roundtrip(&original), original);
+        }
+    }
+
+    #[test]
+    fn oisy_trade_side_roundtrips() {
+        for side in [OisyTradeSide::Buy, OisyTradeSide::Sell] {
+            assert_eq!(roundtrip(&side), side);
         }
     }
 


### PR DESCRIPTION
# Motivation

OISY Trade is being registered as a swap provider: a swap deposits into the DEX, places a fill-or-kill order, then withdraws — three canister calls with the user's funds in the DEX's custody in between. Surviving a refresh or a closed tab means the flow has to be an Active User Transaction, so `ActiveUserTransactionData` needs an `OisyTrade` variant.

Unlike every other provider's row, this one opens **before** the first trade-canister call rather than after the point of no return: it is the recovery record that tells a later session which token to pull back out of custody — destination on a fill, source on a kill.

Backend prerequisite only. No frontend writes such rows yet, and the provider stays behind `OISY_TRADE_SWAP_ENABLED` (`false`).

BREAKING CHANGE: `ActiveUserTransactionData` gains an `OisyTrade` variant. Because this type is returned by `create_active_user_transaction`, `update_active_user_transaction`, and `get_active_user_transactions`, a client built against the previous candid interface cannot decode an active transaction whose `data` is `OisyTrade`. Only newer frontends create such rows; deploy the backend ahead of (or together with) the frontend that starts writing them.
