### PR TITLE
fix(frontend): check a native EVM send against the fee it authorises

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import { SEND_TRANSACTION_PRIORITY_ENABLED } from '$env/send-transaction-priority.env';
 	import { ETH_FEE_CONTEXT_KEY, type EthFeeContext } from '$eth/stores/eth-fee.store';
 	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 	import { isSupportedEvmNativeTokenId } from '$evm/utils/native-token.utils';
@@ -66,9 +67,15 @@
 				})
 			: ZERO;
 
-		// If ETH, the balance should cover the user-entered amount plus the min gas fee
+		// The chain requires the balance to cover the amount plus `maxFeePerGas * gas`, so the ceiling
+		// is what decides whether a native send is affordable. `minGasFee` omits the base fee
+		// entirely and therefore bounds nothing the chain enforces.
 		if (isSupportedEthTokenId($sendTokenId) || isSupportedEvmNativeTokenId($sendTokenId)) {
-			const total = userAmount + ($minGasFee ?? ZERO);
+			const gasFee = SEND_TRANSACTION_PRIORITY_ENABLED
+				? ($maxGasFee ?? ZERO)
+				: ($minGasFee ?? ZERO);
+
+			const total = userAmount + gasFee;
 
 			if (total > parsedSendBalance) {
 				return new InsufficientFundsError($i18n.send.assertion.insufficient_funds_for_gas);

--- a/src/frontend/src/tests/eth/components/send/EthSendAmount.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendAmount.spec.ts
@@ -1,0 +1,96 @@
+import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
+import EthSendAmount from '$eth/components/send/EthSendAmount.svelte';
+import { ETH_FEE_CONTEXT_KEY, initEthFeeContext, initEthFeeStore } from '$eth/stores/eth-fee.store';
+import { TOKEN_INPUT_CURRENCY_TOKEN } from '$lib/constants/test-ids.constants';
+import { balancesStore } from '$lib/stores/balances.store';
+import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+
+describe('EthSendAmount', () => {
+	const gas = 21_000n;
+	const baseFeePerGas = 20n;
+	const maxPriorityFeePerGas = 2n;
+	const maxFeePerGas = 100n;
+
+	// What the chain demands the sender hold: amount + maxFeePerGas * gas.
+	const ceiling = maxFeePerGas * gas;
+	// What the old check demanded, which omits the base fee entirely.
+	const tipOnly = maxPriorityFeePerGas * gas;
+
+	const balance = 1_000_000n;
+
+	const setup = () => {
+		const feeStore = initEthFeeStore();
+		feeStore.setFee({ maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas, gas });
+
+		const context = new Map<symbol, unknown>();
+		context.set(
+			ETH_FEE_CONTEXT_KEY,
+			initEthFeeContext({
+				feeStore,
+				feeSymbolStore: writable(ETHEREUM_TOKEN.symbol),
+				feeTokenIdStore: writable(ETHEREUM_TOKEN.id),
+				feeDecimalsStore: writable(ETHEREUM_TOKEN.decimals),
+				feeExchangeRateStore: writable(undefined)
+			})
+		);
+		context.set(SEND_CONTEXT_KEY, initSendContext({ token: ETHEREUM_TOKEN }));
+
+		balancesStore.set({ id: ETHEREUM_TOKEN.id, data: { data: balance, certified: true } });
+
+		return { context };
+	};
+
+	const enter = async (value: bigint) => {
+		const { context } = setup();
+
+		const { container } = render(EthSendAmount, {
+			context,
+			props: {
+				amount: undefined,
+				insufficientFunds: false,
+				nativeEthereumToken: ETHEREUM_TOKEN,
+				onTokensList: () => undefined
+			}
+		});
+
+		const input: HTMLInputElement | null = container.querySelector(
+			`input[data-tid="${TOKEN_INPUT_CURRENCY_TOKEN}"]`
+		);
+
+		expect(input).not.toBeNull();
+
+		await fireEvent.input(input as HTMLInputElement, {
+			target: { value: formatWei(value) }
+		});
+
+		return { container };
+	};
+
+	const formatWei = (value: bigint): string => {
+		const asString = value.toString().padStart(ETHEREUM_TOKEN.decimals + 1, '0');
+		const whole = asString.slice(0, -ETHEREUM_TOKEN.decimals);
+		const fraction = asString.slice(-ETHEREUM_TOKEN.decimals);
+
+		return `${whole}.${fraction}`;
+	};
+
+	it('rejects an amount that leaves less than the authorised ceiling', async () => {
+		// Affordable under the old tip-only rule, unaffordable to the chain: the send would pass
+		// validation and then fail to cover its own base fee.
+		const { container } = await enter(balance - tipOnly);
+
+		await waitFor(() => {
+			expect(container).toHaveTextContent('Insufficient');
+		});
+	});
+
+	it('accepts an amount that leaves the ceiling covered', async () => {
+		const { container } = await enter(balance - ceiling);
+
+		await waitFor(() => {
+			expect(container).not.toHaveTextContent('Insufficient');
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

A native ETH or EVM send can pass the amount validation and then be unable to cover its own fee.

`EthSendAmount.customValidate` checks `amount + minGasFee` against the balance, and `minGasFee` is `maxPriorityFeePerGas * gas`. That omits the base fee entirely, so it bounds nothing the chain enforces: a transaction is only valid if the sender holds `value + maxFeePerGas * gas`. With a 20 gwei base fee and a 2 gwei tip, the check demands roughly a tenth of what is actually required, so any amount in that gap is accepted here and rejected on chain.

The ERC-20 branch immediately below already checks against `maxGasFee`, and the Max button already reserves `maxGasFee`, so the native branch was the odd one out rather than the intended design.

Recorded as a pending decision in the priority spec; this closes it.

# Changes

- The native branch checks against `maxGasFee`, the ceiling the transaction authorises, matching the ERC-20 branch and the Max button.
- Behind `SEND_TRANSACTION_PRIORITY_ENABLED`, so beta and production keep the current behaviour while this is exercised in local and staging.

The Max button is unaffected in practice: it already reserves `maxGasFee`, so the amount it produces satisfies the stricter check exactly.

# Tests

New `EthSendAmount.spec.ts`, the first for this component:

- an amount that leaves only the tip covered is rejected. This is the bug: it passes under the old rule and fails on chain.
- an amount that leaves the ceiling covered is accepted, so the fix does not simply reject everything.

I verified the first fails when the check is put back on `minGasFee`, so it pins the behaviour rather than passing alongside it.

`check`, `check:tests`, eslint and prettier clean. `tests/eth`: 4119 passed.
