### PR TITLE
feat(frontend): name the Solana programs a transaction ran through

### DIFF
--- a/src/frontend/src/env/programs/programs.sol.env.ts
+++ b/src/frontend/src/env/programs/programs.sol.env.ts
@@ -1,0 +1,29 @@
+import type { ProgramUi } from '$lib/types/program';
+import jup from '$sol/assets/jup.svg';
+import orca from '$sol/assets/orca.svg';
+import ray from '$sol/assets/ray.svg';
+
+/**
+ * The Solana programs OISY can name.
+ *
+ * Small on purpose. A program the list does not carry is shown as its address, which is honest;
+ * guessing a name from anything the chain offers would not be, since the only on-chain data a
+ * program account holds is its code.
+ */
+export const SOLANA_PROGRAMS: ProgramUi[] = [
+	{
+		address: 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc',
+		name: 'Orca Whirlpools',
+		icon: orca
+	},
+	{
+		address: 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4',
+		name: 'Jupiter',
+		icon: jup
+	},
+	{
+		address: 'routeUGWgWzqBWFcrCfv8tritsqukccJPu3q5GPP3xS',
+		name: 'Raydium Router',
+		icon: ray
+	}
+];

--- a/src/frontend/src/lib/components/contact/ContactOrToken.svelte
+++ b/src/frontend/src/lib/components/contact/ContactOrToken.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import ContactWithAvatar from '$lib/components/contact/ContactWithAvatar.svelte';
+	import ProgramAsContact from '$lib/components/contact/ProgramAsContact.svelte';
 	import TokenAsContact from '$lib/components/tokens/TokenAsContact.svelte';
 	import { allTokens } from '$lib/derived/all-tokens.derived';
 	import { allContacts } from '$lib/derived/contacts.derived';
+	import { allPrograms } from '$lib/derived/programs.derived';
 	import { filterAddressFromContact, getContactForAddress } from '$lib/utils/contact.utils';
 	import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import { findPutativeToken } from '$lib/utils/tokens.utils';
@@ -17,6 +19,12 @@
 
 	let putativeToken = $derived(findPutativeToken({ tokens: $allTokens, identifier }));
 
