### PR TITLE
feat(frontend): list the Solana instructions the wallet cannot read

### DIFF
--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "Revoke spender",
 			"instruction_set_authority": "Change account authority to",
 			"instruction_route": "Swap route via",
+			"instruction_unknown": "Unrecognised instruction",
+			"instruction_unknown_via": "Unrecognised instruction via",
 			"instruction_rent": "rent $amount SOL",
 			"instruction_rent_returned": "rent returned to your wallet",
 			"instruction_returned": "$amount SOL returned to your wallet",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -2018,6 +2018,8 @@
 			"instruction_revoke": "",
 			"instruction_set_authority": "",
 			"instruction_route": "",
+			"instruction_unknown": "",
+			"instruction_unknown_via": "",
 			"instruction_rent": "",
 			"instruction_rent_returned": "",
 			"instruction_returned": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1689,6 +1689,8 @@ interface I18nTransaction {
 		instruction_revoke: string;
 		instruction_set_authority: string;
 		instruction_route: string;
+		instruction_unknown: string;
+		instruction_unknown_via: string;
 		instruction_rent: string;
 		instruction_rent_returned: string;
 		instruction_returned: string;

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -133,9 +133,14 @@
 
 	// The programs the run went through, in the order it reached them and each named once. The
 	// message names none of them itself: a routed swap performs every call inside another program.
+	//
+	// Only the programs that moved something. An instruction the wallet could not read names its
+	// program too, and most transactions carry a couple that change nothing the user holds, so
+	// counting those here would bury the program that did the work among its housekeeping.
 	let venues = $derived([
 		...new Set(
 			flattenInstructions(instructions ?? [])
+				.filter(({ kind }) => kind !== 'unknown')
 				.map(({ program }) => program)
 				.filter(nonNullish)
 		)

--- a/src/frontend/src/sol/services/sol-simulation.services.ts
+++ b/src/frontend/src/sol/services/sol-simulation.services.ts
@@ -99,7 +99,11 @@ const simulate = async ({
 		})),
 		ownedAddresses: [address, ...ownedAddresses],
 		addressToToken,
-		accountLamports
+		accountLamports,
+		// A run whose calls all happen inside a program the wallet cannot read produces no effects
+		// at all, and the review then listed nothing for a transaction that plainly does something.
+		// Saying which programs it hands the instructions to is worth more than an empty list.
+		includeUnrecognised: true
 	});
 
 	// The message read on its own, without the nested calls the run reveals: a second account of

