### PR TITLE
fix(frontend): show active transactions time since their last status change

### DIFF
--- a/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
+++ b/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
@@ -15,6 +15,7 @@
 	import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
 	import { ONESEC_EXTERNAL_REF_KEYS } from '$lib/types/onesec-swap';
 	import { SwapProvider } from '$lib/types/swap';
+	import { activeUserTransactionTimestampNs } from '$lib/utils/active-user-transactions.utils';
 	import { isChainFusionActiveUserTransaction } from '$lib/utils/chain-fusion-swap-active-tx.utils';
 	import { formatNanosecondsToShortRelativeTime } from '$lib/utils/format.utils';
 	import {
@@ -123,9 +124,11 @@
 			: `${sourceNetwork} → ${destinationNetwork}`
 	);
 
-	const createdAgo = $derived(
+	// Time since the last status change, not since creation: a settled swap
+	// should read "1m ago" when it just turned green, however long it ran.
+	const timeAgo = $derived(
 		formatNanosecondsToShortRelativeTime({
-			nanoseconds: tx.created_at_ns,
+			nanoseconds: activeUserTransactionTimestampNs(tx),
 			language: $currentLanguage
 		})
 	);
@@ -193,7 +196,7 @@
 
 		{#snippet descriptionEnd()}
 			<div class="ml-2">
-				{createdAgo}
+				{timeAgo}
 			</div>
 		{/snippet}
 	</LogoButton>

--- a/src/frontend/src/lib/utils/active-user-transactions.utils.ts
+++ b/src/frontend/src/lib/utils/active-user-transactions.utils.ts
@@ -34,7 +34,8 @@ export const sortActiveUserTransactionsByTimestampDesc = (
 	transactions: ActiveUserTransaction[]
 ): ActiveUserTransaction[] =>
 	[...transactions].sort((a, b) => {
-		const [timestampA, timestampB] = [a, b].map(activeUserTransactionTimestampNs);
+		const timestampA = activeUserTransactionTimestampNs(a);
+		const timestampB = activeUserTransactionTimestampNs(b);
 
 		return timestampA < timestampB ? 1 : timestampA > timestampB ? -1 : 0;
 	});

--- a/src/frontend/src/lib/utils/active-user-transactions.utils.ts
+++ b/src/frontend/src/lib/utils/active-user-transactions.utils.ts
@@ -20,12 +20,24 @@ export const isTerminalActiveUserTransactionStatus = (
 export const isTerminalActiveUserTransaction = (tx: ActiveUserTransaction): boolean =>
 	isTerminalActiveUserTransactionStatus(tx.status);
 
-export const sortActiveUserTransactionsByCreatedAtDesc = (
+// The timestamp a row is presented (and ordered) by: the moment it reached its
+// last status, not the moment it was opened. A terminal row is never written
+// again (the pollers only touch pending rows, and every flow persists learned
+// refs *before* the terminal write), so `updated_at_ns` is exactly when it
+// succeeded or failed. A still-running row keeps `created_at_ns`: its
+// `updated_at_ns` also moves on ref / progress-step writes, which are not
+// status changes, and "started x ago" is what we want to show there anyway.
+export const activeUserTransactionTimestampNs = (tx: ActiveUserTransaction): bigint =>
+	isTerminalActiveUserTransaction(tx) ? tx.updated_at_ns : tx.created_at_ns;
+
+export const sortActiveUserTransactionsByTimestampDesc = (
 	transactions: ActiveUserTransaction[]
 ): ActiveUserTransaction[] =>
-	[...transactions].sort((a, b) =>
-		a.created_at_ns < b.created_at_ns ? 1 : a.created_at_ns > b.created_at_ns ? -1 : 0
-	);
+	[...transactions].sort((a, b) => {
+		const [timestampA, timestampB] = [a, b].map(activeUserTransactionTimestampNs);
+
+		return timestampA < timestampB ? 1 : timestampA > timestampB ? -1 : 0;
+	});
 
 export const activeUserTransactionsStateToList = (
 	state: ActiveUserTransactionsStoreData
@@ -34,7 +46,7 @@ export const activeUserTransactionsStateToList = (
 		return [];
 	}
 
-	return sortActiveUserTransactionsByCreatedAtDesc(Object.values(state.data));
+	return sortActiveUserTransactionsByTimestampDesc(Object.values(state.data));
 };
 
 export const isActiveUserTransactionUnseen = ({

--- a/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
@@ -1,5 +1,7 @@
 import ActiveUserTransactionItem from '$lib/components/active-user-transactions/ActiveUserTransactionItem.svelte';
+import { NANO_SECONDS_IN_MILLISECOND, NANO_SECONDS_IN_SECOND } from '$lib/constants/app.constants';
 import en from '$lib/i18n/en.json';
+import { formatNanosecondsToShortRelativeTime } from '$lib/utils/format.utils';
 import {
 	mockChainFusionActiveUserTransaction,
 	mockLiquidiumActiveUserTransaction,
@@ -71,6 +73,63 @@ describe('ActiveUserTransactionItem', () => {
 		expect(screen.getByText(`${en.liquidium.text.action_supply} 1 BTC`)).toBeInTheDocument();
 		expect(screen.getByText('Liquidium')).toBeInTheDocument();
 		expect(screen.queryByText(/→/)).not.toBeInTheDocument();
+	});
+
+	describe('relative time', () => {
+		const now = new Date(2026, 0, 1, 12);
+		const nowNs = BigInt(now.getTime()) * NANO_SECONDS_IN_MILLISECOND;
+		const threeHoursAgoNs = nowNs - 3n * 60n * 60n * NANO_SECONDS_IN_SECOND;
+		const oneMinuteAgoNs = nowNs - 60n * NANO_SECONDS_IN_SECOND;
+
+		const relativeTime = (nanoseconds: bigint): string =>
+			formatNanosecondsToShortRelativeTime({ nanoseconds, currentDate: now });
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(now);
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('shows the time since the terminal status change, not since creation', () => {
+			const { container } = render(ActiveUserTransactionItem, {
+				props: {
+					tx: {
+						...mockNearIntentsActiveUserTransaction,
+						status: { Succeeded: null },
+						created_at_ns: threeHoursAgoNs,
+						updated_at_ns: oneMinuteAgoNs
+					},
+					isUnseen: false,
+					dismissing: false,
+					onDismiss: vi.fn()
+				}
+			});
+
+			expect(container).toHaveTextContent(relativeTime(oneMinuteAgoNs));
+			expect(container).not.toHaveTextContent(relativeTime(threeHoursAgoNs));
+		});
+
+		it('shows the time since creation while the transaction is still running', () => {
+			const { container } = render(ActiveUserTransactionItem, {
+				props: {
+					tx: {
+						...mockNearIntentsActiveUserTransaction,
+						status: { Executing: null },
+						created_at_ns: threeHoursAgoNs,
+						updated_at_ns: oneMinuteAgoNs
+					},
+					isUnseen: false,
+					dismissing: false,
+					onDismiss: vi.fn()
+				}
+			});
+
+			expect(container).toHaveTextContent(relativeTime(threeHoursAgoNs));
+			expect(container).not.toHaveTextContent(relativeTime(oneMinuteAgoNs));
+		});
 	});
 
 	it('calls onDismiss from a terminal Liquidium row', async () => {

--- a/src/frontend/src/tests/lib/utils/active-user-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/active-user-transactions.utils.spec.ts
@@ -1,11 +1,12 @@
 import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
 import {
 	activeUserTransactionsStateToList,
+	activeUserTransactionTimestampNs,
 	advanceStatus,
 	hasActiveUserTransactionPollUpdateChanges,
 	isActiveUserTransactionUnseen,
 	isTerminalActiveUserTransaction,
-	sortActiveUserTransactionsByCreatedAtDesc
+	sortActiveUserTransactionsByTimestampDesc
 } from '$lib/utils/active-user-transactions.utils';
 import { mockActiveUserTransaction } from '$tests/mocks/active-user-transactions.mock';
 
@@ -29,13 +30,70 @@ describe('active-user-transactions.utils', () => {
 		});
 	});
 
-	describe('sortActiveUserTransactionsByCreatedAtDesc', () => {
+	describe('activeUserTransactionTimestampNs', () => {
+		it('returns updated_at_ns for terminal transactions', () => {
+			expect(
+				activeUserTransactionTimestampNs(
+					buildTx({ status: { Succeeded: null }, created_at_ns: 1n, updated_at_ns: 5n })
+				)
+			).toBe(5n);
+
+			expect(
+				activeUserTransactionTimestampNs(
+					buildTx({ status: { Failed: null }, created_at_ns: 1n, updated_at_ns: 5n })
+				)
+			).toBe(5n);
+		});
+
+		it('returns created_at_ns for transactions still in progress', () => {
+			expect(
+				activeUserTransactionTimestampNs(
+					buildTx({ status: { Pending: null }, created_at_ns: 1n, updated_at_ns: 5n })
+				)
+			).toBe(1n);
+
+			expect(
+				activeUserTransactionTimestampNs(
+					buildTx({ status: { Executing: null }, created_at_ns: 1n, updated_at_ns: 5n })
+				)
+			).toBe(1n);
+		});
+	});
+
+	describe('sortActiveUserTransactionsByTimestampDesc', () => {
 		it('returns transactions newest-first by created_at_ns', () => {
 			const a = buildTx({ id: 'a', created_at_ns: 1n });
 			const b = buildTx({ id: 'b', created_at_ns: 3n });
 			const c = buildTx({ id: 'c', created_at_ns: 2n });
 
-			expect(sortActiveUserTransactionsByCreatedAtDesc([a, b, c]).map((t) => t.id)).toEqual([
+			expect(sortActiveUserTransactionsByTimestampDesc([a, b, c]).map((t) => t.id)).toEqual([
+				'b',
+				'c',
+				'a'
+			]);
+		});
+
+		it('orders terminal transactions by updated_at_ns', () => {
+			const a = buildTx({
+				id: 'a',
+				status: { Succeeded: null },
+				created_at_ns: 3n,
+				updated_at_ns: 4n
+			});
+			const b = buildTx({
+				id: 'b',
+				status: { Succeeded: null },
+				created_at_ns: 1n,
+				updated_at_ns: 9n
+			});
+			const c = buildTx({
+				id: 'c',
+				status: { Pending: null },
+				created_at_ns: 6n,
+				updated_at_ns: 7n
+			});
+
+			expect(sortActiveUserTransactionsByTimestampDesc([a, b, c]).map((t) => t.id)).toEqual([
 				'b',
 				'c',
 				'a'
@@ -47,7 +105,7 @@ describe('active-user-transactions.utils', () => {
 			const b = buildTx({ id: 'b', created_at_ns: 2n });
 			const input = [a, b];
 
-			sortActiveUserTransactionsByCreatedAtDesc(input);
+			sortActiveUserTransactionsByTimestampDesc(input);
 
 			expect(input.map((t) => t.id)).toEqual(['a', 'b']);
 		});


### PR DESCRIPTION
# Motivation

The relative time on an active user transaction row was always computed from `created_at_ns`, so a swap that had just settled still read "1h ago" instead of "1m ago". The time shown should be the one of the latest status change: when the row "became green", not when it was opened.

# Changes

- Add `activeUserTransactionTimestampNs`: `updated_at_ns` for terminal rows, `created_at_ns` for rows still running. A terminal row is never written again (the pollers only touch pending rows, and every flow persists learned refs before the terminal write), so `updated_at_ns` is exactly when it succeeded or failed. A running row keeps its creation time, since its `updated_at_ns` also moves on ref and progress-step writes, which are not status changes.
- Use it in `ActiveUserTransactionItem` for the relative time label.
- Order the list by the same timestamp, so the Failed and Previous sections read newest-first by the time actually displayed.
- No backend or candid change.

# Tests

- New unit tests for the timestamp helper and the sorting.
- New `ActiveUserTransactionItem` tests covering both cases: a settled row shows the time since it settled, a running row shows the time since it started.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` and `npm run test` all pass.
