### PR TITLE
feat(frontend): badge both sides of a Solana swap as a swap

### DIFF
--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -41,10 +41,12 @@
 		from?: string;
 		// Overrides the type-derived To/From prefix: a swap's address is a venue, not a recipient.
 		addressPrefixLabel?: string;
-		// Overrides the type-derived badge. A Solana swap is stored as a send or a receive of one
-		// of its two sides, so the type alone would badge half of it with an arrow out and half
-		// with an arrow in.
+		// Overrides the icon the type would choose, which is the badge over a token logo and the
+		// icon itself in the transaction layout. A Solana swap is stored as a send or a receive of
+		// one of its two sides, so the type alone would mark half of it with an arrow out and half
+		// with an arrow in. Pass the label with it: the type no longer describes what is shown.
 		icon?: Component;
+		iconAriaLabel?: string;
 		tokenId?: number | bigint | string;
 		children: Snippet;
 		onClick?: () => void;
@@ -65,6 +67,7 @@
 		from,
 		addressPrefixLabel,
 		icon: iconOverride,
+		iconAriaLabel,
 		tokenId,
 		children,
 		onClick,
@@ -74,6 +77,8 @@
 	}: Props = $props();
 
 	const cardIcon: Component = $derived(iconOverride ?? mapTransactionIcon({ type, status }));
+
+	const cardIconLabel: string = $derived(iconAriaLabel ?? type);
 
 	const iconWithOpacity: boolean = $derived(status === 'pending' || status === 'unconfirmed');
 
