### PR TITLE
fix(frontend): decouple mainnet BTC balance loading from ckBTC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "2.5.4",
+	"version": "2.5.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet",
-			"version": "2.5.4",
+			"version": "2.5.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/ic-pub-key": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet",
-	"version": "2.5.4",
+	"version": "2.5.5",
 	"private": true,
 	"license": "Apache-2.0",
 	"repository": {

--- a/src/frontend/src/btc/components/core/BtcLoaderWallets.svelte
+++ b/src/frontend/src/btc/components/core/BtcLoaderWallets.svelte
@@ -2,7 +2,7 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { enabledBitcoinTokens } from '$btc/derived/tokens.derived';
 	import { BtcWalletWorker } from '$btc/services/worker.btc-wallet.services';
-	import { BTC_MAINNET_TOKEN } from '$env/tokens/tokens.btc.env';
+	import { IC_CKBTC_MINTER_CANISTER_ID } from '$env/tokens/tokens-icrc/tokens.icrc.ck.btc.env';
 	import WalletWorkers from '$lib/components/core/WalletWorkers.svelte';
 	import { LOCAL } from '$lib/constants/app.constants';
 	import {
@@ -10,21 +10,12 @@
 		btcAddressRegtest,
 		btcAddressTestnet
 	} from '$lib/derived/address.derived';
-	import { tokens } from '$lib/derived/tokens.derived';
 	import type { InitWalletWorkerFn } from '$lib/types/listener';
 	import {
 		isNetworkIdBTCMainnet,
 		isNetworkIdBTCRegtest,
 		isNetworkIdBTCTestnet
 	} from '$lib/utils/network.utils';
-	import { findTwinToken } from '$lib/utils/token.utils';
-
-	let ckBtcToken = $derived(
-		findTwinToken({
-			tokenToPair: BTC_MAINNET_TOKEN,
-			tokens: $tokens
-		})
-	);
 
 	// Locally, only the Regtest worker has to be launched, in all other envs - testnet and mainnet
 	let walletWorkerTokens = $derived(
@@ -33,18 +24,18 @@
 				? isNetworkIdBTCRegtest(networkId) && nonNullish($btcAddressRegtest)
 				: !isNetworkIdBTCRegtest(networkId) &&
 					((isNetworkIdBTCTestnet(networkId) && nonNullish($btcAddressTestnet)) ||
-						// To query mainnet BTC balance, we need to wait for ckBtcToken.minterCanisterId to be available
-						(nonNullish(ckBtcToken) &&
-							isNetworkIdBTCMainnet(networkId) &&
-							nonNullish($btcAddressMainnet)))
+						(isNetworkIdBTCMainnet(networkId) && nonNullish($btcAddressMainnet)))
 		)
 	);
 
+	// The minter canister id is only a lookup key into BITCOIN_CANISTER_IDS; reading it from the
+	// env constant instead of the loaded ckBTC token keeps the BTC balance independent of the
+	// ckBTC ledger, which would otherwise stall the worker whenever that ledger is unreachable.
 	const initWalletWorker: InitWalletWorkerFn = ({ token }) =>
 		BtcWalletWorker.init({
 			token,
 			...(isNetworkIdBTCMainnet(token.network.id) && {
-				minterCanisterId: ckBtcToken?.minterCanisterId
+				minterCanisterId: IC_CKBTC_MINTER_CANISTER_ID
 			})
 		});
 </script>


### PR DESCRIPTION
# Motivation

Mainnet BTC balances hang on a skeleton loader whenever the ckBTC ledger (`mxzaz-hqaaa-aaaar-qaada-cai`) is unreachable — as observed in production today, where the replica rejects `icrc1_metadata` with `IC0508 / Canister is stopped`.

The chain: `loadIcrcData` only commits a token to `icrcDefaultTokensStore` once `icrc1_metadata` resolves, and ckBTC is not in the `ICRC_TOKENS_METADATA` fallback map, so it needs the live ledger call. When that call rejects, ckBTC never enters `$tokens`, `findTwinToken` returns `undefined`, and the `nonNullish(ckBtcToken)` guard in `BtcLoaderWallets` filters BTC mainnet out of `walletWorkerTokens`. The wallet worker is therefore never started at all — no requests are made to the signer, to the Bitcoin canister, or to the transaction providers. The balance is not failing; it is never requested, which is why the UI shows an indefinite skeleton rather than an error state.

This coupling is incidental. Neither BTC balance path touches ckBTC:

- the uncertified query path calls the IC **Bitcoin** canister `ghsi2-tqaaa-aaaan-aaaca-cai`, using `minterCanisterId` purely as a lookup key into `BITCOIN_CANISTER_IDS`; the minter itself is never called;
- the certified path calls `getBtcBalance` on the **signer** canister and does not use `minterCanisterId` at all.

The only thing the ckBTC token contributed was a string that is already a build-time constant, routed through a live canister call to reach it.
