### PR TITLE
fix(frontend): settle a stuck BTC → ckBTC AUT against the ckBTC ledger

### DIFF
--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -198,6 +198,11 @@ export const ONESEC_FORWARDING_NOTIFY_INTERVAL_MILLIS = SECONDS_IN_MINUTE * 1_00
 // entirely while the deposit is still gathering confirmations.
 export const CHAIN_FUSION_UPDATE_BALANCE_INTERVAL_MILLIS = SECONDS_IN_MINUTE * 1_000; // 1 minute
 
+// Page size for a pending ckBTC deposit's walk over the account's ledger history looking
+// for its own mint. The walk itself is bounded by the row's creation time, not by a page
+// count — see `hasCkBtcMintForDeposit`.
+export const CHAIN_FUSION_CKBTC_MINT_LOOKUP_PAGE_SIZE = 100n;
+
 // User Snapshot
 export const USER_SNAPSHOT_TIMER_INTERVAL_MILLIS = SECONDS_IN_MINUTE * 5 * 1_000; // 5 minutes in milliseconds
 

--- a/src/frontend/src/lib/services/chain-fusion-swap-active-tx.services.ts
+++ b/src/frontend/src/lib/services/chain-fusion-swap-active-tx.services.ts
@@ -6,6 +6,7 @@ import type {
 } from '$declarations/backend/backend.did';
 import { ETHEREUM_NETWORK_ID } from '$env/networks/networks.eth.env';
 import { BITCOIN_CANISTER_IDS } from '$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env';
+import { ICRC_CK_TOKENS, PUBLIC_ICRC_TOKENS } from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
 import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import type { EthAddress } from '$eth/types/address';
@@ -18,7 +19,11 @@ import {
 	withdrawalStatuses
 } from '$icp/api/ckbtc-minter.api';
 import { retrieveEthStatus } from '$icp/api/cketh-minter.api';
