### PR TITLE
style(frontend): colour the desktop priority choice like the mobile one

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeePriority.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeePriority.svelte
@@ -83,7 +83,7 @@
 					</span>
 
 					<Responsive up="md">
-						<span class="text-sm font-bold text-primary">{selectedName}</span>
+						<span class="text-sm font-bold text-brand-primary-alt">{selectedName}</span>
 					</Responsive>
 				</span>
 			{/snippet}
@@ -126,3 +126,9 @@
 		</CollapsibleBottomSheet>
 	</div>
 {/if}
+
+<style lang="scss">
+	:global([data-tid='eth-fee-priority'] button.collapsible-expand-icon) {
+		color: var(--color-foreground-brand-primary-alt);
+	}
+</style>


### PR DESCRIPTION
# Motivation

On a small screen the current priority renders as a link, so it and its chevron are blue. On a large screen the same value sits in the collapsed header in plain bold, and the chevron is Collapsible's default grey. Two treatments for one control. QA asked for the desktop one to match.

# Changes

- The header value uses `text-brand-primary-alt`, the same token `Button link` resolves to.
- The chevron is coloured to match via a scoped `:global` rule.

The chevron belongs to `Collapsible`, which exposes no colour prop, so there is no way to reach it from props alone. The rule is scoped to `[data-tid='eth-fee-priority']` so every other collapsible in the app keeps its default. Adding a prop to `Collapsible` would be the tidier fix if a second caller ever needs this, but one caller does not justify widening a shared component's API.

Note the rule sets the CSS variable directly rather than `@apply text-brand-primary-alt`: `@apply` cannot resolve utilities inside a component style block without a `@reference` directive, and fails the build.

# Tests

Covered by the existing `EthFeePriority.spec.ts`. This is colour only, and jsdom does not compute styles, so an assertion here would test nothing.

`check`, `check:tests`, eslint and prettier clean.

> Stacked on #13929, which touches the same file.
