### PR TITLE
fix(frontend): keep the BTC swap UTXO context alive across wizard steps

### DIFF
--- a/src/frontend/src/btc/components/swap/SwapBtcContexts.svelte
+++ b/src/frontend/src/btc/components/swap/SwapBtcContexts.svelte
@@ -42,8 +42,8 @@
 </script>
 
 <!--
-  UTXO selection for a Bitcoin-source swap, mounted *above* the quote fan-out rather than
-  inside the wizard. Two reasons:
+  UTXO selection for a Bitcoin-source swap, mounted in `SwapModalWizardSteps` — above both
+  the quote fan-out and the per-step `{#key}`, rather than inside the wizard. Three reasons:
 
   - The BTC → ckBTC quote prices the Bitcoin network fee from `allUtxosStore`,
     `feeRatePercentilesStore` and `btcPendingSentTransactionsStore`, and it reads them
@@ -52,6 +52,10 @@
     quote coming back empty and the form briefly claiming no swap is offered.
   - The form needs a fee before any offer exists, for the Max button and the amount
     validation. `UtxosFeeLoader` prices a default amount on mount, so it has one.
+  - The teardown below, and the `UtxosFeeContexts` store, must outlive a step change. Below
+    the `{#key}` they did not: walking from the form to Review cleared all three stores and
+    handed Review a fresh empty fee store, so a confirmation before the refill landed failed
+    on a missing fee.
 
   The loader is rendered beside the content, not around it, so that switching the source
   token away from Bitcoin unmounts the loader without also remounting the swap flow.

--- a/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
+++ b/src/frontend/src/lib/components/swap/SwapModalWizardSteps.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { get } from 'svelte/store';
+	import SwapBtcContexts from '$btc/components/swap/SwapBtcContexts.svelte';
 	import SwapProviderListModal from '$lib/components/swap/SwapProviderListModal.svelte';
 	import SwapTokenWizard from '$lib/components/swap/SwapTokenWizard.svelte';
 	import SwapTokensList from '$lib/components/swap/SwapTokensList.svelte';
@@ -31,6 +32,7 @@
 	import type { SwapMappedResult, SwapSelectTokenType } from '$lib/types/swap';
 	import type { Token } from '$lib/types/token';
 	import type { WizardModal, WizardStep, WizardSteps } from '$lib/types/wizard';
+	import { isNetworkIdBitcoin } from '$lib/utils/network.utils';
 	import { tryParseToken } from '$lib/utils/parse.utils';
 	import { networksWithSupport } from '$lib/utils/swap-tokens-filter.utils';
 	import { goToWizardStep } from '$lib/utils/wizard-modal.utils';
@@ -81,6 +83,8 @@
 		getContext<ModalNetworksListContext>(MODAL_NETWORKS_LIST_CONTEXT_KEY);
 
 	const { store: swapAmountsStore } = getContext<SwapAmountsContext>(SWAP_AMOUNTS_CONTEXT_KEY);
+
+	let isBitcoinSource = $derived(isNetworkIdBitcoin($sourceToken?.network?.id));
 
 	type TokenSide = 'source' | 'destination';
 
@@ -260,39 +264,50 @@
 	};
 </script>
 
