### PR TITLE
feat(frontend): show what a Solana transaction cost only on the SOL page

### DIFF
--- a/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
+++ b/src/frontend/src/lib/components/transactions/TransactionsDateGroup.svelte
@@ -12,10 +12,13 @@
 	interface Props {
 		formattedDate: string;
 		transactions: AllTransactionUiWithCmpNonEmptyList;
+		// Whether the list this group belongs to is filtered to a single token. What a transaction
+		// did to that one token is then the subject, rather than what it did overall.
+		singleToken?: boolean;
 		testId?: string;
 	}
 
-	let { formattedDate, transactions, testId }: Props = $props();
+	let { formattedDate, transactions, singleToken = false, testId }: Props = $props();
 
 	let capitalizedFormattedDate = $derived(capitalizeFirstLetter(formattedDate));
 </script>
@@ -36,7 +39,7 @@
 					{:else if component === 'ethereum'}
 						<EthTransaction iconType="token" {token} {transaction} />
 					{:else if component === 'solana'}
-						<SolTransaction iconType="token" {token} {transaction} />
+						<SolTransaction iconType="token" {singleToken} {token} {transaction} />
 					{:else}
 						<IcTransaction iconType="token" {token} {transaction} />
 					{/if}

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -20,9 +20,12 @@
 		transaction: SolTransactionUi;
 		token: Token;
 		iconType?: 'token' | 'transaction';
+		// Whether this row sits in a list filtered to one token. The activity shows what a
+		// transaction moved; a token's own page shows what it did to that token, cost included.
+		singleToken?: boolean;
 	}
 
-	let { transaction, token, iconType = 'transaction' }: Props = $props();
+	let { transaction, token, iconType = 'transaction', singleToken = false }: Props = $props();
 
 	let { type, value, timestamp, status, to, from, toOwner, fromOwner, summary, netChanges, fee } =
 		$derived(transaction);
@@ -77,20 +80,23 @@
 		nonNullish(value) ? (type === 'send' ? value * -1n : value) : undefined
 	);
 
-	// Every row shows the net of the token it is about. A swap keeps a row per side, so each shows
-	// its own half; a self-transfer nets to zero, which is exactly what it did to that token.
+	// What the transaction moved in this row's token, with the cost left out. A swap keeps a row
+	// per side, so each shows its own half; a self-transfer nets to zero, which is exactly what it
+	// did to that token. The net already excludes the fee.
+	let movedAmount = $derived(
+		nonNullish(tokenNetChange) ? tokenNetChange.delta : isNullish(summary) ? fallbackAmount : ZERO
+	);
+
+	// A token's own page is where the cost of using it belongs. For SOL that is the fee on top of
+	// whatever the transaction moved, and for a transaction that moved no SOL at all it is the
+	// whole story: the wallet paid to send something else.
 	//
-	// SOL is the exception: its net leaves the fee out, because the modal states the cost apart
-	// from what moved. A row has no such second line, so here it is the whole change to the
-	// wallet, transfers and rent and fee together, which is what the balance actually did.
+	// The activity never shows it. A swap into SOL whose fee outweighed what it bought would read
+	// there as a loss, on the row that says what was bought.
 	let displayAmount = $derived(
-		nonNullish(tokenNetChange)
-			? isSolNetBalanceChangeSol(tokenNetChange)
-				? tokenNetChange.delta - (fee ?? ZERO)
-				: tokenNetChange.delta
-			: isNullish(summary)
-				? fallbackAmount
-				: ZERO
+		singleToken && !isTokenSpl(token)
+			? (tokenNetChange?.delta ?? ZERO) - (fee ?? ZERO)
+			: movedAmount
 	);
 
 	let pending = $derived(status === 'processed' || isNullish(status));

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -94,9 +94,7 @@
 	// The activity never shows it. A swap into SOL whose fee outweighed what it bought would read
 	// there as a loss, on the row that says what was bought.
 	let displayAmount = $derived(
-		singleToken && !isTokenSpl(token)
-			? (tokenNetChange?.delta ?? ZERO) - (fee ?? ZERO)
-			: movedAmount
+		singleToken && !isTokenSpl(token) ? movedAmount - (fee ?? ZERO) : movedAmount
 	);
 
 	let pending = $derived(status === 'processed' || isNullish(status));

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -94,7 +94,9 @@
 	// The activity never shows it. A swap into SOL whose fee outweighed what it bought would read
 	// there as a loss, on the row that says what was bought.
 	let displayAmount = $derived(
-		singleToken && !isTokenSpl(token) ? movedAmount - (fee ?? ZERO) : movedAmount
+		singleToken && !isTokenSpl(token) && nonNullish(movedAmount)
+			? movedAmount - (fee ?? ZERO)
+			: movedAmount
 	);
 
 	let pending = $derived(status === 'processed' || isNullish(status));

