### PR TITLE
fix(frontend): substitute i18n placeholders in a single pass

### DIFF
--- a/src/frontend/src/lib/utils/i18n.utils.ts
+++ b/src/frontend/src/lib/utils/i18n.utils.ts
@@ -20,17 +20,34 @@ export interface I18nSubstitutions {
 }
 
 /**
+ * Substitutes every placeholder in a single pass, so that a value is never re-scanned once inserted.
+ * Values are frequently third-party controlled (token symbols, NFT collection names), and a second
+ * pass would let them rewrite the surrounding sentence: either through the `$&`, `` $` ``, `$'` and
+ * `$$` patterns that `String.replace` expands in a replacement string, or by carrying a placeholder
+ * key that a later substitution would then fill in.
+ *
+ * Longer keys are matched first so a key that is a prefix of another one does not shadow it.
+ *
  * @example
  * ("Why $1?", {$1: "World", Why: "Hello", "?": "!"}) => "Hello World!"
  */
 // eslint-disable-next-line local-rules/prefer-object-params -- This function is used a lot throughout the codebase, and it's easier/clearer to use it with separate arguments.
 export const replacePlaceholders = (text: string, substitutions: I18nSubstitutions): string => {
-	let result = text;
-	for (const [key, value] of Object.entries(substitutions)) {
-		result = result.replace(new RegExp(escapeRegExp(key), 'g'), value);
+	const keys = Object.keys(substitutions);
+
+	if (keys.length === 0) {
+		return text;
 	}
 
-	return result;
+	const placeholders = new RegExp(
+		[...keys]
+			.sort((a, b) => b.length - a.length)
+			.map(escapeRegExp)
+			.join('|'),
+		'g'
+	);
+
+	return text.replace(placeholders, (match) => substitutions[match]);
 };
 
 /**

--- a/src/frontend/src/tests/lib/utils/i18n.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/i18n.utils.spec.ts
@@ -61,6 +61,43 @@ describe('i18n-utils', () => {
 			).toBe('The quick brown fox jumps over the lazy dog');
 		});
 
+		it('should insert regexp replacement patterns in the value literally', () => {
+			const template = 'Move $collection to spam?';
+
+			expect(replacePlaceholders(template, { $collection: '$&' })).toBe('Move $& to spam?');
+
+			expect(replacePlaceholders(template, { $collection: '$`' })).toBe('Move $` to spam?');
+
+			expect(replacePlaceholders(template, { $collection: "$'" })).toBe("Move $' to spam?");
+
+			expect(replacePlaceholders(template, { $collection: '$$' })).toBe('Move $$ to spam?');
+
+			expect(replacePlaceholders(template, { $collection: '$1' })).toBe('Move $1 to spam?');
+		});
+
+		it('should not substitute a placeholder key carried by another value', () => {
+			expect(
+				replacePlaceholders('Send $amount of $token to $to', {
+					$token: 'X$amount Y',
+					$amount: '5.00',
+					$to: 'the address'
+				})
+			).toBe('Send 5.00 of X$amount Y to the address');
+		});
+
+		it('should prefer the longest key when one key is a prefix of another', () => {
+			expect(
+				replacePlaceholders('$token_symbol on $token', {
+					$token: 'Ethereum',
+					$token_symbol: 'ETH'
+				})
+			).toBe('ETH on Ethereum');
+		});
+
+		it('should return the original text when there is nothing to substitute', () => {
+			expect(replacePlaceholders('Lorem Ipsum!', {})).toBe('Lorem Ipsum!');
+		});
+
 		it('should replace Oisy placeholders', () => {
 			expect(
 				replaceOisyPlaceholders(


### PR DESCRIPTION
# Motivation

`replacePlaceholders` escaped the placeholder key but passed the value straight to `String.replace` as a replacement string, so `$&`, `` $` ``, `$'` and `$$` in a value were expanded by the engine instead of inserted literally. Many call sites substitute on-chain metadata such as NFT collection names and custom token symbols, so a crafted name could garble the sentence around it in confirmation modals and warnings. A collection named `$'` renders as `Move ' to spam? to spam?` instead of showing the name.

Substitutions were also applied one key after another, so a value inserted early was scanned again by the remaining keys and could absorb them.

No markup or script injection, since output is escaped by Svelte or sanitized by DOMPurify. The impact is misleading text in dialogs that ask the user to confirm something.

# Changes

- Replace the per-key loop with a single pass over all placeholders, using a function replacement so values are inserted literally.
- Match the longest key first, so a key that is a prefix of another one does not shadow it. Previously `$token` consumed the start of `$token_symbol`.
- Return the text untouched when there is nothing to substitute.

# Tests

New cases in `i18n.utils.spec.ts` cover `$&`, `` $` ``, `$'`, `$$` and `$1` in a value, a value carrying another placeholder key, the prefix case, and empty substitutions. Six fail on the previous implementation.

Gates pass locally: format, lint, `check` (0 errors, 0 warnings) and `test` (17725 passed, no failures), which exercises the ~215 files calling this function.