### PR TITLE
feat(frontend): drop the signer row from the Solana WalletConnect sign review

### DIFF
--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -20,6 +20,7 @@
 		// and a zero there would read as a figure the decode never produced. Both default to shown.
 		showAmount?: boolean;
 		showBalance?: boolean;
+		showSigner?: boolean;
 		showNullishAmountLabel?: boolean;
 		showUnlimitedAmountLabel?: boolean;
 		sourceNetwork: Snippet;
@@ -37,6 +38,7 @@
 		application,
 		showAmount = true,
 		showBalance = true,
+		showSigner = true,
 		showNullishAmountLabel = false,
 		showUnlimitedAmountLabel = false,
 		sourceNetwork,
@@ -61,7 +63,7 @@
 	/>
 {/if}
 
-<SendSource {balance} {exchangeRate} {showBalance} {source} {token} />
+<SendSource {balance} {exchangeRate} {showBalance} {showSigner} {source} {token} />
 
 {#if nonNullish(destination)}
 	<SendDataDestination {destination} />

--- a/src/frontend/src/lib/components/send/SendSource.svelte
+++ b/src/frontend/src/lib/components/send/SendSource.svelte
@@ -14,9 +14,17 @@
 		source: string;
 		exchangeRate?: number;
 		showBalance?: boolean;
+		showSigner?: boolean;
 	}
 
