### PR TITLE
style(frontend): move the Solana simulation note up with the other notices

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -144,8 +144,6 @@
 		<MessageBox level="warning">{$i18n.wallet_connect.text.high_prioritization_fee}</MessageBox>
 	{/if}
 
-	<!-- Last of the notices: it qualifies how the review below was obtained rather than warning
-	     about anything the message does, and it only has something to say once a simulation ran. -->
 	{#if nonNullish(preview)}
 		<MessageBox level="plain">{$i18n.wallet_connect.text.simulation_note}</MessageBox>
 	{/if}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -144,6 +144,12 @@
 		<MessageBox level="warning">{$i18n.wallet_connect.text.high_prioritization_fee}</MessageBox>
 	{/if}
 
+	<!-- Last of the notices: it qualifies how the review below was obtained rather than warning
+	     about anything the message does, and it only has something to say once a simulation ran. -->
+	{#if nonNullish(preview)}
+		<MessageBox level="plain">{$i18n.wallet_connect.text.simulation_note}</MessageBox>
+	{/if}
+
 	<!-- The review names no recipient of its own: a single destination had to pick one winner out
 	     of a swap, and where the value ends up is what the simulated balance changes describe. An
 	     approval is the exception, since its delegate is not a recipient and keeps its own row. -->

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -122,5 +122,3 @@
 		{/each}
 	</div>
 </WalletConnectModalValue>
-
-<MessageBox level="plain">{$i18n.wallet_connect.text.simulation_note}</MessageBox>

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -296,6 +296,37 @@ describe('SolWalletConnectSignReview', () => {
 		});
 	});
 
+	describe('the simulation note', () => {
+		const preview = { solDelta: -5_000n, tokenDeltas: [], controlChanges: [] };
+
+		it('should state that the real execution can differ once a simulation ran', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: { ...props, preview }
+			});
+
+			expect(getByText(en.wallet_connect.text.simulation_note)).toBeInTheDocument();
+		});
+
+		it('should say nothing when no simulation was obtained', () => {
+			const { queryByText } = render(SolWalletConnectSignReview, { props });
+
+			expect(queryByText(en.wallet_connect.text.simulation_note)).not.toBeInTheDocument();
+		});
+
+		it('should render the note above the transaction data', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: { ...props, preview }
+			});
+
+			const note = getByText(en.wallet_connect.text.simulation_note);
+			const application = getByText(en.wallet_connect.text.application);
+
+			expect(note.compareDocumentPosition(application) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+		});
+	});
+
 	describe('when the decode produced no amount', () => {
 		const undecodedProps = { ...props, amount: undefined };
 

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
@@ -136,13 +136,4 @@ describe('SolWalletConnectSimulationPreview', () => {
 
 		expect(queryByText(en.wallet_connect.text.simulation_control_change)).not.toBeInTheDocument();
 	});
-
-	it('should always state that the real execution can differ', () => {
-		const { getByText } = render(
-			SolWalletConnectSimulationPreview,
-			props({ tokenDeltas: [], controlChanges: [] })
-		);
-
-		expect(getByText(en.wallet_connect.text.simulation_note)).toBeInTheDocument();
-	});
 });


### PR DESCRIPTION
# Motivation

The simulation note ("Simulated against the network's current state...") rendered at the end of `SolWalletConnectSimulationPreview`, which is to say wherever that component happened to stop. On screen that put it after the simulated balance changes, where it reads as a caption belonging to that one section.

It is not a caption for that section. It qualifies how the whole review was obtained, and it is an informational caveat rather than a warning about anything the message does, so it belongs with the other notices at the top and last among them.

# Changes

- Move the `simulation_note` message box out of `SolWalletConnectSimulationPreview` and into `SolWalletConnectSignReview`, below the unreviewed instructions warning and the two prioritization fee notices.
- Guard it on the presence of a simulation, which the preview component did implicitly by only ever rendering when there was one. A review with no simulation says nothing about simulation, as before.

The ranking among the notices is unchanged in spirit: what a message does to the user's funds outranks what it costs to send, and both outrank a note about how the figures were produced.

# Tests

- The case asserting the note moves from `SolWalletConnectSimulationPreview.spec.ts` to `SolWalletConnectSignReview.spec.ts`, since that is now the component that renders it.
- Two new cases alongside it: the note is absent when no simulation was obtained, and it renders above the transaction data.
- `npm run check` is clean at 0 errors and 0 warnings, lint passes with `--max-warnings 0`, and the WalletConnect Solana suite passes 57 tests.