### PR TITLE
feat(frontend): read a lookup table instruction instead of leaving it unreviewed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,7 @@ updates:
     groups:
       solana-kit:
         patterns:
+          - '@solana-program/address-lookup-table'
           - '@solana-program/compute-budget'
           - '@solana-program/system'
           - '@solana-program/token'

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"@metamask/detect-provider": "^2.0.0",
 				"@plausible-analytics/tracker": "^0.4.5",
 				"@reown/walletkit": "^1.5.5",
+				"@solana-program/address-lookup-table": "^0.13.0",
 				"@solana-program/compute-budget": "^0.17.0",
 				"@solana-program/system": "^0.13.0",
 				"@solana-program/token": "^0.15.0",
@@ -2838,6 +2839,18 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@solana-program/address-lookup-table": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@solana-program/address-lookup-table/-/address-lookup-table-0.13.0.tgz",
+			"integrity": "sha512-UCxrapY8AA3wFzGpfYcXvs41alPTVFWdM7MGoz8IL6F+EL3BJ+4XVcUIj3UT3K9Sp14hPVPAIMFqnE4iOX7VMw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=24.0.0"
+			},
+			"peerDependencies": {
+				"@solana/kit": "^7.0.0"
 			}
 		},
 		"node_modules/@solana-program/compute-budget": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"@metamask/detect-provider": "^2.0.0",
 		"@plausible-analytics/tracker": "^0.4.5",
 		"@reown/walletkit": "^1.5.5",
+		"@solana-program/address-lookup-table": "^0.13.0",
 		"@solana-program/compute-budget": "^0.17.0",
 		"@solana-program/system": "^0.13.0",
 		"@solana-program/token": "^0.15.0",

--- a/src/frontend/src/sol/constants/sol.constants.ts
+++ b/src/frontend/src/sol/constants/sol.constants.ts
@@ -6,6 +6,7 @@ export const TOKEN_PROGRAM_ADDRESS = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5D
 export const TOKEN_2022_PROGRAM_ADDRESS = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb';
 export const ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS =
 	'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
+export const ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS = 'AddressLookupTab1e1111111111111111111111111';
 
 // Solana transaction fee
 // It can be hard-coded since it is not changed unsless under community proposal, with time in advance.

--- a/src/frontend/src/sol/types/sol-instructions.ts
+++ b/src/frontend/src/sol/types/sol-instructions.ts
@@ -1,5 +1,6 @@
 import type { SolAddress } from '$sol/types/address';
 import type { SolRpcTransactionRaw } from '$sol/types/sol-transaction';
