### PR TITLE
feat(frontend): say what a closed Solana account hands back

### DIFF
--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "الحالة",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Stav",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Status",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "Swap route via",
 			"instruction_rent": "rent $amount SOL",
 			"instruction_rent_returned": "rent returned to your wallet",
+			"instruction_returned": "$amount SOL returned to your wallet",
 			"instruction_own_account": "your account",
 			"raw_value": "Raw value",
 			"status": "Status",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Estado",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Statut",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "स्थिति",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Stato",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "ステータス",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "상태",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Status",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Status",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Статус",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "Trạng thái",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2004,6 +2004,7 @@
 			"instruction_route": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
+			"instruction_returned": "",
 			"instruction_own_account": "",
 			"raw_value": "",
 			"status": "状态",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1677,6 +1677,7 @@ interface I18nTransaction {
 		instruction_route: string;
 		instruction_rent: string;
 		instruction_rent_returned: string;
+		instruction_returned: string;
 		instruction_own_account: string;
 		raw_value: string;
 		status: string;

--- a/src/frontend/src/sol/services/sol-simulation.services.ts
+++ b/src/frontend/src/sol/services/sol-simulation.services.ts
@@ -78,6 +78,13 @@ const simulate = async ({
 		addressToToken
 	});
 
+	// The lamports each account holds going in, so a close can say what it hands back.
+	const accountLamports = addresses.reduce<Record<SolAddress, bigint>>((acc, account, index) => {
+		const lamports = preAccounts[index]?.lamports;
+
+		return nonNullish(lamports) ? { ...acc, [account]: lamports } : acc;
+	}, {});
+
 	// The kit instructions are not parsed, so they contribute nothing themselves; iterating them is
 	// what attaches each simulated nested call to the instruction that made it.
 	const instructions = mapSolInstructionSummaries({
@@ -87,7 +94,8 @@ const simulate = async ({
 			instructions: [...inner]
 		})),
 		ownedAddresses: [address, ...ownedAddresses],
-		addressToToken
+		addressToToken,
+		accountLamports
 	});
 
 	// The message read on its own, without the nested calls the run reveals: a second account of

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -15,6 +15,7 @@ import {
 	loadSolUserTransactions,
 	saveSolFinalizedTransactions
 } from '$sol/services/sol-user-transactions.services';
