### PR TITLE
feat(frontend): one sentence for a Solana transaction, wherever it appears

### DIFF
--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1972,7 +1972,7 @@
 			"to_ata_copied": "Recipient token account (ATA) copied to clipboard.",
 			"block": "Block",
 			"kind_other": "Interaction",
-			"summary_swap": "Swap $spent $spent_symbol to $received $received_symbol",
+			"summary_swap": "Swap $spent_symbol to $received_symbol",
 			"summary_self": "Self-transfer $amount $symbol",
 			"swap_on": "On",
 			"interacted_with": "Interacted with",

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -31,6 +31,7 @@
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 	import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
 	import { solAccountExplorerUrl } from '$sol/utils/sol-explorer.utils';
+	import { formatSolTransactionSummary } from '$sol/utils/sol-transaction-summary.utils';
 	import { findEnabledSplToken } from '$sol/utils/spl.utils';
 
 	interface Props {
@@ -79,26 +80,31 @@
 			? SOLANA_TOKEN.decimals
 			: (splToken(change.tokenAddress)?.decimals ?? 0));
 
-	// The hero speaks in the summary's terms: the word is the kind, the figure is the main change
-	// in its own token, and a swap shows the pair. Records without a summary keep the old rendering.
-	let kindLabel = $derived(
-		isNullish(summary)
-			? undefined
-			: summary.kind === 'send'
-				? $i18n.send.text.send
-				: summary.kind === 'receive'
-					? $i18n.receive.text.receive
-					: summary.kind === 'swap'
-						? $i18n.swap.text.swap
-						: $i18n.transaction.text.kind_other
-	);
-
-	const heroAmount = (change: SolNetBalanceChange): string =>
-		`${formatToken({
+	// The bare figure. The sentence appends the symbol itself, and the hero title pairs it with
+	// one below.
+	const figureOf = (change: SolNetBalanceChange): string =>
+		formatToken({
 			value: absBigInt(change.delta),
 			unitName: decimalsOf(change),
 			displayDecimals: decimalsOf(change)
-		})} ${symbolOf(change.tokenAddress)}`;
+		});
+
+	// The same sentence the rows carry, so a transaction reads identically wherever it is met.
+	// The figure below it is the detail this view exists for. Records without a summary keep the
+	// old rendering.
+	let kindLabel = $derived(
+		nonNullish(summary)
+			? formatSolTransactionSummary({
+					summary,
+					i18n: $i18n,
+					symbolOf,
+					amountOf: figureOf
+				})
+			: undefined
+	);
+
+	const heroAmount = (change: SolNetBalanceChange): string =>
+		`${figureOf(change)} ${symbolOf(change.tokenAddress)}`;
 
 	// The token the transaction is about, which is not always the token whose page opened the
 	// modal: a USD1 send opened from the SOL page is still a USD1 send, and showing the SOL logo

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -82,12 +82,15 @@
 
 	// The bare figure. The sentence appends the symbol itself, and the hero title pairs it with
 	// one below.
-	const figureOf = (change: SolNetBalanceChange): string =>
-		formatToken({
+	const figureOf = (change: SolNetBalanceChange): string => {
+		const decimals = decimalsOf(change);
+
+		return formatToken({
 			value: absBigInt(change.delta),
-			unitName: decimalsOf(change),
-			displayDecimals: decimalsOf(change)
+			unitName: decimals,
+			displayDecimals: decimals
 		});
+	};
 
 	// The same sentence the rows carry, so a transaction reads identically wherever it is met.
 	// The figure below it is the detail this view exists for. Records without a summary keep the

--- a/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
@@ -183,8 +183,9 @@ export const deriveSolTransactionSummary = ({
  * One transaction summary as the sentence that names it.
  *
  * A swap says its pair, because in a day of swaps that is the only thing telling one row from
- * another. Everything else is a word: the figure belongs to the amount column, and repeating it
- * in the sentence says the same thing twice.
+ * another. Everything else is a word. No figures anywhere but the self-transfer, whose net is zero
+ * by definition: the amount column beside the sentence carries them, and saying them twice reads
+ * as two movements.
  *
  * The symbols and the formatting come from the caller, since what a mint is called depends on the
  * view asking: a list numbers its unnamed mints against the others beside them.
@@ -219,12 +220,12 @@ export const formatSolTransactionSummary = ({
 			: i18n.transaction.text.kind_other;
 	}
 
+	// The pair, without the figures: the amount column beside the sentence already carries them,
+	// and one row of a swap shows one of the two anyway.
 	if (kind === 'swap') {
 		return nonNullish(spent) && nonNullish(received)
 			? replacePlaceholders(i18n.transaction.text.summary_swap, {
-					$spent: amountOf(spent),
 					$spent_symbol: symbolOf(spent.tokenAddress),
-					$received: amountOf(received),
 					$received_symbol: symbolOf(received.tokenAddress)
 				})
 			: i18n.swap.text.swap;

--- a/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
@@ -186,7 +186,8 @@ describe('SolTransactionModal', () => {
 			expect(getByText(shortenWithMiddleEllipsis({ text: mockSolAddress2 }))).toBeInTheDocument();
 		});
 
-		it('should show the pair at the ends of a swap in the hero', () => {
+		// The sentence the rows carry, over the figures this view exists to show.
+		it('should show the same sentence as the rows, over the pair, in the hero', () => {
 			const { getByText } = render(SolTransactionModal, {
 				props: {
 					transaction: {
@@ -201,7 +202,7 @@ describe('SolTransactionModal', () => {
 				}
 			});
 
-			expect(getByText(en.swap.text.swap)).toBeInTheDocument();
+			expect(getByText(`Swap SOL to ${en.transaction.text.unknown_token}`)).toBeInTheDocument();
 			expect(getByText(/1 SOL → 0\.046099/)).toBeInTheDocument();
 		});
 

--- a/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
@@ -150,15 +150,16 @@ describe('sol-transaction-summary.utils', () => {
 			expect(format({ kind: 'receive', received: { delta: 1n } })).toBe(en.receive.text.receive);
 		});
 
-		// In a day of swaps the pair is the only thing telling one row from another.
-		it('should say a swap as its pair', () => {
+		// In a day of swaps the pair is the only thing telling one row from another. The figures
+		// stay out: the amount column beside the sentence carries them.
+		it('should say a swap as its pair, without the figures', () => {
 			expect(
 				format({
 					kind: 'swap',
 					spent: { delta: -5n, tokenAddress: 'USDC' },
 					received: { delta: 7n, tokenAddress: 'RAY' }
 				})
-			).toBe('Swap 5 USDC to 7 RAY');
+			).toBe('Swap USDC to RAY');
 		});
 
 		// The asset never left, so the amount column shows zero and the sentence is the only place


### PR DESCRIPTION
# Motivation

A swap reads three different ways today. The activity row says `Swap 0.123 USDC to 0.046099 RAY`; the details header says `Swap` over an arrow between the same two figures; and because one transaction now produces a row per token it moved, each row repeats its own amount in a column sitting right beside a sentence that already said it.

# Changes

The sentence names the pair and nothing else: `Swap USDC to RAY`. The amount column carries the figures, and one row of a swap shows one side of the pair anyway.

The details header is that same sentence, with the figures below it, which is where a details view should put them. So a transaction reads identically in the activity, in a token view and in its own modal.

A self-transfer keeps its amount. Its net is zero by definition, so the column beside it has nothing to show and the sentence is the only place the figure can appear.

# Tests

The formatter case now expects the pair without figures, and the modal case asserts the header carries the same sentence the rows do, over the pair. `npm run check` and lint clean, 1884 Solana tests pass.