### PR TITLE
style(frontend): move the Solana WalletConnect fee notices above the transaction data

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -143,6 +143,16 @@
 		<MessageBox level="warning">{$i18n.wallet_connect.text.unreviewed_instructions}</MessageBox>
 	{/if}
 
+	<!-- A steep priority fee is a legitimate choice when the network is congested, so both tiers
+	     inform instead of blocking the way invalid typed data does on Ethereum. That is also why the
+	     pair sits last among the notices: what a message does to the user's funds outranks what it
+	     costs to send. -->
+	{#if dappPrioritizationFee}
+		<MessageBox level="info">{$i18n.wallet_connect.text.dapp_prioritization_fee}</MessageBox>
+	{:else if highPrioritizationFee}
+		<MessageBox level="warning">{$i18n.wallet_connect.text.high_prioritization_fee}</MessageBox>
+	{/if}
+
 	<SendData
 		{amount}
 		{application}
@@ -169,14 +179,6 @@
 			<WalletConnectModalValue label={$i18n.fee.text.prioritization_fee} ref="prioritization-fee">
 				{@render feeValue(prioritizationFee)}
 			</WalletConnectModalValue>
-		{/if}
-
-		<!-- A steep priority fee is a legitimate choice when the network is congested, so both tiers
-		     inform instead of blocking the way invalid typed data does on Ethereum. -->
-		{#if dappPrioritizationFee}
-			<MessageBox level="info">{$i18n.wallet_connect.text.dapp_prioritization_fee}</MessageBox>
-		{:else if highPrioritizationFee}
-			<MessageBox level="warning">{$i18n.wallet_connect.text.high_prioritization_fee}</MessageBox>
 		{/if}
 
 		{#if nonNullish(preview)}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -143,10 +143,6 @@
 		<MessageBox level="warning">{$i18n.wallet_connect.text.unreviewed_instructions}</MessageBox>
 	{/if}
 
-	<!-- A steep priority fee is a legitimate choice when the network is congested, so both tiers
-	     inform instead of blocking the way invalid typed data does on Ethereum. That is also why the
-	     pair sits last among the notices: what a message does to the user's funds outranks what it
-	     costs to send. -->
 	{#if dappPrioritizationFee}
 		<MessageBox level="info">{$i18n.wallet_connect.text.dapp_prioritization_fee}</MessageBox>
 	{:else if highPrioritizationFee}

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -250,6 +250,41 @@ describe('SolWalletConnectSignReview', () => {
 			expect(getByText('0.000005 SOL')).toBeInTheDocument();
 			expect(getByText(en.wallet_connect.text.high_prioritization_fee)).toBeInTheDocument();
 		});
+
+		it('should render the notice above the transaction data', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: {
+					...props,
+					prioritizationFee: 3_000_000n,
+					prioritizationFeeEstimate: networkEstimate
+				}
+			});
+
+			const notice = getByText(en.wallet_connect.text.dapp_prioritization_fee);
+			const application = getByText(en.wallet_connect.text.application);
+
+			expect(notice.compareDocumentPosition(application) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+		});
+
+		it('should render the warning below the unreviewed instructions warning', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: {
+					...props,
+					unreviewed: true,
+					prioritizationFee: 5_600_000n,
+					prioritizationFeeEstimate: networkEstimate
+				}
+			});
+
+			const unreviewed = getByText(en.wallet_connect.text.unreviewed_instructions);
+			const warning = getByText(en.wallet_connect.text.high_prioritization_fee);
+
+			expect(unreviewed.compareDocumentPosition(warning) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+		});
 	});
 
 	describe('when the decode produced no amount', () => {


### PR DESCRIPTION
# Motivation

In the Solana WalletConnect sign review, the two prioritization fee notices rendered between the fee rows and the simulated changes. A user scrolling towards the approve button therefore met them *after* the data they qualify, which is the wrong order for something meant to give pause. Notices belong at the top, where they are read before the transaction is inspected rather than after.

# Changes

- Move the `dapp_prioritization_fee` info box and the `high_prioritization_fee` warning out of the `SendData` body and to the top of the review, directly below the unreviewed instructions warning.
- Both sit last among the notices on purpose: what a message does to the user's funds outranks what it costs to send. The ordering is left to the markup rather than to a comment, and the tests below are what hold it in place.
- Drop the explanatory comment that used to sit above the pair, including the two lines that predated this change. Without the ranking sentence the remainder restated what the markup already shows.

No wording, threshold or condition changed. This is placement only.

Two message boxes in this review are still rendered by child components and so remain lower in the document: the control change warning inside `SolWalletConnectSimulationPreview` and the partial parties warning inside `SolWalletConnectTransferParties`. Hoisting those is a separate change; once hoisted they belong above the fee pair.

# Tests

- Two new cases in `SolWalletConnectSignReview.spec.ts`: the notice renders above the transaction data, and the warning renders below the unreviewed instructions warning.
- The first was confirmed to fail against the previous layout, so it guards the ordering rather than restating it.
- `npm run format`, `npm run lint -- --max-warnings 0` and `npm run check` are clean, and the WalletConnect suite for this area passes 53/53.
