### PR TITLE
feat(frontend): drop the amount and the wallet balance from the Solana review

### DIFF
--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -13,7 +13,6 @@
 		amount?: bigint;
 		token: OptionToken;
 		exchangeRate?: number;
-		// Only read where the balance row is shown, so a caller that hides it need not have one.
 		balance?: OptionBalance;
 		source: string;
 		application: string;

--- a/src/frontend/src/lib/components/send/SendData.svelte
+++ b/src/frontend/src/lib/components/send/SendData.svelte
@@ -13,7 +13,8 @@
 		amount?: bigint;
 		token: OptionToken;
 		exchangeRate?: number;
-		balance: OptionBalance;
+		// Only read where the balance row is shown, so a caller that hides it need not have one.
+		balance?: OptionBalance;
 		source: string;
 		application: string;
 		// A caller whose decode produced no amount has nothing to say in the amount and balance rows,

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -76,7 +76,6 @@
 
 	let signWithSending = $derived(method === SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION);
 
-	let amount = $state<bigint | undefined>();
 	let destination = $state<OptionSolAddress>();
 	let tokenAddress = $state<OptionSolAddress>();
 	let isApproval = $state<boolean | undefined>();
@@ -96,7 +95,6 @@
 	const updateData = async () => {
 		try {
 			({
-				amount,
 				destination,
 				tokenAddress,
 				isApproval,
@@ -225,7 +223,6 @@
 			/>
 		{:else if currentStep?.name === WizardStepsSign.REVIEW}
 			<SolWalletConnectSignReview
-				{amount}
 				{application}
 				approveDisabled={!decoded}
 				{data}

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -12,7 +12,6 @@
 	import WalletConnectModalValue from '$lib/components/wallet-connect/WalletConnectModalValue.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { exchanges } from '$lib/derived/exchange.derived';
-	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
 	import { absBigInt, maxBigInt } from '$lib/utils/bigint.utils';
@@ -41,7 +40,6 @@
 	} from '$sol/utils/sol-transaction-summary.utils';
 
 	interface Props {
-		amount?: bigint;
 		destination: string;
 		source: string;
 		application: string;
@@ -72,7 +70,6 @@
 	}
 
 	let {
-		amount,
 		destination,
 		source,
 		application,
@@ -93,13 +90,6 @@
 	}: Props = $props();
 
 	let activeTab = $state('summary');
-
-	let balance = $derived($balancesStore?.[token.id]?.data);
-
-	// Instructions OISY cannot decode yield no amount and no balance worth showing: what the
-	// transaction does is then told by the simulated changes alone. The rows are dropped rather
-	// than filled with a zero the decode never produced.
-	let decoded = $derived(nonNullish(amount));
 
 	// What the token accounts cost this message: the rent of the ones it opens, less what the ones
 	// it closes hand back. Charged like a fee and part of neither the base nor the bid, so it is
@@ -297,12 +287,10 @@
 	     here it costs a row without saying anything about the message in front of the user. The
 	     Ethereum review keeps the row, which is why this is opted out rather than removed. -->
 			<SendData
-				{amount}
 				{application}
-				{balance}
 				destination={null}
-				showAmount={decoded}
-				showBalance={decoded}
+				showAmount={false}
+				showBalance={false}
 				showSigner={false}
 				{source}
 				{token}

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -773,17 +773,20 @@ describe('SolWalletConnectSignReview', () => {
 		});
 	});
 
-	// The two rows describe what will be signed, which the simulation only predicts.
-	it('should render the amount and the balance of a decoded transfer', () => {
+	// A decoded amount is one movement out of however many the message makes, and on a swap it is
+	// one leg of the pair, stated as though it were the whole. The simulated changes below it say
+	// what actually moves, so the row contradicted them; the balance is the wallet's, not the
+	// message's, and says nothing about what is being signed.
+	it('should state neither an amount nor the wallet balance', () => {
 		balancesStore.set({ id: SOLANA_TOKEN.id, data: { data: 5_000_000_000n, certified: false } });
 
-		const { getByText, container } = render(SolWalletConnectSignReview, { props });
+		const { queryByText, container } = render(SolWalletConnectSignReview, { props });
 
-		expect(getByText(en.core.text.amount)).toBeInTheDocument();
-		expect(container.querySelector('#amount')).toHaveTextContent('0.001 SOL');
+		expect(queryByText(en.core.text.amount)).not.toBeInTheDocument();
+		expect(container.querySelector('#amount')).toBeNull();
 
-		expect(getByText(en.send.text.balance)).toBeInTheDocument();
-		expect(container.querySelector('#balance')).toHaveTextContent('5 SOL');
+		expect(queryByText(en.send.text.balance)).not.toBeInTheDocument();
+		expect(container.querySelector('#balance')).toBeNull();
 	});
 
 	// The delegate of an approval is not a recipient, so it keeps its own row even though the

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSignReview.spec.ts
@@ -10,7 +10,6 @@ import { fireEvent, render } from '@testing-library/svelte';
 
 describe('SolWalletConnectSignReview', () => {
 	const props = {
-		amount: 1_000_000n,
 		application: 'https://example.com',
 		destination: mockSolAddress2,
 		source: mockSolAddress,
@@ -621,7 +620,6 @@ describe('SolWalletConnectSignReview', () => {
 			const { getByText } = render(SolWalletConnectSignReview, {
 				props: {
 					...props,
-					amount: 1n,
 					prioritizationFee: 1_000_000_001n,
 					prioritizationFeeEstimate: networkEstimate
 				}


### PR DESCRIPTION
# Motivation

The Solana WalletConnect review states an `Amount` above its simulated balance changes, and the two disagree. The amount is one movement out of however many the message makes, and on a swap it is one leg of the pair presented as though it were the whole: a swap of 0.01 SOL for 1.02 USDC reads

```
Amount                     0.01 SOL
Simulated balance changes  -0.010007 SOL
                           +1.02204 USDC
```

That is the same picking of a winner among equals that took the destination row out of this review.

The `Balance` row is the wallet's balance, not the message's. It says nothing about what is being signed, and the wallet shows it elsewhere.

# Changes

Both rows go. What the message does is the sentence at the top and the simulated changes under it; what it costs is the fee block.

The decoded amount is no longer read by the review at all, so it stops being passed to it and the modal stops holding it. `SendData` takes `balance` as optional, since a caller that hides the row has no need of one.

# Tests

The case that asserted both rows now asserts their absence. Every other Solana and send case is unchanged and passes.