### PR TITLE
style(frontend): reword the WalletConnect simulation label to simulated balance changes

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1604,7 +1604,7 @@
 			"amount": "Amount",
 			"hex_data": "HEX Data",
 			"unreviewed_instructions": "This transaction contains instructions OISY can't decode, so the review below may be incomplete. Only sign if you trust this app.",
-			"simulated_changes": "Simulated changes to your accounts",
+			"simulated_changes": "Simulated balance changes",
 			"simulation_note": "Simulated against the network's current state. What happens when the transaction actually runs can differ.",
 			"simulation_control_change": "This transaction would change who controls one or more of your accounts. Approving it can hand over an account itself, not only what is in it.",
 			"simulation_new_owner": "New account owner",


### PR DESCRIPTION
# Motivation

The Solana WalletConnect sign review shows a simulation section whose heading reads "Simulated changes to your accounts". The phrasing is longer than it needs to be and does not say what the section actually lists, which is the balance deltas the transaction would produce. "Simulated balance changes" is shorter, is more accurate about the content, and fits the tighter heading style used elsewhere in the review.

# Changes

- Reword `wallet_connect.text.simulated_changes` in `src/frontend/src/lib/i18n/en.json` from "Simulated changes to your accounts" to "Simulated balance changes".
- The key itself is unchanged, so every caller keeps working untouched. Non-`en` locales are left alone: they still hold empty placeholders for this key and are synced structurally by the `auto-update-i18n` workflow.

# Tests

- `npm run i18n` regenerates cleanly with no change to `src/frontend/src/lib/types/i18n.d.ts` (the key path is untouched).
- `npm run format`, `npm run lint -- --max-warnings 0` and `npm run check` all pass (`check`: 0 errors, 0 warnings).
- `npx vitest run src/frontend/src/tests/sol/components/wallet-connect/` passes, 5 files and 51 tests. `SolWalletConnectSignReview.spec.ts` asserts against `en.wallet_connect.text.simulated_changes` rather than a hard-coded string, so it follows the new copy automatically. A repo-wide grep confirmed no other test or component hard-codes the old English text.
