### PR TITLE
feat(frontend): back ERC-20 transaction history with the canister cache

### DIFF
--- a/src/frontend/src/eth/components/transactions/EthTransactionsScroll.svelte
+++ b/src/frontend/src/eth/components/transactions/EthTransactionsScroll.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
-	import { isNullish } from '@dfinity/utils';
+	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
 	import type { TokenId as BackendTokenId } from '$declarations/backend/backend.did';
 	import { sortedEthTransactions } from '$eth/derived/eth-transactions.derived';
+	import { loadNextErc20UserTransactions } from '$eth/services/erc20-user-transactions.services';
 	import {
 		getEthBackendPaginationCursor,
 		loadNextEthUserTransactions
 	} from '$eth/services/eth-user-transactions.services';
+	import type { Erc20Token } from '$eth/types/erc20';
+	import { isTokenErc20 } from '$eth/utils/erc20.utils';
 	import { isTokenEthereumNative } from '$eth/utils/native-token.utils';
+	import { erc20BackendTokenId } from '$eth/utils/user-transactions.utils';
 	import InfiniteScroll from '$lib/components/ui/InfiniteScroll.svelte';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
@@ -24,12 +28,16 @@
 
 	let disableInfiniteScroll = $state(false);
 
-	// Older history is fetched with `txlist`, which only answers for the chain's native asset. An ERC
-	// token's earlier transfers are not reachable this way, so its list stays where the loader left it.
+	// ERC-4626 shares the ERC-20 transfer shape but has its own standard code, so it never matches
+	// here and its list still stays where the loader left it.
+	let erc20Token: Erc20Token | undefined = $derived(isTokenErc20(token) ? token : undefined);
+
 	let transactionTokenId: BackendTokenId | undefined = $derived(
-		isNetworkEthereum(token.network) && isTokenEthereumNative(token)
-			? { EvmNative: token.network.chainId }
-			: undefined
+		nonNullish(erc20Token)
+			? erc20BackendTokenId(erc20Token)
+			: isNetworkEthereum(token.network) && isTokenEthereumNative(token)
+				? { EvmNative: token.network.chainId }
+				: undefined
 	);
 
 	const onIntersect = async () => {
@@ -47,15 +55,25 @@
 			return;
 		}
 
