### PR TITLE
feat(frontend): add OISY Trade as swap provider

### DIFF
--- a/src/frontend/src/env/oisy-trade-swap.ts
+++ b/src/frontend/src/env/oisy-trade-swap.ts
@@ -1,0 +1,12 @@
+import { OISY_TRADE_ENABLED } from '$env/oisy-trade';
+import { LOCAL } from '$lib/constants/app.constants';
+
+// Gate for the OISY Trade *swap provider*, separate from `OISY_TRADE_ENABLED`,
+// which gates the Trading surface. The two answer different questions — "is the
+// swap integration ready?" versus "is the venue up?" — so the provider requires
+// both: a canister outage has to take the swap offer down with the Trading tab
+// rather than leave a provider quoting against a dead canister.
+export const OISY_TRADE_SWAP_ENABLED = LOCAL;
+
+// The double gate expressed once, rather than re-anded at each call site.
+export const oisyTradeSwapEnabled = OISY_TRADE_SWAP_ENABLED && OISY_TRADE_ENABLED;

--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -213,13 +213,23 @@
 			return undefined;
 		}
 
-		const result = fetchOisyTradeQuote({
-			sourceToken: $sourceToken,
-			destinationToken: $destinationToken,
-			sourceAmount
-		});
+		// Guarded even though the quote is contractually non-throwing: it converts a
+		// human price through `toPriceUnits`, and `Number.toFixed` switches to
+		// exponential notation at 1e21, which `BigInt` refuses. The registry's
+		// `getQuote` has the same catch. Here the call sits inside a `$derived.by`,
+		// where an escaping error would take the whole form down — and the worst
+		// outcome this branch can honestly report is "no explanation".
+		try {
+			const result = fetchOisyTradeQuote({
+				sourceToken: $sourceToken,
+				destinationToken: $destinationToken,
+				sourceAmount
+			});
 
-		return result.ok ? undefined : result.errorKind;
+			return result.ok ? undefined : result.errorKind;
+		} catch (_: unknown) {
+			return undefined;
+		}
 	});
 
 	// The shipped Limit Order copy, filled from the same `toPairView` fields that

--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -2,15 +2,22 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
+	import { oisyTradeSwapEnabled } from '$env/oisy-trade-swap';
 	import { isTokenCkBtcLedger } from '$icp/utils/ic-send.utils';
+	import { isIcToken } from '$icp/validation/ic-token.validation';
 	import SwapFees from '$lib/components/swap/SwapFees.svelte';
 	import SwapForm from '$lib/components/swap/SwapForm.svelte';
 	import SwapProvider from '$lib/components/swap/SwapProvider.svelte';
 	import Hr from '$lib/components/ui/Hr.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
