### PR TITLE
feat(frontend): enable NEAR Intents BTC swaps in production

### DIFF
--- a/src/frontend/src/env/rest/near-intents.env.ts
+++ b/src/frontend/src/env/rest/near-intents.env.ts
@@ -1,12 +1,10 @@
-import { LOCAL, STAGING } from '$lib/constants/app.constants';
 import { UrlSchema } from '$lib/validation/url.validation';
 import { safeParse } from '$lib/validation/utils.validation';
 
 export const NEAR_INTENTS_SWAP_ENABLED = true;
 
-// BTC via NEAR Intents rolls out on local and staging first; production stays off
-// until the flag is flipped deliberately.
-export const NEAR_INTENTS_BTC_SWAP_ENABLED = LOCAL || STAGING;
+// Kept as a kill switch: BTC via NEAR Intents shipped to production after staging QA.
+export const NEAR_INTENTS_BTC_SWAP_ENABLED = true;
 
 // Apparently we do not need any API keys for Near Intents; we can make unauthorised calls
 export const NEAR_INTENTS_API_KEY = import.meta.env.VITE_NEAR_INTENTS_API_KEY;


### PR DESCRIPTION
# Motivation

Staging QA for BTC swaps via NEAR Intents passed on 2026-08-27 (both directions settle to Succeeded, active-user-transaction tracking survives modal close and refresh, UTXO locking and the ToS gate verified; see the closed-out spec docs/ai/spec-driven-development/specs/2026-08-25-feat-near-intents-btc-swap.md). Per the spec's rollout plan, production enablement is this deliberate one-line flip.

# Changes

- NEAR_INTENTS_BTC_SWAP_ENABLED goes from LOCAL || STAGING to true, keeping the constant as a kill switch, mirroring NEAR_INTENTS_SWAP_ENABLED.
- Drop the now-unused LOCAL/STAGING imports and update the rollout comment.

# Tests

- No behavior change on local and staging (the flag was already truthy there); vitest already ran with the flag truthy, so no test deltas.
- prettier clean locally; eslint and svelte-check could not be run locally in this environment for this change, CI covers both along with the full suite.