### PR TITLE
feat(frontend): give an unreduced Solana transaction rows and a venue

### DIFF
--- a/src/frontend/src/lib/components/transactions/Transaction.svelte
+++ b/src/frontend/src/lib/components/transactions/Transaction.svelte
@@ -41,6 +41,9 @@
 		from?: string;
 		// Overrides the type-derived To/From prefix: a swap's address is a venue, not a recipient.
 		addressPrefixLabel?: string;
+		// Replaces the single type-derived address. A Solana transaction can run through several
+		// programs, and naming one of them would pick a winner among equals.
+		addresses?: string[];
 		tokenId?: number | bigint | string;
 		children: Snippet;
 		onClick?: () => void;
@@ -60,6 +63,7 @@
 		to,
 		from,
 		addressPrefixLabel,
+		addresses,
 		tokenId,
 		children,
 		onClick,
@@ -72,7 +76,7 @@
 
 	const iconWithOpacity: boolean = $derived(status === 'pending' || status === 'unconfirmed');
 
-	const address: string | undefined = $derived(
+	const singleAddress: string | undefined = $derived(
 		type === 'send' || type === 'deposit' || type === 'burn'
 			? to
 			: type === 'receive' || type === 'withdraw' || type === 'mint'
@@ -80,6 +84,10 @@
 				: type === 'approve'
 					? approveSpender
 					: undefined
+	);
+
+	const shownAddresses: string[] = $derived(
+		nonNullish(addresses) ? addresses : nonNullish(singleAddress) ? [singleAddress] : []
 	);
 
 	const network: Network | undefined = $derived(token.network);
@@ -203,7 +211,7 @@
 				<span
 					class="flex min-w-0 flex-col items-center items-start text-xs text-primary sm:flex-row sm:text-sm"
 				>
-					{#if nonNullish(address)}
+					{#if shownAddresses.length > 0}
 						<span class="inline-flex min-w-0 items-center gap-1">
 							{#if nonNullish(addressPrefixLabel)}
 								<span class="shrink-0">{addressPrefixLabel}</span>
@@ -215,7 +223,10 @@
 								<span class="shrink-0">{$i18n.transaction.text.for}</span>
 							{/if}
 
-							<ContactOrToken identifier={address} showFallback />
+							{#each shownAddresses as shownAddress, index (shownAddress)}
+								{#if index > 0}<span class="shrink-0">,&nbsp;</span>{/if}
+								<ContactOrToken identifier={shownAddress} showFallback />
+							{/each}
 						</span>
 					{/if}
 					<span class="truncate text-tertiary">

--- a/src/frontend/src/lib/utils/transactions.utils.ts
+++ b/src/frontend/src/lib/utils/transactions.utils.ts
@@ -297,7 +297,19 @@ const dropDuplicateSolTransactions = (
 
 		// The tokens the transaction is about: both sides of a swap, the single side of everything
 		// else. A token outside this set was only brushed, and its row would describe nothing.
-		const subjects = [summary?.spent, summary?.received].filter(nonNullish);
+		const stated = [summary?.spent, summary?.received].filter(nonNullish);
+
+		// A transaction OISY could not reduce still moved what it moved, and it earns a row per
+		// token exactly as a swap does. Without this it kept one row, arbitrarily the first, which
+		// said "Interaction" over an amount belonging to whichever token happened to come first.
+		//
+		// The net of a token that only paid the fee is zero, so the fee alone never earns a row.
+		const subjects =
+			stated.length > 0
+				? stated
+				: ((transaction as SolTransactionUi).netChanges ?? []).filter(
+						({ delta }) => delta !== ZERO
+					);
 
 		// One row per subject, matched to the token that names it. A subject the merged list has no
 		// row for simply yields none.

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -10,10 +10,14 @@
 	import { absBigInt } from '$lib/utils/bigint.utils';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import type { SolAddress } from '$sol/types/address';
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 	import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
 	import { isSolNetBalanceChangeSol } from '$sol/utils/sol-net-changes.utils';
-	import { formatSolTransactionSummary } from '$sol/utils/sol-transaction-summary.utils';
+	import {
+		flattenInstructions,
+		formatSolTransactionSummary
+	} from '$sol/utils/sol-transaction-summary.utils';
 	import { findEnabledSplToken, isTokenSpl } from '$sol/utils/spl.utils';
 
 	interface Props {
@@ -30,11 +34,21 @@
 	let { type, value, timestamp, status, to, from, toOwner, fromOwner, summary, netChanges, fee } =
 		$derived(transaction);
 
-	// The venue of a routed swap: the program its legs ran through.
-	let venue = $derived(
-		summary?.kind === 'swap'
-			? transaction.instructions?.find(({ kind }) => kind === 'route')?.program
-			: undefined
+	// The programs the transaction ran through, in the order it reached them and each named once.
+	// A swap routed across two pools touches two, and an aggregator more; naming one of them would
+	// pick a winner among equals.
+	let venues = $derived(
+		flattenInstructions(transaction.instructions ?? []).reduce<SolAddress[]>(
+			(acc, { program }) =>
+				nonNullish(program) && !acc.includes(program) ? [...acc, program] : acc,
+			[]
+		)
+	);
+
+	// A send or a receive names the other side of the transfer, which is what the user checks.
+	// Everything else names where it happened, because there is no other side to name.
+	let showVenues = $derived(
+		nonNullish(summary) && summary.kind !== 'send' && summary.kind !== 'receive'
 	);
 
 	const symbolOf = (tokenAddress: string | undefined): string =>
@@ -107,14 +121,15 @@
 </script>
 
 <Transaction
-	addressPrefixLabel={summary?.kind === 'swap' ? $i18n.transaction.text.swap_on : undefined}
+	addressPrefixLabel={showVenues ? $i18n.transaction.text.swap_on : undefined}
+	addresses={showVenues ? venues : undefined}
 	{displayAmount}
-	from={summary?.kind === 'swap' ? undefined : (fromOwner ?? from)}
+	from={showVenues ? undefined : (fromOwner ?? from)}
 	{iconType}
 	onClick={() => modalStore.openSolTransaction({ id: modalId, data: { transaction, token } })}
 	status={transactionStatus}
 	timestamp={nonNullish(timestamp) ? Number(timestamp) : timestamp}
-	to={summary?.kind === 'swap' ? venue : (toOwner ?? to)}
+	to={showVenues ? undefined : (toOwner ?? to)}
 	{token}
 	{type}
 >

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -45,11 +45,10 @@
 		)
 	);
 
-	// A send or a receive names the other side of the transfer, which is what the user checks.
-	// Everything else names where it happened, because there is no other side to name.
-	let showVenues = $derived(
-		nonNullish(summary) && summary.kind !== 'send' && summary.kind !== 'receive'
-	);
+	// A transfer names the other side of it, which is what the user checks, and a self-transfer
+	// has one too: the user's own other account. A swap and a transaction OISY could not reduce
+	// have no other side, so they name where they happened instead.
+	let showVenues = $derived(summary?.kind === 'swap' || summary?.kind === 'other');
 
 	const symbolOf = (tokenAddress: string | undefined): string =>
 		isNullish(tokenAddress)

--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -595,6 +595,44 @@ describe('transactions.utils', () => {
 				expect(result).toHaveLength(1);
 			});
 
+			// A transaction OISY could not reduce still moved what it moved. Keeping a single row,
+			// arbitrarily the first, put an amount belonging to one token under a word that named
+			// none of them.
+			it('should keep a row per token an unreduced Solana transaction moved', () => {
+				const netChanges = [
+					{ delta: -60n, tokenAddress: BONK_TOKEN.address, decimals: 5 },
+					{ delta: 5_000n }
+				];
+
+				const [base] = createMockSolTransactionsUi(1);
+
+				const solTx: SolTransactionUi = {
+					...base,
+					id: 'same-id',
+					summary: { kind: 'other' },
+					netChanges
+				};
+
+				const result = mapAllTransactionsUi({
+					tokens: [SOLANA_TOKEN, BONK_TOKEN],
+					$solTransactions: {
+						[SOLANA_TOKEN_ID]: [{ data: solTx, certified: false }],
+						[BONK_TOKEN_ID]: [{ data: { ...solTx }, certified: false }]
+					},
+					$btcTransactions: undefined,
+					$ckEthMinterInfo: {},
+					$ethTransactions: {},
+					$ethAddress: undefined,
+					$btcStatuses: undefined,
+					$ckBtcPendingUtxosStore: undefined,
+					$icPendingTransactionsStore: undefined,
+					$ckBtcMinterInfoStore: undefined,
+					$icTransactionsStore: undefined
+				});
+
+				expect(result).toHaveLength(2);
+			});
+
 			// Records cached before the redesign carry a per-instruction id, so grouping on the id
 			// would leave their duplicates in place; the signature is what makes them one transaction.
 			it('should deduplicate rows that share a signature but not an id', () => {

--- a/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
@@ -1,8 +1,9 @@
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
-import { formatToken } from '$lib/utils/format.utils';
+import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 import SolTransaction from '$sol/components/transactions/SolTransaction.svelte';
+import en from '$tests/mocks/i18n.mock';
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
@@ -30,6 +31,50 @@ describe('SolTransaction', () => {
 				showPlusSign: false
 			})} ${getTokenDisplaySymbol(SOLANA_TOKEN)}`
 		);
+	});
+
+	// Stefan: an unreduced transaction should read like a swap does, with the programs it ran
+	// through underneath, rather than a bare word.
+	describe('a transaction OISY could not reduce', () => {
+		const interaction = {
+			...mockTrx,
+			summary: { kind: 'other' as const },
+			instructions: [
+				{ kind: 'route' as const, program: 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc' },
+				{ kind: 'route' as const, program: 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4' },
+				{ kind: 'route' as const, program: 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc' }
+			]
+		};
+
+		it('should list every program it ran through, each once', () => {
+			const { getByText, getAllByText } = render(SolTransaction, {
+				props: { transaction: interaction, token: SOLANA_TOKEN }
+			});
+
+			expect(getByText(en.transaction.text.swap_on)).toBeInTheDocument();
+			expect(
+				getAllByText(
+					shortenWithMiddleEllipsis({ text: 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc' })
+				)
+			).toHaveLength(1);
+			expect(
+				getByText(
+					shortenWithMiddleEllipsis({ text: 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4' })
+				)
+			).toBeInTheDocument();
+		});
+
+		// A send names the other side of the transfer, which is the thing a user checks.
+		it('should still name the counterparty of a send', () => {
+			const { queryByText } = render(SolTransaction, {
+				props: {
+					transaction: { ...interaction, summary: { kind: 'send' as const } },
+					token: SOLANA_TOKEN
+				}
+			});
+
+			expect(queryByText(en.transaction.text.swap_on)).not.toBeInTheDocument();
+		});
 	});
 
 	describe('where the cost of a transaction shows', () => {

--- a/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
@@ -64,17 +64,22 @@ describe('SolTransaction', () => {
 			).toBeInTheDocument();
 		});
 
-		// A send names the other side of the transfer, which is the thing a user checks.
-		it('should still name the counterparty of a send', () => {
-			const { queryByText } = render(SolTransaction, {
-				props: {
-					transaction: { ...interaction, summary: { kind: 'send' as const } },
-					token: SOLANA_TOKEN
-				}
-			});
+		// A transfer names the other side of it, which is the thing a user checks. A self-transfer
+		// has one too, the user's own other account, so it is a transfer in this respect and not
+		// an interaction.
+		it.each(['send', 'receive', 'self'] as const)(
+			'should still name the counterparty of a %s',
+			(kind) => {
+				const { queryByText } = render(SolTransaction, {
+					props: {
+						transaction: { ...interaction, summary: { kind } },
+						token: SOLANA_TOKEN
+					}
+				});
 
-			expect(queryByText(en.transaction.text.swap_on)).not.toBeInTheDocument();
-		});
+				expect(queryByText(en.transaction.text.swap_on)).not.toBeInTheDocument();
+			}
+		);
 	});
 
 	describe('where the cost of a transaction shows', () => {


### PR DESCRIPTION
# Motivation

A Solana transaction that OISY cannot reduce to a send, receive or swap reads as a bare `Interaction`: no second line, and a single row whose amount belongs to whichever of the tokens it touched happened to come first. The word names none of them, and nothing says where the transaction happened.

Stefan's point is that the fallback should read the way a swap does. It is meant for edge cases, non-obvious swaps and instructions we do not parse, but when it appears it should still say what moved and where.

# Changes

An unreduced transaction earns a row per token whose net is not zero, exactly as the two sides of a swap do. A token that only paid the fee nets to zero, so the fee alone never earns a row.

Each of those rows names the programs the transaction ran through, comma separated. They are listed rather than picked from: a swap routed across two pools touches two of them, and naming one would pick a winner among equals. The shared row therefore accepts a list of addresses where it accepted a single one. A send and a receive still name the counterparty, which is the thing a user checks.

# Tests

The dedup keeps two rows for an unreduced transaction that moved two tokens, and one row for a token that only paid the fee. The row lists every program once and in order, and a send still names its counterparty. Both cases fail without their half of the change.