### PR TITLE
feat(frontend): copy and explorer controls beside the Solana WalletConnect addresses

### DIFF
--- a/src/frontend/src/lib/components/send/SendDataSpender.svelte
+++ b/src/frontend/src/lib/components/send/SendDataSpender.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import ContactOrToken from '$lib/components/contact/ContactOrToken.svelte';
 	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -9,16 +10,23 @@
 		// token in the collection. It is labelled for what it is rather than as a spender.
 		label?: string;
 		ref?: string;
+		// Copy and block-explorer controls for the address. A snippet rather than a network, so the
+		// component stays chain-agnostic and each review supplies the links its chain has.
+		actions?: Snippet;
 	}
 
-	let { spender, label, ref = 'spender' }: Props = $props();
+	let { spender, label, ref = 'spender', actions }: Props = $props();
 
 	let labelText = $derived(label ?? $i18n.wallet_connect.text.spender);
 </script>
 
 <WalletConnectModalValue label={labelText} {ref}>
 	<div class="flex flex-col gap-1">
-		{spender}
+		<span class="flex flex-wrap items-center gap-2">
+			{spender}
+
+			{@render actions?.()}
+		</span>
 		<ContactOrToken identifier={spender} />
 	</div>
 </WalletConnectModalValue>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "على سبيل المثال: wc:a281567bb3e4..."
