### PR TITLE
style(frontend): tighten the spacing in the priority option label

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeePriorityOption.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeePriorityOption.svelte
@@ -47,8 +47,8 @@
 		value={priority}
 	/>
 
-	<span class="flex min-w-0 items-baseline gap-2">
-		<span class="font-bold whitespace-nowrap text-primary">{name} {emoji}</span>
+	<span class="flex min-w-0 items-baseline gap-1.5">
+		<span class="font-bold whitespace-nowrap text-primary">{name}{emoji}</span>
 		<span class="min-w-0 truncate text-sm text-tertiary">{description}</span>
 	</span>
 


### PR DESCRIPTION
# Motivation

QA feedback on the priority option rows: the emoji sits too far from the descriptor, and there is an unwanted space between the tier name and its emoji.

# Changes

Both are spacing on the same label group, so they are one change rather than two PRs stacked on the same line:

- the gap between the name group and the descriptor drops from `gap-2` to `gap-1.5`, bringing the emoji closer to the text it sits next to without closing it up entirely
- the literal space between the name and the emoji is removed, so it reads `Slow🐢` rather than `Slow 🐢`

# Tests

Covered by the existing `EthFeePriority.spec.ts`, which still passes at 8.

Worth noting for anyone reading those tests later: the header assertion matches the tier name exactly, so it deliberately does not match an option row, whose text is now `Normal⚡`. That still holds after this change, and I re-ran the suite to confirm rather than assuming.

`check`, `check:tests`, eslint and prettier clean.
