### PR TITLE
feat(frontend): drop the signer row from the Ethereum WalletConnect review

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
@@ -239,6 +239,7 @@
 				showAmount={!noAmount}
 				showBalance={!noAmount}
 				showNullishAmountLabel={unverifiableErc20}
+				showSigner={false}
 				showUnlimitedAmountLabel={erc20Approve || allowanceIncrease}
 				source={$ethAddress ?? ''}
 				{token}

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectSendReview.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectSendReview.spec.ts
@@ -123,8 +123,10 @@ describe('EthWalletConnectSendReview', () => {
 		expect(getByRole('button', { name: en.core.text.approve })).not.toBeDisabled();
 	});
 
-	it('should render the signer row', () => {
-		const { getByText, container } = render(EthWalletConnectSendReview, {
+	// The signer is the wallet the request was sent to, which the user opened to read this. It says
+	// nothing about the request and takes a row from the facts that do.
+	it('should not render the signer row', () => {
+		const { queryByText, container } = render(EthWalletConnectSendReview, {
 			props: {
 				...props,
 				destination: UNKNOWN_CONTRACT
@@ -132,8 +134,8 @@ describe('EthWalletConnectSendReview', () => {
 			context: mockContext
 		});
 
-		expect(getByText(en.wallet_connect.text.signer)).toBeInTheDocument();
-		expect(container.querySelector('#signer')).not.toBeNull();
+		expect(queryByText(en.wallet_connect.text.signer)).not.toBeInTheDocument();
+		expect(container.querySelector('#signer')).toBeNull();
 	});
 
 	it('should never summarize an ERC20 transfer as a native zero-value send', () => {


### PR DESCRIPTION
# Motivation

The signer row states the wallet address the request arrived at. The user opened that wallet in order to read the review, so it tells them something they already know, and it costs a row in a screen whose whole job is to state the few facts that matter about what would be signed.

The same row was dropped from the Solana sign review in #13805, which added the `showSigner` prop for exactly this. Ethereum kept it at the time; this brings it in line.

# Changes

- `EthWalletConnectSendReview` passes `showSigner={false}`, the mechanism `SendSource` already exposes.
- The source address is still passed. Nothing else reads it today, but leaving it keeps the prop set honest rather than encoding an assumption about what the shared component does with it.

# Tests

The spec asserted the signer row rendered; it now asserts it does not, both by label and by the `#signer` element. Full `src/frontend/src/tests/eth` and the WalletConnect wiring suite pass (4139 tests). Lint clean.