+import type { ParsedAddressLookupTableInstruction } from '@solana-program/address-lookup-table';
 import type { ParsedComputeBudgetInstruction } from '@solana-program/compute-budget';
 import type { ParsedSystemInstruction } from '@solana-program/system';
 import type {
@@ -14,13 +15,15 @@ export type SolParsedSystemInstruction = ParsedSystemInstruction<SolAddress>;
 export type SolParsedTokenInstruction = ParsedTokenInstruction<SolAddress>;
 export type SolParsedToken2022Instruction = ParsedToken2022Instruction<SolAddress>;
 export type SolParsedAtaInstruction = ParsedAssociatedTokenInstruction<SolAddress>;
+export type SolParsedLookupTableInstruction = ParsedAddressLookupTableInstruction<SolAddress>;
 
 export type SolParsedInstruction =
 	| SolParsedComputeBudgetInstruction
 	| SolParsedSystemInstruction
 	| SolParsedTokenInstruction
 	| SolParsedToken2022Instruction
-	| SolParsedAtaInstruction;
+	| SolParsedAtaInstruction
+	| SolParsedLookupTableInstruction;
 
 export type SolInstruction = Instruction;
 

--- a/src/frontend/src/sol/utils/sol-instructions-lookup-table.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions-lookup-table.utils.ts
@@ -1,0 +1,54 @@
+import type { SolInstruction, SolParsedLookupTableInstruction } from '$sol/types/sol-instructions';
+import { assertNever } from '@dfinity/utils';
+import {
+	AddressLookupTableInstruction,
+	identifyAddressLookupTableInstruction,
+	parseCloseLookupTableInstruction,
+	parseCreateLookupTableInstruction,
+	parseDeactivateLookupTableInstruction,
+	parseExtendLookupTableInstruction,
+	parseFreezeLookupTableInstruction
+} from '@solana-program/address-lookup-table';
+import { assertIsInstructionWithAccounts, assertIsInstructionWithData } from '@solana/kit';
+
+export const parseSolLookupTableInstruction = (
+	instruction: SolInstruction
+): SolParsedLookupTableInstruction => {
+	assertIsInstructionWithData<Uint8Array>(instruction);
+	assertIsInstructionWithAccounts(instruction);
+
+	const decodedInstruction = identifyAddressLookupTableInstruction(instruction);
+	switch (decodedInstruction) {
+		case AddressLookupTableInstruction.CreateLookupTable:
+			return {
+				...parseCreateLookupTableInstruction(instruction),
+				instructionType: AddressLookupTableInstruction.CreateLookupTable
+			};
+		case AddressLookupTableInstruction.FreezeLookupTable:
+			return {
+				...parseFreezeLookupTableInstruction(instruction),
+				instructionType: AddressLookupTableInstruction.FreezeLookupTable
+			};
+		case AddressLookupTableInstruction.ExtendLookupTable:
+			return {
+				...parseExtendLookupTableInstruction(instruction),
+				instructionType: AddressLookupTableInstruction.ExtendLookupTable
+			};
+		case AddressLookupTableInstruction.DeactivateLookupTable:
+			return {
+				...parseDeactivateLookupTableInstruction(instruction),
+				instructionType: AddressLookupTableInstruction.DeactivateLookupTable
+			};
+		case AddressLookupTableInstruction.CloseLookupTable:
+			return {
+				...parseCloseLookupTableInstruction(instruction),
+				instructionType: AddressLookupTableInstruction.CloseLookupTable
+			};
+		default: {
+			assertNever(
+				decodedInstruction,
+				`Unknown Solana Address Lookup Table instruction: ${decodedInstruction}`
+			);
+		}
+	}
+};

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -3,6 +3,7 @@ import type { NullishIdentity } from '$lib/types/identity';
 import { consoleWarn } from '$lib/utils/console.utils';
 import { getAccountInfo } from '$sol/api/solana.api';
 import {
+	ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS,
 	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
 	COMPUTE_BUDGET_PROGRAM_ADDRESS,
 	SYSTEM_PROGRAM_ADDRESS,
@@ -20,10 +21,12 @@ import type { MappedSolTransaction, SolMappedTransaction } from '$sol/types/sol-
 import type { SplTokenAddress } from '$sol/types/spl';
 import { parseSolAtaInstruction } from '$sol/utils/sol-instructions-ata.utils';
 import { parseSolComputeBudgetInstruction } from '$sol/utils/sol-instructions-compute-budget.utils';
+import { parseSolLookupTableInstruction } from '$sol/utils/sol-instructions-lookup-table.utils';
 import { parseSolSystemInstruction } from '$sol/utils/sol-instructions-system.utils';
 import { parseSolToken2022Instruction } from '$sol/utils/sol-instructions-token-2022.utils';
 import { parseSolTokenInstruction } from '$sol/utils/sol-instructions-token.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
+import { AddressLookupTableInstruction } from '@solana-program/address-lookup-table';
 import { ComputeBudgetInstruction } from '@solana-program/compute-budget';
 import { SystemInstruction } from '@solana-program/system';
 import { AssociatedTokenInstruction, TokenInstruction } from '@solana-program/token';
@@ -389,6 +392,10 @@ const parseSolInstruction = (
 		return parseSolAtaInstruction(instruction);
 	}
 
+	if (programAddress === ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS) {
+		return parseSolLookupTableInstruction(instruction);
+	}
+
 	consoleWarn(`Could not parse Solana instruction for program ${programAddress}`);
 
 	return instruction;
@@ -659,6 +666,35 @@ const mapSolAtaInstruction = (instruction: SolParsedInstruction): MappedSolTrans
 	return unreviewedInstruction();
 };
 
+const mapSolLookupTableInstruction = (instruction: SolParsedInstruction): MappedSolTransaction => {
+	const { instructionType } = instruction;
+
+	// A lookup table is addressing, not value: it lets a message name accounts in fewer bytes and
+	// grants no one anything. Creating and extending one costs rent, which the instruction does not
+	// carry, the runtime works it out from the size; the same is already true of the token accounts
+	// a swap opens along the way.
+	if (
+		instructionType === AddressLookupTableInstruction.CreateLookupTable ||
+		instructionType === AddressLookupTableInstruction.ExtendLookupTable ||
+		instructionType === AddressLookupTableInstruction.FreezeLookupTable ||
+		instructionType === AddressLookupTableInstruction.DeactivateLookupTable
+	) {
+		return ignoredInstruction();
+	}
+
+	// Closing hands the table's whole balance to a recipient the instruction names, and only the
+	// table's own authority can ask for it, so the balance leaving is the user's. Neither the amount
+	// nor the recipient fits the single-value summary, which is what would let it ride along
+	// unseen behind whatever else the message does.
+	if (instructionType === AddressLookupTableInstruction.CloseLookupTable) {
+		return unfaithfulInstruction();
+	}
+
+	consoleWarn(`Could not map Solana Address Lookup Table instruction of type ${instructionType}`);
+
+	return unreviewedInstruction();
+};
+
 export const mapSolInstruction = (instruction: SolInstruction): MappedSolTransaction => {
 	// Compute budget instructions can never move funds, but they do set the prioritisation
 	// fee the wallet pays in SOL, so their directives are surfaced rather than ignored.
@@ -690,6 +726,10 @@ export const mapSolInstruction = (instruction: SolInstruction): MappedSolTransac
 
 	if (programAddress === ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS) {
 		return mapSolAtaInstruction(parsedInstruction);
+	}
+
+	if (programAddress === ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS) {
+		return mapSolLookupTableInstruction(parsedInstruction);
 	}
 
 	consoleWarn(`Could not map Solana instruction for program ${programAddress}`);

--- a/src/frontend/src/tests/sol/utils/sol-instructions-lookup-table.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions-lookup-table.utils.spec.ts
@@ -1,0 +1,95 @@
+import { ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
+import type { SolInstruction } from '$sol/types/sol-instructions';
+import { parseSolLookupTableInstruction } from '$sol/utils/sol-instructions-lookup-table.utils';
+import { mockSolAddress } from '$tests/mocks/sol.mock';
+import {
+	AddressLookupTableInstruction,
+	identifyAddressLookupTableInstruction,
+	parseCloseLookupTableInstruction,
+	parseCreateLookupTableInstruction,
+	parseDeactivateLookupTableInstruction,
+	parseExtendLookupTableInstruction,
+	parseFreezeLookupTableInstruction
+} from '@solana-program/address-lookup-table';
+import { address } from '@solana/kit';
+
+vi.mock(import('@solana-program/address-lookup-table'), async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		identifyAddressLookupTableInstruction: vi.fn(),
+		parseCreateLookupTableInstruction: vi.fn(),
+		parseFreezeLookupTableInstruction: vi.fn(),
+		parseExtendLookupTableInstruction: vi.fn(),
+		parseDeactivateLookupTableInstruction: vi.fn(),
+		parseCloseLookupTableInstruction: vi.fn()
+	};
+});
+
+describe('sol-instructions-lookup-table.utils', () => {
+	describe('parseSolLookupTableInstruction', () => {
+		const mockInstruction: SolInstruction = {
+			accounts: [{ address: address(mockSolAddress), role: 3 }],
+			data: new Uint8Array([1, 2, 3]),
+			programAddress: address(ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS)
+		};
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should raise an error if the instruction is missing the data', () => {
+			const { data: _, ...withoutData } = mockInstruction;
+
+			expect(() => parseSolLookupTableInstruction(withoutData)).toThrow(
+				'The instruction does not have any data'
+			);
+		});
+
+		it('should raise an error if the instruction is missing the accounts', () => {
+			const { accounts: _, ...withoutAccounts } = mockInstruction;
+
+			expect(() => parseSolLookupTableInstruction(withoutAccounts)).toThrow(
+				'The instruction does not have any accounts'
+			);
+		});
+
+		it.each([
+			{
+				instructionType: AddressLookupTableInstruction.CreateLookupTable,
+				parser: parseCreateLookupTableInstruction
+			},
+			{
+				instructionType: AddressLookupTableInstruction.FreezeLookupTable,
+				parser: parseFreezeLookupTableInstruction
+			},
+			{
+				instructionType: AddressLookupTableInstruction.ExtendLookupTable,
+				parser: parseExtendLookupTableInstruction
+			},
+			{
+				instructionType: AddressLookupTableInstruction.DeactivateLookupTable,
+				parser: parseDeactivateLookupTableInstruction
+			},
+			{
+				instructionType: AddressLookupTableInstruction.CloseLookupTable,
+				parser: parseCloseLookupTableInstruction
+			}
+		])('should parse a $instructionType instruction', ({ instructionType, parser }) => {
+			vi.mocked(identifyAddressLookupTableInstruction).mockReturnValue(instructionType);
+
+			expect(parseSolLookupTableInstruction(mockInstruction)).toStrictEqual({ instructionType });
+
+			expect(parser).toHaveBeenCalledExactlyOnceWith(mockInstruction);
+		});
+
+		it('should raise an error if it is not a recognised Address Lookup Table instruction', () => {
+			// @ts-expect-error intentional for testing unknown discriminant
+			vi.mocked(identifyAddressLookupTableInstruction).mockReturnValue('unknown-instruction');
+
+			expect(() => parseSolLookupTableInstruction(mockInstruction)).toThrow(
+				'Unknown Solana Address Lookup Table instruction: unknown-instruction'
+			);
+		});
+	});
+});