+	// A program is never a contact and never a token: it is the thing a transaction ran through,
+	// and the curated list is the only place its name lives.
+	let program = $derived(
+		nonNullish(identifier) ? $allPrograms.find(({ address }) => address === identifier) : undefined
+	);
+
 	let contact = $derived(
 		nonNullish(identifier)
 			? getContactForAddress({ addressString: identifier, contactList: $allContacts })
@@ -28,6 +36,8 @@
 
 {#if nonNullish(putativeToken)}
 	<TokenAsContact token={putativeToken} />
+{:else if nonNullish(program)}
+	<ProgramAsContact {program} />
 {:else if nonNullish(contact)}
 	<ContactWithAvatar {contact} {contactAddress} />
 {:else if showFallback && nonNullish(identifier)}

--- a/src/frontend/src/lib/components/contact/ProgramAsContact.svelte
+++ b/src/frontend/src/lib/components/contact/ProgramAsContact.svelte
@@ -16,7 +16,9 @@
 		<Logo alt={program.name} size="xxs" src={program.icon} />
 	</span>
 
-	<span class="inline-block max-w-38 truncate">
-		{program.name}
+	<span class="flex min-w-0 flex-wrap items-center">
+		<span class="inline-block max-w-38 truncate">
+			{program.name}
+		</span>
 	</span>
 </span>

--- a/src/frontend/src/lib/components/contact/ProgramAsContact.svelte
+++ b/src/frontend/src/lib/components/contact/ProgramAsContact.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { slide } from 'svelte/transition';
+	import Logo from '$lib/components/ui/Logo.svelte';
+	import { SLIDE_PARAMS } from '$lib/constants/transition.constants';
+	import type { ProgramUi } from '$lib/types/program';
+
+	interface Props {
+		program: ProgramUi;
+	}
+
+	const { program }: Props = $props();
+</script>
+
+<span class="inline-flex min-w-0 items-center gap-1" in:slide={SLIDE_PARAMS}>
+	<span class="shrink-0">
+		<Logo alt={program.name} size="xxs" src={program.icon} />
+	</span>
+
+	<span class="inline-block max-w-38 truncate">
+		{program.name}
+	</span>
+</span>

--- a/src/frontend/src/lib/derived/programs.derived.ts
+++ b/src/frontend/src/lib/derived/programs.derived.ts
@@ -1,0 +1,11 @@
+import { SOLANA_PROGRAMS } from '$env/programs/programs.sol.env';
+import type { ProgramUi } from '$lib/types/program';
+import { readable, type Readable } from 'svelte/store';
+
+/**
+ * Every program OISY can name, across the chains that have any.
+ *
+ * A store rather than the array itself, so the day a chain resolves its programs at runtime the
+ * consumers do not change.
+ */
+export const allPrograms: Readable<ProgramUi[]> = readable(SOLANA_PROGRAMS);

--- a/src/frontend/src/lib/types/program.ts
+++ b/src/frontend/src/lib/types/program.ts
@@ -1,0 +1,12 @@
+/**
+ * A program a transaction ran through, named for the user.
+ *
+ * A Solana program carries no name on chain: the account holds executable code and nothing that
+ * says whose it is. So a name and an icon can only come from a list we curate, keyed by the one
+ * thing the transaction does state, which is the address.
+ */
+export interface ProgramUi {
+	address: string;
+	name: string;
+	icon: string;
+}

--- a/src/frontend/src/tests/lib/components/contact/ContactOrToken.spec.ts
+++ b/src/frontend/src/tests/lib/components/contact/ContactOrToken.spec.ts
@@ -1,134 +1,31 @@
+import { SOLANA_PROGRAMS } from '$env/programs/programs.sol.env';
 import ContactOrToken from '$lib/components/contact/ContactOrToken.svelte';
-import * as allTokensDerived from '$lib/derived/all-tokens.derived';
-import * as contactsDerived from '$lib/derived/contacts.derived';
-import type { ContactUi } from '$lib/types/contact';
-import type { Token } from '$lib/types/token';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
-import { getMockContactsUi, mockContactEthAddressUi } from '$tests/mocks/contacts.mock';
-import { mockLedgerCanisterId, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
-const mockAllTokens = (tokens: Token[]) => {
-	vi.spyOn(allTokensDerived.allTokens, 'subscribe').mockImplementation((fn) => {
-		fn(tokens.map((t) => ({ ...t, enabled: true })));
-		return () => {};
-	});
-};
-
-const mockAllContacts = (contacts: ContactUi[]) => {
-	vi.spyOn(contactsDerived.allContacts, 'subscribe').mockImplementation((fn) => {
-		fn(contacts);
-		return () => {};
-	});
-};
-
 describe('ContactOrToken', () => {
-	const ethAddress = mockContactEthAddressUi.address;
+	const [program] = SOLANA_PROGRAMS;
 
-	const [mockContact] = getMockContactsUi({
-		n: 1,
-		name: 'Alice',
-		addresses: [{ address: ethAddress, addressType: 'Eth', label: 'Main wallet' }]
-	});
-
-	beforeEach(() => {
-		vi.restoreAllMocks();
-
-		mockAllTokens([]);
-
-		mockAllContacts([]);
-	});
-
-	it('should render nothing when identifier is undefined', () => {
-		const { container } = render(ContactOrToken, {
-			props: { identifier: undefined }
-		});
-
-		expect(container.textContent?.trim()).toBe('');
-	});
-
-	it('should render nothing when identifier does not match any token or contact and showFallback is false', () => {
-		const { container } = render(ContactOrToken, {
-			props: { identifier: ethAddress }
-		});
-
-		expect(container.textContent?.trim()).toBe('');
-	});
-
-	it('should render TokenAsContact when identifier matches a token', () => {
-		mockAllTokens([mockValidIcToken]);
-
-		const { getByText } = render(ContactOrToken, {
-			props: { identifier: mockLedgerCanisterId }
-		});
-
-		expect(getByText(mockValidIcToken.name)).toBeInTheDocument();
-		expect(getByText(mockValidIcToken.symbol)).toBeInTheDocument();
-	});
-
-	it('should render ContactWithAvatar when identifier matches a contact', () => {
-		mockAllContacts([mockContact]);
-
-		const { getByText } = render(ContactOrToken, {
-			props: { identifier: ethAddress }
-		});
-
-		expect(getByText('Alice')).toBeInTheDocument();
-	});
-
-	it('should render contact address label when present', () => {
-		mockAllContacts([mockContact]);
-
-		const { getByText } = render(ContactOrToken, {
-			props: { identifier: ethAddress }
-		});
-
-		expect(getByText('Main wallet')).toBeInTheDocument();
-	});
-
-	it('should render shortened identifier as fallback when showFallback is true', () => {
-		const longIdentifier = '0x1234567890abcdef1234567890abcdef12345678';
-
-		const { getByText } = render(ContactOrToken, {
-			props: { identifier: longIdentifier, showFallback: true }
-		});
-
-		expect(getByText(shortenWithMiddleEllipsis({ text: longIdentifier }))).toBeInTheDocument();
-	});
-
-	it('should not render fallback when showFallback is false', () => {
-		const longIdentifier = '0x1234567890abcdef1234567890abcdef12345678';
-
-		const { container } = render(ContactOrToken, {
-			props: { identifier: longIdentifier, showFallback: false }
-		});
-
-		expect(container.textContent?.trim()).toBe('');
-	});
-
-	it('should prioritise token over contact when both match', () => {
-		mockAllTokens([mockValidIcToken]);
-		mockAllContacts([
-			getMockContactsUi({
-				n: 1,
-				name: 'Token Contact',
-				addresses: [{ address: mockLedgerCanisterId, addressType: 'Icrcv2' }]
-			})[0]
-		]);
-
+	// A Solana program holds only executable code on chain, so the curated list is the one place
+	// its name lives. Without it a swap says which pool it ran through in base58.
+	it('should name a program from the curated list', () => {
 		const { getByText, queryByText } = render(ContactOrToken, {
-			props: { identifier: mockLedgerCanisterId }
+			props: { identifier: program.address, showFallback: true }
 		});
 
-		expect(getByText(mockValidIcToken.name)).toBeInTheDocument();
-		expect(queryByText('Token Contact')).not.toBeInTheDocument();
+		expect(getByText(program.name)).toBeInTheDocument();
+		expect(
+			queryByText(shortenWithMiddleEllipsis({ text: program.address }))
+		).not.toBeInTheDocument();
 	});
 
-	it('should not render fallback when identifier is undefined even with showFallback true', () => {
-		const { container } = render(ContactOrToken, {
-			props: { identifier: undefined, showFallback: true }
+	it('should fall back to the address for a program it cannot name', () => {
+		const unknown = 'HFqU5x6ZWQXvHqPvzWPXFRuVXsyfMPYbhVdiJPB2bU7gRe';
+
+		const { getByText } = render(ContactOrToken, {
+			props: { identifier: unknown, showFallback: true }
 		});
 
-		expect(container.textContent?.trim()).toBe('');
+		expect(getByText(shortenWithMiddleEllipsis({ text: unknown }))).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/contact/ContactOrToken.spec.ts
+++ b/src/frontend/src/tests/lib/components/contact/ContactOrToken.spec.ts
@@ -1,31 +1,163 @@
 import { SOLANA_PROGRAMS } from '$env/programs/programs.sol.env';
 import ContactOrToken from '$lib/components/contact/ContactOrToken.svelte';
+import * as allTokensDerived from '$lib/derived/all-tokens.derived';
+import * as contactsDerived from '$lib/derived/contacts.derived';
+import type { ContactUi } from '$lib/types/contact';
+import type { Token } from '$lib/types/token';
 import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
+import { getMockContactsUi, mockContactEthAddressUi } from '$tests/mocks/contacts.mock';
+import { mockLedgerCanisterId, mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { render } from '@testing-library/svelte';
 
+const mockAllTokens = (tokens: Token[]) => {
+	vi.spyOn(allTokensDerived.allTokens, 'subscribe').mockImplementation((fn) => {
+		fn(tokens.map((t) => ({ ...t, enabled: true })));
+		return () => {};
+	});
+};
+
+const mockAllContacts = (contacts: ContactUi[]) => {
+	vi.spyOn(contactsDerived.allContacts, 'subscribe').mockImplementation((fn) => {
+		fn(contacts);
+		return () => {};
+	});
+};
+
 describe('ContactOrToken', () => {
-	const [program] = SOLANA_PROGRAMS;
+	const ethAddress = mockContactEthAddressUi.address;
 
-	// A Solana program holds only executable code on chain, so the curated list is the one place
-	// its name lives. Without it a swap says which pool it ran through in base58.
-	it('should name a program from the curated list', () => {
-		const { getByText, queryByText } = render(ContactOrToken, {
-			props: { identifier: program.address, showFallback: true }
-		});
-
-		expect(getByText(program.name)).toBeInTheDocument();
-		expect(
-			queryByText(shortenWithMiddleEllipsis({ text: program.address }))
-		).not.toBeInTheDocument();
+	const [mockContact] = getMockContactsUi({
+		n: 1,
+		name: 'Alice',
+		addresses: [{ address: ethAddress, addressType: 'Eth', label: 'Main wallet' }]
 	});
 
-	it('should fall back to the address for a program it cannot name', () => {
-		const unknown = 'HFqU5x6ZWQXvHqPvzWPXFRuVXsyfMPYbhVdiJPB2bU7gRe';
+	beforeEach(() => {
+		vi.restoreAllMocks();
 
-		const { getByText } = render(ContactOrToken, {
-			props: { identifier: unknown, showFallback: true }
+		mockAllTokens([]);
+
+		mockAllContacts([]);
+	});
+
+	it('should render nothing when identifier is undefined', () => {
+		const { container } = render(ContactOrToken, {
+			props: { identifier: undefined }
 		});
 
-		expect(getByText(shortenWithMiddleEllipsis({ text: unknown }))).toBeInTheDocument();
+		expect(container.textContent?.trim()).toBe('');
+	});
+
+	it('should render nothing when identifier does not match any token or contact and showFallback is false', () => {
+		const { container } = render(ContactOrToken, {
+			props: { identifier: ethAddress }
+		});
+
+		expect(container.textContent?.trim()).toBe('');
+	});
+
+	it('should render TokenAsContact when identifier matches a token', () => {
+		mockAllTokens([mockValidIcToken]);
+
+		const { getByText } = render(ContactOrToken, {
+			props: { identifier: mockLedgerCanisterId }
+		});
+
+		expect(getByText(mockValidIcToken.name)).toBeInTheDocument();
+		expect(getByText(mockValidIcToken.symbol)).toBeInTheDocument();
+	});
+
+	it('should render ContactWithAvatar when identifier matches a contact', () => {
+		mockAllContacts([mockContact]);
+
+		const { getByText } = render(ContactOrToken, {
+			props: { identifier: ethAddress }
+		});
+
+		expect(getByText('Alice')).toBeInTheDocument();
+	});
+
+	it('should render contact address label when present', () => {
+		mockAllContacts([mockContact]);
+
+		const { getByText } = render(ContactOrToken, {
+			props: { identifier: ethAddress }
+		});
+
+		expect(getByText('Main wallet')).toBeInTheDocument();
+	});
+
+	it('should render shortened identifier as fallback when showFallback is true', () => {
+		const longIdentifier = '0x1234567890abcdef1234567890abcdef12345678';
+
+		const { getByText } = render(ContactOrToken, {
+			props: { identifier: longIdentifier, showFallback: true }
+		});
+
+		expect(getByText(shortenWithMiddleEllipsis({ text: longIdentifier }))).toBeInTheDocument();
+	});
+
+	it('should not render fallback when showFallback is false', () => {
+		const longIdentifier = '0x1234567890abcdef1234567890abcdef12345678';
+
+		const { container } = render(ContactOrToken, {
+			props: { identifier: longIdentifier, showFallback: false }
+		});
+
+		expect(container.textContent?.trim()).toBe('');
+	});
+
+	it('should prioritise token over contact when both match', () => {
+		mockAllTokens([mockValidIcToken]);
+		mockAllContacts([
+			getMockContactsUi({
+				n: 1,
+				name: 'Token Contact',
+				addresses: [{ address: mockLedgerCanisterId, addressType: 'Icrcv2' }]
+			})[0]
+		]);
+
+		const { getByText, queryByText } = render(ContactOrToken, {
+			props: { identifier: mockLedgerCanisterId }
+		});
+
+		expect(getByText(mockValidIcToken.name)).toBeInTheDocument();
+		expect(queryByText('Token Contact')).not.toBeInTheDocument();
+	});
+
+	describe('a program', () => {
+		const [program] = SOLANA_PROGRAMS;
+
+		// A Solana program account holds executable code and nothing that says whose it is, so the
+		// curated list is the one place its name lives. Without it a swap says which pool it ran
+		// through in base58.
+		it('should render the name and not the address', () => {
+			const { getByText, queryByText } = render(ContactOrToken, {
+				props: { identifier: program.address, showFallback: true }
+			});
+
+			expect(getByText(program.name)).toBeInTheDocument();
+			expect(
+				queryByText(shortenWithMiddleEllipsis({ text: program.address }))
+			).not.toBeInTheDocument();
+		});
+
+		it('should fall back to the address for a program it cannot name', () => {
+			const unknown = 'HFqU5x6ZWQXvHqPvzWPXFRuVXsyfMPYbhVdiJPB2bU7gRe';
+
+			const { getByText } = render(ContactOrToken, {
+				props: { identifier: unknown, showFallback: true }
+			});
+
+			expect(getByText(shortenWithMiddleEllipsis({ text: unknown }))).toBeInTheDocument();
+		});
+	});
+
+	it('should not render fallback when identifier is undefined even with showFallback true', () => {
+		const { container } = render(ContactOrToken, {
+			props: { identifier: undefined, showFallback: true }
+		});
+
+		expect(container.textContent?.trim()).toBe('');
 	});
 });


### PR DESCRIPTION
# Motivation

A swap in the activity says it ran `On whirLbM...3uctyCc`, which tells the user nothing about where their money went. A Solana program account holds executable code and nothing that says whose it is, so unlike a Token-2022 mint there is nothing on chain to read. A name can only come from a list we curate against the one thing the transaction does state, which is the address.

# Changes

A curated list of programs, each with a name and an icon, resolved by address wherever an address is displayed. This is the mechanism the SPL tokens already use, so the icons come from the same assets.

Three entries to start: Orca Whirlpools, Jupiter and Raydium Router, all seen in real wallet history. The list is short on purpose. An address it does not carry is still shown as an address, which is honest, rather than guessed at.

# Tests

A curated address renders its name and not its base58; an address the list does not carry still renders shortened. `npm run check`, `check:tests` and lint clean, 1930 tests pass.