### PR TITLE
feat(frontend): number the mints the transaction modal cannot name

### DIFF
--- a/src/frontend/src/sol/components/transactions/SolInstructionsList.svelte
+++ b/src/frontend/src/sol/components/transactions/SolInstructionsList.svelte
@@ -6,10 +6,15 @@
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
 	import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
 	import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
 	import { solAccountExplorerUrl } from '$sol/utils/sol-explorer.utils';
-	import { formatSolInstructionSummary } from '$sol/utils/sol-transaction-summary.utils';
+	import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
+	import {
+		flattenInstructions,
+		formatSolInstructionSummary
+	} from '$sol/utils/sol-transaction-summary.utils';
 	import { findEnabledSplToken } from '$sol/utils/spl.utils';
 
 	interface Props {
@@ -29,10 +34,27 @@
 			networkId: token.network.id
 		});
 
+	// The mints this list mentions, so a placeholder is numbered against the others it stands
+	// with. A list naming two mints "Unknown token" twice says less than their addresses would.
+	let unknownTokenAddresses = $derived(
+		solUnknownTokenAddresses({
+			tokenAddresses: flattenInstructions(instructions).map(({ tokenAddress }) => tokenAddress),
+			tokens: $enabledSplTokens,
+			networkId: token.network.id,
+			metadata: $splTokenMetadataStore
+		})
+	);
+
 	const symbolOf = (tokenAddress: string | undefined): string =>
-		isNullish(tokenAddress)
-			? SOLANA_TOKEN.symbol
-			: (splToken(tokenAddress)?.symbol ?? $i18n.transaction.text.unknown_token);
+		solTokenSymbol({
+			tokenAddress,
+			tokens: $enabledSplTokens,
+			networkId: token.network.id,
+			metadata: $splTokenMetadataStore,
+			unknownTokenAddresses,
+			unknownTokenLabel: $i18n.transaction.text.unknown_token,
+			nativeSymbol: SOLANA_TOKEN.symbol
+		});
 
 	const decimalsOf = (tokenAddress: string | undefined): number =>
 		isNullish(tokenAddress)

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -28,9 +28,11 @@
 	import { isNetworkSolana } from '$lib/utils/network.utils';
 	import SolInstructionsList from '$sol/components/transactions/SolInstructionsList.svelte';
 	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 	import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
 	import { solAccountExplorerUrl } from '$sol/utils/sol-explorer.utils';
+	import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
 	import { formatSolTransactionSummary } from '$sol/utils/sol-transaction-summary.utils';
 	import { findEnabledSplToken } from '$sol/utils/spl.utils';
 
@@ -69,10 +71,27 @@
 				})
 			: undefined;
 
+	// The mints this modal mentions, so a placeholder is numbered against the others beside it and
+	// against the same list the instruction tab counts off.
+	let unknownTokenAddresses = $derived(
+		solUnknownTokenAddresses({
+			tokenAddresses: (netChanges ?? []).map(({ tokenAddress }) => tokenAddress),
+			tokens: $enabledSplTokens,
+			networkId: token?.network.id ?? SOLANA_TOKEN.network.id,
+			metadata: $splTokenMetadataStore
+		})
+	);
+
 	const symbolOf = (tokenAddress: string | undefined): string =>
-		isNullish(tokenAddress)
-			? SOLANA_TOKEN.symbol
-			: (splToken(tokenAddress)?.symbol ?? $i18n.transaction.text.unknown_token);
+		solTokenSymbol({
+			tokenAddress,
+			tokens: $enabledSplTokens,
+			networkId: token?.network.id ?? SOLANA_TOKEN.network.id,
+			metadata: $splTokenMetadataStore,
+			unknownTokenAddresses,
+			unknownTokenLabel: $i18n.transaction.text.unknown_token,
+			nativeSymbol: SOLANA_TOKEN.symbol
+		});
 
 	const decimalsOf = (change: SolNetBalanceChange): number =>
 		change.decimals ??