+import { loadSplTokenMetadata } from '$sol/services/spl-token-metadata.services';
 import {
 	solTransactionsStore,
 	type SolCertifiedTransaction
@@ -173,6 +174,14 @@ export const fetchSolTransactionsForSignature = async ({
 		...(nonNullish(ataAddress) ? [ataAddress] : [])
 	];
 
+	// What each account held going in, so a close can say what it hands back: the instruction
+	// itself states no amount, and for a wrapped SOL account it is the wrapped SOL too.
+	const accountLamports = parsedAccountKeys.reduce<Record<SolAddress, bigint>>(
+		(acc, { pubkey }, index) =>
+			index < (preBalances ?? []).length ? { ...acc, [pubkey]: (preBalances ?? [])[index] } : acc,
+		{}
+	);
+
 	const instructionSummaries = mapSolInstructionSummaries({
 		instructions: [...instructions],
 		innerInstructions: [...putativeInnerInstructions].map(({ index, instructions: inner }) => ({
@@ -180,7 +189,8 @@ export const fetchSolTransactionsForSignature = async ({
 			instructions: [...inner]
 		})),
 		ownedAddresses,
-		addressToToken
+		addressToToken,
+		accountLamports
 	});
 
 	const netChanges = mapSolNetBalanceChanges({
@@ -199,6 +209,13 @@ export const fetchSolTransactionsForSignature = async ({
 	if (instructionSummaries.length === 0 && netChanges.length === 0) {
 		return [];
 	}
+
+	// Name the mints this record mentions. Best effort: an unnamed token still renders, and the
+	// loader skips mints it has already asked about, so a busy wallet does not re-ask per page.
+	await loadSplTokenMetadata({
+		tokenAddresses: netChanges.map(({ tokenAddress }) => tokenAddress).filter(nonNullish),
+		network
+	});
 
 	const summary = deriveSolTransactionSummary({
 		netChanges,

--- a/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
@@ -1,3 +1,4 @@
+import { SOLANA_DEFAULT_DECIMALS } from '$env/tokens/tokens.sol.env';
 import { ZERO } from '$lib/constants/app.constants';
 import { absBigInt } from '$lib/utils/bigint.utils';
 import { formatToken } from '$lib/utils/format.utils';
@@ -239,7 +240,7 @@ export const formatSolTransactionSummary = ({
  * stays a renderer. The children of a route are the caller's to indent, not this function's.
  */
 export const formatSolInstructionSummary = ({
-	instruction: { kind, amount: value, tokenAddress, decimals, counterparty, own, rent },
+	instruction: { kind, amount: value, tokenAddress, decimals, counterparty, own, rent, returned },
 	i18n,
 	symbolOf,
 	decimalsOf
@@ -286,10 +287,22 @@ export const formatSolInstructionSummary = ({
 		};
 	}
 
+	// Closing hands back the account's whole balance, which for a wrapped SOL account is the rent
+	// plus the SOL that was wrapped. Saying "rent" for that understates it by whatever was wrapped.
+	const returnedDetail = nonNullish(returned)
+		? replacePlaceholders(i18n.transaction.text.instruction_returned, {
+				$amount: formatToken({
+					value: returned,
+					unitName: SOLANA_DEFAULT_DECIMALS,
+					displayDecimals: SOLANA_DEFAULT_DECIMALS
+				})
+			})
+		: i18n.transaction.text.instruction_rent_returned;
+
 	if (kind === 'unwrap') {
 		return {
 			text: i18n.transaction.text.instruction_unwrap,
-			detail: i18n.transaction.text.instruction_rent_returned
+			detail: returnedDetail
 		};
 	}
 
@@ -309,7 +322,7 @@ export const formatSolInstructionSummary = ({
 	if (kind === 'closeTokenAccount') {
 		return {
 			text: i18n.transaction.text.instruction_close_account,
-			detail: i18n.transaction.text.instruction_rent_returned
+			detail: returnedDetail
 		};
 	}
 

--- a/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
@@ -1,9 +1,12 @@
+import { SOLANA_DEFAULT_DECIMALS } from '$env/tokens/tokens.sol.env';
 import { ZERO } from '$lib/constants/app.constants';
+import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
 import type { SolTransactionSummary } from '$sol/types/sol-transaction-summary';
 import { mapSolInstructionSummaries } from '$sol/utils/sol-instruction-summary.utils';
 import { mapSolNetBalanceChanges } from '$sol/utils/sol-net-changes.utils';
 import {
 	deriveSolTransactionSummary,
+	formatSolInstructionSummary,
 	formatSolTransactionSummary
 } from '$sol/utils/sol-transaction-summary.utils';
 import en from '$tests/mocks/i18n.mock';
@@ -172,6 +175,36 @@ describe('sol-transaction-summary.utils', () => {
 
 		it('should fall back to a word for a transaction it cannot reduce', () => {
 			expect(format({ kind: 'other' })).toBe(en.transaction.text.kind_other);
+		});
+	});
+
+	describe('formatSolInstructionSummary', () => {
+		const detailOf = (instruction: SolInstructionSummary): string | undefined =>
+			formatSolInstructionSummary({
+				instruction,
+				i18n: en,
+				symbolOf: (tokenAddress) => tokenAddress ?? 'SOL',
+				decimalsOf: () => SOLANA_DEFAULT_DECIMALS
+			}).detail;
+
+		// Closing hands back the account's whole balance. For a wrapped SOL account that is the
+		// rent plus the SOL that was wrapped, so calling it rent understates it by the wrapping.
+		it('should say what a close hands back when the amount is known', () => {
+			expect(detailOf({ kind: 'closeTokenAccount', returned: 5_002_039_280n })).toBe(
+				'5.00203928 SOL returned to your wallet'
+			);
+		});
+
+		it('should fall back to naming the rent when the amount is not known', () => {
+			expect(detailOf({ kind: 'closeTokenAccount' })).toBe(
+				en.transaction.text.instruction_rent_returned
+			);
+		});
+
+		it('should say the same of an unwrap, which is a close', () => {
+			expect(detailOf({ kind: 'unwrap', returned: 2_039_280n })).toBe(
+				'0.00203928 SOL returned to your wallet'
+			);
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Closing a token account hands back its whole balance. The derivation already works that out, but neither caller passed it the balances each account held going in, so the amount was never available and every close read `rent returned to your wallet` regardless of what it returned.

For a wrapped SOL account that balance is the rent plus the SOL that was wrapped. Unwrapping five SOL therefore claimed to hand back two thousandths of one.

# Changes

Both callers now pass the balances: the confirmed transaction from the pre-balances the RPC returns, and the simulated message from the accounts read before the run.

The sentence names the amount when it is known, and falls back to naming the rent when it is not, since a close whose balance we could not read still returns the rent.

# Tests

A close and an unwrap each state their amount, and a close without one still names the rent. The first two fail if the sentence goes back to naming the rent unconditionally.