--- a/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instructions.utils.spec.ts
@@ -1,6 +1,7 @@
 import { JUP_TOKEN } from '$env/tokens/tokens-spl/tokens.jup.env';
 import { ZERO } from '$lib/constants/app.constants';
 import {
+	ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS,
 	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
 	COMPUTE_BUDGET_PROGRAM_ADDRESS,
 	SYSTEM_PROGRAM_ADDRESS,
@@ -15,6 +16,8 @@ import * as solInstructionsAtaUtils from '$sol/utils/sol-instructions-ata.utils'
 import { parseSolAtaInstruction } from '$sol/utils/sol-instructions-ata.utils';
 import * as solInstructionsComputeBudgetUtils from '$sol/utils/sol-instructions-compute-budget.utils';
 import { parseSolComputeBudgetInstruction } from '$sol/utils/sol-instructions-compute-budget.utils';
+import * as solInstructionsLookupTableUtils from '$sol/utils/sol-instructions-lookup-table.utils';
+import { parseSolLookupTableInstruction } from '$sol/utils/sol-instructions-lookup-table.utils';
 import * as solInstructionsSystemUtils from '$sol/utils/sol-instructions-system.utils';
 import { parseSolSystemInstruction } from '$sol/utils/sol-instructions-system.utils';
 import * as solInstructionsToken2022Utils from '$sol/utils/sol-instructions-token-2022.utils';
@@ -26,6 +29,13 @@ import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockSolParsedTransactionMessage } from '$tests/mocks/sol-transactions.mock';
 import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
 import { assertNonNullish } from '@dfinity/utils';
