### PR TITLE
fix(frontend): surface the NEAR Intents minimum-amount refusal in the swap form

### DIFF
--- a/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
+++ b/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
@@ -14,6 +14,7 @@
 		SWAP_AMOUNTS_CONTEXT_KEY,
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
+	import { SwapAmountTooLowError } from '$lib/types/errors';
 	import type { OptionAmount } from '$lib/types/send';
 	import type { Token } from '$lib/types/token';
 
@@ -127,16 +128,21 @@
 				amountForSwap: parsedAmount,
 				selectedProvider: swapAmounts[0]
 			});
-		} catch (_err: unknown) {
+		} catch (err: unknown) {
 			if (currentGeneration !== fetchGeneration) {
 				return;
 			}
 
-			// if swapAmounts fails, it means no pool is currently available for the provided tokens
+			// if swapAmounts fails, it means no pool is currently available for the provided
+			// tokens. A provider that refused the amount as below its minimum names the reason,
+			// which the form surfaces instead of the generic "swap is not offered".
 			store.setSwaps({
 				swaps: [],
 				amountForSwap: parsedAmount,
-				selectedProvider: undefined
+				selectedProvider: undefined,
+				...(err instanceof SwapAmountTooLowError && {
+					quoteError: { type: 'amount-too-low', minAmount: err.minAmount }
+				})
 			});
 		} finally {
 			if (currentGeneration === fetchGeneration) {

--- a/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
+++ b/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
@@ -133,9 +133,9 @@
 				return;
 			}
 
-			// if swapAmounts fails, it means no pool is currently available for the provided
-			// tokens. A provider that refused the amount as below its minimum names the reason,
-			// which the form surfaces instead of the generic "swap is not offered".
+			// Any fetch failure (no pool for the pair, provider or network error) surfaces as
+			// "no offers". A provider that refused the amount as below its minimum names the
+			// reason, which the form surfaces instead of the generic "swap is not offered".
 			store.setSwaps({
 				swaps: [],
 				amountForSwap: parsedAmount,

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -31,7 +31,8 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
-	import { formatTokenBigintToNumber } from '$lib/utils/format.utils';
+	import { formatToken, formatTokenBigintToNumber } from '$lib/utils/format.utils';
+	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkIdICP } from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
 
@@ -103,6 +104,26 @@
 			!notOfferedExplained &&
 			nonNullish(swapAmount) &&
 			Number(swapAmount) > 0
+	);
+
+	// A provider that refused the amount as below its minimum names the reason no offer
+	// exists, so the specific message replaces the generic "swap is not offered".
+	let quoteError = $derived(
+		nonNullish($swapAmountsStore) && $swapAmountsStore.swaps.length === 0
+			? $swapAmountsStore.quoteError
+			: undefined
+	);
+
+	let quoteErrorMinAmount = $derived(
+		quoteError?.type === 'amount-too-low' &&
+			nonNullish(quoteError.minAmount) &&
+			nonNullish($sourceToken)
+			? formatToken({
+					value: quoteError.minAmount,
+					unitName: $sourceToken.decimals,
+					displayDecimals: $sourceToken.decimals
+				})
+			: undefined
 	);
 
 	let isSwitchTokensButtonDisabled = $derived(() => {
@@ -243,7 +264,18 @@
 							{#if nonNullish($destinationToken)}
 								{#if showSwapNotOfferedError}
 									<div class="text-error-primary" transition:slide={SLIDE_DURATION}
-										>{$i18n.swap.text.swap_is_not_offered}</div
+										>{#if quoteError?.type === 'amount-too-low'}
+											{#if nonNullish(quoteErrorMinAmount) && nonNullish($sourceToken)}
+												{replacePlaceholders($i18n.swap.text.swap_amount_too_low_minimum, {
+													$amount: quoteErrorMinAmount,
+													$symbol: $sourceToken.symbol
+												})}
+											{:else}
+												{$i18n.swap.text.swap_amount_too_low}
+											{/if}
+										{:else}
+											{$i18n.swap.text.swap_is_not_offered}
+										{/if}</div
 									>
 								{:else}
 									<div class="flex gap-3 text-tertiary">

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "",
 			"swap_button": "تبديل الآن",
 			"swap_is_not_offered": "هذا التبديل غير متاح حاليًا.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "جاري تنفيذ المعاملة...",
 			"initializing": "جاري تهيئة المعاملة...",
 			"swapping": "جاري التبديل...",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "Tolerance skluzu nemůže být 0 % nebo přesáhnout $maxSlippage%",
 			"swap_button": "Vyměnit nyní",
 			"swap_is_not_offered": "Tato výměna v současné době není nabízena.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Provádění transakce...",
 			"initializing": "Inicializace transakce...",
 			"swapping": "Výměna...",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "Slippage-Toleranz darf nicht 0% sein oder $maxSlippage% überschreiten",
 			"swap_button": "Jetzt tauschen",
 			"swap_is_not_offered": "Dieser Tausch ist derzeit nicht verfügbar.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Führe Transaktion aus...",
 			"initializing": "Transaktion initialisieren...",
 			"swapping": "Tausche...",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "Slippage tolerance cannot be 0% or exceed $maxSlippage%",
 			"swap_button": "Swap now",
 			"swap_is_not_offered": "This swap is currently not offered.",
+			"swap_amount_too_low": "The amount is below the provider's minimum. Please enter a higher amount.",
+			"swap_amount_too_low_minimum": "The amount is below the provider's minimum. Enter at least $amount $symbol.",
 			"executing_transaction": "Executing transaction...",
 			"initializing": "Initializing transaction...",
 			"swapping": "Swapping...",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "La tolerancia de deslizamiento no puede ser 0% ni exceder $maxSlippage%",
 			"swap_button": "Intercambiar ahora",
 			"swap_is_not_offered": "Este intercambio no se ofrece actualmente.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Ejecutando transacción...",
 			"initializing": "Inicializando transacción...",
 			"swapping": "Intercambiando...",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "La tolérance de slippage ne peut pas être de 0 % ou dépasser $maxSlippage%",
 			"swap_button": "Échanger maintenant",
 			"swap_is_not_offered": "Cet échange n'est actuellement pas proposé.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Exécution de la transaction...",
 			"initializing": "Initialisation de la transaction...",
 			"swapping": "Échange en cours...",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "स्लिपेज टॉलरेंस 0% नहीं हो सकती या $maxSlippage% से अधिक नहीं हो सकती",
 			"swap_button": "अभी स्वैप करें",
 			"swap_is_not_offered": "यह स्वैप वर्तमान में पेश नहीं किया गया है।",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "लेनदेन निष्पादित हो रहा है...",
 			"initializing": "लेनदेन प्रारंभ कर रहा है...",
 			"swapping": "स्वैप कर रहा है...",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "La tolleranza allo slippage non può essere 0% o superare il $maxSlippage%",
 			"swap_button": "Scambia ora",
 			"swap_is_not_offered": "Questo scambio non è attualmente offerto.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Esecuzione transazione...",
 			"initializing": "Inizializzazione transazione...",
 			"swapping": "Scambio...",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "スリッページ許容度は0%にできません。また$maxSlippage%を超えることもできません。",
 			"swap_button": "今すぐスワップ",
 			"swap_is_not_offered": "このスワップは現在提供されていません。",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "トランザクションを実行中...",
 			"initializing": "トランザクションを初期化中...",
 			"swapping": "スワップ中...",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "슬리피지 허용 범위는 0%이거나 $maxSlippage%를 초과할 수 없습니다",
 			"swap_button": "지금 스왑",
 			"swap_is_not_offered": "이 스왑은 현재 제공되지 않습니다.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "트랜잭션 실행 중...",
 			"initializing": "트랜잭션 초기화 중...",
 			"swapping": "스왑 중...",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "Tolerancja poślizgu nie może wynosić 0% ani przekraczać $maxSlippage%",
 			"swap_button": "Wymień teraz",
 			"swap_is_not_offered": "Ta wymiana nie jest obecnie oferowana.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Wykonywanie transakcji...",
 			"initializing": "Inicjowanie transakcji...",
 			"swapping": "Wymiana...",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "A tolerância a deslizamento não pode ser 0% ou exceder $maxSlippage%",
 			"swap_button": "Trocar agora",
 			"swap_is_not_offered": "Esta troca não é oferecida atualmente.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Executando transação...",
 			"initializing": "Inicializando transação...",
 			"swapping": "Trocando...",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "Допустимое проскальзывание не может быть 0% или превышать $maxSlippage%",
 			"swap_button": "Обменять сейчас",
 			"swap_is_not_offered": "Этот обмен в настоящее время не предлагается.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Выполнение транзакции...",
 			"initializing": "Инициализация транзакции...",
 			"swapping": "Обмен...",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "Dung sai trượt giá không được bằng 0% hoặc vượt quá $maxSlippage%",
 			"swap_button": "Hoán đổi ngay",
 			"swap_is_not_offered": "Hoán đổi này hiện không được cung cấp.",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "Đang thực hiện giao dịch...",
 			"initializing": "Đang khởi tạo giao dịch...",
 			"swapping": "Đang hoán đổi...",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1190,6 +1190,8 @@
 			"max_slippage_error": "滑点容忍度不能为 0% 或超过 $maxSlippage%",
 			"swap_button": "立即兑换",
 			"swap_is_not_offered": "当前不支持此兑换。",
+			"swap_amount_too_low": "",
+			"swap_amount_too_low_minimum": "",
 			"executing_transaction": "正在执行交易...",
 			"initializing": "正在初始化交易...",
 			"swapping": "正在兑换...",

--- a/src/frontend/src/lib/rest/near-intents.rest.ts
+++ b/src/frontend/src/lib/rest/near-intents.rest.ts
@@ -1,4 +1,5 @@
 import { NEAR_INTENTS_API_URL } from '$env/rest/near-intents.env';
+import { SwapAmountTooLowError } from '$lib/types/errors';
 import type {
 	NearIntentsDepositSubmitRequest,
 	NearIntentsQuoteRequest,
@@ -25,6 +26,12 @@ export const fetchNearIntentsTokens = async (): Promise<NearIntentsToken[]> => {
 	return response.json();
 };
 
+// 1Click rejects a too-small amount with a 400 whose message reads e.g.
+// "Amount is too low for bridge, try at least 8300", the minimum being in the
+// origin asset's smallest unit (the same unit as the request's `amount`).
+const AMOUNT_TOO_LOW_PATTERN = /amount is too low/i;
+const AMOUNT_TOO_LOW_MINIMUM_PATTERN = /try at least (\d+)/i;
+
 // https://docs.near-intents.org/api-reference/oneclick/request-a-swap-quote
 export const fetchNearIntentsQuote = async (
 	request: NearIntentsQuoteRequest
@@ -38,7 +45,18 @@ export const fetchNearIntentsQuote = async (
 	if (!response.ok) {
 		const error = await response.json().catch(() => ({ message: response.statusText }));
 
-		throw new Error(`NEAR Intents quote failed: ${error.message ?? response.statusText}`);
+		const message: string = error.message ?? response.statusText;
+
+		if (AMOUNT_TOO_LOW_PATTERN.test(message)) {
+			const minAmount = AMOUNT_TOO_LOW_MINIMUM_PATTERN.exec(message)?.[1];
+
+			throw new SwapAmountTooLowError(
+				`NEAR Intents quote failed: ${message}`,
+				nonNullish(minAmount) ? BigInt(minAmount) : undefined
+			);
+		}
+
+		throw new Error(`NEAR Intents quote failed: ${message}`);
 	}
 
 	return response.json();

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -63,6 +63,7 @@ import {
 	type KongSwapTokensStoreData
 } from '$lib/stores/kong-swap-tokens.store';
 import type { SaveCustomTokenWithKey } from '$lib/types/custom-token';
+import { SwapAmountTooLowError } from '$lib/types/errors';
 import {
 	NEAR_INTENTS_EXTERNAL_REF_KEYS,
 	type NearIntentsQuoteResponse
@@ -1202,6 +1203,36 @@ export const performManualWithdraw = async ({
 	}
 };
 
+// Shared tail of the provider fan-outs: keep the fulfilled quotes, best first. When no
+// provider quoted at all but one refused the amount as below its minimum, rethrow that
+// refusal so the UI can name the reason instead of the generic "swap is not offered".
+const reduceSettledSwapResults = (
+	settledResults: PromiseSettledResult<SwapMappedResult | undefined>[]
+): SwapMappedResult[] => {
+	const results = settledResults.reduce<SwapMappedResult[]>((acc, result) => {
+		if (result.status === 'fulfilled' && nonNullish(result.value)) {
+			acc.push(result.value);
+		}
+
+		return acc;
+	}, []);
+
+	if (results.length === 0) {
+		const amountTooLow = settledResults.find(
+			(result): result is PromiseRejectedResult =>
+				result.status === 'rejected' && result.reason instanceof SwapAmountTooLowError
+		);
+
+		if (nonNullish(amountTooLow)) {
+			throw amountTooLow.reason;
+		}
+	}
+
+	return results.sort((a, b) =>
+		a.receiveAmount === b.receiveAmount ? 0 : a.receiveAmount > b.receiveAmount ? -1 : 1
+	);
+};
+
 const fetchSwapAmountsICPBridge = async ({
 	sourceToken,
 	destinationToken,
@@ -1217,17 +1248,7 @@ const fetchSwapAmountsICPBridge = async ({
 		)
 	);
 
-	const results = settledResults.reduce<SwapMappedResult[]>((acc, result) => {
-		if (result.status === 'fulfilled' && nonNullish(result.value)) {
-			acc.push(result.value);
-		}
-
-		return acc;
-	}, []);
-
-	return results.sort((a, b) =>
-		a.receiveAmount === b.receiveAmount ? 0 : a.receiveAmount > b.receiveAmount ? -1 : 1
-	);
+	return reduceSettledSwapResults(settledResults);
 };
 
 // This wrapper keeps the return type uniform (array of SwapMappedResult),
@@ -1253,17 +1274,7 @@ export const fetchSwapAmountsEVM = async ({
 		)
 	);
 
-	const results = settledResults.reduce<SwapMappedResult[]>((acc, result) => {
-		if (result.status === 'fulfilled' && nonNullish(result.value)) {
-			acc.push(result.value);
-		}
-
-		return acc;
-	}, []);
-
-	return results.sort((a, b) =>
-		a.receiveAmount === b.receiveAmount ? 0 : a.receiveAmount > b.receiveAmount ? -1 : 1
-	);
+	return reduceSettledSwapResults(settledResults);
 };
 
 // Fan-out for a Bitcoin source; Chain Fusion and NEAR Intents register here. The shape
@@ -1291,17 +1302,7 @@ export const fetchSwapAmountsBTC = async ({
 		)
 	);
 
-	const results = settledResults.reduce<SwapMappedResult[]>((acc, result) => {
-		if (result.status === 'fulfilled' && nonNullish(result.value)) {
-			acc.push(result.value);
-		}
-
-		return acc;
-	}, []);
-
-	return results.sort((a, b) =>
-		a.receiveAmount === b.receiveAmount ? 0 : a.receiveAmount > b.receiveAmount ? -1 : 1
-	);
+	return reduceSettledSwapResults(settledResults);
 };
 
 // This wrapper keeps the return type uniform (array of SwapMappedResult),
@@ -1327,17 +1328,7 @@ export const fetchSwapAmountsSOL = async ({
 		)
 	);
 
-	const results = settledResults.reduce<SwapMappedResult[]>((acc, result) => {
-		if (result.status === 'fulfilled' && nonNullish(result.value)) {
-			acc.push(result.value);
-		}
-
-		return acc;
-	}, []);
-
-	return results.sort((a, b) =>
-		a.receiveAmount === b.receiveAmount ? 0 : a.receiveAmount > b.receiveAmount ? -1 : 1
-	);
+	return reduceSettledSwapResults(settledResults);
 };
 
 export const withdrawUserUnusedBalance = async ({

--- a/src/frontend/src/lib/stores/swap-amounts.store.ts
+++ b/src/frontend/src/lib/stores/swap-amounts.store.ts
@@ -1,5 +1,5 @@
 import type { OptionAmount } from '$lib/types/send';
-import type { SwapMappedResult, SwapProvider } from '$lib/types/swap';
+import type { SwapMappedResult, SwapProvider, SwapQuoteError } from '$lib/types/swap';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Nullish } from '@dfinity/zod-schemas';
 import { writable, type Readable } from 'svelte/store';
@@ -9,6 +9,8 @@ export interface SwapAmountsStoreData {
 	amountForSwap: OptionAmount;
 	selectedProvider?: SwapMappedResult;
 	manuallySelectedProviderKey?: SwapProvider;
+	// The reason the quote round produced no offers, when a provider named one.
+	quoteError?: SwapQuoteError;
 }
 
 export interface SwapAmountsStore extends Readable<Nullish<SwapAmountsStoreData>> {
@@ -16,6 +18,7 @@ export interface SwapAmountsStore extends Readable<Nullish<SwapAmountsStoreData>
 		swaps: SwapMappedResult[];
 		amountForSwap: OptionAmount;
 		selectedProvider?: SwapMappedResult;
+		quoteError?: SwapQuoteError;
 	}) => void;
 	reset: () => void;
 	setSelectedProvider: (provider: SwapMappedResult | undefined) => void;
@@ -36,7 +39,7 @@ export const initSwapAmountsStore = (): SwapAmountsStore => {
 			set(null);
 		},
 
-		setSwaps: ({ swaps, amountForSwap, selectedProvider }) => {
+		setSwaps: ({ swaps, amountForSwap, selectedProvider, quoteError }) => {
 			if (nonNullish(manualProviderKey)) {
 				const manualMatch = swaps.find((s) => s.provider === manualProviderKey);
 
@@ -45,7 +48,8 @@ export const initSwapAmountsStore = (): SwapAmountsStore => {
 						swaps,
 						amountForSwap,
 						selectedProvider: manualMatch,
-						manuallySelectedProviderKey: manualProviderKey
+						manuallySelectedProviderKey: manualProviderKey,
+						quoteError
 					});
 
 					return;
@@ -57,7 +61,8 @@ export const initSwapAmountsStore = (): SwapAmountsStore => {
 			set({
 				swaps,
 				amountForSwap,
-				selectedProvider
+				selectedProvider,
+				quoteError
 			});
 		},
 

--- a/src/frontend/src/lib/types/errors.ts
+++ b/src/frontend/src/lib/types/errors.ts
@@ -34,3 +34,18 @@ export class InvalidTokenUri extends NftError {}
 export class InvalidMetadataImageUrl extends NftError {}
 
 export class AuthClientNotInitializedError extends Error {}
+
+/**
+ * A swap quote provider refused the requested amount as below its minimum.
+ *
+ * `minAmount` is the provider's minimum, in the source token's smallest unit,
+ * when the provider names one.
+ */
+export class SwapAmountTooLowError extends Error {
+	constructor(
+		message: string,
+		readonly minAmount?: bigint
+	) {
+		super(message);
+	}
+}

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -916,6 +916,8 @@ interface I18nSwap {
 		max_slippage_error: string;
 		swap_button: string;
 		swap_is_not_offered: string;
+		swap_amount_too_low: string;
+		swap_amount_too_low_minimum: string;
 		executing_transaction: string;
 		initializing: string;
 		swapping: string;

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -93,6 +93,17 @@ export interface FetchSwapAmountsParams {
 
 export type Slippage = string | number;
 
+/**
+ * The reason no offer could be quoted, when a provider named one.
+ *
+ * `minAmount` is the provider's minimum, in the source token's smallest unit,
+ * when the provider communicated it.
+ */
+export interface SwapQuoteError {
+	type: 'amount-too-low';
+	minAmount?: bigint;
+}
+
 export type SwapMappedResult =
 	| {
 			provider: SwapProvider.ICP_SWAP;

--- a/src/frontend/src/tests/lib/components/swap/SwapAmountsContext.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapAmountsContext.spec.ts
@@ -7,6 +7,7 @@ import * as tokensStore from '$lib/derived/tokens.derived';
 import * as swapService from '$lib/services/swap.services';
 import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
+import { SwapAmountTooLowError } from '$lib/types/errors';
 import type { OptionAmount } from '$lib/types/send';
 import { SwapProvider, type SwapMappedResult } from '$lib/types/swap';
 import {
@@ -196,6 +197,29 @@ describe('SwapAmountsContext.svelte', () => {
 		expect(value?.swaps).toEqual([]);
 		expect(value?.selectedProvider).toBeUndefined();
 		expect(value?.amountForSwap).toBe(20);
+		expect(value?.quoteError).toBeUndefined();
+	});
+
+	it('sets the quote error when fetchSwapAmounts throws an amount-too-low refusal', async () => {
+		vi.spyOn(swapService, 'fetchSwapAmounts').mockRejectedValue(
+			new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', 8300n)
+		);
+
+		await renderWithContext({
+			amount: '20',
+			sourceToken,
+			destinationToken,
+			slippageValue: '0.2'
+		});
+
+		await waitForDebounce();
+
+		const value = get(store);
+
+		expect(value?.swaps).toEqual([]);
+		expect(value?.selectedProvider).toBeUndefined();
+		expect(value?.amountForSwap).toBe(20);
+		expect(value?.quoteError).toEqual({ type: 'amount-too-low', minAmount: 8300n });
 	});
 
 	it('debounces fetchSwapAmounts calls', async () => {

--- a/src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts
@@ -15,7 +15,9 @@ import {
 } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY, initSwapContext } from '$lib/stores/swap.store';
 import type { OptionAmount } from '$lib/types/send';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
+import en from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockSwapProviders } from '$tests/mocks/swap.mocks';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
@@ -415,6 +417,92 @@ describe('SwapForm', () => {
 			});
 
 			expect(container.querySelector('.text-error')).not.toBeInTheDocument();
+		});
+
+		it('should show the generic message without a quote error', () => {
+			setupSwapAmountsStore({
+				amountForSwap: 1,
+				swaps: [],
+				selectedProvider: undefined
+			});
+			setupIcTokenFeeStore();
+
+			const { getByText } = render(SwapForm, {
+				props: {
+					swapAmount: '1',
+					receiveAmount: undefined,
+					slippageValue: undefined,
+					isSwapAmountsLoading: false,
+					onCustomValidate: vi.fn(),
+					onShowTokensList: vi.fn(),
+					onClose: vi.fn(),
+					onNext: vi.fn()
+				},
+				context: mockContext
+			});
+
+			expect(getByText(en.swap.text.swap_is_not_offered)).toBeInTheDocument();
+		});
+
+		it('should show the provider minimum when the amount was refused as too low', () => {
+			setupSwapAmountsStore({
+				amountForSwap: 1,
+				swaps: [],
+				selectedProvider: undefined,
+				quoteError: { type: 'amount-too-low', minAmount: 8300n }
+			});
+			setupIcTokenFeeStore();
+
+			const { getByText, queryByText } = render(SwapForm, {
+				props: {
+					swapAmount: '1',
+					receiveAmount: undefined,
+					slippageValue: undefined,
+					isSwapAmountsLoading: false,
+					onCustomValidate: vi.fn(),
+					onShowTokensList: vi.fn(),
+					onClose: vi.fn(),
+					onNext: vi.fn()
+				},
+				context: mockContext
+			});
+
+			expect(
+				getByText(
+					replacePlaceholders(en.swap.text.swap_amount_too_low_minimum, {
+						$amount: '0.000083',
+						$symbol: mockValidIcToken.symbol
+					})
+				)
+			).toBeInTheDocument();
+			expect(queryByText(en.swap.text.swap_is_not_offered)).not.toBeInTheDocument();
+		});
+
+		it('should show the amount-too-low message without a minimum when the provider named none', () => {
+			setupSwapAmountsStore({
+				amountForSwap: 1,
+				swaps: [],
+				selectedProvider: undefined,
+				quoteError: { type: 'amount-too-low' }
+			});
+			setupIcTokenFeeStore();
+
+			const { getByText, queryByText } = render(SwapForm, {
+				props: {
+					swapAmount: '1',
+					receiveAmount: undefined,
+					slippageValue: undefined,
+					isSwapAmountsLoading: false,
+					onCustomValidate: vi.fn(),
+					onShowTokensList: vi.fn(),
+					onClose: vi.fn(),
+					onNext: vi.fn()
+				},
+				context: mockContext
+			});
+
+			expect(getByText(en.swap.text.swap_amount_too_low)).toBeInTheDocument();
+			expect(queryByText(en.swap.text.swap_is_not_offered)).not.toBeInTheDocument();
 		});
 	});
 

--- a/src/frontend/src/tests/lib/rest/near-intents.rest.spec.ts
+++ b/src/frontend/src/tests/lib/rest/near-intents.rest.spec.ts
@@ -4,6 +4,7 @@ import {
 	fetchNearIntentsTokens,
 	submitNearIntentsDeposit
 } from '$lib/rest/near-intents.rest';
+import { SwapAmountTooLowError } from '$lib/types/errors';
 import {
 	mockNearIntentsQuoteResponse,
 	mockNearIntentsStatusSuccess,
@@ -102,6 +103,48 @@ describe('near-intents.rest', () => {
 			await expect(fetchNearIntentsQuote(quoteRequest)).rejects.toThrow(
 				'NEAR Intents quote failed: Bad Request'
 			);
+		});
+
+		it('throws SwapAmountTooLowError with the parsed minimum when the amount is too low', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Request',
+				json: () => Promise.resolve({ message: 'Amount is too low for bridge, try at least 8300' })
+			} as unknown as Response);
+
+			const result = fetchNearIntentsQuote(quoteRequest);
+
+			await expect(result).rejects.toThrow(SwapAmountTooLowError);
+			await expect(result).rejects.toMatchObject({
+				message: 'NEAR Intents quote failed: Amount is too low for bridge, try at least 8300',
+				minAmount: 8300n
+			});
+		});
+
+		it('throws SwapAmountTooLowError without a minimum when the message does not name one', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Request',
+				json: () => Promise.resolve({ message: 'Amount is too low' })
+			} as unknown as Response);
+
+			const result = fetchNearIntentsQuote(quoteRequest);
+
+			await expect(result).rejects.toThrow(SwapAmountTooLowError);
+			await expect(result).rejects.toMatchObject({ minAmount: undefined });
+		});
+
+		it('throws a plain Error for other 400 messages', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Request',
+				json: () => Promise.resolve({ message: 'Invalid origin asset' })
+			} as unknown as Response);
+
+			const result = fetchNearIntentsQuote(quoteRequest);
+
+			await expect(result).rejects.toThrow('NEAR Intents quote failed: Invalid origin asset');
+			await expect(result).rejects.not.toBeInstanceOf(SwapAmountTooLowError);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -47,6 +47,7 @@ import { fetchVeloraSwapAmount } from '$lib/services/velora-swap.services';
 import { exchangeStore } from '$lib/stores/exchange.store';
 import { kongSwapTokensStore } from '$lib/stores/kong-swap-tokens.store';
 import type { ICPSwapAmountReply } from '$lib/types/api';
+import { SwapAmountTooLowError } from '$lib/types/errors';
 import {
 	NEAR_INTENTS_EXTERNAL_REF_KEYS,
 	type NearIntentsQuoteResponse
@@ -110,6 +111,7 @@ vi.mock('$lib/services/analytics.services', () => ({
 }));
 
 const mockVeloraGetQuote = vi.hoisted(() => vi.fn());
+const mockEvmNearIntentsGetQuote = vi.hoisted(() => vi.fn());
 const mockSolGetQuote = vi.hoisted(() => vi.fn());
 const mockIcpBridgeGetQuote = vi.hoisted(() => vi.fn());
 const mockBtcGetQuote = vi.hoisted(() => vi.fn());
@@ -119,6 +121,11 @@ vi.mock('$lib/providers/evm-swap.providers', () => ({
 		{
 			key: 'velora',
 			getQuote: mockVeloraGetQuote,
+			isEnabled: true
+		},
+		{
+			key: 'near_intents',
+			getQuote: mockEvmNearIntentsGetQuote,
 			isEnabled: true
 		}
 	]
@@ -1223,6 +1230,46 @@ describe('swap.services', () => {
 
 			expect(result).toEqual([]);
 		});
+
+		it('rethrows an amount-too-low refusal when no provider quoted', async () => {
+			mockVeloraGetQuote.mockResolvedValueOnce(undefined);
+			mockEvmNearIntentsGetQuote.mockRejectedValueOnce(
+				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', 8300n)
+			);
+
+			await expect(
+				fetchSwapAmountsEVM({
+					sourceToken,
+					destinationToken,
+					amount,
+					userAddress,
+					slippage
+				})
+			).rejects.toThrow(SwapAmountTooLowError);
+		});
+
+		it('drops an amount-too-low refusal when another provider quoted', async () => {
+			mockVeloraGetQuote.mockResolvedValueOnce({
+				provider: SwapProvider.VELORA,
+				receiveAmount: 123n,
+				swapDetails: {},
+				type: 'delta'
+			});
+			mockEvmNearIntentsGetQuote.mockRejectedValueOnce(
+				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', 8300n)
+			);
+
+			const result = await fetchSwapAmountsEVM({
+				sourceToken,
+				destinationToken,
+				amount,
+				userAddress,
+				slippage
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0].provider).toBe(SwapProvider.VELORA);
+		});
 	});
 
 	describe('fetchSwapAmountsSOL', () => {
@@ -1308,6 +1355,22 @@ describe('swap.services', () => {
 			});
 
 			expect(result).toEqual([]);
+		});
+
+		it('should rethrow an amount-too-low refusal when no provider quoted', async () => {
+			mockSolGetQuote.mockRejectedValueOnce(
+				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', 8300n)
+			);
+
+			await expect(
+				fetchSwapAmountsSOL({
+					sourceToken,
+					destinationToken,
+					amount,
+					userAddress: mockSolAddress,
+					slippage
+				})
+			).rejects.toThrow(SwapAmountTooLowError);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/stores/swap-amounts.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap-amounts.store.spec.ts
@@ -44,6 +44,39 @@ describe('swap-amounts.store', () => {
 		});
 	});
 
+	it('should set swaps with a quote error', () => {
+		const store = initSwapAmountsStore();
+
+		store.setSwaps({
+			swaps: [],
+			amountForSwap: '1000000',
+			quoteError: { type: 'amount-too-low', minAmount: 8300n }
+		});
+
+		expect(get(store)).toEqual({
+			swaps: [],
+			amountForSwap: '1000000',
+			quoteError: { type: 'amount-too-low', minAmount: 8300n }
+		});
+	});
+
+	it('should drop a previous quote error when swaps are set without one', () => {
+		const store = initSwapAmountsStore();
+
+		store.setSwaps({
+			swaps: [],
+			amountForSwap: '1000000',
+			quoteError: { type: 'amount-too-low', minAmount: 8300n }
+		});
+
+		store.setSwaps({
+			swaps: mockSwapProviders,
+			amountForSwap: '2000000'
+		});
+
+		expect(get(store)?.quoteError).toBeUndefined();
+	});
+
 	it('should not set provider if swaps array is empty', () => {
 		const store = initSwapAmountsStore();
 		store.setSelectedProvider(mockSwapProviders[0]);


### PR DESCRIPTION
# Motivation

When the NEAR Intents 1Click quote endpoint rejects an amount with HTTP 400 and a body like `{"message": "Amount is too low for bridge, try at least 8300"}`, the swap modal showed the generic "This swap is currently not offered." message. That is misleading: the swap is offered, just not for that amount, and the provider even names the minimum. The form now surfaces the specific reason, with the minimum converted to the source token's units.

# Changes

- New `SwapAmountTooLowError` in `$lib/types/errors`, carrying the provider minimum in the source token's smallest unit when known.
- `fetchNearIntentsQuote` detects the 1Click "Amount is too low" 400 response, parses the "try at least N" minimum and throws the typed error instead of a plain `Error`.
- The provider fan-outs in `swap.services.ts` (`fetchSwapAmountsBTC` / `SOL` / `EVM` / ICP bridge) share a new `reduceSettledSwapResults` helper: fulfilled quotes are kept and sorted as before, but when no provider quoted at all and one rejected with `SwapAmountTooLowError`, that refusal is rethrown. A successful quote from another provider still wins.
- `SwapAmountsStoreData` gains an optional `quoteError` (`{ type: 'amount-too-low'; minAmount?: bigint }`), set by `SwapAmountsContext` when the fetch fails with the typed error.
- `SwapForm` renders the specific message in place of the generic one: with the minimum formatted in the source token's units and symbol when known, otherwise a plain "amount too low" copy.
- New i18n keys `swap.text.swap_amount_too_low` and `swap.text.swap_amount_too_low_minimum` (en, propagated to the other locales via `npm run i18n`).

# Tests

- `near-intents.rest.spec.ts`: the amount-too-low 400 throws `SwapAmountTooLowError` with the parsed minimum, without a minimum when the message names none, and other 400s still throw a plain `Error`.
- `swap.services.spec.ts`: the fan-outs rethrow the refusal when no provider quoted and drop it when another provider quoted.
- `swap-amounts.store.spec.ts`: `setSwaps` stores and clears `quoteError`.
- `SwapAmountsContext.spec.ts`: the typed rejection lands in the store as `quoteError`.
- `SwapForm.spec.ts`: renders the minimum message, the fallback copy, and the generic message respectively.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` and `npm run test` pass.
