### PR TITLE
refactor(frontend): read a mint's name out of its own cluster inside the util

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -10,11 +10,9 @@
 	import SolAddressActions from '$sol/components/wallet-connect/SolAddressActions.svelte';
 	import { enabledSplTokens } from '$sol/derived/spl.derived';
 	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
-	import { SolanaNetworks } from '$sol/types/network';
 	import type { SolSimulationControlField, SolSimulationPreview } from '$sol/types/sol-simulation';
 	import type { SplTokenAddress } from '$sol/types/spl';
 	import type { SplCustomToken } from '$sol/types/spl-custom-token';
-	import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
 	import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
 
 	interface Props {
@@ -36,17 +34,12 @@
 	// Mints nothing can name, in the order they appear. The wallet's own list answers first, then
 	// the name a Token-2022 mint carries in its own account; the numbered placeholder is what is
 	// left when neither does.
-	let networkMetadata = $derived(
-		$splTokenMetadataStore[mapNetworkIdToNetwork(feeToken.network.id) ?? SolanaNetworks.mainnet] ??
-			{}
-	);
-
 	let unknownTokenAddresses = $derived(
 		solUnknownTokenAddresses({
 			tokenAddresses: tokenDeltas.map(({ tokenAddress }) => tokenAddress),
 			tokens: $enabledSplTokens,
 			networkId: feeToken.network.id,
-			metadata: networkMetadata
+			metadata: $splTokenMetadataStore
 		})
 	);
 
@@ -55,7 +48,7 @@
 			tokenAddress,
 			tokens: $enabledSplTokens,
 			networkId: feeToken.network.id,
-			metadata: networkMetadata,
+			metadata: $splTokenMetadataStore,
 			unknownTokenAddresses,
 			unknownTokenLabel: $i18n.transaction.text.unknown_token,
 			nativeSymbol: feeToken.symbol

--- a/src/frontend/src/sol/utils/sol-token-name.utils.ts
+++ b/src/frontend/src/sol/utils/sol-token-name.utils.ts
@@ -1,9 +1,26 @@
 import type { NetworkId } from '$lib/types/network';
-import type { SplTokenMetadata } from '$sol/stores/spl-token-metadata.store';
+import type { SplTokenMetadata, SplTokenMetadataData } from '$sol/stores/spl-token-metadata.store';
 import type { SplTokenAddress } from '$sol/types/spl';
 import type { SplCustomToken } from '$sol/types/spl-custom-token';
+import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
 import { findEnabledSplToken } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
+
+/**
+ * The names known for one cluster. The same mint address exists on several of them and carries
+ * different data on each, so a name is only ever read out of the cluster it was fetched from.
+ */
+const namesOn = ({
+	metadata,
+	networkId
+}: {
+	metadata: SplTokenMetadataData;
+	networkId: NetworkId;
+}): Partial<Record<SplTokenAddress, SplTokenMetadata>> => {
+	const network = mapNetworkIdToNetwork(networkId);
+
+	return nonNullish(network) ? (metadata[network] ?? {}) : {};
+};
 
 /**
  * How a mint is named, wherever one is named.
@@ -28,7 +45,7 @@ export const solTokenSymbol = ({
 	tokenAddress: SplTokenAddress | undefined;
 	tokens: SplCustomToken[];
 	networkId: NetworkId;
-	metadata: Partial<Record<SplTokenAddress, SplTokenMetadata>>;
+	metadata: SplTokenMetadataData;
 	unknownTokenAddresses: SplTokenAddress[];
 	unknownTokenLabel: string;
 	nativeSymbol: string;
@@ -43,7 +60,7 @@ export const solTokenSymbol = ({
 		return listed;
 	}
 
-	const onChain = metadata[tokenAddress]?.symbol;
+	const onChain = namesOn({ metadata, networkId })[tokenAddress]?.symbol;
 
 	if (notEmptyString(onChain)) {
 		return onChain;
@@ -69,14 +86,16 @@ export const solUnknownTokenAddresses = ({
 	tokenAddresses: (SplTokenAddress | undefined)[];
 	tokens: SplCustomToken[];
 	networkId: NetworkId;
-	metadata: Partial<Record<SplTokenAddress, SplTokenMetadata>>;
-}): SplTokenAddress[] =>
-	tokenAddresses.reduce<SplTokenAddress[]>((acc, tokenAddress) => {
+	metadata: SplTokenMetadataData;
+}): SplTokenAddress[] => {
+	const names = namesOn({ metadata, networkId });
+
+	return tokenAddresses.reduce<SplTokenAddress[]>((acc, tokenAddress) => {
 		if (
 			isNullish(tokenAddress) ||
 			acc.includes(tokenAddress) ||
 			nonNullish(findEnabledSplToken({ tokens, tokenAddress, networkId })) ||
-			notEmptyString(metadata[tokenAddress]?.symbol)
+			notEmptyString(names[tokenAddress]?.symbol)
 		) {
 			return acc;
 		}
@@ -84,3 +103,4 @@ export const solUnknownTokenAddresses = ({
 		acc.push(tokenAddress);
 		return acc;
 	}, []);
+};

--- a/src/frontend/src/tests/sol/utils/sol-token-name.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-token-name.utils.spec.ts
@@ -1,9 +1,18 @@
+import { SolanaNetworks } from '$sol/types/network';
+import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
 import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
 import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 
 describe('sol-token-name.utils', () => {
 	const tokens = [{ ...mockValidSplToken, version: undefined, enabled: true }];
 	const { network } = mockValidSplToken;
+	const cluster = mapNetworkIdToNetwork(network.id);
+
+	// The store holds a map per cluster, and a name is only ever read out of the one it was
+	// fetched from.
+	const on = (metadata: Record<string, { name: string; symbol: string }>) => ({
+		[cluster ?? SolanaNetworks.mainnet]: metadata
+	});
 	const args = {
 		tokens,
 		networkId: network.id,
@@ -17,7 +26,7 @@ describe('sol-token-name.utils', () => {
 				solTokenSymbol({
 					...args,
 					tokenAddress: mockValidSplToken.address,
-					metadata: { [mockValidSplToken.address]: { name: 'Other', symbol: 'OTHER' } },
+					metadata: on({ [mockValidSplToken.address]: { name: 'Other', symbol: 'OTHER' } }),
 					unknownTokenAddresses: []
 				})
 			).toBe(mockValidSplToken.symbol);
@@ -30,10 +39,25 @@ describe('sol-token-name.utils', () => {
 				solTokenSymbol({
 					...args,
 					tokenAddress: 'unlisted-mint',
-					metadata: { 'unlisted-mint': { name: 'Pump', symbol: 'PUMP' } },
+					metadata: on({ 'unlisted-mint': { name: 'Pump', symbol: 'PUMP' } }),
 					unknownTokenAddresses: []
 				})
 			).toBe('PUMP');
+		});
+
+		// The same mint address exists on several clusters and carries different data on each, so a
+		// devnet mint must not inherit the name its mainnet namesake happens to have.
+		it('should ignore a name held for another cluster', () => {
+			expect(
+				solTokenSymbol({
+					...args,
+					tokenAddress: 'unlisted-mint',
+					metadata: {
+						[SolanaNetworks.devnet]: { 'unlisted-mint': { name: 'Pump', symbol: 'PUMP' } }
+					},
+					unknownTokenAddresses: ['unlisted-mint']
+				})
+			).toBe('Unknown token');
 		});
 
 		it('should fall back to the placeholder, unnumbered when it stands alone', () => {
@@ -41,7 +65,7 @@ describe('sol-token-name.utils', () => {
 				solTokenSymbol({
 					...args,
 					tokenAddress: 'nameless',
-					metadata: {},
+					metadata: on({}),
 					unknownTokenAddresses: ['nameless']
 				})
 			).toBe('Unknown token');
@@ -52,7 +76,7 @@ describe('sol-token-name.utils', () => {
 			const unknownTokenAddresses = ['first', 'second'];
 
 			expect(
-				solTokenSymbol({ ...args, tokenAddress: 'second', metadata: {}, unknownTokenAddresses })
+				solTokenSymbol({ ...args, tokenAddress: 'second', metadata: on({}), unknownTokenAddresses })
 			).toBe('Unknown token 2');
 		});
 
@@ -61,7 +85,7 @@ describe('sol-token-name.utils', () => {
 				solTokenSymbol({
 					...args,
 					tokenAddress: undefined,
-					metadata: {},
+					metadata: on({}),
 					unknownTokenAddresses: []
 				})
 			).toBe('SOL');
@@ -74,7 +98,7 @@ describe('sol-token-name.utils', () => {
 			solTokenSymbol({
 				...args,
 				tokenAddress: 'shared-address',
-				metadata: {},
+				metadata: on({}),
 				unknownTokenAddresses: ['shared-address']
 			})
 		).toBe('Unknown token');
@@ -94,7 +118,7 @@ describe('sol-token-name.utils', () => {
 					],
 					tokens,
 					networkId: network.id,
-					metadata: { 'named-on-chain': { name: 'Pump', symbol: 'PUMP' } }
+					metadata: on({ 'named-on-chain': { name: 'Pump', symbol: 'PUMP' } })
 				})
 			).toStrictEqual(['nameless-b', 'nameless-a']);
 		});

--- a/src/frontend/src/tests/sol/utils/sol-token-name.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-token-name.utils.spec.ts
@@ -1,3 +1,4 @@
+import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { SolanaNetworks } from '$sol/types/network';
 import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
 import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
@@ -92,6 +93,20 @@ describe('sol-token-name.utils', () => {
 		});
 	});
 
+	// A network with no Solana cluster behind it has no names of its own, and must not be handed
+	// mainnet's for want of an answer.
+	it('should name nothing for a network that is not a Solana cluster', () => {
+		expect(
+			solTokenSymbol({
+				...args,
+				networkId: ETHEREUM_NETWORK_ID,
+				tokenAddress: 'unlisted-mint',
+				metadata: on({ 'unlisted-mint': { name: 'Pump', symbol: 'PUMP' } }),
+				unknownTokenAddresses: ['unlisted-mint']
+			})
+		).toBe('Unknown token');
+	});
+
 	// The same mint address exists on several clusters and carries different data on each.
 	it('should not lend one network name to another', () => {
 		expect(
@@ -121,6 +136,19 @@ describe('sol-token-name.utils', () => {
 					metadata: on({ 'named-on-chain': { name: 'Pump', symbol: 'PUMP' } })
 				})
 			).toStrictEqual(['nameless-b', 'nameless-a']);
+		});
+
+		// The counting reads the same per-cluster map the naming does, so it counts a mint as
+		// nameless wherever no cluster of ours answers for it.
+		it('should count a mint as nameless when the network is not a Solana cluster', () => {
+			expect(
+				solUnknownTokenAddresses({
+					tokenAddresses: ['named-on-chain'],
+					tokens,
+					networkId: ETHEREUM_NETWORK_ID,
+					metadata: on({ 'named-on-chain': { name: 'Pump', symbol: 'PUMP' } })
+				})
+			).toStrictEqual(['named-on-chain']);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The Solana token naming helpers take the metadata store and the network the view is about. Selecting the right cluster out of the store was left to the caller, so every call site repeated the same lookup, and the one that existed fell back to mainnet for a network it could not map, which is the borrowing the per-cluster keying was meant to stop.

# Changes

The helpers take the store as it is and select the cluster themselves, once. A network that does not map now names nothing rather than answering with mainnet's data.

# Tests

A case holds a name under one cluster and asks for the same mint on another, expecting the placeholder. The existing cases moved to the store's shape. `npm run check` clean, 75 tests pass across the naming util and the WalletConnect review.