### PR TITLE
fix(frontend): quote and disclose Chain Fusion Bitcoin swap fees

### DIFF
--- a/src/frontend/src/btc/components/swap/SwapBtcFees.svelte
+++ b/src/frontend/src/btc/components/swap/SwapBtcFees.svelte
@@ -15,7 +15,8 @@
 		type SwapAmountsContext
 	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
-	import { SwapProvider } from '$lib/types/swap';
+	import { SwapProvider, type ChainFusionFee } from '$lib/types/swap';
+	import { chainFusionFeeSectionFees } from '$lib/utils/chain-fusion-swap.utils';
 	import { resolveText } from '$lib/utils/i18n.utils';
 
 	const { sourceToken, sourceTokenExchangeRate } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
@@ -26,10 +27,11 @@
 
 	// The Bitcoin counterpart of `SwapFees`, which cannot serve this form: it reads the IC
 	// token fee context, which only the ICP-source wizard sets. Same rule as there — every
-	// fee the quote priced, so the total is the user's whole cost of the conversion.
+	// fee the user pays on top of the amount, so the total is their whole cost out of balance,
+	// while the ones the minter withholds are disclosed in the provider sheet.
 	let fees = $derived(
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.CHAIN_FUSION
-			? $swapAmountsStore.selectedProvider.swapDetails.sourceFees
+			? chainFusionFeeSectionFees($swapAmountsStore.selectedProvider.swapDetails.sourceFees)
 			: undefined
 	);
 
@@ -45,34 +47,44 @@
 	);
 </script>
 
