### PR TITLE
fix(frontend): de-flake the metadata-only ERC20 spec

### DIFF
--- a/src/frontend/src/tests/eth/services/erc20.services.metadata-only.spec.ts
+++ b/src/frontend/src/tests/eth/services/erc20.services.metadata-only.spec.ts
@@ -1,7 +1,14 @@
 import type { CustomToken } from '$declarations/backend/backend.did';
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import type * as TokensErc20Env from '$env/tokens/tokens.erc20.env';
 import { ERC20_SUGGESTED_TOKENS } from '$env/tokens/tokens.erc20.env';
 import type { InfuraErc20Provider } from '$eth/providers/infura-erc20.providers';
+import * as infuraProvidersModule from '$eth/providers/infura-erc20.providers';
+import { loadCustomTokens, loadDefaultErc20Tokens } from '$eth/services/erc20.services';
+import { erc20CustomTokensStore } from '$eth/stores/erc20-custom-tokens.store';
+import { erc20DefaultTokensStore } from '$eth/stores/erc20-default-tokens.store';
+import { listCustomTokens } from '$lib/api/backend.api';
+import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
 import { get } from 'svelte/store';
@@ -23,6 +30,10 @@ vi.mock('$lib/api/backend.api', () => ({
 	listCustomTokens: vi.fn()
 }));
 
+// The hoisted mock injects the metadata-only token into the curated defaults before
+// `erc20.services` evaluates `ALL_DEFAULT_ERC20_TOKENS`, so the service under test can
+// be imported statically: re-importing it after `vi.resetModules()` re-transformed its
+// whole graph inside the test body and timed out under a parallel suite run.
 vi.mock('$env/tokens/tokens.erc20.env', async (importOriginal) => {
 	const actual = await importOriginal<typeof TokensErc20Env>();
 	const { ETHEREUM_NETWORK } = await import('$env/networks/networks.eth.env');
@@ -49,18 +60,17 @@ vi.mock('$env/tokens/tokens.erc20.env', async (importOriginal) => {
 });
 
 describe('erc20.services - metadataOnly', () => {
-	it('excludes metadata-only tokens from the visible default-tokens store', async () => {
-		vi.resetModules();
+	beforeEach(() => {
+		vi.clearAllMocks();
 
-		// Configure the fresh (post-reset) infura mock the re-imported service will use.
-		const infuraProviders = await import('$eth/providers/infura-erc20.providers');
-		vi.mocked(infuraProviders.infuraErc20Providers).mockReturnValue({
+		erc20DefaultTokensStore.reset();
+		erc20CustomTokensStore.resetAll();
+	});
+
+	it('excludes metadata-only tokens from the visible default-tokens store', async () => {
+		vi.mocked(infuraProvidersModule.infuraErc20Providers).mockReturnValue({
 			metadata: vi.fn().mockResolvedValue({ name: 'Weenus', symbol: 'WEENUS', decimals: 18 })
 		} as unknown as InfuraErc20Provider);
-
-		const { loadDefaultErc20Tokens } = await import('$eth/services/erc20.services');
-		const { erc20DefaultTokensStore } = await import('$eth/stores/erc20-default-tokens.store');
-		erc20DefaultTokensStore.reset();
 
 		await loadDefaultErc20Tokens();
 
@@ -72,16 +82,11 @@ describe('erc20.services - metadataOnly', () => {
 	});
 
 	it('still enriches a manually imported custom token at the metadata-only address', async () => {
-		vi.resetModules();
-
-		const infuraProviders = await import('$eth/providers/infura-erc20.providers');
 		const metadataMock = vi.fn().mockResolvedValue({ name: 'X', symbol: 'X', decimals: 18 });
-		vi.mocked(infuraProviders.infuraErc20Providers).mockReturnValue({
+		vi.mocked(infuraProvidersModule.infuraErc20Providers).mockReturnValue({
 			metadata: metadataMock
 		} as unknown as InfuraErc20Provider);
 
-		const { ETHEREUM_NETWORK } = await import('$env/networks/networks.eth.env');
-		const { listCustomTokens } = await import('$lib/api/backend.api');
 		const customToken: CustomToken = {
 			token: {
 				Erc20: {
@@ -97,12 +102,7 @@ describe('erc20.services - metadataOnly', () => {
 		};
 		vi.mocked(listCustomTokens).mockResolvedValue([customToken]);
 
-		const { mockAuthStore } = await import('$tests/mocks/auth.mock');
 		mockAuthStore();
-
-		const { loadCustomTokens } = await import('$eth/services/erc20.services');
-		const { erc20CustomTokensStore } = await import('$eth/stores/erc20-custom-tokens.store');
-		erc20CustomTokensStore.resetAll();
 
 		await loadCustomTokens({ identity: mockIdentity });
 


### PR DESCRIPTION
# Motivation

`erc20.services.metadata-only.spec.ts` fails intermittently when the whole `src/frontend/src/tests/eth/services` directory is run, roughly 1 run in 3 to 6, while passing consistently in isolation.

The failure is a 5s test timeout, not a wrong assertion:

```
FAIL src/frontend/src/tests/eth/services/erc20.services.metadata-only.spec.ts > excludes metadata-only tokens from the visible default-tokens store
Error: Test timed out in 5000ms.
```

The first test called `vi.resetModules()` and then re-imported `$eth/services/erc20.services` from inside the test body. That drops the module cache and forces a cold re-transform of the service's whole import graph while the timeout clock is running. In isolation there is CPU to spare, so it finishes; with 26 spec files competing for workers it regularly does not.

The reset was never necessary. `vi.mock` is hoisted, so the `tokens.erc20.env` mock that injects the metadata-only token is already in place before `erc20.services` evaluates its module-level `ALL_DEFAULT_ERC20_TOKENS`, static import included.

# Changes

- Drop `vi.resetModules()` and the in-test dynamic re-imports, importing the service, the stores and the mocked modules statically instead. The heavy import now happens during the file's collection phase, which is not bound by the per-test timeout.
- Move the store resets into a `beforeEach`, alongside `vi.clearAllMocks()`.
- Use a namespace import for the Infura providers module, matching the sibling `erc20.services.spec.ts`.

Assertions are unchanged. No production code is touched.

# Tests

Both tests were mutation-checked against the production code to confirm they still catch the regressions they were written for:

- Removing the `.filter(({ metadataOnly }) => !metadataOnly)` in `loadDefaultErc20Tokens` fails test 1 with `expected true to be falsy`.
- Making the enrichment lookup skip metadata-only tokens fails test 2 with `expected false to be truthy`.

Determinism: `npx vitest run src/frontend/src/tests/eth/services` run 17 times, 349 passed every time, 0 failures. Six of those runs were done with a concurrent lint run loading the CPU, to stress the exact timing condition that produced the flake. Before the change the same command failed twice in 14 runs.

In-test duration for the previously failing test drops from a 5000ms timeout to 23ms.

Gates: `npm run format`, `npm run lint -- --max-warnings 0` and `npm run check:tests` (7202 files, 0 errors, 0 warnings) all pass.