--- a/src/frontend/src/tests/sol/components/transactions/SolInstructionsList.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolInstructionsList.spec.ts
@@ -1,0 +1,48 @@
+import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import SolInstructionsList from '$sol/components/transactions/SolInstructionsList.svelte';
+import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
+import en from '$tests/mocks/i18n.mock';
+import { mockSolAddress2 } from '$tests/mocks/sol.mock';
+import { render } from '@testing-library/svelte';
+
+describe('SolInstructionsList', () => {
+	const send = (tokenAddress: string): SolInstructionSummary => ({
+		kind: 'send',
+		amount: 1_000_000n,
+		decimals: 6,
+		tokenAddress,
+		counterparty: mockSolAddress2
+	});
+
+	// Two lines both reading "Unknown token" say less than the addresses would, since nothing
+	// tells them apart. The row and the modal already count them off; this list did not.
+	it('should number the mints it cannot name', () => {
+		const { getByTestId } = render(SolInstructionsList, {
+			props: {
+				instructions: [send('first-unnamed'), send('second-unnamed')],
+				token: SOLANA_TOKEN
+			}
+		});
+
+		expect(getByTestId('sol-instructions-list')).toHaveTextContent(
+			`${en.transaction.text.unknown_token} 1`
+		);
+		expect(getByTestId('sol-instructions-list')).toHaveTextContent(
+			`${en.transaction.text.unknown_token} 2`
+		);
+	});
+
+	// One of a kind needs no number: there is nothing to tell it apart from.
+	it('should leave a lone unnamed mint unnumbered', () => {
+		const { getByTestId } = render(SolInstructionsList, {
+			props: { instructions: [send('only-unnamed')], token: SOLANA_TOKEN }
+		});
+
+		expect(getByTestId('sol-instructions-list')).toHaveTextContent(
+			en.transaction.text.unknown_token
+		);
+		expect(getByTestId('sol-instructions-list')).not.toHaveTextContent(
+			`${en.transaction.text.unknown_token} 1`
+		);
+	});
+});

--- a/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransactionModal.spec.ts
@@ -257,4 +257,32 @@ describe('SolTransactionModal', () => {
 			expect(getByText(en.transaction.text.tab_unavailable)).toBeInTheDocument();
 		});
 	});
+
+	// Two rows both reading "Unknown token" are worse than an address: nothing tells them apart.
+	// The numbering counts off the mints this modal shows, in the order it shows them.
+	it('should number the mints it cannot name', () => {
+		const { getByText } = render(SolTransactionModal, {
+			props: {
+				transaction: {
+					...mockSolTransactionUi,
+					summary: {
+						kind: 'swap' as const,
+						spent: { delta: -5n, tokenAddress: 'first-unnamed', decimals: 0 },
+						received: { delta: 7n, tokenAddress: 'second-unnamed', decimals: 0 }
+					},
+					netChanges: [
+						{ delta: -5n, tokenAddress: 'first-unnamed', decimals: 0 },
+						{ delta: 7n, tokenAddress: 'second-unnamed', decimals: 0 }
+					]
+				},
+				token: SOLANA_TOKEN
+			}
+		});
+
+		expect(
+			getByText(
+				`Swap ${en.transaction.text.unknown_token} 1 to ${en.transaction.text.unknown_token} 2`
+			)
+		).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
# Motivation

The activity row and the instruction list count off the mints nothing can name, so two of them read `Unknown token 1` and `Unknown token 2`. The transaction modal did not, so a swap between two unnamed mints opened as `Unknown token to Unknown token`, where nothing tells the two apart and the raw address would have said more.

# Changes

The modal numbers them the same way, against the mints it shows and in the order it shows them, so a placeholder means the same thing wherever the user meets it.

# Tests

A swap between two unnamed mints reads `Unknown token 1 to Unknown token 2`. It fails without the change.