### PR TITLE
fix(frontend): stop the collapsible toggle submitting its surrounding form

### DIFF
--- a/src/frontend/src/lib/components/ui/Collapsible.svelte
+++ b/src/frontend/src/lib/components/ui/Collapsible.svelte
@@ -89,6 +89,7 @@
 				data-tid="collapsible-expand-button"
 				tabindex="-1"
 				title={expanded ? $i18n.core.text.collapse : $i18n.core.text.expand}
+				type="button"
 			>
 				<IconExpandMore />
 			</button>

--- a/src/frontend/src/tests/lib/components/ui/Collapsible.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/Collapsible.spec.ts
@@ -1,0 +1,22 @@
+import CollapsibleTest from '$tests/lib/components/ui/CollapsibleTest.svelte';
+import { render, waitFor } from '@testing-library/svelte';
+
+describe('Collapsible', () => {
+	it('toggles without submitting a surrounding form', async () => {
+		const onSubmit = vi.fn();
+
+		const { getByTestId } = render(CollapsibleTest, { props: { onSubmit } });
+
+		const toggle = getByTestId('collapsible-expand-button');
+
+		// A bare <button> defaults to type="submit". Inside a form, expanding a section would submit
+		// it and run the browser's validation over fields the user has not reached yet.
+		expect(toggle).toHaveAttribute('type', 'button');
+
+		toggle.click();
+
+		await waitFor(() => {
+			expect(onSubmit).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/components/ui/CollapsibleTest.svelte
+++ b/src/frontend/src/tests/lib/components/ui/CollapsibleTest.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Collapsible from '$lib/components/ui/Collapsible.svelte';
+
+	interface Props {
+		onSubmit: () => void;
+	}
+
+	let { onSubmit }: Props = $props();
+</script>
+
+<form onsubmit={onSubmit}>
+	<Collapsible>
+		{#snippet header()}
+			<span>header</span>
+		{/snippet}
+
+		<span>content</span>
+	</Collapsible>
+</form>


### PR DESCRIPTION
# Motivation

Collapsing the priority section on desktop pops "Please fill out this field" on the amount input.

`Collapsible`'s expand button is a bare `<button>` with no `type`, so it defaults to `type="submit"`. Inside the send `<form>` that submits the form, and the browser runs HTML5 validation over fields the user has not reached yet.

This is the same defect fixed on the priority trigger and the sheet's Done button in #13921, but one level down in the shared component, which is why it survived: those fixes only covered the buttons this feature owns.

# Changes

- `type="button"` on the collapsible toggle.

It is a shared component, but the change is correct for every caller: an expand toggle should never submit anything. Eight components use `Collapsible`, and the send form is the one that currently sits inside a `<form>`, so it is the only visible symptom today. Anything else placed in a form later would have hit it too.

# Tests

New `Collapsible.spec.ts`, the first for this component: it renders inside a form, asserts the toggle is `type="button"`, and asserts clicking it does not fire submit. I verified it fails when the attribute is removed.

`check`, `check:tests`, eslint and prettier clean. The `lib/components/ui` suite passes at 278.
