### PR TITLE
test(frontend): make the native send solvency cases discriminate

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -71,8 +71,10 @@
 		// is what decides whether a native send is affordable. `minGasFee` omits the base fee
 		// entirely and therefore bounds nothing the chain enforces.
 		if (isSupportedEthTokenId($sendTokenId) || isSupportedEvmNativeTokenId($sendTokenId)) {
+			// Falling back to the tip rather than to zero: an unknown ceiling must not weaken the check
+			// below what it was before the flag.
 			const gasFee = SEND_TRANSACTION_PRIORITY_ENABLED
-				? ($maxGasFee ?? ZERO)
+				? ($maxGasFee ?? $minGasFee ?? ZERO)
 				: ($minGasFee ?? ZERO);
 
 			const total = userAmount + gasFee;

--- a/src/frontend/src/tests/eth/components/send/EthSendAmount.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendAmount.spec.ts
@@ -4,21 +4,33 @@ import { ETH_FEE_CONTEXT_KEY, initEthFeeContext, initEthFeeStore } from '$eth/st
 import { TOKEN_INPUT_CURRENCY_TOKEN } from '$lib/constants/test-ids.constants';
 import { balancesStore } from '$lib/stores/balances.store';
 import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
+import en from '$tests/mocks/i18n.mock';
+import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 
 describe('EthSendAmount', () => {
 	const gas = 21_000n;
-	const baseFeePerGas = 20n;
-	const maxPriorityFeePerGas = 2n;
 	const maxFeePerGas = 100n;
+	const maxPriorityFeePerGas = 2n;
+	const baseFeePerGas = 20n;
 
-	// What the chain demands the sender hold: amount + maxFeePerGas * gas.
+	// What the chain demands the sender hold on top of the amount.
 	const ceiling = maxFeePerGas * gas;
-	// What the old check demanded, which omits the base fee entirely.
+	// What the previous check demanded, which omits the base fee.
 	const tipOnly = maxPriorityFeePerGas * gas;
 
-	const balance = 1_000_000n;
+	// Comfortably above the ceiling, so `balance - ceiling` stays positive: a negative amount is
+	// rejected as invalid before this validation runs.
+	const balance = 10_000_000n;
+
+	const expectedError = en.send.assertion.insufficient_funds_for_gas;
+
+	const toEther = (value: bigint): string => {
+		const padded = value.toString().padStart(ETHEREUM_TOKEN.decimals + 1, '0');
+
+		return `${padded.slice(0, -ETHEREUM_TOKEN.decimals)}.${padded.slice(-ETHEREUM_TOKEN.decimals)}`;
+	};
 
 	const setup = () => {
 		const feeStore = initEthFeeStore();
@@ -39,13 +51,7 @@ describe('EthSendAmount', () => {
 
 		balancesStore.set({ id: ETHEREUM_TOKEN.id, data: { data: balance, certified: true } });
 
-		return { context };
-	};
-
-	const enter = async (value: bigint) => {
-		const { context } = setup();
-
-		const { container } = render(EthSendAmount, {
+		const { container, queryByText } = render(EthSendAmount, {
 			context,
 			props: {
 				amount: undefined,
@@ -59,38 +65,36 @@ describe('EthSendAmount', () => {
 			`input[data-tid="${TOKEN_INPUT_CURRENCY_TOKEN}"]`
 		);
 
-		expect(input).not.toBeNull();
+		assertNonNullish(input);
 
-		await fireEvent.input(input as HTMLInputElement, {
-			target: { value: formatWei(value) }
-		});
-
-		return { container };
+		return { input, queryByText };
 	};
 
-	const formatWei = (value: bigint): string => {
-		const asString = value.toString().padStart(ETHEREUM_TOKEN.decimals + 1, '0');
-		const whole = asString.slice(0, -ETHEREUM_TOKEN.decimals);
-		const fraction = asString.slice(-ETHEREUM_TOKEN.decimals);
+	it('rejects an amount that leaves only the tip covered', async () => {
+		const { input, queryByText } = setup();
 
-		return `${whole}.${fraction}`;
-	};
-
-	it('rejects an amount that leaves less than the authorised ceiling', async () => {
-		// Affordable under the old tip-only rule, unaffordable to the chain: the send would pass
-		// validation and then fail to cover its own base fee.
-		const { container } = await enter(balance - tipOnly);
+		await fireEvent.input(input, { target: { value: toEther(balance - tipOnly) } });
 
 		await waitFor(() => {
-			expect(container).toHaveTextContent('Insufficient');
+			expect(queryByText(expectedError)).toBeInTheDocument();
 		});
 	});
 
 	it('accepts an amount that leaves the ceiling covered', async () => {
-		const { container } = await enter(balance - ceiling);
+		const { input, queryByText } = setup();
+
+		// Start from a rejected amount so the message is on screen. Waiting for it to disappear only
+		// proves anything if it was there to begin with.
+		await fireEvent.input(input, { target: { value: toEther(balance - tipOnly) } });
 
 		await waitFor(() => {
-			expect(container).not.toHaveTextContent('Insufficient');
+			expect(queryByText(expectedError)).toBeInTheDocument();
+		});
+
+		await fireEvent.input(input, { target: { value: toEther(balance - ceiling) } });
+
+		await waitFor(() => {
+			expect(queryByText(expectedError)).not.toBeInTheDocument();
 		});
 	});
 });

--- a/src/frontend/src/tests/eth/components/send/EthSendAmount.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendAmount.spec.ts
@@ -32,9 +32,14 @@ describe('EthSendAmount', () => {
 		return `${padded.slice(0, -ETHEREUM_TOKEN.decimals)}.${padded.slice(-ETHEREUM_TOKEN.decimals)}`;
 	};
 
-	const setup = () => {
+	const setup = ({ ceilingKnown = true }: { ceilingKnown?: boolean } = {}) => {
 		const feeStore = initEthFeeStore();
-		feeStore.setFee({ maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas, gas });
+		feeStore.setFee({
+			maxFeePerGas: ceilingKnown ? maxFeePerGas : null,
+			maxPriorityFeePerGas,
+			baseFeePerGas,
+			gas
+		});
 
 		const context = new Map<symbol, unknown>();
 		context.set(
@@ -70,10 +75,25 @@ describe('EthSendAmount', () => {
 		return { input, queryByText };
 	};
 
+	const setupWithoutCeiling = () => setup({ ceilingKnown: false });
+
 	it('rejects an amount that leaves only the tip covered', async () => {
 		const { input, queryByText } = setup();
 
 		await fireEvent.input(input, { target: { value: toEther(balance - tipOnly) } });
+
+		await waitFor(() => {
+			expect(queryByText(expectedError)).toBeInTheDocument();
+		});
+	});
+
+	it('still demands the tip when the ceiling is unknown', async () => {
+		// `maxFeePerGas` can come back null, which leaves `maxGasFee` undefined. Falling through to
+		// zero there would accept an amount that cannot even cover the tip, making the check weaker
+		// than the one it replaced.
+		const { input, queryByText } = setupWithoutCeiling();
+
+		await fireEvent.input(input, { target: { value: toEther(balance - 1n) } });
 
 		await waitFor(() => {
 			expect(queryByText(expectedError)).toBeInTheDocument();


### PR DESCRIPTION
# Motivation

Follow-up to #13924. Copilot raised four points on that PR and all four were right, but it entered the merge queue before I could push, so it merged without them. This lands them.

The source fix in #13924 was correct in substance. What was wrong was one fallback and the quality of the test guarding it.

# Changes

**The fallback could weaken the check it replaced.** `gasFee` fell through to `ZERO` when `$maxGasFee` was undefined, which happens when `maxFeePerGas` is null. That is looser than the `minGasFee` it replaced. It now falls back to `$maxGasFee ?? $minGasFee ?? ZERO`.

**The "accepts" case passed for the wrong reason, twice over.**

- `balance` was `1_000_000` against a ceiling of `2_100_000`, so `balance - ceiling` was negative and `invalidAmount` cleared the error before the rule under test ever ran. Balance raised to `10_000_000`.
- `waitFor` with a negated assertion passes on its first tick, before any error could render, so the assertion was vacuous regardless. The case now enters a rejected amount first, waits for the message, then enters an affordable one and waits for it to clear. Waiting for something to disappear only proves anything if it was there.

**Assertions use `en.send.assertion.insufficient_funds_for_gas`** instead of the substring `Insufficient`, matching `BtcSendAmount.spec.ts`.

# Tests

Both cases now discriminate in both directions, which I verified by mutating the rule:

- reverting to `minGasFee` fails the reject case
- doubling the ceiling fails the accept case

Neither held before this PR: the accept case passed under every mutation I tried.

`check`, `check:tests`, eslint and prettier clean.