+import {
+	getCloseLookupTableInstruction,
+	getCreateLookupTableInstruction,
+	getDeactivateLookupTableInstruction,
+	getExtendLookupTableInstruction,
+	getFreezeLookupTableInstruction
+} from '@solana-program/address-lookup-table';
 import {
 	getRequestUnitsInstruction,
 	getSetLoadedAccountsDataSizeLimitInstruction
@@ -55,6 +65,7 @@ import {
 	address,
 	createNoopSigner,
 	type Base58EncodedBytes,
+	type ProgramDerivedAddress,
 	type Rpc,
 	type SolanaRpcApi
 } from '@solana/kit';
@@ -890,6 +901,7 @@ describe('sol-instructions.utils', () => {
 			vi.spyOn(solInstructionsTokenUtils, 'parseSolTokenInstruction');
 			vi.spyOn(solInstructionsToken2022Utils, 'parseSolToken2022Instruction');
 			vi.spyOn(solInstructionsAtaUtils, 'parseSolAtaInstruction');
+			vi.spyOn(solInstructionsLookupTableUtils, 'parseSolLookupTableInstruction');
 		});
 
 		it('should surface the directives of a Compute Budget instruction', () => {
@@ -1243,6 +1255,80 @@ describe('sol-instructions.utils', () => {
 			expect(console.warn).not.toHaveBeenCalled();
 		});
 
+		describe('with an Address Lookup Table instruction', () => {
+			const mockAuthority = createNoopSigner(address(mockSolAddress));
+
+			// Deriving the table's address needs SubtleCrypto, which the test environment does not
+			// offer; the mapping never looks at it.
+			const mockLookupTable = [address(mockSolAddress2), 254] as unknown as ProgramDerivedAddress;
+
+			it('should ignore a CreateLookupTable instruction', () => {
+				const instruction = getCreateLookupTableInstruction({
+					address: mockLookupTable,
+					authority: address(mockSolAddress),
+					payer: mockAuthority,
+					recentSlot: 123n
+				});
+
+				expect(mapSolInstruction(instruction)).toStrictEqual({ amount: undefined });
+
+				expect(parseSolLookupTableInstruction).toHaveBeenCalledExactlyOnceWith(instruction);
+				expect(console.warn).not.toHaveBeenCalled();
+			});
+
+			it('should ignore an ExtendLookupTable instruction', () => {
+				const instruction = getExtendLookupTableInstruction({
+					address: address(mockSolAddress2),
+					authority: mockAuthority,
+					payer: mockAuthority,
+					addresses: [address(mockSolAddress)]
+				});
+
+				expect(mapSolInstruction(instruction)).toStrictEqual({ amount: undefined });
+
+				expect(console.warn).not.toHaveBeenCalled();
+			});
+
+			it('should ignore a FreezeLookupTable instruction', () => {
+				const instruction = getFreezeLookupTableInstruction({
+					address: address(mockSolAddress2),
+					authority: mockAuthority
+				});
+
+				expect(mapSolInstruction(instruction)).toStrictEqual({ amount: undefined });
+
+				expect(console.warn).not.toHaveBeenCalled();
+			});
+
+			it('should ignore a DeactivateLookupTable instruction', () => {
+				const instruction = getDeactivateLookupTableInstruction({
+					address: address(mockSolAddress2),
+					authority: mockAuthority
+				});
+
+				expect(mapSolInstruction(instruction)).toStrictEqual({ amount: undefined });
+
+				expect(console.warn).not.toHaveBeenCalled();
+			});
+
+			// The balance it returns is the user's rent and the recipient is the instruction's own
+			// choice, neither of which the single-value summary can carry.
+			it('should fail closed on a CloseLookupTable instruction', () => {
+				const instruction = getCloseLookupTableInstruction({
+					address: address(mockSolAddress2),
+					authority: mockAuthority,
+					recipient: address(mockSolAddress)
+				});
+
+				expect(mapSolInstruction(instruction)).toStrictEqual({
+					amount: undefined,
+					ambiguous: true
+				});
+
+				expect(console.warn).not.toHaveBeenCalled();
+			});
+		});
+
 		it('should return undefined for unrecognized instruction', () => {
 			const [mockInstruction1, mockInstruction2] = mockInstructions.filter(
 				({ programAddress }) =>
@@ -1250,7 +1336,8 @@ describe('sol-instructions.utils', () => {
 						COMPUTE_BUDGET_PROGRAM_ADDRESS,
 						SYSTEM_PROGRAM_ADDRESS,
 						TOKEN_PROGRAM_ADDRESS,
-						TOKEN_2022_PROGRAM_ADDRESS
+						TOKEN_2022_PROGRAM_ADDRESS,
+						ADDRESS_LOOKUP_TABLE_PROGRAM_ADDRESS
 					].includes(programAddress)
 			);
 
@@ -1268,6 +1355,7 @@ describe('sol-instructions.utils', () => {
 			expect(parseSolTokenInstruction).not.toHaveBeenCalled();
 			expect(parseSolToken2022Instruction).not.toHaveBeenCalled();
 			expect(parseSolAtaInstruction).not.toHaveBeenCalled();
+			expect(parseSolLookupTableInstruction).not.toHaveBeenCalled();
 
 			expect(console.warn).toHaveBeenCalledExactlyOnceWith(
 				`Could not parse Solana instruction for program ${mockInstruction1.programAddress}`


### PR DESCRIPTION
# Motivation

A lookup table is addressing, not value: it lets a message name accounts in fewer bytes and grants no one anything. OISY does not decode the Address Lookup Table program, so a message that sets one up warns that the review is incomplete over instructions that move nothing but rent. The token accounts a swap opens along the way are already treated as ignorable for the same reason.

Note this is only about the five ALT instructions. Resolving the addresses a v0 message looks up is already handled: `parseSolBase64TransactionMessage` decompiles through `decompileTransactionMessageFetchingLookupTables`, which fetches the tables from the RPC.

# Changes

- Add `@solana-program/address-lookup-table`, pinned to the `@solana/kit` 7 line the other `@solana-program` packages are on, and add it to the `solana-kit` dependabot group so it moves with them.
- Decode the five Address Lookup Table instructions.
- Map create, extend, freeze and deactivate as no-ops. Creating and extending costs rent, which the instruction does not carry: the runtime works it out from the size.
- Fail closed on close. It hands the table's whole balance to a recipient the instruction names, and only the table's own authority can ask for it, so the balance leaving is the user's. Neither the amount nor the recipient fits the single-value summary, which is what would let it ride along unseen behind whatever else the message does.

# Tests

New spec for the parser covering all five instructions, missing data and missing accounts. Cases added to the dispatcher spec for each instruction, including the close that fails closed.

`npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` all clean; 1897 Solana tests pass.