### PR TITLE
feat(frontend): list the programs a Solana message would run through

### DIFF
--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -128,13 +128,13 @@
 
 	// The programs the run went through, in the order it reached them and each named once. The
 	// message names none of them itself: a routed swap performs every call inside another program.
-	let venues = $derived(
-		flattenInstructions(instructions ?? []).reduce<SolAddress[]>(
-			(acc, { program }) =>
-				nonNullish(program) && !acc.includes(program) ? [...acc, program] : acc,
-			[]
+	let venues = $derived([
+		...new Set(
+			flattenInstructions(instructions ?? [])
+				.map(({ program }) => program)
+				.filter(nonNullish)
 		)
-	);
+	]);
 
 	// The mints this line names, so an unnamed one is numbered against the others it stands with.
 	let summaryTokenAddresses = $derived(

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -15,7 +15,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 	import { absBigInt, maxBigInt } from '$lib/utils/bigint.utils';
-	import { formatToken } from '$lib/utils/format.utils';
+	import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import SolInstructionsList from '$sol/components/transactions/SolInstructionsList.svelte';
 	import SolAddressActions from '$sol/components/wallet-connect/SolAddressActions.svelte';
 	import SolWalletConnectSimulationPreview from '$sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte';
@@ -28,13 +28,17 @@
 	} from '$sol/constants/sol.constants';
 	import { enabledSplTokens } from '$sol/derived/spl.derived';
 	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
+	import type { SolAddress } from '$sol/types/address';
 	import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
 	import type { SolSimulationPreview } from '$sol/types/sol-simulation';
 	import type { SolTransferParties } from '$sol/types/sol-transaction';
 	import type { SolTransactionSummary } from '$sol/types/sol-transaction-summary';
 	import { solMessageMatchesSimulation } from '$sol/utils/sol-message-summary.utils';
 	import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
-	import { formatSolTransactionSummary } from '$sol/utils/sol-transaction-summary.utils';
+	import {
+		flattenInstructions,
+		formatSolTransactionSummary
+	} from '$sol/utils/sol-transaction-summary.utils';
 
 	interface Props {
 		amount?: bigint;
@@ -120,6 +124,16 @@
 			solMessageMatchesSimulation({ summary: messageSummary, preview, costs })
 			? messageSummary
 			: undefined
+	);
+
+	// The programs the run went through, in the order it reached them and each named once. The
+	// message names none of them itself: a routed swap performs every call inside another program.
+	let venues = $derived(
+		flattenInstructions(instructions ?? []).reduce<SolAddress[]>(
+			(acc, { program }) =>
+				nonNullish(program) && !acc.includes(program) ? [...acc, program] : acc,
+			[]
+		)
 	);
 
 	// The mints this line names, so an unnamed one is numbered against the others it stands with.
@@ -285,6 +299,23 @@
 
 		{#if nonNullish(preview)}
 			<SolWalletConnectSimulationPreview {feeToken} {preview} />
+		{/if}
+
+		<!-- Where the transaction would run. A program is the closest thing a Solana message has to
+		     a recipient, and it is the one party the user can look up before signing, so each is
+		     listed with the actions to copy it or open it. -->
+		{#if venues.length > 0}
+			<WalletConnectModalValue label={$i18n.transaction.text.swap_on} ref="venues">
+				<div class="flex flex-col gap-1">
+					{#each venues as venue (venue)}
+						<span class="flex items-center gap-1" data-tid="venue">
+							{shortenWithMiddleEllipsis({ text: venue })}
+
+							<SolAddressActions address={venue} network={token.network} />
+						</span>
+					{/each}
+				</div>
+			</WalletConnectModalValue>
 		{/if}
 
 		<!-- One heading, and under it what the transaction actually charges: the base fee every

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -28,7 +28,6 @@
 	} from '$sol/constants/sol.constants';
 	import { enabledSplTokens } from '$sol/derived/spl.derived';
 	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
-	import type { SolAddress } from '$sol/types/address';
 	import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
 	import type { SolSimulationPreview } from '$sol/types/sol-simulation';
 	import type { SolTransferParties } from '$sol/types/sol-transaction';

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -270,6 +270,13 @@ describe('SolWalletConnectSignReview', () => {
 			expect(venues).toHaveLength(2);
 			expect(venues[0]).toHaveTextContent(shortenWithMiddleEllipsis({ text: ORCA }));
 			expect(venues[1]).toHaveTextContent(shortenWithMiddleEllipsis({ text: JUPITER }));
+
+			// An address the user cannot copy or look up is barely worth showing: checking the
+			// program before signing is the whole reason it is here.
+			[ORCA, JUPITER].forEach((program, index) => {
+				expect(venues[index].querySelector('button')).toBeInTheDocument();
+				expect(venues[index].querySelector(`a[href*="${program}"]`)).toBeInTheDocument();
+			});
 		});
 
 		it('should show no group when the run named no program', () => {

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -1,6 +1,7 @@
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { balancesStore } from '$lib/stores/balances.store';
 import { exchangeStore } from '$lib/stores/exchange.store';
+import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import SolWalletConnectSignReview from '$sol/components/wallet-connect/SolWalletConnectSignReview.svelte';
 import en from '$tests/mocks/i18n.mock';
@@ -243,6 +244,38 @@ describe('SolWalletConnectSignReview', () => {
 			});
 
 			expect(queryByTestId('message-summary')).not.toBeInTheDocument();
+		});
+	});
+
+	// A program is the closest thing a Solana message has to a recipient, and the one party the
+	// user can look up before signing.
+	describe('the programs the run goes through', () => {
+		const ORCA = 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc';
+		const JUPITER = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4';
+
+		it('should list each program once, with its actions', () => {
+			const { getAllByTestId } = render(SolWalletConnectSignReview, {
+				props: {
+					...props,
+					instructions: [
+						{ kind: 'route' as const, program: ORCA },
+						{ kind: 'route' as const, program: JUPITER },
+						{ kind: 'route' as const, program: ORCA }
+					]
+				}
+			});
+
+			const venues = getAllByTestId('venue');
+
+			expect(venues).toHaveLength(2);
+			expect(venues[0]).toHaveTextContent(shortenWithMiddleEllipsis({ text: ORCA }));
+			expect(venues[1]).toHaveTextContent(shortenWithMiddleEllipsis({ text: JUPITER }));
+		});
+
+		it('should show no group when the run named no program', () => {
+			const { queryByTestId } = render(SolWalletConnectSignReview, { props });
+
+			expect(queryByTestId('venue')).not.toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The Solana WalletConnect review says what a message would move and never where it would run. A program is the closest thing a Solana message has to a recipient, and it is the one party a user can actually look up before signing, so it belongs on the Summary tab beside the amounts rather than buried in the instruction list.

# Changes

The programs the simulated run goes through are listed under their own heading, each with the actions to copy the address or open it in an explorer.

They come from the run rather than the message because the message names none of them: a routed swap performs every call inside another program. They are listed and not picked from, since a route across two pools touches two of them and choosing one names a winner among equals.

Addresses, not names. The list is what we have.

# Tests

Each program is listed once and in the order the run reached it, and the group is absent when the run named none. The first fails without the change.