### PR TITLE
refactor(frontend): fill the balance map in place

### DIFF
--- a/src/frontend/src/sol/services/sol-simulation.services.ts
+++ b/src/frontend/src/sol/services/sol-simulation.services.ts
@@ -82,7 +82,11 @@ const simulate = async ({
 	const accountLamports = addresses.reduce<Record<SolAddress, bigint>>((acc, account, index) => {
 		const lamports = preAccounts[index]?.lamports;
 
-		return nonNullish(lamports) ? { ...acc, [account]: lamports } : acc;
+		if (nonNullish(lamports)) {
+			acc[account] = lamports;
+		}
+
+		return acc;
 	}, {});
 
 	// The kit instructions are not parsed, so they contribute nothing themselves; iterating them is

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -177,8 +177,15 @@ export const fetchSolTransactionsForSignature = async ({
 	// What each account held going in, so a close can say what it hands back: the instruction
 	// itself states no amount, and for a wrapped SOL account it is the wrapped SOL too.
 	const accountLamports = parsedAccountKeys.reduce<Record<SolAddress, bigint>>(
-		(acc, { pubkey }, index) =>
-			index < (preBalances ?? []).length ? { ...acc, [pubkey]: (preBalances ?? [])[index] } : acc,
+		(acc, { pubkey }, index) => {
+			const lamports = (preBalances ?? [])[index];
+
+			if (nonNullish(lamports)) {
+				acc[pubkey] = lamports;
+			}
+
+			return acc;
+		},
 		{}
 	);
 

--- a/src/frontend/src/sol/services/sol-transactions.services.ts
+++ b/src/frontend/src/sol/services/sol-transactions.services.ts
@@ -176,9 +176,11 @@ export const fetchSolTransactionsForSignature = async ({
 
 	// What each account held going in, so a close can say what it hands back: the instruction
 	// itself states no amount, and for a wrapped SOL account it is the wrapped SOL too.
+	const balances = preBalances ?? [];
+
 	const accountLamports = parsedAccountKeys.reduce<Record<SolAddress, bigint>>(
 		(acc, { pubkey }, index) => {
-			const lamports = (preBalances ?? [])[index];
+			const lamports = balances[index];
 
 			if (nonNullish(lamports)) {
 				acc[pubkey] = lamports;


### PR DESCRIPTION
# Motivation

Both readers of the per-account balances built their map by spreading the accumulator on every entry, so a transaction touching many accounts allocated one object per account to produce the same mapping.

Raised on the branch that introduced them, which had already entered the merge queue and could not be pushed to, so it comes as a follow-up.

# Changes

The accumulator is filled in place.

The confirmed-transaction reader also now guards on the balance itself rather than on the length of the list: the same test where the list is dense, and a safer one where it is not.

# Tests

No behaviour change, so no new cases. 1973 Solana tests pass, `npm run check` and lint clean.