-{#if nonNullish(fees) && nonNullish(totalFee) && nonNullish($sourceToken)}
-	<ModalExpandableValues>
-		{#snippet listHeader()}
-			<FeeDisplay
-				decimals={$sourceToken.decimals}
-				exchangeRate={$sourceTokenExchangeRate}
-				feeAmount={totalFee}
-				symbol={$sourceToken.symbol}
-				zeroAmountLabel={$i18n.fee.text.zero_fee}
-			>
-				{#snippet label()}{$i18n.swap.text.total_fee}{/snippet}
-			</FeeDisplay>
-		{/snippet}
+{#snippet feeRow({ labelPath, fee, token }: ChainFusionFee)}
+	<FeeDisplay
+		decimals={token.decimals}
+		exchangeRate={$exchanges?.[token.id]?.usd}
+		feeAmount={fee}
+		symbol={token.symbol}
+		zeroAmountLabel={$i18n.fee.text.zero_fee}
+	>
+		{#snippet label()}{resolveText({ i18n: $i18n, path: labelPath })}{/snippet}
+	</FeeDisplay>
+{/snippet}
 
-		{#snippet listItems()}
-			{#each fees as { labelPath, fee, token } (labelPath)}
+{#if nonNullish(fees) && nonNullish(totalFee) && nonNullish($sourceToken)}
+	<!-- A total of one fee is that fee: a collapsible whose only item repeats its header
+		 says nothing, so a single row stands on its own under its own label. -->
+	{#if fees.length === 1}
+		{@render feeRow(fees[0])}
+	{:else}
+		<ModalExpandableValues>
+			{#snippet listHeader()}
 				<FeeDisplay
-					decimals={token.decimals}
-					exchangeRate={$exchanges?.[token.id]?.usd}
-					feeAmount={fee}
-					symbol={token.symbol}
+					decimals={$sourceToken.decimals}
+					exchangeRate={$sourceTokenExchangeRate}
+					feeAmount={totalFee}
+					symbol={$sourceToken.symbol}
 					zeroAmountLabel={$i18n.fee.text.zero_fee}
 				>
-					{#snippet label()}{resolveText({ i18n: $i18n, path: labelPath })}{/snippet}
+					{#snippet label()}{$i18n.swap.text.total_fee}{/snippet}
 				</FeeDisplay>
-			{/each}
-		{/snippet}
-	</ModalExpandableValues>
+			{/snippet}
+
+			{#snippet listItems()}
+				{#each fees as chainFusionFee (chainFusionFee.labelPath)}
+					{@render feeRow(chainFusionFee)}
+				{/each}
+			{/snippet}
+		</ModalExpandableValues>
+	{/if}
 {:else if nonNullish(satoshisFee) && nonNullish($sourceToken)}
 	<FeeDisplay
 		decimals={$sourceToken.decimals}

--- a/src/frontend/src/lib/components/swap/SwapDetailsChainFusion.svelte
+++ b/src/frontend/src/lib/components/swap/SwapDetailsChainFusion.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
+	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
+	import { exchanges } from '$lib/derived/exchange.derived';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import type { SwapMappedResult, SwapProvider } from '$lib/types/swap';
+	import { chainFusionProviderDetailsFees } from '$lib/utils/chain-fusion-swap.utils';
 	import { formatToken } from '$lib/utils/format.utils';
+	import { resolveText } from '$lib/utils/i18n.utils';
 
 	interface Props {
 		provider: Extract<SwapMappedResult, { provider: SwapProvider.CHAIN_FUSION }>;
@@ -15,10 +19,15 @@
 
 	const { sourceToken } = getContext<SwapContext>(SWAP_CONTEXT_KEY);
 
-	// No fees here, deliberately. This sheet is the provider's identity — name, website and the
-	// constraints it imposes — while the fee breakdown belongs to the form's fee section, which
-	// carries every component and their total. Splitting the fees across both surfaces meant
-	// either duplicating them or leaving each surface incomplete.
+	// Only the fees the minter withholds from the converted amount, which the fee section
+	// leaves out because they are already priced into the receive amount — the rest of the
+	// breakdown, and the total, stay with the form. Never summed: a total of a subset of the
+	// fees would be a third figure that answers no question the user has.
+	const providerFees = $derived([
+		...chainFusionProviderDetailsFees(provider.swapDetails.sourceFees),
+		...chainFusionProviderDetailsFees(provider.swapDetails.externalFees)
+	]);
+
 	const formattedMinimumAmount = $derived(
 		nonNullish(provider.swapDetails.minimumAmount) && nonNullish($sourceToken)
 			? formatToken({
@@ -29,6 +38,20 @@
 			: undefined
 	);
 </script>
+
+<!-- Keyed by index, like `SwapDetailsOisyTrade`'s rows: the list is fixed per direction and
+	 never reordered, and the label is not a safe identity across a future itemization. -->
+{#each providerFees as { labelPath, fee, token }, index (index)}
+	<FeeDisplay
+		decimals={token.decimals}
+		exchangeRate={$exchanges?.[token.id]?.usd}
+		feeAmount={fee}
+		symbol={token.symbol}
+		zeroAmountLabel={$i18n.fee.text.zero_fee}
+	>
+		{#snippet label()}{resolveText({ i18n: $i18n, path: labelPath })}{/snippet}
+	</FeeDisplay>
+{/each}
 
 {#if nonNullish(formattedMinimumAmount) && nonNullish($sourceToken)}
 	<ModalValue>

--- a/src/frontend/src/lib/components/swap/SwapFees.svelte
+++ b/src/frontend/src/lib/components/swap/SwapFees.svelte
@@ -2,6 +2,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { IC_TOKEN_FEE_CONTEXT_KEY, type IcTokenFeeContext } from '$icp/stores/ic-token-fee.store';
+	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
 	import SwapFee from '$lib/components/swap/SwapFee.svelte';
 	import ModalExpandableValues from '$lib/components/ui/ModalExpandableValues.svelte';
 	import ModalValue from '$lib/components/ui/ModalValue.svelte';
@@ -17,6 +18,7 @@
 	} from '$lib/stores/swap-amounts.store';
 	import { SWAP_CONTEXT_KEY, type SwapContext } from '$lib/stores/swap.store';
 	import { SwapProvider } from '$lib/types/swap';
+	import { chainFusionFeeSectionFees } from '$lib/utils/chain-fusion-swap.utils';
 	import { formatToken, formatCurrency } from '$lib/utils/format.utils';
 	import { resolveText } from '$lib/utils/i18n.utils';
 	import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
@@ -54,17 +56,15 @@
 			: '0'
 	);
 
-	// Every fee the quote priced, including the ones the minter withholds from the amount it
-	// converts. The total shown has to be the user's whole cost — what they pay out of balance
-	// plus what is taken out of what lands — or the gap between the pay and receive amounts is
-	// accounted for nowhere. `deductedFromAmount` decides the receive amount, not what is
-	// disclosed.
+	// Every fee the quote priced except the ones the provider sheet discloses instead, so the
+	// total shown here is the user's cost out of balance. Nullish only when the offer is not a
+	// Chain Fusion one, which is what picks the generic rows below — an empty array would not.
 	let chainFusionFees = $derived(
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.CHAIN_FUSION
-			? [
+			? chainFusionFeeSectionFees([
 					...$swapAmountsStore.selectedProvider.swapDetails.sourceFees,
 					...$swapAmountsStore.selectedProvider.swapDetails.externalFees
-				]
+				])
 			: undefined
 	);
 
@@ -144,37 +144,53 @@
 </script>
 
 {#if nonNullish($destinationToken) && nonNullish($sourceToken)}
-	<ModalExpandableValues>
-		{#snippet listHeader()}
-			<ModalValue>
-				{#snippet label()}
-					{$i18n.swap.text.total_fee}
-				{/snippet}
+	<!-- A total of one fee is that fee: a collapsible whose only item repeats its header says
+		 nothing, so a lone quote-priced row stands on its own under its own label, with its
+		 fiat value like the header would have carried. -->
+	{#if nonNullish(chainFusionFees) && chainFusionFees.length === 1}
+		{@const [{ labelPath, fee, token }] = chainFusionFees}
+		<FeeDisplay
+			decimals={token.decimals}
+			exchangeRate={$exchanges?.[token.id]?.usd}
+			feeAmount={fee}
+			symbol={getTokenDisplaySymbol(token)}
+			zeroAmountLabel={$i18n.fee.text.zero_fee}
+		>
+			{#snippet label()}{resolveText({ i18n: $i18n, path: labelPath })}{/snippet}
+		</FeeDisplay>
+	{:else}
+		<ModalExpandableValues>
+			{#snippet listHeader()}
+				<ModalValue>
+					{#snippet label()}
+						{$i18n.swap.text.total_fee}
+					{/snippet}
 
-				{#snippet mainValue()}
-					{#if isLoading}
-						<div class="w-14 sm:w-16">
-							<SkeletonText />
-						</div>
-					{:else if isNullish(totalFeeUsd)}
-						{sourceTokenSubtotal} {getTokenDisplaySymbol($sourceToken)}
-					{:else}
-						{formatCurrency({
-							value: totalFeeUsd,
-							currency: $currentCurrency,
-							exchangeRate: $currencyExchangeStore,
-							language: $currentLanguage,
-							notBelowThreshold: true
-						})}
-					{/if}
-				{/snippet}
-			</ModalValue>
-		{/snippet}
+					{#snippet mainValue()}
+						{#if isLoading}
+							<div class="w-14 sm:w-16">
+								<SkeletonText />
+							</div>
+						{:else if isNullish(totalFeeUsd)}
+							{sourceTokenSubtotal} {getTokenDisplaySymbol($sourceToken)}
+						{:else}
+							{formatCurrency({
+								value: totalFeeUsd,
+								currency: $currentCurrency,
+								exchangeRate: $currencyExchangeStore,
+								language: $currentLanguage,
+								notBelowThreshold: true
+							})}
+						{/if}
+					{/snippet}
+				</ModalValue>
+			{/snippet}
 
-		{#snippet listItems()}
-			{#each feeRows as { label, amount, symbol }, index (index)}
-				<SwapFee fee={amount} feeLabel={label} {symbol} />
-			{/each}
-		{/snippet}
-	</ModalExpandableValues>
+			{#snippet listItems()}
+				{#each feeRows as { label, amount, symbol }, index (index)}
+					<SwapFee fee={amount} feeLabel={label} {symbol} />
+				{/each}
+			{/snippet}
+		</ModalExpandableValues>
+	{/if}
 {/if}

--- a/src/frontend/src/lib/services/chain-fusion-swap.services.ts
+++ b/src/frontend/src/lib/services/chain-fusion-swap.services.ts
@@ -336,11 +336,15 @@ const resolveCkErc20WithdrawalDetails = async (
 };
 
 /**
- * ckBTC → BTC. Three fees, itemized exactly as `IcTokenFees` does, and only one of them
- * comes out of what the user receives: the Bitcoin network and minter fees the ckBTC
- * minter pays out of the amount it withdraws, which is the `totalDestinationTokenFee` the
- * Convert flow deducts too. The ledger fee (for `icrc2_approve`) and the KYT fee are
- * charged beside the amount.
+ * ckBTC → BTC. Two fees, and only one of them comes out of what the user receives: the
+ * Bitcoin network and minter fees the ckBTC minter pays out of the amount it withdraws,
+ * which is the `totalDestinationTokenFee` the Convert flow deducts too. The ledger fee (for
+ * `icrc2_approve`) is charged beside the amount.
+ *
+ * `IcTokenFees`'s third row, the KYT fee, is deliberately absent: the user is not charged it
+ * on this side of the pair, unlike on a deposit. Finalized withdrawals pay out exactly
+ * `amount - bitcoin_fee - minter_fee`, and the minter burns the full `amount` with no check
+ * fee in the memo — the Convert flow lists a fee nobody pays.
  *
  * The fee estimate depends on the amount, so unlike the Ethereum arms this query re-runs on
  * every debounced amount change. It does *not* refresh beyond that: `SwapTokenWizard` sets
@@ -390,11 +394,6 @@ const resolveCkBtcWithdrawalDetails = async ({
 	return {
 		sourceFees: [
 			{ labelPath: 'fee.text.fee', fee, token: sourceToken },
-			{
-				labelPath: 'fee.text.estimated_inter_network',
-				fee: minterInfo.data.kyt_fee,
-				token: sourceToken
-			},
 			{
 				labelPath: 'fee.text.estimated_btc',
 				fee: bitcoin_fee + minter_fee,

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -322,15 +322,18 @@ export type ChainFusionFee = ProviderFee & {
 	/**
 	 * Whether the fee comes out of the converted amount, reducing what the user receives.
 	 *
-	 * It decides the receive amount and nothing else: every fee is disclosed either way, in
-	 * the form's fee section, because the total shown there has to be the user's whole cost of
-	 * the conversion. The provider sheet carries no fees.
+	 * It decides two things at once: the receive amount, and where the fee is disclosed. A
+	 * deducted fee is already visible as the gap between the pay and receive amounts, so it is
+	 * stated in the provider sheet; a fee paid on top is itemized and totaled in the form's fee
+	 * section — see `chainFusionProviderDetailsFees` / `chainFusionFeeSectionFees`.
 	 *
 	 * The test is what the minter actually takes out of the amount it credits or pays out,
 	 * which is not the same as what the Convert flow displays — a real BTC → ckBTC
 	 * conversion showed Convert quoting 1:1 while the minter withheld its KYT fee. So:
 	 * - **Flagged:** the ckBTC KYT fee on a BTC → ckBTC deposit, and the Bitcoin network +
 	 *   minter fee on a ckBTC → BTC withdrawal (`IcTokenFees`'s `totalDestinationTokenFee`).
+	 *   Not the KYT fee on a withdrawal: finalized withdrawals pay out exactly
+	 *   `amount - bitcoin_fee - minter_fee`.
 	 * - **Not flagged:** a ck ledger fee, because `approve(amount)` debits `amount + fee`
 	 *   while the minter moves the full `amount`.
 	 * - **Not flagged:** the BTC network fee of a deposit — UTXO selection covers it out of

--- a/src/frontend/src/lib/utils/chain-fusion-swap.utils.ts
+++ b/src/frontend/src/lib/utils/chain-fusion-swap.utils.ts
@@ -150,6 +150,23 @@ export const asCkTwinOf = ({
 	isCkTokenWithTwin(ckToken) && ckToken.twinToken.id === nativeToken.id ? ckToken : undefined;
 
 /**
+ * Splits the quoted fees by the surface that discloses them.
+ *
+ * A fee the minter withholds from the amount it converts is already visible as the gap
+ * between the pay and the receive amount, so itemizing it below the form as well reads as a
+ * second, separate charge. Those belong to the provider sheet — the same division Velora
+ * makes, whose Delta gas comes out of the receive amount and is stated there as its network
+ * cost rather than in the fee section. Everything the user pays on top of the amount stays
+ * in the fee section, whose total has to be the whole cost paid out of balance. The two are
+ * complementary: every quoted fee lands on exactly one surface.
+ */
+export const chainFusionFeeSectionFees = (fees: ChainFusionFee[]): ChainFusionFee[] =>
+	fees.filter(({ deductedFromAmount }) => deductedFromAmount !== true);
+
+export const chainFusionProviderDetailsFees = (fees: ChainFusionFee[]): ChainFusionFee[] =>
+	fees.filter(({ deductedFromAmount }) => deductedFromAmount === true);
+
+/**
  * A ck conversion is 1:1, so the received amount is the source amount less only the
  * fees the minter actually takes out of it — see `ChainFusionFee.deductedFromAmount`.
  * Fees charged on top, such as a ck ledger fee, are itemized below the form and must

--- a/src/frontend/src/tests/btc/components/swap/SwapBtcFees.spec.ts
+++ b/src/frontend/src/tests/btc/components/swap/SwapBtcFees.spec.ts
@@ -16,6 +16,12 @@ describe('SwapBtcFees', () => {
 		receiveAmount: 1_000_000n,
 		swapDetails: {
 			sourceFees: [
+				{
+					labelPath: 'fee.text.convert_inter_network_fee',
+					fee: 100n,
+					token: BTC_MAINNET_TOKEN,
+					deductedFromAmount: true
+				},
 				{ labelPath: 'fee.text.convert_btc_network_fee', fee: 1_000n, token: BTC_MAINNET_TOKEN }
 			],
 			externalFees: []
@@ -60,14 +66,51 @@ describe('SwapBtcFees', () => {
 		return context;
 	};
 
-	it('renders the priced fee breakdown for a Chain Fusion offer', () => {
+	// A total of one fee is that fee, so the lone row stands on its own under its own label
+	// rather than under a "Total fee" header it would only repeat.
+	it('renders a lone priced fee as a single row, without a total', () => {
 		const { getByText, queryByText } = render(SwapBtcFees, {
 			context: createContext({ offer: chainFusionOffer })
 		});
 
-		expect(getByText(en.swap.text.total_fee)).toBeInTheDocument();
 		expect(getByText(en.fee.text.convert_btc_network_fee)).toBeInTheDocument();
+		expect(getByText('0.00001 BTC')).toBeInTheDocument();
+		expect(queryByText(en.swap.text.total_fee)).not.toBeInTheDocument();
 		expect(queryByText(en.fee.text.network_fee)).not.toBeInTheDocument();
+	});
+
+	// The KYT fee the ckBTC minter withholds is already priced into the receive amount, so the
+	// provider sheet states it and this section does not — a deposit's whole cost out of
+	// balance is the Bitcoin network fee alone.
+	it('leaves out the fee the provider sheet discloses', () => {
+		const { queryByText } = render(SwapBtcFees, {
+			context: createContext({ offer: chainFusionOffer })
+		});
+
+		expect(queryByText(en.fee.text.convert_inter_network_fee)).not.toBeInTheDocument();
+		expect(queryByText('0.000001 BTC')).not.toBeInTheDocument();
+	});
+
+	it('totals several priced fees under a collapsible header', () => {
+		const { getByText } = render(SwapBtcFees, {
+			context: createContext({
+				offer: {
+					...chainFusionOffer,
+					swapDetails: {
+						sourceFees: [
+							...chainFusionOffer.swapDetails.sourceFees,
+							{ labelPath: 'fee.text.fee', fee: 500n, token: BTC_MAINNET_TOKEN }
+						],
+						externalFees: []
+					}
+				}
+			})
+		});
+
+		expect(getByText(en.swap.text.total_fee)).toBeInTheDocument();
+		expect(getByText('0.000015 BTC')).toBeInTheDocument();
+		expect(getByText(en.fee.text.convert_btc_network_fee)).toBeInTheDocument();
+		expect(getByText(en.fee.text.fee)).toBeInTheDocument();
 	});
 
 	// The NEAR Intents quote prices its own fees into the receive amount; the deposit's

--- a/src/frontend/src/tests/btc/components/swap/SwapBtcForm.spec.ts
+++ b/src/frontend/src/tests/btc/components/swap/SwapBtcForm.spec.ts
@@ -131,16 +131,16 @@ describe('SwapBtcForm', () => {
 		vi.clearAllMocks();
 	});
 
-	// The Convert flow's breakdown minus its zero-valued conversion-fee row, and including the
-	// KYT fee the minter withholds — which `SwapFees` would have filtered out as already
+	// The Convert flow's breakdown minus its zero-valued conversion-fee row, and minus the KYT
+	// fee the minter withholds — which the provider sheet states instead, since it is already
 	// reflected in the receive amount.
 	it('itemizes the deposit fees from the selected offer', () => {
 		const { getByText, queryByText } = render(SwapBtcForm, { props, context: createContext() });
 
-		expect(getByText(en.swap.text.total_fee)).toBeInTheDocument();
-		expect(getByText(en.fee.text.convert_inter_network_fee)).toBeInTheDocument();
 		expect(getByText(en.fee.text.convert_btc_network_fee)).toBeInTheDocument();
 		expect(queryByText(en.fee.text.convert_fee)).not.toBeInTheDocument();
+		// One fee left means one row, not a "Total fee" header over a list of one.
+		expect(queryByText(en.swap.text.total_fee)).not.toBeInTheDocument();
 	});
 
 	it('renders both token inputs and the provider row', () => {
@@ -210,18 +210,21 @@ describe('SwapBtcForm', () => {
 		});
 	});
 
-	// The gap between the pay and receive amounts is the KYT fee, so it has to be part of the
-	// total the form reports — otherwise nothing on the form accounts for it.
-	it('counts the deducted KYT fee into the total', () => {
-		const { getByText } = render(SwapBtcForm, { props, context: createContext() });
+	// The KYT fee is already the gap between the pay and receive amounts, so the fee section
+	// reports only what the deposit costs on top of it — the Bitcoin network fee. The provider
+	// sheet states the KYT fee; counting it here as well would read as a second charge.
+	it('keeps the deducted KYT fee out of the fee section', () => {
+		const { getByText, queryByText } = render(SwapBtcForm, { props, context: createContext() });
 
-		const total = formatToken({
-			value: KYT_FEE + mockUtxosFee.feeSatoshis,
-			unitName: BTC_MAINNET_TOKEN.decimals,
-			displayDecimals: BTC_MAINNET_TOKEN.decimals
-		});
+		const asBtc = (value: bigint) =>
+			`${formatToken({
+				value,
+				unitName: BTC_MAINNET_TOKEN.decimals,
+				displayDecimals: BTC_MAINNET_TOKEN.decimals
+			})} ${BTC_MAINNET_TOKEN.symbol}`;
 
-		expect(getByText(`${total} ${BTC_MAINNET_TOKEN.symbol}`)).toBeInTheDocument();
+		expect(getByText(asBtc(mockUtxosFee.feeSatoshis))).toBeInTheDocument();
+		expect(queryByText(asBtc(KYT_FEE + mockUtxosFee.feeSatoshis))).not.toBeInTheDocument();
 	});
 
 	// The quote refuses to price an unusable selection, so the absent offer is explained by

--- a/src/frontend/src/tests/btc/components/swap/SwapBtcWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/swap/SwapBtcWizard.spec.ts
@@ -165,16 +165,19 @@ describe('SwapBtcWizard', () => {
 			expect(getByText(en.swap.text.review_button)).toBeInTheDocument();
 		});
 
-		it('renders the review step with the fee breakdown', () => {
+		// The offer prices a single fee, which stands as its own row rather than under a
+		// "Total fee" header it would only repeat.
+		it('renders the review step with the fee row', () => {
 			const { context } = createContext();
 
-			const { getByText } = render(SwapBtcWizard, {
+			const { getByText, queryByText } = render(SwapBtcWizard, {
 				props: { ...baseProps, currentStep: { name: WizardStepsSwap.REVIEW, title: 'Swap' } },
 				context
 			});
 
 			expect(getByText(en.swap.text.swap_button)).toBeInTheDocument();
-			expect(getByText(en.swap.text.total_fee)).toBeInTheDocument();
+			expect(getByText(en.fee.text.convert_btc_network_fee)).toBeInTheDocument();
+			expect(queryByText(en.swap.text.total_fee)).not.toBeInTheDocument();
 		});
 
 		it('renders the review step with the network fee for a NEAR Intents offer', () => {

--- a/src/frontend/src/tests/lib/components/swap/SwapDetailsChainFusion.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapDetailsChainFusion.spec.ts
@@ -43,15 +43,14 @@ describe('SwapDetailsChainFusion', () => {
 		swapDetails
 	});
 
-	// The fee breakdown belongs to the form's fee section, which carries every component and
-	// their total. This sheet is the provider's identity and the constraints it imposes, so a
-	// fee row here would either duplicate that list or leave both surfaces incomplete.
-	it('renders no fee rows at all', () => {
-		const { queryByText } = render(SwapDetailsChainFusion, {
+	// The fee section itemizes what the user pays out of balance and totals it. A fee the
+	// minter instead withholds from the amount it converts is already priced into the receive
+	// amount, so it is disclosed here and nowhere else — the Velora division.
+	it('renders the fees deducted from the receive amount, with their value', () => {
+		const { getByText } = render(SwapDetailsChainFusion, {
 			props: {
 				provider: makeProvider({
 					sourceFees: [
-						{ labelPath: 'fee.text.fee', fee: 10_000n, token: sourceToken },
 						{
 							labelPath: 'fee.text.convert_inter_network_fee',
 							fee: 5_000n,
@@ -59,6 +58,31 @@ describe('SwapDetailsChainFusion', () => {
 							deductedFromAmount: true
 						}
 					],
+					externalFees: [
+						{
+							labelPath: 'fee.text.estimated_eth',
+							fee: 2_000_000_000_000n,
+							token: ckEthToken,
+							deductedFromAmount: true
+						}
+					]
+				})
+			},
+			context: makeContext()
+		});
+
+		expect(getByText(en.fee.text.convert_inter_network_fee)).toBeInTheDocument();
+		expect(getByText('0.005 ckUSDC')).toBeInTheDocument();
+		expect(getByText(en.fee.text.estimated_eth)).toBeInTheDocument();
+		expect(getByText('0.000002 ckETH')).toBeInTheDocument();
+	});
+
+	// A fee paid on top of the amount is the fee section's, total included.
+	it('renders no row for a fee charged on top of the amount', () => {
+		const { queryByText } = render(SwapDetailsChainFusion, {
+			props: {
+				provider: makeProvider({
+					sourceFees: [{ labelPath: 'fee.text.fee', fee: 10_000n, token: sourceToken }],
 					externalFees: [
 						{ labelPath: 'fee.text.estimated_eth', fee: 2_000_000_000_000n, token: ckEthToken }
 					]
@@ -68,10 +92,8 @@ describe('SwapDetailsChainFusion', () => {
 		});
 
 		expect(queryByText(en.fee.text.fee)).not.toBeInTheDocument();
-		expect(queryByText(en.fee.text.convert_inter_network_fee)).not.toBeInTheDocument();
 		expect(queryByText(en.fee.text.estimated_eth)).not.toBeInTheDocument();
 		expect(queryByText('0.01 ckUSDC')).not.toBeInTheDocument();
-		expect(queryByText('0.005 ckUSDC')).not.toBeInTheDocument();
 		expect(queryByText('0.000002 ckETH')).not.toBeInTheDocument();
 	});
 

--- a/src/frontend/src/tests/lib/components/swap/SwapFees.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapFees.spec.ts
@@ -119,17 +119,19 @@ describe('SwapFees', () => {
 
 			expect(getByText(en.fee.text.estimated_eth)).toBeInTheDocument();
 			expect(getByText('0.000002 ckETH')).toBeInTheDocument();
+			// Two rows, so the collapsible total stays.
+			expect(getByText(en.swap.text.total_fee)).toBeInTheDocument();
 		});
 
-		// The total has to be the user's whole cost, so a fee the minter withholds is disclosed
-		// here too — otherwise nothing on the form accounts for the gap between the pay and
-		// receive amounts. `deductedFromAmount` decides the receive amount, not the disclosure.
-		it('lists a fee the minter takes out of the converted amount', () => {
-			const { getByText } = renderChainFusion({
+		// A fee the minter withholds from the converted amount is already the gap between the pay
+		// and receive amounts, and the provider sheet states it. Counting it here as well would
+		// read as a second charge, so the total is what the user pays out of balance alone.
+		it('leaves out a fee deducted from the receive amount, total included', () => {
+			const { getAllByText, queryByText } = renderChainFusion({
 				sourceFees: [
 					{ labelPath: 'fee.text.fee', fee: LEDGER_FEE, token: sourceToken },
 					{
-						labelPath: 'fee.text.estimated_eth',
+						labelPath: 'fee.text.estimated_btc',
 						fee: 5_000n,
 						token: sourceToken,
 						deductedFromAmount: true
@@ -138,9 +140,12 @@ describe('SwapFees', () => {
 				externalFees: []
 			});
 
-			expect(getByText(en.fee.text.fee)).toBeInTheDocument();
-			expect(getByText(en.fee.text.estimated_eth)).toBeInTheDocument();
-			expect(getByText('0.005 ckUSDC')).toBeInTheDocument();
+			expect(queryByText(en.fee.text.estimated_btc)).not.toBeInTheDocument();
+			expect(queryByText('0.005 ckUSDC')).not.toBeInTheDocument();
+			// The ledger fee is left alone, so it stands as a single row — no "Total fee" header
+			// to repeat it under.
+			expect(getAllByText('0.01 ckUSDC')).toHaveLength(1);
+			expect(queryByText(en.swap.text.total_fee)).not.toBeInTheDocument();
 		});
 
 		it('totals only the source-token rows when a fee token has no exchange rate', () => {

--- a/src/frontend/src/tests/lib/services/chain-fusion-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/chain-fusion-swap.services.spec.ts
@@ -995,19 +995,17 @@ describe('chain-fusion-swap.services', () => {
 		});
 
 		// Only the fee the minter pays out of what it withdraws reduces the receive amount —
-		// the same one `IcTokenFees` reports as a destination-token fee.
-		it('should deduct only the Bitcoin network and minter fees', async () => {
+		// the same one `IcTokenFees` reports as a destination-token fee. Verified against
+		// finalized withdrawals: they pay out exactly `amount - bitcoin_fee - minter_fee`. The
+		// KYT fee `IcTokenFees` also lists is not charged to the user on a withdrawal, so it
+		// is not quoted at all — neither deducted nor on top.
+		it('should deduct only the Bitcoin network and minter fees, and not quote the KYT fee', async () => {
 			await expect(icpQuote()).resolves.toStrictEqual({
 				provider: SwapProvider.CHAIN_FUSION,
 				receiveAmount: AMOUNT - (BITCOIN_FEE + MINTER_FEE),
 				swapDetails: {
 					sourceFees: [
 						{ labelPath: 'fee.text.fee', fee: CK_LEDGER_FEE, token: ckBtcSource },
-						{
-							labelPath: 'fee.text.estimated_inter_network',
-							fee: mockCkBtcMinterInfo.kyt_fee,
-							token: ckBtcSource
-						},
 						{
 							labelPath: 'fee.text.estimated_btc',
 							fee: BITCOIN_FEE + MINTER_FEE,

--- a/src/frontend/src/tests/lib/utils/chain-fusion-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/chain-fusion-swap.utils.spec.ts
@@ -12,6 +12,8 @@ import type { Token } from '$lib/types/token';
 import {
 	asCkTwinOf,
 	chainFusionCompatibleDestinations,
+	chainFusionFeeSectionFees,
+	chainFusionProviderDetailsFees,
 	chainFusionSupportedSourceTokens,
 	computeChainFusionReceiveAmount,
 	toChainFusionPairs
@@ -304,6 +306,31 @@ describe('chain-fusion-swap.utils', () => {
 
 		it('should reject a non-IC token on the ck side', () => {
 			expect(asCkTwinOf({ ckToken: USDC_TOKEN, nativeToken: ETHEREUM_TOKEN })).toBeUndefined();
+		});
+	});
+
+	describe('fee disclosure split', () => {
+		const fees = [makeOnTopFee(10n), makeFee(5n), makeOnTopFee(1n), makeFee(20n)];
+
+		it('should keep every fee charged on top of the amount in the fee section', () => {
+			expect(chainFusionFeeSectionFees(fees)).toStrictEqual([makeOnTopFee(10n), makeOnTopFee(1n)]);
+		});
+
+		it('should hand the provider sheet only the fees deducted from the amount', () => {
+			expect(chainFusionProviderDetailsFees(fees)).toStrictEqual([makeFee(5n), makeFee(20n)]);
+		});
+
+		it('should split an empty list into two empty lists', () => {
+			expect(chainFusionFeeSectionFees([])).toStrictEqual([]);
+			expect(chainFusionProviderDetailsFees([])).toStrictEqual([]);
+		});
+
+		// Together they have to be the whole list, or a fee the quote priced is disclosed nowhere.
+		it('should account for every fee exactly once', () => {
+			expect([
+				...chainFusionFeeSectionFees(fees),
+				...chainFusionProviderDetailsFees(fees)
+			]).toHaveLength(fees.length);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The BTC ↔ ckBTC swap modal listed the inter-network (KYT) fee in the "fees" section even though the minter withholds it from the amount it credits — so the same cost was shown twice: once as the gap between pay and receive, once as a line item.

Investigating the other direction turned up a quoting bug: ckBTC → BTC listed a KYT fee the user is never charged. Verified against mainnet — two finalized withdrawals paid out exactly `amount - bitcoin_fee - minter_fee` (gap − tx fee = 326 = `minter_fee`), and `retrieve_btc_with_approval` burns the full `amount` with `kyt_fee: None` in the memo. The minter absorbs the check fee on withdrawals.


# Changes

- Quote: drop the phantom KYT fee from the ckBTC → BTC arm.
- Split fee disclosure on the existing `deductedFromAmount`, one rule both directions: provider sheet = fees taken out of the receive amount, fee section = fees paid on top.
- BTC → ckBTC: sheet shows the inter-network fee; section shows the Bitcoin network fee.
- ckBTC → BTC: sheet shows the estimated BTC fee; section shows the ledger fee.
- Render sheet fees as amount + fiat (`FeeDisplay`), matching `SwapDetailsOisyTrade`.
- Collapse the fee section to a flat row when only one fee remains — a "Total fee" collapsible over a single item just repeated its own header. Multi-fee arms (ckETH → ETH, ckERC20 → ERC20) and the generic non-Chain Fusion path are unchanged.


# Tests

Added.