-{#key currentStep?.name}
-	{#if currentStep?.name === WizardStepsSwap.TOKENS_LIST}
-		<SwapTokensList
-			onCloseTokensList={closeTokenList}
-			onSelectNetworkFilter={() => goToStep(WizardStepsSwap.FILTER_NETWORKS)}
-			onSelectToken={selectToken}
-			side={selectTokenType}
-		/>
-	{:else if currentStep?.name === WizardStepsSwap.FILTER_NETWORKS}
-		<ModalNetworksFilter
-			{allNetworksEnabled}
-			filteredNetworks={$filteredNetworks}
-			onNetworkFilter={() => goToStep(WizardStepsSwap.TOKENS_LIST)}
-			showStakeBalance={false}
-		/>
-	{:else if currentStep?.name === WizardStepsSwap.SELECT_PROVIDER}
-		<SwapProviderListModal
-			onCloseProviderList={() => goToStep(WizardStepsSwap.SWAP)}
-			onSelectProvider={selectProvider}
-		/>
-	{:else if currentStep?.name === WizardStepsSwap.SWAP || currentStep?.name === WizardStepsSwap.REVIEW || currentStep?.name === WizardStepsSwap.SWAPPING}
-		<SwapTokenWizard
-			{currentStep}
-			onBack={() => modal?.back()}
-			{onClose}
-			onNext={() => modal?.next()}
-			onShowProviderList={() => goToStep(WizardStepsSwap.SELECT_PROVIDER)}
-			onShowTokensList={showTokensList}
-			bind:swapAmount
-			bind:receiveAmount
-			bind:slippageValue
-			bind:swapProgressStep
-			bind:swapFailedProgressSteps
-		/>
-	{/if}
-{/key}
+<!--
+  Wraps the keyed block rather than sitting inside it. `{#key}` rebuilds its whole subtree on
+  every step change, and `SwapBtcContexts` owns two things that must not be rebuilt with it:
+  the `UtxosFeeContexts` store, and a teardown that clears the UTXO set, the fee percentiles
+  and the reserved outpoints. Mounted inside, the walk from the form to Review wiped all four
+  and left Review waiting on two update calls to refill them — a confirmation inside that
+  window failed on a missing fee, and every rebuild also spent one of the fifteen calls a
+  minute the backend allows for the reserved-outpoint list.
+-->
+<SwapBtcContexts amount={swapAmount} load={isBitcoinSource} networkId={$sourceToken?.network?.id}>
+	{#key currentStep?.name}
+		{#if currentStep?.name === WizardStepsSwap.TOKENS_LIST}
+			<SwapTokensList
+				onCloseTokensList={closeTokenList}
+				onSelectNetworkFilter={() => goToStep(WizardStepsSwap.FILTER_NETWORKS)}
+				onSelectToken={selectToken}
+				side={selectTokenType}
+			/>
+		{:else if currentStep?.name === WizardStepsSwap.FILTER_NETWORKS}
+			<ModalNetworksFilter
+				{allNetworksEnabled}
+				filteredNetworks={$filteredNetworks}
+				onNetworkFilter={() => goToStep(WizardStepsSwap.TOKENS_LIST)}
+				showStakeBalance={false}
+			/>
+		{:else if currentStep?.name === WizardStepsSwap.SELECT_PROVIDER}
+			<SwapProviderListModal
+				onCloseProviderList={() => goToStep(WizardStepsSwap.SWAP)}
+				onSelectProvider={selectProvider}
+			/>
+		{:else if currentStep?.name === WizardStepsSwap.SWAP || currentStep?.name === WizardStepsSwap.REVIEW || currentStep?.name === WizardStepsSwap.SWAPPING}
+			<SwapTokenWizard
+				{currentStep}
+				onBack={() => modal?.back()}
+				{onClose}
+				onNext={() => modal?.next()}
+				onShowProviderList={() => goToStep(WizardStepsSwap.SELECT_PROVIDER)}
+				onShowTokensList={showTokensList}
+				bind:swapAmount
+				bind:receiveAmount
+				bind:slippageValue
+				bind:swapProgressStep
+				bind:swapFailedProgressSteps
+			/>
+		{/if}
+	{/key}
+</SwapBtcContexts>

--- a/src/frontend/src/lib/components/swap/SwapTokenWizard.svelte
+++ b/src/frontend/src/lib/components/swap/SwapTokenWizard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import SwapBtcContexts from '$btc/components/swap/SwapBtcContexts.svelte';
 	import SwapBtcWizard from '$btc/components/swap/SwapBtcWizard.svelte';
 	import SwapEthWizard from '$eth/components/swap/SwapEthWizard.svelte';
 	import SwapIcpWizard from '$icp/components/swap/SwapIcpWizard.svelte';
@@ -66,79 +65,77 @@
 	);
 </script>
 
-<SwapBtcContexts amount={swapAmount} load={isBitcoinSource} networkId={$sourceToken?.network?.id}>
-	<SwapAmountsContext
-		amount={swapAmount}
-		destinationToken={$destinationToken}
-		{enableAmountUpdates}
-		isSourceTokenIcrc2={$isSourceTokenIcrc2}
-		pauseAmountUpdates={shouldPause}
-		{slippageValue}
-		sourceToken={$sourceToken}
-		bind:isSwapAmountsLoading
-	>
-		{#if isNullish($sourceToken) || isNetworkIdICP($sourceToken.network.id)}
-			<SwapIcpWizard
-				{currentStep}
-				{isSwapAmountsLoading}
-				{onBack}
-				{onClose}
-				{onNext}
-				{onShowProviderList}
-				{onShowTokensList}
-				bind:swapAmount
-				bind:receiveAmount
-				bind:slippageValue
-				bind:swapProgressStep
-			/>
-		{:else if isNetworkIdSolana($sourceToken.network.id)}
-			<SwapSolWizard
-				{currentStep}
-				{isSwapAmountsLoading}
-				{onBack}
-				{onClose}
-				{onNext}
-				{onShowProviderList}
-				{onShowTokensList}
-				{onStartTriggerAmount}
-				{onStopTriggerAmount}
-				bind:swapAmount
-				bind:receiveAmount
-				bind:slippageValue
-				bind:swapProgressStep
-			/>
-		{:else if isBitcoinSource}
-			<SwapBtcWizard
-				{currentStep}
-				{isSwapAmountsLoading}
-				{onBack}
-				{onClose}
-				{onNext}
-				{onShowProviderList}
-				{onShowTokensList}
-				{onStartTriggerAmount}
-				{onStopTriggerAmount}
-				bind:swapAmount
-				bind:receiveAmount
-				bind:slippageValue
-				bind:swapProgressStep
-			/>
-		{:else}
-			<SwapEthWizard
-				{currentStep}
-				{isSwapAmountsLoading}
-				{onBack}
-				{onClose}
-				{onNext}
-				{onShowProviderList}
-				{onShowTokensList}
-				{onStartTriggerAmount}
-				{onStopTriggerAmount}
-				bind:swapAmount
-				bind:receiveAmount
-				bind:slippageValue
-				bind:swapProgressStep
-			/>
-		{/if}
-	</SwapAmountsContext>
-</SwapBtcContexts>
+<SwapAmountsContext
+	amount={swapAmount}
+	destinationToken={$destinationToken}
+	{enableAmountUpdates}
+	isSourceTokenIcrc2={$isSourceTokenIcrc2}
+	pauseAmountUpdates={shouldPause}
+	{slippageValue}
+	sourceToken={$sourceToken}
+	bind:isSwapAmountsLoading
+>
+	{#if isNullish($sourceToken) || isNetworkIdICP($sourceToken.network.id)}
+		<SwapIcpWizard
+			{currentStep}
+			{isSwapAmountsLoading}
+			{onBack}
+			{onClose}
+			{onNext}
+			{onShowProviderList}
+			{onShowTokensList}
+			bind:swapAmount
+			bind:receiveAmount
+			bind:slippageValue
+			bind:swapProgressStep
+		/>
+	{:else if isNetworkIdSolana($sourceToken.network.id)}
+		<SwapSolWizard
+			{currentStep}
+			{isSwapAmountsLoading}
+			{onBack}
+			{onClose}
+			{onNext}
+			{onShowProviderList}
+			{onShowTokensList}
+			{onStartTriggerAmount}
+			{onStopTriggerAmount}
+			bind:swapAmount
+			bind:receiveAmount
+			bind:slippageValue
+			bind:swapProgressStep
+		/>
+	{:else if isBitcoinSource}
+		<SwapBtcWizard
+			{currentStep}
+			{isSwapAmountsLoading}
+			{onBack}
+			{onClose}
+			{onNext}
+			{onShowProviderList}
+			{onShowTokensList}
+			{onStartTriggerAmount}
+			{onStopTriggerAmount}
+			bind:swapAmount
+			bind:receiveAmount
+			bind:slippageValue
+			bind:swapProgressStep
+		/>
+	{:else}
+		<SwapEthWizard
+			{currentStep}
+			{isSwapAmountsLoading}
+			{onBack}
+			{onClose}
+			{onNext}
+			{onShowProviderList}
+			{onShowTokensList}
+			{onStartTriggerAmount}
+			{onStopTriggerAmount}
+			bind:swapAmount
+			bind:receiveAmount
+			bind:slippageValue
+			bind:swapProgressStep
+		/>
+	{/if}
+</SwapAmountsContext>

--- a/src/frontend/src/tests/lib/components/swap/SwapModalWizardSteps.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapModalWizardSteps.spec.ts
@@ -1,3 +1,8 @@
+import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
+import { allUtxosStore } from '$btc/stores/all-utxos.store';
+import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
+import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
+import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
 import { IC_TOKEN_FEE_CONTEXT_KEY, icTokenFeeStore } from '$icp/stores/ic-token-fee.store';
 import SwapModalWizardSteps from '$lib/components/swap/SwapModalWizardSteps.svelte';
 import {
@@ -6,6 +11,7 @@ import {
 	SWAP_MODAL_SELECT_PROVIDER_STEP,
 	SWAP_SWITCH_TOKENS_BUTTON
 } from '$lib/constants/test-ids.constants';
+import * as addressDerived from '$lib/derived/address.derived';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
 import { WizardStepsSwap } from '$lib/enums/wizard-steps';
 import {
@@ -23,14 +29,33 @@ import {
 } from '$lib/stores/swap-amounts.store';
 import { SWAP_CONTEXT_KEY, initSwapContext } from '$lib/stores/swap.store';
 import type { WizardModal, WizardStep } from '$lib/types/wizard';
+import { mockBtcAddress, mockUtxo } from '$tests/mocks/btc.mock';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockSwapProviders } from '$tests/mocks/swap.mocks';
 import { render } from '@testing-library/svelte';
-import { readable } from 'svelte/store';
+import { tick } from 'svelte';
+import { get, readable } from 'svelte/store';
 
 vi.mock('$icp/api/icrc-ledger.api', () => ({
 	icrc1SupportedStandards: () => Promise.resolve([])
+}));
+
+// A Bitcoin source mounts the real UTXO loaders, whose whole job is to call out.
+vi.mock('$btc/services/btc-utxos.service', async () => {
+	const { ZERO } = await import('$lib/constants/app.constants');
+	return {
+		getFeeRateFromPercentiles: vi.fn().mockResolvedValue(2_000n),
+		prepareBtcSend: vi.fn().mockReturnValue({ feeSatoshis: ZERO, utxos: [] })
+	};
+});
+
+vi.mock('$icp/api/bitcoin.api', () => ({
+	getUtxosQuery: vi.fn().mockResolvedValue({ utxos: [], tip_height: 0, tip_block_hash: [] })
+}));
+
+vi.mock('$btc/services/btc-pending-sent-transactions.services', () => ({
+	loadBtcPendingSentTransactions: vi.fn().mockResolvedValue(undefined)
 }));
 
 describe('SwapModalWizardSteps', () => {
@@ -91,6 +116,48 @@ describe('SwapModalWizardSteps', () => {
 		);
 	};
 
+	const renderSwapModalWizardSteps = (currentStep: WizardStep<WizardStepsSwap>) =>
+		render(SwapModalWizardSteps, {
+			props: {
+				swapAmount: '1',
+				receiveAmount: 2,
+				slippageValue: undefined,
+				onClose: vi.fn(),
+				currentStep,
+				showSelectProviderModal: false,
+				swapProgressStep: ProgressStepsSwap.INITIALIZATION,
+				allNetworksEnabled: true,
+				modal: mockModal as unknown as WizardModal<WizardStepsSwap>,
+				steps: [
+					{
+						name: WizardStepsSwap.SWAP,
+						title: en.swap.text.swap
+					},
+					{
+						name: WizardStepsSwap.REVIEW,
+						title: en.swap.text.review
+					},
+					{
+						name: WizardStepsSwap.SWAPPING,
+						title: en.swap.text.executing_transaction
+					},
+					{
+						name: WizardStepsSwap.TOKENS_LIST,
+						title: en.send.text.select_token
+					},
+					{
+						name: WizardStepsSwap.FILTER_NETWORKS,
+						title: en.send.text.select_network_filter
+					},
+					{
+						name: WizardStepsSwap.SELECT_PROVIDER,
+						title: en.swap.text.select_swap_provider
+					}
+				]
+			},
+			context: mockContext
+		});
+
 	describe('display values', () => {
 		beforeEach(() => {
 			setupSwapAmountsStore(mockSwapAmounts);
@@ -98,48 +165,6 @@ describe('SwapModalWizardSteps', () => {
 			setupModalTokensListContext();
 			setupModalNetworksListContext();
 		});
-
-		const renderSwapModalWizardSteps = (currentStep: WizardStep<WizardStepsSwap>) =>
-			render(SwapModalWizardSteps, {
-				props: {
-					swapAmount: '1',
-					receiveAmount: 2,
-					slippageValue: undefined,
-					onClose: vi.fn(),
-					currentStep,
-					showSelectProviderModal: false,
-					swapProgressStep: ProgressStepsSwap.INITIALIZATION,
-					allNetworksEnabled: true,
-					modal: mockModal as unknown as WizardModal<WizardStepsSwap>,
-					steps: [
-						{
-							name: WizardStepsSwap.SWAP,
-							title: en.swap.text.swap
-						},
-						{
-							name: WizardStepsSwap.REVIEW,
-							title: en.swap.text.review
-						},
-						{
-							name: WizardStepsSwap.SWAPPING,
-							title: en.swap.text.executing_transaction
-						},
-						{
-							name: WizardStepsSwap.TOKENS_LIST,
-							title: en.send.text.select_token
-						},
-						{
-							name: WizardStepsSwap.FILTER_NETWORKS,
-							title: en.send.text.select_network_filter
-						},
-						{
-							name: WizardStepsSwap.SELECT_PROVIDER,
-							title: en.swap.text.select_swap_provider
-						}
-					]
-				},
-				context: mockContext
-			});
 
 		it('should display TOKENS_LIST step', () => {
 			const { getByTestId } = renderSwapModalWizardSteps({
@@ -193,6 +218,72 @@ describe('SwapModalWizardSteps', () => {
 			});
 
 			expect(getByText(en.swap.text.initializing)).toBeInTheDocument();
+		});
+	});
+
+	// `SwapBtcContexts` wraps the per-step `{#key}` rather than sitting inside it. Below the
+	// key, walking from the form to Review tore it down: its teardown clears the three
+	// Bitcoin stores, and its `UtxosFeeContexts` handed Review a fresh empty fee store. The
+	// refill needs two update calls, and confirming inside that window failed on a missing
+	// fee — the "error on the first click, works on the second" the swap flow used to show.
+	describe('Bitcoin source across a step change', () => {
+		const fillBtcStores = () => {
+			allUtxosStore.setAllUtxos({ allUtxos: [mockUtxo] });
+			feeRatePercentilesStore.setFeeRateFromPercentiles({ feeRateFromPercentiles: 2_000n });
+			btcPendingSentTransactionsStore.setPendingTransactions({
+				address: mockBtcAddress,
+				pendingTransactions: []
+			});
+		};
+
+		const btcStoresPopulated = () =>
+			[
+				get(allUtxosStore)?.allUtxos,
+				get(feeRatePercentilesStore)?.feeRateFromPercentiles,
+				get(btcPendingSentTransactionsStore)[mockBtcAddress]
+			].every((value) => value !== undefined && value !== null);
+
+		beforeEach(() => {
+			allUtxosStore.reset();
+			feeRatePercentilesStore.reset();
+			btcPendingSentTransactionsStore.reset();
+
+			vi.spyOn(addressDerived, 'btcAddressMainnet', 'get').mockReturnValue(
+				readable(mockBtcAddress)
+			);
+
+			setupSwapAmountsStore(mockSwapAmounts);
+			setupIcTokenFeeStore();
+			setupModalTokensListContext();
+			setupModalNetworksListContext();
+
+			const btcToken = { ...BTC_MAINNET_TOKEN, enabled: true };
+
+			mockContext.set(SWAP_CONTEXT_KEY, {
+				...initSwapContext({ sourceToken: btcToken, destinationToken: btcToken }),
+				sourceTokenExchangeRate: readable(10),
+				destinationTokenExchangeRate: readable(2)
+			});
+		});
+
+		it('keeps the Bitcoin UTXO data when moving from the form to Review', async () => {
+			// Pre-filled, so every loader's effect short-circuits and a later call can only come
+			// from a remount.
+			fillBtcStores();
+
+			const { rerender } = renderSwapModalWizardSteps({
+				name: WizardStepsSwap.SWAP,
+				title: 'title'
+			});
+
+			await tick();
+
+			expect(btcStoresPopulated()).toBeTruthy();
+
+			await rerender({ currentStep: { name: WizardStepsSwap.REVIEW, title: 'title' } });
+
+			expect(btcStoresPopulated()).toBeTruthy();
+			expect(loadBtcPendingSentTransactions).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/components/swap/SwapTokenWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapTokenWizard.spec.ts
@@ -17,6 +17,7 @@ import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
+import { mockUtxosFeeContextEntry } from '$tests/utils/fee.context.test-utils';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
@@ -45,7 +46,7 @@ vi.mock('$icp/api/icrc-ledger.api', () => ({
 	icrc1SupportedStandards: vi.fn()
 }));
 
-// The Bitcoin branch mounts the real UTXO loaders, whose whole job is to call out.
+// The Bitcoin branch fans out a quote that prices its network fee straight from these.
 vi.mock('$btc/services/btc-utxos.service', async () => {
 	const { ZERO } = await import('$lib/constants/app.constants');
 	return {
@@ -171,9 +172,9 @@ describe('SwapTokenWizard', () => {
 		expect(container).toBeTruthy();
 	});
 
-	// The Bitcoin branch is the one dispatch that also has to set up a context of its own:
-	// `SwapBtcContexts` owns the UTXO fee the form reads, and mounts its loaders above the
-	// quote fan-out so the first quote is not priced against empty stores.
+	// The UTXO fee context is supplied here because `SwapBtcContexts` owns it from
+	// `SwapModalWizardSteps`, above the per-step `{#key}` — mounted inside this wizard it
+	// would be torn down and refilled on every step change.
 	it('should render the Bitcoin wizard when sourceToken is on the Bitcoin network', () => {
 		vi.spyOn(addressDerived, 'btcAddressMainnet', 'get').mockImplementation(() =>
 			readable(mockBtcAddress)
@@ -187,6 +188,9 @@ describe('SwapTokenWizard', () => {
 			sourceTokenExchangeRate: readable(10),
 			destinationTokenExchangeRate: readable(2)
 		});
+
+		const [utxosFeeContextKey, utxosFeeContext] = mockUtxosFeeContextEntry();
+		btcMockContext.set(utxosFeeContextKey, utxosFeeContext);
 
 		const { container } = render(SwapTokenWizard, {
 			props: {


### PR DESCRIPTION
# Motivation

Confirming a BTC → ckBTC swap failed instantly on the first click ("Something went wrong while initiating a swap transaction.") and worked on the second.

`SwapBtcContexts` sat inside the `{#key currentStep?.name}` block in `SwapModalWizardSteps`, so every step change destroyed it. Its teardown clears `allUtxosStore`, `feeRatePercentilesStore` and `btcPendingSentTransactionsStore`, and its `UtxosFeeContexts` handed Review a fresh empty fee store. Refilling needs two backend update calls, and confirming inside that window hit the `isNullish(utxosFee)` guard in `SwapBtcWizard`. Each rebuild also spent one of the 15 calls/minute the backend allows for `btc_get_pending_transactions`; past that limit the wrapper silently returns `[]`, so the reserved-UTXO check degrades to a no-op during the retry loop this bug forces.


# Changes

- Mount `SwapBtcContexts` in `SwapModalWizardSteps`, wrapping the keyed block instead of sitting under it; `SwapTokenWizard` no longer mounts it.
- Record the constraint in the `SwapBtcContexts` comment.


# Tests

Added.
