### PR TITLE
fix(frontend): state that the NFT operator grant covers tokens acquired later

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1626,7 +1626,7 @@
 			"unsigned_typed_data_keys": "This app sent extra data its schema doesn't declare. That data isn't covered by the signature, so only the fields below are shown.",
 			"unverifiable_erc20_request": "This request involves a token OISY can't identify or decode. What's shown may differ from what would actually be signed, so approval is disabled.",
 			"unverifiable_approval_for_all_request": "This request would hand an operator control of an NFT collection, and OISY can't decode which operator. What's shown may differ from what would actually be signed, so approval is disabled.",
-			"approval_for_all_grant": "This request lets the operator below transfer any NFT you hold in this collection, at any time, until you revoke it. It moves no funds on its own.",
+			"approval_for_all_grant": "This request lets the operator below transfer any NFT in this collection that you own now or acquire later, at any time, until you revoke it. It moves no funds on its own.",
 			"approval_for_all_revoke": "This request revokes the operator below, so it can no longer transfer the NFTs you hold in this collection.",
 			"raw_copied": "Raw transaction data copied to clipboard.",
 			"sign_message": "Sign Message",


### PR DESCRIPTION
# Motivation

Follow-up to #13789, which added the operator-grant review for `setApprovalForAll`.

The warning it shows reads "any NFT you hold in this collection". In the present tense that describes the user's current holdings, and the authority is wider: the grant is scoped to the collection, so it reaches tokens acquired after the approval as much as tokens held at the time.

That is not a hypothetical misreading. Reviewing the merged copy, a reader took it as a snapshot of the tokens owned when the transaction is published, which is exactly the understatement the message exists to prevent. A user who believes the grant is limited to the two NFTs they own today will weigh it very differently from one who understands it covers the collection indefinitely.

# Changes

Reword `wallet_connect.text.approval_for_all_grant` to say what the grant covers: what the user owns now or acquires later. One string, no logic change.

# Tests

The existing review tests assert against the i18n key rather than a literal, so they follow the new copy: `npx vitest run src/frontend/src/tests/eth/components/wallet-connect/` passes at 53 tests.

`npm run format` and `npm run lint -- --max-warnings 0` clean.