-	let { token, balance, source, exchangeRate, showBalance = true }: Props = $props();
+	let {
+		token,
+		balance,
+		source,
+		exchangeRate,
+		showBalance = true,
+		showSigner = true
+	}: Props = $props();
 </script>
 
 {#if showBalance}
@@ -34,9 +42,11 @@
 	</WalletConnectModalValue>
 {/if}
 
-<WalletConnectModalValue label={$i18n.wallet_connect.text.signer} ref="signer">
-	<div class="flex flex-col gap-1">
-		{source}
-		<ContactOrToken identifier={source} />
-	</div>
-</WalletConnectModalValue>
+{#if showSigner}
+	<WalletConnectModalValue label={$i18n.wallet_connect.text.signer} ref="signer">
+		<div class="flex flex-col gap-1">
+			{source}
+			<ContactOrToken identifier={source} />
+		</div>
+	</WalletConnectModalValue>
+{/if}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -143,6 +143,9 @@
 		<MessageBox level="warning">{$i18n.wallet_connect.text.unreviewed_instructions}</MessageBox>
 	{/if}
 
+	<!-- The signer is the connected account and never varies between the requests of a session, so
+	     here it costs a row without saying anything about the message in front of the user. The
+	     Ethereum review keeps the row, which is why this is opted out rather than removed. -->
 	<SendData
 		{amount}
 		{application}
@@ -150,6 +153,7 @@
 		destination={isApproval || !decoded || showParties ? null : destination}
 		showAmount={decoded}
 		showBalance={decoded}
+		showSigner={false}
 		{source}
 		{token}
 	>

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectSendReview.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectSendReview.spec.ts
@@ -106,6 +106,19 @@ describe('EthWalletConnectSendReview', () => {
 		expect(getByRole('button', { name: en.core.text.approve })).not.toBeDisabled();
 	});
 
+	it('should render the signer row', () => {
+		const { getByText, container } = render(EthWalletConnectSendReview, {
+			props: {
+				...props,
+				destination: UNKNOWN_CONTRACT
+			},
+			context: mockContext
+		});
+
+		expect(getByText(en.wallet_connect.text.signer)).toBeInTheDocument();
+		expect(container.querySelector('#signer')).not.toBeNull();
+	});
+
 	it('should never summarize an ERC20 transfer as a native zero-value send', () => {
 		const { queryByText } = render(EthWalletConnectSendReview, {
 			props: {

--- a/src/frontend/src/tests/lib/components/send/SendSource.spec.ts
+++ b/src/frontend/src/tests/lib/components/send/SendSource.spec.ts
@@ -52,6 +52,14 @@ describe('SendSource', () => {
 		expect(container).toHaveTextContent(en.wallet_connect.text.signer);
 	});
 
+	it('should render the balance but not the signer when the signer is opted out', () => {
+		const { container } = render(SendSource, { ...props, showSigner: false });
+
+		expect(container.querySelector(signerSelector)).toBeNull();
+		expect(container).not.toHaveTextContent(en.wallet_connect.text.signer);
+		expect(container.querySelector(balanceSelector)?.textContent).toContain('BTC');
+	});
+
 	it('should render all field but balance without value', () => {
 		const { container } = render(SendSource, { ...props, token: undefined });
 

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -66,6 +66,15 @@ describe('SolWalletConnectSignReview', () => {
 		expect(queryByText(en.wallet_connect.text.unreviewed_instructions)).not.toBeInTheDocument();
 	});
 
+	it('should not render the signer row', () => {
+		const { queryByText, container } = render(SolWalletConnectSignReview, {
+			props
+		});
+
+		expect(queryByText(en.wallet_connect.text.signer)).not.toBeInTheDocument();
+		expect(container.querySelector('#signer')).toBeNull();
+	});
+
 	it('should render the base network fee as a labelled row', () => {
 		const { getByText } = render(SolWalletConnectSignReview, {
 			props
@@ -276,7 +285,6 @@ describe('SolWalletConnectSignReview', () => {
 
 			expect(getByText(en.wallet_connect.text.application)).toBeInTheDocument();
 			expect(getByText(en.send.text.network)).toBeInTheDocument();
-			expect(getByText(en.wallet_connect.text.signer)).toBeInTheDocument();
 			expect(getByText(en.fee.text.network_fee)).toBeInTheDocument();
 			expect(getByText(en.fee.text.prioritization_fee)).toBeInTheDocument();
 			expect(getByText(en.wallet_connect.text.hex_data)).toBeInTheDocument();


### PR DESCRIPTION
# Motivation

The Solana WalletConnect sign review shows a "Signer" row with the address the request will be signed by. That address is the account the dApp is already connected to and it never varies between the requests of a session, so on this modal it takes up a row without telling the user anything about the message in front of them. Dropping it lets the rows that do describe the request stand out.

The Ethereum WalletConnect send review keeps its signer row. That is why this is an opt-out prop on the shared component rather than a deletion: `SendSource` is shared by both reviews, so removing the row outright would take it away from Ethereum too.

# Changes

- `SendSource`: new `showSigner` prop, defaulting to `true`, gating the signer row. It mirrors the existing `showBalance` prop, and the balance row is untouched.
- `SendData`: threads `showSigner` through to `SendSource`, defaulting to `true`.
- `SolWalletConnectSignReview`: passes `showSigner={false}`, with a comment recording why the Solana review opts out while Ethereum does not. The `source` prop keeps flowing, since `SolWalletConnectTransferParties` still needs it as `userAddress`.
- `EthWalletConnectSendReview`: unchanged, so it keeps the signer row by default.

# Tests

- `SendSource.spec.ts`: new case covering `showSigner: false`, asserting the signer row is gone and the balance row still renders.
- `SolWalletConnectSignReview.spec.ts`: new case asserting the review renders no signer row. The existing "should still render everything that does not depend on the decode" case no longer asserts the signer label.
- `EthWalletConnectSendReview.spec.ts`: new case asserting the Ethereum review still renders the signer row, so the opt-out cannot silently leak across.

Gates run locally on a clean `npm ci`:

- `npx prettier --check` on the changed files: clean.
- `npx eslint --max-warnings 0` on the changed files: clean.
- `npm run check`: 0 errors, 0 warnings.
- `npm run check:tests`: 0 errors, 0 warnings.
- `npx vitest run src/frontend/src/tests/sol/components/wallet-connect/ src/frontend/src/tests/eth/components/wallet-connect/ src/frontend/src/tests/lib/components/send/`: 28 files, 203 tests passed.