--- a/src/frontend/src/sol/services/wallet-connect.services.ts
+++ b/src/frontend/src/sol/services/wallet-connect.services.ts
@@ -172,12 +172,20 @@ export const decode = async ({
 	// The list the Operations tab shows. A simulated run reveals the calls made inside other
 	// programs, which the message states none of; without one, the message's own top-level
 	// instructions are still worth listing, and the review says which of the two it got.
+	//
+	// The message carries its instructions as raw bytes, so none of them can be read into an
+	// effect and every line here is an unrecognised one naming its program. That is the whole
+	// point of listing them: without it this fallback produced nothing at all.
 	const instructions = nonNullish(simulatedInstructions)
 		? namedInstructions
-		: mapSolInstructionSummaries({
-				instructions: [...parsedTransactionMessage.instructions],
-				innerInstructions: [],
-				ownedAddresses: owned?.ownedAddresses ?? []
+		: await loadSolProgramNames({
+				instructions: mapSolInstructionSummaries({
+					instructions: [...parsedTransactionMessage.instructions],
+					innerInstructions: [],
+					ownedAddresses: owned?.ownedAddresses ?? [],
+					includeUnrecognised: true
+				}),
+				network: solNetwork
 			});
 
 	return {

--- a/src/frontend/src/sol/types/sol-instruction-summary.ts
+++ b/src/frontend/src/sol/types/sol-instruction-summary.ts
@@ -19,7 +19,11 @@ export type SolInstructionSummaryKind =
 	| 'closeTokenAccount'
 	| 'approve'
 	| 'revoke'
-	| 'setAuthority';
+	| 'setAuthority'
+	// An instruction the wallet cannot read. It names the program and says nothing about what the
+	// call does, which is still worth a line: an instruction left out of the list is one the user
+	// has no way of knowing is there.
+	| 'unknown';
 
 /**
  * One line of the review's instruction list.

--- a/src/frontend/src/sol/utils/sol-instruction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instruction-summary.utils.ts
@@ -1,5 +1,6 @@
 import { WSOL_TOKEN } from '$env/tokens/tokens-spl/tokens.wsol.env';
 import { ZERO } from '$lib/constants/app.constants';
+import { COMPUTE_BUDGET_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import type { SolAddress } from '$sol/types/address';
 import type {
 	SolInstructionSummary,
@@ -607,6 +608,13 @@ export const mapSolInstructionSummaries = ({
 					}
 
 					const program = programs[index];
+
+					// The review already states what these do, as the priority fee it charges for.
+					// Listing them here as instructions nothing could read would be noise on every
+					// transaction that sets a compute budget, and untrue besides.
+					if (program === COMPUTE_BUDGET_PROGRAM_ADDRESS) {
+						return acc;
+					}
 
 					return [
 						...acc,

--- a/src/frontend/src/sol/utils/sol-instruction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instruction-summary.utils.ts
@@ -541,7 +541,8 @@ export const mapSolInstructionSummaries = ({
 	innerInstructions = [],
 	ownedAddresses,
 	addressToToken = {},
-	accountLamports = {}
+	accountLamports = {},
+	includeUnrecognised = false
 }: {
 	instructions: readonly unknown[];
 	innerInstructions?: readonly SolInstructionGroup[];
@@ -550,6 +551,10 @@ export const mapSolInstructionSummaries = ({
 	// Lamports per account before the transaction ran, from its balance metadata. A close hands
 	// the destination the whole balance, which no instruction states.
 	accountLamports?: Partial<Record<SolAddress, bigint>>;
+	// Whether to keep a line for each top-level instruction that produced no effect of its own.
+	// Off where the list stands beside the balance changes that vouch for it, on where it is the
+	// only account of the transaction there is.
+	includeUnrecognised?: boolean;
 }): SolInstructionSummary[] => {
 	const flattened = flatten({ instructions, innerInstructions });
 
@@ -587,5 +592,33 @@ export const mapSolInstructionSummaries = ({
 		return [...acc, { ...wrapped, ...(nonNullish(rent) && { rent }), parentIndex }];
 	}, []);
 
-	return groupRoutes({ effects, programs });
+	// A top-level instruction none of the effects came from is one the wallet could not read: a
+	// program it does not know, or a message whose instructions carry raw bytes rather than the
+	// parsed form. Kept in the position it holds in the transaction, so the list reads in the
+	// order the run would take rather than as the recognised instructions with the gaps closed up.
+	const covered = new Set(effects.map(({ parentIndex }) => parentIndex));
+
+	const listed = includeUnrecognised
+		? [
+				...effects,
+				...instructions.reduce<Effect[]>((acc, _, index) => {
+					if (covered.has(index)) {
+						return acc;
+					}
+
+					const program = programs[index];
+
+					return [
+						...acc,
+						{
+							kind: 'unknown' as const,
+							...(nonNullish(program) && { program }),
+							parentIndex: index
+						}
+					];
+				}, [])
+			].sort(({ parentIndex: first }, { parentIndex: second }) => first - second)
+		: effects;
+
+	return groupRoutes({ effects: listed, programs });
 };

--- a/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
@@ -240,7 +240,17 @@ export const formatSolTransactionSummary = ({
  * stays a renderer. The children of a route are the caller's to indent, not this function's.
  */
 export const formatSolInstructionSummary = ({
-	instruction: { kind, amount: value, tokenAddress, decimals, counterparty, own, rent, returned },
+	instruction: {
+		kind,
+		amount: value,
+		tokenAddress,
+		decimals,
+		counterparty,
+		own,
+		rent,
+		returned,
+		program
+	},
 	i18n,
 	symbolOf,
 	decimalsOf
@@ -345,6 +355,16 @@ export const formatSolInstructionSummary = ({
 	if (kind === 'route') {
 		return {
 			text: i18n.transaction.text.instruction_route
+		};
+	}
+
+	// Says only that the wallet could not read it. The program beside it is the whole of what is
+	// known, so the line names that program rather than guessing at what the call does.
+	if (kind === 'unknown') {
+		return {
+			text: nonNullish(program)
+				? i18n.transaction.text.instruction_unknown_via
+				: i18n.transaction.text.instruction_unknown
 		};
 	}
 

--- a/src/frontend/src/tests/sol/utils/sol-instruction-summary.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instruction-summary.utils.spec.ts
@@ -550,6 +550,41 @@ describe('sol-instruction-summary.utils', () => {
 				).toStrictEqual(['createTokenAccount', 'send', 'unknown']);
 			});
 
+			// The review states these as the priority fee it charges for, so calling them
+			// unreadable is untrue, and doing it on every transaction that sets a compute budget
+			// buries the instructions that moved something under two lines of housekeeping.
+			it('should not add a line for a compute budget instruction', () => {
+				const withFlag = (
+					mock: Parameters<typeof mapSolInstructionSummaries>[0]
+				): SolInstructionSummary[] =>
+					mapSolInstructionSummaries({ ...mock, includeUnrecognised: true });
+
+				expect(kinds(withFlag(MOCK_SOL_INSTRUCTIONS.DFLOW_SWAP))).toStrictEqual(
+					kinds(mapSolInstructionSummaries(MOCK_SOL_INSTRUCTIONS.DFLOW_SWAP))
+				);
+
+				expect(kinds(withFlag(MOCK_SOL_INSTRUCTIONS.JUPITER_SWAP))).toStrictEqual(
+					kinds(mapSolInstructionSummaries(MOCK_SOL_INSTRUCTIONS.JUPITER_SWAP))
+				);
+			});
+
+			// The case the flag exists for: a transaction whose every call sits inside programs the
+			// wallet cannot read listed nothing whatsoever before.
+			it('should list a transaction it could read nothing of', () => {
+				expect(kinds(mapSolInstructionSummaries(MOCK_SOL_INSTRUCTIONS.THIRD_PARTY))).toStrictEqual(
+					[]
+				);
+
+				expect(
+					kinds(
+						mapSolInstructionSummaries({
+							...MOCK_SOL_INSTRUCTIONS.THIRD_PARTY,
+							includeUnrecognised: true
+						})
+					)
+				).toStrictEqual(['unknown', 'unknown', 'unknown', 'unknown']);
+			});
+
 			it('should drop them by default, so the activity keeps the list it had', () => {
 				const { instructions, ...rest } = MOCK_SOL_INSTRUCTIONS.SPL_SEND_WITH_ATA;
 

--- a/src/frontend/src/tests/sol/utils/sol-instruction-summary.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instruction-summary.utils.spec.ts
@@ -494,6 +494,77 @@ describe('sol-instruction-summary.utils', () => {
 					[]
 				);
 			});
+
+			it('should keep a line naming the program when asked to list what it cannot read', () => {
+				expect(
+					mapSolInstructionSummaries({
+						instructions: [{ programId: 'SomeUnknownProgram', accounts: [], data: 'AQID' }],
+						ownedAddresses: ['ownerWa11etAddress1111111111111111111111111'],
+						includeUnrecognised: true
+					})
+				).toStrictEqual([{ kind: 'unknown', program: 'SomeUnknownProgram' }]);
+			});
+
+			// The regression this exists for. A WalletConnect request carries kit instructions,
+			// whose data is raw bytes rather than the parsed form the RPC returns, so not one of
+			// them yields an effect. Without a line each, the review listed nothing whatsoever for
+			// a transaction the user was being asked to sign.
+			it('should list the instructions of an unsigned message, which are never parsed', () => {
+				const message = [
+					{ programAddress: '11111111111111111111111111111111', accounts: [], data: 'AQID' },
+					{
+						programAddress: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+						accounts: [],
+						data: 'BAUG'
+					}
+				];
+
+				expect(
+					mapSolInstructionSummaries({
+						instructions: message,
+						ownedAddresses: ['ownerWa11etAddress1111111111111111111111111'],
+						includeUnrecognised: true
+					})
+				).toStrictEqual([
+					{ kind: 'unknown', program: '11111111111111111111111111111111' },
+					{ kind: 'unknown', program: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' }
+				]);
+			});
+
+			// The list is read as the order the run takes, so an instruction that says nothing
+			// still holds its place among the ones that do.
+			it('should leave the instructions it can read where they were', () => {
+				const { instructions, ...rest } = MOCK_SOL_INSTRUCTIONS.SPL_SEND_WITH_ATA;
+
+				expect(
+					kinds(
+						mapSolInstructionSummaries({
+							...rest,
+							instructions: [
+								...instructions,
+								{ programId: 'SomeUnknownProgram', accounts: [], data: 'AQID' }
+							],
+							includeUnrecognised: true
+						})
+					)
+				).toStrictEqual(['createTokenAccount', 'send', 'unknown']);
+			});
+
+			it('should drop them by default, so the activity keeps the list it had', () => {
+				const { instructions, ...rest } = MOCK_SOL_INSTRUCTIONS.SPL_SEND_WITH_ATA;
+
+				expect(
+					kinds(
+						mapSolInstructionSummaries({
+							...rest,
+							instructions: [
+								...instructions,
+								{ programId: 'SomeUnknownProgram', accounts: [], data: 'AQID' }
+							]
+						})
+					)
+				).toStrictEqual(['createTokenAccount', 'send']);
+			});
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The Operations tab of the Solana WalletConnect review showed nothing for a good number of requests. The list is built from effects, so a transaction whose calls all happen inside a program OISY does not know produced an empty list and the section was hidden.

Without a simulation this was total. A WalletConnect request carries kit instructions, whose data is raw bytes rather than the parsed form the RPC returns, so none of them can yield an effect: the fallback added in #13917 returned an empty list every time.

# Changes

- A new `unknown` instruction kind, carrying the program and no claim about what the call does.
- `mapSolInstructionSummaries` gains `includeUnrecognised`, keeping a line for each top-level instruction that produced no effect, in the position it holds.
- Opt-in, taken only by the two WalletConnect paths, so the activity list is unchanged.
- Unread programs stay out of the venues line, which would otherwise show Compute Budget on nearly every transaction.

# Tests

Four cases on `mapSolInstructionSummaries`, one of them the regression: kit instructions returned `[]` before and now return a line per instruction naming its program.