### PR TITLE
style(frontend): move the Solana WalletConnect fees below the simulated changes

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -169,6 +169,13 @@
 			<SolWalletConnectTransferParties {parties} userAddress={source} />
 		{/if}
 
+		{#if nonNullish(preview)}
+			<SolWalletConnectSimulationPreview {feeToken} {preview} />
+		{/if}
+
+		<!-- What the transaction costs comes after what it does. The fees are the same on almost
+		     every request, so keeping them above the balance changes pushed the part that actually
+		     varies further from the approve button. -->
 		<WalletConnectModalValue label={$i18n.fee.text.network_fee} ref="network-fee">
 			{@render feeValue(SOLANA_TRANSACTION_FEE_IN_LAMPORTS)}
 		</WalletConnectModalValue>
@@ -177,10 +184,6 @@
 			<WalletConnectModalValue label={$i18n.fee.text.prioritization_fee} ref="prioritization-fee">
 				{@render feeValue(prioritizationFee)}
 			</WalletConnectModalValue>
-		{/if}
-
-		{#if nonNullish(preview)}
-			<SolWalletConnectSimulationPreview {feeToken} {preview} />
 		{/if}
 
 		<WalletConnectData {data} label={$i18n.wallet_connect.text.hex_data} />

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -173,9 +173,6 @@
 			<SolWalletConnectSimulationPreview {feeToken} {preview} />
 		{/if}
 
-		<!-- What the transaction costs comes after what it does. The fees are the same on almost
-		     every request, so keeping them above the balance changes pushed the part that actually
-		     varies further from the approve button. -->
 		<WalletConnectModalValue label={$i18n.fee.text.network_fee} ref="network-fee">
 			{@render feeValue(SOLANA_TRANSACTION_FEE_IN_LAMPORTS)}
 		</WalletConnectModalValue>

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -131,6 +131,37 @@ describe('SolWalletConnectSignReview', () => {
 		expect(queryByText(en.fee.text.prioritization_fee)).not.toBeInTheDocument();
 	});
 
+	describe('the placement of the fees', () => {
+		it('should render the fees below the simulated changes', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: {
+					...props,
+					preview: { solDelta: -5_000n, tokenDeltas: [], controlChanges: [] }
+				}
+			});
+
+			const changes = getByText(en.wallet_connect.text.simulated_changes);
+			const fee = getByText(en.fee.text.network_fee);
+
+			expect(changes.compareDocumentPosition(fee) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+		});
+
+		it('should render the fees above the hex data', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: { ...props, data: 'AQID', prioritizationFee: 238_217n }
+			});
+
+			const fee = getByText(en.fee.text.prioritization_fee);
+			const hex = getByText(en.wallet_connect.text.hex_data);
+
+			expect(fee.compareDocumentPosition(hex) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+		});
+	});
+
 	describe('comparing the requested fee against the baseline', () => {
 		it('should say nothing about a fee in line with the network', () => {
 			const { queryByText } = render(SolWalletConnectSignReview, {


### PR DESCRIPTION
# Motivation

In the Solana WalletConnect sign review the network fee and prioritization fee rows sat immediately after the transfer parties, above the simulated balance changes. The fees are near identical on almost every request, while the balance changes are the part that differs and the part worth reading before approving. Putting the constant part first pushed the variable part further from the approve button.

# Changes

- Move the network fee and prioritization fee rows below the simulated changes and above the HEX data.
- The resulting order is what the review already implies: what the transaction does, what it costs, then the raw bytes behind it.

No wording, threshold, condition or value changed. This is placement only. The two prioritization fee notices are unaffected: they live at the top of the review with the other notices and are not moved here.

# Tests

- Two new cases in `SolWalletConnectSignReview.spec.ts`: the fees render below the simulated changes, and above the HEX data.
- `npm run check` is clean at 0 errors and 0 warnings, lint passes with `--max-warnings 0`, and the WalletConnect Solana suite passes 57 tests.