@@ -156,13 +161,13 @@
 					{#if iconType === 'token'}
 						{#if nonNullish(nft)}
 							<NftLogo
-								badge={{ type: 'icon', icon: cardIcon, ariaLabel: type }}
+								badge={{ type: 'icon', icon: cardIcon, ariaLabel: cardIconLabel }}
 								logoSize="md"
 								{nft}
 							/>
 						{:else}
 							<TokenLogo
-								badge={{ type: 'icon', icon: cardIcon, ariaLabel: type }}
+								badge={{ type: 'icon', icon: cardIcon, ariaLabel: cardIconLabel }}
 								data={token}
 								logoSize="md"
 							/>

--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -41,6 +41,10 @@
 		from?: string;
 		// Overrides the type-derived To/From prefix: a swap's address is a venue, not a recipient.
 		addressPrefixLabel?: string;
+		// Overrides the type-derived badge. A Solana swap is stored as a send or a receive of one
+		// of its two sides, so the type alone would badge half of it with an arrow out and half
+		// with an arrow in.
+		icon?: Component;
 		tokenId?: number | bigint | string;
 		children: Snippet;
 		onClick?: () => void;
@@ -60,6 +64,7 @@
 		to,
 		from,
 		addressPrefixLabel,
+		icon: iconOverride,
 		tokenId,
 		children,
 		onClick,
@@ -68,7 +73,7 @@
 		testId
 	}: Props = $props();
 
-	const cardIcon: Component = $derived(mapTransactionIcon({ type, status }));
+	const cardIcon: Component = $derived(iconOverride ?? mapTransactionIcon({ type, status }));
 
 	const iconWithOpacity: boolean = $derived(status === 'pending' || status === 'unconfirmed');
 

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { SOLANA_DEFAULT_DECIMALS, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+	import IconConvert from '$lib/components/icons/IconConvert.svelte';
 	import Transaction from '$lib/components/transactions/Transaction.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -104,6 +105,7 @@
 	addressPrefixLabel={summary?.kind === 'swap' ? $i18n.transaction.text.swap_on : undefined}
 	{displayAmount}
 	from={summary?.kind === 'swap' ? undefined : (fromOwner ?? from)}
+	icon={summary?.kind === 'swap' ? IconConvert : undefined}
 	{iconType}
 	onClick={() => modalStore.openSolTransaction({ id: modalId, data: { transaction, token } })}
 	status={transactionStatus}

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -106,6 +106,7 @@
 	{displayAmount}
 	from={summary?.kind === 'swap' ? undefined : (fromOwner ?? from)}
 	icon={summary?.kind === 'swap' ? IconConvert : undefined}
+	iconAriaLabel={summary?.kind === 'swap' ? $i18n.swap.text.swap : undefined}
 	{iconType}
 	onClick={() => modalStore.openSolTransaction({ id: modalId, data: { transaction, token } })}
 	status={transactionStatus}

--- a/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
@@ -3,6 +3,7 @@ import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
 import { formatToken } from '$lib/utils/format.utils';
 import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 import SolTransaction from '$sol/components/transactions/SolTransaction.svelte';
+import en from '$tests/mocks/i18n.mock';
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
@@ -61,6 +62,35 @@ describe('SolTransaction', () => {
 
 		expect(sent).not.toBe('');
 		expect(badgeOf('receive')).toBe(sent);
+	});
+
+	// The glyph no longer matches the stored type, so a screen reader announcing that type would
+	// call one half of the swap a send and the other a receive.
+	it('should announce both sides of a swap as a swap', () => {
+		const swap = {
+			...mockTrx,
+			summary: {
+				kind: 'swap' as const,
+				spent: { delta: -100n, tokenAddress: 'USDC', decimals: 6 },
+				received: { delta: 7n, tokenAddress: 'RAY', decimals: 6 }
+			}
+		};
+
+		const labelOf = (type: 'send' | 'receive'): string | null => {
+			const { container } = render(SolTransaction, {
+				props: { transaction: { ...swap, type }, token: SOLANA_TOKEN, iconType: 'token' }
+			});
+
+			return (
+				container
+					.querySelector('[data-tid="icon-badge"]')
+					?.closest('[aria-label]')
+					?.getAttribute('aria-label') ?? null
+			);
+		};
+
+		expect(labelOf('send')).toBe(en.swap.text.swap);
+		expect(labelOf('receive')).toBe(en.swap.text.swap);
 	});
 
 	it('should render correct amount for receive transactions', () => {

--- a/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
@@ -32,6 +32,37 @@ describe('SolTransaction', () => {
 		);
 	});
 
+	// One transaction produces a row per token it moved, and it is stored as a send or a receive
+	// of one of the two sides. Badged by that alone, one half of a swap points out and the other
+	// points in, which reads as two unrelated transfers.
+	it('should badge both sides of a swap the same way', () => {
+		const swap = {
+			...mockTrx,
+			summary: {
+				kind: 'swap' as const,
+				spent: { delta: -100n, tokenAddress: 'USDC', decimals: 6 },
+				received: { delta: 7n, tokenAddress: 'RAY', decimals: 6 }
+			}
+		};
+
+		const badgeOf = (type: 'send' | 'receive'): string => {
+			const { container } = render(SolTransaction, {
+				props: { transaction: { ...swap, type }, token: SOLANA_TOKEN, iconType: 'token' }
+			});
+
+			const badge = container.querySelector('[data-tid="icon-badge"]');
+
+			assertNonNullish(badge);
+
+			return badge.innerHTML;
+		};
+
+		const sent = badgeOf('send');
+
+		expect(sent).not.toBe('');
+		expect(badgeOf('receive')).toBe(sent);
+	});
+
 	it('should render correct amount for receive transactions', () => {
 		const { container } = render(SolTransaction, {
 			props: {


### PR DESCRIPTION
# Motivation

One Solana transaction now produces a row per token it moved, and it is stored as a send or a receive of one of those two sides. The badge on the token logo was derived from that stored type alone, so the two rows of a single swap carried opposite arrows: one pointing out, one pointing in. Side by side they read as two unrelated transfers rather than the two halves of one trade.

# Changes

Both sides carry the convert glyph the wallet already uses for a conversion.

The override is a prop on the row rather than a change to the shared icon mapper: the mapper only knows the stored type, and it is the summary that knows the transaction was a swap. Every other chain is untouched.

# Tests

A case renders the same swap as a send and as a receive and asserts the badge is identical and not empty. It fails without the change.