### PR TITLE
fix(frontend): withhold Max on a native EVM send until the fee is known

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -8,6 +8,7 @@
 	import MaxBalanceButton from '$lib/components/common/MaxBalanceButton.svelte';
 	import TokenInput from '$lib/components/tokens/TokenInput.svelte';
 	import TokenInputAmountExchange from '$lib/components/tokens/TokenInputAmountExchange.svelte';
+	import SkeletonText from '$lib/components/ui/SkeletonText.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
@@ -50,6 +51,12 @@
 	const { sendTokenDecimals, sendBalance, sendTokenId, sendToken, sendTokenExchangeRate } =
 		getContext<SendContext>(SEND_CONTEXT_KEY);
 
+	// The gas comes out of the amount only when the token being sent is the one that pays for it.
+	// An ERC-20 send spends its own balance in full and settles the fee in ETH separately.
+	let feeIsPaidFromAmount = $derived(
+		isSupportedEthTokenId($sendTokenId) || isSupportedEvmNativeTokenId($sendTokenId)
+	);
+
 	const customValidate = (userAmount: bigint): Error | undefined => {
 		if (isNullish($storeFeeData)) {
 			return;
@@ -70,7 +77,7 @@
 		// The chain requires the balance to cover the amount plus `maxFeePerGas * gas`, so the ceiling
 		// is what decides whether a native send is affordable. `minGasFee` omits the base fee
 		// entirely and therefore bounds nothing the chain enforces.
-		if (isSupportedEthTokenId($sendTokenId) || isSupportedEvmNativeTokenId($sendTokenId)) {
+		if (feeIsPaidFromAmount) {
 			// Falling back to the tip rather than to zero: an unknown ceiling must not weaken the check
 			// below what it was before the flag.
 			const gasFee = SEND_TRANSACTION_PRIORITY_ENABLED
@@ -135,14 +142,24 @@
 
 		{#snippet balance()}
 			{#if nonNullish($sendToken)}
-				<MaxBalanceButton
-					balance={$sendBalance}
-					error={nonNullish(insufficientFundsError)}
-					fee={$maxGasFee}
-					token={$sendToken}
-					bind:amount
-					bind:amountSetToMax
-				/>
+				<!-- Until the fee is known, "Max" for a native send would offer the entire balance:
+				     `getMaxTransactionAmount` treats a missing fee as zero, so the amount could not
+				     cover its own gas. Wait for the fee rather than offer an unspendable maximum,
+				     the same way the swap form does. An ERC-20 max does not depend on the fee. -->
+				{#if !feeIsPaidFromAmount || nonNullish($maxGasFee)}
+					<MaxBalanceButton
+						balance={$sendBalance}
+						error={nonNullish(insufficientFundsError)}
+						fee={$maxGasFee}
+						token={$sendToken}
+						bind:amount
+						bind:amountSetToMax
+					/>
+				{:else}
+					<div class="w-14 sm:w-16">
+						<SkeletonText />
+					</div>
+				{/if}
 			{/if}
 		{/snippet}
 	</TokenInput>

--- a/src/frontend/src/tests/eth/components/send/EthSendAmount.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendAmount.spec.ts
@@ -1,9 +1,11 @@
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import EthSendAmount from '$eth/components/send/EthSendAmount.svelte';
 import { ETH_FEE_CONTEXT_KEY, initEthFeeContext, initEthFeeStore } from '$eth/stores/eth-fee.store';
-import { TOKEN_INPUT_CURRENCY_TOKEN } from '$lib/constants/test-ids.constants';
+import { MAX_BUTTON, TOKEN_INPUT_CURRENCY_TOKEN } from '$lib/constants/test-ids.constants';
 import { balancesStore } from '$lib/stores/balances.store';
 import { SEND_CONTEXT_KEY, initSendContext } from '$lib/stores/send.store';
+import type { Token } from '$lib/types/token';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
 import en from '$tests/mocks/i18n.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
@@ -32,14 +34,21 @@ describe('EthSendAmount', () => {
 		return `${padded.slice(0, -ETHEREUM_TOKEN.decimals)}.${padded.slice(-ETHEREUM_TOKEN.decimals)}`;
 	};
 
-	const setup = ({ ceilingKnown = true }: { ceilingKnown?: boolean } = {}) => {
+	const setup = ({
+		ceilingKnown = true,
+		feeResolved = true,
+		token = ETHEREUM_TOKEN
+	}: { ceilingKnown?: boolean; feeResolved?: boolean; token?: Token } = {}) => {
 		const feeStore = initEthFeeStore();
-		feeStore.setFee({
-			maxFeePerGas: ceilingKnown ? maxFeePerGas : null,
-			maxPriorityFeePerGas,
-			baseFeePerGas,
-			gas
-		});
+
+		if (feeResolved) {
+			feeStore.setFee({
+				maxFeePerGas: ceilingKnown ? maxFeePerGas : null,
+				maxPriorityFeePerGas,
+				baseFeePerGas,
+				gas
+			});
+		}
 
 		const context = new Map<symbol, unknown>();
 		context.set(
@@ -52,7 +61,7 @@ describe('EthSendAmount', () => {
 				feeExchangeRateStore: writable(undefined)
 			})
 		);
-		context.set(SEND_CONTEXT_KEY, initSendContext({ token: ETHEREUM_TOKEN }));
+		context.set(SEND_CONTEXT_KEY, initSendContext({ token }));
 
 		balancesStore.set({ id: ETHEREUM_TOKEN.id, data: { data: balance, certified: true } });
 
@@ -72,7 +81,9 @@ describe('EthSendAmount', () => {
 
 		assertNonNullish(input);
 
-		return { input, queryByText };
+		const maxButton = () => container.querySelector(`[data-tid="${MAX_BUTTON}"]`);
+
+		return { input, queryByText, maxButton };
 	};
 
 	const setupWithoutCeiling = () => setup({ ceilingKnown: false });
@@ -115,6 +126,36 @@ describe('EthSendAmount', () => {
 
 		await waitFor(() => {
 			expect(queryByText(expectedError)).not.toBeInTheDocument();
+		});
+	});
+
+	// A "Max" offered before the fee arrives would be the whole balance: `getMaxTransactionAmount`
+	// treats a missing fee as zero, and nothing downstream re-checks it before the amount is
+	// submitted. The button has to wait for a fee it can actually subtract.
+	describe('the Max button', () => {
+		it('is offered once the fee is known', () => {
+			const { maxButton } = setup();
+
+			expect(maxButton()).toBeInTheDocument();
+		});
+
+		it('is withheld while no fee has arrived yet', () => {
+			const { maxButton } = setup({ feeResolved: false });
+
+			expect(maxButton()).not.toBeInTheDocument();
+		});
+
+		it('is withheld when the ceiling comes back unknown', () => {
+			const { maxButton } = setup({ ceilingKnown: false });
+
+			expect(maxButton()).not.toBeInTheDocument();
+		});
+
+		it('is offered for an ERC-20 send, whose maximum is its own balance', () => {
+			// The fee is settled in ETH, so an ERC-20 maximum does not wait on it.
+			const { maxButton } = setup({ feeResolved: false, token: mockValidErc20Token });
+
+			expect(maxButton()).toBeInTheDocument();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

Noticed while QA-ing a Base send on fe2: in the window between opening the send form and the fee resolving, **Max** offers the entire balance. I caught it showing `0.002453569936352484 ETH` against an on-chain balance of exactly `2453569936352484` wei, nothing subtracted.

`getMaxTransactionAmount` defaults `fee` to `ZERO`, so a nullish `$maxGasFee` is indistinguishable from a free transaction. Nothing downstream catches it either: `customValidate` returns early while the fee store is empty, so the amount raises no error. The 500ms re-apply in `MaxBalanceButton` fixes it only if the user waits, and pressing Next inside that window carries the full balance forward.

The result is an amount that cannot cover its own gas on any chain, not just OP-stack ones. Narrow window, but the failure is silent.

# Changes

- Withhold the Max button on a native EVM send until `$maxGasFee` resolves, showing a skeleton meanwhile. This is the pattern `SwapForm` and `ConvertAmountSource` already use, both of which guard on a resolved fee before offering a maximum.
- An ERC-20 maximum is its own token balance and settles the fee in ETH separately, so it keeps the button throughout. The native/ERC-20 split is hoisted into `feeIsPaidFromAmount` and reused by `customValidate`, which already made the same distinction inline.

# Tests

Four cases in `EthSendAmount.spec.ts`: the button appears once the fee is known, is withheld when no fee has arrived and when the ceiling comes back unknown, and stays for an ERC-20 send with no fee at all.

Checked that the two withholding cases fail against `main` and pass with the change, so they pin the bug rather than the implementation.
