### PR TITLE
fix(frontend): issue with switching swap source token

### DIFF
--- a/src/frontend/src/btc/components/swap/SwapBtcForm.svelte
+++ b/src/frontend/src/btc/components/swap/SwapBtcForm.svelte
@@ -123,23 +123,29 @@
 	};
 
 	$effect(() => {
-		if (nonNullish($sourceToken) && nonNullish(swapAmount)) {
-			// Not `parseToken`: the amount outlives a source-token change, so it can carry more
-			// precision than the new token has decimals. Throwing here would abort the effect
-			// flush mid-update and leave the modal unresponsive, so an amount the token cannot
-			// represent is surfaced as a validation error instead.
-			const parsedAmount = tryParseToken({
-				value: `${swapAmount}`,
-				unitName: $sourceToken.decimals
-			});
+		// The error has to go when the amount does: `selectToken` drops `swapAmount` on a
+		// source-token change, and the user can empty the input. `errorType` is passed to
+		// `SwapForm` one-way here — unlike `SwapIcpForm`, which binds it — so nothing downstream
+		// can clear it, and a stale error would hold the form invalid against a blank amount.
+		if (isNullish($sourceToken) || isNullish(swapAmount)) {
+			errorType = undefined;
 
-			const newErrorType = isNullish(parsedAmount)
-				? 'invalid-amount'
-				: customValidate(parsedAmount);
+			return;
+		}
 
-			if (newErrorType !== errorType) {
-				errorType = newErrorType;
-			}
+		// Not `parseToken`: the amount outlives a source-token change, so it can carry more
+		// precision than the new token has decimals. Throwing here would abort the effect
+		// flush mid-update and leave the modal unresponsive, so an amount the token cannot
+		// represent is surfaced as a validation error instead.
+		const parsedAmount = tryParseToken({
+			value: `${swapAmount}`,
+			unitName: $sourceToken.decimals
+		});
+
+		const newErrorType = isNullish(parsedAmount) ? 'invalid-amount' : customValidate(parsedAmount);
+
+		if (newErrorType !== errorType) {
+			errorType = newErrorType;
 		}
 	});
 </script>

--- a/src/frontend/src/btc/components/swap/SwapBtcForm.svelte
+++ b/src/frontend/src/btc/components/swap/SwapBtcForm.svelte
@@ -24,7 +24,7 @@
 	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
-	import { parseToken } from '$lib/utils/parse.utils';
+	import { parseToken, tryParseToken } from '$lib/utils/parse.utils';
 
 	interface Props {
 		swapAmount: OptionAmount;
@@ -124,12 +124,18 @@
 
 	$effect(() => {
 		if (nonNullish($sourceToken) && nonNullish(swapAmount)) {
-			const parsedAmount = parseToken({
+			// Not `parseToken`: the amount outlives a source-token change, so it can carry more
+			// precision than the new token has decimals. Throwing here would abort the effect
+			// flush mid-update and leave the modal unresponsive, so an amount the token cannot
+			// represent is surfaced as a validation error instead.
+			const parsedAmount = tryParseToken({
 				value: `${swapAmount}`,
 				unitName: $sourceToken.decimals
 			});
 
-			const newErrorType = customValidate(parsedAmount);
+			const newErrorType = isNullish(parsedAmount)
+				? 'invalid-amount'
+				: customValidate(parsedAmount);
 
 			if (newErrorType !== errorType) {
 				errorType = newErrorType;

--- a/src/frontend/src/eth/components/swap/SwapEthForm.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthForm.svelte
@@ -23,7 +23,7 @@
 	import type { Token } from '$lib/types/token';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { formatToken } from '$lib/utils/format.utils';
-	import { parseToken } from '$lib/utils/parse.utils';
+	import { parseToken, tryParseToken } from '$lib/utils/parse.utils';
 
 	interface Props {
 		swapAmount: OptionAmount;
@@ -125,12 +125,19 @@
 
 	$effect(() => {
 		if (nonNullish($sourceToken) && nonNullish(swapAmount)) {
-			const parsedAmount = parseToken({
+			// Not `parseToken`: the amount outlives a source-token change, so it can carry more
+			// precision than the new token has decimals. Throwing here would abort the effect
+			// flush mid-update and leave the modal unresponsive, so an amount the token cannot
+			// represent is surfaced as a validation error instead.
+			const parsedAmount = tryParseToken({
 				value: `${swapAmount}`,
 				unitName: $sourceToken.decimals
 			});
 
-			const newErrorType = customValidate(parsedAmount);
+			const newErrorType = isNullish(parsedAmount)
+				? 'invalid-amount'
+				: customValidate(parsedAmount);
+
 			if (newErrorType !== errorType) {
 				errorType = newErrorType;
 			}

--- a/src/frontend/src/eth/components/swap/SwapEthForm.svelte
+++ b/src/frontend/src/eth/components/swap/SwapEthForm.svelte
@@ -124,23 +124,29 @@
 	};
 
 	$effect(() => {
-		if (nonNullish($sourceToken) && nonNullish(swapAmount)) {
-			// Not `parseToken`: the amount outlives a source-token change, so it can carry more
-			// precision than the new token has decimals. Throwing here would abort the effect
-			// flush mid-update and leave the modal unresponsive, so an amount the token cannot
-			// represent is surfaced as a validation error instead.
-			const parsedAmount = tryParseToken({
-				value: `${swapAmount}`,
-				unitName: $sourceToken.decimals
-			});
+		// The error has to go when the amount does: `selectToken` drops `swapAmount` on a
+		// source-token change, and the user can empty the input. `errorType` is passed to
+		// `SwapForm` one-way here — unlike `SwapIcpForm`, which binds it — so nothing downstream
+		// can clear it, and a stale error would hold the form invalid against a blank amount.
+		if (isNullish($sourceToken) || isNullish(swapAmount)) {
+			errorType = undefined;
 
-			const newErrorType = isNullish(parsedAmount)
-				? 'invalid-amount'
-				: customValidate(parsedAmount);
+			return;
+		}
 
-			if (newErrorType !== errorType) {
-				errorType = newErrorType;
-			}
+		// Not `parseToken`: the amount outlives a source-token change, so it can carry more
+		// precision than the new token has decimals. Throwing here would abort the effect
+		// flush mid-update and leave the modal unresponsive, so an amount the token cannot
+		// represent is surfaced as a validation error instead.
+		const parsedAmount = tryParseToken({
+			value: `${swapAmount}`,
+			unitName: $sourceToken.decimals
+		});
+
+		const newErrorType = isNullish(parsedAmount) ? 'invalid-amount' : customValidate(parsedAmount);
+
+		if (newErrorType !== errorType) {
+			errorType = newErrorType;
 		}
 	});
 </script>

--- a/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
@@ -31,6 +31,7 @@
 	import type { SwapMappedResult, SwapSelectTokenType } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
 	import type { WizardModal, WizardStep, WizardSteps } from '$lib/types/wizard';
+	import { tryParseToken } from '$lib/utils/parse.utils';
 	import { networksWithSupport } from '$lib/utils/swap-tokens-filter.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
 
@@ -216,6 +217,18 @@
 
 	const selectToken = (token: Token) => {
 		if (selectTokenType === 'source') {
+			// The amount survives a source-token change, but the new token may not be able to
+			// represent its precision — a Max on BTC (8 decimals) followed by a switch to USDC (6)
+			// leaves an amount no ledger call could express. `tryParseToken` returning `undefined`
+			// is exactly that signal, so drop the amount here rather than carry one the forms can
+			// only reject, alongside the quote `enterTokenList` has already reset.
+			if (
+				nonNullish(swapAmount) &&
+				isNullish(tryParseToken({ value: `${swapAmount}`, unitName: token.decimals }))
+			) {
+				swapAmount = undefined;
+			}
+
 			setSourceToken(token);
 
 			setFilterNetwork(token.network);

--- a/src/frontend/src/sol/components/swap/SwapSolForm.svelte
+++ b/src/frontend/src/sol/components/swap/SwapSolForm.svelte
@@ -96,23 +96,29 @@
 	};
 
 	$effect(() => {
-		if (nonNullish($sourceToken) && nonNullish(swapAmount)) {
-			// Not `parseToken`: the amount outlives a source-token change, so it can carry more
-			// precision than the new token has decimals. Throwing here would abort the effect
-			// flush mid-update and leave the modal unresponsive, so an amount the token cannot
-			// represent is surfaced as a validation error instead.
-			const parsedAmount = tryParseToken({
-				value: `${swapAmount}`,
-				unitName: $sourceToken.decimals
-			});
+		// The error has to go when the amount does: `selectToken` drops `swapAmount` on a
+		// source-token change, and the user can empty the input. `errorType` is passed to
+		// `SwapForm` one-way here — unlike `SwapIcpForm`, which binds it — so nothing downstream
+		// can clear it, and a stale error would hold the form invalid against a blank amount.
+		if (isNullish($sourceToken) || isNullish(swapAmount)) {
+			errorType = undefined;
 
-			const newErrorType = isNullish(parsedAmount)
-				? 'invalid-amount'
-				: customValidate(parsedAmount);
+			return;
+		}
 
-			if (newErrorType !== errorType) {
-				errorType = newErrorType;
-			}
+		// Not `parseToken`: the amount outlives a source-token change, so it can carry more
+		// precision than the new token has decimals. Throwing here would abort the effect
+		// flush mid-update and leave the modal unresponsive, so an amount the token cannot
+		// represent is surfaced as a validation error instead.
+		const parsedAmount = tryParseToken({
+			value: `${swapAmount}`,
+			unitName: $sourceToken.decimals
+		});
+
+		const newErrorType = isNullish(parsedAmount) ? 'invalid-amount' : customValidate(parsedAmount);
+
+		if (newErrorType !== errorType) {
+			errorType = newErrorType;
 		}
 	});
 </script>

--- a/src/frontend/src/sol/components/swap/SwapSolForm.svelte
+++ b/src/frontend/src/sol/components/swap/SwapSolForm.svelte
@@ -16,7 +16,7 @@
 	import type { TokenActionErrorType } from '$lib/types/token-action';
 	import { formatToken } from '$lib/utils/format.utils';
 	import { isNetworkIdSOLDevnet, isNetworkIdSOLLocal } from '$lib/utils/network.utils';
-	import { parseToken } from '$lib/utils/parse.utils';
+	import { parseToken, tryParseToken } from '$lib/utils/parse.utils';
 	import SwapSolFees from '$sol/components/swap/SwapSolFees.svelte';
 	import { SOL_FEE_CONTEXT_KEY, type FeeContext } from '$sol/stores/sol-fee.store';
 	import { isTokenSpl } from '$sol/utils/spl.utils';
@@ -97,12 +97,19 @@
 
 	$effect(() => {
 		if (nonNullish($sourceToken) && nonNullish(swapAmount)) {
-			const parsedAmount = parseToken({
+			// Not `parseToken`: the amount outlives a source-token change, so it can carry more
+			// precision than the new token has decimals. Throwing here would abort the effect
+			// flush mid-update and leave the modal unresponsive, so an amount the token cannot
+			// represent is surfaced as a validation error instead.
+			const parsedAmount = tryParseToken({
 				value: `${swapAmount}`,
 				unitName: $sourceToken.decimals
 			});
 
-			const newErrorType = customValidate(parsedAmount);
+			const newErrorType = isNullish(parsedAmount)
+				? 'invalid-amount'
+				: customValidate(parsedAmount);
+
 			if (newErrorType !== errorType) {
 				errorType = newErrorType;
 			}


### PR DESCRIPTION
# Motivation

Changing the source token after clicking max button could crash the Swap modal and leave it stuck — no close button, no Cancel, no Escape. Only a page reload recovered it.

Steps to reproduce:
1. Open Swap, pick BTC as source and ckBTC as destination.
2. Press **Max** — this is what makes it deterministic, since Max fills the full-precision balance (`0.00031673`, 8 decimals).
3. Wait for the offer.
4. Change the source token to ETH USDC (6 decimals).

The amount is not reset when the source token changes, so an 8-decimal value is left under a 6-decimal token. `SwapEthForm` then parses it with the new token's decimals via `parseToken`, a raw `ethers.parseUnits`, which throws an error.


# Changes

Two independent layers, both needed:

- **Guard** — `SwapEthForm`, `SwapBtcForm` and `SwapSolForm` now parse with `tryParseToken` and surface `undefined` as the existing `'invalid-amount'` error type instead of throwing. Nothing can abort the effect flush any more, so the modal always stays closable. This is the idiom `SwapIcpForm` and `TokenInputContent` already use.
- **Clear** — `SwapModalWizardSteps.selectToken()` drops `swapAmount` on a source change when the new token cannot represent it. `tryParseToken` returning `undefined` *is* that signal, so the check reuses the same primitive as the guard rather than introducing a rounding rule of its own. It sits alongside the `swapAmountsStore.reset()` that `enterTokenList()` already does, so the stale amount and the stale quote are discarded together.