-import { CHAIN_FUSION_UPDATE_BALANCE_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+import { getTransactions } from '$icp/api/icrc-index-ng.api';
+import {
+	CHAIN_FUSION_CKBTC_MINT_LOOKUP_PAGE_SIZE,
+	CHAIN_FUSION_UPDATE_BALANCE_INTERVAL_MILLIS
+} from '$lib/constants/app.constants';
 import { applyActiveUserTransactionPollUpdate } from '$lib/services/active-user-transactions.services';
 import {
 	CHAIN_FUSION_EXTERNAL_REF_KEYS,
@@ -45,6 +50,7 @@ import {
 	toChainFusionExternalRefsMap,
 	toChainFusionWithdrawalLearnedRefs,
 	toChainFusionWithdrawalStatus,
+	toCkBtcMintDepositTxid,
 	type ChainFusionBtcMintOutcome,
 	type ChainFusionMintOutcome
 } from '$lib/utils/chain-fusion-swap-active-tx.utils';
@@ -364,6 +370,82 @@ const resolveBtcDepositConfirmations = async ({
 	return nonNullish(utxo) ? tipHeight - utxo.height + 1 : undefined;
 };
 
+// The ckBTC ledger index a minter's mints land in — the pairing already lives in the ck
+// token data; only ckBTC entries can match a ckBTC minter id.
+const toCkBtcIndexCanisterId = (minterCanisterId: string): string | undefined =>
+	[...ICRC_CK_TOKENS, ...PUBLIC_ICRC_TOKENS].find(
+		(token) => token.minterCanisterId === minterCanisterId
+	)?.indexCanisterId;
+
+/**
+ * Whether the ckBTC ledger records a mint crediting this deposit to the account.
+ *
+ * Read only to break the tie below, where a deposit is absent from both the minter's known
+ * UTXOs and its own deposit address. Walked backwards from the account's newest transaction
+ * and bounded by the row's creation time rather than a page count: the row is durable and
+ * resumes on login, so its mint can sit arbitrarily deep behind traffic that accrued while
+ * the user was away — but it can never predate the row that initiated the deposit.
+ */
+const hasCkBtcMintForDeposit = async ({
+	identity,
+	indexCanisterId,
+	txid,
+	createdAtNs
+}: {
+	identity: Identity;
+	indexCanisterId: string;
+	txid: string;
+	createdAtNs: bigint;
+}): Promise<boolean> => {
+	let start: bigint | undefined;
+	let hasOlderPages = true;
+
+	while (hasOlderPages) {
+		const { transactions, oldest_tx_id } = await getTransactions({
+			identity,
+			indexCanisterId,
+			owner: identity.getPrincipal(),
+			start,
+			maxResults: CHAIN_FUSION_CKBTC_MINT_LOOKUP_PAGE_SIZE,
+			certified: false
+		});
+
+		if (transactions.length === 0) {
+			return false;
+		}
+
+		const minted = transactions.some(({ transaction: { mint } }) => {
+			const memo = fromNullable(fromNullable(mint)?.memo ?? []);
+
+			return nonNullish(memo) && toCkBtcMintDepositTxid(memo) === txid;
+		});
+
+		if (minted) {
+			return true;
+		}
+
+		const oldestFetched = transactions.reduce((min, tx) => (tx.id < min.id ? tx : min));
+
+		// The mint cannot predate the row that initiated the deposit, so everything past this
+		// point is other traffic.
+		if (oldestFetched.transaction.timestamp < createdAtNs) {
+			return false;
+		}
+
+		// Stop when the account's history is exhausted — or, defensively, when a page fails to
+		// move the cursor: the walk synthesizes its own cursor, unlike the canister-issued
+		// `next_page` token `getAllAddressUtxos` follows.
+		const oldestTxId = fromNullable(oldest_tx_id);
+		hasOlderPages =
+			(isNullish(oldestTxId) || oldestFetched.id > oldestTxId) &&
+			(isNullish(start) || oldestFetched.id < start);
+
+		start = oldestFetched.id;
+	}
+
+	return false;
+};
+
 /**
  * Resolves a ckBTC deposit's state, and — this is the one poller in the codebase
  * that mutates — asks the minter to mint when the deposit is ready for it.
@@ -393,12 +475,14 @@ const resolveBtcDepositConfirmations = async ({
 const resolveChainFusionBtcMintOutcome = async ({
 	identity,
 	txId,
+	createdAtNs,
 	data,
 	refs,
 	caches
 }: {
 	identity: Identity;
 	txId: string;
+	createdAtNs: bigint;
 	data: ChainFusionData;
 	refs: Partial<Record<ChainFusionExternalRefKey, string>>;
 	caches: ChainFusionPollCaches;
@@ -439,7 +523,25 @@ const resolveChainFusionBtcMintOutcome = async ({
 		});
 
 		if (isNullish(confirmations)) {
-			return 'unseen';
+			// Absent from the deposit address, having already been absent from the minter's known
+			// UTXOs. That is the shape of a deposit the Bitcoin canister has not indexed yet — and
+			// equally of one the minter minted and has since *spent* to fund a withdrawal, which
+			// erases it from both. The ledger settles it: the minter's mint memo names the outpoint
+			// it credited and stays on the account for good.
+			const indexCanisterId = toCkBtcIndexCanisterId(minterCanisterId);
+
+			if (isNullish(indexCanisterId)) {
+				return 'unseen';
+			}
+
+			const minted = await hasCkBtcMintForDeposit({
+				identity,
+				indexCanisterId,
+				txid,
+				createdAtNs
+			});
+
+			return minted ? 'minted' : 'unseen';
 		}
 
 		const { min_confirmations } = await memoize({
@@ -495,6 +597,7 @@ const pollChainFusionBtcMint = async ({
 	const outcome = await resolveChainFusionBtcMintOutcome({
 		identity,
 		txId: tx.id,
+		createdAtNs: tx.created_at_ns,
 		data,
 		refs,
 		caches

--- a/src/frontend/src/lib/utils/chain-fusion-swap-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/chain-fusion-swap-active-tx.utils.ts
@@ -12,6 +12,7 @@ import {
 import type { EthAddress } from '$eth/types/address';
 import { tokenAddressToHex } from '$eth/utils/token.utils';
 import { utxoTxIdToString } from '$icp/utils/btc.utils';
+import { decodeMintMemo, MINT_MEMO_CONVERT } from '$icp/utils/ckbtc-memo.utils';
 import { i18n } from '$lib/stores/i18n.store';
 import {
 	CHAIN_FUSION_EXTERNAL_REF_KEYS,
@@ -361,6 +362,35 @@ const toUtxoStatusUtxo = (utxosStatus: CkBtcMinterDid.UtxoStatus): CkBtcMinterDi
 			: 'Tainted' in utxosStatus
 				? utxosStatus.Tainted
 				: utxosStatus.ValueTooSmall;
+
+/**
+ * The deposit a ckBTC mint credited, as the human-readable txid the row snapshots.
+ *
+ * The minter stamps every deposit it converts with a memo naming the outpoint it consumed,
+ * which is the only *durable* record that a deposit was credited: `get_known_utxos` and the
+ * deposit address both stop mentioning a UTXO the moment the minter spends it to fund a
+ * withdrawal — see `resolveChainFusionBtcMintOutcome`.
+ *
+ * `undefined` for anything that is not a deposit credit: a KYT-fee mint, a legacy 0- or
+ * 32-byte memo, a `Convert` memo without the outpoint, or a memo the decoder rejects. The
+ * throw is swallowed rather than logged because a foreign memo shape is not this row's
+ * problem — the account's whole mint history is scanned, most of it unrelated.
+ */
+export const toCkBtcMintDepositTxid = (memo: Uint8Array): string | undefined => {
+	try {
+		const decoded = decodeMintMemo(memo);
+
+		if (decoded[0] !== MINT_MEMO_CONVERT) {
+			return undefined;
+		}
+
+		const [, [txid]] = decoded;
+
+		return nonNullish(txid) ? utxoTxIdToString(txid) : undefined;
+	} catch (_: unknown) {
+		return undefined;
+	}
+};
 
 // Minter and Bitcoin-canister UTXOs carry the txid in internal byte order; the
 // row snapshots the human-readable one the signer returned.

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -267,7 +267,7 @@
 	     Stated as plain text and not as a heading: it is a reading of the transaction, and the
 	     figures under it are what the user checks it against. -->
 	{#if nonNullish(summaryText)}
-		<p class="text-primary my-4" data-tid="message-summary">{summaryText}</p>
+		<p class="my-4 text-primary" data-tid="message-summary">{summaryText}</p>
 	{/if}
 
 	<!-- What the transaction does, and separately what it is made of. The operations are the

--- a/src/frontend/src/tests/lib/services/chain-fusion-swap-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/chain-fusion-swap-active-tx.services.spec.ts
@@ -69,13 +69,16 @@ vi.mock('$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env', async (importOriginal)
 
 // The ck token data carries no mainnet ckBTC entry under `DFX_NETWORK=local`, which would
 // leave the minter without a ledger index to settle the double-absent deposit against.
+// Typed rather than cast, so a change to the required `IcCkInterface` fields breaks here
+// instead of letting the lookup read a shape the env can no longer produce.
 vi.mock('$env/tokens/tokens-icrc/tokens.icrc.ck.env', async (importOriginal) => ({
 	...(await importOriginal<typeof ckEnv>()),
 	PUBLIC_ICRC_TOKENS: [
 		{
-			minterCanisterId: MINTER_CANISTER_ID,
-			indexCanisterId: INDEX_CANISTER_ID
-		} as unknown as IcCkInterface
+			ledgerCanisterId: IC_CKBTC_LEDGER,
+			indexCanisterId: INDEX_CANISTER_ID,
+			minterCanisterId: MINTER_CANISTER_ID
+		} satisfies IcCkInterface
 	]
 }));
 
@@ -95,15 +98,17 @@ vi.mock('$lib/services/active-user-transactions.services', () => ({
 	applyActiveUserTransactionPollUpdate: vi.fn()
 }));
 
-// Hoisted: the canister-id factory above runs before the module body.
-const { MINTER_CANISTER_ID, BITCOIN_CANISTER_ID, INDEX_CANISTER_ID } = vi.hoisted(() => ({
-	MINTER_CANISTER_ID: 'sv3dd-oaaaa-aaaar-qacoa-cai',
-	BITCOIN_CANISTER_ID: 'ghsi2-tqaaa-aaaan-aaaca-cai',
-	INDEX_CANISTER_ID: 'n5wcd-faaaa-aaaar-qaaea-cai'
-}));
+// Hoisted: the canister-id factories above run before the module body.
+const { MINTER_CANISTER_ID, BITCOIN_CANISTER_ID, INDEX_CANISTER_ID, IC_CKBTC_LEDGER } = vi.hoisted(
+	() => ({
+		MINTER_CANISTER_ID: 'sv3dd-oaaaa-aaaar-qacoa-cai',
+		BITCOIN_CANISTER_ID: 'ghsi2-tqaaa-aaaan-aaaca-cai',
+		INDEX_CANISTER_ID: 'n5wcd-faaaa-aaaar-qaaea-cai',
+		IC_CKBTC_LEDGER: 'mxzaz-hqaaa-aaaar-qaada-cai'
+	})
+);
 
 const CKETH_LEDGER = 'ss2fx-dyaaa-aaaar-qacoq-cai';
-const IC_CKBTC_LEDGER = 'mxzaz-hqaaa-aaaar-qaada-cai';
 
 // `mockUtxo` sits at height 1 000; the ckBTC minter's floor is six confirmations.
 const DEPOSIT_TXID = utxoTxIdToString(mockUtxo.outpoint.txid);

--- a/src/frontend/src/tests/lib/services/chain-fusion-swap-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/chain-fusion-swap-active-tx.services.spec.ts
@@ -5,6 +5,7 @@ import type {
 } from '$declarations/backend/backend.did';
 import { CKERC20_HELPER_CONTRACT_SIGNATURE } from '$env/networks/networks.cketh.env';
 import type * as ckBtcEnv from '$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env';
+import type * as ckEnv from '$env/tokens/tokens-icrc/tokens.icrc.ck.env';
 import { infuraCkETHProviders } from '$eth/providers/infura-cketh.providers';
 import { infuraProviders } from '$eth/providers/infura.providers';
 import { tokenAddressToHex } from '$eth/utils/token.utils';
@@ -17,8 +18,10 @@ import {
 	withdrawalStatuses
 } from '$icp/api/ckbtc-minter.api';
 import { retrieveEthStatus } from '$icp/api/cketh-minter.api';
+import { getTransactions } from '$icp/api/icrc-index-ng.api';
+import type { IcCkInterface } from '$icp/types/ic-token';
 import { utxoTxIdToString } from '$icp/utils/btc.utils';
-import { CHAIN_FUSION_UPDATE_BALANCE_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+import { CHAIN_FUSION_UPDATE_BALANCE_INTERVAL_MILLIS, ZERO } from '$lib/constants/app.constants';
 import { applyActiveUserTransactionPollUpdate } from '$lib/services/active-user-transactions.services';
 import {
 	pollChainFusionActiveUserTransactions,
@@ -34,6 +37,8 @@ import { mockIdentity } from '$tests/mocks/identity.mock';
 import { toNullable } from '@dfinity/utils';
 import { MinterNoNewUtxosError, type CkBtcMinterDid } from '@icp-sdk/canisters/ckbtc';
 import { encodePrincipalToEthAddress } from '@icp-sdk/canisters/cketh';
+import type { IcrcIndexDid } from '@icp-sdk/canisters/ledger/icrc';
+import { Cbor } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 
 vi.mock('$icp/api/cketh-minter.api', () => ({
@@ -51,11 +56,27 @@ vi.mock('$icp/api/bitcoin.api', () => ({
 	getUtxosQuery: vi.fn()
 }));
 
+vi.mock('$icp/api/icrc-index-ng.api', () => ({
+	getTransactions: vi.fn()
+}));
+
 // `BITCOIN_CANISTER_IDS` is empty under `DFX_NETWORK=local`, which would make every case
 // take the "Bitcoin canister not deployed" path and skip the confirmation gate entirely.
 vi.mock('$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env', async (importOriginal) => ({
 	...(await importOriginal<typeof ckBtcEnv>()),
 	BITCOIN_CANISTER_IDS: { [MINTER_CANISTER_ID]: BITCOIN_CANISTER_ID }
+}));
+
+// The ck token data carries no mainnet ckBTC entry under `DFX_NETWORK=local`, which would
+// leave the minter without a ledger index to settle the double-absent deposit against.
+vi.mock('$env/tokens/tokens-icrc/tokens.icrc.ck.env', async (importOriginal) => ({
+	...(await importOriginal<typeof ckEnv>()),
+	PUBLIC_ICRC_TOKENS: [
+		{
+			minterCanisterId: MINTER_CANISTER_ID,
+			indexCanisterId: INDEX_CANISTER_ID
+		} as unknown as IcCkInterface
+	]
 }));
 
 vi.mock('$icp-eth/api/cketh-minter.api', () => ({
@@ -74,10 +95,11 @@ vi.mock('$lib/services/active-user-transactions.services', () => ({
 	applyActiveUserTransactionPollUpdate: vi.fn()
 }));
 
-// Hoisted: the `BITCOIN_CANISTER_IDS` factory above runs before the module body.
-const { MINTER_CANISTER_ID, BITCOIN_CANISTER_ID } = vi.hoisted(() => ({
+// Hoisted: the canister-id factory above runs before the module body.
+const { MINTER_CANISTER_ID, BITCOIN_CANISTER_ID, INDEX_CANISTER_ID } = vi.hoisted(() => ({
 	MINTER_CANISTER_ID: 'sv3dd-oaaaa-aaaar-qacoa-cai',
-	BITCOIN_CANISTER_ID: 'ghsi2-tqaaa-aaaan-aaaca-cai'
+	BITCOIN_CANISTER_ID: 'ghsi2-tqaaa-aaaan-aaaca-cai',
+	INDEX_CANISTER_ID: 'n5wcd-faaaa-aaaar-qaaea-cai'
 }));
 
 const CKETH_LEDGER = 'ss2fx-dyaaa-aaaar-qacoq-cai';
@@ -191,6 +213,41 @@ const setDepositUtxos = ({
 		next_page: []
 	});
 
+// One page of the account's mint history as the index canister returns it. `utxos` name
+// the deposits the minter credited, encoded exactly as its `Convert` mint memo does.
+// Mints are stamped after the row's creation (`created_at_ns: 1n`) unless a test dates
+// them earlier to exercise the walk's cutoff; `hasMore` leaves older history behind the
+// page instead of ending it at the account's oldest transaction.
+const ledgerMintsPage = ({
+	utxos,
+	firstId = 100n,
+	timestamp = 1n,
+	hasMore = false
+}: {
+	utxos: CkBtcMinterDid.Utxo[];
+	firstId?: bigint;
+	timestamp?: bigint;
+	hasMore?: boolean;
+}): IcrcIndexDid.GetTransactions =>
+	({
+		balance: ZERO,
+		oldest_tx_id: utxos.length === 0 ? [] : [hasMore ? ZERO : firstId - BigInt(utxos.length - 1)],
+		transactions: utxos.map(({ outpoint: { txid, vout } }, index) => ({
+			id: firstId - BigInt(index),
+			transaction: {
+				kind: 'mint',
+				mint: [{ memo: [new Uint8Array(Cbor.encode([0, [txid, vout, 100]]))] }],
+				burn: [],
+				transfer: [],
+				approve: [],
+				timestamp
+			}
+		}))
+	}) as unknown as IcrcIndexDid.GetTransactions;
+
+const setLedgerMints = (utxos: CkBtcMinterDid.Utxo[]) =>
+	vi.mocked(getTransactions).mockResolvedValue(ledgerMintsPage({ utxos }));
+
 const setLastObservedBlock = (blockNumber: number | undefined) =>
 	vi.mocked(minterInfo).mockResolvedValue({
 		...mockCkMinterInfo,
@@ -222,6 +279,7 @@ describe('chain-fusion-swap-active-tx.services', () => {
 		vi.mocked(getKnownUtxos).mockResolvedValue([]);
 		vi.mocked(updateBalance).mockResolvedValue([]);
 		setDepositUtxos();
+		setLedgerMints([]);
 	});
 
 	it('should do nothing for an empty batch', async () => {
@@ -462,6 +520,60 @@ describe('chain-fusion-swap-active-tx.services', () => {
 			await poll([btcMintTx()]);
 
 			expect(updateBalance).not.toHaveBeenCalled();
+			expect(lastUpdate()).toStrictEqual({ status: { Executing: null } });
+		});
+
+		// The minter spends a deposit once it has minted it, which erases it from both the
+		// known UTXOs and the deposit address — the same shape as a deposit that was never
+		// indexed. Without the ledger the row would sit Executing for good.
+		it('should succeed a deposit the ledger shows as minted after the minter spent it', async () => {
+			setDepositUtxos({ utxos: [OTHER_UTXO] });
+			setLedgerMints([mockUtxo]);
+
+			await poll([btcMintTx()]);
+
+			expect(getTransactions).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ identity: mockIdentity, indexCanisterId: INDEX_CANISTER_ID })
+			);
+			expect(updateBalance).not.toHaveBeenCalled();
+			expect(lastUpdate()).toStrictEqual({ status: { Succeeded: null } });
+		});
+
+		it('should keep a deposit executing when the ledger only shows unrelated mints', async () => {
+			setDepositUtxos({ utxos: [OTHER_UTXO] });
+			setLedgerMints([OTHER_UTXO]);
+
+			await poll([btcMintTx()]);
+
+			expect(lastUpdate()).toStrictEqual({ status: { Executing: null } });
+		});
+
+		// `get_account_transactions` pages; a mint deeper than the first page must still
+		// settle the row.
+		it('should find the mint beyond the first page of the account history', async () => {
+			setDepositUtxos({ utxos: [OTHER_UTXO] });
+			vi.mocked(getTransactions)
+				.mockResolvedValueOnce(ledgerMintsPage({ utxos: [OTHER_UTXO], hasMore: true }))
+				.mockResolvedValueOnce(ledgerMintsPage({ utxos: [mockUtxo], firstId: 50n }));
+
+			await poll([btcMintTx()]);
+
+			expect(getTransactions).toHaveBeenCalledTimes(2);
+			expect(getTransactions).toHaveBeenNthCalledWith(2, expect.objectContaining({ start: 100n }));
+			expect(lastUpdate()).toStrictEqual({ status: { Succeeded: null } });
+		});
+
+		// The walk is bounded by the row's creation time: a mint cannot predate the row that
+		// initiated the deposit, so older pages are never fetched however deep the history goes.
+		it('should stop walking the account history behind the row creation time', async () => {
+			setDepositUtxos({ utxos: [OTHER_UTXO] });
+			vi.mocked(getTransactions).mockResolvedValue(
+				ledgerMintsPage({ utxos: [OTHER_UTXO], timestamp: ZERO, hasMore: true })
+			);
+
+			await poll([btcMintTx()]);
+
+			expect(getTransactions).toHaveBeenCalledOnce();
 			expect(lastUpdate()).toStrictEqual({ status: { Executing: null } });
 		});
 

--- a/src/frontend/src/tests/lib/utils/chain-fusion-swap-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/chain-fusion-swap-active-tx.utils.spec.ts
@@ -38,6 +38,7 @@ import {
 	toChainFusionExternalRefsMap,
 	toChainFusionWithdrawalLearnedRefs,
 	toChainFusionWithdrawalStatus,
+	toCkBtcMintDepositTxid,
 	type ChainFusionBtcMintOutcome,
 	type ChainFusionMintOutcome
 } from '$lib/utils/chain-fusion-swap-active-tx.utils';
@@ -46,6 +47,7 @@ import { mockValidIcCkToken } from '$tests/mocks/ic-tokens.mock';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
 import type { CkBtcMinterDid } from '@icp-sdk/canisters/ckbtc';
 import { encodePrincipalToEthAddress, type CkEthMinterDid } from '@icp-sdk/canisters/cketh';
+import { Cbor } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 
 const CKETH_LEDGER = 'ss2fx-dyaaa-aaaar-qacoq-cai';
@@ -595,6 +597,43 @@ describe('chain-fusion-swap-active-tx.utils', () => {
 		it('should match the row txid against the reversed on-chain one', () => {
 			expect(isSameUtxoTxid({ utxo: mockUtxo, txid: txid.toUpperCase() })).toBeTruthy();
 			expect(isSameUtxoTxid({ utxo: otherUtxo, txid })).toBeFalsy();
+		});
+	});
+
+	describe('toCkBtcMintDepositTxid', () => {
+		const depositTxid = utxoTxIdToString(mockUtxo.outpoint.txid);
+
+		const unrelatedUtxo: CkBtcMinterDid.Utxo = {
+			...mockUtxo,
+			outpoint: { txid: Uint8Array.from([9, 9, 9]), vout: 0 }
+		};
+
+		const convertMemo = (utxo: CkBtcMinterDid.Utxo) =>
+			new Uint8Array(Cbor.encode([0, [utxo.outpoint.txid, utxo.outpoint.vout, 100]]));
+
+		// Same byte-order flip as `isSameUtxoTxid`: the memo carries the outpoint, the row
+		// carries what the signer returned.
+		it('should read the deposit txid out of a convert mint memo', () => {
+			expect(toCkBtcMintDepositTxid(convertMemo(mockUtxo))).toBe(depositTxid);
+			expect(toCkBtcMintDepositTxid(convertMemo(unrelatedUtxo))).not.toBe(depositTxid);
+		});
+
+		it('should ignore a mint that credited no deposit', () => {
+			// The minter paying itself accumulated check fees.
+			expect(toCkBtcMintDepositTxid(new Uint8Array(Cbor.encode([1])))).toBeUndefined();
+
+			// A convert memo the minter wrote without the outpoint.
+			expect(
+				toCkBtcMintDepositTxid(new Uint8Array(Cbor.encode([0, [undefined, 0, 100]])))
+			).toBeUndefined();
+		});
+
+		// Legacy mints carry a 0- or 32-byte memo the decoder rejects outright, and the
+		// account's history holds mints from flows that are none of this row's business.
+		it('should ignore a memo it cannot decode', () => {
+			expect(toCkBtcMintDepositTxid(new Uint8Array(0))).toBeUndefined();
+			expect(toCkBtcMintDepositTxid(new Uint8Array(32))).toBeUndefined();
+			expect(toCkBtcMintDepositTxid(Uint8Array.from([1, 2, 3]))).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
# Motivation

A BTC → ckBTC active-transaction row could sit in `Executing` forever after the conversion had actually completed.

The poller reads a deposit that is absent from both the minter's `get_known_utxos` and the Bitcoin canister's view of the deposit address as `unseen`. But that is also what a *succeeded* deposit looks like: once the minter mints a deposit and later spends that UTXO to fund a withdrawal, the outpoint disappears from both. `update_balance` then answers `NoNewUtxos` with an empty pending list — identical to an unbroadcast deposit. No minter-side signal separates the two, so the row never terminalizes.

The Convert flow avoids this only because its pending row is ephemeral UI state that evaporates when the minter stops mentioning the UTXO. A durable row needs the evidence read directly.


# Changes

- `toCkBtcMintDepositTxid`: decodes a ckBTC `Convert` mint memo to the deposit txid — the only durable record that the minter credited a deposit. Returns `undefined` for KYT-fee mints, legacy memos and undecodable bytes.
- `hasCkBtcMintForDeposit`: on the double-absent path only, walks the account's ckBTC ledger history backwards via the index canister and reports `minted` when it finds that mint.
- The walk is bounded by the row's `created_at_ns`, not a page count: a durable row resumes on login, so its mint can sit deep behind traffic accrued while the user was away — but it can never predate the row itself. Also stops at `oldest_tx_id`, and defensively if a page fails to advance the cursor.
- The minter → index-canister pairing comes from the existing ck token data, so no new env map. `tokens.icrc.ck.btc.env.ts` is untouched.

# Tests

Added.