-		const { hasMore } = await loadNextEthUserTransactions({
-			identity: $authIdentity,
-			address: $ethAddress,
-			transactionTokenId,
-			tokenId: token.id,
-			networkId: token.network.id,
-			cursor: getEthBackendPaginationCursor(token.id),
-			oldestLoadedBlockNumber
-		});
+		const { hasMore } = nonNullish(erc20Token)
+			? await loadNextErc20UserTransactions({
+					identity: $authIdentity,
+					address: $ethAddress,
+					transactionTokenId,
+					token: erc20Token,
+					tokenId: token.id,
+					networkId: token.network.id,
+					oldestLoadedBlockNumber
+				})
+			: await loadNextEthUserTransactions({
+					identity: $authIdentity,
+					address: $ethAddress,
+					transactionTokenId,
+					tokenId: token.id,
+					networkId: token.network.id,
+					cursor: getEthBackendPaginationCursor(token.id),
+					oldestLoadedBlockNumber
+				});
 
 		if (!hasMore) {
 			disableInfiniteScroll = true;

--- a/src/frontend/src/eth/providers/etherscan.providers.ts
+++ b/src/frontend/src/eth/providers/etherscan.providers.ts
@@ -151,8 +151,11 @@ export class EtherscanProvider {
 	// Docs: https://docs.etherscan.io/etherscan-v2/api-endpoints/accounts#get-a-list-of-erc20-token-transfer-events-by-address
 	erc20Transactions = async ({
 		address,
-		contract: { address: contractAddress }
-	}: {
+		contract: { address: contractAddress },
+		startBlock,
+		endBlock,
+		sort
+	}: Omit<TransactionsParams, 'address'> & {
 		address: EthAddress;
 		contract: Erc20Token | Erc4626Token;
 	}): Promise<Transaction[]> => {
@@ -160,8 +163,9 @@ export class EtherscanProvider {
 			action: 'tokentx',
 			contractAddress,
 			address,
-			startblock: 0,
-			sort: 'desc'
+			startblock: startBlock ?? 0,
+			...(nonNullish(endBlock) ? { endblock: endBlock } : {}),
+			sort: sort ?? 'desc'
 		};
 
 		const result: EtherscanProviderTokenTransferTransaction[] | string = await this.provider.fetch(

--- a/src/frontend/src/eth/services/erc20-user-transactions.services.ts
+++ b/src/frontend/src/eth/services/erc20-user-transactions.services.ts
@@ -1,0 +1,225 @@
+import type { TokenId as BackendTokenId } from '$declarations/backend/backend.did';
+import { alchemyProviders } from '$eth/providers/alchemy.providers';
+import { etherscanProviders } from '$eth/providers/etherscan.providers';
+import { infuraProviders } from '$eth/providers/infura.providers';
+import {
+	getEthBackendPaginationCursor,
+	setEthBackendPaginationCursor
+} from '$eth/services/eth-user-transactions.services';
+import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
+import type { EthAddress, OptionEthAddress } from '$eth/types/address';
+import type { Erc20Token } from '$eth/types/erc20';
+import type { Erc4626Token } from '$eth/types/erc4626';
+import { filterSpamErc20Transfers } from '$eth/utils/eth-transactions-spam.utils';
+import {
+	isTransactionFinalized,
+	mapTransactionToUserTransaction,
+	mapUserTransactionToTransaction
+} from '$eth/utils/user-transactions.utils';
+import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+import { retryWithDelay } from '$lib/services/rest.services';
+import {
+	loadUserTransactions,
+	saveFinalizedTransactions
+} from '$lib/services/user-transactions.services';
+import type { NullishIdentity } from '$lib/types/identity';
+import type { NetworkId } from '$lib/types/network';
+import type { TokenId } from '$lib/types/token';
+import type { Transaction } from '$lib/types/transaction';
+import type { LoadUserTransactionsResult } from '$lib/types/user-transactions';
+import type { ResultSuccess } from '$lib/types/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+
+/**
+ * Fetches ERC-20 transfers from Etherscan and drops address-poisoning spam.
+ *
+ * `startBlock` / `endBlock` bound the window so incremental loads never refetch history the
+ * backend already holds. That matters more here than for the native asset: the spam filter
+ * resolves the outer transaction sender over RPC for every zero-value transfer, so each
+ * refetched page costs Alchemy calls on top of the Etherscan one.
+ */
+export const fetchErc20Transfers = async ({
+	networkId,
+	token,
+	address,
+	startBlock,
+	endBlock
+}: {
+	networkId: NetworkId;
+	token: Erc20Token | Erc4626Token;
+	address: EthAddress;
+	startBlock?: number;
+	endBlock?: number;
+}): Promise<Transaction[]> => {
+	const { erc20Transactions } = etherscanProviders(networkId);
+
+	const transactions = await retryWithDelay({
+		request: async () =>
+			await erc20Transactions({
+				contract: token,
+				address,
+				...(nonNullish(startBlock) && { startBlock }),
+				...(nonNullish(endBlock) && { endBlock })
+			})
+	});
+
+	const { getTransaction } = alchemyProviders(networkId);
+
+	return filterSpamErc20Transfers({
+		transactions,
+		userAddress: address,
+		// The `transaction.from` is the `Transfer` event's _from (who tokens move from), not
+		// the EOA that signed the tx. In address-poisoning scams the attacker emits
+		// `Transfer(victim, attacker, 0)`, so `transaction.from == victim`. We need the
+		// outer tx sender via RPC to tell whether the user actually initiated it.
+		getTransactionSender: async (hash: string): Promise<EthAddress | undefined> => {
+			const tx = await getTransaction(hash);
+			return tx?.from;
+		}
+	});
+};
+
+/**
+ * Loads a page of stored ERC-20 transfers from the backend.
+ */
+export const loadErc20UserTransactions = ({
+	identity,
+	tokenId,
+	start,
+	maxResults = WALLET_PAGINATION
+}: {
+	identity: NullishIdentity;
+	tokenId: BackendTokenId;
+	start?: bigint;
+	maxResults?: bigint;
+}): Promise<LoadUserTransactionsResult<Transaction> | undefined> =>
+	loadUserTransactions({
+		identity,
+		tokenId,
+		start,
+		maxResults,
+		mapFromBackend: mapUserTransactionToTransaction
+	});
+
+/**
+ * Persists finalized ERC-20 transfers to the backend.
+ *
+ * Only transfers already filtered by {@link fetchErc20Transfers} reach here, so the spam
+ * verdict is stored alongside the transfer and never has to be recomputed.
+ */
+export const saveErc20FinalizedTransactions = ({
+	identity,
+	tokenId,
+	transactions,
+	currentBlockNumber
+}: {
+	identity: NullishIdentity;
+	tokenId: BackendTokenId;
+	transactions: Transaction[];
+	currentBlockNumber: number;
+}): Promise<ResultSuccess> =>
+	saveFinalizedTransactions({
+		identity,
+		tokenId,
+		transactions,
+		isFinalizedFn: (tx) =>
+			isTransactionFinalized({ blockNumber: tx.blockNumber, currentBlockNumber }),
+		mapToBackend: mapTransactionToUserTransaction,
+		canSave: (tx) => nonNullish(tx.blockNumber) && nonNullish(tx.hash)
+	});
+
+/**
+ * Loads the next page of older ERC-20 transfers: the backend cache first, then Etherscan
+ * once the stored pages run out. Mirrors `loadNextEthUserTransactions` for the native asset.
+ *
+ * @returns Whether more pages may exist beyond the returned batch.
+ */
+export const loadNextErc20UserTransactions = async ({
+	identity,
+	address,
+	transactionTokenId,
+	token,
+	tokenId,
+	networkId,
+	oldestLoadedBlockNumber
+}: {
+	identity: NullishIdentity;
+	address: OptionEthAddress;
+	transactionTokenId: BackendTokenId;
+	token: Erc20Token;
+	tokenId: TokenId;
+	networkId: NetworkId;
+	oldestLoadedBlockNumber: number | undefined;
+}): Promise<{ hasMore: boolean }> => {
+	const cursor = getEthBackendPaginationCursor(tokenId);
+
+	if (nonNullish(cursor)) {
+		const result = await loadErc20UserTransactions({
+			identity,
+			tokenId: transactionTokenId,
+			start: cursor,
+			maxResults: WALLET_PAGINATION
+		});
+
+		if (nonNullish(result) && result.transactions.length > 0) {
+			ethTransactionsStore.append({
+				tokenId,
+				transactions: result.transactions.map((transaction) => ({
+					data: transaction,
+					certified: false
+				}))
+			});
+
+			setEthBackendPaginationCursor({ tokenId, nextStart: result.nextStart });
+
+			return { hasMore: nonNullish(result.nextStart) || nonNullish(result.oldestBlockIndex) };
+		}
+	}
+
+	// The backend has nothing more to give, so the next intersection must not ask it again.
+	setEthBackendPaginationCursor({ tokenId, nextStart: undefined });
+
+	if (isNullish(address) || isNullish(oldestLoadedBlockNumber) || oldestLoadedBlockNumber <= 0) {
+		return { hasMore: false };
+	}
+
+	try {
+		const olderTransactions = await fetchErc20Transfers({
+			networkId,
+			token,
+			address,
+			endBlock: oldestLoadedBlockNumber - 1
+		});
+
+		if (olderTransactions.length === 0) {
+			return { hasMore: false };
+		}
+
+		ethTransactionsStore.append({
+			tokenId,
+			transactions: olderTransactions.map((transaction) => ({
+				data: transaction,
+				certified: false
+			}))
+		});
+
+		try {
+			const { getBlockNumber } = infuraProviders(networkId);
+
+			const latestBlockNumber = await getBlockNumber();
+
+			await saveErc20FinalizedTransactions({
+				identity,
+				tokenId: transactionTokenId,
+				transactions: olderTransactions,
+				currentBlockNumber: latestBlockNumber
+			});
+		} catch (_: unknown) {
+			// We silently ignore the saving errors since it is just useful for the next time, and not necessary for the user experience
+		}
+
+		return { hasMore: true };
+	} catch (_: unknown) {
+		return { hasMore: false };
+	}
+};

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -124,27 +124,23 @@ const resolveEthIncrementalStartBlock = ({
 };
 
 /**
- * Whether the chain has produced a block at or above `startBlock`.
+ * The chain's latest block, or `undefined` when it cannot be read.
  *
- * Guards the incremental fetch: when the tip has not moved past everything we already hold, the
- * explorer call cannot return anything new and is worth skipping outright.
+ * Two callers want it: the incremental fetch skips the explorer entirely when the tip has not
+ * moved past everything we already hold, and the save uses it as the reference the finality check
+ * measures against.
  */
-const chainTipReachesStartBlock = async ({
-	networkId,
-	startBlock
+const readChainTip = async ({
+	networkId
 }: {
 	networkId: NetworkId;
-	startBlock: number;
-}): Promise<boolean> => {
+}): Promise<number | undefined> => {
 	try {
 		const { getBlockNumber } = infuraProviders(networkId);
 
-		const latestBlockNumber = await getBlockNumber();
-
-		return latestBlockNumber >= startBlock;
+		return await getBlockNumber();
 	} catch (_: unknown) {
-		// If we cannot read the tip, still query the explorer rather than leave the UI stale.
-		return true;
+		return undefined;
 	}
 };
 
@@ -167,7 +163,10 @@ const loadNewEthNativeTransactionsAfterStartBlock = async ({
 		return transactionsProvider({ address, startBlock: 0, sort: 'desc' });
 	}
 
-	if (!(await chainTipReachesStartBlock({ networkId, startBlock }))) {
+	const chainTip = await readChainTip({ networkId });
+
+	// If we cannot read the tip, still query Etherscan rather than leave the UI stale.
+	if (nonNullish(chainTip) && chainTip < startBlock) {
 		return [];
 	}
 
@@ -215,15 +214,20 @@ const loadCachedErc20Transactions = async ({
 			: maxEthBlockNumberInStore(tokenId)
 	});
 
-	const newTransactions =
-		startBlock > 0 && !(await chainTipReachesStartBlock({ networkId, startBlock }))
-			? []
-			: await fetchErc20Transfers({
-					networkId,
-					token,
-					address,
-					...(startBlock > 0 && { startBlock })
-				});
+	// One read serves both purposes below: skipping a fetch that cannot return anything, and giving
+	// the finality check a real reference point rather than the batch's own newest block.
+	const chainTip = await readChainTip({ networkId });
+
+	const tipIsBehindWhatWeHold = startBlock > 0 && nonNullish(chainTip) && chainTip < startBlock;
+
+	const newTransactions = tipIsBehindWhatWeHold
+		? []
+		: await fetchErc20Transfers({
+				networkId,
+				token,
+				address,
+				...(startBlock > 0 && { startBlock })
+			});
 
 	const certifiedTransactions = [...newTransactions, ...(stored?.transactions ?? [])].map(
 		(transaction) => ({
@@ -248,12 +252,17 @@ const loadCachedErc20Transactions = async ({
 		const blockNumbers = newTransactions.map(({ blockNumber }) => blockNumber).filter(nonNullish);
 		const maxBlockNumber = blockNumbers.length > 0 ? Math.max(...blockNumbers) : 0;
 
+		// The batch's own newest block under-states how far behind the chain the rest of it sits, so
+		// measuring finality against it holds back transfers that are already final. Fall back to it
+		// only when the tip could not be read, where being conservative beats persisting too early.
+		const currentBlockNumber = chainTip ?? maxBlockNumber;
+
 		if (maxBlockNumber > 0) {
 			saveErc20FinalizedTransactions({
 				identity,
 				tokenId: transactionTokenId,
 				transactions: newTransactions,
-				currentBlockNumber: maxBlockNumber
+				currentBlockNumber
 			}).catch((err) =>
 				consoleError('Background save of finalized ERC-20 transactions failed:', err)
 			);

--- a/src/frontend/src/eth/services/eth-transactions.services.ts
+++ b/src/frontend/src/eth/services/eth-transactions.services.ts
@@ -5,9 +5,13 @@ import { enabledErc1155Tokens } from '$eth/derived/erc1155.derived';
 import { enabledErc20Tokens } from '$eth/derived/erc20.derived';
 import { erc4626Tokens } from '$eth/derived/erc4626.derived';
 import { enabledErc721Tokens } from '$eth/derived/erc721.derived';
-import { alchemyProviders } from '$eth/providers/alchemy.providers';
 import { etherscanProviders } from '$eth/providers/etherscan.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
+import {
+	fetchErc20Transfers,
+	loadErc20UserTransactions,
+	saveErc20FinalizedTransactions
+} from '$eth/services/erc20-user-transactions.services';
 import {
 	loadEthUserTransactions,
 	saveEthFinalizedTransactions,
@@ -16,7 +20,7 @@ import {
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import type { EthAddress } from '$eth/types/address';
 import type { Erc1155CustomToken } from '$eth/types/erc1155-custom-token';
-import type { Erc20CustomToken } from '$eth/types/erc20-custom-token';
+import type { Erc20Token } from '$eth/types/erc20';
 import type { Erc4626CustomToken } from '$eth/types/erc4626-custom-token';
 import type { Erc721CustomToken } from '$eth/types/erc721-custom-token';
 import type { EthereumChainId } from '$eth/types/network';
@@ -24,8 +28,8 @@ import { isTokenErc1155 } from '$eth/utils/erc1155.utils';
 import { isTokenErc20 } from '$eth/utils/erc20.utils';
 import { isTokenErc4626 } from '$eth/utils/erc4626.utils';
 import { isTokenErc721 } from '$eth/utils/erc721.utils';
-import { filterSpamErc20Transfers } from '$eth/utils/eth-transactions-spam.utils';
 import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
+import { erc20BackendTokenId } from '$eth/utils/user-transactions.utils';
 import { isSupportedEvmNativeTokenId } from '$evm/utils/native-token.utils';
 import { TRACK_COUNT_ETH_LOADING_TRANSACTIONS_ERROR } from '$lib/constants/analytics.constants';
 import { ZERO_ETH_ADDRESS } from '$lib/constants/app.constants';
@@ -65,7 +69,7 @@ export const loadEthereumTransactions = ({
 		return loadEthTransactions({ identity, networkId, tokenId, chainId, updateOnly, silent });
 	}
 
-	return loadErcTransactions({ networkId, tokenId, standard, updateOnly });
+	return loadErcTransactions({ identity, networkId, tokenId, standard, updateOnly });
 };
 
 // If we use the update method instead of the set method, we can keep the existing transactions and just update their data.
@@ -82,7 +86,7 @@ export const reloadEthereumTransactions = (params: {
 const hasStoredEthTransactions = (tokenId: TokenId): boolean =>
 	(get(ethTransactionsStore)?.[tokenId] ?? []).length > 0;
 
-const maxEthNativeBlockNumberInStore = (tokenId: TokenId): number | undefined => {
+const maxEthBlockNumberInStore = (tokenId: TokenId): number | undefined => {
 	const rows = get(ethTransactionsStore)?.[tokenId];
 
 	if (isNullish(rows) || rows.length === 0) {
@@ -120,6 +124,31 @@ const resolveEthIncrementalStartBlock = ({
 };
 
 /**
+ * Whether the chain has produced a block at or above `startBlock`.
+ *
+ * Guards the incremental fetch: when the tip has not moved past everything we already hold, the
+ * explorer call cannot return anything new and is worth skipping outright.
+ */
+const chainTipReachesStartBlock = async ({
+	networkId,
+	startBlock
+}: {
+	networkId: NetworkId;
+	startBlock: number;
+}): Promise<boolean> => {
+	try {
+		const { getBlockNumber } = infuraProviders(networkId);
+
+		const latestBlockNumber = await getBlockNumber();
+
+		return latestBlockNumber >= startBlock;
+	} catch (_: unknown) {
+		// If we cannot read the tip, still query the explorer rather than leave the UI stale.
+		return true;
+	}
+};
+
+/**
  * Fetches native ETH history from Etherscan after `startBlock` (exclusive lower bound in API terms).
  * For incremental loads, skips the request when Infura reports the chain tip is still below `startBlock`.
  */
@@ -138,24 +167,98 @@ const loadNewEthNativeTransactionsAfterStartBlock = async ({
 		return transactionsProvider({ address, startBlock: 0, sort: 'desc' });
 	}
 
-	const tipReachesStartBlock = await (async (): Promise<boolean> => {
-		try {
-			const { getBlockNumber } = infuraProviders(networkId);
-
-			const latestBlockNumber = await getBlockNumber();
-
-			return latestBlockNumber >= startBlock;
-		} catch (_: unknown) {
-			// If we cannot read the tip, still query Etherscan rather than leave the UI stale.
-			return true;
-		}
-	})();
-
-	if (!tipReachesStartBlock) {
+	if (!(await chainTipReachesStartBlock({ networkId, startBlock }))) {
 		return [];
 	}
 
 	return transactionsProvider({ address, startBlock, sort: 'desc' });
+};
+
+/**
+ * Fetches ERC-20 transfers newer than what the backend cache and the store already hold, writes the
+ * combined list to the store, and persists the finalized newcomers for the next session.
+ *
+ * The native counterpart is `loadEthTransactions`; the shapes are deliberately parallel.
+ */
+const loadCachedErc20Transactions = async ({
+	identity,
+	networkId,
+	token,
+	tokenId,
+	address,
+	updateOnly
+}: {
+	identity: NullishIdentity;
+	networkId: NetworkId;
+	token: Erc20Token;
+	tokenId: TokenId;
+	address: EthAddress;
+	updateOnly: boolean;
+}): Promise<void> => {
+	const transactionTokenId = erc20BackendTokenId(token);
+
+	const stored = USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED
+		? await loadErc20UserTransactions({ identity, tokenId: transactionTokenId })
+		: undefined;
+
+	// Only while the list is being built from scratch. The periodic refresh comes through here too,
+	// so resetting the cursor unconditionally would send the next scroll back over pages the user
+	// already has.
+	if (!hasStoredEthTransactions(tokenId)) {
+		setEthBackendPaginationCursor({ tokenId, nextStart: stored?.nextStart });
+	}
+
+	const startBlock = resolveEthIncrementalStartBlock({
+		newestStoredBlockIndex: stored?.newestBlockIndex,
+		maxBlockFromTransactionsStore: nonNullish(stored?.newestBlockIndex)
+			? undefined
+			: maxEthBlockNumberInStore(tokenId)
+	});
+
+	const newTransactions =
+		startBlock > 0 && !(await chainTipReachesStartBlock({ networkId, startBlock }))
+			? []
+			: await fetchErc20Transfers({
+					networkId,
+					token,
+					address,
+					...(startBlock > 0 && { startBlock })
+				});
+
+	const certifiedTransactions = [...newTransactions, ...(stored?.transactions ?? [])].map(
+		(transaction) => ({
+			data: transaction,
+			// We set the certified property to false because we don't have a way to certify ERC transactions for now.
+			certified: false
+		})
+	);
+
+	if (updateOnly) {
+		certifiedTransactions.forEach((transaction) =>
+			ethTransactionsStore.update({ tokenId, transaction })
+		);
+	} else {
+		// Prepended rather than set, because this batch is not the whole history: it is the newest
+		// stored page plus whatever is newer than it. Replacing the slot would throw away every older
+		// page the user scrolled in.
+		ethTransactionsStore.prepend({ tokenId, transactions: certifiedTransactions });
+	}
+
+	if (USER_TRANSACTIONS_LOAD_FROM_BACKEND_ENABLED && newTransactions.length > 0) {
+		const blockNumbers = newTransactions.map(({ blockNumber }) => blockNumber).filter(nonNullish);
+		const maxBlockNumber = blockNumbers.length > 0 ? Math.max(...blockNumbers) : 0;
+
+		if (maxBlockNumber > 0) {
+			saveErc20FinalizedTransactions({
+				identity,
+				tokenId: transactionTokenId,
+				transactions: newTransactions,
+				currentBlockNumber: maxBlockNumber
+			}).catch((err) =>
+				consoleError('Background save of finalized ERC-20 transactions failed:', err)
+			);
+		}
+	}
 };
 
 const loadEthTransactions = async ({
@@ -197,7 +300,7 @@ const loadEthTransactions = async ({
 			newestStoredBlockIndex: stored?.newestBlockIndex,
 			maxBlockFromTransactionsStore: nonNullish(stored?.newestBlockIndex)
 				? undefined
-				: maxEthNativeBlockNumberInStore(tokenId)
+				: maxEthBlockNumberInStore(tokenId)
 		});
 
 		const newTransactions = await loadNewEthNativeTransactionsAfterStartBlock({
@@ -273,11 +376,13 @@ const loadEthTransactions = async ({
 };
 
 const loadErcTransactions = async ({
+	identity,
 	networkId,
 	tokenId,
 	standard,
 	updateOnly = false
 }: {
+	identity: NullishIdentity;
 	networkId: NetworkId;
 	tokenId: TokenId;
 	standard: TokenStandard;
@@ -305,15 +410,28 @@ const loadErcTransactions = async ({
 	}
 
 	try {
+		// ERC-20 is the only ERC standard backed by the canister cache, so it is the only one that
+		// loads incrementally. The others still refetch their full history from Etherscan.
+		if (isTokenErc20(token)) {
+			await loadCachedErc20Transactions({
+				identity,
+				networkId,
+				token,
+				tokenId,
+				address,
+				updateOnly
+			});
+
+			return { success: true };
+		}
+
 		const transactions = isTokenErc4626(token)
 			? await loadErc4626Transactions({ networkId, token, address })
-			: isTokenErc20(token)
-				? await loadErc20Transactions({ networkId, token, address })
-				: isTokenErc721(token)
-					? await loadErc721Transactions({ networkId, token, address })
-					: isTokenErc1155(token)
-						? await loadErc1155Transactions({ networkId, token, address })
-						: [];
+			: isTokenErc721(token)
+				? await loadErc721Transactions({ networkId, token, address })
+				: isTokenErc1155(token)
+					? await loadErc1155Transactions({ networkId, token, address })
+					: [];
 
 		const certifiedTransactions = transactions.map((transaction) => ({
 			data: transaction,
@@ -355,37 +473,6 @@ const loadErcTransactions = async ({
 	return { success: true };
 };
 
-const loadErc20Transactions = async ({
-	networkId,
-	token,
-	address
-}: {
-	networkId: NetworkId;
-	token: Erc20CustomToken | Erc4626CustomToken;
-	address: Address;
-}): Promise<Transaction[]> => {
-	const { erc20Transactions } = etherscanProviders(networkId);
-
-	const transactions = await retryWithDelay({
-		request: async () => await erc20Transactions({ contract: token, address })
-	});
-
-	const { getTransaction } = alchemyProviders(networkId);
-
-	return filterSpamErc20Transfers({
-		transactions,
-		userAddress: address,
-		// The `transaction.from` is the `Transfer` event's _from (who tokens move from), not
-		// the EOA that signed the tx. In address-poisoning scams the attacker emits
-		// `Transfer(victim, attacker, 0)`, so `transaction.from == victim`. We need the
-		// outer tx sender via RPC to tell whether the user actually initiated it.
-		getTransactionSender: async (hash: string): Promise<EthAddress | undefined> => {
-			const tx = await getTransaction(hash);
-			return tx?.from;
-		}
-	});
-};
-
 /**
  * Loads ERC4626 vault token transactions and normalizes mint/burn addresses for UI/analytics.
  *
@@ -413,7 +500,7 @@ const loadErc4626Transactions = async ({
 	token: Erc4626CustomToken;
 	address: Address;
 }): Promise<Transaction[]> => {
-	const transactions = await loadErc20Transactions({ networkId, token, address });
+	const transactions = await fetchErc20Transfers({ networkId, token, address });
 
 	return transactions.map((tx) => {
 		const isMint = tx.from.toLowerCase() === ZERO_ETH_ADDRESS;

--- a/src/frontend/src/eth/utils/user-transactions.utils.ts
+++ b/src/frontend/src/eth/utils/user-transactions.utils.ts
@@ -1,4 +1,5 @@
-import type { UserTransaction } from '$declarations/backend/backend.did';
+import type { TokenId as BackendTokenId, UserTransaction } from '$declarations/backend/backend.did';
+import type { Erc20Token } from '$eth/types/erc20';
 import { ZERO } from '$lib/constants/app.constants';
 import type { Transaction } from '$lib/types/transaction';
 import { fromNullable, isNullish, nonNullish, toNullable } from '@dfinity/utils';
@@ -104,3 +105,13 @@ export const isTransactionFinalized = ({
 	blockNumber?: number;
 	currentBlockNumber: number;
 }): boolean => nonNullish(blockNumber) && currentBlockNumber - blockNumber >= ETH_FINALITY_BLOCKS;
+
+/**
+ * Derives the backend `TokenId` for an ERC-20 token: its contract address paired with the chain id.
+ */
+export const erc20BackendTokenId = ({
+	address,
+	network: { chainId }
+}: Pick<Erc20Token, 'address' | 'network'>): BackendTokenId => ({
+	Erc20: [address, chainId]
+});

--- a/src/frontend/src/tests/eth/components/transactions/EthTransactionsScroll.spec.ts
+++ b/src/frontend/src/tests/eth/components/transactions/EthTransactionsScroll.spec.ts
@@ -2,11 +2,13 @@ import { BASE_NETWORK } from '$env/networks/networks-evm/networks.evm.base.env';
 import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { BASE_ETH_TOKEN } from '$env/tokens/tokens-evm/tokens-base/tokens.eth.env';
 import EthTransactionsScroll from '$eth/components/transactions/EthTransactionsScroll.svelte';
+import * as erc20UserTransactionsServices from '$eth/services/erc20-user-transactions.services';
 import * as ethUserTransactionsServices from '$eth/services/eth-user-transactions.services';
 import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
 import { token } from '$lib/stores/token.store';
 import type { TokenId } from '$lib/types/token';
 import type { Transaction } from '$lib/types/transaction';
+import { AZUKI_ELEMENTAL_BEANS_TOKEN } from '$tests/mocks/erc721-tokens.mock';
 import { createMockEthTransactions } from '$tests/mocks/eth-transactions.mock';
 import {
 	IntersectionObserverActive,
@@ -30,6 +32,7 @@ describe('EthTransactionsScroll', () => {
 	const oldestLoadedBlockNumber = 100;
 
 	let loadNextSpy: MockInstance;
+	let loadNextErc20Spy: MockInstance;
 
 	const setTransactions = ({ tokenId }: { tokenId: TokenId }) => {
 		ethTransactionsStore.set({
@@ -58,6 +61,10 @@ describe('EthTransactionsScroll', () => {
 
 		loadNextSpy = vi
 			.spyOn(ethUserTransactionsServices, 'loadNextEthUserTransactions')
+			.mockResolvedValue({ hasMore: true });
+
+		loadNextErc20Spy = vi
+			.spyOn(erc20UserTransactionsServices, 'loadNextErc20UserTransactions')
 			.mockResolvedValue({ hasMore: true });
 
 		setTransactions({ tokenId: mockToken.id });
@@ -102,8 +109,7 @@ describe('EthTransactionsScroll', () => {
 		expect(loadNextSpy).not.toHaveBeenCalled();
 	});
 
-	it('should not load anything for a token whose history is not the chain history', () => {
-		// Older ERC20 transfers come from `tokentx`, which this path does not query.
+	it('should page an ERC20 token through its own loader', () => {
 		token.set(USDC_TOKEN);
 
 		setTransactions({ tokenId: USDC_TOKEN.id });
@@ -111,5 +117,27 @@ describe('EthTransactionsScroll', () => {
 		render(EthTransactionsScroll, { token: USDC_TOKEN, children: mockSnippet });
 
 		expect(loadNextSpy).not.toHaveBeenCalled();
+
+		expect(loadNextErc20Spy).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({
+				transactionTokenId: { Erc20: [USDC_TOKEN.address, USDC_TOKEN.network.chainId] },
+				token: USDC_TOKEN,
+				tokenId: USDC_TOKEN.id,
+				networkId: USDC_TOKEN.network.id,
+				oldestLoadedBlockNumber
+			})
+		);
+	});
+
+	it('should not load anything for a token whose history is not the chain history', () => {
+		// ERC-721 history comes from `tokennfttx`, which neither of these paths queries.
+		token.set(AZUKI_ELEMENTAL_BEANS_TOKEN);
+
+		setTransactions({ tokenId: AZUKI_ELEMENTAL_BEANS_TOKEN.id });
+
+		render(EthTransactionsScroll, { token: AZUKI_ELEMENTAL_BEANS_TOKEN, children: mockSnippet });
+
+		expect(loadNextSpy).not.toHaveBeenCalled();
+		expect(loadNextErc20Spy).not.toHaveBeenCalled();
 	});
 });

--- a/src/frontend/src/tests/eth/services/erc20-user-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc20-user-transactions.services.spec.ts
@@ -1,0 +1,285 @@
+import type { TokenId as BackendTokenId } from '$declarations/backend/backend.did';
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import type { AlchemyProvider } from '$eth/providers/alchemy.providers';
+import * as alchemyProvidersModule from '$eth/providers/alchemy.providers';
+import type { EtherscanProvider } from '$eth/providers/etherscan.providers';
+import * as etherscanProvidersModule from '$eth/providers/etherscan.providers';
+import type { InfuraProvider } from '$eth/providers/infura.providers';
+import * as infuraProvidersModule from '$eth/providers/infura.providers';
+import {
+	fetchErc20Transfers,
+	loadNextErc20UserTransactions,
+	saveErc20FinalizedTransactions
+} from '$eth/services/erc20-user-transactions.services';
+import { setEthBackendPaginationCursor } from '$eth/services/eth-user-transactions.services';
+import { ethTransactionsStore } from '$eth/stores/eth-transactions.store';
+import { ZERO } from '$lib/constants/app.constants';
+import type { Transaction } from '$lib/types/transaction';
+import { mockEthAddress } from '$tests/mocks/eth.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { createMockBackendUserTransaction } from '$tests/mocks/user-transactions.mock';
+import { get } from 'svelte/store';
+import type { MockInstance } from 'vitest';
+
+vi.mock('$lib/api/backend.api', () => ({
+	getUserTransactions: vi.fn(),
+	saveUserTransactions: vi.fn()
+}));
+
+vi.mock('$eth/providers/etherscan.providers', () => ({
+	etherscanProviders: vi.fn()
+}));
+
+vi.mock('$eth/providers/infura.providers', () => ({
+	infuraProviders: vi.fn()
+}));
+
+vi.mock('$eth/providers/alchemy.providers', () => ({
+	alchemyProviders: vi.fn()
+}));
+
+describe('erc20-user-transactions.services', () => {
+	const backendTokenId: BackendTokenId = {
+		Erc20: [USDC_TOKEN.address, USDC_TOKEN.network.chainId]
+	};
+
+	let mockGetUserTransactions: MockInstance;
+	let mockSaveUserTransactions: MockInstance;
+	let mockErc20Transactions: MockInstance;
+	let mockGetBlockNumber: MockInstance;
+	let mockGetTransaction: MockInstance;
+
+	const makeTx = ({
+		hash,
+		blockNumber,
+		value = 1000n
+	}: {
+		hash: string;
+		blockNumber: number;
+		value?: bigint;
+	}): Transaction => ({
+		hash,
+		blockNumber,
+		timestamp: blockNumber * 10,
+		from: mockEthAddress,
+		to: '0xrecipient',
+		nonce: 1,
+		value,
+		chainId: USDC_TOKEN.network.chainId,
+		gasLimit: 21000n,
+		gasPrice: 20_000_000_000n,
+		gasUsed: 21000n,
+		data: ''
+	});
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+
+		ethTransactionsStore.reinitialize();
+
+		setEthBackendPaginationCursor({ tokenId: USDC_TOKEN.id, nextStart: undefined });
+
+		const backendApi = await import('$lib/api/backend.api');
+		mockGetUserTransactions = vi.mocked(backendApi.getUserTransactions);
+		mockSaveUserTransactions = vi.mocked(backendApi.saveUserTransactions);
+
+		mockErc20Transactions = vi.fn().mockResolvedValue([]);
+		mockGetBlockNumber = vi.fn().mockResolvedValue(1_000_000);
+		mockGetTransaction = vi.fn().mockResolvedValue({ from: mockEthAddress });
+
+		vi.spyOn(etherscanProvidersModule, 'etherscanProviders').mockReturnValue({
+			erc20Transactions: mockErc20Transactions
+		} as unknown as EtherscanProvider);
+
+		vi.spyOn(infuraProvidersModule, 'infuraProviders').mockReturnValue({
+			getBlockNumber: mockGetBlockNumber
+		} as unknown as InfuraProvider);
+
+		vi.spyOn(alchemyProvidersModule, 'alchemyProviders').mockReturnValue({
+			getTransaction: mockGetTransaction
+		} as unknown as AlchemyProvider);
+	});
+
+	describe('fetchErc20Transfers', () => {
+		it('should forward the block window to Etherscan', async () => {
+			await fetchErc20Transfers({
+				networkId: ETHEREUM_NETWORK_ID,
+				token: USDC_TOKEN,
+				address: mockEthAddress,
+				startBlock: 500,
+				endBlock: 900
+			});
+
+			expect(mockErc20Transactions).toHaveBeenCalledExactlyOnceWith({
+				contract: USDC_TOKEN,
+				address: mockEthAddress,
+				startBlock: 500,
+				endBlock: 900
+			});
+		});
+
+		it('should omit the bounds when none are given', async () => {
+			await fetchErc20Transfers({
+				networkId: ETHEREUM_NETWORK_ID,
+				token: USDC_TOKEN,
+				address: mockEthAddress
+			});
+
+			expect(mockErc20Transactions).toHaveBeenCalledExactlyOnceWith({
+				contract: USDC_TOKEN,
+				address: mockEthAddress
+			});
+		});
+
+		it('should drop zero-value transfers the user did not sign', async () => {
+			const kept = makeTx({ hash: '0xkept', blockNumber: 10 });
+			const spam = makeTx({ hash: '0xspam', blockNumber: 11, value: ZERO });
+
+			mockErc20Transactions.mockResolvedValue([kept, spam]);
+			mockGetTransaction.mockResolvedValue({ from: '0xattacker' });
+
+			const result = await fetchErc20Transfers({
+				networkId: ETHEREUM_NETWORK_ID,
+				token: USDC_TOKEN,
+				address: mockEthAddress
+			});
+
+			expect(result).toEqual([kept]);
+		});
+	});
+
+	describe('saveErc20FinalizedTransactions', () => {
+		it('should only persist transfers deep enough behind the tip', async () => {
+			const finalized = makeTx({ hash: '0xold', blockNumber: 100 });
+			const tooRecent = makeTx({ hash: '0xnew', blockNumber: 990 });
+
+			await saveErc20FinalizedTransactions({
+				identity: mockIdentity,
+				tokenId: backendTokenId,
+				transactions: [finalized, tooRecent],
+				currentBlockNumber: 1000
+			});
+
+			expect(mockSaveUserTransactions).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					tokenId: backendTokenId,
+					transactions: [expect.objectContaining({ id: '0xold' })]
+				})
+			);
+		});
+	});
+
+	describe('loadNextErc20UserTransactions', () => {
+		it('should serve the next page from the backend without touching Etherscan', async () => {
+			setEthBackendPaginationCursor({ tokenId: USDC_TOKEN.id, nextStart: 42n });
+
+			mockGetUserTransactions.mockResolvedValue({
+				transactions: [
+					createMockBackendUserTransaction({
+						hash: '0xstored',
+						blockIndex: 50n,
+						timestamp: 500n
+					})
+				],
+				newestBlockIndex: 50n,
+				oldestBlockIndex: 50n,
+				totalStored: 1n,
+				nextStart: 32n
+			});
+
+			const { hasMore } = await loadNextErc20UserTransactions({
+				identity: mockIdentity,
+				address: mockEthAddress,
+				transactionTokenId: backendTokenId,
+				token: USDC_TOKEN,
+				tokenId: USDC_TOKEN.id,
+				networkId: ETHEREUM_NETWORK_ID,
+				oldestLoadedBlockNumber: 60
+			});
+
+			expect(hasMore).toBeTruthy();
+			expect(mockErc20Transactions).not.toHaveBeenCalled();
+
+			expect(get(ethTransactionsStore)?.[USDC_TOKEN.id]).toHaveLength(1);
+		});
+
+		it('should fall back to Etherscan below the oldest loaded block once the cache is drained', async () => {
+			const older = makeTx({ hash: '0xolder', blockNumber: 20 });
+
+			mockErc20Transactions.mockResolvedValue([older]);
+
+			const { hasMore } = await loadNextErc20UserTransactions({
+				identity: mockIdentity,
+				address: mockEthAddress,
+				transactionTokenId: backendTokenId,
+				token: USDC_TOKEN,
+				tokenId: USDC_TOKEN.id,
+				networkId: ETHEREUM_NETWORK_ID,
+				oldestLoadedBlockNumber: 60
+			});
+
+			expect(hasMore).toBeTruthy();
+
+			expect(mockErc20Transactions).toHaveBeenCalledExactlyOnceWith({
+				contract: USDC_TOKEN,
+				address: mockEthAddress,
+				endBlock: 59
+			});
+
+			expect(get(ethTransactionsStore)?.[USDC_TOKEN.id]).toHaveLength(1);
+		});
+
+		it('should persist what Etherscan returned against the real chain tip', async () => {
+			mockErc20Transactions.mockResolvedValue([makeTx({ hash: '0xolder', blockNumber: 20 })]);
+
+			await loadNextErc20UserTransactions({
+				identity: mockIdentity,
+				address: mockEthAddress,
+				transactionTokenId: backendTokenId,
+				token: USDC_TOKEN,
+				tokenId: USDC_TOKEN.id,
+				networkId: ETHEREUM_NETWORK_ID,
+				oldestLoadedBlockNumber: 60
+			});
+
+			expect(mockGetBlockNumber).toHaveBeenCalledOnce();
+
+			expect(mockSaveUserTransactions).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					tokenId: backendTokenId,
+					transactions: [expect.objectContaining({ id: '0xolder' })]
+				})
+			);
+		});
+
+		it('should report no more pages when Etherscan has nothing older', async () => {
+			const { hasMore } = await loadNextErc20UserTransactions({
+				identity: mockIdentity,
+				address: mockEthAddress,
+				transactionTokenId: backendTokenId,
+				token: USDC_TOKEN,
+				tokenId: USDC_TOKEN.id,
+				networkId: ETHEREUM_NETWORK_ID,
+				oldestLoadedBlockNumber: 60
+			});
+
+			expect(hasMore).toBeFalsy();
+		});
+
+		it('should not query Etherscan without an oldest loaded block', async () => {
+			const { hasMore } = await loadNextErc20UserTransactions({
+				identity: mockIdentity,
+				address: mockEthAddress,
+				transactionTokenId: backendTokenId,
+				token: USDC_TOKEN,
+				tokenId: USDC_TOKEN.id,
+				networkId: ETHEREUM_NETWORK_ID,
+				oldestLoadedBlockNumber: undefined
+			});
+
+			expect(hasMore).toBeFalsy();
+			expect(mockErc20Transactions).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -422,6 +422,34 @@ describe('eth-transactions.services', () => {
 				);
 			});
 
+			it('should measure finality against the chain tip, not the batch', async () => {
+				const [newer] = createMockEthTransactions(1);
+
+				mockErc20Transactions.mockResolvedValue([newer]);
+
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(12_345_678);
+
+				await load();
+
+				expect(saveErc20FinalizedTransactions).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({ currentBlockNumber: 12_345_678 })
+				);
+			});
+
+			it('should fall back to the batch newest block when the tip cannot be read', async () => {
+				const [newer] = createMockEthTransactions(1);
+
+				mockErc20Transactions.mockResolvedValue([{ ...newer, blockNumber: 4242 }]);
+
+				infuraMocks.mockInfuraGetBlockNumber.mockRejectedValueOnce(new Error('no provider'));
+
+				await load();
+
+				expect(saveErc20FinalizedTransactions).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({ currentBlockNumber: 4242 })
+				);
+			});
+
 			it('should not persist anything when Etherscan returned nothing new', async () => {
 				await load();
 

--- a/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transactions.services.spec.ts
@@ -6,6 +6,11 @@ import { USDT_TOKEN, USDT_TOKEN_ID } from '$env/tokens/tokens-erc20/tokens.usdt.
 import { ETHEREUM_TOKEN, ETHEREUM_TOKEN_ID } from '$env/tokens/tokens.eth.env';
 import type { EtherscanProvider } from '$eth/providers/etherscan.providers';
 import * as etherscanProvidersModule from '$eth/providers/etherscan.providers';
+import type * as Erc20UserTransactionsServices from '$eth/services/erc20-user-transactions.services';
+import {
+	loadErc20UserTransactions,
+	saveErc20FinalizedTransactions
+} from '$eth/services/erc20-user-transactions.services';
 import {
 	loadEthereumTransactions,
 	reloadEthereumTransactions
@@ -50,6 +55,14 @@ vi.mock('$eth/services/eth-user-transactions.services', () => ({
 	setEthBackendPaginationCursor: vi.fn()
 }));
 
+// Only the canister round-trips are stubbed; `fetchErc20Transfers` stays real so it keeps
+// exercising the mocked Etherscan provider.
+vi.mock('$eth/services/erc20-user-transactions.services', async (importOriginal) => ({
+	...(await importOriginal<typeof Erc20UserTransactionsServices>()),
+	loadErc20UserTransactions: vi.fn(),
+	saveErc20FinalizedTransactions: vi.fn()
+}));
+
 vi.mock('$lib/utils/console.utils', () => ({
 	consoleError: vi.fn()
 }));
@@ -79,6 +92,9 @@ describe('eth-transactions.services', () => {
 
 		ethAddressStore.set({ data: mockEthAddress, certified: false });
 		erc20CustomTokensStore.setAll(mockErc20CustomTokens);
+
+		vi.mocked(loadErc20UserTransactions).mockResolvedValue(undefined);
+		vi.mocked(saveErc20FinalizedTransactions).mockResolvedValue({ success: true });
 	});
 
 	describe('loadEthereumTransactions', () => {
@@ -295,6 +311,123 @@ describe('eth-transactions.services', () => {
 				}
 			);
 		}, 60000);
+
+		describe('when token is ERC20 and backed by the canister cache', () => {
+			const mockErc20Transactions = vi.fn();
+
+			const {
+				id: tokenId,
+				network: { id: networkId, chainId },
+				standard,
+				address: contractAddress
+			} = USDC_TOKEN;
+
+			const backendTokenId = { Erc20: [contractAddress, chainId] };
+
+			beforeEach(() => {
+				ethTransactionsStore.reinitialize();
+
+				mockErc20Transactions.mockResolvedValue([]);
+
+				vi.spyOn(etherscanProvidersModule, 'etherscanProviders').mockReturnValue({
+					erc20Transactions: mockErc20Transactions
+				} as unknown as EtherscanProvider);
+
+				vi.mocked(loadErc20UserTransactions).mockResolvedValue(undefined);
+			});
+
+			const load = () =>
+				loadEthereumTransactions({
+					identity: mockIdentity,
+					networkId,
+					tokenId,
+					chainId,
+					standard
+				});
+
+			it('should read the stored page under the ERC20 token id', async () => {
+				await load();
+
+				expect(loadErc20UserTransactions).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({ identity: mockIdentity, tokenId: backendTokenId })
+				);
+			});
+
+			it('should ask Etherscan only for blocks above the newest stored one', async () => {
+				vi.mocked(loadErc20UserTransactions).mockResolvedValue({
+					transactions: [],
+					newestBlockIndex: 500n,
+					oldestBlockIndex: 100n,
+					totalStored: 4n,
+					nextStart: undefined
+				});
+
+				await load();
+
+				expect(mockErc20Transactions).toHaveBeenCalledExactlyOnceWith({
+					contract: { ...USDC_TOKEN, enabled: true },
+					address: mockEthAddress,
+					startBlock: 501
+				});
+			});
+
+			it('should skip Etherscan entirely while the tip is still below the stored height', async () => {
+				vi.mocked(loadErc20UserTransactions).mockResolvedValue({
+					transactions: [],
+					newestBlockIndex: 500n,
+					oldestBlockIndex: 100n,
+					totalStored: 4n,
+					nextStart: undefined
+				});
+
+				infuraMocks.mockInfuraGetBlockNumber.mockResolvedValueOnce(400);
+
+				await load();
+
+				expect(mockErc20Transactions).not.toHaveBeenCalled();
+			});
+
+			it('should keep the stored page in the store alongside the newer transactions', async () => {
+				const [stored] = createMockEthTransactions(1);
+				const newer = { ...stored, hash: '0xnewer', blockNumber: 900 };
+
+				vi.mocked(loadErc20UserTransactions).mockResolvedValue({
+					transactions: [stored],
+					newestBlockIndex: 500n,
+					oldestBlockIndex: 100n,
+					totalStored: 4n,
+					nextStart: 3n
+				});
+
+				mockErc20Transactions.mockResolvedValue([newer]);
+
+				await load();
+
+				expect(get(ethTransactionsStore)?.[tokenId]).toHaveLength(2);
+			});
+
+			it('should persist the newly fetched transactions', async () => {
+				const [newer] = createMockEthTransactions(1);
+
+				mockErc20Transactions.mockResolvedValue([newer]);
+
+				await load();
+
+				expect(saveErc20FinalizedTransactions).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						identity: mockIdentity,
+						tokenId: backendTokenId,
+						transactions: [newer]
+					})
+				);
+			});
+
+			it('should not persist anything when Etherscan returned nothing new', async () => {
+				await load();
+
+				expect(saveErc20FinalizedTransactions).not.toHaveBeenCalled();
+			});
+		});
 
 		describe('when token is native ETH', () => {
 			let etherscanProvidersSpy: MockInstance;


### PR DESCRIPTION
# Motivation

ERC-20 was the last major transfer list still refetching its whole history from Etherscan on every load. `erc20Transactions` hardcoded `startblock: 0` with no `endblock` and no pagination, so every wallet refresh pulled the full history again.

That is also the most expensive list to refetch. The address-poisoning filter resolves the outer transaction sender over RPC for every zero-value transfer, so each refetched page costs a batch of Alchemy calls on top of the Etherscan one. Caching the post-filter result means that work happens once per transfer, ever.

ETH-native and Solana (native and SPL) already read from the canister cache. This brings ERC-20 in line with them.

# Changes

- `erc20Transactions` now accepts `startBlock` / `endBlock` / `sort`, mirroring `getHistory`.
- New `erc20BackendTokenId` mapping an ERC-20 token to the backend `TokenId` variant `Erc20(address, chainId)`.
- New `erc20-user-transactions.services.ts`: backend read and write, the shared Etherscan-plus-spam-filter fetch, and `loadNextErc20UserTransactions` for scroll pagination (cache pages first, Etherscan below the oldest loaded block once drained).
- The ERC-20 head load reads the stored page, asks Etherscan only for blocks above the newest stored height, and `prepend`s rather than `set`s so scrolled-in pages survive the 30s refresh.
- `EthTransactionsScroll` now pages ERC-20 tokens instead of disabling itself for them.
- Extracted the chain-tip guard shared by the native and ERC-20 incremental fetches, so neither calls the explorer when the tip has not moved past what we already hold.
- ERC-4626 now reuses the shared fetcher rather than its own copy. Its behaviour is unchanged: it is not cached, and its scroll stays disabled.

Backend needs no changes. The `Erc20` `TokenId` variant and `EvmTransactionData` already exist and are unused until now.

# Tests

- New `erc20-user-transactions.services.spec.ts` (9 tests): block-window forwarding, spam filtering, finality gating on save, cache-before-Etherscan paging, the `endBlock` bound, saving against the real chain tip, and the two no-more-pages exits.
- New describe block in `eth-transactions.services.spec.ts` (6 tests) for the head load: reads under the ERC-20 token id, asks only for blocks above the stored height, skips Etherscan entirely while the tip is behind, keeps the stored page alongside newer transactions, and persists only what is new.
- `EthTransactionsScroll.spec.ts` updated: the case that asserted ERC-20 does not paginate now asserts it paginates through its own loader, with ERC-721 taking over as the standard that stays disabled.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` and `npx tsc --project tsconfig.spec.json` all clean for the touched files.
- Full `src/frontend/src/tests/eth` and `src/frontend/src/tests/evm` run: 3954 passed. Two suites under `eth/components/stake/harvest-autopilot` fail to resolve `onesec-bridge`; that is pre-existing on this machine and unrelated to these files.