### PR TITLE
style(frontend): quote only the fiat value on the priority options

### DIFF
--- a/src/frontend/src/eth/components/fee/EthFeePriority.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeePriority.svelte
@@ -107,7 +107,6 @@
 							{onSelect}
 							{priority}
 							selected={priority === $sendEthFeePriority}
-							symbol={$feeSymbolStore}
 							testId={`${ETH_FEE_PRIORITY_OPTION}-${priority}`}
 						/>
 					{/each}

--- a/src/frontend/src/eth/components/fee/EthFeePriority.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeePriority.svelte
@@ -19,13 +19,8 @@
 
 	const { sendEthFeePriority } = getContext<SendContext>(SEND_CONTEXT_KEY);
 
-	const {
-		feeStore,
-		feePrioritiesStore,
-		feeSymbolStore,
-		feeDecimalsStore,
-		feeExchangeRateStore
-	}: EthFeeContext = getContext<EthFeeContext>(ETH_FEE_CONTEXT_KEY);
+	const { feeStore, feePrioritiesStore, feeDecimalsStore, feeExchangeRateStore }: EthFeeContext =
+		getContext<EthFeeContext>(ETH_FEE_CONTEXT_KEY);
 
 	const options = $derived([
 		{
@@ -69,7 +64,7 @@
 	const onSelect = (priority: EthFeePriority) => sendEthFeePriority.set(priority);
 </script>
 
-{#if nonNullish($feePrioritiesStore) && nonNullish($feeSymbolStore) && nonNullish($feeDecimalsStore)}
+{#if nonNullish($feePrioritiesStore) && nonNullish($feeDecimalsStore)}
 	<div class="mb-4" data-tid={ETH_FEE_PRIORITY}>
 		<CollapsibleBottomSheet sheetTitle={$i18n.fee.text.priority}>
 			{#snippet contentHeader()}

--- a/src/frontend/src/eth/components/fee/EthFeePriorityOption.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeePriorityOption.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
-	import FeeDisplay from '$lib/components/fee/FeeDisplay.svelte';
+	import ConvertAmountExchange from '$lib/components/convert/ConvertAmountExchange.svelte';
 	import type { EthFeePriority } from '$lib/enums/eth-fee-priority';
+	import { formatToken } from '$lib/utils/format.utils';
 
 	interface Props {
 		priority: EthFeePriority;
@@ -10,7 +11,6 @@
 		emoji: string;
 		selected: boolean;
 		fee?: bigint;
-		symbol: string;
 		decimals: number;
 		exchangeRate?: number;
 		groupName: string;
@@ -25,7 +25,6 @@
 		emoji,
 		selected,
 		fee,
-		symbol,
 		decimals,
 		exchangeRate,
 		groupName,
@@ -54,7 +53,10 @@
 
 	<span class="ml-auto shrink-0 pl-2 text-right">
 		{#if nonNullish(fee)}
-			<FeeDisplay {decimals} {exchangeRate} feeAmount={fee} {symbol} />
+			<ConvertAmountExchange
+				amount={formatToken({ value: fee, displayDecimals: decimals, unitName: decimals })}
+				{exchangeRate}
+			/>
 		{/if}
 	</span>
 </label>

--- a/src/frontend/src/eth/components/fee/EthFeePriorityOption.svelte
+++ b/src/frontend/src/eth/components/fee/EthFeePriorityOption.svelte
@@ -51,7 +51,7 @@
 		<span class="min-w-0 truncate text-sm text-tertiary">{description}</span>
 	</span>
 
-	<span class="ml-auto shrink-0 pl-2 text-right">
+	<span class="ml-auto shrink-0 pl-2 text-right text-sm text-tertiary">
 		{#if nonNullish(fee)}
 			<ConvertAmountExchange
 				amount={formatToken({ value: fee, displayDecimals: decimals, unitName: decimals })}

--- a/src/frontend/src/tests/eth/components/fee/EthFeePriority.spec.ts
+++ b/src/frontend/src/tests/eth/components/fee/EthFeePriority.spec.ts
@@ -32,7 +32,10 @@ describe('EthFeePriority', () => {
 	// The rows quote fiat only, so an exchange rate is required for them to render at all.
 	const exchangeRate = 3_000;
 
-	const setup = ({ withPriorities = true }: { withPriorities?: boolean } = {}) => {
+	const setup = ({
+		withPriorities = true,
+		withSymbol = true
+	}: { withPriorities?: boolean; withSymbol?: boolean } = {}) => {
 		const feeStore = initEthFeeStore();
 		feeStore.setFee({
 			...priorities.perPriority[Priority.NORMAL],
@@ -47,7 +50,7 @@ describe('EthFeePriority', () => {
 
 		const feeContext = initEthFeeContext({
 			feeStore,
-			feeSymbolStore: writable(ETHEREUM_TOKEN.symbol),
+			feeSymbolStore: writable(withSymbol ? ETHEREUM_TOKEN.symbol : undefined),
 			feeTokenIdStore: writable(ETHEREUM_TOKEN.id),
 			feeDecimalsStore: writable(ETHEREUM_TOKEN.decimals),
 			feeExchangeRateStore: writable(exchangeRate)
@@ -172,6 +175,16 @@ describe('EthFeePriority', () => {
 
 		await waitFor(() => {
 			expect(getAllByText(en.fee.text.priority_normal)).toHaveLength(1);
+		});
+	});
+
+	it('renders without a fee symbol, which it no longer displays', async () => {
+		const { context } = setup({ withSymbol: false });
+
+		const { getByTestId } = render(EthFeePriority, { context });
+
+		await waitFor(() => {
+			expect(getByTestId(ETH_FEE_PRIORITY)).toBeInTheDocument();
 		});
 	});
 

--- a/src/frontend/src/tests/eth/components/fee/EthFeePriority.spec.ts
+++ b/src/frontend/src/tests/eth/components/fee/EthFeePriority.spec.ts
@@ -2,9 +2,8 @@ import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import EthFeePriority from '$eth/components/fee/EthFeePriority.svelte';
 import { ETH_FEE_CONTEXT_KEY, initEthFeeContext, initEthFeeStore } from '$eth/stores/eth-fee.store';
 import type { EthFeePriorities } from '$eth/types/fee';
-import { estimatedGasFee } from '$eth/utils/fee.utils';
-import { ZERO } from '$lib/constants/app.constants';
 import {
+	CONVERT_AMOUNT_EXCHANGE_VALUE,
 	ETH_FEE_PRIORITY,
 	ETH_FEE_PRIORITY_OPTION,
 	ETH_FEE_PRIORITY_TRIGGER
@@ -12,7 +11,6 @@ import {
 import { EthFeePriority as Priority } from '$lib/enums/eth-fee-priority';
 import { screensStore } from '$lib/stores/screens.store';
 import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
-import { formatToken } from '$lib/utils/format.utils';
 import en from '$tests/mocks/i18n.mock';
 import { render, waitFor, within } from '@testing-library/svelte';
 import { get, writable } from 'svelte/store';
@@ -23,13 +21,16 @@ describe('EthFeePriority', () => {
 	// The ceiling is identical across priorities on purpose: it is dominated by the shared base fee,
 	// so only the tip may move the displayed amounts apart.
 	const priorities: EthFeePriorities = {
-		baseFeePerGas: 20n,
+		baseFeePerGas: 20_000_000_000n,
 		perPriority: {
-			[Priority.SLOW]: { maxFeePerGas: 100n, maxPriorityFeePerGas: 1n },
-			[Priority.NORMAL]: { maxFeePerGas: 100n, maxPriorityFeePerGas: 5n },
-			[Priority.FAST]: { maxFeePerGas: 100n, maxPriorityFeePerGas: 20n }
+			[Priority.SLOW]: { maxFeePerGas: 100_000_000_000n, maxPriorityFeePerGas: 1_000_000_000n },
+			[Priority.NORMAL]: { maxFeePerGas: 100_000_000_000n, maxPriorityFeePerGas: 5_000_000_000n },
+			[Priority.FAST]: { maxFeePerGas: 100_000_000_000n, maxPriorityFeePerGas: 20_000_000_000n }
 		}
 	};
+
+	// The rows quote fiat only, so an exchange rate is required for them to render at all.
+	const exchangeRate = 3_000;
 
 	const setup = ({ withPriorities = true }: { withPriorities?: boolean } = {}) => {
 		const feeStore = initEthFeeStore();
@@ -49,7 +50,7 @@ describe('EthFeePriority', () => {
 			feeSymbolStore: writable(ETHEREUM_TOKEN.symbol),
 			feeTokenIdStore: writable(ETHEREUM_TOKEN.id),
 			feeDecimalsStore: writable(ETHEREUM_TOKEN.decimals),
-			feeExchangeRateStore: writable(undefined)
+			feeExchangeRateStore: writable(exchangeRate)
 		});
 
 		if (withPriorities) {
@@ -83,25 +84,16 @@ describe('EthFeePriority', () => {
 	it('prices each option on the same gas limit, so only the tip separates them', async () => {
 		const { context } = setup();
 
-		const { container } = render(EthFeePriority, { context });
+		const { findAllByTestId } = render(EthFeePriority, { context });
 
-		await waitFor(() => {
-			Object.values(Priority).forEach((priority) => {
-				const expected = estimatedGasFee({
-					...priorities.perPriority[priority],
-					baseFeePerGas: priorities.baseFeePerGas,
-					gas
-				});
+		const values = await findAllByTestId(CONVERT_AMOUNT_EXCHANGE_VALUE);
 
-				expect(container).toHaveTextContent(
-					formatToken({
-						value: expected ?? ZERO,
-						displayDecimals: ETHEREUM_TOKEN.decimals,
-						unitName: ETHEREUM_TOKEN.decimals
-					})
-				);
-			});
-		});
+		expect(values).toHaveLength(Object.values(Priority).length);
+
+		// Asserting distinctness rather than exact strings: the point is that the shared base fee and
+		// gas limit cancel out and only the tip moves the amounts, and the formatted currency string
+		// depends on locale and currency stores that are not what this test is about.
+		expect(new Set(values.map(({ textContent }) => textContent)).size).toBe(values.length);
 	});
 
 	it('records the choice in the send context', async () => {


### PR DESCRIPTION
# Motivation

QA feedback: the priority options should not repeat the native amount. Each row showed `0.00000050616 ETH  < $0.01`, three times over, which is a lot of precision for a choice that is really about relative cost. The `Estimated fee` row below still quotes the native amount for the selected tier, so it is not lost.

# Changes

- The option rows render `ConvertAmountExchange` directly instead of `FeeDisplay`, so only the fiat value shows.
- `symbol` is no longer needed by the option and is dropped from its props and from the caller.

I rendered the fiat component directly rather than adding a "hide the amount" prop to the shared `FeeDisplay` / `ConvertAmountDisplay`, which have many other callers. One consumer does not justify widening a shared API.

**Worth knowing before this merges:** `ConvertAmountExchange` renders nothing at all when the exchange rate is unavailable. Previously such a row still showed the native amount; now it will be blank. That is a real behaviour change for anyone whose exchange rates have not loaded, or a token with no rate. Say the word if you would rather it fell back to the native amount instead of showing nothing.

# Tests

The pricing test asserted the native text, which no longer renders, so it is reworked:

- fee values raised to realistic gwei scale and an exchange rate supplied, since the rows need one to render at all
- it now asserts three fiat values are present and all distinct, which is the actual claim: the shared base fee and gas limit cancel out and only the tip moves the amounts

Distinctness rather than exact strings, because the formatted currency depends on locale and currency stores that are not what this test is about. I verified it fails when all three rows are made to quote the same value.

`check`, `check:tests`, eslint and prettier clean. `tests/eth`: 4123 passed.
