### PR TITLE
fix(frontend): keep EVM sends working when the Gas API does not cover the chain

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeeContext.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeeContext.svelte
@@ -159,11 +159,13 @@
 			// `fetchedFeeData` prices the tier they have already moved away from. Re-read the choice
 			// now and take that tier out of the sample we just received. The re-pricing effect cannot
 			// rescue this: it tracks the choice alone, and the choice has not changed since it ran.
-			const feeData = {
-				...fetchedFeeData,
-				...priorities.perPriority[priority],
-				baseFeePerGas: priorities.baseFeePerGas
-			};
+			const feeData = nonNullish(priorities)
+				? {
+						...fetchedFeeData,
+						...priorities.perPriority[priority],
+						baseFeePerGas: priorities.baseFeePerGas
+					}
+				: fetchedFeeData;
 
 			const { safeEstimateGas, estimateGas } = provider;
 

--- a/src/frontend/src/eth/services/fee.services.ts
+++ b/src/frontend/src/eth/services/fee.services.ts
@@ -32,6 +32,7 @@ import type { TransactionFeeData } from '$lib/types/transaction';
 import { maxBigInt } from '$lib/utils/bigint.utils';
 import { consoleWarn } from '$lib/utils/console.utils';
 import { isNetworkIdICP } from '$lib/utils/network.utils';
+import { nonNullish } from '@dfinity/utils';
 
 const BSC_CHAIN_IDS: EthereumChainId[] = [BSC_MAINNET_NETWORK.chainId, BSC_TESTNET_NETWORK.chainId];
 
@@ -65,6 +66,23 @@ const getGasFeeFloor = (
 				maxPriorityFeePerGas: BSC_MIN_MAX_PRIORITY_FEE_PER_GAS
 			}
 		: { maxFeePerGas: null, maxPriorityFeePerGas: null };
