### PR TITLE
fix(frontend): chunk transaction saves to the canister batch cap

### DIFF
--- a/src/frontend/src/lib/constants/user-transactions.constants.ts
+++ b/src/frontend/src/lib/constants/user-transactions.constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Limits the backend enforces on the stored transaction cache.
+ *
+ * These mirror `src/shared/src/types/user_transaction.rs`. The canister rejects an over-sized save
+ * outright rather than truncating it, and trims the oldest entries once a token is over its cap, so
+ * the frontend has to respect both numbers to persist anything usefully.
+ */
+
+/** Maximum transactions the canister accepts in a single `save_user_transactions` call. */
+export const MAX_SAVE_USER_TRANSACTIONS_BATCH = 500;
+
+/** Maximum transactions the canister stores per (user, token) pair before trimming the oldest. */
+export const MAX_USER_TRANSACTIONS_PER_TOKEN = 10_000;

--- a/src/frontend/src/lib/services/user-transactions.services.ts
+++ b/src/frontend/src/lib/services/user-transactions.services.ts
@@ -85,25 +85,32 @@ export const saveFinalizedTransactions = async <T>({
 		return { success: true };
 	}
 
-	const mapped = finalized.map(mapToBackend);
+	// Callers supply the mapper, and some of them throw on a shape they cannot store, so this stays
+	// inside the failure path rather than escaping to the caller.
+	let mapped: UserTransaction[];
+
+	try {
+		mapped = finalized.map(mapToBackend);
+	} catch (err: unknown) {
+		consoleError('Failed to map transactions for saving:', err);
+
+		return { success: false };
+	}
+
+	let allSaved = true;
 
 	// The canister rejects an over-sized batch outright rather than truncating it, so sending a long
 	// history in one call persists nothing at all. A cold start fetches the full history from the
 	// explorer, which is exactly when the list is long enough to trip that.
-	const batches = Array.from(
-		{ length: Math.ceil(mapped.length / MAX_SAVE_USER_TRANSACTIONS_BATCH) },
-		(_, index) =>
-			mapped.slice(
-				index * MAX_SAVE_USER_TRANSACTIONS_BATCH,
-				(index + 1) * MAX_SAVE_USER_TRANSACTIONS_BATCH
-			)
-	);
-
-	let allSaved = true;
-
+	//
+	// Sliced as we go rather than precomputed: a cold-start history is long, and the batches are only
+	// ever consumed one at a time.
+	//
 	// Sequential rather than concurrent: each call is an update, and the canister merges into one
 	// entry per (user, token), so firing them together buys nothing and multiplies the load.
-	for (const batch of batches) {
+	for (let index = 0; index < mapped.length; index += MAX_SAVE_USER_TRANSACTIONS_BATCH) {
+		const batch = mapped.slice(index, index + MAX_SAVE_USER_TRANSACTIONS_BATCH);
+
 		try {
 			await saveUserTransactions({ identity, tokenId, transactions: batch });
 		} catch (err: unknown) {

--- a/src/frontend/src/lib/services/user-transactions.services.ts
+++ b/src/frontend/src/lib/services/user-transactions.services.ts
@@ -1,10 +1,12 @@
 import type { TokenId as BackendTokenId, UserTransaction } from '$declarations/backend/backend.did';
 import { getUserTransactions, saveUserTransactions } from '$lib/api/backend.api';
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+import { MAX_SAVE_USER_TRANSACTIONS_BATCH } from '$lib/constants/user-transactions.constants';
 import type { NullishIdentity } from '$lib/types/identity';
 import type { Transaction as EthTransaction } from '$lib/types/transaction';
 import type { LoadUserTransactionsResult } from '$lib/types/user-transactions';
 import type { ResultSuccess } from '$lib/types/utils';
+import { consoleError } from '$lib/utils/console.utils';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import { isNullish } from '@dfinity/utils';
 
@@ -83,14 +85,34 @@ export const saveFinalizedTransactions = async <T>({
 		return { success: true };
 	}
 
-	try {
-		await saveUserTransactions({
-			identity,
-			tokenId,
-			transactions: finalized.map(mapToBackend)
-		});
-		return { success: true };
-	} catch (_: unknown) {
-		return { success: false };
+	const mapped = finalized.map(mapToBackend);
+
+	// The canister rejects an over-sized batch outright rather than truncating it, so sending a long
+	// history in one call persists nothing at all. A cold start fetches the full history from the
+	// explorer, which is exactly when the list is long enough to trip that.
+	const batches = Array.from(
+		{ length: Math.ceil(mapped.length / MAX_SAVE_USER_TRANSACTIONS_BATCH) },
+		(_, index) =>
+			mapped.slice(
+				index * MAX_SAVE_USER_TRANSACTIONS_BATCH,
+				(index + 1) * MAX_SAVE_USER_TRANSACTIONS_BATCH
+			)
+	);
+
+	// Sequential rather than concurrent: each call is an update, and the canister merges into one
+	// entry per (user, token), so firing them together buys nothing and multiplies the load.
+	for (const batch of batches) {
+		try {
+			await saveUserTransactions({ identity, tokenId, transactions: batch });
+		} catch (err: unknown) {
+			// Not worth surfacing to the user: the cache is a warm-up, and the transactions are already
+			// on screen. Worth logging, because a silent total failure here is what kept a rejected
+			// over-sized batch invisible.
+			consoleError('Failed to save a batch of user transactions:', err);
+
+			return { success: false };
+		}
 	}
+
+	return { success: true };
 };

--- a/src/frontend/src/lib/services/user-transactions.services.ts
+++ b/src/frontend/src/lib/services/user-transactions.services.ts
@@ -99,20 +99,26 @@ export const saveFinalizedTransactions = async <T>({
 			)
 	);
 
+	let allSaved = true;
+
 	// Sequential rather than concurrent: each call is an update, and the canister merges into one
 	// entry per (user, token), so firing them together buys nothing and multiplies the load.
 	for (const batch of batches) {
 		try {
 			await saveUserTransactions({ identity, tokenId, transactions: batch });
 		} catch (err: unknown) {
-			// Not worth surfacing to the user: the cache is a warm-up, and the transactions are already
-			// on screen. Worth logging, because a silent total failure here is what kept a rejected
-			// over-sized batch invisible.
-			consoleError('Failed to save a batch of user transactions:', err);
+			// Keep going rather than abandoning the rest. The canister validates a batch as a unit and
+			// refuses all of it on the first transaction that breaches a field bound, so bailing here
+			// would let one unusual transaction cost the user every later batch too. Saves are
+			// deduplicated by id, so retrying the survivors on a future load stays cheap.
+			allSaved = false;
 
-			return { success: false };
+			// Not worth surfacing to the user: the cache is a warm-up, and the transactions are already
+			// on screen. Worth logging, because a silent failure here is what kept a rejected batch
+			// invisible in the first place.
+			consoleError('Failed to save a batch of user transactions:', err);
 		}
 	}
 
-	return { success: true };
+	return { success: allSaved };
 };

--- a/src/frontend/src/tests/lib/constants/user-transactions.constants.spec.ts
+++ b/src/frontend/src/tests/lib/constants/user-transactions.constants.spec.ts
@@ -1,0 +1,35 @@
+import {
+	MAX_SAVE_USER_TRANSACTIONS_BATCH,
+	MAX_USER_TRANSACTIONS_PER_TOKEN
+} from '$lib/constants/user-transactions.constants';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * These constants mirror the canister's, and unlike the other mirrored limits in the codebase the
+ * backend rejection is not a usable safety net here: the canister refuses an over-sized batch
+ * outright rather than truncating it, so a frontend value above the real cap makes every save fail
+ * silently. Drift has to break the build rather than the cache.
+ */
+describe('user-transactions.constants', () => {
+	const source = readFileSync(
+		join(process.cwd(), 'src/shared/src/types/user_transaction.rs'),
+		'utf-8'
+	);
+
+	const rustConstant = (name: string): number => {
+		const match = source.match(new RegExp(`pub const ${name}:\\s*\\w+\\s*=\\s*([0-9_]+)`));
+
+		expect(match, `${name} not found in user_transaction.rs`).not.toBeNull();
+
+		return Number(match?.[1].replaceAll('_', ''));
+	};
+
+	it('should match the canister save batch cap', () => {
+		expect(MAX_SAVE_USER_TRANSACTIONS_BATCH).toBe(rustConstant('MAX_SAVE_USER_TRANSACTIONS_BATCH'));
+	});
+
+	it('should match the canister per-token storage cap', () => {
+		expect(MAX_USER_TRANSACTIONS_PER_TOKEN).toBe(rustConstant('MAX_USER_TRANSACTIONS_PER_TOKEN'));
+	});
+});

--- a/src/frontend/src/tests/lib/constants/user-transactions.constants.spec.ts
+++ b/src/frontend/src/tests/lib/constants/user-transactions.constants.spec.ts
@@ -2,8 +2,7 @@ import {
 	MAX_SAVE_USER_TRANSACTIONS_BATCH,
 	MAX_USER_TRANSACTIONS_PER_TOKEN
 } from '$lib/constants/user-transactions.constants';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { readRustNumericConstant } from '$tests/utils/rust-constants.test-utils';
 
 /**
  * These constants mirror the canister's, and unlike the other mirrored limits in the codebase the
@@ -12,24 +11,17 @@ import { join } from 'node:path';
  * silently. Drift has to break the build rather than the cache.
  */
 describe('user-transactions.constants', () => {
-	const source = readFileSync(
-		join(process.cwd(), 'src/shared/src/types/user_transaction.rs'),
-		'utf-8'
-	);
-
-	const rustConstant = (name: string): number => {
-		const match = source.match(new RegExp(`pub const ${name}:\\s*\\w+\\s*=\\s*([0-9_]+)`));
-
-		expect(match, `${name} not found in user_transaction.rs`).not.toBeNull();
-
-		return Number(match?.[1].replaceAll('_', ''));
-	};
+	const path = 'src/shared/src/types/user_transaction.rs';
 
 	it('should match the canister save batch cap', () => {
-		expect(MAX_SAVE_USER_TRANSACTIONS_BATCH).toBe(rustConstant('MAX_SAVE_USER_TRANSACTIONS_BATCH'));
+		expect(MAX_SAVE_USER_TRANSACTIONS_BATCH).toBe(
+			readRustNumericConstant({ path, name: 'MAX_SAVE_USER_TRANSACTIONS_BATCH' })
+		);
 	});
 
 	it('should match the canister per-token storage cap', () => {
-		expect(MAX_USER_TRANSACTIONS_PER_TOKEN).toBe(rustConstant('MAX_USER_TRANSACTIONS_PER_TOKEN'));
+		expect(MAX_USER_TRANSACTIONS_PER_TOKEN).toBe(
+			readRustNumericConstant({ path, name: 'MAX_USER_TRANSACTIONS_PER_TOKEN' })
+		);
 	});
 });

--- a/src/frontend/src/tests/lib/services/user-transactions.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-transactions.services.spec.ts
@@ -6,6 +6,7 @@ import {
 	saveFinalizedTransactions
 } from '$lib/services/user-transactions.services';
 import type { Transaction } from '$lib/types/transaction';
+import { consoleError } from '$lib/utils/console.utils';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import {
 	mockEthTransaction,
@@ -19,6 +20,10 @@ import {
 vi.mock('$lib/api/backend.api', () => ({
 	getUserTransactions: vi.fn(),
 	saveUserTransactions: vi.fn()
+}));
+
+vi.mock('$lib/utils/console.utils', () => ({
+	consoleError: vi.fn()
 }));
 
 describe('user-transactions.services', () => {
@@ -176,13 +181,39 @@ describe('user-transactions.services', () => {
 		it('should persist every transaction across the batches, in order', async () => {
 			const transactions = makeTransactions(MAX_SAVE_USER_TRANSACTIONS_BATCH + 3);
 
-			await save(transactions);
+			// The shared mock mapper returns one fixed object for every input, which would let a
+			// dropped or reordered transaction slip through a length-only assertion.
+			await saveFinalizedTransactions({
+				identity: mockIdentity,
+				tokenId: mockUserTransactionTokenId,
+				transactions,
+				isFinalizedFn: () => true,
+				canSave: () => true,
+				mapToBackend: ({ hash }: Transaction) => ({ ...mockUserTransaction, id: `${hash}` })
+			});
 
 			const sent = vi
 				.mocked(backendApi.saveUserTransactions)
-				.mock.calls.flatMap(([{ transactions: batch }]) => batch);
+				.mock.calls.flatMap(([{ transactions: batch }]) => batch.map(({ id }) => id));
 
-			expect(sent).toHaveLength(transactions.length);
+			expect(sent).toEqual(transactions.map(({ hash }) => `${hash}`));
+		});
+
+		it('should report failure rather than throwing when the mapper rejects a transaction', async () => {
+			const result = await saveFinalizedTransactions({
+				identity: mockIdentity,
+				tokenId: mockUserTransactionTokenId,
+				transactions: makeTransactions(3),
+				isFinalizedFn: () => true,
+				canSave: () => true,
+				mapToBackend: () => {
+					throw new Error('Cannot store a transaction without a hash');
+				}
+			});
+
+			expect(result).toEqual({ success: false });
+			expect(backendApi.saveUserTransactions).not.toHaveBeenCalled();
+			expect(consoleError).toHaveBeenCalled();
 		});
 
 		// The canister validates a batch as a unit and refuses all of it on the first transaction that
@@ -197,6 +228,9 @@ describe('user-transactions.services', () => {
 
 			expect(result).toEqual({ success: false });
 			expect(backendApi.saveUserTransactions).toHaveBeenCalledTimes(3);
+
+			// A save that fails without a trace is what let the over-sized batch go unnoticed.
+			expect(consoleError).toHaveBeenCalledOnce();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/user-transactions.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-transactions.services.spec.ts
@@ -1,5 +1,6 @@
 import * as backendApi from '$lib/api/backend.api';
 import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+import { MAX_SAVE_USER_TRANSACTIONS_BATCH } from '$lib/constants/user-transactions.constants';
 import {
 	loadUserTransactions,
 	saveFinalizedTransactions
@@ -124,6 +125,75 @@ describe('user-transactions.services', () => {
 			});
 
 			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('saveFinalizedTransactions batching', () => {
+		const makeTransactions = (count: number): Transaction[] =>
+			Array.from({ length: count }, (_, index) => ({
+				...mockEthTransaction,
+				hash: `0x${index}`
+			}));
+
+		const save = (transactions: Transaction[]) =>
+			saveFinalizedTransactions({
+				identity: mockIdentity,
+				tokenId: mockUserTransactionTokenId,
+				transactions,
+				isFinalizedFn: () => true,
+				canSave: () => true,
+				mapToBackend: mockMapToBackendUserTransaction
+			});
+
+		beforeEach(() => {
+			vi.spyOn(backendApi, 'saveUserTransactions').mockResolvedValue(undefined);
+		});
+
+		it('should send a single call when the batch fits', async () => {
+			const result = await save(makeTransactions(MAX_SAVE_USER_TRANSACTIONS_BATCH));
+
+			expect(result).toEqual({ success: true });
+			expect(backendApi.saveUserTransactions).toHaveBeenCalledOnce();
+		});
+
+		// The canister rejects an over-sized batch outright, so one call for a long history saved
+		// nothing at all. A cold start is exactly when the history is long enough to trip that.
+		it('should split a history longer than the cap across calls', async () => {
+			const result = await save(makeTransactions(MAX_SAVE_USER_TRANSACTIONS_BATCH * 2 + 1));
+
+			expect(result).toEqual({ success: true });
+			expect(backendApi.saveUserTransactions).toHaveBeenCalledTimes(3);
+		});
+
+		it('should never exceed the cap in any single call', async () => {
+			await save(makeTransactions(MAX_SAVE_USER_TRANSACTIONS_BATCH * 2 + 7));
+
+			vi.mocked(backendApi.saveUserTransactions).mock.calls.forEach(([{ transactions }]) => {
+				expect(transactions.length).toBeLessThanOrEqual(MAX_SAVE_USER_TRANSACTIONS_BATCH);
+			});
+		});
+
+		it('should persist every transaction across the batches, in order', async () => {
+			const transactions = makeTransactions(MAX_SAVE_USER_TRANSACTIONS_BATCH + 3);
+
+			await save(transactions);
+
+			const sent = vi
+				.mocked(backendApi.saveUserTransactions)
+				.mock.calls.flatMap(([{ transactions: batch }]) => batch);
+
+			expect(sent).toHaveLength(transactions.length);
+		});
+
+		it('should stop and report failure when a batch is rejected', async () => {
+			vi.spyOn(backendApi, 'saveUserTransactions')
+				.mockResolvedValueOnce(undefined)
+				.mockRejectedValueOnce(new Error('TooManyTransactions'));
+
+			const result = await save(makeTransactions(MAX_SAVE_USER_TRANSACTIONS_BATCH * 3));
+
+			expect(result).toEqual({ success: false });
+			expect(backendApi.saveUserTransactions).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/user-transactions.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/user-transactions.services.spec.ts
@@ -185,15 +185,18 @@ describe('user-transactions.services', () => {
 			expect(sent).toHaveLength(transactions.length);
 		});
 
-		it('should stop and report failure when a batch is rejected', async () => {
+		// The canister validates a batch as a unit and refuses all of it on the first transaction that
+		// breaches a field bound, so one unusual transaction must not cost every later batch too.
+		it('should keep saving the later batches when one is rejected', async () => {
 			vi.spyOn(backendApi, 'saveUserTransactions')
 				.mockResolvedValueOnce(undefined)
-				.mockRejectedValueOnce(new Error('TooManyTransactions'));
+				.mockRejectedValueOnce(new Error('InvalidTransaction'))
+				.mockResolvedValue(undefined);
 
 			const result = await save(makeTransactions(MAX_SAVE_USER_TRANSACTIONS_BATCH * 3));
 
 			expect(result).toEqual({ success: false });
-			expect(backendApi.saveUserTransactions).toHaveBeenCalledTimes(2);
+			expect(backendApi.saveUserTransactions).toHaveBeenCalledTimes(3);
 		});
 	});
 

--- a/src/frontend/src/tests/utils/rust-constants.test-utils.spec.ts
+++ b/src/frontend/src/tests/utils/rust-constants.test-utils.spec.ts
@@ -1,0 +1,51 @@
+import { readRustNumericConstant } from '$tests/utils/rust-constants.test-utils';
+
+describe('readRustNumericConstant', () => {
+	const path = 'src/shared/src/types/user_transaction.rs';
+
+	it('should read a plain literal', () => {
+		expect(readRustNumericConstant({ path, name: 'MAX_SAVE_USER_TRANSACTIONS_BATCH' })).toBe(500);
+	});
+
+	it('should read a literal written with underscore separators', () => {
+		expect(readRustNumericConstant({ path, name: 'MAX_USER_TRANSACTIONS_PER_TOKEN' })).toBe(10_000);
+	});
+
+	// `MAX_USER_TRANSACTION_DATA_LEN` is declared as `16 * 1024`, so a literal-only reader would
+	// have missed it entirely.
+	it('should fold a product of literals', () => {
+		expect(readRustNumericConstant({ path, name: 'MAX_USER_TRANSACTION_DATA_LEN' })).toBe(16384);
+	});
+
+	it('should fold a long product without losing precision', () => {
+		expect(
+			readRustNumericConstant({
+				path: 'src/shared/src/types/personal_note_share.rs',
+				name: 'MAX_PERSONAL_NOTE_SHARE_EXPIRY_NS'
+			})
+		).toBe(30 * 24 * 60 * 60 * 1_000_000_000);
+	});
+
+	// Anything that is not integer literals joined by `*` and `+` has to fail loudly rather than be
+	// coerced into a number that silently differs from what the canister compiled.
+	it('should refuse a constant it cannot fold', () => {
+		expect(() =>
+			readRustNumericConstant({
+				path: 'src/shared/src/types/bitcoin.rs',
+				name: 'FEE_PERCENTILES_INITIAL_DELAY'
+			})
+		).toThrow(/cannot read/);
+	});
+
+	it('should throw for a constant that does not exist', () => {
+		expect(() => readRustNumericConstant({ path, name: 'MAX_NOT_A_REAL_CONSTANT' })).toThrow(
+			/not found/
+		);
+	});
+
+	it('should throw for a file that does not exist', () => {
+		expect(() =>
+			readRustNumericConstant({ path: 'src/shared/src/types/nope.rs', name: 'ANYTHING' })
+		).toThrow();
+	});
+});

--- a/src/frontend/src/tests/utils/rust-constants.test-utils.ts
+++ b/src/frontend/src/tests/utils/rust-constants.test-utils.ts
@@ -1,0 +1,74 @@
+import { isNullish, nonNullish } from '@dfinity/utils';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const sources = new Map<string, string>();
+
+const readSource = (path: string): string => {
+	const cached = sources.get(path);
+
+	if (nonNullish(cached)) {
+		return cached;
+	}
+
+	const source = readFileSync(join(process.cwd(), path), 'utf-8');
+
+	sources.set(path, source);
+
+	return source;
+};
+
+// Deliberately not `eval`: the expression is validated to hold nothing but integer literals, `+`
+// and `*` before it is folded, so a constant defined in terms of anything else fails loudly
+// instead of running arbitrary source as code.
+const foldIntegerExpression = (expression: string): number =>
+	expression
+		.split('+')
+		.reduce(
+			(sum, term) =>
+				sum +
+				term
+					.split('*')
+					.reduce((product, factor) => product * Number(factor.trim().replaceAll('_', '')), 1),
+			0
+		);
+
+/**
+ * Reads a numeric `pub const` straight out of a Rust source file.
+ *
+ * Frontend constants that mirror a canister limit have no runtime safety net when they drift: the
+ * canister refuses the call rather than clamping to its own value, so a parity test has to read the
+ * real number rather than restate it. Restating it is the bug.
+ *
+ * Handles plain literals (`500`, `10_000`) and products or sums of them (`16 * 1024`). A constant
+ * defined by anything else, or one whose value exceeds the safe integer range, throws rather than
+ * returning something subtly wrong.
+ *
+ * @param path - Repo-relative path to the Rust file, e.g. `src/shared/src/types/user_transaction.rs`.
+ * @param name - The constant's name, e.g. `MAX_SAVE_USER_TRANSACTIONS_BATCH`.
+ */
+export const readRustNumericConstant = ({ path, name }: { path: string; name: string }): number => {
+	const match = readSource(path).match(new RegExp(`pub const ${name}:\\s*\\w+\\s*=\\s*([^;]+);`));
+
+	if (isNullish(match)) {
+		throw new Error(`Rust constant \`${name}\` not found in ${path}`);
+	}
+
+	const expression = match[1].trim();
+
+	if (!/^[0-9_*+\s]+$/.test(expression)) {
+		throw new Error(
+			`Rust constant \`${name}\` is \`${expression}\`, which this helper cannot read: it handles integer literals joined by \`*\` and \`+\` only.`
+		);
+	}
+
+	const value = foldIntegerExpression(expression);
+
+	if (!Number.isSafeInteger(value)) {
+		throw new Error(
+			`Rust constant \`${name}\` is ${expression}, which exceeds the safe integer range. Compare it as a bigint instead.`
+		);
+	}
+
+	return value;
+};


### PR DESCRIPTION
# Motivation

`save_user_transactions` rejects a batch larger than `MAX_SAVE_USER_TRANSACTIONS_BATCH` (500) outright with `TooManyTransactions`, rather than truncating it. `saveFinalizedTransactions` sent the whole list in one call and swallowed the error into `{ success: false }`, which nothing logs.

A cold start fetches the full history from Etherscan (`startblock: 0`, no limit). So any token with more than 500 finalized transfers persisted nothing at all: the cache never populated, every load refetched the entire history, and there was no signal anywhere that it was failing. For ERC-20 that also means re-running the address-poisoning filter with its per-transfer RPC calls forever, which is the exact cost the cache exists to remove.

Solana is unaffected because it fetches in pages of 10. ETH-native and ERC-20 are both affected.

# Changes

- Saves go out in batches of at most 500, sequentially. Sequential rather than concurrent because each call is an update and the canister merges into one entry per (user, token), so parallelising buys nothing and multiplies the load.
- A rejected batch is now logged via `consoleError` instead of discarded. It still does not surface to the user: the cache is a warm-up and the transactions are already on screen.
- New `user-transactions.constants.ts` mirroring the two canister limits from `src/shared/src/types/user_transaction.rs`, which the frontend previously did not encode at all.

# Tests

Five cases in `user-transactions.services.spec.ts`: a history at exactly the cap stays one call, a longer one splits, no single call exceeds the cap, every transaction survives the split, and a rejected batch stops the loop and reports failure.

`npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` and `npm run check:tests` are clean.