### PR TITLE
style(frontend): drop the info icon from the priority row

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeePriority.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeePriority.svelte
@@ -8,7 +8,6 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import CollapsibleBottomSheet from '$lib/components/ui/CollapsibleBottomSheet.svelte';
 	import Responsive from '$lib/components/ui/Responsive.svelte';
-	import Tooltip from '$lib/components/ui/Tooltip.svelte';
 	import {
 		ETH_FEE_PRIORITY,
 		ETH_FEE_PRIORITY_OPTION,
@@ -75,12 +74,7 @@
 		<CollapsibleBottomSheet sheetTitle={$i18n.fee.text.priority}>
 			{#snippet contentHeader()}
 				<span class="flex min-w-0 flex-1 items-center justify-between gap-2">
-					<span class="flex items-center gap-1 text-sm text-tertiary">
-						{$i18n.fee.text.priority}
-						<Tooltip text={$i18n.fee.info.priority}>
-							<span class="text-tertiary">ⓘ</span>
-						</Tooltip>
-					</span>
+					<span class="text-sm text-tertiary">{$i18n.fee.text.priority}</span>
 
 					<Responsive up="md">
 						<span class="text-sm font-bold text-primary">{selectedName}</span>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "رصيد غير كافٍ لتغطية الرسوم."
 		},

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Nedostatečný zůstatek k pokrytí poplatků."
 		},

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Unzureichendes Guthaben, um die Gebühren zu decken."
 		},

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "Priority",
 			"ata_kind": "Account rent"
 		},
-		"info": {
-			"priority": "Priority affects speed and fees. Higher priority usually means faster processing."
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Insufficient balance to cover the fees."
 		},

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Saldo insuficiente para cubrir las comisiones."
 		},

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Solde insuffisant pour couvrir les frais."
 		},

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "शुल्क को कवर करने के लिए अपर्याप्त बैलेंस।"
 		},

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Saldo insufficiente per coprire le fee."
 		},

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "手数料をカバーするのに十分な資金がありません。"
 		},

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "수수료를 충당할 잔액이 부족합니다."
 		},

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Niewystarczające saldo na pokrycie opłat."
 		},

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Saldo insuficiente para cobrir as taxas."
 		},

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Недостаточный баланс для покрытия комиссий."
 		},

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "Số dư không đủ để trả phí."
 		},

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1582,9 +1582,6 @@
 			"prioritization_kind": "",
 			"ata_kind": ""
 		},
-		"info": {
-			"priority": ""
-		},
 		"assertion": {
 			"insufficient_funds_for_fee": "余额不足以支付手续费。"
 		},

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1272,7 +1272,6 @@ interface I18nFee {
 		prioritization_kind: string;
 		ata_kind: string;
 	};
-	info: { priority: string };
 	assertion: { insufficient_funds_for_fee: string };
 	error: { cannot_fetch_gas_fee: string };
 }


### PR DESCRIPTION
# Motivation

QA feedback: the ⓘ next to `Priority` is not wanted.

# Changes

- Removes the icon and the `Tooltip` that wrapped it.
- Removes `fee.info.priority`, which existed only to feed that tooltip and is now unreferenced. Left in place it would be a dead key.

Worth knowing before this merges: that string was the copy the designer wrote for this row ("Priority affects speed and fees. Higher priority usually means faster processing."). Removing the icon is the only way to surface it, so the explanation goes away with it. Easy to restore from history if the icon comes back.

# Tests

Covered by the existing `EthFeePriority.spec.ts`, which still passes. Nothing asserted the icon, and asserting its absence would just restate the markup.

`check`, `check:tests`, eslint and prettier clean.