+	import {
+		fetchOisyTradeQuote,
+		oisyTradeSwapPairTable
+	} from '$lib/services/oisy-trade-swap.services';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
+	import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
 	import {
 		SWAP_AMOUNTS_CONTEXT_KEY,
 		type SwapAmountsContext
@@ -23,6 +30,8 @@
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
+	import { findOisyTradePair } from '$lib/utils/oisy-trade-swap.utils';
+	import { formatTradeAmount, toPairView } from '$lib/utils/oisy-trade.utils';
 	import { tryParseToken } from '$lib/utils/parse.utils';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
 
@@ -68,6 +77,12 @@
 	// fee is what the Convert flow reserves for these same directions (`IcTokenFees` →
 	// `ConvertAmountSource`), so Max clears the balance instead of stranding a fee, and the
 	// number here agrees with the rows `SwapFees` and the provider sheet show.
+	//
+	// The two-leg branch is load-bearing for OISY Trade as well, for its own reason: its
+	// deposit is `icrc2_approve` + `icrc2_transfer_from`, and the canister requires the
+	// on-ledger balance to cover `amount + 2 × ledger_fee`. It only ever quotes ICRC-2
+	// sources and is never Chain Fusion, so it lands on this branch by construction —
+	// narrowing the condition would silently make Max unspendable there.
 	let ledgerFeeLegs = $derived($isSourceTokenIcrc2 && isNullish(chainFusionDetails) ? 2n : 1n);
 
 	let totalFee = $derived(
@@ -132,6 +147,127 @@
 				: $i18n.send.info.cketh_certified
 			: undefined
 	);
+
+	// OISY Trade is the only ICP provider that can refuse an otherwise fine amount: a
+	// fill-or-kill order has to sit on its pair's lot grid and inside the pair's notional
+	// bounds, so an off-grid amount simply produces no offer. Naming that reason is only
+	// honest when it is the whole story — while any other provider still quotes, the swap
+	// *is* offered and the grid is OISY Trade's business alone. Hence the empty-offer-list
+	// gate, which mirrors the one `SwapForm` puts on its own generic message.
+	let noOfferQuoted = $derived(
+		nonNullish($swapAmountsStore) &&
+			$swapAmountsStore.swaps.length === 0 &&
+			!isSwapAmountsLoading &&
+			nonNullish(swapAmount) &&
+			Number(swapAmount) > 0
+	);
+
+	let oisyTradePair = $derived.by(() => {
+		// `pairs` is read for its reactivity as much as for the guard: the table lives in
+		// `oisyTradeStore`, and `oisyTradeSwapPairTable` reaches it through `get`, which on
+		// its own would not re-run this when a table that loaded late finally lands.
+		const { pairs } = $oisyTradeStore;
+
+		if (
+			!oisyTradeSwapEnabled ||
+			isNullish(pairs) ||
+			isNullish($sourceToken) ||
+			isNullish($destinationToken)
+		) {
+			return undefined;
+		}
+
+		return findOisyTradePair({
+			sourceToken: $sourceToken,
+			destinationToken: $destinationToken,
+			table: oisyTradeSwapPairTable()
+		});
+	});
+
+	// Asked of the service rather than read off the fan-out: the fan-out carries offers
+	// only, so a rejection never reaches the store. The quote is a synchronous read over
+	// the already-cached pair table, so asking again here costs nothing.
+	let oisyTradeErrorKind = $derived.by(() => {
+		if (
+			!noOfferQuoted ||
+			// A source ledger without ICRC-2 cannot be deposited on OISY Trade at all —
+			// the fan-out drops its quote in the mapping branch — so the grid is not the
+			// reason there is no offer, and naming a lot size would wrongly imply that
+			// fixing the amount could produce one.
+			$isSourceTokenIcrc2 !== true ||
+			isNullish(oisyTradePair) ||
+			isNullish($sourceToken) ||
+			isNullish($destinationToken) ||
+			!isIcToken($sourceToken) ||
+			!isIcToken($destinationToken)
+		) {
+			return undefined;
+		}
+
+		const sourceAmount = tryParseToken({
+			value: `${swapAmount}`,
+			unitName: $sourceToken.decimals
+		});
+
+		if (isNullish(sourceAmount)) {
+			return undefined;
+		}
+
+		const result = fetchOisyTradeQuote({
+			sourceToken: $sourceToken,
+			destinationToken: $destinationToken,
+			sourceAmount
+		});
+
+		return result.ok ? undefined : result.errorKind;
+	});
+
+	// The shipped Limit Order copy, filled from the same `toPairView` fields that
+	// `LimitOrderTradePairBox` fills it from, so the two surfaces cannot come to disagree
+	// about what is orderable.
+	let oisyTradeNotOfferedMessage = $derived.by(() => {
+		if (isNullish(oisyTradeErrorKind) || isNullish(oisyTradePair)) {
+			return undefined;
+		}
+
+		const {
+			baseSymbol,
+			quoteSymbol,
+			baseDecimals,
+			quoteDecimals,
+			lotSize,
+			minNotional,
+			maxNotional
+		} = toPairView(oisyTradePair);
+		const t = $i18n.trading.limit_order;
+
+		switch (oisyTradeErrorKind) {
+			case 'lot':
+				return replacePlaceholders(t.error_lot_multiple, {
+					$step: formatTradeAmount({ amount: lotSize, decimals: baseDecimals }),
+					$symbol: baseSymbol
+				});
+			case 'min_notional':
+				return replacePlaceholders(t.error_min_notional, {
+					$amount: formatTradeAmount({ amount: minNotional, decimals: quoteDecimals }),
+					$symbol: quoteSymbol
+				});
+			case 'max_notional':
+				return replacePlaceholders(t.error_max_notional, {
+					$amount: formatTradeAmount({ amount: maxNotional ?? 0, decimals: quoteDecimals }),
+					$symbol: quoteSymbol
+				});
+			// `balance` is unreachable here: the quote deliberately validates with no balance,
+			// so an unaffordable amount still produces an offer and the form's own
+			// insufficient-funds check reports it, exactly as for every other provider.
+			default:
+				return undefined;
+		}
+	});
+
+	// Both are error-level and mutually exclusive in practice: a Chain Fusion input error
+	// needs an offer to exist, and this message only appears when none did.
+	let messageBoxError = $derived(errorMessage ?? oisyTradeNotOfferedMessage);
 
 	const customValidate = (userAmount: bigint): TokenActionErrorType => {
 		if (isNullish($sourceToken)) {
@@ -199,6 +335,7 @@
 <SwapForm
 	fee={totalFee}
 	{isSwapAmountsLoading}
+	notOfferedExplained={nonNullish(oisyTradeNotOfferedMessage)}
 	{onClose}
 	onCustomValidate={customValidate}
 	{onNext}
@@ -209,10 +346,10 @@
 	bind:errorType
 >
 	{#snippet message()}
-		{#if nonNullish(errorMessage) || nonNullish(infoMessage)}
+		{#if nonNullish(messageBoxError) || nonNullish(infoMessage)}
 			<div in:fade>
-				<MessageBox level={nonNullish(errorMessage) ? 'error' : 'info'}>
-					{errorMessage ?? infoMessage}
+				<MessageBox level={nonNullish(messageBoxError) ? 'error' : 'info'}>
+					{messageBoxError ?? infoMessage}
 				</MessageBox>
 			</div>
 		{/if}

--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -26,6 +26,8 @@
 	import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 	import { trackEvent } from '$lib/services/analytics.services';
 	import { fetchChainFusionIcpSwap } from '$lib/services/chain-fusion-swap.services';
+	import { fetchOisyTradeSwap } from '$lib/services/oisy-trade-swap.services';
+	import { OisyTradeSwapError } from '$lib/services/swap-errors.services';
 	import {
 		enableSwapDestinationToken,
 		fetchOneSecIcpToEvmSwap,
@@ -110,6 +112,17 @@
 
 	let isChainFusionProvider = $derived(
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.CHAIN_FUSION
+	);
+
+	// OISY Trade settles in the foreground for now: deposit, fill-or-kill order, and the
+	// withdrawal that brings the destination token back, all inside the modal. It is
+	// deliberately absent from `isActiveTransactionSwap` below until it has an Active User
+	// Transaction row to hand the settlement to — closing the modal earlier would leave the
+	// funds in DEX custody with nothing watching them.
+	let oisyTradeDetails = $derived(
+		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.OISY_TRADE
+			? $swapAmountsStore.selectedProvider.swapDetails
+			: undefined
 	);
 
 	// The user's own address on the destination chain, which is where the minter pays the
@@ -213,6 +226,31 @@
 					setFailedProgressStep,
 					swapId: crypto.randomUUID()
 				});
+			} else if ($swapAmountsStore.selectedProvider.provider === SwapProvider.OISY_TRADE) {
+				// Dispatched explicitly rather than through `swapService`, like 1Sec and Chain
+				// Fusion above: the reviewed order — side, price, quantity, deposit amount —
+				// cannot travel through `SwapParams`, and re-deriving it here would let the book
+				// move between Review and submit.
+				if (isNullish(oisyTradeDetails) || !isIcToken($destinationToken)) {
+					toastsError({
+						msg: { text: $i18n.swap.error.unexpected_missing_data }
+					});
+					onBack();
+					return;
+				}
+
+				await fetchOisyTradeSwap({
+					identity: $authIdentity,
+					progress,
+					sourceToken: $sourceToken as IcToken,
+					destinationToken: $destinationToken,
+					order: oisyTradeDetails.order,
+					enableDestinationToken: () =>
+						enableSwapDestinationToken({
+							destinationToken: $destinationToken,
+							identity: $authIdentity
+						})
+				});
 			} else if ($swapAmountsStore.selectedProvider.provider === SwapProvider.CHAIN_FUSION) {
 				if (isNullish(destinationAddress)) {
 					toastsError({
@@ -306,6 +344,16 @@
 					),
 					variant: 'info'
 				});
+			} else if (err instanceof OisyTradeSwapError) {
+				// A killed fill-or-kill order is an expected market outcome — the source
+				// funds are already back in the wallet when it is thrown — so it reads as
+				// info in Review, like slippage, never as an unexpected-error toast. An
+				// unresolved settlement asks the user to check the Trading tab, hence the
+				// warning level.
+				failedSwapError.set({
+					message: err.message,
+					variant: err.kind === 'killed' ? 'info' : 'warning'
+				});
 			} else {
 				failedSwapError.set(undefined);
 				toastsError({
@@ -323,7 +371,11 @@
 					name: TRACK_COUNT_SWAP_ERROR,
 					metadata: {
 						...swapTrackingMetadata,
-						errorKey: isSwapError(err) ? err.code : ''
+						errorKey: isSwapError(err)
+							? err.code
+							: err instanceof OisyTradeSwapError
+								? err.kind
+								: ''
 					}
 				});
 			}
@@ -359,7 +411,7 @@
 				swapWithActiveTransaction={isActiveTransactionSwap}
 				swapWithBridging={isOneSecProvider}
 				swapWithWithdrawing={$swapAmountsStore?.selectedProvider?.provider ===
-					SwapProvider.ICP_SWAP}
+					SwapProvider.ICP_SWAP || nonNullish(oisyTradeDetails)}
 				bind:failedSteps={swapFailedProgressSteps}
 			/>
 		{/if}

--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -345,14 +345,14 @@
 					variant: 'info'
 				});
 			} else if (err instanceof OisyTradeSwapError) {
-				// A killed fill-or-kill order is an expected market outcome — the source
-				// funds are already back in the wallet when it is thrown — so it reads as
-				// info in Review, like slippage, never as an unexpected-error toast. An
-				// unresolved settlement asks the user to check the Trading tab, hence the
-				// warning level.
+				// A killed fill-or-kill order — or one the canister refused — is an
+				// expected outcome whose source funds are already back in the wallet when
+				// it is thrown, so it reads as info in Review, like slippage, never as an
+				// unexpected-error toast. The other kinds ask the user to check the
+				// Trading tab, hence the warning level.
 				failedSwapError.set({
 					message: err.message,
-					variant: err.kind === 'killed' ? 'info' : 'warning'
+					variant: err.kind === 'killed' || err.kind === 'not_placed' ? 'info' : 'warning'
 				});
 			} else {
 				failedSwapError.set(undefined);

--- a/src/frontend/src/lib/components/swap/SwapDetailsOisyTrade.svelte
+++ b/src/frontend/src/lib/components/swap/SwapDetailsOisyTrade.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
+	import LimitOrderTermsList from '$lib/components/trading/limit-order/LimitOrderTermsList.svelte';
+	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { exchanges } from '$lib/derived/exchange.derived';
+	import { i18n } from '$lib/stores/i18n.store';
+	import type { SwapMappedResult, SwapProvider } from '$lib/types/swap';
+	import { formatToken } from '$lib/utils/format.utils';
+	import { resolveText } from '$lib/utils/i18n.utils';
+	import { feeBpsToPercent } from '$lib/utils/oisy-trade.utils';
+
+	interface Props {
+		provider: Extract<SwapMappedResult, { provider: SwapProvider.OISY_TRADE }>;
+	}
+
+	const { provider }: Props = $props();
+
+	const { fees, takerFeeBps, minNotional, quoteToken } = $derived(provider.swapDetails);
+
+	const takerFee = $derived(feeBpsToPercent(takerFeeBps));
+
+	const formattedMinNotional = $derived(
+		formatToken({
+			value: minNotional,
+			unitName: quoteToken.decimals,
+			displayDecimals: quoteToken.decimals
+		})
+	);
+</script>
+
+<!-- The venue / order-type / taker-rate rows are the shipped Trading component,
+	 not a rebuild: `takerOnly` is exactly the fill-or-kill case it was written for,
+	 and its DEX row is already marked like Swap's provider row. -->
+<LimitOrderTermsList
+	makerFee={null}
+	orderTypeLabel={$i18n.trading.limit_order.order_type_fok}
+	{takerFee}
+	takerOnly
+/>
+
+<!-- Rates and amounts are complementary, not alternatives: the rows above answer
+	 "what does this venue charge", these answer "what does this swap cost".
+	 Itemized and never summed — the fees span two tokens, so a single total would
+	 be a cross-token addition. -->
+<!-- Keyed by index, like `SwapFees`' own fee rows: the list is fixed-length and never
+	 reordered, and neither field is a safe identity — two of the three fees are
+	 denominated in the same token, and a future itemization could reuse a label. -->
+{#each fees as { labelPath, fee, token }, index (index)}
+	<FeeDisplay
+		decimals={token.decimals}
+		exchangeRate={$exchanges?.[token.id]?.usd}
+		feeAmount={fee}
+		symbol={token.symbol}
+		zeroAmountLabel={$i18n.fee.text.zero_fee}
+	>
+		{#snippet label()}{resolveText({ i18n: $i18n, path: labelPath })}{/snippet}
+	</FeeDisplay>
+{/each}
+
+<ModalValue>
+	{#snippet label()}
+		{$i18n.swap.text.oisy_trade_minimum_notional}
+	{/snippet}
+
+	{#snippet mainValue()}
+		{formattedMinNotional}
+		{quoteToken.symbol}
+	{/snippet}
+</ModalValue>

--- a/src/frontend/src/lib/components/swap/SwapProvider.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProvider.svelte
@@ -2,6 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { CHAIN_FUSION_SWAP_ENABLED } from '$env/chain-fusion-swap.env';
+	import { oisyTradeSwapEnabled } from '$env/oisy-trade-swap';
 	import { KONGSWAP_PROVIDER_ENABLED } from '$env/rest/kongswap.env';
 	import { NEAR_INTENTS_SWAP_ENABLED } from '$env/rest/near-intents.env';
 	import { ONESEC_SWAP_ENABLED } from '$env/rest/onesec.env';
@@ -9,6 +10,7 @@
 	import SwapDetailsIcp from '$lib/components/swap/SwapDetailsIcp.svelte';
 	import SwapDetailsKong from '$lib/components/swap/SwapDetailsKongSwap.svelte';
 	import SwapDetailsNearIntents from '$lib/components/swap/SwapDetailsNearIntents.svelte';
+	import SwapDetailsOisyTrade from '$lib/components/swap/SwapDetailsOisyTrade.svelte';
 	import SwapDetailsOneSec from '$lib/components/swap/SwapDetailsOneSec.svelte';
 	import SwapDetailsVelora from '$lib/components/swap/SwapDetailsVelora.svelte';
 	import BestRateBadge from '$lib/components/ui/BestRateBadge.svelte';
@@ -121,6 +123,8 @@
 				<SwapDetailsOneSec provider={selectedProvider} />
 			{:else if selectedProvider.provider === SwapProvider.CHAIN_FUSION && CHAIN_FUSION_SWAP_ENABLED}
 				<SwapDetailsChainFusion provider={selectedProvider} />
+			{:else if selectedProvider.provider === SwapProvider.OISY_TRADE && oisyTradeSwapEnabled}
+				<SwapDetailsOisyTrade provider={selectedProvider} />
 			{/if}
 		{/snippet}
 		{#snippet contentFooter(closeFn)}

--- a/src/frontend/src/lib/constants/oisy-trade.constants.ts
+++ b/src/frontend/src/lib/constants/oisy-trade.constants.ts
@@ -12,6 +12,13 @@ export const OISY_TRADE_ANALYTICS_PROVIDER_NAME = 'OISY Trade';
 // Mirrors the Liquidium polling cadence.
 export const OISY_TRADE_POLL_INTERVAL_MILLIS = 30_000;
 
+// How often the swap flow re-reads a fill-or-kill order it has just placed, while
+// the modal waits for it to settle. Deliberately much tighter than
+// `OISY_TRADE_POLL_INTERVAL_MILLIS`, which paces a background refresh of a tab the
+// user left open: a FOK order is decided in the matching round that follows it, and
+// here somebody is watching a spinner for exactly this interval.
+export const OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS = 2_000;
+
 // The oisy_trade canister caps a `get_my_orders` page (`ByPage.length`) at 100.
 export const OISY_TRADE_ORDERS_PAGE_SIZE = 100;
 

--- a/src/frontend/src/lib/constants/swap.constants.ts
+++ b/src/frontend/src/lib/constants/swap.constants.ts
@@ -14,6 +14,10 @@ import {
 } from '$env/rest/near-intents.env';
 import { ONESEC_SWAP_ENABLED } from '$env/rest/onesec.env';
 import { ICRC_CK_TOKENS, PUBLIC_ICRC_TOKENS } from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
+import {
+	OISY_TRADE_LEARN_MORE_URL,
+	OISY_TRADE_PROVIDER_NAME
+} from '$lib/constants/oisy-trade.constants';
 import type { NetworkId } from '$lib/types/network';
 import { SwapProvider, type ChainFusionPair, type SwapProvidersConfig } from '$lib/types/swap';
 import { toChainFusionPairs } from '$lib/utils/chain-fusion-swap.utils';
@@ -92,7 +96,17 @@ export const swapProvidersDetails: Partial<Record<SwapProvider, SwapProvidersCon
 					logo: '/images/dapps/onesec-logo.svg'
 				}
 			}
-		: {})
+		: {}),
+	// Unconditional, unlike the flag-gated entries above: `ActiveUserTransactionItem`
+	// resolves a row's provider name through this map, and an AUT row outlives a flag
+	// rollback — a gated entry would leave historical rows nameless. `website` is the
+	// docs page rather than an external venue, because this is the one in-house
+	// provider, and it is where the Trading tab and deposit flow already point.
+	[SwapProvider.OISY_TRADE]: {
+		website: OISY_TRADE_LEARN_MORE_URL,
+		name: OISY_TRADE_PROVIDER_NAME,
+		logo: '/images/dapps/oisy-trade-logo.svg'
+	}
 };
 
 const SUPPORTED_CROSS_SWAP_EVM_NETWORK_IDS = [

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "تعذر استرجاع سعر واحد على الأقل من الرموز. يرجى <strong>التحقق بشكل مستقل</strong> من أن عرض المبادلة هذا يقدم صفقة عادلة.<br>لاحظ أن إعداد الانزلاق السعري <strong>لا</strong> يحميك من عرض بقيمة استلام أقل بكثير!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "Cenu alespoň jednoho z tokenů se nepodařilo získat. <strong>Nezávisle ověřte</strong>, zda tato nabídka swapu představuje férovou výměnu.<br>Upozorňujeme, že nastavení slippage vás <strong>nechrání</strong> před nabídkou s podstatně nižší přijatou hodnotou!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "Der Preis für mindestens einen der Token konnte nicht abgerufen werden. Bitte <strong>überprüfe unabhängig</strong>, ob dieses Swap-Angebot ein faires Geschäft darstellt.<br>Beachte, dass die Slippage-Einstellung dich <strong>nicht</strong> vor einem Angebot mit einem deutlich geringeren Erhaltsbetrag schützt!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "Transfer fee",
 			"onesec_protocol_fee": "Protocol fee",
 			"chain_fusion_minimum_amount": "Minimum amount",
+			"oisy_trade_minimum_notional": "Minimum order value",
+			"oisy_trade_deposit_fee": "Deposit ledger fees",
+			"oisy_trade_taker_fee": "Taker fee",
+			"oisy_trade_withdrawal_fee": "Withdrawal ledger fee",
 			"value_difference_error_confirmation": "The value difference is very high, and you would lose a significant value in this swap. Please confirm that you want to proceed.",
 			"value_difference_missing_price_confirmation": "The price for at least one of the tokens could not be retrieved. Please <strong>verify independently</strong> that this swap offer provides a fair deal.<br>Note that the slippage setting does <strong>not</strong> protect you from an offer with a much lower receive value!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "The swap transaction was refunded.",
 			"swap_replaced_or_dropped": "This swap transaction was replaced or dropped before it was confirmed.",
 			"near_intents_quote_unverified": "This swap quote could not be verified as genuine, so no funds were sent. Please try again or choose a different provider.",
-			"near_intents_quote_expired": "This swap quote has expired, so no funds were sent. Please try again to get a fresh quote."
+			"near_intents_quote_expired": "This swap quote has expired, so no funds were sent. Please try again to get a fresh quote.",
+			"oisy_trade_order_killed": "The order could not be filled in full at the reviewed price, so it was canceled and your funds were returned to your wallet. You were only charged network fees.",
+			"oisy_trade_settlement_unresolved": "The order could no longer be found, and neither token is held on OISY Trade. Please check your balances in the Trading tab before trying again."
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "This swap quote could not be verified as genuine, so no funds were sent. Please try again or choose a different provider.",
 			"near_intents_quote_expired": "This swap quote has expired, so no funds were sent. Please try again to get a fresh quote.",
 			"oisy_trade_order_killed": "The order could not be filled in full at the reviewed price, so it was canceled and your funds were returned to your wallet. You were only charged network fees.",
-			"oisy_trade_settlement_unresolved": "The order could no longer be found, and neither token is held on OISY Trade. Please check your balances in the Trading tab before trying again."
+			"oisy_trade_settlement_unresolved": "The order could no longer be found, and neither token is held on OISY Trade. Please check your balances in the Trading tab before trying again.",
+			"oisy_trade_order_not_placed": "OISY Trade did not accept the order, so your funds were returned to your wallet. You were only charged network fees.",
+			"oisy_trade_recovery_failed": "OISY Trade did not accept the order, and your funds could not be returned to your wallet automatically. Please check your balances in the Trading tab to withdraw them."
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "No se pudo obtener el precio de al menos uno de los tokens. Por favor, <strong>verifica de forma independiente</strong> que esta oferta de intercambio sea justa.<br>Ten en cuenta que la configuración de slippage <strong>no</strong> te protege de una oferta con un valor de recepción mucho menor."
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "Le prix d'au moins un des tokens n'a pas pu être récupéré. Veuillez <strong>vérifier de manière indépendante</strong> que cette offre de swap est équitable.<br>Notez que le réglage du slippage ne vous protège <strong>pas</strong> d'une offre avec une valeur de réception bien inférieure !"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "कम से कम एक टोकन की कीमत प्राप्त नहीं की जा सकी। कृपया <strong>स्वतंत्र रूप से सत्यापित करें</strong> कि यह स्वैप ऑफर उचित सौदा है।<br>ध्यान दें कि स्लिपेज सेटिंग आपको बहुत कम प्राप्त मूल्य वाले ऑफर से सुरक्षित <strong>नहीं</strong> करती है!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "Non è stato possibile recuperare il prezzo di almeno uno dei token. <strong>Verifica in modo indipendente</strong> che questa offerta di swap sia equa.<br>Nota che l'impostazione dello slippage <strong>non</strong> ti protegge da un'offerta con un valore di ricezione molto inferiore!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "少なくとも1つのトークンの価格を取得できませんでした。このスワップオファーが公正な取引であることを<strong>独自に確認</strong>してください。<br>スリッページ設定は、受取額が大幅に低いオファーからは保護<strong>されません</strong>のでご注意ください！"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "토큰 중 하나 이상의 가격을 가져올 수 없습니다. 이 스왑 제안이 공정한 거래인지 <strong>독립적으로 확인</strong>해 주세요.<br>슬리피지 설정은 받는 가치가 훨씬 낮은 제안으로부터 사용자를 보호하지 <strong>않습니다</strong>!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "Nie udało się pobrać ceny przynajmniej jednego z tokenów. <strong>Zweryfikuj niezależnie</strong>, czy ta oferta wymiany jest uczciwa.<br>Pamiętaj, że ustawienie poślizgu (slippage) <strong>nie</strong> chroni Cię przed ofertą z dużo niższą wartością otrzymywaną!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "Não foi possível obter o preço de pelo menos um dos tokens. Por favor, <strong>verifique de forma independente</strong> se esta oferta de swap é justa.<br>Observe que a configuração de slippage <strong>não</strong> o protege de uma oferta com um valor de recebimento muito menor!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "Не удалось получить цену хотя бы одного из токенов. Пожалуйста, <strong>проверьте самостоятельно</strong>, что это предложение свопа является справедливым.<br>Обратите внимание, что настройка проскальзывания <strong>не</strong> защищает вас от предложения с гораздо меньшей суммой получения!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "Không thể truy xuất giá của ít nhất một trong các token. Vui lòng <strong>xác minh độc lập</strong> rằng giao dịch swap này là một thỏa thuận công bằng.<br>Lưu ý rằng cài đặt trượt giá <strong>không</strong> bảo vệ bạn khỏi giao dịch với giá trị nhận thấp hơn nhiều!"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1254,7 +1254,9 @@
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
 			"oisy_trade_order_killed": "",
-			"oisy_trade_settlement_unresolved": ""
+			"oisy_trade_settlement_unresolved": "",
+			"oisy_trade_order_not_placed": "",
+			"oisy_trade_recovery_failed": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1223,6 +1223,10 @@
 			"onesec_transfer_fee": "",
 			"onesec_protocol_fee": "",
 			"chain_fusion_minimum_amount": "",
+			"oisy_trade_minimum_notional": "",
+			"oisy_trade_deposit_fee": "",
+			"oisy_trade_taker_fee": "",
+			"oisy_trade_withdrawal_fee": "",
 			"value_difference_error_confirmation": "",
 			"value_difference_missing_price_confirmation": "无法获取至少一种代币的价格。请<strong>独立核实</strong>此次兑换报价是否公平。<br>请注意,滑点设置<strong>不会</strong>保护您免受接收价值大幅降低的报价。"
 		},
@@ -1248,7 +1252,9 @@
 			"swap_refunded": "",
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
-			"near_intents_quote_expired": ""
+			"near_intents_quote_expired": "",
+			"oisy_trade_order_killed": "",
+			"oisy_trade_settlement_unresolved": ""
 		}
 	},
 	"buy": {

--- a/src/frontend/src/lib/providers/swap.providers.ts
+++ b/src/frontend/src/lib/providers/swap.providers.ts
@@ -1,8 +1,16 @@
+import { oisyTradeSwapEnabled } from '$env/oisy-trade-swap';
 import { KONGSWAP_PROVIDER_ENABLED } from '$env/rest/kongswap.env';
 import { kongSwapAmounts } from '$lib/api/kong_backend.api';
 import { icpSwapAmounts, icpSwapSupportedTokens } from '$lib/services/icp-swap.services';
 import { kongSwapSupportedTokens } from '$lib/services/kong-swap.services';
+import {
+	fetchOisyTradeQuote,
+	loadOisyTradeSwapPairs,
+	mapOisyTradeQuoteResult,
+	oisyTradeSwapPairTable
+} from '$lib/services/oisy-trade-swap.services';
 import { SwapProvider, type SwapProviderConfig } from '$lib/types/swap';
+import { oisyTradeCompatibleDestinations } from '$lib/utils/oisy-trade-swap.utils';
 import { buildSymmetricSupportedDestinations } from '$lib/utils/swap-providers.utils';
 import { mapIcpSwapResult, mapKongSwapResult } from '$lib/utils/swap.utils';
 
@@ -25,5 +33,43 @@ export const swapProviders: SwapProviderConfig[] = [
 		isEnabled: true,
 		getSupportedTokens: icpSwapSupportedTokens,
 		getSupportedDestinations: symmetricIcpDestinations
+	},
+	{
+		key: SwapProvider.OISY_TRADE,
+		// The quote itself is synchronous — it reads the cached pair table — so the
+		// registry's async contract is satisfied here rather than inside it. The
+		// fan-out only carries offers, so a rejection collapses to `undefined` at
+		// this boundary; its `errorKind` stays on the service for the form's
+		// empty-offer-list explanation.
+		//
+		// The catch is load-bearing rather than defensive. `fetchSwapAmountsICP`
+		// calls every `getQuote` inside a `.map()` and only hands the resulting
+		// array to `Promise.allSettled` afterwards, so a *synchronous* throw here
+		// would escape the settling and reject the whole fan-out — taking ICPSwap's
+		// and KongSwap's offers down with it. Those two are async functions, which
+		// gives them this containment for free; a sync quote has to ask for it.
+		// Rejecting rather than swallowing keeps a genuine failure in the per-provider
+		// `SWAP_OFFER` error analytics, where an empty result would hide it.
+		getQuote: (params) => {
+			try {
+				const result = fetchOisyTradeQuote(params);
+
+				return Promise.resolve(result.ok ? result.quote : undefined);
+			} catch (err: unknown) {
+				return Promise.reject(err);
+			}
+		},
+		mapQuoteResult: mapOisyTradeQuoteResult,
+		isEnabled: oisyTradeSwapEnabled,
+		// Fetches and caches; the sync `getSupportedDestinations` below then reads
+		// that cache. `loadSwapSupportedTokens` awaits every `getSupportedTokens`
+		// before any destination is computed, so the table is always populated by
+		// the time the narrowing runs.
+		getSupportedTokens: loadOisyTradeSwapPairs,
+		// Directed, unlike its two siblings: a token's destinations are its pair
+		// counterparts, not the whole supported set, so `buildSymmetricSupportedDestinations`
+		// cannot serve here.
+		getSupportedDestinations: ({ sourceToken }) =>
+			oisyTradeCompatibleDestinations({ sourceToken, table: oisyTradeSwapPairTable() })
 	}
 ];

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -317,8 +317,57 @@ const freeBalanceOf = ({
 	balances.find(({ token: { id } }) => id.ledger_id.toText() === token.ledgerCanisterId)?.balance
 		.free ?? ZERO;
 
+/** The caller's free DEX balance of a swap's two legs, in each token's base units. */
+export interface OisyTradeFreeBalances {
+	source: bigint;
+	destination: bigint;
+}
+
 /**
- * Withdraws a token's whole free balance, or nothing when that would be dust.
+ * Reads both legs' free DEX balance.
+ *
+ * Taken **before the deposit** to establish what was already in custody, so
+ * settlement can act on the difference rather than on the account-wide totals. A
+ * user can arrive at a swap with either leg already funded from the Trading tab —
+ * they may have deposited to place limit orders — and those balances are not this
+ * swap's to move or to draw conclusions from.
+ */
+export const readOisyTradeFreeBalances = async ({
+	identity,
+	sourceToken,
+	destinationToken
+}: {
+	identity: Identity;
+	sourceToken: IcToken;
+	destinationToken: IcToken;
+}): Promise<OisyTradeFreeBalances> => {
+	const balances = await getBalances({
+		identity,
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+	});
+
+	return {
+		source: freeBalanceOf({ balances, token: sourceToken }),
+		destination: freeBalanceOf({ balances, token: destinationToken })
+	};
+};
+
+/**
+ * What this order added to a leg's free balance: the current balance less the
+ * baseline, floored at zero.
+ *
+ * Floored rather than signed because a baseline can go stale in the one direction
+ * that matters — the user withdrawing from the Trading tab mid-flow makes it too
+ * high — and a negative delta says only "less is here than before", never how much
+ * of what remains is ours. Under-counting leaves funds in DEX custody where the
+ * Trading tab still shows them; over-counting would withdraw someone else's
+ * deposit. Erring toward the former is the whole point of the baseline.
+ */
+const attributable = ({ current, baseline }: { current: bigint; baseline: bigint }): bigint =>
+	current > baseline ? current - baseline : ZERO;
+
+/**
+ * Withdraws an amount from a token's free DEX balance, or nothing when it is dust.
  *
  * `withdraw` refuses an `amount` at or below the ledger fee (`AmountTooSmall`), so a
  * small enough residue is permanently unwithdrawable. Skipping it silently is the
@@ -334,11 +383,11 @@ const freeBalanceOf = ({
 const withdrawFreeBalance = async ({
 	identity,
 	token,
-	free
+	amount
 }: {
 	identity: Identity;
 	token: IcToken;
-	free: bigint;
+	amount: bigint;
 }): Promise<bigint | undefined> => {
 	const fee = getTokenFee(token);
 
@@ -346,7 +395,7 @@ const withdrawFreeBalance = async ({
 		throw new Error(get(i18n).trading.deposit.error.unknown_fee);
 	}
 
-	if (free <= fee) {
+	if (amount <= fee) {
 		return undefined;
 	}
 
@@ -355,7 +404,7 @@ const withdrawFreeBalance = async ({
 		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity,
 		request: {
 			token_id: { ledger_id: Principal.fromText(token.ledgerCanisterId) },
-			amount: free
+			amount
 		}
 	});
 
@@ -370,11 +419,18 @@ const withdrawFreeBalance = async ({
  * in the next step calls it once per tick. A function that looped internally would
  * hang a poller tick on an order that never resolves.
  *
- * It takes the order id and the two tokens as arguments rather than reading them
- * from anywhere, so that poller can pass them straight out of an Active User
- * Transaction's refs.
+ * It takes the order id, the two tokens and the pre-deposit `baseline` as arguments
+ * rather than reading them from anywhere, so that poller can pass them straight out
+ * of an Active User Transaction's refs.
  *
- * The terminal action is always *withdraw the free balance of both legs*: a Buy that
+ * Everything it acts on is **the difference from that baseline**, never the
+ * account-wide free balance. A user can arrive at a swap with either leg already
+ * funded from the Trading tab, and withdrawing the account-wide total would evacuate
+ * a balance they parked there deliberately — their own funds, but not this swap's to
+ * move. The same distinction decides the status: a pre-existing destination balance
+ * must not let a killed order read as filled.
+ *
+ * The terminal action is *withdraw what this order added to both legs*: a Buy that
  * crosses below its limit price has its unspent reserve released back to free
  * balance, so even a successful swap can leave source behind. The fill / kill
  * distinction decides the reported status, never the shape of the withdrawal.
@@ -383,12 +439,15 @@ export const settleOisyTradeSwap = async ({
 	identity,
 	orderId,
 	sourceToken,
-	destinationToken
+	destinationToken,
+	baseline
 }: {
 	identity: Identity;
 	orderId: OrderId;
 	sourceToken: IcToken;
 	destinationToken: IcToken;
+	// Both legs' free balance as it stood before the deposit.
+	baseline: OisyTradeFreeBalances;
 }): Promise<OisyTradeSettlement> => {
 	const order = await readOisyTradeOrder({ identity, orderId });
 
@@ -399,25 +458,27 @@ export const settleOisyTradeSwap = async ({
 		return { status: 'pending', withdrawals: [] };
 	}
 
-	const balances = await getBalances({
-		identity,
-		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+	const current = await readOisyTradeFreeBalances({ identity, sourceToken, destinationToken });
+
+	const sourceAdded = attributable({ current: current.source, baseline: baseline.source });
+	const destinationAdded = attributable({
+		current: current.destination,
+		baseline: baseline.destination
 	});
 
-	const sourceFree = freeBalanceOf({ balances, token: sourceToken });
-	const destinationFree = freeBalanceOf({ balances, token: destinationToken });
-
-	// With the order still known, its status is the answer. Without it, the balances
-	// are — which is what makes this correct however long the canister retains a
-	// terminal order: destination in custody means it filled, source means it did not,
-	// and neither means the withdrawal already happened in an earlier attempt.
+	// With the order still known, its status is the answer. Without it, what this order
+	// *added* is — which is what makes this correct however long the canister retains a
+	// terminal order: destination added means it filled, source added means it did not,
+	// and neither means the withdrawal already happened in an earlier attempt. Reading
+	// the account-wide balance here instead would call a killed order filled for any user
+	// who already held the destination token on the DEX.
 	const status: OisyTradeSettlementStatus = nonNullish(order)
 		? 'Filled' in order.status
 			? 'filled'
 			: 'killed'
-		: destinationFree > ZERO
+		: destinationAdded > ZERO
 			? 'filled'
-			: sourceFree > ZERO
+			: sourceAdded > ZERO
 				? 'killed'
 				: 'unresolved';
 
@@ -431,12 +492,12 @@ export const settleOisyTradeSwap = async ({
 	const [primary, residue] =
 		status === 'filled'
 			? ([
-					[destinationToken, destinationFree],
-					[sourceToken, sourceFree]
+					[destinationToken, destinationAdded],
+					[sourceToken, sourceAdded]
 				] as const)
 			: ([
-					[sourceToken, sourceFree],
-					[destinationToken, destinationFree]
+					[sourceToken, sourceAdded],
+					[destinationToken, destinationAdded]
 				] as const);
 
 	// Sequential, not concurrent: the canister rejects a second withdrawal while one is
@@ -444,20 +505,29 @@ export const settleOisyTradeSwap = async ({
 	// together would race each other straight into it.
 	//
 	// The primary withdrawal is allowed to throw — it is the whole point of settling, and
-	// the caller retries it. The residue is best-effort: it is the smaller amount by
-	// construction, and letting it fail the settlement would strand an operation whose
-	// funds have already arrived, which is precisely the outcome this step exists to avoid.
+	// the caller retries it. The residue splits by failure class: a *transient* failure
+	// propagates too, because the caller's retry loop re-enters this function, where the
+	// withdrawn primary's delta reads zero (dust-skipped) and only the residue is left —
+	// the baseline arithmetic is what makes the retry idempotent. A *definitive* failure
+	// is swallowed and logged instead: the smaller amount must not fail an operation
+	// whose funds have already arrived, and the outcome it reports — a fill or a kill —
+	// is true regardless. Surfacing that stranded residue to the user is deferred to
+	// step 2, where the AUT row is the right home for it.
 	const primaryBlockIndex = await withdrawFreeBalance({
 		identity,
 		token: primary[0],
-		free: primary[1]
+		amount: primary[1]
 	});
 
 	const residueBlockIndex = await withdrawFreeBalance({
 		identity,
 		token: residue[0],
-		free: residue[1]
+		amount: residue[1]
 	}).catch((err: unknown) => {
+		if (isRetryableOisyTradeError(err)) {
+			throw err;
+		}
+
 		consoleError(err);
 
 		return undefined;
@@ -483,6 +553,7 @@ const settleUntilTerminal = async (params: {
 	orderId: OrderId;
 	sourceToken: IcToken;
 	destinationToken: IcToken;
+	baseline: OisyTradeFreeBalances;
 }): Promise<OisyTradeSettlement> => {
 	for (;;) {
 		try {
@@ -504,6 +575,50 @@ const settleUntilTerminal = async (params: {
 };
 
 /**
+ * Recovers a deposit whose order the canister refused to accept.
+ *
+ * Only the source leg: no order ever existed, so nothing has touched the
+ * destination. And only what the deposit added — the delta from the pre-deposit
+ * baseline, not `depositAmount`, so a concurrent Trading-tab withdrawal cannot
+ * make it over-draw a balance the user moved themselves.
+ *
+ * Retries transient failures unbounded, exactly like `settleUntilTerminal` and
+ * for the same reason: giving up on a ledger's bad minute would end the flow with
+ * the funds still in DEX custody and nothing watching them. The balances are
+ * re-read on every attempt so a retry acts on what is actually there.
+ */
+const recoverOisyTradeDeposit = async (params: {
+	identity: Identity;
+	sourceToken: IcToken;
+	destinationToken: IcToken;
+	baseline: OisyTradeFreeBalances;
+}): Promise<void> => {
+	const { identity, sourceToken, baseline } = params;
+
+	for (;;) {
+		try {
+			const current = await readOisyTradeFreeBalances(params);
+
+			await withdrawFreeBalance({
+				identity,
+				token: sourceToken,
+				amount: attributable({ current: current.source, baseline: baseline.source })
+			});
+
+			return;
+		} catch (err: unknown) {
+			if (!isRetryableOisyTradeError(err)) {
+				throw err;
+			}
+		}
+
+		await new Promise((resolve) =>
+			setTimeout(resolve, OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS)
+		);
+	}
+};
+
+/**
  * Executes a reviewed OISY Trade offer: approve → deposit → fill-or-kill order →
  * settle → withdraw.
  *
@@ -511,12 +626,13 @@ const settleUntilTerminal = async (params: {
  * book moves, and re-resolving them here would silently change what the user agreed
  * to between Review and submit.
  *
- * Throws an `OisyTradeSwapError` on a killed order. That is unlike every other
- * provider, where a failed swap means nothing moved: here the funds have been to the
- * DEX and back, so the error is raised only *after* the source token has been
- * withdrawn — the user is never told the swap failed while their money is still in
- * someone else's custody. The typed error is what lets the wizard present a kill as
- * the expected market outcome it is, rather than as an unexpected failure.
+ * Throws an `OisyTradeSwapError` on a killed order — and on one the canister
+ * refused to accept. That is unlike every other provider, where a failed swap means
+ * nothing moved: here the funds have been to the DEX and back, so in both cases the
+ * error is raised only *after* the source token has been withdrawn — the user is
+ * never told the swap failed while their money is still in someone else's custody.
+ * The typed error is what lets the wizard present either as the expected outcome it
+ * is, rather than as an unexpected failure.
  */
 export const fetchOisyTradeSwap = async ({
 	identity,
@@ -559,6 +675,18 @@ export const fetchOisyTradeSwap = async ({
 	};
 
 	progress(ProgressStepsSwap.APPROVE);
+
+	// Read before anything moves, so settlement can tell this order's funds apart from
+	// whatever the user already had on the DEX. It has to precede the deposit
+	// specifically: the deposit itself credits the source leg, and a baseline taken
+	// after it would make a killed order's returned reserve look like someone else's
+	// balance and be left behind. Step 2 captures this into the row's refs at creation,
+	// which is the same point in the flow.
+	const baseline = await readOisyTradeFreeBalances({
+		identity,
+		sourceToken,
+		destinationToken
+	});
 
 	trackDepositWithdraw({
 		direction: 'deposit',
@@ -618,6 +746,42 @@ export const fetchOisyTradeSwap = async ({
 			error: replaceIcErrorFields(err)
 		});
 
+		// An `OisyTradeError` is the canister replying with an `Err` — the order was
+		// definitively not accepted, so the deposit sits in free balance with no
+		// order reserving it. Recover it before surfacing the failure: rethrowing
+		// here would return the wizard to Review with the funds still in DEX
+		// custody, and a retry would deposit again — with a fresh baseline that
+		// classifies the first deposit as a pre-existing holding no later
+		// settlement would ever sweep. Recovery beats re-submitting even for a
+		// `retryable` rejection: the reviewed FOK price goes stale, and Review is
+		// where a fresh quote comes from.
+		//
+		// Anything else is ambiguous — the call may have reached the canister and
+		// only the reply been lost, so an order may exist with the reserve locked
+		// and no id to poll it by. Withdrawing here could race that live order, so
+		// the error is rethrown and the case belongs to the durable recovery record
+		// (the AUT row's "deposit landed, order never placed" path, step 2).
+		if (err instanceof OisyTradeError) {
+			progress(ProgressStepsSwap.WITHDRAW);
+
+			try {
+				await recoverOisyTradeDeposit({ identity, sourceToken, destinationToken, baseline });
+			} catch (recoveryErr: unknown) {
+				consoleError(recoveryErr);
+
+				// The one error raised while funds are still in DEX custody, which is
+				// why its message points at the Trading tab, where the balance shows.
+				throw new OisyTradeSwapError(swapI18n.error.oisy_trade_recovery_failed, 'recovery_failed');
+			}
+
+			// Like a kill: the funds came back as the source token — refresh the
+			// wallet so the recovered balance is visible, and never enable — or
+			// reach the UPDATE_UI step for — a destination token that never arrived.
+			await waitAndTriggerWallet();
+
+			throw new OisyTradeSwapError(swapI18n.error.oisy_trade_order_not_placed, 'not_placed');
+		}
+
 		throw err;
 	}
 
@@ -632,7 +796,8 @@ export const fetchOisyTradeSwap = async ({
 		identity,
 		orderId,
 		sourceToken,
-		destinationToken
+		destinationToken,
+		baseline
 	});
 
 	// Nothing was withdrawn and nothing says how the order ended, so there is no

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -1,0 +1,649 @@
+import type {
+	OrderId,
+	OrderRecord,
+	OrderStatus,
+	TradingPairInfo,
+	UserTokenBalance
+} from '$declarations/oisy_trade/oisy_trade.did';
+import type { IcToken } from '$icp/types/ic-token';
+import { getTokenFee } from '$icp/utils/token.utils';
+import { getBalances, getMyOrders, getTradingPairs, withdraw } from '$lib/api/oisy-trade.api';
+import { OisyTradeError } from '$lib/canisters/oisy-trade.errors';
+import { ZERO } from '$lib/constants/app.constants';
+import { OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
+import { exchanges } from '$lib/derived/exchange.derived';
+import { PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
+import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import { approveAndDepositOisyTrade } from '$lib/services/oisy-trade.deposit.services';
+import { placeLimitOrder } from '$lib/services/oisy-trade.services';
+import { OisyTradeSwapError } from '$lib/services/swap-errors.services';
+import { trackDepositWithdraw, trackLimitOrder } from '$lib/services/trading-analytics.services';
+import { i18n } from '$lib/stores/i18n.store';
+import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
+import type {
+	OisyTradeFee,
+	OisyTradeQuote,
+	OisyTradeQuoteResult,
+	OisyTradeResolvedOrder
+} from '$lib/types/oisy-trade-swap';
+import { SwapProvider, type SwapMappedResult } from '$lib/types/swap';
+import { consoleError } from '$lib/utils/console.utils';
+import { replaceIcErrorFields } from '$lib/utils/error.utils';
+import {
+	computeOisyTradeReceiveAmount,
+	findOisyTradePair,
+	oisyTradeSupportedSourceTokens,
+	resolveOisyTradeOrder,
+	toOisyTradeCandidSide,
+	toOisyTradePairTable
+} from '$lib/utils/oisy-trade-swap.utils';
+import { toPairView } from '$lib/utils/oisy-trade.utils';
+import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { Principal } from '@icp-sdk/core/principal';
+import { formatUnits } from 'ethers/utils';
+import { get } from 'svelte/store';
+
+/**
+ * The placeholder rate: one whole quote token per one whole base token.
+ *
+ * Replaced by the real order-book walk in its own spec. Everything downstream —
+ * the quantity, the reserve, the notional gate, the receive amount — is derived
+ * from the price, so that follow-up changes where this number comes from and
+ * nothing else. See the spec's "The 1:1 placeholder" section for why the flag
+ * must stay `false` until then.
+ */
+const OISY_TRADE_PLACEHOLDER_PRICE = 1;
+
+const BASIS_POINTS = 10_000n;
+
+/**
+ * Fetches the pair table, caches it, and reports which ledgers OISY Trade can
+ * quote as a source.
+ *
+ * Deliberately not `loadOisyTrade`, which also fetches supported tokens,
+ * balances and up to five pages of order history — none of which the quote path
+ * reads. The write goes through `setPairs` so it cannot clobber whatever the
+ * Trading tab has loaded.
+ *
+ * `resolveProviderGroup` substitutes an empty set when this throws, which is the
+ * correct degradation: an empty source set means the provider contributes
+ * nothing and `getSupportedDestinations` returns `undefined` — no offer, no error.
+ */
+export const loadOisyTradeSwapPairs = async ({
+	identity
+}: {
+	identity: Identity;
+}): Promise<Set<string>> => {
+	const pairs = await getTradingPairs({
+		identity,
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+	});
+
+	oisyTradeStore.setPairs(pairs);
+
+	return oisyTradeSupportedSourceTokens(toOisyTradePairTable(pairs));
+};
+
+/** The cached table, narrowed to actively-trading pairs. */
+export const oisyTradeSwapPairTable = (): TradingPairInfo[] =>
+	toOisyTradePairTable(get(oisyTradeStore).pairs ?? []);
+
+const takerFeeAmount = ({ gross, takerFeeBps }: { gross: bigint; takerFeeBps: number }): bigint =>
+	(gross * BigInt(takerFeeBps)) / BASIS_POINTS;
+
+/**
+ * Quotes a fill-or-kill order, or the reason there is none.
+ *
+ * Returns `ok: false` rather than throwing on every "cannot quote" case — no
+ * pair, a halted pair, an unorderable amount, a missing ledger fee. The fan-out
+ * discards rejections anyway, but a rejection keeps a non-offer out of the error
+ * analytics, where it would read as a broken provider rather than an absent one,
+ * and `errorKind` is what the form's empty-offer-list explanation names.
+ *
+ * Synchronous: `getSupportedTokens` has already cached the pair table by the
+ * time any quote runs, so there is nothing to await. The registry's `getQuote`
+ * contract is async, and the adaptation happens at that boundary rather than by
+ * making this function pretend to be asynchronous.
+ */
+export const fetchOisyTradeQuote = ({
+	sourceToken,
+	destinationToken,
+	sourceAmount
+}: {
+	sourceToken: IcToken;
+	destinationToken: IcToken;
+	sourceAmount: bigint;
+}): OisyTradeQuoteResult => {
+	const table = oisyTradeSwapPairTable();
+	const pair = findOisyTradePair({ sourceToken, destinationToken, table });
+
+	if (isNullish(pair)) {
+		return { ok: false };
+	}
+
+	const resolution = resolveOisyTradeOrder({
+		sourceToken,
+		amount: sourceAmount,
+		price: OISY_TRADE_PLACEHOLDER_PRICE,
+		pair
+	});
+
+	if (!resolution.ok) {
+		return { ok: false, errorKind: resolution.errorKind };
+	}
+
+	const { order } = resolution;
+
+	const sourceLedgerFee = getTokenFee(sourceToken);
+	const destinationLedgerFee = getTokenFee(destinationToken);
+
+	if (isNullish(sourceLedgerFee) || isNullish(destinationLedgerFee)) {
+		return { ok: false };
+	}
+
+	const pairView = toPairView(pair);
+
+	// What the order fills for, before the venue and the ledger take their cuts.
+	// At the placeholder price this is the deposited amount rescaled to the
+	// destination's decimals; the real calculation replaces the price it derives
+	// from, not this step.
+	//
+	// `depositAmount` was derived from the *pair's* decimals (`toPairView` reads
+	// them off the canister's leg metadata) and is rescaled here with the *token's*
+	// — two records describing the same two ledgers. They agree by construction, and
+	// nothing enforces it: a disagreement would move the receive amount by a power
+	// of ten silently, so the pair is the authority for anything the canister will
+	// check and the token only ever formats what the wallet displays.
+	const gross = computeOisyTradeReceiveAmount({
+		amount: order.depositAmount,
+		sourceDecimals: sourceToken.decimals,
+		destinationDecimals: destinationToken.decimals
+	});
+
+	const takerFee = takerFeeAmount({ gross, takerFeeBps: pairView.takerFeeBps });
+
+	// Both destination-denominated fees come out of what the user receives: the
+	// venue withholds its taker fee from the credited transfer, and `withdraw`
+	// deducts the ledger fee from the amount it pays out.
+	const receiveAmount = gross - takerFee - destinationLedgerFee;
+
+	if (receiveAmount <= ZERO) {
+		return { ok: false };
+	}
+
+	const fees: OisyTradeFee[] = [
+		{
+			// `icrc2_approve` and `icrc2_transfer_from` are each charged by the ledger,
+			// on top of the deposited amount rather than out of it.
+			labelPath: 'swap.text.oisy_trade_deposit_fee',
+			fee: sourceLedgerFee * 2n,
+			token: sourceToken
+		},
+		{
+			labelPath: 'swap.text.oisy_trade_taker_fee',
+			fee: takerFee,
+			token: destinationToken
+		},
+		{
+			labelPath: 'swap.text.oisy_trade_withdrawal_fee',
+			fee: destinationLedgerFee,
+			token: destinationToken
+		}
+	];
+
+	return {
+		ok: true,
+		quote: {
+			receiveAmount,
+			swapDetails: {
+				fees,
+				takerFeeBps: pairView.takerFeeBps,
+				minNotional: pair.min_notional,
+				quoteToken: order.side === 'sell' ? destinationToken : sourceToken,
+				order
+			}
+		}
+	};
+};
+
+export const mapOisyTradeQuoteResult = ({
+	quote
+}: {
+	quote: OisyTradeQuote;
+}): SwapMappedResult => ({
+	provider: SwapProvider.OISY_TRADE,
+	receiveAmount: quote.receiveAmount,
+	swapDetails: quote.swapDetails
+});
+
+/**
+ * How a settlement attempt resolved.
+ *
+ * `pending` is the only non-final one: the order is still `Pending` or `Open`, so
+ * nothing has been withdrawn and the caller should ask again. `unresolved` means the
+ * order is gone and neither leg holds anything withdrawable — there is nothing left
+ * to settle, and nothing that says how it ended.
+ */
+export type OisyTradeSettlementStatus = 'pending' | 'filled' | 'killed' | 'unresolved';
+
+export interface OisyTradeSettlement {
+	status: OisyTradeSettlementStatus;
+	// Ledger block indices of the withdrawals this attempt paid out. Empty while
+	// pending, and on a terminal outcome whose free balances were all dust.
+	withdrawals: bigint[];
+}
+
+/**
+ * Whether a failure is worth trying again, which is the only question settlement
+ * asks of an error.
+ *
+ * `OisyTradeTemporaryError` covers `LedgerTemporarilyUnavailable`,
+ * `OperationInProgress` and `CallFailed` — all transient, and
+ * `OperationInProgress` is the likeliest of the three in practice, since it fires
+ * whenever another deposit or withdrawal is already in flight for the same
+ * `(caller, token)`. Treating one of those as final would end the operation with
+ * the user's funds still in DEX custody, which is the single most damaging thing
+ * this integration can do.
+ */
+export const isRetryableOisyTradeError = (err: unknown): boolean =>
+	err instanceof OisyTradeError && err.retryable;
+
+// The `{ token, amount, usdPrice, usdValue }` shape both Trading trackers take, from
+// a base-unit amount. Mirrors what `depositOisyTrade` assembles for the Trading tab,
+// so the two surfaces report the same dimensions for the same movement.
+const toTradeAnalytics = ({ token, amount }: { token: IcToken; amount: bigint }) => {
+	const volume = formatUnits(amount, token.decimals);
+	const usdPrice = get(exchanges)?.[token.id]?.usd;
+
+	return {
+		token: token.symbol,
+		amount: volume,
+		usdPrice,
+		usdValue: nonNullish(usdPrice) ? usdPrice * Number(volume) : undefined
+	};
+};
+
+// `Pending` and `Open` are the two non-terminal states. A fill-or-kill order never
+// rests, so `Open` should be unreachable — it counts as still-pending rather than
+// being asserted on, since a killed FOK is `Expired` and turning an engine
+// implementation detail into a stuck settlement would be the worse failure.
+const isTerminalOrderStatus = (status: OrderStatus): boolean =>
+	'Filled' in status || 'Expired' in status || 'Canceled' in status;
+
+const ORDER_NOT_FOUND_REASON = 'OrderNotFound';
+
+/**
+ * The order, or `undefined` if the canister no longer knows it.
+ *
+ * "Not found" has two documented spellings — an empty `Ok` vec and
+ * `Err: OrderNotFound` — and the did does not say whether terminal orders are
+ * retained, so both are treated as the same answer and resolved from the balances.
+ */
+const readOisyTradeOrder = async ({
+	identity,
+	orderId
+}: {
+	identity: Identity;
+	orderId: OrderId;
+}): Promise<OrderRecord | undefined> => {
+	const nullishIdentityErrorMessage = get(i18n).auth.error.no_internet_identity;
+
+	try {
+		const [found] = await getMyOrders({
+			identity,
+			nullishIdentityErrorMessage,
+			args: { filter: { ById: orderId } }
+		});
+
+		return found?.order;
+	} catch (err: unknown) {
+		if (err instanceof OisyTradeError && err.reason === ORDER_NOT_FOUND_REASON) {
+			return undefined;
+		}
+
+		throw err;
+	}
+};
+
+const freeBalanceOf = ({
+	balances,
+	token
+}: {
+	balances: UserTokenBalance[];
+	token: IcToken;
+}): bigint =>
+	balances.find(({ token: { id } }) => id.ledger_id.toText() === token.ledgerCanisterId)?.balance
+		.free ?? ZERO;
+
+/**
+ * Withdraws a token's whole free balance, or nothing when that would be dust.
+ *
+ * `withdraw` refuses an amount at or below the ledger fee (`AmountTooSmall`), so a
+ * small enough residue is permanently unwithdrawable. Skipping it silently is the
+ * point rather than an omission: treating it as a failed settlement would strand the
+ * entire operation on a few base units nobody can move.
+ */
+const withdrawFreeBalance = async ({
+	identity,
+	token,
+	free
+}: {
+	identity: Identity;
+	token: IcToken;
+	free: bigint;
+}): Promise<bigint | undefined> => {
+	const fee = getTokenFee(token);
+
+	if (isNullish(fee) || free <= fee) {
+		return undefined;
+	}
+
+	const { block_index } = await withdraw({
+		identity,
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity,
+		request: {
+			token_id: { ledger_id: Principal.fromText(token.ledgerCanisterId) },
+			amount: free
+		}
+	});
+
+	return block_index;
+};
+
+/**
+ * One settlement attempt for a placed fill-or-kill order.
+ *
+ * Deliberately **one attempt, not a loop**: the swap wizard drives it on its own
+ * short interval while the modal is open, and the background poller that takes over
+ * in the next step calls it once per tick. A function that looped internally would
+ * hang a poller tick on an order that never resolves.
+ *
+ * It takes the order id and the two tokens as arguments rather than reading them
+ * from anywhere, so that poller can pass them straight out of an Active User
+ * Transaction's refs.
+ *
+ * The terminal action is always *withdraw the free balance of both legs*: a Buy that
+ * crosses below its limit price has its unspent reserve released back to free
+ * balance, so even a successful swap can leave source behind. The fill / kill
+ * distinction decides the reported status, never the shape of the withdrawal.
+ */
+export const settleOisyTradeSwap = async ({
+	identity,
+	orderId,
+	sourceToken,
+	destinationToken
+}: {
+	identity: Identity;
+	orderId: OrderId;
+	sourceToken: IcToken;
+	destinationToken: IcToken;
+}): Promise<OisyTradeSettlement> => {
+	const order = await readOisyTradeOrder({ identity, orderId });
+
+	// A live order's reserve is locked — "funds reserved by open orders are not
+	// withdrawable until the order fills or is canceled" — so there is nothing to
+	// withdraw here, and asking would only fail.
+	if (nonNullish(order) && !isTerminalOrderStatus(order.status)) {
+		return { status: 'pending', withdrawals: [] };
+	}
+
+	const balances = await getBalances({
+		identity,
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
+	});
+
+	const sourceFree = freeBalanceOf({ balances, token: sourceToken });
+	const destinationFree = freeBalanceOf({ balances, token: destinationToken });
+
+	// With the order still known, its status is the answer. Without it, the balances
+	// are — which is what makes this correct however long the canister retains a
+	// terminal order: destination in custody means it filled, source means it did not,
+	// and neither means the withdrawal already happened in an earlier attempt.
+	const status: OisyTradeSettlementStatus = nonNullish(order)
+		? 'Filled' in order.status
+			? 'filled'
+			: 'killed'
+		: destinationFree > ZERO
+			? 'filled'
+			: sourceFree > ZERO
+				? 'killed'
+				: 'unresolved';
+
+	if (status === 'unresolved') {
+		return { status, withdrawals: [] };
+	}
+
+	// The leg the funds came back in, and the leg that may hold a residue. A Buy that
+	// crosses below its limit has its unspent reserve released back to free balance, so
+	// a *successful* swap can still leave source behind.
+	const [primary, residue] =
+		status === 'filled'
+			? ([
+					[destinationToken, destinationFree],
+					[sourceToken, sourceFree]
+				] as const)
+			: ([
+					[sourceToken, sourceFree],
+					[destinationToken, destinationFree]
+				] as const);
+
+	// Sequential, not concurrent: the canister rejects a second withdrawal while one is
+	// already in flight for the same caller (`OperationInProgress`), so two legs issued
+	// together would race each other straight into it.
+	//
+	// The primary withdrawal is allowed to throw — it is the whole point of settling, and
+	// the caller retries it. The residue is best-effort: it is the smaller amount by
+	// construction, and letting it fail the settlement would strand an operation whose
+	// funds have already arrived, which is precisely the outcome this step exists to avoid.
+	const primaryBlockIndex = await withdrawFreeBalance({
+		identity,
+		token: primary[0],
+		free: primary[1]
+	});
+
+	const residueBlockIndex = await withdrawFreeBalance({
+		identity,
+		token: residue[0],
+		free: residue[1]
+	}).catch((err: unknown) => {
+		consoleError(err);
+
+		return undefined;
+	});
+
+	return {
+		status,
+		withdrawals: [primaryBlockIndex, residueBlockIndex].filter(nonNullish)
+	};
+};
+
+/**
+ * Settles in the foreground, retrying until the order reaches a terminal state.
+ *
+ * Unbounded on purpose: the modal stays open until the user's funds are back in
+ * their wallet, because until the next step's Active User Transaction row exists
+ * there is nothing else watching them. A retryable failure — a ledger having a bad
+ * minute, or a concurrent operation on the same token — is a reason to ask again,
+ * never a reason to stop; anything else ends the swap.
+ */
+const settleUntilTerminal = async (params: {
+	identity: Identity;
+	orderId: OrderId;
+	sourceToken: IcToken;
+	destinationToken: IcToken;
+}): Promise<OisyTradeSettlement> => {
+	for (;;) {
+		try {
+			const settlement = await settleOisyTradeSwap(params);
+
+			if (settlement.status !== 'pending') {
+				return settlement;
+			}
+		} catch (err: unknown) {
+			if (!isRetryableOisyTradeError(err)) {
+				throw err;
+			}
+		}
+
+		await new Promise((resolve) =>
+			setTimeout(resolve, OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS)
+		);
+	}
+};
+
+/**
+ * Executes a reviewed OISY Trade offer: approve → deposit → fill-or-kill order →
+ * settle → withdraw.
+ *
+ * The price and quantity come from the reviewed quote and are never re-derived. The
+ * book moves, and re-resolving them here would silently change what the user agreed
+ * to between Review and submit.
+ *
+ * Throws an `OisyTradeSwapError` on a killed order. That is unlike every other
+ * provider, where a failed swap means nothing moved: here the funds have been to the
+ * DEX and back, so the error is raised only *after* the source token has been
+ * withdrawn — the user is never told the swap failed while their money is still in
+ * someone else's custody. The typed error is what lets the wizard present a kill as
+ * the expected market outcome it is, rather than as an unexpected failure.
+ */
+export const fetchOisyTradeSwap = async ({
+	identity,
+	progress,
+	sourceToken,
+	destinationToken,
+	order,
+	enableDestinationToken
+}: {
+	identity: Identity;
+	progress: (step: ProgressStepsSwap) => void;
+	sourceToken: IcToken;
+	destinationToken: IcToken;
+	// The order the quote resolved and the user reviewed.
+	order: OisyTradeResolvedOrder;
+	enableDestinationToken?: () => Promise<void>;
+}): Promise<OisyTradeSettlement> => {
+	const { swap: swapI18n } = get(i18n);
+
+	// A swap-placed order genuinely *is* a deposit and a limit order, so both Trading
+	// funnels fire alongside the swap funnel's own events in `SwapIcpWizard`. Omitting
+	// them would leave a hole in the Trading funnel exactly proportional to how well
+	// this provider does in Swap.
+	const [baseToken, quoteToken] =
+		order.side === 'sell' ? [sourceToken, destinationToken] : [destinationToken, sourceToken];
+
+	const depositAnalytics = toTradeAnalytics({
+		token: sourceToken,
+		amount: order.depositAmount
+	});
+
+	const orderAnalytics = {
+		action: 'create' as const,
+		base: baseToken.symbol,
+		quote: quoteToken.symbol,
+		side: order.side,
+		orderType: 'FOK' as const,
+		baseAmount: formatUnits(order.quantity, baseToken.decimals),
+		price: formatUnits(order.price, quoteToken.decimals)
+	};
+
+	progress(ProgressStepsSwap.APPROVE);
+
+	trackDepositWithdraw({
+		direction: 'deposit',
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.EXECUTING,
+		...depositAnalytics
+	});
+
+	try {
+		await approveAndDepositOisyTrade({
+			identity,
+			token: sourceToken,
+			amount: order.depositAmount,
+			onApproved: () => progress(ProgressStepsSwap.SWAP)
+		});
+	} catch (err: unknown) {
+		trackDepositWithdraw({
+			direction: 'deposit',
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+			...depositAnalytics,
+			error: replaceIcErrorFields(err)
+		});
+
+		throw err;
+	}
+
+	trackDepositWithdraw({
+		direction: 'deposit',
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
+		...depositAnalytics
+	});
+
+	trackLimitOrder({
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.EXECUTING,
+		...orderAnalytics
+	});
+
+	let orderId: OrderId;
+
+	try {
+		orderId = await placeLimitOrder({
+			identity,
+			request: {
+				pair: order.pair,
+				side: toOisyTradeCandidSide(order.side),
+				quantity: order.quantity,
+				price: order.price,
+				// Always fill-or-kill. A swap is a single atomic "this amount, now, or not at
+				// all" — it has no resting semantics, no cancel button and no order row the
+				// user is expected to babysit. `GoodTilCanceled` stays the Limit Order flow's.
+				time_in_force: [{ FillOrKill: null }]
+			}
+		});
+	} catch (err: unknown) {
+		trackLimitOrder({
+			resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.ERROR,
+			...orderAnalytics,
+			error: replaceIcErrorFields(err)
+		});
+
+		throw err;
+	}
+
+	trackLimitOrder({
+		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
+		...orderAnalytics
+	});
+
+	progress(ProgressStepsSwap.WITHDRAW);
+
+	const settlement = await settleUntilTerminal({
+		identity,
+		orderId,
+		sourceToken,
+		destinationToken
+	});
+
+	// Nothing was withdrawn and nothing says how the order ended, so there is no
+	// wallet change to refresh and no destination token to enable.
+	if (settlement.status === 'unresolved') {
+		throw new OisyTradeSwapError(swapI18n.error.oisy_trade_settlement_unresolved, 'unresolved');
+	}
+
+	// A killed order's funds came back as the *source* token: refresh the wallet
+	// so the recovered balance is visible, but never enable — and never reach the
+	// UPDATE_UI step for — a destination token the user did not receive.
+	if (settlement.status === 'killed') {
+		await waitAndTriggerWallet();
+
+		throw new OisyTradeSwapError(swapI18n.error.oisy_trade_order_killed, 'killed');
+	}
+
+	progress(ProgressStepsSwap.UPDATE_UI);
+
+	await enableDestinationToken?.();
+	await waitAndTriggerWallet();
+
+	return settlement;
+};

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -320,10 +320,16 @@ const freeBalanceOf = ({
 /**
  * Withdraws a token's whole free balance, or nothing when that would be dust.
  *
- * `withdraw` refuses an amount at or below the ledger fee (`AmountTooSmall`), so a
+ * `withdraw` refuses an `amount` at or below the ledger fee (`AmountTooSmall`), so a
  * small enough residue is permanently unwithdrawable. Skipping it silently is the
  * point rather than an omission: treating it as a failed settlement would strand the
  * entire operation on a few base units nobody can move.
+ *
+ * An unknown fee is deliberately *not* folded into that skip — it says nothing about
+ * whether the balance is withdrawable, and skipping would let settlement report the
+ * swap `filled` or `killed` with the funds still in DEX custody. Unreachable in
+ * practice (`IcTokenSchema` requires `fee`, and the quote refuses a pair whose ledger
+ * fees it cannot read), so it throws rather than earning its own error type.
  */
 const withdrawFreeBalance = async ({
 	identity,
@@ -336,7 +342,11 @@ const withdrawFreeBalance = async ({
 }): Promise<bigint | undefined> => {
 	const fee = getTokenFee(token);
 
-	if (isNullish(fee) || free <= fee) {
+	if (isNullish(fee)) {
+		throw new Error(get(i18n).trading.deposit.error.unknown_fee);
+	}
+
+	if (free <= fee) {
 		return undefined;
 	}
 

--- a/src/frontend/src/lib/services/oisy-trade.deposit.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade.deposit.services.ts
@@ -20,6 +20,57 @@ import { get } from 'svelte/store';
 
 const APPROVE_EXPIRATION_MINUTES = 5n;
 
+/**
+ * The two calls a deposit is made of, with none of the surrounding policy:
+ * `icrc2_approve` on the token ledger for `amount + ledger_fee` (the
+ * `icrc2_transfer_from` fee is charged against the allowance on top of the
+ * amount), then `deposit` on the DEX, which pulls the funds and credits the
+ * caller's free balance. Returns the ledger block index of the transfer.
+ *
+ * Extracted so the swap flow can run the same two calls under different
+ * surroundings: it needs them to **throw** so the wizard's catch can present the
+ * error, to drive `ProgressStepsSwap` rather than the Trading enum, and to skip
+ * the Trading store reload. Bending `depositOisyTrade`'s contract to serve two
+ * callers, or duplicating the calls, were the alternatives.
+ */
+export const approveAndDepositOisyTrade = async ({
+	identity,
+	token,
+	amount,
+	onApproved
+}: {
+	identity: NonNullable<NullishIdentity>;
+	token: IcToken;
+	// Amount to deposit, in the token's smallest units.
+	amount: bigint;
+	// Fired between the two calls, so each caller advances its own progress enum.
+	onApproved?: () => void;
+}): Promise<bigint> => {
+	assertNonNullish(OISY_TRADE_CANISTER_ID);
+
+	const { ledgerCanisterId } = token;
+	const fee = getTokenFee(token);
+
+	assertNonNullish(fee, get(i18n).trading.deposit.error.unknown_fee);
+
+	await approve({
+		identity,
+		ledgerCanisterId,
+		amount: amount + fee,
+		spender: { owner: Principal.fromText(OISY_TRADE_CANISTER_ID) },
+		expiresAt: nowInBigIntNanoSeconds() + APPROVE_EXPIRATION_MINUTES * NANO_SECONDS_IN_MINUTE
+	});
+
+	onApproved?.();
+
+	const { block_index } = await depositApi({
+		identity,
+		request: { token_id: { ledger_id: Principal.fromText(ledgerCanisterId) }, amount }
+	});
+
+	return block_index;
+};
+
 export interface DepositOisyTradeParams {
 	identity: NullishIdentity;
 	token: IcToken;
@@ -53,12 +104,11 @@ export const depositOisyTrade = async ({
 
 	try {
 		assertNonNullish(identity, auth.error.no_internet_identity);
+		// Pre-flight, kept here so an unknown fee still fails *before* the funnel
+		// records an attempt. `approveAndDepositOisyTrade` asserts both again, since
+		// it cannot assume a caller checked.
 		assertNonNullish(OISY_TRADE_CANISTER_ID);
-
-		const { ledgerCanisterId } = token;
-		const fee = getTokenFee(token);
-
-		assertNonNullish(fee, trading.deposit.error.unknown_fee);
+		assertNonNullish(getTokenFee(token), trading.deposit.error.unknown_fee);
 
 		trackDepositWithdraw({
 			direction: 'deposit',
@@ -68,19 +118,11 @@ export const depositOisyTrade = async ({
 
 		progress?.(ProgressStepsTradingDeposit.APPROVE);
 
-		await approve({
+		await approveAndDepositOisyTrade({
 			identity,
-			ledgerCanisterId,
-			amount: amount + fee,
-			spender: { owner: Principal.fromText(OISY_TRADE_CANISTER_ID) },
-			expiresAt: nowInBigIntNanoSeconds() + APPROVE_EXPIRATION_MINUTES * NANO_SECONDS_IN_MINUTE
-		});
-
-		progress?.(ProgressStepsTradingDeposit.DEPOSIT);
-
-		await depositApi({
-			identity,
-			request: { token_id: { ledger_id: Principal.fromText(ledgerCanisterId) }, amount }
+			token,
+			amount,
+			onApproved: () => progress?.(ProgressStepsTradingDeposit.DEPOSIT)
 		});
 
 		progress?.(ProgressStepsTradingDeposit.UPDATE_UI);

--- a/src/frontend/src/lib/services/swap-errors.services.ts
+++ b/src/frontend/src/lib/services/swap-errors.services.ts
@@ -31,3 +31,28 @@ export class SwapError extends Error {
 		this.swapSucceded = swapSucceded;
 	}
 }
+
+/**
+ * How an OISY Trade swap ended when the destination token did not arrive.
+ *
+ * `killed` is a fill-or-kill order the book could not fill — an expected market
+ * outcome, and the source funds have already been withdrawn back to the wallet
+ * when this is thrown. `unresolved` means the settlement found neither the order
+ * nor any balance in DEX custody, so there is nothing left to recover and nothing
+ * that says how the order ended.
+ *
+ * A dedicated class, and defined here rather than next to its thrower, so
+ * `SwapIcpWizard` can recognize both by `instanceof` and present them in Review
+ * (like slippage-exceeded) instead of as an unexpected-error toast — even when a
+ * test mocks the OISY Trade services module away. `kind` also rides into the
+ * failure analytics as the error key.
+ */
+export class OisyTradeSwapError extends Error {
+	constructor(
+		message: string,
+		public readonly kind: 'killed' | 'unresolved'
+	) {
+		super(message);
+		this.name = 'OisyTradeSwapError';
+	}
+}

--- a/src/frontend/src/lib/services/swap-errors.services.ts
+++ b/src/frontend/src/lib/services/swap-errors.services.ts
@@ -37,20 +37,24 @@ export class SwapError extends Error {
  *
  * `killed` is a fill-or-kill order the book could not fill — an expected market
  * outcome, and the source funds have already been withdrawn back to the wallet
- * when this is thrown. `unresolved` means the settlement found neither the order
- * nor any balance in DEX custody, so there is nothing left to recover and nothing
- * that says how the order ended.
+ * when this is thrown. `not_placed` is an order the canister refused to accept —
+ * likewise thrown only once the deposit has been recovered to the wallet.
+ * `unresolved` means the settlement found neither the order nor any balance in
+ * DEX custody, so there is nothing left to recover and nothing that says how the
+ * order ended. `recovery_failed` is the one kind raised while funds are still in
+ * DEX custody: the order was refused and withdrawing the deposit back failed, so
+ * the message points the user at the Trading tab, where the balance is visible.
  *
  * A dedicated class, and defined here rather than next to its thrower, so
- * `SwapIcpWizard` can recognize both by `instanceof` and present them in Review
- * (like slippage-exceeded) instead of as an unexpected-error toast — even when a
- * test mocks the OISY Trade services module away. `kind` also rides into the
- * failure analytics as the error key.
+ * `SwapIcpWizard` can recognize all of them by `instanceof` and present them in
+ * Review (like slippage-exceeded) instead of as an unexpected-error toast — even
+ * when a test mocks the OISY Trade services module away. `kind` also rides into
+ * the failure analytics as the error key.
  */
 export class OisyTradeSwapError extends Error {
 	constructor(
 		message: string,
-		public readonly kind: 'killed' | 'unresolved'
+		public readonly kind: 'killed' | 'not_placed' | 'unresolved' | 'recovery_failed'
 	) {
 		super(message);
 		this.name = 'OisyTradeSwapError';

--- a/src/frontend/src/lib/services/swap.services.ts
+++ b/src/frontend/src/lib/services/swap.services.ts
@@ -68,6 +68,7 @@ import {
 	NEAR_INTENTS_EXTERNAL_REF_KEYS,
 	type NearIntentsQuoteResponse
 } from '$lib/types/near-intents';
+import type { OisyTradeQuote } from '$lib/types/oisy-trade-swap';
 import type { Amount } from '$lib/types/send';
 import {
 	SwapErrorCodes,
@@ -584,6 +585,12 @@ const fetchSwapAmountsICP = async ({
 					slippage,
 					destToken: destinationToken as IcToken
 				});
+			} else if (provider.key === SwapProvider.OISY_TRADE && isSourceTokenIcrc2) {
+				// Gated on ICRC-2 like ICPSwap: the deposit leg is `icrc2_approve` plus
+				// `icrc2_transfer_from`, so a source ledger without ICRC-2 cannot be
+				// deposited at all.
+				const quote = result.value as OisyTradeQuote | undefined;
+				mapped = nonNullish(quote) ? provider.mapQuoteResult({ quote }) : undefined;
 			}
 
 			if (nonNullish(mapped)) {
@@ -1134,6 +1141,12 @@ export const swapService = {
 	// `fetchChainFusionIcpSwap` and never reaches this entry — exactly as it does for
 	// 1Sec above.
 	[SwapProvider.CHAIN_FUSION]: () => {
+		throw new Error(get(i18n).swap.error.unexpected);
+	},
+	// OISY Trade needs the resolved order parameters — side, price, quantity —
+	// which `SwapParams` cannot carry, so `SwapIcpWizard` dispatches it explicitly
+	// and never reaches this entry, exactly as it does for 1Sec and Chain Fusion.
+	[SwapProvider.OISY_TRADE]: () => {
 		throw new Error(get(i18n).swap.error.unexpected);
 	}
 } satisfies Record<SwapProvider, (params: SwapParams) => Promise<void>>;

--- a/src/frontend/src/lib/stores/oisy-trade.store.ts
+++ b/src/frontend/src/lib/stores/oisy-trade.store.ts
@@ -1,8 +1,20 @@
+import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 import type { OisyTradeStoreData } from '$lib/types/oisy-trade';
 import { writable, type Readable } from 'svelte/store';
 
 export interface OisyTradeStore extends Readable<OisyTradeStoreData> {
 	set: (data: OisyTradeStoreData) => void;
+	/**
+	 * Writes only `pairs`, leaving the Trading tab's `supportedTokens` / `balances`
+	 * / `orders` untouched.
+	 *
+	 * The swap quote path needs the pair table and nothing else, while `set`
+	 * replaces all four fields at once — so without this the swap loader would wipe
+	 * whatever the Trading tab had loaded, and vice versa. Keeping one store for
+	 * pairs rather than a second one means the two surfaces cannot go stale against
+	 * each other, and the fetch can be skipped when either has already run.
+	 */
+	setPairs: (pairs: TradingPairInfo[]) => void;
 	reset: () => void;
 }
 
@@ -13,11 +25,12 @@ const initOisyTradeStore = (): OisyTradeStore => {
 		balances: undefined,
 		orders: undefined
 	};
-	const { subscribe, set } = writable<OisyTradeStoreData>(defaultStoreValue);
+	const { subscribe, set, update } = writable<OisyTradeStoreData>(defaultStoreValue);
 
 	return {
 		subscribe,
 		set,
+		setPairs: (pairs: TradingPairInfo[]) => update((state) => ({ ...state, pairs })),
 		reset: () => set(defaultStoreValue)
 	};
 };

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -981,6 +981,8 @@ interface I18nSwap {
 		near_intents_quote_expired: string;
 		oisy_trade_order_killed: string;
 		oisy_trade_settlement_unresolved: string;
+		oisy_trade_order_not_placed: string;
+		oisy_trade_recovery_failed: string;
 	};
 }
 

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -949,6 +949,10 @@ interface I18nSwap {
 		onesec_transfer_fee: string;
 		onesec_protocol_fee: string;
 		chain_fusion_minimum_amount: string;
+		oisy_trade_minimum_notional: string;
+		oisy_trade_deposit_fee: string;
+		oisy_trade_taker_fee: string;
+		oisy_trade_withdrawal_fee: string;
 		value_difference_error_confirmation: string;
 		value_difference_missing_price_confirmation: string;
 	};
@@ -975,6 +979,8 @@ interface I18nSwap {
 		swap_replaced_or_dropped: string;
 		near_intents_quote_unverified: string;
 		near_intents_quote_expired: string;
+		oisy_trade_order_killed: string;
+		oisy_trade_settlement_unresolved: string;
 	};
 }
 

--- a/src/frontend/src/lib/types/oisy-trade-swap.ts
+++ b/src/frontend/src/lib/types/oisy-trade-swap.ts
@@ -1,0 +1,112 @@
+import type { TradingPair } from '$declarations/oisy_trade/oisy_trade.did';
+import type { ProviderFee } from '$lib/types/swap';
+import type { Token } from '$lib/types/token';
+import type { FieldErrorKind, LimitOrderSide } from '$lib/utils/oisy-trade.utils';
+
+export const OISY_TRADE_EXTERNAL_REF_KEYS = {
+	// The poll key. `get_my_orders` with `ById` is the only settlement oracle,
+	// and this is written the moment `add_limit_order` returns.
+	ORDER_ID: 'order_id',
+	// Proof the deposit landed, and the only thing that separates a row whose
+	// deposit stalled from one that never started — the two resolve differently
+	// (withdraw and fail, versus delete).
+	DEPOSIT_BLOCK_INDEX: 'deposit_block_index',
+	// The price and quantity actually submitted, for traceability and for the
+	// failure message. Snapshotted rather than re-derived, because the book moves
+	// and the row has to keep describing the order the user reviewed.
+	ORDER_PRICE: 'order_price',
+	ORDER_QUANTITY: 'order_quantity',
+	// The destination (or recovered source) withdrawal that closes the row.
+	WITHDRAW_BLOCK_INDEX: 'withdraw_block_index',
+	// Display + analytics metadata snapshotted at creation. These reuse OneSec's
+	// exact key strings — `ActiveUserTransactionItem` reads *every* row's refs
+	// through `toOneSecExternalRefsMap`, so a fifth swap provider renders for free
+	// only by speaking the same vocabulary. They stay correct across refresh and
+	// cross-session resume, and after the user disables one of the two tokens.
+	AMOUNT: 'amount',
+	USD_SOURCE_VALUE: 'usd_source_value',
+	SOURCE_TOKEN_SYMBOL: 'source_token_symbol',
+	SOURCE_NETWORK_SYMBOL: 'source_network_symbol',
+	DESTINATION_TOKEN_SYMBOL: 'destination_token_symbol',
+	DESTINATION_NETWORK_SYMBOL: 'destination_network_symbol'
+} as const;
+
+export type OisyTradeExternalRefKey =
+	(typeof OISY_TRADE_EXTERNAL_REF_KEYS)[keyof typeof OISY_TRADE_EXTERNAL_REF_KEYS];
+
+// Deliberately absent: the order side and the pair's base / quote legs. All
+// three are fixed at creation and ride in the AUT `data` variant instead —
+// `OisyTradeData.side` plus the source and destination tokens determine them
+// (`Sell` means base is the source and quote the destination, `Buy` the
+// reverse). Writing them as refs as well would be two representations of one
+// fact with nothing keeping them agreed.
+
+export type OisyTradeFee = ProviderFee & {
+	// i18n path resolved at render time, so the fee list carries no copy itself.
+	// Same shape as `ChainFusionFee`, and rendered the same way.
+	labelPath: string;
+};
+
+/**
+ * The order parameters the quote resolved, carried through to execution.
+ *
+ * Carried in the quote rather than re-derived at submit time on purpose: the
+ * quote is what the user reviewed, and re-deriving the price after Review would
+ * let the book move underneath them, silently changing what they agreed to.
+ * `LimitOrderWizard` freezes its market snapshot at Review for the same reason.
+ */
+export interface OisyTradeResolvedOrder {
+	side: LimitOrderSide;
+	pair: TradingPair;
+	// Quote-token smallest units per one *whole* base token, on the pair's tick
+	// grid — the candid `price` convention, not a human rate.
+	price: bigint;
+	// Base-token smallest units, a multiple of the pair's lot size.
+	quantity: bigint;
+	// What the deposit leg actually moves, in *source*-token smallest units:
+	// the quantity on a Sell, the order's reserve at the limit price on a Buy.
+	// Depositing exactly what the order reserves leaves the unorderable slice of
+	// the typed amount in the user's wallet, where it costs no fee and needs no
+	// withdrawal.
+	depositAmount: bigint;
+}
+
+/**
+ * What `getQuote` hands back before it becomes a `SwapMappedResult`.
+ *
+ * The registry's `swapProviders` group splits quoting from mapping, so this is
+ * the intermediate — the same split ICPSwap uses, rather than a new shape.
+ */
+export interface OisyTradeQuote {
+	receiveAmount: bigint;
+	swapDetails: OisyTradeSwapDetails;
+}
+
+/**
+ * A quote, or the named reason there is none.
+ *
+ * The fan-out itself only carries offers — the registry adapter drops the
+ * rejection — but `errorKind` maps one-to-one onto the shipped Limit Order i18n
+ * copy, and it is what lets the form explain an empty offer list (via
+ * `notOfferedExplained` + `message`) instead of the generic "swap is not
+ * offered". Rejections without a kind (no pair, halted pair, unknown ledger fee)
+ * have nothing user-actionable to say.
+ */
+export type OisyTradeQuoteResult =
+	{ ok: true; quote: OisyTradeQuote } | { ok: false; errorKind?: FieldErrorKind };
+
+export interface OisyTradeSwapDetails {
+	// Itemized, never summed: the three fees are denominated in two different
+	// tokens, so a single total would be a cross-token addition.
+	fees: OisyTradeFee[];
+	// The pair's taker rate, in basis points. A fill-or-kill order either crosses
+	// the book immediately or is killed, so it can never rest and earn the maker
+	// rate — `maker_fee_bps` is irrelevant here and is never displayed.
+	takerFeeBps: number;
+	// The pair's floor, in quote-token smallest units, with the token it is
+	// denominated in. Carried here so the provider sheet renders from the offer
+	// alone, like every other `SwapDetails*`, rather than re-reading the pair table.
+	minNotional: bigint;
+	quoteToken: Token;
+	order: OisyTradeResolvedOrder;
+}

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -12,6 +12,7 @@ import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import type { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import type { Address, OptionAddress } from '$lib/types/address';
 import type { NearIntentsQuoteResponse } from '$lib/types/near-intents';
+import type { OisyTradeQuote, OisyTradeSwapDetails } from '$lib/types/oisy-trade-swap';
 import type { Amount, OptionAmount } from '$lib/types/send';
 import type { Token } from '$lib/types/token';
 import type { RequiredTransactionFeeData } from '$lib/types/transaction';
@@ -49,7 +50,8 @@ export enum SwapProvider {
 	VELORA = 'velora',
 	NEAR_INTENTS = 'nearIntents',
 	ONE_SEC = 'oneSec',
-	CHAIN_FUSION = 'chainFusion'
+	CHAIN_FUSION = 'chainFusion',
+	OISY_TRADE = 'oisyTrade'
 }
 
 export enum VeloraSwapTypes {
@@ -157,6 +159,15 @@ export type SwapMappedResult =
 			receiveAmount: bigint;
 			swapDetails: ChainFusionSwapDetails;
 			type?: string;
+	  }
+	| {
+			provider: SwapProvider.OISY_TRADE;
+			receiveAmount: bigint;
+			// No `receiveOutMinimum`: a fill-or-kill order has no slippage semantics —
+			// it fills at the submitted price or is killed — so the slippage control
+			// must not affect this offer.
+			swapDetails: OisyTradeSwapDetails;
+			type?: string;
 	  };
 
 interface KongQuoteParams {
@@ -189,7 +200,16 @@ type KongSwapProvider = BaseSwapProvider<SwapProvider.KONG_SWAP, SwapAmountsRepl
 
 type IcpSwapProvider = BaseSwapProvider<SwapProvider.ICP_SWAP, ICPSwapResult, IcpQuoteParams>;
 
-export type SwapProviderConfig = KongSwapProvider | IcpSwapProvider;
+// `getQuote` may resolve to `undefined` — an unorderable amount or an unpaired
+// token is a non-offer, not an error — so `fetchSwapAmountsICP` maps only when a
+// quote actually came back.
+type OisyTradeSwapProvider = BaseSwapProvider<
+	SwapProvider.OISY_TRADE,
+	OisyTradeQuote | undefined,
+	{ quote: OisyTradeQuote }
+>;
+
+export type SwapProviderConfig = KongSwapProvider | IcpSwapProvider | OisyTradeSwapProvider;
 
 export interface EvmSwapProviderConfig {
 	key: SwapProvider;

--- a/src/frontend/src/lib/utils/oisy-trade-swap.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade-swap.utils.ts
@@ -1,0 +1,285 @@
+import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
+import { ZERO } from '$lib/constants/app.constants';
+import type { OisyTradeResolvedOrder } from '$lib/types/oisy-trade-swap';
+import type { SwapCategorizedTokenIds } from '$lib/types/swap';
+import type { Token } from '$lib/types/token';
+import {
+	floorToStep,
+	toCandidSide,
+	toPairView,
+	toPriceUnits,
+	toQuantity,
+	toTradingPair,
+	validateAmount,
+	type FieldErrorKind,
+	type LimitOrderSide
+} from '$lib/utils/oisy-trade.utils';
+import { resolveSwapTokenLookup } from '$lib/utils/swap-tokens-filter.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+
+/**
+ * Adapter from the swap flow onto the shipped Trading helpers — deliberately
+ * thin. The grid arithmetic (lot multiples, tick alignment, notional bounds)
+ * lives in `oisy-trade.utils.ts` and is reached through it, never reimplemented:
+ * the Swap and Limit Order surfaces have to agree about what is orderable, and a
+ * divergence would only show up for amounts near a boundary.
+ *
+ * Every function takes the pair table as an argument rather than reading the
+ * store, so they stay pure and testable — a store-reading util would see an
+ * empty table in every vitest run. Chain Fusion made the same choice.
+ */
+
+// The ledger-id text of a pair leg. Must stay in the identifier space
+// `resolveSwapTokenLookup` produces for the `icp` category (an IC token's
+// `ledgerCanisterId`), since the registry matches source tokens against this set.
+const legLedgerId = (leg: TradingPairInfo['base']): string => leg.id.ledger_id.toText();
+
+const isTrading = ({ status }: TradingPairInfo): boolean => 'Trading' in status;
+
+/**
+ * The actively-trading pairs. A `Halted` pair is dropped from both the source set
+ * and the destination sets: the canister rejects new orders on it with
+ * `TemporaryError: TradingHalted`, so quoting it would offer a swap that cannot
+ * execute.
+ */
+export const toOisyTradePairTable = (pairs: TradingPairInfo[]): TradingPairInfo[] =>
+	pairs.filter(isTrading);
+
+/** Every ledger that is a leg of an actively-trading pair, in either position. */
+export const oisyTradeSupportedSourceTokens = (table: TradingPairInfo[]): Set<string> =>
+	new Set(table.flatMap((pair) => [legLedgerId(pair.base), legLedgerId(pair.quote)]));
+
+const icpLedgerId = (token: Token): string | undefined => {
+	const lookup = resolveSwapTokenLookup({ token });
+
+	return lookup?.category === 'icp' ? lookup.identifier : undefined;
+};
+
+/**
+ * A source token's valid destinations: its pair counterparts, and only those.
+ *
+ * Directed, which is why `buildSymmetricSupportedDestinations` cannot serve here
+ * — that returns the whole supported-source set, correct for ICPSwap and
+ * KongSwap, wrong for a pair table.
+ */
+export const oisyTradeCompatibleDestinations = ({
+	sourceToken,
+	table
+}: {
+	sourceToken: Token;
+	table: TradingPairInfo[];
+}): SwapCategorizedTokenIds | undefined => {
+	const sourceLedgerId = icpLedgerId(sourceToken);
+
+	if (isNullish(sourceLedgerId)) {
+		return undefined;
+	}
+
+	const counterparts = table.reduce<Set<string>>((acc, pair) => {
+		const base = legLedgerId(pair.base);
+		const quote = legLedgerId(pair.quote);
+
+		if (base === sourceLedgerId) {
+			acc.add(quote);
+		} else if (quote === sourceLedgerId) {
+			acc.add(base);
+		}
+
+		return acc;
+	}, new Set());
+
+	return counterparts.size > 0 ? { icp: counterparts } : undefined;
+};
+
+/** The pair these two tokens trade on, if any — the guard the execution PR shares. */
+export const findOisyTradePair = ({
+	sourceToken,
+	destinationToken,
+	table
+}: {
+	sourceToken: Token;
+	destinationToken: Token;
+	table: TradingPairInfo[];
+}): TradingPairInfo | undefined => {
+	const sourceLedgerId = icpLedgerId(sourceToken);
+	const destinationLedgerId = icpLedgerId(destinationToken);
+
+	if (isNullish(sourceLedgerId) || isNullish(destinationLedgerId)) {
+		return undefined;
+	}
+
+	return table.find((pair) => {
+		const base = legLedgerId(pair.base);
+		const quote = legLedgerId(pair.quote);
+
+		return (
+			(base === sourceLedgerId && quote === destinationLedgerId) ||
+			(quote === sourceLedgerId && base === destinationLedgerId)
+		);
+	});
+};
+
+export const isOisyTradePair = (params: {
+	sourceToken: Token;
+	destinationToken: Token;
+	table: TradingPairInfo[];
+}): boolean => nonNullish(findOisyTradePair(params));
+
+/**
+ * Which side of the pair the source token sits on: spending the base token is a
+ * Sell, spending the quote token is a Buy.
+ */
+export const resolveOisyTradeSide = ({
+	sourceToken,
+	pair
+}: {
+	sourceToken: Token;
+	pair: TradingPairInfo;
+}): LimitOrderSide | undefined => {
+	const sourceLedgerId = icpLedgerId(sourceToken);
+
+	if (isNullish(sourceLedgerId)) {
+		return undefined;
+	}
+
+	if (sourceLedgerId === legLedgerId(pair.base)) {
+		return 'sell';
+	}
+
+	return sourceLedgerId === legLedgerId(pair.quote) ? 'buy' : undefined;
+};
+
+export type OisyTradeOrderResolution =
+	{ ok: true; order: OisyTradeResolvedOrder } | { ok: false; errorKind?: FieldErrorKind };
+
+/**
+ * The typed source amount resolved into a submittable fill-or-kill order.
+ *
+ * Works in the human float domain and converts at the candid boundary, exactly
+ * as `LimitOrderWizard.place()` already ships: the quantity ends up on the lot
+ * grid (validated on a Sell, floored on a Buy) and the price snapped to the
+ * tick grid, so both carry at most `decimalsOfStep(step)` decimal places. Only
+ * the Buy-side reserve is computed in bigint, because it is an exact base-unit
+ * quantity the canister enforces.
+ *
+ * Returns `ok: false` rather than throwing when the amount is not orderable —
+ * OISY Trade simply contributes no offer, and `errorKind` lets the form name the
+ * reason when no other provider quoted either.
+ */
+export const resolveOisyTradeOrder = ({
+	sourceToken,
+	amount,
+	price,
+	freeBalance,
+	pair
+}: {
+	sourceToken: Token;
+	// Source-token smallest units, as the quote fan-out carries it.
+	amount: bigint;
+	// Human quote-per-whole-base rate. Snapped to the tick grid here.
+	price: number;
+	/**
+	 * Human source-token balance the order has to fit inside.
+	 *
+	 * Optional because the quote path has no balance to offer — `SwapQuoteParams`
+	 * carries only the identity, the two tokens and the amount. Left unset, the
+	 * affordability leg of `validateAmount` is a no-op and only the grid rules
+	 * apply, which is also the behaviour the offer list wants: every other provider
+	 * quotes an unaffordable amount and lets the form report insufficient funds, so
+	 * suppressing the offer here would make OISY Trade blink out where its peers
+	 * still appear. Execution passes the real figure.
+	 */
+	freeBalance?: number;
+	pair: TradingPairInfo;
+}): OisyTradeOrderResolution => {
+	const side = resolveOisyTradeSide({ sourceToken, pair });
+
+	if (isNullish(side)) {
+		return { ok: false };
+	}
+
+	const pairView = toPairView(pair);
+	const tickedPrice = floorToStep({ value: price, step: pairView.tickSize });
+
+	if (!(tickedPrice > 0)) {
+		return { ok: false };
+	}
+
+	const sourceAmount = Number(amount) / 10 ** sourceToken.decimals;
+
+	// A Sell spends the base token outright, and mirrors the Limit Order form:
+	// the typed amount is validated against the lot grid by `validateAmount`
+	// below, never rounded — an off-grid amount produces no offer. A Buy's
+	// quantity is derived (the base amount its quote spend affords at the limit
+	// price), which the user cannot control by typing, so only there is it
+	// floored to the grid, and the deposit shrinks to the order's reserve.
+	const baseAmount =
+		side === 'sell'
+			? sourceAmount
+			: floorToStep({ value: sourceAmount / tickedPrice, step: pairView.lotSize });
+
+	if (!(baseAmount > 0)) {
+		return { ok: false, errorKind: 'lot' };
+	}
+
+	const { ok, errorKind } = validateAmount({
+		side,
+		baseAmount,
+		price: tickedPrice,
+		freeBalance: freeBalance ?? Number.POSITIVE_INFINITY,
+		pair: pairView
+	});
+
+	if (!ok) {
+		return { ok: false, errorKind };
+	}
+
+	const quantity = toQuantity({ baseAmount, baseDecimals: pairView.baseDecimals });
+	const priceUnits = toPriceUnits({
+		price: tickedPrice,
+		quoteDecimals: pairView.quoteDecimals
+	});
+
+	// `notional = price × quantity / 10^base_decimals`, in quote smallest units —
+	// the did's convention, since a price is quoted per *whole* base token.
+	const reserve = (priceUnits * quantity) / 10n ** BigInt(pairView.baseDecimals);
+
+	if (side === 'buy' && !(reserve > ZERO)) {
+		return { ok: false, errorKind: 'min_notional' };
+	}
+
+	return {
+		ok: true,
+		order: {
+			side,
+			pair: toTradingPair(pair),
+			price: priceUnits,
+			quantity,
+			depositAmount: side === 'sell' ? quantity : reserve
+		}
+	};
+};
+
+/** The candid `Side` for a resolved order, re-exported so callers need one import. */
+export const toOisyTradeCandidSide = toCandidSide;
+
+/**
+ * Placeholder receive amount: the source amount at a 1:1 *human-unit* rate.
+ *
+ * A decimal rescale, not a copy — `receiveAmount` is in destination base units,
+ * so 1 ICP (8 dp) → 1 ckUSDT (6 dp) is `1_000_000`, not `100_000_000`. Passing
+ * the bigint through unchanged would be wrong by `10^(dest − source)`.
+ *
+ * Replaced wholesale by the real order-book walk in its own spec; nothing
+ * downstream reads anything but the result, so this is the only function that
+ * changes. Multiplication first, integer division last, bigint throughout.
+ */
+export const computeOisyTradeReceiveAmount = ({
+	amount,
+	sourceDecimals,
+	destinationDecimals
+}: {
+	amount: bigint;
+	sourceDecimals: number;
+	destinationDecimals: number;
+}): bigint => (amount * 10n ** BigInt(destinationDecimals)) / 10n ** BigInt(sourceDecimals);

--- a/src/frontend/src/lib/utils/oisy-trade-swap.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade-swap.utils.ts
@@ -8,14 +8,13 @@ import {
 	toCandidSide,
 	toPairView,
 	toPriceUnits,
-	toQuantity,
 	toTradingPair,
 	validateAmount,
 	type FieldErrorKind,
 	type LimitOrderSide
 } from '$lib/utils/oisy-trade.utils';
 import { resolveSwapTokenLookup } from '$lib/utils/swap-tokens-filter.utils';
-import { isNullish, nonNullish } from '@dfinity/utils';
+import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
 
 /**
  * Adapter from the swap flow onto the shipped Trading helpers — deliberately
@@ -155,12 +154,27 @@ export type OisyTradeOrderResolution =
 /**
  * The typed source amount resolved into a submittable fill-or-kill order.
  *
- * Works in the human float domain and converts at the candid boundary, exactly
- * as `LimitOrderWizard.place()` already ships: the quantity ends up on the lot
- * grid (validated on a Sell, floored on a Buy) and the price snapped to the
- * tick grid, so both carry at most `decimalsOfStep(step)` decimal places. Only
- * the Buy-side reserve is computed in bigint, because it is an exact base-unit
- * quantity the canister enforces.
+ * Every value the canister will check — the quantity, the price and the notional
+ * — is derived in **bigint**, and the three grid rules are re-checked exactly
+ * against the pair's own base-unit steps after `validateAmount` has had its say.
+ *
+ * That exactness is not belt-and-braces. `validateAmount` and its helpers work in
+ * the human float domain, which is safe for 6- and 8-decimal tokens but not for
+ * 18: converting base units to a human float and back is not an identity, and
+ * `isMultipleOfStep` allows a 1e-6 *relative* tolerance, which for an 18-decimal
+ * token is ~1e9 base units of slack. Measured, 7.3% of on-grid ckETH amounts —
+ * starting at 0.009 ckETH — came back from the float round-trip one base unit off
+ * the lot grid while still passing the float check. The canister rejects such an
+ * order with `InvalidQuantity`, and it does so *after* `deposit` has already moved
+ * the funds into DEX custody, so a float verdict here is a stranded-funds bug
+ * rather than a rounding curiosity. The shipped Limit Order form has the same
+ * float round-trip, but nothing precedes its `add_limit_order`, so there the same
+ * rejection costs nothing.
+ *
+ * `validateAmount` is still the gate for affordability and for the `errorKind`
+ * precedence the form's messages depend on, so the two surfaces cannot disagree
+ * about *why* an amount is unorderable — only about the last base unit, where this
+ * one is right.
  *
  * Returns `ok: false` rather than throwing when the amount is not orderable —
  * OISY Trade simply contributes no offer, and `errorKind` lets the form name the
@@ -205,26 +219,36 @@ export const resolveOisyTradeOrder = ({
 		return { ok: false };
 	}
 
-	const sourceAmount = Number(amount) / 10 ** sourceToken.decimals;
+	const priceUnits = toPriceUnits({
+		price: tickedPrice,
+		quoteDecimals: pairView.quoteDecimals
+	});
 
-	// A Sell spends the base token outright, and mirrors the Limit Order form:
-	// the typed amount is validated against the lot grid by `validateAmount`
-	// below, never rounded — an off-grid amount produces no offer. A Buy's
-	// quantity is derived (the base amount its quote spend affords at the limit
-	// price), which the user cannot control by typing, so only there is it
-	// floored to the grid, and the deposit shrinks to the order's reserve.
-	const baseAmount =
-		side === 'sell'
-			? sourceAmount
-			: floorToStep({ value: sourceAmount / tickedPrice, step: pairView.lotSize });
+	if (priceUnits <= ZERO || priceUnits % pair.tick_size !== ZERO) {
+		return { ok: false };
+	}
 
-	if (!(baseAmount > 0)) {
+	const baseUnit = 10n ** BigInt(pairView.baseDecimals);
+
+	// A Sell spends the base token outright, so the typed amount *is* the quantity —
+	// no conversion, and so no rounding residue at all. A Buy's quantity is derived
+	// (the base amount its quote spend affords at the limit price), which the user
+	// cannot control by typing, so only there is it floored to the grid and the
+	// deposit shrunk to the order's reserve. Inverting the did's
+	// `notional = price × quantity / 10^base_decimals` gives the affordable quantity.
+	const rawQuantity = side === 'sell' ? amount : (amount * baseUnit) / priceUnits;
+	const quantity = side === 'sell' ? rawQuantity : rawQuantity - (rawQuantity % pair.lot_size);
+
+	if (quantity <= ZERO) {
 		return { ok: false, errorKind: 'lot' };
 	}
 
+	// In quote smallest units. Exact, and the same value the Buy path deposits.
+	const notional = (priceUnits * quantity) / baseUnit;
+
 	const { ok, errorKind } = validateAmount({
 		side,
-		baseAmount,
+		baseAmount: Number(quantity) / 10 ** pairView.baseDecimals,
 		price: tickedPrice,
 		freeBalance: freeBalance ?? Number.POSITIVE_INFINITY,
 		pair: pairView
@@ -234,18 +258,21 @@ export const resolveOisyTradeOrder = ({
 		return { ok: false, errorKind };
 	}
 
-	const quantity = toQuantity({ baseAmount, baseDecimals: pairView.baseDecimals });
-	const priceUnits = toPriceUnits({
-		price: tickedPrice,
-		quoteDecimals: pairView.quoteDecimals
-	});
+	// The exact re-check of what the canister enforces. A float verdict can accept
+	// each of these for an 18-decimal token — see the note above — and every
+	// rejection here would otherwise land after the deposit.
+	if (quantity % pair.lot_size !== ZERO) {
+		return { ok: false, errorKind: 'lot' };
+	}
 
-	// `notional = price × quantity / 10^base_decimals`, in quote smallest units —
-	// the did's convention, since a price is quoted per *whole* base token.
-	const reserve = (priceUnits * quantity) / 10n ** BigInt(pairView.baseDecimals);
-
-	if (side === 'buy' && !(reserve > ZERO)) {
+	if (notional < pair.min_notional) {
 		return { ok: false, errorKind: 'min_notional' };
+	}
+
+	const maxNotional = fromNullable(pair.max_notional);
+
+	if (nonNullish(maxNotional) && notional > maxNotional) {
+		return { ok: false, errorKind: 'max_notional' };
 	}
 
 	return {
@@ -255,7 +282,7 @@ export const resolveOisyTradeOrder = ({
 			pair: toTradingPair(pair),
 			price: priceUnits,
 			quantity,
-			depositAmount: side === 'sell' ? quantity : reserve
+			depositAmount: side === 'sell' ? quantity : notional
 		}
 	};
 };

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpForm.spec.ts
@@ -1,16 +1,19 @@
+import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
 import { IC_CKETH_LEDGER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.eth.env';
 import SwapIcpForm from '$icp/components/swap/SwapIcpForm.svelte';
 import { IC_TOKEN_FEE_CONTEXT_KEY, icTokenFeeStore } from '$icp/stores/ic-token-fee.store';
 import type { IcTokenToggleable } from '$icp/types/ic-token-toggleable';
 import { ZERO } from '$lib/constants/app.constants';
 import {
+	MAX_BUTTON,
 	SWAP_SWITCH_TOKENS_BUTTON,
 	TOKEN_INPUT_CURRENCY_TOKEN
 } from '$lib/constants/test-ids.constants';
 import { balancesStore } from '$lib/stores/balances.store';
+import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
 import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY, initSwapContext } from '$lib/stores/swap.store';
-import type { ChainFusionSwapDetails } from '$lib/types/swap';
+import type { ChainFusionSwapDetails, SwapMappedResult } from '$lib/types/swap';
 import { formatToken } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import { parseTokenId } from '$lib/validation/token.validation';
@@ -18,8 +21,17 @@ import en from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockChainFusionProvider, mockOneSecProvider } from '$tests/mocks/swap.mocks';
 import { assertNonNullish } from '@dfinity/utils';
+import { Principal } from '@icp-sdk/core/principal';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
+
+// The form reads the flag at module scope, so it has to be true before the component is
+// first imported. The OISY Trade cases below are the only ones that depend on it; with an
+// empty pair table the flag changes nothing, so leaving it on for the whole file is inert.
+vi.mock('$env/oisy-trade-swap', () => ({
+	OISY_TRADE_SWAP_ENABLED: true,
+	oisyTradeSwapEnabled: true
+}));
 
 describe('SwapIcpForm', () => {
 	const mockContext = new Map();
@@ -548,6 +560,222 @@ describe('SwapIcpForm', () => {
 
 				expect(queryByText(minimumAmountMessage)).not.toBeInTheDocument();
 			});
+		});
+	});
+
+	// OISY Trade is the only ICP provider that refuses an amount outright — a fill-or-kill
+	// order has to sit on the pair's lot grid and inside its notional bounds. The form has to
+	// name that reason when it is the whole story, and stay entirely out of the way when it
+	// is not: the grid is OISY Trade's business, and four other providers quote the same pair.
+	describe('OISY Trade grid explanation', () => {
+		const ICP_LEDGER = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
+		const CKUSDC_LEDGER = 'xevnm-gaaaa-aaaar-qafnq-cai';
+
+		const icpToken = {
+			...mockValidIcToken,
+			ledgerCanisterId: ICP_LEDGER,
+			decimals: 8,
+			symbol: 'ICP',
+			fee: 10_000n
+		};
+
+		const usdcToken = {
+			...mockValidIcToken,
+			id: parseTokenId('CkUsdcTokenId'),
+			ledgerCanisterId: CKUSDC_LEDGER,
+			decimals: 6,
+			symbol: 'ckUSDC',
+			fee: 10_000n
+		};
+
+		// A 0.01 ICP lot, so 1.23 sits on the grid and 1.234 does not. The tick is 0.001
+		// ckUSDC per whole ICP, which the 1:1 placeholder price floors onto exactly.
+		const buildPair = ({ minNotional = 1_000n }: { minNotional?: bigint } = {}) =>
+			({
+				status: { Trading: null },
+				base: {
+					id: { ledger_id: Principal.fromText(ICP_LEDGER) },
+					metadata: { symbol: 'ICP', decimals: 8 }
+				},
+				quote: {
+					id: { ledger_id: Principal.fromText(CKUSDC_LEDGER) },
+					metadata: { symbol: 'ckUSDC', decimals: 6 }
+				},
+				lot_size: 1_000_000n,
+				tick_size: 1_000n,
+				min_notional: minNotional,
+				max_notional: [],
+				maker_fee_bps: 5,
+				taker_fee_bps: 10
+			}) as unknown as TradingPairInfo;
+
+		const lotMessage = replacePlaceholders(en.trading.limit_order.error_lot_multiple, {
+			$step: '0.01',
+			$symbol: 'ICP'
+		});
+
+		// `amountForSwap` has to match what the user types, or `SwapForm` reads the quote as
+		// still loading and neither message is reached.
+		const renderWithOisyTradePair = ({
+			swaps = [],
+			amountForSwap,
+			minNotional,
+			pairs = [buildPair({ minNotional })],
+			isSourceTokenIcrc2 = true
+		}: {
+			swaps?: SwapMappedResult[];
+			amountForSwap: number;
+			minNotional?: bigint;
+			pairs?: TradingPairInfo[];
+			isSourceTokenIcrc2?: boolean;
+		}) => {
+			oisyTradeStore.setPairs(pairs);
+
+			balancesStore.set({
+				id: icpToken.id,
+				data: { data: 100_000_000_000n, certified: true }
+			});
+
+			mockContext.set(SWAP_CONTEXT_KEY, {
+				...initSwapContext({
+					sourceToken: icpToken as IcTokenToggleable,
+					destinationToken: usdcToken as IcTokenToggleable
+				}),
+				sourceTokenExchangeRate: readable(10),
+				destinationTokenExchangeRate: readable(2),
+				isSourceTokenIcrc2: readable(isSourceTokenIcrc2)
+			});
+
+			icTokenFeeStore.setIcTokenFee({ tokenSymbol: icpToken.symbol, fee: 1000n });
+
+			const amountsStore = initSwapAmountsStore();
+			amountsStore.setSwaps({ swaps, amountForSwap, selectedProvider: swaps[0] });
+			mockContext.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: amountsStore });
+
+			return render(SwapIcpForm, {
+				props: { ...props, swapAmount: undefined },
+				context: mockContext
+			});
+		};
+
+		afterEach(() => {
+			oisyTradeStore.reset();
+		});
+
+		it('names the lot grid when no provider quoted the amount', async () => {
+			const { container, getByText } = renderWithOisyTradePair({ amountForSwap: 1.234 });
+
+			await enterAmount({ container, value: '1.234' });
+
+			await waitFor(() => {
+				expect(getByText(lotMessage)).toBeInTheDocument();
+			});
+		});
+
+		// The generic message and the specific one contradict each other: a swap *is* offered,
+		// just not for this amount. `notOfferedExplained` is what suppresses the generic one.
+		it('replaces the generic not-offered message rather than doubling it', async () => {
+			const { container, getByText, queryByText } = renderWithOisyTradePair({
+				amountForSwap: 1.234
+			});
+
+			await enterAmount({ container, value: '1.234' });
+
+			await waitFor(() => {
+				expect(getByText(lotMessage)).toBeInTheDocument();
+			});
+
+			expect(queryByText(en.swap.text.swap_is_not_offered)).not.toBeInTheDocument();
+		});
+
+		// A 1 ICP order at the 1:1 placeholder is a notional of 1 ckUSDC, under a floor of 10.
+		it('names the minimum order value when the amount is on the grid but too small', async () => {
+			const { container, getByText } = renderWithOisyTradePair({
+				amountForSwap: 1,
+				minNotional: 10_000_000n
+			});
+
+			await enterAmount({ container, value: '1' });
+
+			await waitFor(() => {
+				expect(
+					getByText(
+						replacePlaceholders(en.trading.limit_order.error_min_notional, {
+							$amount: '10',
+							$symbol: 'ckUSDC'
+						})
+					)
+				).toBeInTheDocument();
+			});
+		});
+
+		// The single highest-risk behaviour in the integration: an ICP source has five
+		// providers, and OISY Trade's lot grid must never reach `errorType` and disable Review
+		// for someone swapping 1.234 ICP through a provider that does not care about lots.
+		it('leaves Review enabled for an off-grid amount another provider quotes', async () => {
+			const { container, getByText, queryByText } = renderWithOisyTradePair({
+				swaps: [mockOneSecProvider],
+				amountForSwap: 1.234
+			});
+
+			await enterAmount({ container, value: '1.234' });
+
+			await waitFor(() => {
+				expect(getByText(en.swap.text.review_button).closest('button')).not.toBeDisabled();
+			});
+
+			expect(queryByText(lotMessage)).not.toBeInTheDocument();
+		});
+
+		// A source ledger without ICRC-2 cannot be deposited on OISY Trade at all, so the
+		// grid is not the reason there is no offer: the generic message stands rather than
+		// a lot-size hint that would wrongly imply fixing the amount could produce one.
+		it('says nothing when the source ledger has no ICRC-2', async () => {
+			const { container, getByText, queryByText } = renderWithOisyTradePair({
+				amountForSwap: 1.234,
+				isSourceTokenIcrc2: false
+			});
+
+			await enterAmount({ container, value: '1.234' });
+
+			await waitFor(() => {
+				expect(getByText(en.swap.text.swap_is_not_offered)).toBeInTheDocument();
+			});
+
+			expect(queryByText(lotMessage)).not.toBeInTheDocument();
+		});
+
+		// No pair means no opinion: the absence is not OISY Trade's to explain, so the generic
+		// message stands.
+		it('says nothing when the two tokens are not an OISY Trade pair', async () => {
+			const { container, getByText, queryByText } = renderWithOisyTradePair({
+				amountForSwap: 1.234,
+				pairs: []
+			});
+
+			await enterAmount({ container, value: '1.234' });
+
+			await waitFor(() => {
+				expect(getByText(en.swap.text.swap_is_not_offered)).toBeInTheDocument();
+			});
+
+			expect(queryByText(lotMessage)).not.toBeInTheDocument();
+		});
+
+		// `deposit` requires the on-ledger balance to cover `amount + 2 × ledger_fee`, because
+		// the ledger charges on both `icrc2_approve` and `icrc2_transfer_from`. The ICRC-2
+		// branch of `ledgerFeeLegs` already reserves exactly that, and OISY Trade only ever
+		// quotes ICRC-2 sources — so Max is spendable here by construction, and this locks it.
+		it('holds back two ledger fees on an ICRC-2 source, which is what the deposit needs', () => {
+			const { getByTestId } = renderWithOisyTradePair({ amountForSwap: 1.23 });
+
+			expect(getByTestId(MAX_BUTTON)).toHaveTextContent(
+				formatToken({
+					value: 100_000_000_000n - 2n * props.sourceTokenFee,
+					unitName: icpToken.decimals,
+					displayDecimals: icpToken.decimals
+				})
+			);
 		});
 	});
 });

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
@@ -11,8 +11,9 @@ import * as addrDerived from '$lib/derived/address.derived';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 import * as analytics from '$lib/services/analytics.services';
+import { OisyTradeSwapError } from '$lib/services/swap-errors.services';
 import { SWAP_AMOUNTS_CONTEXT_KEY, initSwapAmountsStore } from '$lib/stores/swap-amounts.store';
-import { SWAP_CONTEXT_KEY } from '$lib/stores/swap.store';
+import { SWAP_CONTEXT_KEY, type SwapError } from '$lib/stores/swap.store';
 import * as toasts from '$lib/stores/toasts.store';
 import { SwapProvider, type ChainFusionSwapDetails } from '$lib/types/swap';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
@@ -23,11 +24,12 @@ import en from '$tests/mocks/i18n.mock';
 import { mockValidIcCkToken, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import {
 	mockChainFusionProvider,
+	mockOisyTradeProvider,
 	mockOneSecProvider,
 	mockSwapProviders
 } from '$tests/mocks/swap.mocks';
 import { fireEvent, render } from '@testing-library/svelte';
-import { readable, writable } from 'svelte/store';
+import { get, readable, writable, type Writable } from 'svelte/store';
 
 vi.mock('$icp/services/icrc.services', () => ({
 	isIcrcTokenSupportIcrc2: vi.fn()
@@ -40,6 +42,7 @@ vi.mock('$icp/api/icrc-ledger.api', () => ({
 const mockSwapFn = vi.fn();
 const mockOneSecFn = vi.fn();
 const mockChainFusionFn = vi.fn();
+const mockOisyTradeFn = vi.fn();
 
 vi.mock('$lib/services/swap.services', () => ({
 	fetchOneSecIcpToEvmSwap: (...args: unknown[]) => mockOneSecFn(...args),
@@ -51,6 +54,13 @@ vi.mock('$lib/services/swap.services', () => ({
 
 vi.mock('$lib/services/chain-fusion-swap.services', () => ({
 	fetchChainFusionIcpSwap: (...args: unknown[]) => mockChainFusionFn(...args)
+}));
+
+// A factory mock, so the real module's canister-facing dependency tree is never
+// loaded. `OisyTradeSwapError` deliberately lives in `swap-errors.services`, not
+// here, so the wizard's `instanceof` branch still sees the real class.
+vi.mock('$lib/services/oisy-trade-swap.services', () => ({
+	fetchOisyTradeSwap: (...args: unknown[]) => mockOisyTradeFn(...args)
 }));
 
 const mockToken = { ...mockValidIcToken, enabled: true } as IcToken;
@@ -357,6 +367,95 @@ describe('SwapIcpWizard', () => {
 
 				expect(mockOneSecFn).not.toHaveBeenCalled();
 				expect(toasts.toastsError).toHaveBeenCalled();
+				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+			});
+		});
+
+		describe('OISY Trade swap', () => {
+			const setOisyTradeContext = () => {
+				const oisyTradeAmountsStore = initSwapAmountsStore();
+				oisyTradeAmountsStore.setSwaps({
+					swaps: [mockOisyTradeProvider],
+					amountForSwap: 1,
+					selectedProvider: mockOisyTradeProvider
+				});
+				mockContext.set(SWAP_AMOUNTS_CONTEXT_KEY, { store: oisyTradeAmountsStore });
+			};
+
+			const submit = async () => {
+				const { getByText, queryByRole } = renderWithStep(WizardStepsSwap.REVIEW);
+
+				const valueDifferenceCheckbox = queryByRole('checkbox');
+				if (valueDifferenceCheckbox) {
+					await fireEvent.click(valueDifferenceCheckbox);
+				}
+
+				await fireEvent.click(getByText(en.swap.text.swap_button));
+				await vi.runOnlyPendingTimersAsync();
+			};
+
+			const readFailedSwapError = () => {
+				const { failedSwapError } = mockContext.get(SWAP_CONTEXT_KEY) as {
+					failedSwapError: Writable<SwapError | undefined>;
+				};
+
+				return get(failedSwapError);
+			};
+
+			beforeEach(() => {
+				mockOisyTradeFn.mockResolvedValue({ status: 'filled', withdrawals: [42n] });
+				setOisyTradeContext();
+			});
+
+			it('dispatches the reviewed order and closes on success', async () => {
+				await submit();
+
+				expect(mockOisyTradeFn).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						sourceToken: mockToken,
+						destinationToken: mockDestToken,
+						// The order the quote resolved and the user reviewed — never re-derived.
+						order: mockOisyTradeProvider.swapDetails.order
+					})
+				);
+				expect(BASE_PROPS.onClose).toHaveBeenCalledOnce();
+				expect(BASE_PROPS.onBack).not.toHaveBeenCalled();
+			});
+
+			// A killed fill-or-kill order is an expected market outcome whose funds are
+			// already back in the wallet, so it lands in Review as info — like
+			// slippage-exceeded — and never in the unexpected-error toast, where the
+			// reassuring copy would read as a failure detail.
+			it('presents a killed order in Review rather than as an unexpected error', async () => {
+				mockOisyTradeFn.mockRejectedValue(
+					new OisyTradeSwapError(en.swap.error.oisy_trade_order_killed, 'killed')
+				);
+
+				await submit();
+
+				expect(readFailedSwapError()).toEqual({
+					message: en.swap.error.oisy_trade_order_killed,
+					variant: 'info'
+				});
+				expect(toasts.toastsError).not.toHaveBeenCalled();
+				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+				expect(BASE_PROPS.onClose).not.toHaveBeenCalled();
+			});
+
+			// An unresolved settlement asks the user to check the Trading tab, so it is a
+			// warning rather than info — but still a Review message, not a toast.
+			it('presents an unresolved settlement as a warning in Review', async () => {
+				mockOisyTradeFn.mockRejectedValue(
+					new OisyTradeSwapError(en.swap.error.oisy_trade_settlement_unresolved, 'unresolved')
+				);
+
+				await submit();
+
+				expect(readFailedSwapError()).toEqual({
+					message: en.swap.error.oisy_trade_settlement_unresolved,
+					variant: 'warning'
+				});
+				expect(toasts.toastsError).not.toHaveBeenCalled();
 				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
 			});
 		});

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
@@ -458,6 +458,41 @@ describe('SwapIcpWizard', () => {
 				expect(toasts.toastsError).not.toHaveBeenCalled();
 				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
 			});
+
+			// An order the canister refused has had its deposit recovered by the time the
+			// error is thrown — like a kill, the funds are already back — so it reads as
+			// info in Review, never as an unexpected-error toast.
+			it('presents a rejected order whose deposit was recovered as info in Review', async () => {
+				mockOisyTradeFn.mockRejectedValue(
+					new OisyTradeSwapError(en.swap.error.oisy_trade_order_not_placed, 'not_placed')
+				);
+
+				await submit();
+
+				expect(readFailedSwapError()).toEqual({
+					message: en.swap.error.oisy_trade_order_not_placed,
+					variant: 'info'
+				});
+				expect(toasts.toastsError).not.toHaveBeenCalled();
+				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+			});
+
+			// A failed recovery is the one case where the funds are still in DEX custody
+			// when the error surfaces, so it warns and points at the Trading tab.
+			it('presents a failed deposit recovery as a warning in Review', async () => {
+				mockOisyTradeFn.mockRejectedValue(
+					new OisyTradeSwapError(en.swap.error.oisy_trade_recovery_failed, 'recovery_failed')
+				);
+
+				await submit();
+
+				expect(readFailedSwapError()).toEqual({
+					message: en.swap.error.oisy_trade_recovery_failed,
+					variant: 'warning'
+				});
+				expect(toasts.toastsError).not.toHaveBeenCalled();
+				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+			});
 		});
 
 		describe('Chain Fusion ICP→Ethereum withdrawal', () => {

--- a/src/frontend/src/tests/lib/components/swap/SwapDetailsOisyTrade.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapDetailsOisyTrade.spec.ts
@@ -1,0 +1,139 @@
+import type { TradingPair } from '$declarations/oisy_trade/oisy_trade.did';
+import SwapDetailsOisyTrade from '$lib/components/swap/SwapDetailsOisyTrade.svelte';
+import { ZERO } from '$lib/constants/app.constants';
+import type { OisyTradeSwapDetails } from '$lib/types/oisy-trade-swap';
+import { SwapProvider } from '$lib/types/swap';
+import type { Token } from '$lib/types/token';
+import { parseTokenId } from '$lib/validation/token.validation';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import en from '$tests/mocks/i18n.mock';
+import { render } from '@testing-library/svelte';
+
+describe('SwapDetailsOisyTrade', () => {
+	const quoteToken: Token = {
+		...mockValidErc20Token,
+		id: parseTokenId('ckUSDC'),
+		decimals: 6,
+		symbol: 'ckUSDC'
+	};
+
+	const baseToken: Token = {
+		...mockValidErc20Token,
+		id: parseTokenId('ICP'),
+		decimals: 8,
+		symbol: 'ICP'
+	};
+
+	const order: OisyTradeSwapDetails['order'] = {
+		side: 'sell',
+		pair: {} as unknown as TradingPair,
+		price: 10_000_000n,
+		quantity: 200_000_000n,
+		depositAmount: 200_000_000n
+	};
+
+	const makeProvider = (swapDetails: Partial<OisyTradeSwapDetails> = {}) => ({
+		provider: SwapProvider.OISY_TRADE as const,
+		receiveAmount: 20_000_000n,
+		swapDetails: {
+			fees: [],
+			takerFeeBps: 10,
+			minNotional: 5_000_000n,
+			quoteToken,
+			order,
+			...swapDetails
+		}
+	});
+
+	it('renders the taker rate and never the maker rate', () => {
+		const { getByText, queryByText } = render(SwapDetailsOisyTrade, {
+			props: { provider: makeProvider({ takerFeeBps: 10 }) }
+		});
+
+		// A fill-or-kill order can never rest, so the maker row would be a rate the
+		// user cannot reach.
+		expect(getByText(en.trading.limit_order.fee_taker)).toBeInTheDocument();
+		expect(queryByText(en.trading.limit_order.fee_maker_taker)).not.toBeInTheDocument();
+		expect(getByText('0.1%')).toBeInTheDocument();
+	});
+
+	it('renders the fill-or-kill order type', () => {
+		const { getByText } = render(SwapDetailsOisyTrade, {
+			props: { provider: makeProvider() }
+		});
+
+		expect(getByText(en.trading.limit_order.order_type_fok)).toBeInTheDocument();
+	});
+
+	it('renders one row per fee and never sums them, even across two tokens', () => {
+		const { getByText, queryByText } = render(SwapDetailsOisyTrade, {
+			props: {
+				provider: makeProvider({
+					fees: [
+						{
+							labelPath: 'swap.text.oisy_trade_deposit_fee',
+							fee: 20_000n,
+							token: baseToken
+						},
+						{
+							labelPath: 'swap.text.oisy_trade_taker_fee',
+							fee: 20_000n,
+							token: quoteToken
+						},
+						{
+							labelPath: 'swap.text.oisy_trade_withdrawal_fee',
+							fee: 10_000n,
+							token: quoteToken
+						}
+					]
+				})
+			}
+		});
+
+		expect(getByText(en.swap.text.oisy_trade_deposit_fee)).toBeInTheDocument();
+		expect(getByText(en.swap.text.oisy_trade_taker_fee)).toBeInTheDocument();
+		expect(getByText(en.swap.text.oisy_trade_withdrawal_fee)).toBeInTheDocument();
+
+		// The two same-token fees stay separate: 0.02 + 0.01 must not appear as 0.03.
+		expect(queryByText('0.03 ckUSDC')).not.toBeInTheDocument();
+	});
+
+	it('renders a zero fee as free rather than dropping the row', () => {
+		const { getByText } = render(SwapDetailsOisyTrade, {
+			props: {
+				provider: makeProvider({
+					fees: [
+						{
+							labelPath: 'swap.text.oisy_trade_taker_fee',
+							fee: ZERO,
+							token: quoteToken
+						}
+					]
+				})
+			}
+		});
+
+		expect(getByText(en.swap.text.oisy_trade_taker_fee)).toBeInTheDocument();
+		expect(getByText(en.fee.text.zero_fee)).toBeInTheDocument();
+	});
+
+	it('renders the minimum notional in quote-token units', () => {
+		const { getByText } = render(SwapDetailsOisyTrade, {
+			props: { provider: makeProvider({ minNotional: 5_000_000n }) }
+		});
+
+		expect(getByText(en.swap.text.oisy_trade_minimum_notional)).toBeInTheDocument();
+		expect(getByText('5 ckUSDC')).toBeInTheDocument();
+	});
+
+	it('renders the minimum notional at full precision rather than the default rounding', () => {
+		// The floor is what the canister enforces, so the sheet must state it exactly
+		// rather than the 4-decimal display default.
+		const { getByText, queryByText } = render(SwapDetailsOisyTrade, {
+			props: { provider: makeProvider({ minNotional: 5_123_456n }) }
+		});
+
+		expect(getByText('5.123456 ckUSDC')).toBeInTheDocument();
+		expect(queryByText('5.1235 ckUSDC')).not.toBeInTheDocument();
+	});
+});

--- a/src/frontend/src/tests/lib/providers/swap.providers.spec.ts
+++ b/src/frontend/src/tests/lib/providers/swap.providers.spec.ts
@@ -1,0 +1,24 @@
+import { oisyTradeSwapEnabled } from '$env/oisy-trade-swap';
+import { swapProviders } from '$lib/providers/swap.providers';
+import { SwapProvider } from '$lib/types/swap';
+
+// Deliberately unmocked: these assert the shipped registry entry. Behaviour
+// with the flag on is covered in `oisy-trade-swap.services.spec.ts`, which
+// mocks it true.
+describe('swapProviders', () => {
+	const oisyTrade = () => swapProviders.find(({ key }) => key === SwapProvider.OISY_TRADE);
+
+	it('registers OISY Trade so the entry cannot be dropped by accident', () => {
+		expect(oisyTrade()).toBeDefined();
+	});
+
+	// Against the *derived* gate, not `OISY_TRADE_SWAP_ENABLED` alone. The two
+	// coincide only while `OISY_TRADE_ENABLED` is true, so comparing to the raw
+	// flag would still pass if the registry stopped honouring the venue's own kill
+	// switch — which is exactly the case this guards: a canister outage has to take
+	// the swap offer down with the Trading tab, not leave a provider quoting
+	// against a dead canister.
+	it('gates the entry on the double flag, so a venue outage disables the offer', () => {
+		expect(oisyTrade()?.isEnabled).toBe(oisyTradeSwapEnabled);
+	});
+});

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -427,11 +427,15 @@ describe('oisy-trade-swap.services', () => {
 	describe('settleOisyTradeSwap', () => {
 		const ORDER_ID = 'order-1';
 
+		// A zero baseline means nothing was on the DEX before the deposit, so everything
+		// free is this order's and the assertions below read as plain balances. The
+		// pre-existing-balance cases pass their own.
 		const settleParams = {
 			identity: mockIdentity,
 			orderId: ORDER_ID,
 			sourceToken: ICP,
-			destinationToken: CKUSDC
+			destinationToken: CKUSDC,
+			baseline: { source: ZERO, destination: ZERO }
 		};
 
 		const userOrder = (status: OrderStatus) =>
@@ -540,9 +544,10 @@ describe('oisy-trade-swap.services', () => {
 			expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(CKUSDC_LEDGER);
 		});
 
-		// The residue is the smaller amount by construction; letting it fail the settlement
-		// would strand an operation whose funds have already arrived.
-		it('does not let a failing residue withdrawal block the primary one', async () => {
+		// The residue is the smaller amount by construction; letting a *definitive*
+		// failure of it fail the settlement would strand an operation whose funds have
+		// already arrived — and the reported outcome is true regardless.
+		it('does not let a definitive residue withdrawal failure block the primary one', async () => {
 			const consoleErrorSpy = vi
 				.spyOn(consoleUtils, 'consoleError')
 				.mockImplementation(() => undefined);
@@ -560,6 +565,106 @@ describe('oisy-trade-swap.services', () => {
 			expect(settlement.withdrawals).toEqual([42n]);
 			// Swallowed, but not silently: the residue is still owed to the user.
 			expect(consoleErrorSpy).toHaveBeenCalledWith(residueError);
+		});
+
+		// A transient residue failure propagates instead: the caller's retry loop
+		// re-enters the settlement, where the withdrawn primary's delta reads zero and
+		// only the residue is left to take. Swallowing it would report success with
+		// funds silently left in DEX custody.
+		it('propagates a retryable residue withdrawal failure to the caller', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+			mockBalances({ source: 200_000_000n, destination: 2_000_000n });
+			vi.spyOn(oisyTradeApi, 'withdraw')
+				.mockResolvedValueOnce({ block_index: 42n })
+				.mockRejectedValueOnce(
+					new OisyTradeTemporaryError({ message: 'busy', reason: 'OperationInProgress' })
+				);
+
+			await expect(settleOisyTradeSwap(settleParams)).rejects.toThrow('busy');
+		});
+
+		// A user can arrive at a swap with either leg already funded from the Trading tab —
+		// they may have deposited there to place limit orders. Those balances are their own
+		// funds, but not this swap's to move or to draw conclusions from.
+		describe('a pre-existing DEX balance', () => {
+			it('withdraws only what this order added, leaving the rest on the DEX', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+				// 100 ckUSDT parked from the Trading tab, plus 2 credited by this fill.
+				mockBalances({ source: 50_000_000n, destination: 102_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap({
+					...settleParams,
+					baseline: { source: 50_000_000n, destination: 100_000_000n }
+				});
+
+				expect(settlement.status).toBe('filled');
+				// The fill only, not the 100 that was already there.
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 2_000_000n })
+					})
+				);
+				expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(CKUSDC_LEDGER);
+			});
+
+			// The dangerous half: with the order gone, the classification falls back to the
+			// balances. Reading the account-wide total would call this killed order filled
+			// purely because the user happened to hold the destination token already.
+			it('does not let a held destination balance report a killed order as filled', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([]);
+				// The source came back (the kill), and the destination holding is untouched.
+				mockBalances({ source: 200_000_000n, destination: 100_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap({
+					...settleParams,
+					baseline: { source: ZERO, destination: 100_000_000n }
+				});
+
+				expect(settlement.status).toBe('killed');
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 200_000_000n })
+					})
+				);
+				expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(ICP_LEDGER);
+			});
+
+			// Nothing of ours on either leg, so there is nothing to settle and nothing that
+			// says how it ended — even though both legs hold plenty.
+			it('reports unresolved when a vanished order added nothing to either leg', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([]);
+				mockBalances({ source: 50_000_000n, destination: 100_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap({
+					...settleParams,
+					baseline: { source: 50_000_000n, destination: 100_000_000n }
+				});
+
+				expect(settlement).toEqual({ status: 'unresolved', withdrawals: [] });
+				expect(withdrawSpy).not.toHaveBeenCalled();
+			});
+
+			// A baseline can only go stale in one direction — the user withdrawing from the
+			// Trading tab mid-flow makes it too high — and the delta is floored at zero
+			// rather than going negative. That leaves the fill on the DEX, where the Trading
+			// tab still shows it; the alternative reading would withdraw someone else's
+			// deposit, which is the outcome the baseline exists to prevent.
+			it('withdraws nothing rather than over-claiming when the baseline is stale', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+				mockBalances({ source: ZERO, destination: 2_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap({
+					...settleParams,
+					baseline: { source: ZERO, destination: 100_000_000n }
+				});
+
+				expect(settlement).toEqual({ status: 'filled', withdrawals: [] });
+				expect(withdrawSpy).not.toHaveBeenCalled();
+			});
 		});
 
 		// An unknown ledger fee says nothing about whether the balance is withdrawable, so
@@ -689,17 +794,33 @@ describe('oisy-trade-swap.services', () => {
 			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([
 				{ id: 'order-1', order: { status: { Filled: null } }, pair: {} }
 			] as unknown as UserOrder[]);
-			vi.spyOn(oisyTradeApi, 'getBalances').mockResolvedValue([
-				{
-					token: { id: { ledger_id: Principal.fromText(CKUSDC_LEDGER) } },
-					balance: { free: 2_000_000n, reserved: ZERO }
-				}
-			] as unknown as UserTokenBalance[]);
+			// The first read is the pre-deposit baseline — nothing on the DEX yet — and
+			// every read after it sees what the fill credited. Returning the credited
+			// balance to the baseline read as well would make it look like a holding the
+			// user already had, and settlement would correctly leave it alone.
+			vi.spyOn(oisyTradeApi, 'getBalances')
+				.mockResolvedValueOnce([])
+				.mockResolvedValue([
+					{
+						token: { id: { ledger_id: Principal.fromText(CKUSDC_LEDGER) } },
+						balance: { free: 2_000_000n, reserved: ZERO }
+					}
+				] as unknown as UserTokenBalance[]);
 			vi.spyOn(oisyTradeApi, 'withdraw').mockResolvedValue({ block_index: 42n });
 		});
 
 		const run = (params = {}) =>
 			fetchOisyTradeSwap({ ...swapParams, progress: vi.fn(), ...params });
+
+		// `mockResolvedValueOnce` queues survive re-spying, so a test supplying its own
+		// sequence of balance reads has to clear the one `beforeEach` queued — otherwise
+		// its first value lands on the baseline read and everything shifts by one.
+		const resetBalanceReads = () => {
+			const spy = vi.spyOn(oisyTradeApi, 'getBalances');
+			spy.mockReset();
+
+			return spy;
+		};
 
 		it('submits a fill-or-kill order at the reviewed price and quantity', async () => {
 			await run();
@@ -783,6 +904,34 @@ describe('oisy-trade-swap.services', () => {
 			);
 		});
 
+		// Ordering, not just presence: the deposit credits the source leg, so a baseline
+		// taken after it would make a killed order's returned reserve look like a balance
+		// the user already had and leave it on the DEX.
+		it('reads the balance baseline before depositing', async () => {
+			const calls: string[] = [];
+
+			resetBalanceReads().mockImplementation(() => {
+				calls.push('getBalances');
+
+				return Promise.resolve([
+					{
+						token: { id: { ledger_id: Principal.fromText(CKUSDC_LEDGER) } },
+						balance: { free: 2_000_000n, reserved: ZERO }
+					}
+				] as unknown as UserTokenBalance[]);
+			});
+			depositSpy.mockImplementation(() => {
+				calls.push('deposit');
+
+				return Promise.resolve({ block_index: 7n });
+			});
+
+			await run();
+
+			expect(calls[0]).toBe('getBalances');
+			expect(calls.indexOf('deposit')).toBeGreaterThan(0);
+		});
+
 		it('never places an order when the deposit fails', async () => {
 			depositSpy.mockRejectedValue(new Error('deposit failed'));
 
@@ -801,12 +950,15 @@ describe('oisy-trade-swap.services', () => {
 			const withdrawSpy = vi.spyOn(oisyTradeApi, 'withdraw').mockResolvedValue({
 				block_index: 42n
 			});
-			vi.spyOn(oisyTradeApi, 'getBalances').mockResolvedValue([
-				{
-					token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
-					balance: { free: 300_000_000n, reserved: ZERO }
-				}
-			] as unknown as UserTokenBalance[]);
+			// Baseline first (nothing held), then the source the kill released back.
+			resetBalanceReads()
+				.mockResolvedValueOnce([])
+				.mockResolvedValue([
+					{
+						token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+						balance: { free: 300_000_000n, reserved: ZERO }
+					}
+				] as unknown as UserTokenBalance[]);
 
 			const progress = vi.fn();
 			const enableDestinationToken = vi.fn();
@@ -847,6 +999,107 @@ describe('oisy-trade-swap.services', () => {
 
 			expect(walletSpy).not.toHaveBeenCalled();
 			expect(enableDestinationToken).not.toHaveBeenCalled();
+		});
+
+		// The canister replying with an `Err` means the order was definitively not
+		// accepted: the deposit sits in free balance with no order reserving it, and
+		// rethrowing would return the wizard to Review with the funds still in DEX
+		// custody — where a retry's fresh baseline would classify them as a holding no
+		// later settlement sweeps.
+		describe('an order the canister rejected', () => {
+			beforeEach(() => {
+				addLimitOrderSpy.mockRejectedValue(
+					new OisyTradeRequestError({ message: 'off grid', reason: 'InvalidQuantity' })
+				);
+
+				// Baseline first — the user already holds some source on the DEX — then
+				// what the deposit added on top of it.
+				resetBalanceReads()
+					.mockResolvedValueOnce([
+						{
+							token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+							balance: { free: 50_000_000n, reserved: ZERO }
+						}
+					] as unknown as UserTokenBalance[])
+					.mockResolvedValue([
+						{
+							token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+							balance: { free: 350_000_000n, reserved: ZERO }
+						}
+					] as unknown as UserTokenBalance[]);
+			});
+
+			it('recovers the deposit before reporting the rejection', async () => {
+				const withdrawSpy = vi.spyOn(oisyTradeApi, 'withdraw');
+				const walletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
+				const getMyOrdersSpy = vi.spyOn(oisyTradeApi, 'getMyOrders');
+				const enableDestinationToken = vi.fn();
+				const progress = vi.fn();
+
+				await expect(run({ progress, enableDestinationToken })).rejects.toMatchObject({
+					name: 'OisyTradeSwapError',
+					kind: 'not_placed',
+					message: en.swap.error.oisy_trade_order_not_placed
+				});
+
+				// Only what the deposit added — never the account-wide free balance, part
+				// of which the user funded from the Trading tab.
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 300_000_000n })
+					})
+				);
+				expect(withdrawSpy.mock.calls[0][0].request.token_id.ledger_id.toText()).toBe(ICP_LEDGER);
+
+				// No order exists, so there is nothing to settle; the recovered source
+				// balance is refreshed, and the destination token the user never received
+				// is neither enabled nor reached in the progress bar.
+				expect(getMyOrdersSpy).not.toHaveBeenCalled();
+				expect(walletSpy).toHaveBeenCalledOnce();
+				expect(enableDestinationToken).not.toHaveBeenCalled();
+				expect(progress.mock.calls.flat()).toEqual([
+					ProgressStepsSwap.APPROVE,
+					ProgressStepsSwap.SWAP,
+					ProgressStepsSwap.WITHDRAW
+				]);
+			});
+
+			it('reports a failed recovery pointing at the Trading tab', async () => {
+				const recoveryError = new OisyTradeRequestError({
+					message: 'nope',
+					reason: 'InsufficientBalance'
+				});
+				vi.spyOn(oisyTradeApi, 'withdraw').mockRejectedValue(recoveryError);
+				const consoleErrorSpy = vi
+					.spyOn(consoleUtils, 'consoleError')
+					.mockImplementation(() => undefined);
+				const walletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
+
+				await expect(run()).rejects.toMatchObject({
+					name: 'OisyTradeSwapError',
+					kind: 'recovery_failed',
+					message: en.swap.error.oisy_trade_recovery_failed
+				});
+
+				// The funds are still in DEX custody, so there is no wallet change to show.
+				expect(walletSpy).not.toHaveBeenCalled();
+				expect(consoleErrorSpy).toHaveBeenCalledWith(recoveryError);
+			});
+		});
+
+		// A failure that is not the canister's `Err` reply is ambiguous — the call may
+		// have landed and only the reply been lost, so an order may exist with the
+		// reserve locked. Withdrawing here could race that live order, so the error
+		// propagates untouched and the case belongs to step 2's durable recovery record.
+		it('rethrows an ambiguous placement failure without touching the deposit', async () => {
+			addLimitOrderSpy.mockRejectedValue(new Error('reply lost'));
+			const withdrawSpy = vi.spyOn(oisyTradeApi, 'withdraw');
+			const walletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
+
+			await expect(run()).rejects.toThrow('reply lost');
+
+			expect(withdrawSpy).not.toHaveBeenCalled();
+			expect(walletSpy).not.toHaveBeenCalled();
 		});
 
 		describe('retrying', () => {
@@ -895,6 +1148,101 @@ describe('oisy-trade-swap.services', () => {
 
 				expect(settlement).toEqual({ status: 'filled', withdrawals: [42n] });
 				expect(withdrawSpy).toHaveBeenCalledTimes(2);
+			});
+
+			// A filled Buy whose price-improved fill released unspent reserve: the primary
+			// (destination) withdrawal lands, the residue (source) withdrawal fails
+			// transiently, and the retry re-enters the settlement — where the withdrawn
+			// primary's delta reads zero and only the residue is left to take. The swap
+			// still succeeds, with no funds left behind.
+			it('retries a retryable residue withdrawal failure and still succeeds', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([
+					{ id: 'order-1', order: { status: { Filled: null } }, pair: {} }
+				] as unknown as UserOrder[]);
+				resetBalanceReads()
+					// Baseline: nothing on the DEX.
+					.mockResolvedValueOnce([])
+					// After the fill: the credited destination plus the released source reserve.
+					.mockResolvedValueOnce([
+						{
+							token: { id: { ledger_id: Principal.fromText(CKUSDC_LEDGER) } },
+							balance: { free: 2_000_000n, reserved: ZERO }
+						},
+						{
+							token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+							balance: { free: 100_000_000n, reserved: ZERO }
+						}
+					] as unknown as UserTokenBalance[])
+					// After the primary withdrawal: only the residue remains.
+					.mockResolvedValue([
+						{
+							token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+							balance: { free: 100_000_000n, reserved: ZERO }
+						}
+					] as unknown as UserTokenBalance[]);
+				const withdrawSpy = vi
+					.spyOn(oisyTradeApi, 'withdraw')
+					.mockResolvedValueOnce({ block_index: 42n })
+					.mockRejectedValueOnce(
+						new OisyTradeTemporaryError({ message: 'busy', reason: 'OperationInProgress' })
+					)
+					.mockResolvedValue({ block_index: 43n });
+
+				const promise = run();
+
+				// The retry's sleep is scheduled deep in a promise chain, so a single
+				// advance can complete before the timer even exists — `vi.waitFor`
+				// advances the fake timers by `interval` on every check instead.
+				await vi.waitFor(() => expect(withdrawSpy).toHaveBeenCalledTimes(3), {
+					interval: OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS,
+					timeout: 4 * OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS
+				});
+
+				// The second attempt's outcome: the primary is dust-skipped (already
+				// withdrawn) and the residue's block index is the one reported.
+				await expect(promise).resolves.toEqual({ status: 'filled', withdrawals: [43n] });
+			});
+
+			// The recovery withdrawal honours the same retry policy as settlement, and for
+			// the same reason: giving up on a transient failure would end the flow with
+			// the funds still in DEX custody and nothing watching them.
+			it('retries a retryable recovery failure after a rejected order', async () => {
+				addLimitOrderSpy.mockRejectedValue(
+					new OisyTradeRequestError({ message: 'off grid', reason: 'InvalidQuantity' })
+				);
+				resetBalanceReads()
+					.mockResolvedValueOnce([])
+					.mockResolvedValue([
+						{
+							token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+							balance: { free: 300_000_000n, reserved: ZERO }
+						}
+					] as unknown as UserTokenBalance[]);
+				const withdrawSpy = vi
+					.spyOn(oisyTradeApi, 'withdraw')
+					.mockRejectedValueOnce(
+						new OisyTradeTemporaryError({ message: 'busy', reason: 'OperationInProgress' })
+					)
+					.mockResolvedValue({ block_index: 42n });
+
+				const promise = run();
+				// The flow rejects while the timers below advance, which would otherwise
+				// fire as an unhandled rejection; the assertion re-awaits the same promise.
+				promise.catch(() => undefined);
+
+				// The retry's sleep is scheduled deep in a promise chain, so a single
+				// advance can complete before the timer even exists. `vi.waitFor` advances
+				// the fake timers by `interval` on every check, which reaches it
+				// deterministically — provided each step covers the whole poll interval.
+				await vi.waitFor(() => expect(withdrawSpy).toHaveBeenCalledTimes(2), {
+					interval: OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS,
+					timeout: 4 * OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS
+				});
+
+				await expect(promise).rejects.toMatchObject({
+					name: 'OisyTradeSwapError',
+					kind: 'not_placed'
+				});
 			});
 
 			// No timer advance: a non-retryable failure ends the swap on the first attempt,

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -1,0 +1,897 @@
+import type {
+	OrderStatus,
+	TradingPairInfo,
+	UserOrder,
+	UserTokenBalance
+} from '$declarations/oisy_trade/oisy_trade.did';
+import * as icrcLedgerApi from '$icp/api/icrc-ledger.api';
+import type { IcToken } from '$icp/types/ic-token';
+import * as oisyTradeApi from '$lib/api/oisy-trade.api';
+import { OisyTradeRequestError, OisyTradeTemporaryError } from '$lib/canisters/oisy-trade.errors';
+import * as appConstants from '$lib/constants/app.constants';
+import { ZERO } from '$lib/constants/app.constants';
+import { OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
+import { PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
+import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import * as oisyTradeSwapServices from '$lib/services/oisy-trade-swap.services';
+import {
+	fetchOisyTradeQuote,
+	fetchOisyTradeSwap,
+	loadOisyTradeSwapPairs,
+	mapOisyTradeQuoteResult,
+	oisyTradeSwapPairTable,
+	settleOisyTradeSwap
+} from '$lib/services/oisy-trade-swap.services';
+import { fetchSwapAmounts } from '$lib/services/swap.services';
+import * as tradingAnalytics from '$lib/services/trading-analytics.services';
+import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
+import type { OisyTradeResolvedOrder } from '$lib/types/oisy-trade-swap';
+import { SwapProvider } from '$lib/types/swap';
+import * as consoleUtils from '$lib/utils/console.utils';
+import * as walletUtils from '$lib/utils/wallet.utils';
+import en from '$tests/mocks/i18n.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { Principal } from '@icp-sdk/core/principal';
+import { get } from 'svelte/store';
+import type { MockInstance } from 'vitest';
+
+// The registry reads the flag at module scope, so it has to be true before
+// `swap.providers` is first imported — hence `vi.hoisted` rather than a plain let.
+const mockEnv = vi.hoisted(() => ({ enabled: true }));
+
+vi.mock('$env/oisy-trade-swap', () => ({
+	get OISY_TRADE_SWAP_ENABLED() {
+		return mockEnv.enabled;
+	},
+	get oisyTradeSwapEnabled() {
+		return mockEnv.enabled;
+	}
+}));
+
+// The two sibling providers in the same registry. Neither should contribute to
+// the fan-out assertions below, which are about OISY Trade alone.
+vi.mock('$lib/api/kong_backend.api', () => ({
+	kongSwapAmounts: () => Promise.reject(new Error('kong unavailable in test'))
+}));
+
+vi.mock('$lib/services/icp-swap.services', () => ({
+	icpSwapAmounts: () => Promise.reject(new Error('icpSwap unavailable in test')),
+	icpSwapSupportedTokens: () => Promise.resolve(new Set<string>())
+}));
+
+const ICP_LEDGER = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
+const CKUSDC_LEDGER = 'xevnm-gaaaa-aaaar-qafnq-cai';
+const CKBTC_LEDGER = 'mxzaz-hqaaa-aaaar-qaada-cai';
+
+const icToken = ({
+	ledgerCanisterId,
+	decimals,
+	symbol,
+	fee
+}: {
+	ledgerCanisterId: string;
+	decimals: number;
+	symbol: string;
+	fee: bigint;
+}): IcToken => ({ ...mockValidIcToken, ledgerCanisterId, decimals, symbol, fee });
+
+// 8 dp, 10_000 e8s ledger fee.
+const ICP = icToken({
+	ledgerCanisterId: ICP_LEDGER,
+	decimals: 8,
+	symbol: 'ICP',
+	fee: 10_000n
+});
+// 6 dp, 10_000 (0.01 ckUSDC) ledger fee.
+const CKUSDC = icToken({
+	ledgerCanisterId: CKUSDC_LEDGER,
+	decimals: 6,
+	symbol: 'ckUSDC',
+	fee: 10_000n
+});
+const CKBTC = icToken({
+	ledgerCanisterId: CKBTC_LEDGER,
+	decimals: 8,
+	symbol: 'ckBTC',
+	fee: 10n
+});
+
+const buildPair = ({
+	base,
+	quote,
+	halted = false,
+	lotSize = 1_000_000n,
+	minNotional = 1_000n,
+	takerFeeBps = 10
+}: {
+	base: IcToken;
+	quote: IcToken;
+	halted?: boolean;
+	lotSize?: bigint;
+	minNotional?: bigint;
+	takerFeeBps?: number;
+}): TradingPairInfo =>
+	({
+		status: halted ? { Halted: null } : { Trading: null },
+		base: {
+			id: { ledger_id: Principal.fromText(base.ledgerCanisterId) },
+			metadata: { symbol: base.symbol, decimals: base.decimals }
+		},
+		quote: {
+			id: { ledger_id: Principal.fromText(quote.ledgerCanisterId) },
+			metadata: { symbol: quote.symbol, decimals: quote.decimals }
+		},
+		lot_size: lotSize,
+		tick_size: 1_000n,
+		min_notional: minNotional,
+		max_notional: [],
+		maker_fee_bps: 5,
+		taker_fee_bps: takerFeeBps
+	}) as unknown as TradingPairInfo;
+
+const icpUsdc = buildPair({ base: ICP, quote: CKUSDC });
+
+describe('oisy-trade-swap.services', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		oisyTradeStore.reset();
+	});
+
+	describe('loadOisyTradeSwapPairs', () => {
+		it('caches the table and reports both legs as quotable sources', async () => {
+			vi.spyOn(oisyTradeApi, 'getTradingPairs').mockResolvedValue([icpUsdc]);
+
+			const supported = await loadOisyTradeSwapPairs({ identity: mockIdentity });
+
+			expect(supported).toEqual(new Set([ICP_LEDGER, CKUSDC_LEDGER]));
+			expect(oisyTradeSwapPairTable()).toEqual([icpUsdc]);
+		});
+
+		it('excludes halted pairs from the supported set', async () => {
+			vi.spyOn(oisyTradeApi, 'getTradingPairs').mockResolvedValue([
+				buildPair({ base: ICP, quote: CKUSDC, halted: true })
+			]);
+
+			const supported = await loadOisyTradeSwapPairs({ identity: mockIdentity });
+
+			expect(supported).toEqual(new Set());
+		});
+
+		it('writes pairs without clobbering what the Trading tab loaded', async () => {
+			// `set` replaces all four fields; the swap loader must not wipe the
+			// balances and orders the Trading tab put there.
+			const balances = [{ marker: 'balances' }] as unknown as never;
+			const orders = [{ marker: 'orders' }] as unknown as never;
+			oisyTradeStore.set({
+				pairs: undefined,
+				supportedTokens: undefined,
+				balances,
+				orders
+			});
+
+			vi.spyOn(oisyTradeApi, 'getTradingPairs').mockResolvedValue([icpUsdc]);
+
+			await loadOisyTradeSwapPairs({ identity: mockIdentity });
+
+			expect(get(oisyTradeStore).balances).toBe(balances);
+			expect(get(oisyTradeStore).orders).toBe(orders);
+			expect(get(oisyTradeStore).pairs).toEqual([icpUsdc]);
+		});
+	});
+
+	describe('fetchOisyTradeQuote', () => {
+		beforeEach(() => {
+			oisyTradeStore.setPairs([icpUsdc]);
+		});
+
+		it('quotes a sell, netting both destination-denominated fees off the fill', () => {
+			// 2 ICP at the 1:1 placeholder → 2 ckUSDC gross (2_000_000 at 6 dp).
+			// Taker 10 bps = 2_000; withdrawal ledger fee = 10_000.
+			const result = fetchOisyTradeQuote({
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				sourceAmount: 200_000_000n
+			});
+
+			assert(result.ok);
+
+			expect(result.quote.receiveAmount).toBe(2_000_000n - 2_000n - 10_000n);
+			expect(result.quote.swapDetails.order.side).toBe('sell');
+			expect(result.quote.swapDetails.order.depositAmount).toBe(200_000_000n);
+		});
+
+		it('quotes a buy in the other direction', () => {
+			// 2 ckUSDC at 1:1 → 2 ICP gross (200_000_000 at 8 dp).
+			// Taker 10 bps = 200_000; withdrawal ledger fee = 10_000.
+			const result = fetchOisyTradeQuote({
+				sourceToken: CKUSDC,
+				destinationToken: ICP,
+				sourceAmount: 2_000_000n
+			});
+
+			assert(result.ok);
+
+			expect(result.quote.receiveAmount).toBe(200_000_000n - 200_000n - 10_000n);
+			expect(result.quote.swapDetails.order.side).toBe('buy');
+		});
+
+		it('itemizes the three fees in their own tokens and never sums them', () => {
+			const result = fetchOisyTradeQuote({
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				sourceAmount: 200_000_000n
+			});
+
+			assert(result.ok);
+
+			expect(result.quote.swapDetails.fees).toEqual([
+				// Two source ledger fees — approve and transfer_from — paid on top.
+				{ labelPath: 'swap.text.oisy_trade_deposit_fee', fee: 20_000n, token: ICP },
+				{ labelPath: 'swap.text.oisy_trade_taker_fee', fee: 2_000n, token: CKUSDC },
+				{ labelPath: 'swap.text.oisy_trade_withdrawal_fee', fee: 10_000n, token: CKUSDC }
+			]);
+		});
+
+		it('carries the taker rate and the pair floor for the sheet', () => {
+			const result = fetchOisyTradeQuote({
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				sourceAmount: 200_000_000n
+			});
+
+			assert(result.ok);
+
+			expect(result.quote.swapDetails.takerFeeBps).toBe(10);
+			expect(result.quote.swapDetails.minNotional).toBe(1_000n);
+			// The quote leg is the destination on a sell.
+			expect(result.quote.swapDetails.quoteToken).toBe(CKUSDC);
+		});
+
+		it('rejects a halted pair without a reason to name', () => {
+			oisyTradeStore.setPairs([buildPair({ base: ICP, quote: CKUSDC, halted: true })]);
+
+			expect(
+				fetchOisyTradeQuote({
+					sourceToken: ICP,
+					destinationToken: CKUSDC,
+					sourceAmount: 200_000_000n
+				})
+			).toEqual({ ok: false });
+		});
+
+		it('rejects tokens that share no pair', () => {
+			expect(
+				fetchOisyTradeQuote({
+					sourceToken: ICP,
+					destinationToken: CKBTC,
+					sourceAmount: 200_000_000n
+				})
+			).toEqual({ ok: false });
+		});
+
+		it('rejects every quote while the pair table has not loaded', () => {
+			oisyTradeStore.reset();
+
+			expect(
+				fetchOisyTradeQuote({
+					sourceToken: ICP,
+					destinationToken: CKUSDC,
+					sourceAmount: 200_000_000n
+				})
+			).toEqual({ ok: false });
+		});
+
+		it('rejects an amount off the lot grid, naming the reason for the form', () => {
+			expect(
+				fetchOisyTradeQuote({
+					sourceToken: ICP,
+					destinationToken: CKUSDC,
+					sourceAmount: 100_000n
+				})
+			).toEqual({ ok: false, errorKind: 'lot' });
+		});
+
+		it('rejects a quote whose fees would swallow the whole fill', () => {
+			// 0.01 ICP → 10_000 gross ckUSDC, exactly the withdrawal ledger fee.
+			expect(
+				fetchOisyTradeQuote({
+					sourceToken: ICP,
+					destinationToken: CKUSDC,
+					sourceAmount: 1_000_000n
+				})
+			).toEqual({ ok: false });
+		});
+
+		it('rejects a quote when a ledger fee is unknown', () => {
+			const feeless = { ...CKUSDC, fee: undefined } as unknown as IcToken;
+
+			expect(
+				fetchOisyTradeQuote({
+					sourceToken: ICP,
+					destinationToken: feeless,
+					sourceAmount: 200_000_000n
+				})
+			).toEqual({ ok: false });
+		});
+	});
+
+	// `fetchSwapAmountsICP` maps provider results by key in an inline if/else
+	// chain. A registered provider whose key is missing from that chain quotes
+	// successfully and is then discarded with `mapped` left `undefined` — no
+	// error, no offer, nothing in the logs. This is the single most likely way
+	// for the integration to look broken for no reason, so the branch is pinned.
+	describe('fetchSwapAmountsICP mapping branch', () => {
+		const fanOutParams = {
+			identity: mockIdentity,
+			tokens: [],
+			slippage: 0.5,
+			userEthAddress: undefined,
+			userSolAddress: undefined,
+			userBtcAddress: undefined
+		};
+
+		beforeEach(() => {
+			oisyTradeStore.setPairs([icpUsdc]);
+		});
+
+		it('carries an OISY Trade quote through the fan-out into the results', async () => {
+			const results = await fetchSwapAmounts({
+				...fanOutParams,
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				amount: 2,
+				isSourceTokenIcrc2: true
+			});
+
+			const offer = results.find(({ provider }) => provider === SwapProvider.OISY_TRADE);
+
+			expect(offer).toBeDefined();
+			expect(offer?.receiveAmount).toBe(2_000_000n - 2_000n - 10_000n);
+		});
+
+		it('drops the offer when the source ledger has no ICRC-2', async () => {
+			// The deposit leg is `icrc2_approve` + `icrc2_transfer_from`, so a source
+			// without ICRC-2 cannot be deposited at all.
+			const results = await fetchSwapAmounts({
+				...fanOutParams,
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				amount: 2,
+				isSourceTokenIcrc2: false
+			});
+
+			expect(results.find(({ provider }) => provider === SwapProvider.OISY_TRADE)).toBeUndefined();
+		});
+
+		it('contributes nothing when the pair table is empty', async () => {
+			oisyTradeStore.reset();
+
+			const results = await fetchSwapAmounts({
+				...fanOutParams,
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				amount: 2,
+				isSourceTokenIcrc2: true
+			});
+
+			expect(results.find(({ provider }) => provider === SwapProvider.OISY_TRADE)).toBeUndefined();
+		});
+
+		// Every `getQuote` is called inside a `.map()` whose array only afterwards
+		// reaches `Promise.allSettled`, so a *synchronous* throw escapes the settling
+		// and rejects the entire fan-out — losing ICPSwap's and KongSwap's offers
+		// along with OISY Trade's. The two siblings are async functions and get that
+		// containment for free; this entry is a sync quote and has to ask for it.
+		// `fetchOisyTradeQuote` is written not to throw, so this pins the containment
+		// rather than a reachable path — and the order-book walk that replaces the
+		// placeholder lands in exactly this function.
+		it('contains a synchronous quote failure rather than rejecting the fan-out', async () => {
+			vi.spyOn(oisyTradeSwapServices, 'fetchOisyTradeQuote').mockImplementation(() => {
+				throw new Error('synchronous quote failure');
+			});
+
+			await expect(
+				fetchSwapAmounts({
+					...fanOutParams,
+					sourceToken: ICP,
+					destinationToken: CKUSDC,
+					amount: 2,
+					isSourceTokenIcrc2: true
+				})
+			).resolves.toEqual([]);
+		});
+	});
+
+	describe('mapOisyTradeQuoteResult', () => {
+		it('tags the mapped offer with the OISY Trade provider', () => {
+			oisyTradeStore.setPairs([icpUsdc]);
+
+			const result = fetchOisyTradeQuote({
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				sourceAmount: 200_000_000n
+			});
+
+			assert(result.ok);
+
+			const mapped = mapOisyTradeQuoteResult({ quote: result.quote });
+
+			expect(mapped.provider).toBe(SwapProvider.OISY_TRADE);
+			expect(mapped.receiveAmount).toBe(result.quote.receiveAmount);
+			// No `receiveOutMinimum`: fill-or-kill has no slippage semantics.
+			expect(mapped).not.toHaveProperty('receiveOutMinimum');
+		});
+	});
+
+	describe('settleOisyTradeSwap', () => {
+		const ORDER_ID = 'order-1';
+
+		const settleParams = {
+			identity: mockIdentity,
+			orderId: ORDER_ID,
+			sourceToken: ICP,
+			destinationToken: CKUSDC
+		};
+
+		const userOrder = (status: OrderStatus) =>
+			[{ id: ORDER_ID, order: { status }, pair: {} }] as unknown as UserOrder[];
+
+		const balance = ({ token, free }: { token: IcToken; free: bigint }) =>
+			({
+				token: { id: { ledger_id: Principal.fromText(token.ledgerCanisterId) } },
+				balance: { free, reserved: ZERO }
+			}) as unknown as UserTokenBalance;
+
+		const mockBalances = ({ source, destination }: { source: bigint; destination: bigint }) =>
+			vi
+				.spyOn(oisyTradeApi, 'getBalances')
+				.mockResolvedValue([
+					balance({ token: ICP, free: source }),
+					balance({ token: CKUSDC, free: destination })
+				]);
+
+		const mockWithdraw = () =>
+			vi.spyOn(oisyTradeApi, 'withdraw').mockResolvedValue({ block_index: 42n });
+
+		const ledgerOf = (call: { request: { token_id: { ledger_id: Principal } } }) =>
+			call.request.token_id.ledger_id.toText();
+
+		// A live order's reserve is locked — "funds reserved by open orders are not
+		// withdrawable until the order fills or is canceled" — so asking would only fail.
+		it.each([['Pending'], ['Open']])(
+			'withdraws nothing while the order is %s',
+			async (state: string) => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(
+					userOrder({ [state]: null } as unknown as OrderStatus)
+				);
+				const balances = mockBalances({ source: ZERO, destination: ZERO });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap(settleParams);
+
+				expect(settlement).toEqual({ status: 'pending', withdrawals: [] });
+				expect(withdrawSpy).not.toHaveBeenCalled();
+				// Not even read: a pending order settles nothing, so the balances are moot.
+				expect(balances).not.toHaveBeenCalled();
+			}
+		);
+
+		it('withdraws the destination token on a filled order', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+			mockBalances({ source: ZERO, destination: 2_000_000n });
+			const withdrawSpy = mockWithdraw();
+
+			const settlement = await settleOisyTradeSwap(settleParams);
+
+			expect(settlement.status).toBe('filled');
+			expect(settlement.withdrawals).toEqual([42n]);
+			expect(withdrawSpy).toHaveBeenCalledOnce();
+			expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(CKUSDC_LEDGER);
+		});
+
+		// A killed order is a *failed swap whose funds came back* — the source token, not
+		// the destination, and the whole reason the error is raised only after this ran.
+		it.each([['Expired'], ['Canceled']])(
+			'withdraws the source token back on a %s order',
+			async (state: string) => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(
+					userOrder({ [state]: null } as unknown as OrderStatus)
+				);
+				mockBalances({ source: 200_000_000n, destination: ZERO });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap(settleParams);
+
+				expect(settlement.status).toBe('killed');
+				expect(withdrawSpy).toHaveBeenCalledOnce();
+				expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(ICP_LEDGER);
+			}
+		);
+
+		// A Buy that crosses below its limit price has the unspent reserve released back to
+		// free balance, so a *successful* swap still has source to sweep.
+		it('sweeps a source residue alongside the destination on a fill', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+			mockBalances({ source: 200_000_000n, destination: 2_000_000n });
+			const withdrawSpy = mockWithdraw();
+
+			const settlement = await settleOisyTradeSwap(settleParams);
+
+			expect(settlement.withdrawals).toHaveLength(2);
+			expect(withdrawSpy).toHaveBeenCalledTimes(2);
+			// Destination first: it is what the user is waiting for.
+			expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(CKUSDC_LEDGER);
+			expect(ledgerOf(withdrawSpy.mock.calls[1][0])).toBe(ICP_LEDGER);
+		});
+
+		// `withdraw` refuses an amount at or below the ledger fee (`AmountTooSmall`), so a
+		// residue that small can never be moved. Retrying it would strand the settlement.
+		it('skips a dust residue instead of failing the settlement', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+			// ICP's ledger fee is 10_000; a residue at the fee is unwithdrawable.
+			mockBalances({ source: 10_000n, destination: 2_000_000n });
+			const withdrawSpy = mockWithdraw();
+
+			const settlement = await settleOisyTradeSwap(settleParams);
+
+			expect(settlement.status).toBe('filled');
+			expect(withdrawSpy).toHaveBeenCalledOnce();
+			expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(CKUSDC_LEDGER);
+		});
+
+		// The residue is the smaller amount by construction; letting it fail the settlement
+		// would strand an operation whose funds have already arrived.
+		it('does not let a failing residue withdrawal block the primary one', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(consoleUtils, 'consoleError')
+				.mockImplementation(() => undefined);
+
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+			mockBalances({ source: 200_000_000n, destination: 2_000_000n });
+			const residueError = new Error('residue withdrawal failed');
+			vi.spyOn(oisyTradeApi, 'withdraw')
+				.mockResolvedValueOnce({ block_index: 42n })
+				.mockRejectedValueOnce(residueError);
+
+			const settlement = await settleOisyTradeSwap(settleParams);
+
+			expect(settlement.status).toBe('filled');
+			expect(settlement.withdrawals).toEqual([42n]);
+			// Swallowed, but not silently: the residue is still owed to the user.
+			expect(consoleErrorSpy).toHaveBeenCalledWith(residueError);
+		});
+
+		// "Not found" has two documented spellings and the did never says whether terminal
+		// orders are retained, so both resolve from the balances instead — which is what
+		// keeps settlement correct either way.
+		it.each([
+			{
+				label: 'an empty result',
+				mockOrders: () => vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([])
+			},
+			{
+				label: 'an OrderNotFound error',
+				mockOrders: () =>
+					vi
+						.spyOn(oisyTradeApi, 'getMyOrders')
+						.mockRejectedValue(
+							new OisyTradeRequestError({ message: 'gone', reason: 'OrderNotFound' })
+						)
+			}
+		])(
+			'resolves a fill from the balances when the order reads as $label',
+			async ({ mockOrders }) => {
+				mockOrders();
+				mockBalances({ source: ZERO, destination: 2_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap(settleParams);
+
+				expect(settlement.status).toBe('filled');
+				expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(CKUSDC_LEDGER);
+			}
+		);
+
+		it('resolves a kill from the balances when the order is gone', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([]);
+			mockBalances({ source: 200_000_000n, destination: ZERO });
+			mockWithdraw();
+
+			const { status } = await settleOisyTradeSwap(settleParams);
+
+			expect(status).toBe('killed');
+		});
+
+		it('reports an unresolved settlement when nothing is left in custody', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([]);
+			mockBalances({ source: ZERO, destination: ZERO });
+			const withdrawSpy = mockWithdraw();
+
+			const settlement = await settleOisyTradeSwap(settleParams);
+
+			expect(settlement).toEqual({ status: 'unresolved', withdrawals: [] });
+			expect(withdrawSpy).not.toHaveBeenCalled();
+		});
+
+		// Any other canister error is the caller's to handle, not something to swallow into
+		// a "nothing to settle" answer.
+		it('propagates an order read failure that is not a missing order', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockRejectedValue(
+				new OisyTradeTemporaryError({ message: 'busy', reason: 'OperationInProgress' })
+			);
+
+			await expect(settleOisyTradeSwap(settleParams)).rejects.toThrow('busy');
+		});
+	});
+
+	describe('fetchOisyTradeSwap', () => {
+		// Distinctive values, so the assertions below prove these were carried through from
+		// the reviewed quote rather than re-derived from the amount and the pair.
+		const sellOrder: OisyTradeResolvedOrder = {
+			side: 'sell',
+			pair: {
+				base: Principal.fromText(ICP_LEDGER),
+				quote: Principal.fromText(CKUSDC_LEDGER)
+			},
+			price: 1_234_000n,
+			quantity: 300_000_000n,
+			depositAmount: 300_000_000n
+		};
+
+		// A Buy spends the quote token, so the deposit is the order's reserve at the limit
+		// price — `price × quantity / 10^baseDecimals` — not the typed amount.
+		const buyOrder: OisyTradeResolvedOrder = {
+			...sellOrder,
+			side: 'buy',
+			depositAmount: 3_702_000n
+		};
+
+		const swapParams = {
+			identity: mockIdentity,
+			sourceToken: ICP,
+			destinationToken: CKUSDC,
+			order: sellOrder
+		};
+
+		let approveSpy: MockInstance;
+		let depositSpy: MockInstance;
+		let addLimitOrderSpy: MockInstance;
+
+		beforeEach(() => {
+			vi.spyOn(appConstants, 'OISY_TRADE_CANISTER_ID', 'get').mockImplementation(() => 'aaaaa-aa');
+
+			approveSpy = vi.spyOn(icrcLedgerApi, 'approve').mockResolvedValue(1n);
+			depositSpy = vi.spyOn(oisyTradeApi, 'deposit').mockResolvedValue({ block_index: 7n });
+			addLimitOrderSpy = vi.spyOn(oisyTradeApi, 'addLimitOrder').mockResolvedValue('order-1');
+
+			vi.spyOn(walletUtils, 'waitAndTriggerWallet').mockResolvedValue(undefined);
+
+			// Filled and credited, which is the happy path every test below starts from.
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([
+				{ id: 'order-1', order: { status: { Filled: null } }, pair: {} }
+			] as unknown as UserOrder[]);
+			vi.spyOn(oisyTradeApi, 'getBalances').mockResolvedValue([
+				{
+					token: { id: { ledger_id: Principal.fromText(CKUSDC_LEDGER) } },
+					balance: { free: 2_000_000n, reserved: ZERO }
+				}
+			] as unknown as UserTokenBalance[]);
+			vi.spyOn(oisyTradeApi, 'withdraw').mockResolvedValue({ block_index: 42n });
+		});
+
+		const run = (params = {}) =>
+			fetchOisyTradeSwap({ ...swapParams, progress: vi.fn(), ...params });
+
+		it('submits a fill-or-kill order at the reviewed price and quantity', async () => {
+			await run();
+
+			expect(addLimitOrderSpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					request: {
+						pair: sellOrder.pair,
+						side: { Sell: null },
+						quantity: sellOrder.quantity,
+						price: sellOrder.price,
+						time_in_force: [{ FillOrKill: null }]
+					}
+				})
+			);
+		});
+
+		it('deposits exactly the ordered quantity on a sell', async () => {
+			await run();
+
+			expect(depositSpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					request: expect.objectContaining({ amount: sellOrder.quantity })
+				})
+			);
+			// The allowance has to cover the `icrc2_transfer_from` fee on top of the amount.
+			expect(approveSpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ amount: sellOrder.quantity + ICP.fee })
+			);
+		});
+
+		// The unorderable slice of the typed amount never leaves the wallet: the user pays
+		// slightly less than they typed rather than receiving less than they were quoted.
+		it('deposits the order reserve rather than the typed amount on a buy', async () => {
+			await run({ order: buyOrder });
+
+			expect(depositSpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					request: expect.objectContaining({ amount: buyOrder.depositAmount })
+				})
+			);
+		});
+
+		it('walks the progress steps and enables the destination token', async () => {
+			const progress = vi.fn();
+			const enableDestinationToken = vi.fn().mockResolvedValue(undefined);
+
+			await run({ progress, enableDestinationToken });
+
+			expect(progress.mock.calls.flat()).toEqual([
+				ProgressStepsSwap.APPROVE,
+				ProgressStepsSwap.SWAP,
+				ProgressStepsSwap.WITHDRAW,
+				ProgressStepsSwap.UPDATE_UI
+			]);
+			expect(enableDestinationToken).toHaveBeenCalledOnce();
+		});
+
+		// A swap-placed order genuinely is a deposit and a limit order, so dropping either
+		// event would leave a hole in the Trading funnel proportional to Swap's success.
+		it('fires both Trading funnels alongside the swap', async () => {
+			const depositSpyTracker = vi.spyOn(tradingAnalytics, 'trackDepositWithdraw');
+			const orderSpyTracker = vi.spyOn(tradingAnalytics, 'trackLimitOrder');
+
+			await run();
+
+			expect(depositSpyTracker).toHaveBeenCalledWith(
+				expect.objectContaining({
+					direction: 'deposit',
+					resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
+					token: ICP.symbol
+				})
+			);
+			expect(orderSpyTracker).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: 'create',
+					orderType: 'FOK',
+					side: 'sell',
+					resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS
+				})
+			);
+		});
+
+		it('never places an order when the deposit fails', async () => {
+			depositSpy.mockRejectedValue(new Error('deposit failed'));
+
+			await expect(run()).rejects.toThrow('deposit failed');
+
+			expect(addLimitOrderSpy).not.toHaveBeenCalled();
+		});
+
+		// The one case unlike every other provider: the swap failed, but the funds came back.
+		// The error is raised only *after* the source token has been withdrawn, so the user is
+		// never told the swap failed while their money is still in someone else's custody.
+		it('withdraws the source back before reporting a killed order', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([
+				{ id: 'order-1', order: { status: { Expired: null } }, pair: {} }
+			] as unknown as UserOrder[]);
+			const withdrawSpy = vi.spyOn(oisyTradeApi, 'withdraw').mockResolvedValue({
+				block_index: 42n
+			});
+			vi.spyOn(oisyTradeApi, 'getBalances').mockResolvedValue([
+				{
+					token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+					balance: { free: 300_000_000n, reserved: ZERO }
+				}
+			] as unknown as UserTokenBalance[]);
+
+			const progress = vi.fn();
+			const enableDestinationToken = vi.fn();
+			const walletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
+
+			// The typed error, with `kind`, is what the wizard branches on to present a
+			// kill as the expected market outcome it is rather than an unexpected failure.
+			await expect(run({ progress, enableDestinationToken })).rejects.toMatchObject({
+				name: 'OisyTradeSwapError',
+				kind: 'killed',
+				message: en.swap.error.oisy_trade_order_killed
+			});
+
+			expect(withdrawSpy).toHaveBeenCalledOnce();
+			expect(withdrawSpy.mock.calls[0][0].request.token_id.ledger_id.toText()).toBe(ICP_LEDGER);
+			// The recovered source balance is refreshed, but the user never received the
+			// destination token: nothing enables it, and the progress bar never reaches
+			// the final step.
+			expect(walletSpy).toHaveBeenCalledOnce();
+			expect(enableDestinationToken).not.toHaveBeenCalled();
+			expect(progress).not.toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
+		});
+
+		// Nothing left in custody and nothing that says how the order ended: the error
+		// asks the user to check the Trading tab, and since nothing was withdrawn there
+		// is no wallet change to refresh and no destination token to enable.
+		it('reports an unresolved settlement without refreshing or enabling anything', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([]);
+			vi.spyOn(oisyTradeApi, 'getBalances').mockResolvedValue([]);
+			const walletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
+			const enableDestinationToken = vi.fn();
+
+			await expect(run({ enableDestinationToken })).rejects.toMatchObject({
+				name: 'OisyTradeSwapError',
+				kind: 'unresolved',
+				message: en.swap.error.oisy_trade_settlement_unresolved
+			});
+
+			expect(walletSpy).not.toHaveBeenCalled();
+			expect(enableDestinationToken).not.toHaveBeenCalled();
+		});
+
+		describe('retrying', () => {
+			beforeEach(() => {
+				vi.useFakeTimers();
+			});
+
+			afterEach(() => {
+				vi.useRealTimers();
+			});
+
+			const settleWithFakeTimers = async (promise: Promise<unknown>) => {
+				// One tick of the settle interval is all the mocks below need; the assertion
+				// is that the flow asked a second time rather than giving up on the first.
+				await vi.advanceTimersByTimeAsync(OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS);
+
+				return await promise;
+			};
+
+			it('keeps polling while the order has not settled yet', async () => {
+				const getMyOrdersSpy = vi
+					.spyOn(oisyTradeApi, 'getMyOrders')
+					.mockResolvedValueOnce([
+						{ id: 'order-1', order: { status: { Pending: null } }, pair: {} }
+					] as unknown as UserOrder[])
+					.mockResolvedValue([
+						{ id: 'order-1', order: { status: { Filled: null } }, pair: {} }
+					] as unknown as UserOrder[]);
+
+				await settleWithFakeTimers(run());
+
+				expect(getMyOrdersSpy).toHaveBeenCalledTimes(2);
+			});
+
+			// The most damaging bug this integration can ship is ending the operation on a
+			// transient failure, with the funds still in DEX custody and nothing watching them.
+			it('retries a retryable withdrawal failure rather than failing the swap', async () => {
+				const withdrawSpy = vi
+					.spyOn(oisyTradeApi, 'withdraw')
+					.mockRejectedValueOnce(
+						new OisyTradeTemporaryError({ message: 'busy', reason: 'OperationInProgress' })
+					)
+					.mockResolvedValue({ block_index: 42n });
+
+				const settlement = await settleWithFakeTimers(run());
+
+				expect(settlement).toEqual({ status: 'filled', withdrawals: [42n] });
+				expect(withdrawSpy).toHaveBeenCalledTimes(2);
+			});
+
+			// No timer advance: a non-retryable failure ends the swap on the first attempt,
+			// which is exactly the difference from the test above.
+			it('fails the swap on a withdrawal failure that is not retryable', async () => {
+				const withdrawSpy = vi
+					.spyOn(oisyTradeApi, 'withdraw')
+					.mockRejectedValue(
+						new OisyTradeRequestError({ message: 'nope', reason: 'InsufficientBalance' })
+					);
+
+				await expect(run()).rejects.toThrow('nope');
+
+				expect(withdrawSpy).toHaveBeenCalledOnce();
+			});
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -562,6 +562,24 @@ describe('oisy-trade-swap.services', () => {
 			expect(consoleErrorSpy).toHaveBeenCalledWith(residueError);
 		});
 
+		// An unknown ledger fee says nothing about whether the balance is withdrawable, so
+		// it must not share the dust skip: skipping would report the swap settled with the
+		// funds still in DEX custody. `IcTokenSchema` requires `fee`, so reaching this at
+		// all means constructing a token without one.
+		it('fails rather than skipping the withdrawal when the ledger fee is unknown', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+			mockBalances({ source: ZERO, destination: 2_000_000n });
+			const withdrawSpy = mockWithdraw();
+
+			const feeless = { ...CKUSDC, fee: undefined } as unknown as IcToken;
+
+			await expect(
+				settleOisyTradeSwap({ ...settleParams, destinationToken: feeless })
+			).rejects.toThrow(en.trading.deposit.error.unknown_fee);
+
+			expect(withdrawSpy).not.toHaveBeenCalled();
+		});
+
 		// "Not found" has two documented spellings and the did never says whether terminal
 		// orders are retained, so both resolve from the balances instead — which is what
 		// keeps settlement correct either way.

--- a/src/frontend/src/tests/lib/utils/oisy-trade-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade-swap.utils.spec.ts
@@ -327,6 +327,100 @@ describe('oisy-trade-swap.utils', () => {
 
 			expect(result.ok).toBeFalsy();
 		});
+
+		// An 18-decimal base token is where the human-float round-trip the shipped
+		// Limit Order form uses stops being safe: one lot is 1e15 base units, far
+		// below the 1e-6 *relative* slack `isMultipleOfStep` allows, so a float
+		// verdict can pass a quantity the canister then rejects with
+		// `InvalidQuantity` — after `deposit` has already moved the funds.
+		describe('18-decimal precision', () => {
+			// The same 18-decimal ckETH token the unpaired-token cases use, here given a
+			// pair of its own. 18 dp base, 6 dp quote; lot 0.001 ckETH, tick 0.001 ckUSDC.
+			const cketh = UNPAIRED;
+			const ckethUsdc = buildPair({
+				base: cketh,
+				quote: CKUSDC,
+				lotSize: 1_000_000_000_000_000n
+			});
+
+			const resolve = ({ sourceToken = cketh, amount }: { sourceToken?: Token; amount: bigint }) =>
+				resolveOisyTradeOrder({
+					sourceToken,
+					amount,
+					// Well above the 5 ckUSDC floor at these sizes, and on the tick grid.
+					price: 1000,
+					pair: ckethUsdc
+				});
+
+			// The exact case that regressed: 0.009 ckETH is a clean multiple of the
+			// 0.001 lot, but 9e15/1e18 has no exact binary form, so multiplying back
+			// out produced 8999999999999999 — one base unit off the grid, while the
+			// float lot check still passed. Note 9e15 is *below* `2^53`, so this is the
+			// divide-then-multiply round-trip rather than an unsafe-integer problem.
+			it('keeps an on-grid 0.009 ckETH sell exactly on the lot grid', () => {
+				const result = resolve({ amount: 9_000_000_000_000_000n });
+
+				assert(result.ok);
+
+				expect(result.order.quantity).toBe(9_000_000_000_000_000n);
+				expect(result.order.quantity % ckethUsdc.lot_size).toBe(ZERO);
+				// A Sell deposits the ordered quantity exactly — acceptance criterion 10.
+				expect(result.order.depositAmount).toBe(9_000_000_000_000_000n);
+			});
+
+			// From 5 lots up, since at this price one lot is 1 ckUSDC and the pair's
+			// floor is 5 — below that the rejection is the notional, not the grid.
+			it('round-trips every on-grid quantity without drift', () => {
+				const drifted = Array.from({ length: 200 }, (_, index) => BigInt(index + 5))
+					.map((lots) => ({ lots, amount: lots * ckethUsdc.lot_size }))
+					.filter(({ amount }) => {
+						const result = resolve({ amount });
+
+						return !result.ok || result.order.quantity !== amount;
+					});
+
+				expect(drifted).toEqual([]);
+			});
+
+			// Off the grid by 1e9 base units — a 1e-9 *relative* deviation, which the
+			// float check's 1e-6 tolerance waves through. Only an exact check rejects
+			// it, and rejecting it here is what keeps the deposit from happening.
+			it('refuses an amount off the grid by less than the float tolerance', () => {
+				const result = resolve({ amount: 9_000_000_000_000_000n + 1_000_000_000n });
+
+				assert(!result.ok);
+
+				expect(result.errorKind).toBe('lot');
+			});
+
+			// Above 1e21 base units `Number.toFixed(0)` switches to exponential
+			// notation, which `BigInt` refuses — the old conversion threw a
+			// `SyntaxError` out of a function documented as never throwing.
+			it('resolves an amount past the exponential-notation threshold', () => {
+				const amount = 1_000_007_000_000_000_000_000n;
+
+				expect(() => resolve({ amount })).not.toThrow();
+
+				const result = resolve({ amount });
+
+				assert(result.ok);
+
+				expect(result.order.quantity).toBe(amount);
+			});
+
+			// The derived side: the quantity comes out of a bigint division, so the
+			// deposit is the exact reserve with no residue left in the wallet.
+			it('derives a buy quantity into 18 decimals exactly', () => {
+				const result = resolve({ sourceToken: CKUSDC, amount: 9_000_000n });
+
+				assert(result.ok);
+
+				expect(result.order.side).toBe('buy');
+				expect(result.order.quantity).toBe(9_000_000_000_000_000n);
+				expect(result.order.quantity % ckethUsdc.lot_size).toBe(ZERO);
+				expect(result.order.depositAmount).toBe(9_000_000n);
+			});
+		});
 	});
 
 	describe('computeOisyTradeReceiveAmount', () => {

--- a/src/frontend/src/tests/lib/utils/oisy-trade-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade-swap.utils.spec.ts
@@ -1,0 +1,375 @@
+import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
+import type { IcToken } from '$icp/types/ic-token';
+import { ZERO } from '$lib/constants/app.constants';
+import type { Token } from '$lib/types/token';
+import {
+	computeOisyTradeReceiveAmount,
+	findOisyTradePair,
+	isOisyTradePair,
+	oisyTradeCompatibleDestinations,
+	oisyTradeSupportedSourceTokens,
+	resolveOisyTradeOrder,
+	resolveOisyTradeSide,
+	toOisyTradePairTable
+} from '$lib/utils/oisy-trade-swap.utils';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { Principal } from '@icp-sdk/core/principal';
+
+const ICP_LEDGER = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
+const CKUSDC_LEDGER = 'xevnm-gaaaa-aaaar-qafnq-cai';
+const CKBTC_LEDGER = 'mxzaz-hqaaa-aaaar-qaada-cai';
+const UNPAIRED_LEDGER = 'ss2fx-dyaaa-aaaar-qacoq-cai';
+
+const icToken = ({
+	ledgerCanisterId,
+	decimals,
+	symbol
+}: {
+	ledgerCanisterId: string;
+	decimals: number;
+	symbol: string;
+}): IcToken => ({ ...mockValidIcToken, ledgerCanisterId, decimals, symbol });
+
+const ICP = icToken({ ledgerCanisterId: ICP_LEDGER, decimals: 8, symbol: 'ICP' });
+const CKUSDC = icToken({ ledgerCanisterId: CKUSDC_LEDGER, decimals: 6, symbol: 'ckUSDC' });
+const CKBTC = icToken({ ledgerCanisterId: CKBTC_LEDGER, decimals: 8, symbol: 'ckBTC' });
+const UNPAIRED = icToken({ ledgerCanisterId: UNPAIRED_LEDGER, decimals: 18, symbol: 'ckETH' });
+
+const buildPair = ({
+	base,
+	quote,
+	halted = false,
+	lotSize = 1_000_000n,
+	tickSize = 1_000n,
+	minNotional = 5_000_000n,
+	maxNotional = [] as [] | [bigint]
+}: {
+	base: IcToken;
+	quote: IcToken;
+	halted?: boolean;
+	lotSize?: bigint;
+	tickSize?: bigint;
+	minNotional?: bigint;
+	maxNotional?: [] | [bigint];
+}): TradingPairInfo =>
+	({
+		status: halted ? { Halted: null } : { Trading: null },
+		base: {
+			id: { ledger_id: Principal.fromText(base.ledgerCanisterId) },
+			metadata: { symbol: base.symbol, decimals: base.decimals }
+		},
+		quote: {
+			id: { ledger_id: Principal.fromText(quote.ledgerCanisterId) },
+			metadata: { symbol: quote.symbol, decimals: quote.decimals }
+		},
+		lot_size: lotSize,
+		tick_size: tickSize,
+		min_notional: minNotional,
+		max_notional: maxNotional,
+		maker_fee_bps: 5,
+		taker_fee_bps: 10
+	}) as unknown as TradingPairInfo;
+
+// ICP/ckUSDC: 8 dp base, 6 dp quote. Lot 0.01 ICP, tick 0.001 ckUSDC, floor 5 ckUSDC.
+const icpUsdc = buildPair({ base: ICP, quote: CKUSDC });
+const ckbtcUsdc = buildPair({ base: CKBTC, quote: CKUSDC });
+
+describe('oisy-trade-swap.utils', () => {
+	describe('toOisyTradePairTable', () => {
+		it('keeps actively-trading pairs', () => {
+			expect(toOisyTradePairTable([icpUsdc, ckbtcUsdc])).toHaveLength(2);
+		});
+
+		it('drops halted pairs — the canister rejects new orders on them', () => {
+			const halted = buildPair({ base: ICP, quote: CKUSDC, halted: true });
+
+			expect(toOisyTradePairTable([halted, ckbtcUsdc])).toEqual([ckbtcUsdc]);
+		});
+
+		it('returns nothing when every pair is halted', () => {
+			const halted = buildPair({ base: ICP, quote: CKUSDC, halted: true });
+
+			expect(toOisyTradePairTable([halted])).toEqual([]);
+		});
+	});
+
+	describe('oisyTradeSupportedSourceTokens', () => {
+		it('collects both legs of every pair', () => {
+			expect(oisyTradeSupportedSourceTokens([icpUsdc, ckbtcUsdc])).toEqual(
+				new Set([ICP_LEDGER, CKUSDC_LEDGER, CKBTC_LEDGER])
+			);
+		});
+
+		it('is empty for an empty table, so the provider contributes nothing', () => {
+			expect(oisyTradeSupportedSourceTokens([])).toEqual(new Set());
+		});
+	});
+
+	describe('oisyTradeCompatibleDestinations', () => {
+		const table = [icpUsdc, ckbtcUsdc];
+
+		it('narrows to the pair counterparts only, never the whole supported set', () => {
+			// ckUSDC is paired with both ICP and ckBTC; ICP is paired only with ckUSDC.
+			// A symmetric builder would hand ICP the whole set, which is the bug this guards.
+			expect(oisyTradeCompatibleDestinations({ sourceToken: ICP, table })).toEqual({
+				icp: new Set([CKUSDC_LEDGER])
+			});
+		});
+
+		it('returns every counterpart when the token is a leg of several pairs', () => {
+			expect(oisyTradeCompatibleDestinations({ sourceToken: CKUSDC, table })).toEqual({
+				icp: new Set([ICP_LEDGER, CKBTC_LEDGER])
+			});
+		});
+
+		it('returns undefined for a token in no pair', () => {
+			expect(oisyTradeCompatibleDestinations({ sourceToken: UNPAIRED, table })).toBeUndefined();
+		});
+
+		it('returns undefined for a halted pair, on either side', () => {
+			const halted = toOisyTradePairTable([buildPair({ base: ICP, quote: CKUSDC, halted: true })]);
+
+			expect(oisyTradeCompatibleDestinations({ sourceToken: ICP, table: halted })).toBeUndefined();
+			expect(
+				oisyTradeCompatibleDestinations({ sourceToken: CKUSDC, table: halted })
+			).toBeUndefined();
+		});
+
+		it('returns undefined for a non-IC token', () => {
+			const evmToken = { ...mockValidIcToken, ledgerCanisterId: undefined } as unknown as Token;
+
+			expect(oisyTradeCompatibleDestinations({ sourceToken: evmToken, table })).toBeUndefined();
+		});
+	});
+
+	describe('findOisyTradePair / isOisyTradePair', () => {
+		const table = [icpUsdc, ckbtcUsdc];
+
+		it('finds the pair regardless of which side each token is on', () => {
+			expect(findOisyTradePair({ sourceToken: ICP, destinationToken: CKUSDC, table })).toBe(
+				icpUsdc
+			);
+			expect(findOisyTradePair({ sourceToken: CKUSDC, destinationToken: ICP, table })).toBe(
+				icpUsdc
+			);
+		});
+
+		it('is false for two tokens that share no pair', () => {
+			expect(isOisyTradePair({ sourceToken: ICP, destinationToken: CKBTC, table })).toBeFalsy();
+		});
+	});
+
+	describe('resolveOisyTradeSide', () => {
+		it('spending the base token is a sell', () => {
+			expect(resolveOisyTradeSide({ sourceToken: ICP, pair: icpUsdc })).toBe('sell');
+		});
+
+		it('spending the quote token is a buy', () => {
+			expect(resolveOisyTradeSide({ sourceToken: CKUSDC, pair: icpUsdc })).toBe('buy');
+		});
+
+		it('is undefined for a token that is not a leg', () => {
+			expect(resolveOisyTradeSide({ sourceToken: CKBTC, pair: icpUsdc })).toBeUndefined();
+		});
+	});
+
+	describe('resolveOisyTradeOrder', () => {
+		it('deposits exactly the ordered quantity on a sell', () => {
+			// 2 ICP at 10 ckUSDC — already a lot multiple, so nothing is floored away.
+			const result = resolveOisyTradeOrder({
+				sourceToken: ICP,
+				amount: 200_000_000n,
+				price: 10,
+				freeBalance: 5,
+				pair: icpUsdc
+			});
+
+			assert(result.ok);
+
+			expect(result.order.side).toBe('sell');
+			expect(result.order.quantity).toBe(200_000_000n);
+			expect(result.order.depositAmount).toBe(200_000_000n);
+			// 10 ckUSDC (6 dp) per whole base.
+			expect(result.order.price).toBe(10_000_000n);
+		});
+
+		it('deposits the order reserve on a buy, computed exactly in bigint', () => {
+			// 50 ckUSDC at 10 ckUSDC/ICP buys 5 ICP; the reserve is
+			// price × quantity / 10^baseDecimals = 10_000_000 × 500_000_000 / 10^8.
+			const result = resolveOisyTradeOrder({
+				sourceToken: CKUSDC,
+				amount: 50_000_000n,
+				price: 10,
+				freeBalance: 100,
+				pair: icpUsdc
+			});
+
+			assert(result.ok);
+
+			expect(result.order.side).toBe('buy');
+			expect(result.order.quantity).toBe(500_000_000n);
+			expect(result.order.depositAmount).toBe(50_000_000n);
+		});
+
+		it('refuses a sell amount off the lot grid rather than rounding it, like the Limit Order form', () => {
+			// 2.005 ICP against a 0.01 ICP lot is not a lot multiple. The form never
+			// lets such an amount through (it validates, and floors only in the Max
+			// link), so the swap contributes no offer instead of silently selling less
+			// than the user typed.
+			const result = resolveOisyTradeOrder({
+				sourceToken: ICP,
+				amount: 200_500_000n,
+				price: 10,
+				freeBalance: 5,
+				pair: icpUsdc
+			});
+
+			assert(!result.ok);
+
+			expect(result.errorKind).toBe('lot');
+		});
+
+		it('floors the derived buy quantity to the lot grid, shrinking the deposit to the reserve', () => {
+			// 50.05 ckUSDC at 10 ckUSDC/ICP affords 5.005 ICP, which floors to 5.00 on
+			// the 0.01 lot — a quantity the user cannot control by typing. The deposit
+			// is the reserve at the limit price, so the unorderable 0.05 ckUSDC never
+			// leaves the wallet.
+			const result = resolveOisyTradeOrder({
+				sourceToken: CKUSDC,
+				amount: 50_050_000n,
+				price: 10,
+				freeBalance: 100,
+				pair: icpUsdc
+			});
+
+			assert(result.ok);
+
+			expect(result.order.quantity).toBe(500_000_000n);
+			expect(result.order.depositAmount).toBe(50_000_000n);
+		});
+
+		it('snaps the price down to the tick grid', () => {
+			const result = resolveOisyTradeOrder({
+				sourceToken: ICP,
+				amount: 200_000_000n,
+				price: 10.00099,
+				freeBalance: 5,
+				pair: icpUsdc
+			});
+
+			assert(result.ok);
+
+			// tick is 0.001 ckUSDC, so 10.00099 → 10.000.
+			expect(result.order.price).toBe(10_000_000n);
+		});
+
+		it('refuses an amount below one lot', () => {
+			const result = resolveOisyTradeOrder({
+				sourceToken: ICP,
+				amount: 100_000n,
+				price: 10,
+				freeBalance: 5,
+				pair: icpUsdc
+			});
+
+			expect(result.ok).toBeFalsy();
+		});
+
+		it('refuses a notional below the pair floor, naming the reason', () => {
+			// 0.01 ICP at 10 ckUSDC is a 0.1 ckUSDC notional, under the 5 ckUSDC floor.
+			const result = resolveOisyTradeOrder({
+				sourceToken: ICP,
+				amount: 1_000_000n,
+				price: 10,
+				freeBalance: 5,
+				pair: icpUsdc
+			});
+
+			assert(!result.ok);
+
+			expect(result.errorKind).toBe('min_notional');
+		});
+
+		it('refuses an order the wallet balance cannot cover', () => {
+			const result = resolveOisyTradeOrder({
+				sourceToken: ICP,
+				amount: 200_000_000n,
+				price: 10,
+				freeBalance: 1,
+				pair: icpUsdc
+			});
+
+			assert(!result.ok);
+
+			expect(result.errorKind).toBe('balance');
+		});
+
+		it('refuses a token that is not a leg of the pair', () => {
+			const result = resolveOisyTradeOrder({
+				sourceToken: CKBTC,
+				amount: 200_000_000n,
+				price: 10,
+				freeBalance: 5,
+				pair: icpUsdc
+			});
+
+			expect(result.ok).toBeFalsy();
+		});
+
+		it('refuses a price that floors to zero on the tick grid', () => {
+			const result = resolveOisyTradeOrder({
+				sourceToken: ICP,
+				amount: 200_000_000n,
+				price: 0.0001,
+				freeBalance: 5,
+				pair: icpUsdc
+			});
+
+			expect(result.ok).toBeFalsy();
+		});
+	});
+
+	describe('computeOisyTradeReceiveAmount', () => {
+		it('rescales down across a decimals mismatch', () => {
+			// 1 ICP (8 dp) at 1:1 is 1 ckUSDC (6 dp) — a plain bigint copy is 100× wrong.
+			expect(
+				computeOisyTradeReceiveAmount({
+					amount: 100_000_000n,
+					sourceDecimals: 8,
+					destinationDecimals: 6
+				})
+			).toBe(1_000_000n);
+		});
+
+		it('rescales up in the other direction', () => {
+			expect(
+				computeOisyTradeReceiveAmount({
+					amount: 1_000_000n,
+					sourceDecimals: 6,
+					destinationDecimals: 8
+				})
+			).toBe(100_000_000n);
+		});
+
+		it('passes the amount through when the decimals match', () => {
+			expect(
+				computeOisyTradeReceiveAmount({
+					amount: 12_345n,
+					sourceDecimals: 8,
+					destinationDecimals: 8
+				})
+			).toBe(12_345n);
+		});
+
+		it('floors rather than rounding, so it never over-quotes', () => {
+			// 0.000000019 ICP has no representation at 6 dp; the fraction is dropped.
+			expect(
+				computeOisyTradeReceiveAmount({
+					amount: 19n,
+					sourceDecimals: 8,
+					destinationDecimals: 6
+				})
+			).toBe(ZERO);
+		});
+	});
+});

--- a/src/frontend/src/tests/mocks/swap.mocks.ts
+++ b/src/frontend/src/tests/mocks/swap.mocks.ts
@@ -9,6 +9,7 @@ import {
 } from '$lib/types/swap';
 import { mockNearIntentsQuoteResponse } from '$tests/mocks/near-intents.mock';
 import { mockVeloraDeltaPrice, mockVeloraOptimalRate } from '$tests/mocks/velora.mock';
+import { Principal } from '@icp-sdk/core/principal';
 
 export const mockSwapProviders: SwapMappedResult[] = [
 	{
@@ -74,3 +75,30 @@ export const mockChainFusionProvider = (
 	swapDetails,
 	type: undefined
 });
+
+// Typed as the narrowed union member so tests can reach `swapDetails.order` — the
+// reviewed parameters the wizard hands to `fetchOisyTradeSwap` — without casting.
+export const mockOisyTradeProvider: Extract<
+	SwapMappedResult,
+	{ provider: SwapProvider.OISY_TRADE }
+> = {
+	provider: SwapProvider.OISY_TRADE,
+	receiveAmount: 860000000n,
+	swapDetails: {
+		fees: [],
+		takerFeeBps: 10,
+		minNotional: 5_000_000n,
+		quoteToken: { symbol: 'ckUSDC', decimals: 6 } as IcToken,
+		order: {
+			side: 'sell',
+			pair: {
+				base: Principal.fromText('ryjl3-tyaaa-aaaaa-aaaba-cai'),
+				quote: Principal.fromText('xevnm-gaaaa-aaaar-qafnq-cai')
+			},
+			price: 10_000_000n,
+			quantity: 100_000_000n,
+			depositAmount: 100_000_000n
+		}
+	},
+	type: undefined
+};

--- a/src/frontend/static/images/dapps/oisy-trade-logo.svg
+++ b/src/frontend/static/images/dapps/oisy-trade-logo.svg
@@ -1,0 +1,121 @@
+<svg
+	fill="none"
+	viewBox="0 0 256 256"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<g clip-path="url(#oisyTradeLogoClip)">
+		<g filter="url(#oisyTradeLogoShadow)">
+			<circle cx="128" cy="128" fill="#06f" r="128" />
+		</g>
+		<rect
+			height="76.447"
+			opacity=".7"
+			rx="7.767"
+			stroke="#fff"
+			stroke-width="2.335"
+			transform="rotate(174.862 186.316 171.496)"
+			width="37.462"
+			x="186.316"
+			y="171.496"
+		/>
+		<rect
+			fill="#fff"
+			height="74.721"
+			rx="6.904"
+			stroke="#fff"
+			stroke-width="4.061"
+			transform="rotate(174.862 193.501 163.403)"
+			width="35.736"
+			x="193.501"
+			y="163.403"
+		/>
+		<path
+			d="m143.17 103.413.172-.387a8.93 8.93 0 0 1 2.993-3.657l1.961-1.392q.565-.4 1.06-.882l4.903-4.771"
+			stroke="#fff"
+			stroke-width="2.335"
+		/>
+		<rect
+			height="76.447"
+			opacity=".7"
+			rx="7.767"
+			stroke="#fff"
+			stroke-width="2.335"
+			transform="rotate(174.862 106.457 173.063)"
+			width="37.462"
+			x="106.457"
+			y="173.063"
+		/>
+		<rect
+			fill="#fff"
+			height="74.721"
+			rx="6.904"
+			stroke="#fff"
+			stroke-width="4.061"
+			transform="rotate(174.862 113.642 164.97)"
+			width="35.736"
+			x="113.642"
+			y="164.97"
+		/>
+		<path
+			d="m63.312 104.98.172-.387a8.94 8.94 0 0 1 2.993-3.657l1.961-1.392a9 9 0 0 0 1.06-.882l4.903-4.77"
+			stroke="#fff"
+			stroke-width="2.335"
+		/>
+		<path d="m99.65 168.241 9.875-.963.841 8.63-9.875.962z" fill="#06f" />
+		<rect
+			fill="#fff"
+			height="119.649"
+			rx="3.502"
+			transform="rotate(174.86 101.929 188.565)"
+			width="7.004"
+			x="101.929"
+			y="188.565"
+		/>
+		<rect
+			fill="#fff"
+			height="117.276"
+			rx="3.502"
+			transform="rotate(174.86 181.277 184.05)"
+			width="7.004"
+			x="181.277"
+			y="184.05"
+		/>
+	</g>
+	<defs>
+		<clipPath id="oisyTradeLogoClip">
+			<rect fill="#fff" height="256" rx="128" width="256" />
+		</clipPath>
+		<filter
+			id="oisyTradeLogoShadow"
+			color-interpolation-filters="sRGB"
+			filterUnits="userSpaceOnUse"
+			height="260.151"
+			width="260.151"
+			x="-2"
+			y="-2"
+		>
+			<feFlood flood-opacity="0" result="BackgroundImageFix" />
+			<feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+			<feColorMatrix
+				in="SourceAlpha"
+				result="hardAlpha"
+				values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+			/>
+			<feOffset dx="4.303" dy="4.303" />
+			<feGaussianBlur stdDeviation="1.076" />
+			<feComposite in2="hardAlpha" k2="-1" k3="1" operator="arithmetic" />
+			<feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.55 0" />
+			<feBlend in2="shape" result="effect1_innerShadow" />
+			<feColorMatrix
+				in="SourceAlpha"
+				result="hardAlpha"
+				values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+			/>
+			<feOffset dx="-3" dy="-2.5" />
+			<feGaussianBlur stdDeviation="1" />
+			<feComposite in2="hardAlpha" k2="-1" k3="1" operator="arithmetic" />
+			<feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0" />
+			<feBlend in2="effect1_innerShadow" result="effect2_innerShadow" />
+		</filter>
+	</defs>
+</svg>


### PR DESCRIPTION
# Motivation

OISY Trade is the only venue OISY itself operates, and it is reachable from exactly one place — the Trading tab — through deposit → place order → withdraw, which asks the user to understand custody, order books, lot sizes and time-in-force before they can trade at all. Most people just want to turn X into Y, which is the Swap modal's premise. Registering OISY Trade as a swap provider puts its liquidity into the comparison users already make against ICPSwap and KongSwap, with that three-leg choreography hidden behind the same three steps every other swap uses.


# Changes

Behind a new `OISY_TRADE_SWAP_ENABLED`, gated to `LOCAL` and additionally requiring `OISY_TRADE_ENABLED` — off in every deployed environment. Two things need containing until steps 2 and 3 land: the receive amount is a 1:1 placeholder, and settlement has no recovery record if the tab closes mid-flow. Every non-local environment shares the production `oisy_trade` canister and the mainnet ledgers, so the flag must not widen before both are fixed.


# Tests

Updated/added.