+
+// The Gas API is a best-effort enhancement: it does not cover every chain we support
+// (Arbitrum Sepolia answers 400 "'421614' is not a supported chain id.") and it can be down.
+// Everything it adds sits on top of the provider's own quote, so losing it only makes the estimate
+// coarser and must never block a send. Without the base fee, `estimatedGasFee` falls back to the
+// max fee, which overstates the cost rather than hiding it.
+const getSuggestedFeeDataBestEffort = async (
+	chainId: EthereumChainId
+): Promise<EthFeePriorities | undefined> => {
+	const { getSuggestedFeeData } = new InfuraGasRest(chainId);
+
+	try {
+		return await getSuggestedFeeData();
+	} catch (err: unknown) {
+		consoleWarn(err);
+	}
+};
 
 export const getEthFeeData = ({
 	to,
@@ -161,7 +179,9 @@ export const getEthFeeDataWithProvider = async ({
 	priority?: EthFeePriority;
 }): Promise<{
 	feeData: Omit<TransactionFeeData, 'gas'>;
-	priorities: EthFeePriorities;
+	// Undefined where the Gas API does not cover the chain: the provider's quote is then the only
+	// sample there is, so there are no priorities to choose between.
+	priorities: EthFeePriorities | undefined;
 	provider: InfuraProvider;
 	params: GetFeeData;
 }> => {
@@ -175,9 +195,7 @@ export const getEthFeeDataWithProvider = async ({
 
 	const { maxFeePerGas, maxPriorityFeePerGas, ...feeDataRest } = await getFeeData();
 
-	const { getSuggestedFeeData } = new InfuraGasRest(chainId);
-
-	const { baseFeePerGas, perPriority } = await getSuggestedFeeData();
+	const suggested = await getSuggestedFeeDataBestEffort(chainId);
 
 	// Flat, priority-independent and not refunded: it belongs to the transaction, not to a tier.
 	const l1Fee = await getL1DataFee({ chainId, provider });
@@ -201,19 +219,24 @@ export const getEthFeeDataWithProvider = async ({
 			) ?? null
 	});
 
-	const priorities: EthFeePriorities = {
-		baseFeePerGas,
-		perPriority: {
-			[EthFeePriority.SLOW]: applyFloors(perPriority[EthFeePriority.SLOW]),
-			[EthFeePriority.STANDARD]: applyFloors(perPriority[EthFeePriority.STANDARD]),
-			[EthFeePriority.FAST]: applyFloors(perPriority[EthFeePriority.FAST])
-		}
-	};
+	const priorities: EthFeePriorities | undefined = nonNullish(suggested)
+		? {
+				baseFeePerGas: suggested.baseFeePerGas,
+				perPriority: {
+					[EthFeePriority.SLOW]: applyFloors(suggested.perPriority[EthFeePriority.SLOW]),
+					[EthFeePriority.STANDARD]: applyFloors(suggested.perPriority[EthFeePriority.STANDARD]),
+					[EthFeePriority.FAST]: applyFloors(suggested.perPriority[EthFeePriority.FAST])
+				}
+			}
+		: undefined;
 
+	// With no sample to price the tiers against, the floors still apply: they are what the chain
+	// accepts, not what the Gas API suggested.
 	const feeData = {
 		...feeDataRest,
-		...priorities.perPriority[priority],
-		baseFeePerGas,
+		...(priorities?.perPriority[priority] ??
+			applyFloors({ maxFeePerGas: null, maxPriorityFeePerGas: null })),
+		baseFeePerGas: priorities?.baseFeePerGas ?? null,
 		l1Fee
 	};
 

--- a/src/frontend/src/tests/eth/services/fee.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/fee.services.spec.ts
@@ -1,3 +1,4 @@
+import { ARBITRUM_SEPOLIA_NETWORK } from '$env/networks/networks-evm/networks.evm.arbitrum.env';
 import {
 	BASE_NETWORK,
 	BASE_SEPOLIA_NETWORK
@@ -8,6 +9,7 @@ import {
 } from '$env/networks/networks-evm/networks.evm.bsc.env';
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import * as infuraMod from '$eth/providers/infura.providers';
+import type * as InfuraRestModule from '$eth/rest/infura.rest';
 import { InfuraGasRest } from '$eth/rest/infura.rest';
 import { getEthFeeDataWithProvider } from '$eth/services/fee.services';
 import type { EthFeePerGas, EthFeePriorities } from '$eth/types/fee';
@@ -276,6 +278,80 @@ describe('eth-fee-data.services', () => {
 			expect(result.provider).toHaveProperty('getFeeData');
 			expect(result.provider).toHaveProperty('safeEstimateGas');
 			expect(result.provider).toHaveProperty('estimateGas');
+		});
+
+		describe('when the Gas API answers with a non-OK response', () => {
+			// The MetaMask Gas API does not cover every chain we support: Arbitrum Sepolia
+			// (chain id 421614) answers 400 "'421614' is not a supported chain id.".
+			// Everything it adds sits on top of the provider's own quote, so losing it has to
+			// degrade the estimate rather than block the send.
+			const { chainId } = ARBITRUM_SEPOLIA_NETWORK;
+
+			beforeEach(async () => {
+				vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false } as unknown as Response));
+
+				const { InfuraGasRest: ActualInfuraGasRest } =
+					await vi.importActual<typeof InfuraRestModule>('$eth/rest/infura.rest');
+
+				InfuraGasRest.prototype.getSuggestedFeeData = new ActualInfuraGasRest(
+					chainId
+				).getSuggestedFeeData;
+			});
+
+			afterEach(() => {
+				vi.unstubAllGlobals();
+			});
+
+			it('should fall back to the provider fee data instead of throwing', async () => {
+				const result = await getEthFeeDataWithProvider({
+					networkId: ARBITRUM_SEPOLIA_NETWORK.id,
+					chainId,
+					from: fromAddr,
+					to: toAddr
+				});
+
+				// No base fee either, so `estimatedGasFee` falls back to the max fee.
+				expect(result.feeData).toEqual({
+					gasPrice: null,
+					maxFeePerGas: 10n,
+					maxPriorityFeePerGas: 5n,
+					baseFeePerGas: null
+				});
+			});
+
+			it('should offer no priorities to choose between', async () => {
+				const { priorities } = await getEthFeeDataWithProvider({
+					networkId: ARBITRUM_SEPOLIA_NETWORK.id,
+					chainId,
+					from: fromAddr,
+					to: toAddr
+				});
+
+				expect(priorities).toBeUndefined();
+			});
+
+			it('should still apply the BSC fee floor', async () => {
+				vi.spyOn(infuraMod, 'infuraProviders').mockReturnValue({
+					getFeeData: async () =>
+						await new Promise((resolve) =>
+							resolve({
+								gasPrice: null,
+								maxFeePerGas: 500_000_000n,
+								maxPriorityFeePerGas: 100_000_000n
+							})
+						)
+				} as unknown as ReturnType<typeof infuraMod.infuraProviders>);
+
+				const result = await getEthFeeDataWithProvider({
+					networkId: BSC_MAINNET_NETWORK.id,
+					chainId: BSC_MAINNET_NETWORK.chainId,
+					from: fromAddr,
+					to: toAddr
+				});
+
+				expect(result.feeData.maxFeePerGas).toBe(BSC_MIN_MAX_FEE_PER_GAS);
+				expect(result.feeData.maxPriorityFeePerGas).toBe(BSC_MIN_MAX_PRIORITY_FEE_PER_GAS);
+			});
 		});
 
 		describe('priority selection', () => {


### PR DESCRIPTION
# Motivation

The MetaMask Gas API does not support every chain we offer: Arbitrum Sepolia (421614) answers `400 "'421614' is not a supported chain id."`. `InfuraGasRest.getSuggestedFeeData` threw on that, the throw reached `EthFeeContext`, and the send was left with no fee at all: a "Cannot fetch gas fee" toast, five backoff retries that could never succeed, then "Gas fees not defined" on the final step.

The Gas API is an enhancement, not a source of truth. `provider.getFeeData()` already supplies `maxFeePerGas` and `maxPriorityFeePerGas`.

# Changes

- `getSuggestedFeeDataBestEffort` warns and returns undefined when the Gas API call fails.
- `getEthFeeDataWithProvider` then returns no `priorities` and prices `feeData` through the same `applyFloors` helper, so the provider quote and the BSC floor still apply.
- `EthFeeContext` guards its `priorities.perPriority[priority]` spread.

No priorities is the honest answer, not a special case: without a Gas API sample there is a single quote, so three identical tiers would be a lie. `baseFeePerGas` falls to null, where `estimatedGasFee` already falls back to the max fee.

# Tests

Three regression tests in `fee.services.spec.ts`, all driving the real `InfuraGasRest` with `fetch` stubbed to a non-OK response: the provider fee data survives, no priorities are offered, and the BSC floor still wins.