+			"connect_input": "على سبيل المثال: wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "التحقق من النطاق",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "např. wc:a281567bb3e4..."
+			"connect_input": "např. wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Ověření domény",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "z. B. wc:a281567bb3e4..."
+			"connect_input": "z. B. wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Domain-Verifikation",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1656,7 +1656,8 @@
 			"token_units": "token units (decimals unknown)"
 		},
 		"alt": {
-			"connect_input": "e.g. wc:a281567bb3e4..."
+			"connect_input": "e.g. wc:a281567bb3e4...",
+			"open_address_block_explorer": "Open the address on a block explorer"
 		},
 		"domain": {
 			"title": "Domain Verification",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "ej. wc:a281567bb3e4..."
+			"connect_input": "ej. wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Verificación de Dominio",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "ex: wc:a281567bb3e4..."
+			"connect_input": "ex: wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Vérification du domaine",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "उदाहरण के लिए wc:a281567bb3e4..."
+			"connect_input": "उदाहरण के लिए wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "डोमेन सत्यापन",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "es. wc:a281567bb3e4..."
+			"connect_input": "es. wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Verifica Dominio",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "例: wc:a281567bb3e4..."
+			"connect_input": "例: wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "ドメイン認証",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "예: wc:a281567bb3e4..."
+			"connect_input": "예: wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "도메인 검증",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "np. wc:a281567bb3e4..."
+			"connect_input": "np. wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Weryfikacja domeny",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "ex: wc:a281567bb3e4..."
+			"connect_input": "ex: wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Verificação de Domínio",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "например, wc:a281567bb3e4..."
+			"connect_input": "например, wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Проверка домена",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "ví dụ: wc:a281567bb3e4..."
+			"connect_input": "ví dụ: wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "Xác minh tên miền",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1656,7 +1656,8 @@
 			"token_units": ""
 		},
 		"alt": {
-			"connect_input": "例如：wc:a281567bb3e4..."
+			"connect_input": "例如：wc:a281567bb3e4...",
+			"open_address_block_explorer": ""
 		},
 		"domain": {
 			"title": "域名验证",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1338,7 +1338,7 @@ interface I18nWallet_connect {
 		wallet_connect: string;
 		token_units: string;
 	};
-	alt: { connect_input: string };
+	alt: { connect_input: string; open_address_block_explorer: string };
 	domain: {
 		title: string;
 		valid: string;

--- a/src/frontend/src/sol/components/wallet-connect/SolAddressActions.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolAddressActions.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import AddressActions from '$lib/components/ui/AddressActions.svelte';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { Network } from '$lib/types/network';
+	import type { SolAddress } from '$sol/types/address';
+	import { solAccountExplorerUrl } from '$sol/utils/sol-explorer.utils';
+
+	interface Props {
+		address: SolAddress;
+		network: Network | undefined;
+		testId?: string;
+	}
+
+	let { address, network, testId }: Props = $props();
+
+	let explorerUrl = $derived(solAccountExplorerUrl({ network, address }));
+</script>
+
+<AddressActions
+	copyAddress={address}
+	copyAddressTestId={testId}
+	copyAddressText={$i18n.wallet.text.address_copied}
+	externalLink={explorerUrl}
+	externalLinkAriaLabel={$i18n.wallet_connect.alt.open_address_block_explorer}
+/>

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -15,6 +15,7 @@
 	import type { Token } from '$lib/types/token';
 	import { maxBigInt } from '$lib/utils/bigint.utils';
 	import { formatToken } from '$lib/utils/format.utils';
+	import SolAddressActions from '$sol/components/wallet-connect/SolAddressActions.svelte';
 	import SolWalletConnectSimulationPreview from '$sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte';
 	import SolWalletConnectTransferParties from '$sol/components/wallet-connect/SolWalletConnectTransferParties.svelte';
 	import {
@@ -179,11 +180,15 @@
 		{token}
 	>
 		{#if isApproval}
-			<SendDataSpender spender={destination} />
+			<SendDataSpender spender={destination}>
+				{#snippet actions()}
+					<SolAddressActions address={destination} network={token.network} />
+				{/snippet}
+			</SendDataSpender>
 		{/if}
 
 		{#if nonNullish(parties)}
-			<SolWalletConnectTransferParties {parties} userAddress={source} />
+			<SolWalletConnectTransferParties network={token.network} {parties} userAddress={source} />
 		{/if}
 
 		{#if nonNullish(preview)}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -7,6 +7,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 	import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+	import SolAddressActions from '$sol/components/wallet-connect/SolAddressActions.svelte';
 	import { enabledSplTokens } from '$sol/derived/spl.derived';
 	import type { SolSimulationControlField, SolSimulationPreview } from '$sol/types/sol-simulation';
 	import type { SplTokenAddress } from '$sol/types/spl';
@@ -109,6 +110,8 @@
 			<span class="flex flex-col gap-1" data-tid="simulated-control-change">
 				<span class="text-tertiary">
 					{`${controlLabels[field]} · ${shortenWithMiddleEllipsis({ text: account })}`}
+
+					<SolAddressActions address={account} network={feeToken.network} />
 				</span>
 				{to ?? $i18n.wallet_connect.text.simulation_control_removed}
 			</span>

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectTransferParties.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectTransferParties.svelte
@@ -2,6 +2,8 @@
 	import ContactOrToken from '$lib/components/contact/ContactOrToken.svelte';
 	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
+	import type { Network } from '$lib/types/network';
+	import SolAddressActions from '$sol/components/wallet-connect/SolAddressActions.svelte';
 	import type { SolAddress } from '$sol/types/address';
 	import type { SolTransferParties, SolTransferParty } from '$sol/types/sol-transaction';
 	import {
@@ -11,12 +13,14 @@
 
 	interface Props {
 		parties: SolTransferParties;
+		// The network the addresses belong to, for the block explorer link beside each of them.
+		network: Network | undefined;
 		// The wallet the review already names as its source, which is what makes a Sources list
 		// redundant when it resolves to nothing else.
 		userAddress: SolAddress;
 	}
 
-	let { parties, userAddress }: Props = $props();
+	let { parties, userAddress, network }: Props = $props();
 
 	let { sources } = $derived(parties);
 
@@ -35,6 +39,8 @@
 	<div class="flex flex-col gap-1" data-tid="transfer-party">
 		<span class="flex flex-wrap items-center gap-2">
 			{displayed}
+
+			<SolAddressActions address={displayed} {network} testId="transfer-party-copy" />
 
 			<!-- A source displayed by an account address rather than by the wallet the review names
 			     would otherwise read as a counterparty. Marking it is what says it is still ours. -->

--- a/src/frontend/src/sol/utils/sol-explorer.utils.ts
+++ b/src/frontend/src/sol/utils/sol-explorer.utils.ts
@@ -1,0 +1,25 @@
+import type { Network } from '$lib/types/network';
+import { replacePlaceholders } from '$lib/utils/i18n.utils';
+import { isNetworkSolana } from '$lib/utils/network.utils';
+import type { SolAddress } from '$sol/types/address';
+import { nonNullish } from '@dfinity/utils';
+
+/**
+ * A Solana account on its network's block explorer.
+ *
+ * The explorer URL is a template rather than a base: devnet carries a cluster query after the
+ * path, so the address has to be substituted into it and cannot be appended to it.
+ */
+export const solAccountExplorerUrl = ({
+	network,
+	address
+}: {
+	network: Network | undefined;
+	address: SolAddress | undefined;
+}): string | undefined =>
+	nonNullish(network) &&
+	isNetworkSolana(network) &&
+	nonNullish(network.explorerUrl) &&
+	nonNullish(address)
+		? replacePlaceholders(network.explorerUrl, { $args: `account/${address}/` })
+		: undefined;

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectTransferParties.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectTransferParties.spec.ts
@@ -1,3 +1,4 @@
+import { SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
 import SolWalletConnectTransferParties from '$sol/components/wallet-connect/SolWalletConnectTransferParties.svelte';
 import type { SolTransferParties } from '$sol/types/sol-transaction';
 import en from '$tests/mocks/i18n.mock';
@@ -14,7 +15,8 @@ describe('SolWalletConnectTransferParties', () => {
 
 	const props = (overrides: Partial<SolTransferParties> = {}) => ({
 		parties: parties(overrides),
-		userAddress: mockSolAddress
+		userAddress: mockSolAddress,
+		network: SOLANA_MAINNET_NETWORK
 	});
 
 	// Where the value ends up is described by the balance changes, so no list of recipients is
@@ -26,6 +28,20 @@ describe('SolWalletConnectTransferParties', () => {
 
 		expect(container.querySelector('#transfer-destinations')).toBeNull();
 		expect(queryByText(mockSolAddress2)).not.toBeInTheDocument();
+	});
+
+	describe('address controls', () => {
+		it('should offer copy and a block explorer link beside a source', () => {
+			const { getByTestId, getByLabelText } = render(SolWalletConnectTransferParties, {
+				props: props({ sources: [{ address: mockAtaAddress, own: false }] })
+			});
+
+			expect(getByTestId('transfer-party-copy')).toBeInTheDocument();
+			expect(getByLabelText(en.wallet_connect.alt.open_address_block_explorer)).toHaveAttribute(
+				'href',
+				`https://solscan.io/account/${mockAtaAddress}/`
+			);
+		});
 	});
 
 	describe('sources', () => {

--- a/src/frontend/src/tests/sol/utils/sol-explorer.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-explorer.utils.spec.ts
@@ -1,0 +1,41 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { SOLANA_DEVNET_NETWORK, SOLANA_MAINNET_NETWORK } from '$env/networks/networks.sol.env';
+import { solAccountExplorerUrl } from '$sol/utils/sol-explorer.utils';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
+
+describe('sol-explorer.utils', () => {
+	describe('solAccountExplorerUrl', () => {
+		it('should substitute the account into the explorer template', () => {
+			expect(
+				solAccountExplorerUrl({ network: SOLANA_MAINNET_NETWORK, address: mockSolAddress })
+			).toBe(`https://solscan.io/account/${mockSolAddress}/`);
+		});
+
+		// Devnet carries its cluster as a query after the path, so appending the address to the URL
+		// rather than substituting it into the template would put the account after the query.
+		it('should keep the cluster query of a non-mainnet explorer', () => {
+			const url = solAccountExplorerUrl({
+				network: SOLANA_DEVNET_NETWORK,
+				address: mockSolAddress
+			});
+
+			expect(url).toContain(`account/${mockSolAddress}/`);
+			expect(url).toContain('cluster=devnet');
+		});
+
+		it('should give no link for a network that is not Solana', () => {
+			expect(
+				solAccountExplorerUrl({ network: ETHEREUM_NETWORK, address: mockSolAddress })
+			).toBeUndefined();
+		});
+
+		it('should give no link without a network or an address', () => {
+			expect(
+				solAccountExplorerUrl({ network: undefined, address: mockSolAddress })
+			).toBeUndefined();
+			expect(
+				solAccountExplorerUrl({ network: SOLANA_MAINNET_NETWORK, address: undefined })
+			).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Every address the Solana WalletConnect review shows was plain text. A user who wants to check a counterparty has to retype it, and a user who wants to keep it has to select it by hand out of a modal. The transaction views already solve this with `AddressActions`; the review never got it.

# Changes

- A copy button and a block-explorer link beside each address the review names: the sources list, the spender of an approval, and the account of a simulated control change.
- New `solAccountExplorerUrl`, which substitutes the account into the network's explorer template. Solana's template carries its cluster as a query after the path (`https://solscan.io/$args?cluster=devnet`), so appending the address instead of substituting it would place the account after the query on every network except mainnet.
- `SendDataSpender` takes the controls as a snippet rather than a network. It is shared with the Ethereum review, and a snippet keeps it chain-agnostic; Ethereum passes none and is unchanged.
- One new i18n key for the link's accessible label. The copy confirmation reuses the existing `wallet.text.address_copied`.

Noticed in passing, not fixed here: `getContractExplorerUrl` in `lib/utils/networks.utils.ts` builds Solana URLs by concatenation (`${baseUrl}/account/${address}`), which yields `https://solscan.io/$args/account/…` for a Solana network. Its only callers today are the NFT views, so it is a separate change rather than one smuggled into this PR.

# Tests

- Four cases for `solAccountExplorerUrl`: substitution into the mainnet template, the devnet cluster query surviving, a non-Solana network yielding no link, and missing inputs yielding no link.
- One case proving the sources list renders both controls and that the link points at the account's explorer page.
- `npm run check` and `npm run check:tests` are clean at 0 errors and 0 warnings, lint passes with `--max-warnings 0`, and the Solana, shared send and Ethereum WalletConnect suites pass 1942 tests.