--- a/src/frontend/src/sol/components/transactions/SolTransactions.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactions.svelte
@@ -66,6 +66,7 @@
 				{#each Object.entries(groupedTransactions) as [formattedDate, transactions], index (formattedDate)}
 					<TransactionsDateGroup
 						{formattedDate}
+						singleToken
 						testId={`${TRANSACTIONS_DATE_GROUP_PREFIX}-sol-${index}`}
 						{transactions}
 					/>

--- a/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
@@ -68,6 +68,55 @@ describe('SolTransaction', () => {
 		it('should fold the fee in on the SOL page', () => {
 			expect(amountOf(true)).toContain('-0.00064793');
 		});
+
+		// The case the whole rule exists for: sending an SPL token moves no SOL, but it still
+		// costs some, and the SOL page is the only place that shows it.
+		it('should show the fee alone for a transaction that moved no SOL', () => {
+			const splSend = {
+				...mockTrx,
+				type: 'send' as const,
+				fee: 5_000n,
+				summary: {
+					kind: 'send' as const,
+					spent: { delta: -1_000_000n, tokenAddress: 'USDC', decimals: 6 }
+				},
+				netChanges: [{ delta: -1_000_000n, tokenAddress: 'USDC', decimals: 6 }]
+			};
+
+			const { container } = render(SolTransaction, {
+				props: { transaction: splSend, token: SOLANA_TOKEN, singleToken: true }
+			});
+
+			const amount = container.querySelector('div.leading-5>span.justify-end');
+
+			assertNonNullish(amount);
+
+			expect(amount.textContent).toContain('-0.000005');
+		});
+
+		// A record cached before the redesign carries no summary and no net changes, only its own
+		// signed value. Reading the SOL page off the net alone would report the fee as the whole
+		// transaction.
+		it('should keep a legacy amount on the SOL page, less the fee', () => {
+			const legacy = {
+				...mockTrx,
+				type: 'send' as const,
+				fee: 5_000n,
+				value: 1_000_000n,
+				summary: undefined,
+				netChanges: undefined
+			};
+
+			const { container } = render(SolTransaction, {
+				props: { transaction: legacy, token: SOLANA_TOKEN, singleToken: true }
+			});
+
+			const amount = container.querySelector('div.leading-5>span.justify-end');
+
+			assertNonNullish(amount);
+
+			expect(amount.textContent).toContain('-0.001005');
+		});
 	});
 
 	it('should render correct amount for receive transactions', () => {

--- a/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
@@ -32,6 +32,44 @@ describe('SolTransaction', () => {
 		);
 	});
 
+	describe('where the cost of a transaction shows', () => {
+		const swapIntoSol = {
+			...mockTrx,
+			type: 'receive' as const,
+			fee: 1_270_000n,
+			summary: {
+				kind: 'swap' as const,
+				spent: { delta: -123_000n, tokenAddress: 'USDC', decimals: 6 },
+				received: { delta: 622_070n }
+			},
+			netChanges: [{ delta: 622_070n }, { delta: -123_000n, tokenAddress: 'USDC', decimals: 6 }]
+		};
+
+		const amountOf = (singleToken: boolean): string => {
+			const { container } = render(SolTransaction, {
+				props: { transaction: swapIntoSol, token: SOLANA_TOKEN, singleToken }
+			});
+
+			const amount = container.querySelector('div.leading-5>span.justify-end');
+
+			assertNonNullish(amount);
+
+			return amount.textContent ?? '';
+		};
+
+		// The fee here outweighs what the swap bought. Folded into the activity row it reads as a
+		// loss, on the row whose sentence says SOL was received.
+		it('should show what the swap moved, not the cost, in the activity', () => {
+			expect(amountOf(false)).toContain('0.00062207');
+			expect(amountOf(false)).not.toContain('-');
+		});
+
+		// The SOL page is where what the wallet spends on transactions becomes visible.
+		it('should fold the fee in on the SOL page', () => {
+			expect(amountOf(true)).toContain('-0.00064793');
+		});
+	});
+
 	it('should render correct amount for receive transactions', () => {
 		const { container } = render(SolTransaction, {
 			props: {


### PR DESCRIPTION
# Motivation

Every SOL amount in the activity had the fee folded into it. Two things went wrong.

A swap into SOL whose fee outweighed what it bought read as a loss: `Swap USDC to SOL` beside `-0.00065107 SOL`, on the row whose own sentence says SOL was received. And a transaction that touched SOL only to pay for itself, such as sending an SPL token, read as `0 SOL`, because the fee is only subtracted where a SOL movement already exists.

# Changes

The activity shows what a transaction moved, never what it cost.

A token's own page is where the cost of using that token belongs, so on the SOL page the fee is folded back in. For a transaction that moved no SOL at all, the fee is then the whole story, which is exactly right: the wallet paid to send something else.

The two views are distinguished by a flag on the list, since a list filtered to one token is asking a different question than the activity.

# Tests

The same swap into SOL renders in both views: the activity shows what it bought and no minus sign, the SOL page shows the negative net with the fee folded in. The activity case fails if the fee is folded in regardless of view.