### PR TITLE
feat(frontend): name unlisted mints in the Solana simulated balance changes

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -29,8 +29,32 @@
 			({ address, network: { id } }) => address === tokenAddress && id === feeToken.network.id
 		);
 
-	const symbol = (tokenAddress: SplTokenAddress): string =>
-		splToken(tokenAddress)?.symbol ?? shortenWithMiddleEllipsis({ text: tokenAddress });
+	// Mints OISY cannot name, in the order they appear. A bare address reads as noise next to the
+	// tickers around it, so an unlisted mint is named by position instead and numbered only when
+	// there is more than one to tell apart.
+	let unknownTokenAddresses = $derived(
+		tokenDeltas.reduce<SplTokenAddress[]>(
+			(acc, { tokenAddress }) =>
+				nonNullish(splToken(tokenAddress)) || acc.includes(tokenAddress)
+					? acc
+					: [...acc, tokenAddress],
+			[]
+		)
+	);
+
+	const symbol = (tokenAddress: SplTokenAddress): string => {
+		const known = splToken(tokenAddress)?.symbol;
+
+		if (nonNullish(known)) {
+			return known;
+		}
+
+		const index = unknownTokenAddresses.indexOf(tokenAddress);
+
+		return unknownTokenAddresses.length > 1
+			? `${$i18n.transaction.text.unknown_token} ${index + 1}`
+			: $i18n.transaction.text.unknown_token;
+	};
 
 	// A mint OISY does not know has no rate of its own, and no other token's rate describes it, so
 	// such a delta is left as a bare amount rather than priced against something it is not.

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
@@ -4,6 +4,7 @@ import { exchangeStore } from '$lib/stores/exchange.store';
 import SolWalletConnectSimulationPreview from '$sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte';
 import { splCustomTokensStore } from '$sol/stores/spl-custom-tokens.store';
 import type { SolSimulationPreview } from '$sol/types/sol-simulation';
+import en from '$tests/mocks/i18n.mock';
 import { mockAtaAddress, mockSolAddress2, mockSplAddress } from '$tests/mocks/sol.mock';
 import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { render } from '@testing-library/svelte';

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
@@ -115,7 +115,10 @@ describe('SolWalletConnectSimulationPreview', () => {
 	});
 
 	describe('naming a mint OISY does not know', () => {
-		const otherMint = 'So11111111111111111111111111111111111111112';
+		// Deliberately synthetic. A real mint address would resolve the moment the default SPL
+		// tokens are seeded into the store, and this case would quietly stop exercising the
+		// unlisted path it exists to cover.
+		const otherMint = 'notAKnownMint11111111111111111111111111111';
 
 		const delta = (tokenAddress: string) => ({
 			account: mockAtaAddress,

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
@@ -114,6 +114,62 @@ describe('SolWalletConnectSimulationPreview', () => {
 		expect(queryByTestId(CONVERT_AMOUNT_EXCHANGE_VALUE)).not.toBeInTheDocument();
 	});
 
+	describe('naming a mint OISY does not know', () => {
+		const otherMint = 'So11111111111111111111111111111111111111112';
+
+		const delta = (tokenAddress: string) => ({
+			account: mockAtaAddress,
+			tokenAddress,
+			decimals: 6,
+			delta: 2_500_000n
+		});
+
+		it('should name a lone unlisted mint without numbering it', () => {
+			const { getByTestId } = render(
+				SolWalletConnectSimulationPreview,
+				props({ tokenDeltas: [delta(mockSplAddress)], controlChanges: [] })
+			);
+
+			expect(getByTestId('simulated-token-delta')).toHaveTextContent(
+				en.transaction.text.unknown_token
+			);
+		});
+
+		// Two anonymous rows reading identically is worse than an address: the user cannot tell
+		// which leg is which.
+		it('should number unlisted mints when more than one appears', () => {
+			const { getAllByTestId } = render(
+				SolWalletConnectSimulationPreview,
+				props({ tokenDeltas: [delta(mockSplAddress), delta(otherMint)], controlChanges: [] })
+			);
+
+			const [first, second] = getAllByTestId('simulated-token-delta');
+
+			expect(first).toHaveTextContent(`${en.transaction.text.unknown_token} 1`);
+			expect(second).toHaveTextContent(`${en.transaction.text.unknown_token} 2`);
+		});
+
+		it('should not show the raw mint address', () => {
+			const { queryByText } = render(
+				SolWalletConnectSimulationPreview,
+				props({ tokenDeltas: [delta(mockSplAddress)], controlChanges: [] })
+			);
+
+			expect(queryByText(new RegExp(mockSplAddress.slice(0, 6)))).not.toBeInTheDocument();
+		});
+
+		it('should still prefer the ticker of a mint it knows', () => {
+			enableSplToken();
+
+			const { getByTestId } = render(
+				SolWalletConnectSimulationPreview,
+				props({ tokenDeltas: [delta(mockValidSplToken.address)], controlChanges: [] })
+			);
+
+			expect(getByTestId('simulated-token-delta')).toHaveTextContent(mockValidSplToken.symbol);
+		});
+	});
+
 	// An authority change moves nothing, so it has to be named in its own right or it is invisible.
 	it('should warn about a control change even with no amounts at all', () => {
 		const { getByText, getByTestId } = render(


### PR DESCRIPTION
# Motivation

In the Solana WalletConnect review, a token delta whose mint OISY cannot resolve was labelled with the shortened mint address. Next to the tickers on the rows around it that reads as noise, and it gives the user nothing they can act on: nobody verifies a mint by eye. It also flattens a real distinction, since an unlisted mint and a listed one look equally authoritative once both are just text.

# Changes

- Name an unresolved mint "Unknown token", reusing `transaction.text.unknown_token`, the wording the transaction views already use for the same situation. No new i18n key.
- Number them only when a single message touches more than one unlisted mint. A four-leg route through two anonymous tokens would otherwise render two identical rows, and which leg is which is exactly what the user needs.
- Listed mints are unaffected and still show their ticker.
- The fiat column is unchanged: an unknown mint still shows no value, because no other token's rate describes it.

# Tests

- Four cases in `SolWalletConnectSimulationPreview.spec.ts`: a lone unlisted mint is named without a number, two are numbered in the order they appear, the raw address no longer renders, and a known mint still wins with its ticker.
- Three of the four were confirmed to fail against the previous implementation, so they pin the behaviour rather than restate it.
- `npm run check` is clean (0 errors, 0 warnings), lint passes with `--max-warnings 0`, and the Solana WalletConnect suite passes 63 tests.