### PR TITLE
feat(frontend): name a program from the interface it publishes

### DIFF
--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -16,6 +16,7 @@ import type {
 import type { SplTokenAddress } from '$sol/types/spl';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 import {
+	getBase64Encoder,
 	address as solAddress,
 	type Address,
 	type Base64EncodedWireTransaction,
@@ -334,6 +335,33 @@ export const getAccountInfo = async ({
 	addressMap.set(address, info);
 
 	return info;
+};
+
+/**
+ * The raw bytes of an account, for accounts no server-side parser knows: an Anchor IDL is a
+ * program's own data, so `jsonParsed` hands back the same base64 either way.
+ *
+ * Returns `undefined` for an account that does not exist, which is the common answer here: most
+ * programs publish no IDL.
+ */
+export const getAccountData = async ({
+	address,
+	network
+}: {
+	address: SolAddress;
+	network: SolanaNetworkType;
+}): Promise<Uint8Array<ArrayBuffer> | undefined> => {
+	const { getAccountInfo } = solanaHttpRpc(network);
+
+	const { value } = await getAccountInfo(solAddress(address), { encoding: 'base64' }).send();
+
+	if (isNullish(value)) {
+		return undefined;
+	}
+
+	const [data] = value.data;
+
+	return new Uint8Array(getBase64Encoder().encode(data));
 };
 
 // https://solana.com/docs/tokens/extensions

--- a/src/frontend/src/sol/api/solana.api.ts
+++ b/src/frontend/src/sol/api/solana.api.ts
@@ -21,6 +21,7 @@ import {
 	type Address,
 	type Base64EncodedWireTransaction,
 	type Lamports,
+	type ReadonlyUint8Array,
 	type Signature,
 	type TransactionError
 } from '@solana/kit';
@@ -350,7 +351,7 @@ export const getAccountData = async ({
 }: {
 	address: SolAddress;
 	network: SolanaNetworkType;
-}): Promise<Uint8Array<ArrayBuffer> | undefined> => {
+}): Promise<ReadonlyUint8Array<ArrayBuffer> | undefined> => {
 	const { getAccountInfo } = solanaHttpRpc(network);
 
 	const { value } = await getAccountInfo(solAddress(address), { encoding: 'base64' }).send();
@@ -361,7 +362,7 @@ export const getAccountData = async ({
 
 	const [data] = value.data;
 
-	return new Uint8Array(getBase64Encoder().encode(data));
+	return getBase64Encoder().encode(data);
 };
 
 // https://solana.com/docs/tokens/extensions

--- a/src/frontend/src/sol/components/transactions/SolInstructionsList.svelte
+++ b/src/frontend/src/sol/components/transactions/SolInstructionsList.svelte
@@ -66,6 +66,13 @@
 			<!-- A contact or a token OISY knows names the account; the address is what is left when
 			     neither does. The controls copy and open the address either way, never the name. -->
 			{#if nonNullish(actionAddress)}
+				<!-- A program's published name is the program's own claim about itself, so it is shown
+				     as a label beside the address rather than in place of it: the address is the part
+				     the user can check. -->
+				{#if nonNullish(instruction.programName)}
+					<span class="text-tertiary">{instruction.programName}</span>
+				{/if}
+
 				<ContactOrToken identifier={actionAddress} showFallback />
 
 				<AddressActions

--- a/src/frontend/src/sol/constants/sol.constants.ts
+++ b/src/frontend/src/sol/constants/sol.constants.ts
@@ -7,6 +7,14 @@ export const TOKEN_2022_PROGRAM_ADDRESS = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXE
 export const ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS =
 	'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
 
+// Where and how an Anchor program publishes its own interface. The seed is Anchor's, and so is the
+// account layout: a fixed discriminator it stamps on every IDL account (a constant, not derived
+// from a name), the authority allowed to rewrite it, then the length of the compressed IDL.
+export const ANCHOR_IDL_SEED = 'anchor:idl';
+export const ANCHOR_IDL_ACCOUNT_DISCRIMINATOR = [24, 70, 98, 191, 58, 144, 123, 158];
+export const ANCHOR_IDL_ACCOUNT_LENGTH_OFFSET = 40;
+export const ANCHOR_IDL_ACCOUNT_HEADER_LENGTH = 44;
+
 // Solana transaction fee
 // It can be hard-coded since it is not changed unsless under community proposal, with time in advance.
 // https://solana.com/docs/core/fees#transaction-fees

--- a/src/frontend/src/sol/services/sol-program-name.services.ts
+++ b/src/frontend/src/sol/services/sol-program-name.services.ts
@@ -1,0 +1,96 @@
+import { consoleWarn } from '$lib/utils/console.utils';
+import { getAccountData } from '$sol/api/solana.api';
+import { solProgramNameStore } from '$sol/stores/sol-program-name.store';
+import type { SolAddress } from '$sol/types/address';
+import type { SolanaNetworkType } from '$sol/types/network';
+import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
+import {
+	decodeSolProgramIdlName,
+	findSolProgramIdlAddress
+} from '$sol/utils/sol-program-idl.utils';
+import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
+import { get } from 'svelte/store';
+
+const loadName = async ({
+	programAddress,
+	network
+}: {
+	programAddress: SolAddress;
+	network: SolanaNetworkType;
+}): Promise<string> => {
+	const idlAddress = await findSolProgramIdlAddress({ programAddress });
+
+	const data = await getAccountData({ address: idlAddress, network });
+
+	if (isNullish(data)) {
+		return '';
+	}
+
+	return (await decodeSolProgramIdlName(data)) ?? '';
+};
+
+/**
+ * Names the programs the review is about to show, from the interface each one publishes for itself,
+ * and hands back the same instructions carrying the names that were found.
+ *
+ * Best effort by design, and per program: most programs publish nothing, and a read that fails
+ * leaves one unnamed rather than failing the review it appeared in. Programs already asked about
+ * are not asked again, including the ones that answered with nothing.
+ *
+ * What this produces is a label and only a label. The name is the program's own claim, written by
+ * whoever holds the IDL authority and attested by no one, so it never promotes an instruction out
+ * of unreviewed: it says which door the message knocks on, not what happens behind it.
+ */
+export const loadSolProgramNames = async ({
+	instructions,
+	network
+}: {
+	instructions: SolInstructionSummary[];
+	network: SolanaNetworkType;
+}): Promise<SolInstructionSummary[]> => {
+	const programAddresses = instructions
+		.map(({ program }) => program)
+		.filter((program): program is SolAddress => nonNullish(program));
+
+	const known = get(solProgramNameStore)[network] ?? {};
+
+	const missing = [...new Set(programAddresses)].filter((address) => !(address in known));
+
+	if (missing.length > 0) {
+		const names = await Promise.all(
+			missing.map(async (programAddress) => {
+				try {
+					return await loadName({ programAddress, network });
+				} catch (err: unknown) {
+					consoleWarn(
+						`Could not read the interface Solana program ${programAddress} publishes`,
+						err
+					);
+
+					return undefined;
+				}
+			})
+		);
+
+		solProgramNameStore.set({
+			network,
+			names: missing.reduce<Partial<Record<SolAddress, string>>>((acc, address, index) => {
+				const name = names[index];
+
+				// A program that failed to answer is left out rather than recorded as nameless, so a
+				// timeout during one review does not silence it for the rest of the session.
+				return nonNullish(name) ? { ...acc, [address]: name } : acc;
+			}, {})
+		});
+	}
+
+	const resolved = get(solProgramNameStore)[network] ?? {};
+
+	return instructions.map((instruction) => {
+		const { program } = instruction;
+
+		const programName = nonNullish(program) ? resolved[program] : undefined;
+
+		return notEmptyString(programName) ? { ...instruction, programName } : instruction;
+	});
+};

--- a/src/frontend/src/sol/services/wallet-connect.services.ts
+++ b/src/frontend/src/sol/services/wallet-connect.services.ts
@@ -26,6 +26,7 @@ import {
 	SESSION_REQUEST_SOL_SIGN_TRANSACTION
 } from '$sol/constants/wallet-connect.constants';
 import { solanaHttpRpc } from '$sol/providers/sol-rpc.providers';
+import { loadSolProgramNames } from '$sol/services/sol-program-name.services';
 import {
 	sendSignedTransaction,
 	setLifetimeAndFeePayerToTransaction
@@ -120,18 +121,22 @@ export const decode = async ({
 		parties: simulatedParties
 	} = simulation ?? {};
 
-	// Name the mints the review is about to show. Best effort and awaited, since the review is
-	// synchronous and a name that landed after the modal opened would arrive too late to read.
-	await loadSplTokenMetadata({
-		tokenAddresses: (preview?.tokenDeltas ?? []).map(({ tokenAddress }) => tokenAddress),
-		network: solNetwork
-	});
+	// Name the mints and the programs the review is about to show. Best effort and awaited, since
+	// the review is synchronous and a name that landed after the modal opened would arrive too late
+	// to read.
+	const [namedInstructions] = await Promise.all([
+		loadSolProgramNames({ instructions: simulatedInstructions ?? [], network: solNetwork }),
+		loadSplTokenMetadata({
+			tokenAddresses: (preview?.tokenDeltas ?? []).map(({ tokenAddress }) => tokenAddress),
+			network: solNetwork
+		})
+	]);
 
 	const mapped = {
 		...mappedTransaction,
 		...(nonNullish(prioritizationFeeEstimate) && { prioritizationFeeEstimate }),
 		...(nonNullish(preview) && { preview }),
-		...(nonNullish(simulatedInstructions) && { instructions: simulatedInstructions }),
+		...(nonNullish(simulatedInstructions) && { instructions: namedInstructions }),
 		...(nonNullish(messageSummary) && { messageSummary })
 	};
 

--- a/src/frontend/src/sol/stores/sol-program-name.store.ts
+++ b/src/frontend/src/sol/stores/sol-program-name.store.ts
@@ -1,0 +1,38 @@
+import type { SolAddress } from '$sol/types/address';
+import type { SolanaNetworkType } from '$sol/types/network';
+import { writable, type Readable } from 'svelte/store';
+
+/**
+ * Keyed by network and then by program: the same address is a different deployment on each
+ * cluster, and a devnet program must not inherit a mainnet name.
+ */
+export type SolProgramNameData = Partial<
+	Record<SolanaNetworkType, Partial<Record<SolAddress, string>>>
+>;
+
+interface SolProgramNameStore extends Readable<SolProgramNameData> {
+	set: (params: { network: SolanaNetworkType; names: Partial<Record<SolAddress, string>> }) => void;
+	reset: () => void;
+}
+
+/**
+ * The name a program publishes for itself, for programs OISY does not decode.
+ *
+ * A program that publishes none is recorded under the empty string rather than left out, so it is
+ * asked about once per session instead of once per transaction it appears in.
+ *
+ * Never evicted within a session. An upgrade could change the name under us, which is a stale
+ * label at worst: nothing the review states about value comes from here.
+ */
+const initSolProgramNameStore = (): SolProgramNameStore => {
+	const { subscribe, update, set } = writable<SolProgramNameData>({});
+
+	return {
+		subscribe,
+		set: ({ network, names }) =>
+			update((state) => ({ ...state, [network]: { ...(state[network] ?? {}), ...names } })),
+		reset: () => set({})
+	};
+};
+
+export const solProgramNameStore = initSolProgramNameStore();

--- a/src/frontend/src/sol/stores/sol-program-name.store.ts
+++ b/src/frontend/src/sol/stores/sol-program-name.store.ts
@@ -16,7 +16,7 @@ interface SolProgramNameStore extends Readable<SolProgramNameData> {
 }
 
 /**
- * The name a program publishes for itself, for programs OISY does not decode.
+ * The name a program publishes for itself, read from the interface it keeps on chain.
  *
  * A program that publishes none is recorded under the empty string rather than left out, so it is
  * asked about once per session instead of once per transaction it appears in.

--- a/src/frontend/src/sol/types/sol-instruction-summary.ts
+++ b/src/frontend/src/sol/types/sol-instruction-summary.ts
@@ -51,6 +51,9 @@ export interface SolInstructionSummary {
 	newAuthority?: SolAddress;
 	// The program that produced the legs of a route, when one is known by address.
 	program?: SolAddress;
+	// The name that program publishes for itself, when it publishes one. Its own claim about
+	// itself, attested by nobody: a label for the address, never a statement about what it does.
+	programName?: string;
 	// The legs of a single routed swap. They hang under the route rather than sitting flat among
 	// the top-level effects, which is what keeps a four-leg route from reading as four unrelated
 	// transfers.

--- a/src/frontend/src/sol/utils/sol-program-idl.utils.ts
+++ b/src/frontend/src/sol/utils/sol-program-idl.utils.ts
@@ -9,7 +9,8 @@ import { isNullish, nonNullish } from '@dfinity/utils';
 import {
 	createAddressWithSeed,
 	getProgramDerivedAddress,
-	address as solAddress
+	address as solAddress,
+	type ReadonlyUint8Array
 } from '@solana/kit';
 
 /**
@@ -48,26 +49,34 @@ const inflate = async (bytes: Uint8Array<ArrayBuffer>): Promise<string> => {
 
 	const chunks: Uint8Array[] = [];
 
+	let length = 0;
+
 	let result = await reader.read();
 
 	while (!result.done) {
 		chunks.push(result.value);
 
+		length += result.value.length;
+
 		result = await reader.read();
 	}
 
-	const inflated = chunks.reduce<Uint8Array>((acc, chunk) => {
-		const merged = new Uint8Array(acc.length + chunk.length);
-		merged.set(acc);
-		merged.set(chunk, acc.length);
+	// Sized once from the total rather than regrown per chunk: an IDL arrives in many of them, and
+	// merging pairwise would copy what is already merged again every time.
+	const inflated = new Uint8Array(length);
 
-		return merged;
-	}, new Uint8Array());
+	let offset = 0;
+
+	for (const chunk of chunks) {
+		inflated.set(chunk, offset);
+
+		offset += chunk.length;
+	}
 
 	return new TextDecoder().decode(inflated);
 };
 
-const isIdlAccount = (data: Uint8Array<ArrayBuffer>): boolean =>
+const isIdlAccount = (data: ReadonlyUint8Array<ArrayBuffer>): boolean =>
 	data.length >= ANCHOR_IDL_ACCOUNT_HEADER_LENGTH &&
 	ANCHOR_IDL_ACCOUNT_DISCRIMINATOR.every((byte, index) => data[index] === byte);
 
@@ -86,7 +95,7 @@ const isIdlAccount = (data: Uint8Array<ArrayBuffer>): boolean =>
  * three mean the same thing to the caller: this program does not say what it is.
  */
 export const decodeSolProgramIdlName = async (
-	data: Uint8Array<ArrayBuffer>
+	data: ReadonlyUint8Array<ArrayBuffer>
 ): Promise<string | undefined> => {
 	if (!isIdlAccount(data)) {
 		return undefined;

--- a/src/frontend/src/sol/utils/sol-program-idl.utils.ts
+++ b/src/frontend/src/sol/utils/sol-program-idl.utils.ts
@@ -1,0 +1,128 @@
+import {
+	ANCHOR_IDL_ACCOUNT_DISCRIMINATOR,
+	ANCHOR_IDL_ACCOUNT_HEADER_LENGTH,
+	ANCHOR_IDL_ACCOUNT_LENGTH_OFFSET,
+	ANCHOR_IDL_SEED
+} from '$sol/constants/sol.constants';
+import type { SolAddress } from '$sol/types/address';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import {
+	createAddressWithSeed,
+	getProgramDerivedAddress,
+	address as solAddress
+} from '@solana/kit';
+
+/**
+ * Where a program publishes its own interface, if it publishes one.
+ *
+ * Anchor writes the IDL to an account derived from the program itself, so the address is arrived at
+ * rather than looked up: seedless PDA of the program, then that as the base of a seeded address
+ * owned by the program. Nothing here asks the network anything.
+ */
+export const findSolProgramIdlAddress = async ({
+	programAddress
+}: {
+	programAddress: SolAddress;
+}): Promise<SolAddress> => {
+	const [baseAddress] = await getProgramDerivedAddress({
+		programAddress: solAddress(programAddress),
+		seeds: []
+	});
+
+	return await createAddressWithSeed({
+		baseAddress,
+		programAddress: solAddress(programAddress),
+		seed: ANCHOR_IDL_SEED
+	});
+};
+
+const inflate = async (bytes: Uint8Array<ArrayBuffer>): Promise<string> => {
+	const stream = new ReadableStream<BufferSource>({
+		start: (controller) => {
+			controller.enqueue(bytes);
+			controller.close();
+		}
+	}).pipeThrough(new DecompressionStream('deflate'));
+
+	const reader = stream.getReader();
+
+	const chunks: Uint8Array[] = [];
+
+	let result = await reader.read();
+
+	while (!result.done) {
+		chunks.push(result.value);
+
+		result = await reader.read();
+	}
+
+	const inflated = chunks.reduce<Uint8Array>((acc, chunk) => {
+		const merged = new Uint8Array(acc.length + chunk.length);
+		merged.set(acc);
+		merged.set(chunk, acc.length);
+
+		return merged;
+	}, new Uint8Array());
+
+	return new TextDecoder().decode(inflated);
+};
+
+const isIdlAccount = (data: Uint8Array<ArrayBuffer>): boolean =>
+	data.length >= ANCHOR_IDL_ACCOUNT_HEADER_LENGTH &&
+	ANCHOR_IDL_ACCOUNT_DISCRIMINATOR.every((byte, index) => data[index] === byte);
+
+/**
+ * The name a program gives itself, out of the IDL account's own bytes.
+ *
+ * The layout is Anchor's: a fixed discriminator, the authority allowed to rewrite it, the length of
+ * what follows, then the IDL as zlib-compressed JSON. Anchor moved the name into `metadata` at
+ * 0.30, so both places are read.
+ *
+ * The name is the program's own claim about itself, signed by nothing: the IDL's authority writes
+ * whatever it likes there, and a hostile program can call its drain instruction anything. It is a
+ * label for an instruction the review already refuses to state, never a reason to state one.
+ *
+ * Returns `undefined` for an account that is not an IDL, does not inflate, or is not JSON. All
+ * three mean the same thing to the caller: this program does not say what it is.
+ */
+export const decodeSolProgramIdlName = async (
+	data: Uint8Array<ArrayBuffer>
+): Promise<string | undefined> => {
+	if (!isIdlAccount(data)) {
+		return undefined;
+	}
+
+	const length = new DataView(data.buffer, data.byteOffset).getUint32(
+		ANCHOR_IDL_ACCOUNT_LENGTH_OFFSET,
+		true
+	);
+
+	if (length === 0 || data.length < ANCHOR_IDL_ACCOUNT_HEADER_LENGTH + length) {
+		return undefined;
+	}
+
+	try {
+		const idl: unknown = JSON.parse(
+			await inflate(
+				data.subarray(ANCHOR_IDL_ACCOUNT_HEADER_LENGTH, ANCHOR_IDL_ACCOUNT_HEADER_LENGTH + length)
+			)
+		);
+
+		if (isNullish(idl) || typeof idl !== 'object') {
+			return undefined;
+		}
+
+		const metadata = 'metadata' in idl ? idl.metadata : undefined;
+
+		const name =
+			nonNullish(metadata) && typeof metadata === 'object' && 'name' in metadata
+				? metadata.name
+				: 'name' in idl
+					? idl.name
+					: undefined;
+
+		return typeof name === 'string' && name.length > 0 ? name : undefined;
+	} catch (_: unknown) {
+		return undefined;
+	}
+};

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -1,6 +1,7 @@
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { balancesStore } from '$lib/stores/balances.store';
 import { exchangeStore } from '$lib/stores/exchange.store';
+import { shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import SolWalletConnectSignReview from '$sol/components/wallet-connect/SolWalletConnectSignReview.svelte';
 import en from '$tests/mocks/i18n.mock';
@@ -169,6 +170,50 @@ describe('SolWalletConnectSignReview', () => {
 
 		expect(getByTestId('sol-instructions-list')).toBeInTheDocument();
 		expect(getAllByTestId('sol-instruction')).toHaveLength(2);
+	});
+
+	// The name is a label beside the address, not a replacement for it: the address is the part
+	// the user can check.
+	it('should show the name a program publishes for itself next to its address', () => {
+		const { getAllByTestId } = render(SolWalletConnectSignReview, {
+			props: {
+				...props,
+				instructions: [
+					{
+						kind: 'route' as const,
+						program: mockSolAddress2,
+						programName: 'jupiter',
+						children: [{ kind: 'send' as const, amount: 1_000_000n, counterparty: mockSolAddress2 }]
+					}
+				]
+			}
+		});
+
+		// The legs of the route render as instructions of their own underneath it.
+		const [route] = getAllByTestId('sol-instruction');
+
+		expect(route).toHaveTextContent('jupiter');
+		expect(route).toHaveTextContent(shortenWithMiddleEllipsis({ text: mockSolAddress2 }));
+	});
+
+	it('should show only the address of a program that publishes no name', () => {
+		const { getAllByTestId } = render(SolWalletConnectSignReview, {
+			props: {
+				...props,
+				instructions: [
+					{
+						kind: 'route' as const,
+						program: mockSolAddress2,
+						children: [{ kind: 'send' as const, amount: 1_000_000n, counterparty: mockSolAddress2 }]
+					}
+				]
+			}
+		});
+
+		const [route] = getAllByTestId('sol-instruction');
+
+		expect(route).toHaveTextContent(shortenWithMiddleEllipsis({ text: mockSolAddress2 }));
+		expect(route).not.toHaveTextContent('jupiter');
 	});
 
 	// An unchecked transfer states no decimals, so without the simulated deltas the amount would

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -182,8 +182,8 @@ describe('SolWalletConnectSignReview', () => {
 
 	// The name is a label beside the address, not a replacement for it: the address is the part
 	// the user can check.
-	it('should show the name a program publishes for itself next to its address', () => {
-		const { getAllByTestId } = render(SolWalletConnectSignReview, {
+	it('should show the name a program publishes for itself next to its address', async () => {
+		const queries = render(SolWalletConnectSignReview, {
 			props: {
 				...props,
 				instructions: [
@@ -197,15 +197,17 @@ describe('SolWalletConnectSignReview', () => {
 			}
 		});
 
+		await showOperations(queries);
+
 		// The legs of the route render as instructions of their own underneath it.
-		const [route] = getAllByTestId('sol-instruction');
+		const [route] = queries.getAllByTestId('sol-instruction');
 
 		expect(route).toHaveTextContent('jupiter');
 		expect(route).toHaveTextContent(shortenWithMiddleEllipsis({ text: mockSolAddress2 }));
 	});
 
-	it('should show only the address of a program that publishes no name', () => {
-		const { getAllByTestId } = render(SolWalletConnectSignReview, {
+	it('should show only the address of a program that publishes no name', async () => {
+		const queries = render(SolWalletConnectSignReview, {
 			props: {
 				...props,
 				instructions: [
@@ -218,7 +220,9 @@ describe('SolWalletConnectSignReview', () => {
 			}
 		});
 
-		const [route] = getAllByTestId('sol-instruction');
+		await showOperations(queries);
+
+		const [route] = queries.getAllByTestId('sol-instruction');
 
 		expect(route).toHaveTextContent(shortenWithMiddleEllipsis({ text: mockSolAddress2 }));
 		expect(route).not.toHaveTextContent('jupiter');

--- a/src/frontend/src/tests/sol/services/sol-program-name.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-program-name.services.spec.ts
@@ -1,0 +1,133 @@
+import { getAccountData } from '$sol/api/solana.api';
+import { loadSolProgramNames } from '$sol/services/sol-program-name.services';
+import { solProgramNameStore } from '$sol/stores/sol-program-name.store';
+import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
+import {
+	decodeSolProgramIdlName,
+	findSolProgramIdlAddress
+} from '$sol/utils/sol-program-idl.utils';
+import { mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
+import { get } from 'svelte/store';
+
+vi.mock('$sol/api/solana.api', () => ({
+	getAccountData: vi.fn()
+}));
+
+vi.mock('$sol/utils/sol-program-idl.utils', () => ({
+	findSolProgramIdlAddress: vi.fn(),
+	decodeSolProgramIdlName: vi.fn()
+}));
+
+describe('sol-program-name.services', () => {
+	describe('loadSolProgramNames', () => {
+		const network = 'mainnet' as const;
+
+		const route: SolInstructionSummary = { kind: 'route', program: mockSolAddress };
+		const send: SolInstructionSummary = { kind: 'send', amount: 100n };
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			solProgramNameStore.reset();
+
+			vi.mocked(findSolProgramIdlAddress).mockResolvedValue(mockSolAddress2);
+			vi.mocked(getAccountData).mockResolvedValue(new Uint8Array([1, 2, 3]));
+			vi.mocked(decodeSolProgramIdlName).mockResolvedValue('jupiter');
+		});
+
+		it('should name the program a route ran through', async () => {
+			await expect(loadSolProgramNames({ instructions: [route], network })).resolves.toStrictEqual([
+				{ ...route, programName: 'jupiter' }
+			]);
+
+			expect(findSolProgramIdlAddress).toHaveBeenCalledExactlyOnceWith({
+				programAddress: mockSolAddress
+			});
+			expect(getAccountData).toHaveBeenCalledExactlyOnceWith({
+				address: mockSolAddress2,
+				network
+			});
+		});
+
+		it('should leave an instruction that names no program untouched', async () => {
+			await expect(loadSolProgramNames({ instructions: [send], network })).resolves.toStrictEqual([
+				send
+			]);
+
+			expect(getAccountData).not.toHaveBeenCalled();
+		});
+
+		it('should ask about a program only once, even when it publishes nothing', async () => {
+			vi.mocked(getAccountData).mockResolvedValue(undefined);
+
+			await expect(loadSolProgramNames({ instructions: [route], network })).resolves.toStrictEqual([
+				route
+			]);
+			await expect(loadSolProgramNames({ instructions: [route], network })).resolves.toStrictEqual([
+				route
+			]);
+
+			expect(getAccountData).toHaveBeenCalledOnce();
+		});
+
+		it('should ask about a program only once across reviews', async () => {
+			await loadSolProgramNames({ instructions: [route], network });
+
+			await expect(loadSolProgramNames({ instructions: [route], network })).resolves.toStrictEqual([
+				{ ...route, programName: 'jupiter' }
+			]);
+
+			expect(getAccountData).toHaveBeenCalledOnce();
+		});
+
+		it('should ask about the same program once when it appears twice in one review', async () => {
+			await loadSolProgramNames({ instructions: [route, route], network });
+
+			expect(getAccountData).toHaveBeenCalledOnce();
+		});
+
+		// A program that could not answer is not the same as one that has nothing to say.
+		it('should leave a program unnamed and ask again when the read fails', async () => {
+			vi.mocked(getAccountData).mockRejectedValueOnce(new Error('rate limited'));
+
+			await expect(loadSolProgramNames({ instructions: [route], network })).resolves.toStrictEqual([
+				route
+			]);
+
+			expect(console.warn).toHaveBeenCalledOnce();
+
+			await expect(loadSolProgramNames({ instructions: [route], network })).resolves.toStrictEqual([
+				{ ...route, programName: 'jupiter' }
+			]);
+
+			expect(getAccountData).toHaveBeenCalledTimes(2);
+		});
+
+		it('should not name a program whose account is not an IDL', async () => {
+			vi.mocked(decodeSolProgramIdlName).mockResolvedValue(undefined);
+
+			await expect(loadSolProgramNames({ instructions: [route], network })).resolves.toStrictEqual([
+				route
+			]);
+		});
+
+		// The same address is a different deployment on each cluster.
+		it('should keep the names of one network out of another', async () => {
+			await loadSolProgramNames({ instructions: [route], network });
+
+			expect(get(solProgramNameStore).devnet).toBeUndefined();
+
+			vi.mocked(decodeSolProgramIdlName).mockResolvedValue('something-else');
+
+			await expect(
+				loadSolProgramNames({ instructions: [route], network: 'devnet' })
+			).resolves.toStrictEqual([{ ...route, programName: 'something-else' }]);
+		});
+
+		it('should do nothing when there are no instructions', async () => {
+			await expect(loadSolProgramNames({ instructions: [], network })).resolves.toStrictEqual([]);
+
+			expect(getAccountData).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/frontend/src/tests/sol/utils/sol-program-idl.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-program-idl.utils.spec.ts
@@ -1,0 +1,153 @@
+import { ANCHOR_IDL_ACCOUNT_DISCRIMINATOR } from '$sol/constants/sol.constants';
+import {
+	decodeSolProgramIdlName,
+	findSolProgramIdlAddress
+} from '$sol/utils/sol-program-idl.utils';
+import { deflateSync } from 'node:zlib';
+
+// The addresses below are Anchor's own derivation, checked against the accounts these programs
+// actually publish on mainnet.
+const JUPITER_PROGRAM_ADDRESS = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4';
+const JUPITER_IDL_ADDRESS = 'C88XWfp26heEmDkmfSzeXP7Fd7GQJ2j9dDTUsyiZbUTa';
+const WHIRLPOOL_PROGRAM_ADDRESS = 'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc';
+const WHIRLPOOL_IDL_ADDRESS = '2KFqE4RWoPVbvodo8vbggCFeHPS8TDvgpwp79ALMrcyn';
+
+const idlAccount = ({
+	idl,
+	discriminator = ANCHOR_IDL_ACCOUNT_DISCRIMINATOR,
+	length
+}: {
+	idl: string;
+	discriminator?: number[];
+	length?: number;
+}): Uint8Array<ArrayBuffer> => {
+	const compressed = new Uint8Array(deflateSync(Buffer.from(idl)));
+
+	const data = new Uint8Array(44 + compressed.length);
+
+	data.set(discriminator);
+	// The authority occupies bytes 8 to 39 and is not read.
+	new DataView(data.buffer).setUint32(40, length ?? compressed.length, true);
+	data.set(compressed, 44);
+
+	return data;
+};
+
+describe('sol-program-idl.utils', () => {
+	describe('findSolProgramIdlAddress', () => {
+		beforeAll(() => {
+			// The derivation hashes, which the kit refuses outside a secure context.
+			vi.stubGlobal('isSecureContext', true);
+		});
+
+		afterAll(() => {
+			vi.unstubAllGlobals();
+		});
+
+		it.each([
+			{ programAddress: JUPITER_PROGRAM_ADDRESS, idlAddress: JUPITER_IDL_ADDRESS },
+			{ programAddress: WHIRLPOOL_PROGRAM_ADDRESS, idlAddress: WHIRLPOOL_IDL_ADDRESS }
+		])(
+			'should derive the IDL address of $programAddress',
+			async ({ programAddress, idlAddress }) => {
+				await expect(findSolProgramIdlAddress({ programAddress })).resolves.toBe(idlAddress);
+			}
+		);
+	});
+
+	describe('decodeSolProgramIdlName', () => {
+		it('should read the name an Anchor 0.30 IDL keeps in its metadata', async () => {
+			const data = idlAccount({
+				idl: JSON.stringify({ metadata: { name: 'jupiter', version: '0.1.0' } })
+			});
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBe('jupiter');
+		});
+
+		it('should read the name an older IDL keeps at the top level', async () => {
+			const data = idlAccount({ idl: JSON.stringify({ name: 'whirlpool', version: '0.1.0' }) });
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBe('whirlpool');
+		});
+
+		it('should prefer the metadata name when both are present', async () => {
+			const data = idlAccount({
+				idl: JSON.stringify({ name: 'stale', metadata: { name: 'current' } })
+			});
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBe('current');
+		});
+
+		it('should return undefined for an IDL that names nothing', async () => {
+			const data = idlAccount({ idl: JSON.stringify({ metadata: { version: '0.1.0' } }) });
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+
+		it('should return undefined for an empty name', async () => {
+			const data = idlAccount({ idl: JSON.stringify({ metadata: { name: '' } }) });
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+
+		it('should return undefined for a name that is not a string', async () => {
+			const data = idlAccount({ idl: JSON.stringify({ metadata: { name: 42 } }) });
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+
+		// The account is whatever address the derivation landed on, so it has to prove it is one.
+		it('should return undefined for an account that is not an IDL', async () => {
+			const data = idlAccount({
+				idl: JSON.stringify({ metadata: { name: 'jupiter' } }),
+				discriminator: [1, 2, 3, 4, 5, 6, 7, 8]
+			});
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+
+		it('should return undefined for an account too short to hold a header', async () => {
+			await expect(
+				decodeSolProgramIdlName(new Uint8Array(ANCHOR_IDL_ACCOUNT_DISCRIMINATOR))
+			).resolves.toBeUndefined();
+		});
+
+		it('should return undefined when the length runs past the account', async () => {
+			const data = idlAccount({
+				idl: JSON.stringify({ metadata: { name: 'jupiter' } }),
+				length: 10_000
+			});
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+
+		it('should return undefined for a zero length', async () => {
+			const data = idlAccount({
+				idl: JSON.stringify({ metadata: { name: 'jupiter' } }),
+				length: 0
+			});
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+
+		it('should return undefined for bytes that do not inflate', async () => {
+			const data = new Uint8Array(64);
+			data.set(ANCHOR_IDL_ACCOUNT_DISCRIMINATOR);
+			new DataView(data.buffer).setUint32(40, 20, true);
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+
+		it('should return undefined for an IDL that is not JSON', async () => {
+			const data = idlAccount({ idl: 'not json at all' });
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+
+		it('should return undefined for an IDL that is not an object', async () => {
+			const data = idlAccount({ idl: JSON.stringify('jupiter') });
+
+			await expect(decodeSolProgramIdlName(data)).resolves.toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

A routed swap shows the address of the program it ran through and nothing else, so the review reads `JUP6Lkb...aV4` and the user has to already know what that is. There is no on-chain naming for programs, but Anchor ones publish their interface to an account derived from the program itself, and its metadata carries a name.

Checked against mainnet, seven of the ten programs a Solana WalletConnect request is most likely to hit publish one: Jupiter v6, Orca Whirlpool, Raydium CLMM, Raydium CPMM, Meteora DLMM, Pump.fun and Squads. Raydium AMM v4, Phoenix and Metaplex Token Metadata are not Anchor programs and publish nothing.

# Changes

- Derive the IDL address: seedless PDA of the program, then that as the base of a seeded address owned by it. Nothing is looked up to get there.
- Read the account and decode Anchor's layout: fixed discriminator, IDL authority, length, then zlib-compressed JSON. The name moved into `metadata` at Anchor 0.30, so both places are read.
- Cache per network and per program in a store, including the programs that publish nothing, so each is asked about once a session rather than once per transaction.
- Show the name beside the program's address on a route.

The name is the program's own claim about itself. Whoever holds the IDL authority writes it and nothing attests to it, so a hostile program can call its drain instruction whatever it likes. It is therefore a label beside the address rather than in place of it, the address stays the part the user can check, and it never promotes an instruction out of unreviewed.

Anything that is not an IDL account, does not inflate, or is not JSON returns no name. All three mean the same thing to the caller: this program does not say what it is.

The read is awaited before the modal opens, in parallel with the token metadata the review already waits for, since a name that landed afterwards would arrive too late to read. It carries the same exposure to a slow RPC as that existing read does.

# Tests

New spec for the derivation and the decode, including the two IDL addresses checked against what Jupiter and Orca actually publish on mainnet, and every way the decode declines to name a program. New spec for the service covering caching, negative caching, a failed read that is retried later, and network isolation. Cases added to the sign review spec for a route with and without a published name.

`npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` all clean; 1910 Solana tests pass.