### PR TITLE
style(frontend): hoist the Solana fund warnings above the fee notices

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -138,6 +138,19 @@
 		<MessageBox level="warning">{$i18n.wallet_connect.text.unreviewed_instructions}</MessageBox>
 	{/if}
 
+	<!-- An authority change moves no funds at all, so a diff of amounts alone would describe the
+	     theft as nothing happening. It is named first among the fund warnings for that reason. -->
+	{#if nonNullish(preview) && preview.controlChanges.length > 0}
+		<MessageBox level="warning">{$i18n.wallet_connect.text.simulation_control_change}</MessageBox>
+	{/if}
+
+	<!-- Stated whenever the parties were derived from top-level instructions alone, not only when
+	     something visibly failed: an empty list on a transaction that clearly spends something is
+	     the single most dangerous thing this review can show. -->
+	{#if parties?.partial === true}
+		<MessageBox level="warning">{$i18n.wallet_connect.text.transfer_parties_partial}</MessageBox>
+	{/if}
+
 	{#if dappPrioritizationFee}
 		<MessageBox level="info">{$i18n.wallet_connect.text.dapp_prioritization_fee}</MessageBox>
 	{:else if highPrioritizationFee}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -79,12 +79,6 @@
 	{/if}
 {/snippet}
 
-<!-- An authority change moves no funds at all, so it would be invisible among the amounts. It is
-     named first, on its own, because it is the one that hands over the account itself. -->
-{#if controlChanges.length > 0}
-	<MessageBox level="warning">{$i18n.wallet_connect.text.simulation_control_change}</MessageBox>
-{/if}
-
 <WalletConnectModalValue
 	label={$i18n.wallet_connect.text.simulated_changes}
 	ref="simulated-changes"

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectTransferParties.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectTransferParties.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import ContactOrToken from '$lib/components/contact/ContactOrToken.svelte';
-	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { SolAddress } from '$sol/types/address';
@@ -19,11 +18,11 @@
 
 	let { parties, userAddress }: Props = $props();
 
-	let { sources, partial } = $derived(parties);
+	let { sources } = $derived(parties);
 
 	// Every source is one of the user's own accounts by the rule itself, so a list that resolves to
 	// the wallet the review already displays only repeats it. Suppressing it is safe only because
-	// the partial notice below says when a list could not be built, which is the other thing an
+	// the review's partial notice says when a list could not be built, which is the other thing an
 	// absent section could otherwise mean.
 	let showSources = $derived(
 		sources.length > 0 && !isSolTransferSourcesRedundant({ sources, userAddress })
@@ -61,11 +60,4 @@
 			{/each}
 		</div>
 	</WalletConnectModalValue>
-{/if}
-
-<!-- Stated whenever the parties were derived from top-level instructions alone, not only when
-     something visibly failed: an empty list on a transaction that clearly spends something is the
-     single most dangerous thing this section can show. -->
-{#if partial}
-	<MessageBox level="warning">{$i18n.wallet_connect.text.transfer_parties_partial}</MessageBox>
 {/if}

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -131,6 +131,71 @@ describe('SolWalletConnectSignReview', () => {
 		expect(queryByText(en.fee.text.prioritization_fee)).not.toBeInTheDocument();
 	});
 
+	describe('the warnings about what the transaction does', () => {
+		it('should warn about a control change, above the fee notices', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: {
+					...props,
+					preview: {
+						tokenDeltas: [],
+						controlChanges: [
+							{ account: mockSolAddress2, field: 'owner' as const, to: mockSolAddress }
+						]
+					},
+					prioritizationFee: 5_600_000n,
+					prioritizationFeeEstimate: networkEstimate
+				}
+			});
+
+			const control = getByText(en.wallet_connect.text.simulation_control_change);
+			const fee = getByText(en.wallet_connect.text.high_prioritization_fee);
+
+			expect(control.compareDocumentPosition(fee) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+		});
+
+		it('should not warn about a control change when nothing about control changed', () => {
+			const { queryByText } = render(SolWalletConnectSignReview, {
+				props: {
+					...props,
+					preview: { solDelta: -5_000n, tokenDeltas: [], controlChanges: [] }
+				}
+			});
+
+			expect(queryByText(en.wallet_connect.text.simulation_control_change)).not.toBeInTheDocument();
+		});
+
+		it('should say that the parties are partial, above the fee notices', () => {
+			const { getByText } = render(SolWalletConnectSignReview, {
+				props: {
+					...props,
+					parties: { sources: [], destinations: [], partial: true },
+					prioritizationFee: 5_600_000n,
+					prioritizationFeeEstimate: networkEstimate
+				}
+			});
+
+			const partial = getByText(en.wallet_connect.text.transfer_parties_partial);
+			const fee = getByText(en.wallet_connect.text.high_prioritization_fee);
+
+			expect(partial.compareDocumentPosition(fee) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+		});
+
+		it('should say nothing about partial parties when the lists are complete', () => {
+			const { queryByText } = render(SolWalletConnectSignReview, {
+				props: {
+					...props,
+					parties: { sources: [], destinations: [], partial: false }
+				}
+			});
+
+			expect(queryByText(en.wallet_connect.text.transfer_parties_partial)).not.toBeInTheDocument();
+		});
+	});
+
 	describe('comparing the requested fee against the baseline', () => {
 		it('should say nothing about a fee in line with the network', () => {
 			const { queryByText } = render(SolWalletConnectSignReview, {

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
@@ -115,8 +115,8 @@ describe('SolWalletConnectSimulationPreview', () => {
 	});
 
 	// An authority change moves nothing, so it has to be named in its own right or it is invisible.
-	it('should warn about a control change even with no amounts at all', () => {
-		const { getByText, getByTestId } = render(
+	it('should render a control change even with no amounts at all', () => {
+		const { getByTestId } = render(
 			SolWalletConnectSimulationPreview,
 			props({
 				tokenDeltas: [],
@@ -124,17 +124,7 @@ describe('SolWalletConnectSimulationPreview', () => {
 			})
 		);
 
-		expect(getByText(en.wallet_connect.text.simulation_control_change)).toBeInTheDocument();
 		expect(getByTestId('simulated-control-change')).toHaveTextContent(mockSolAddress2);
-	});
-
-	it('should not warn when nothing about control changed', () => {
-		const { queryByText } = render(
-			SolWalletConnectSimulationPreview,
-			props({ solDelta: -5_000n, tokenDeltas: [], controlChanges: [] })
-		);
-
-		expect(queryByText(en.wallet_connect.text.simulation_control_change)).not.toBeInTheDocument();
 	});
 
 	it('should always state that the real execution can differ', () => {

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectTransferParties.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectTransferParties.spec.ts
@@ -70,31 +70,13 @@ describe('SolWalletConnectTransferParties', () => {
 		});
 	});
 
-	describe('partial lists', () => {
-		it('should say that the lists are partial whenever they were built without inner instructions', () => {
-			const { getByText } = render(SolWalletConnectTransferParties, {
-				props: props({ partial: true })
-			});
-
-			expect(getByText(en.wallet_connect.text.transfer_parties_partial)).toBeInTheDocument();
+	// A hidden Sources list and one that could not be derived must not render identically, which is
+	// why the review states the partial case; here only the absence of the list is checked.
+	it('should render no sources list when it could not be derived', () => {
+		const { queryByText } = render(SolWalletConnectTransferParties, {
+			props: props({ partial: true })
 		});
 
-		// A hidden Sources list and one that could not be derived must not render identically.
-		it('should say so even when the list it produced is empty', () => {
-			const { getByText, queryByText } = render(SolWalletConnectTransferParties, {
-				props: props({ partial: true })
-			});
-
-			expect(queryByText(en.wallet_connect.text.transfer_sources)).not.toBeInTheDocument();
-			expect(getByText(en.wallet_connect.text.transfer_parties_partial)).toBeInTheDocument();
-		});
-
-		it('should say nothing when the lists are complete', () => {
-			const { queryByText } = render(SolWalletConnectTransferParties, {
-				props: props({ sources: [{ address: mockAtaAddress, own: true }] })
-			});
-
-			expect(queryByText(en.wallet_connect.text.transfer_parties_partial)).not.toBeInTheDocument();
-		});
+		expect(queryByText(en.wallet_connect.text.transfer_sources)).not.toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectTransferParties.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectTransferParties.spec.ts
@@ -70,13 +70,14 @@ describe('SolWalletConnectTransferParties', () => {
 		});
 	});
 
-	// A hidden Sources list and one that could not be derived must not render identically, which is
-	// why the review states the partial case; here only the absence of the list is checked.
-	it('should render no sources list when it could not be derived', () => {
+	// The review states the partial case now, above the fee notices. Saying it here as well would
+	// put the same warning on screen twice, so this pins that the component stays silent about it.
+	it('should leave the partial notice to the review', () => {
 		const { queryByText } = render(SolWalletConnectTransferParties, {
-			props: props({ partial: true })
+			props: props({ partial: true, sources: [{ address: mockAtaAddress, own: false }] })
 		});
 
-		expect(queryByText(en.wallet_connect.text.transfer_sources)).not.toBeInTheDocument();
+		expect(queryByText(en.wallet_connect.text.transfer_parties_partial)).not.toBeInTheDocument();
+		expect(queryByText(en.wallet_connect.text.transfer_sources)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
# Motivation

Two of the warnings in the Solana WalletConnect sign review were rendered by the child components that produced them: the control change warning inside `SolWalletConnectSimulationPreview`, the partial parties warning inside `SolWalletConnectTransferParties`. That placed each one below the data it qualifies, and below the prioritization fee notices at the top.

Both say something about what the message does to the user's holdings. An authority change hands over an account without moving a lamport, and a partial parties list means the review could not establish where the value goes. Either outranks what the transaction costs to send, so both belong at the top with the unreviewed instructions warning.

# Changes

- Move the `simulation_control_change` warning from `SolWalletConnectSimulationPreview` to `SolWalletConnectSignReview`, guarded on the preview carrying at least one control change.
- Move the `transfer_parties_partial` warning from `SolWalletConnectTransferParties` to `SolWalletConnectSignReview`, guarded on the parties being partial.
- Drop the now unused `MessageBox` import and `partial` binding from the two child components, and correct the comment in the parties component that referred to a notice which no longer sits below it.

The resulting order at the top of the review is: unreviewed instructions, control change, partial parties, then the two prioritization fee notices. No wording or condition changed, only where each box renders.

# Tests

- The cases asserting each warning move to `SolWalletConnectSignReview.spec.ts`, which is now the component that renders them, and each asserts it renders above the fee notices rather than merely being present.
- Two negative cases alongside them: no control change warning when nothing about control changed, and no partial warning when the lists are complete.
- What stays in the child specs is what those components still own: the preview still renders the control change row, and the parties component still hides a sources list it could not derive.
- `npm run check` is clean at 0 errors and 0 warnings, lint passes with `--max-warnings 0`, and the WalletConnect Solana suite passes 56 tests.