### PR TITLE
feat(frontend): give OISY Trade swaps a durable recovery record

### DIFF
--- a/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpWizard.svelte
@@ -114,11 +114,9 @@
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.CHAIN_FUSION
 	);
 
-	// OISY Trade settles in the foreground for now: deposit, fill-or-kill order, and the
-	// withdrawal that brings the destination token back, all inside the modal. It is
-	// deliberately absent from `isActiveTransactionSwap` below until it has an Active User
-	// Transaction row to hand the settlement to — closing the modal earlier would leave the
-	// funds in DEX custody with nothing watching them.
+	// OISY Trade's background phase is its own order settling: the fill-or-kill order is
+	// placed inside the modal, and the withdrawal that brings either leg back out of DEX
+	// custody is the Active User Transaction poller's.
 	let oisyTradeDetails = $derived(
 		$swapAmountsStore?.selectedProvider?.provider === SwapProvider.OISY_TRADE
 			? $swapAmountsStore.selectedProvider.swapDetails
@@ -134,7 +132,9 @@
 	// These close the modal once the funds have left the wallet and finish settling through
 	// the Active User Transactions store — every ck withdrawal included, whichever minter
 	// pays it out.
-	let isActiveTransactionSwap = $derived(isOneSecProvider || isChainFusionProvider);
+	let isActiveTransactionSwap = $derived(
+		isOneSecProvider || isChainFusionProvider || nonNullish(oisyTradeDetails)
+	);
 
 	$effect(() => {
 		if (isNullish($sourceToken) || !isIcToken($sourceToken)) {
@@ -242,6 +242,7 @@
 				await fetchOisyTradeSwap({
 					identity: $authIdentity,
 					progress,
+					swapId: crypto.randomUUID(),
 					sourceToken: $sourceToken as IcToken,
 					destinationToken: $destinationToken,
 					order: oisyTradeDetails.order,
@@ -345,14 +346,15 @@
 					variant: 'info'
 				});
 			} else if (err instanceof OisyTradeSwapError) {
-				// A killed fill-or-kill order — or one the canister refused — is an
-				// expected outcome whose source funds are already back in the wallet when
-				// it is thrown, so it reads as info in Review, like slippage, never as an
-				// unexpected-error toast. The other kinds ask the user to check the
-				// Trading tab, hence the warning level.
+				// An order the canister refused is an expected outcome whose funds are
+				// already back in the wallet when it is thrown, and an untrackable swap
+				// never moved any — both read as info in Review, like slippage, never as an
+				// unexpected-error toast. `recovery_failed` is the one kind raised with the
+				// funds still in DEX custody, and it asks the user to check the Trading tab,
+				// hence the warning level.
 				failedSwapError.set({
 					message: err.message,
-					variant: err.kind === 'killed' || err.kind === 'not_placed' ? 'info' : 'warning'
+					variant: err.kind === 'recovery_failed' ? 'warning' : 'info'
 				});
 			} else {
 				failedSwapError.set(undefined);
@@ -362,11 +364,23 @@
 				});
 			}
 
-			if (!(
-				isSwapError(err) &&
-				(err.code === SwapErrorCodes.ICP_SWAP_WITHDRAW_SUCCESS ||
-					err.code === SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED)
-			)) {
+			// An OISY Trade order the canister refused already has a `Failed` row — closed by
+			// the flow itself on `not_placed`, by the poller on `recovery_failed` — and the
+			// loader fires the swap's single error event off that row, as it does for every
+			// background-settling provider. Firing here too would count the same swap twice.
+			// `not_trackable` has no row, so it still reports from here.
+			const isReportedByRow =
+				err instanceof OisyTradeSwapError &&
+				(err.kind === 'not_placed' || err.kind === 'recovery_failed');
+
+			if (
+				!(
+					isSwapError(err) &&
+					(err.code === SwapErrorCodes.ICP_SWAP_WITHDRAW_SUCCESS ||
+						err.code === SwapErrorCodes.ICP_SWAP_WITHDRAW_FAILED)
+				) &&
+				!isReportedByRow
+			) {
 				trackEvent({
 					name: TRACK_COUNT_SWAP_ERROR,
 					metadata: {
@@ -407,11 +421,12 @@
 			</SwapReview>
 		{:else if currentStep?.name === WizardStepsSwap.SWAPPING}
 			<SwapProgress
+				sendWithApprovalOnly={nonNullish(oisyTradeDetails)}
 				{swapProgressStep}
 				swapWithActiveTransaction={isActiveTransactionSwap}
 				swapWithBridging={isOneSecProvider}
 				swapWithWithdrawing={$swapAmountsStore?.selectedProvider?.provider ===
-					SwapProvider.ICP_SWAP || nonNullish(oisyTradeDetails)}
+					SwapProvider.ICP_SWAP}
 				bind:failedSteps={swapFailedProgressSteps}
 			/>
 		{/if}

--- a/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
+++ b/src/frontend/src/lib/components/active-user-transactions/ActiveUserTransactionItem.svelte
@@ -24,6 +24,7 @@
 		toLiquidiumExternalRefsMap
 	} from '$lib/utils/liquidium-active-tx.utils';
 	import { isNearIntentsActiveUserTransaction } from '$lib/utils/near-intents-active-tx.utils';
+	import { isOisyTradeActiveUserTransaction } from '$lib/utils/oisy-trade-active-tx.utils';
 	import {
 		isOneSecActiveUserTransaction,
 		toOneSecExternalRefsMap
@@ -43,11 +44,12 @@
 	const isNearIntents = $derived(isNearIntentsActiveUserTransaction(tx));
 	const isVelora = $derived(isVeloraActiveUserTransaction(tx));
 	const isChainFusion = $derived(isChainFusionActiveUserTransaction(tx));
+	const isOisyTrade = $derived(isOisyTradeActiveUserTransaction(tx));
 	// Every swap provider is rendered identically — they share the same
-	// display-ref key names in `external_refs`. Velora's Delta/Market distinction
-	// and Chain Fusion's conversion direction are internal routing and deliberately
-	// not surfaced.
-	const isSwap = $derived(isOneSec || isNearIntents || isVelora || isChainFusion);
+	// display-ref key names in `external_refs`. Velora's Delta/Market distinction,
+	// Chain Fusion's conversion direction and OISY Trade's order side are internal
+	// routing and deliberately not surfaced.
+	const isSwap = $derived(isOneSec || isNearIntents || isVelora || isChainFusion || isOisyTrade);
 	const isLiquidium = $derived(isLiquidiumActiveUserTransaction(tx));
 	const refs = $derived(toOneSecExternalRefsMap(tx.external_refs));
 	const liquidiumRefs = $derived(toLiquidiumExternalRefsMap(tx.external_refs));
@@ -88,7 +90,12 @@
 								// unconditional precisely so a row outliving a flag rollback keeps
 								// its provider name.
 								(swapProvidersDetails[SwapProvider.CHAIN_FUSION]?.name ?? '')
-							: undefined
+							: isOisyTrade
+								? // Unconditional for the same reason, and it matters more here: the
+									// OISY Trade swap flag is expected to move while the real receive
+									// amount lands, and a row can outlive any of that.
+									(swapProvidersDetails[SwapProvider.OISY_TRADE]?.name ?? '')
+								: undefined
 	);
 
 	const titleText = $derived(

--- a/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
+++ b/src/frontend/src/lib/components/loaders/LoaderActiveUserTransactions.svelte
@@ -17,6 +17,7 @@
 	import { pollLiquidiumActiveUserTransactions } from '$lib/services/liquidium-active-tx.services';
 	import { loadLiquidium } from '$lib/services/liquidium.services';
 	import { pollNearIntentsActiveUserTransactions } from '$lib/services/near-intents-active-tx.services';
+	import { pollOisyTradeActiveUserTransactions } from '$lib/services/oisy-trade-active-tx.services';
 	import { pollOneSecActiveUserTransactions } from '$lib/services/onesec-swap.services';
 	import { pollVeloraActiveUserTransactions } from '$lib/services/velora-active-tx.services';
 	import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
@@ -34,6 +35,10 @@
 		buildNearIntentsSwapTrackingMetadata,
 		isNearIntentsActiveUserTransaction
 	} from '$lib/utils/near-intents-active-tx.utils';
+	import {
+		buildOisyTradeSwapTrackingMetadata,
+		isOisyTradeActiveUserTransaction
+	} from '$lib/utils/oisy-trade-active-tx.utils';
 	import {
 		buildOneSecSwapTrackingMetadata,
 		isOneSecActiveUserTransaction
@@ -101,6 +106,12 @@
 
 			if (chainFusion.length > 0) {
 				await pollChainFusionActiveUserTransactions({ identity, transactions: chainFusion });
+			}
+
+			const oisyTrade = $activeUserTransactionsPending.filter(isOisyTradeActiveUserTransaction);
+
+			if (oisyTrade.length > 0) {
+				await pollOisyTradeActiveUserTransactions({ identity, transactions: oisyTrade });
 			}
 		} catch (err: unknown) {
 			consoleError(err);
@@ -217,6 +228,23 @@
 				if (isSucceeded) {
 					shouldRefresh = true;
 				}
+			} else if (
+				isTerminalActiveUserTransaction(tx) &&
+				!alreadyApplied &&
+				isOisyTradeActiveUserTransaction(tx)
+			) {
+				newlyAppliedIds.push(tx.id);
+
+				trackEvent({
+					name: isSucceeded ? TRACK_COUNT_SWAP_SUCCESS : TRACK_COUNT_SWAP_ERROR,
+					metadata: buildOisyTradeSwapTrackingMetadata({ tx })
+				});
+
+				// Unconditional, unlike every other provider's: a failed OISY Trade swap is a
+				// killed fill-or-kill order whose *source* token has just been withdrawn back
+				// to the wallet. Elsewhere a failure means nothing moved and there is nothing
+				// to refresh; here the balance changed either way.
+				shouldRefresh = true;
 			} else if (
 				isTerminalActiveUserTransaction(tx) &&
 				!alreadyApplied &&

--- a/src/frontend/src/lib/components/swap/SwapProgress.svelte
+++ b/src/frontend/src/lib/components/swap/SwapProgress.svelte
@@ -7,6 +7,13 @@
 	interface Props {
 		swapProgressStep?: string;
 		sendWithApproval?: boolean;
+		// The approve row without the two signing rows `sendWithApproval` also brings,
+		// for a flow that approves a ledger allowance and signs nothing the user sees —
+		// OISY Trade, whose deposit leg is `icrc2_approve` then `deposit`. On the ICP
+		// wizard an approve is a plain canister call, so there is no signature to show;
+		// and a step driven into a list that does not render it matches nothing, which
+		// leaves every row unhighlighted until the next step that does exist.
+		sendWithApprovalOnly?: boolean;
 		sendWithTransfer?: boolean;
 		swapWithWithdrawing?: boolean;
 		swapWithActiveTransaction?: boolean;
@@ -20,6 +27,7 @@
 		swapProgressStep = ProgressStepsSwap.INITIALIZATION,
 		failedSteps = $bindable([]),
 		sendWithApproval = false,
+		sendWithApprovalOnly = false,
 		sendWithTransfer = false,
 		swapWithWithdrawing = false,
 		swapWithActiveTransaction = false,
@@ -51,6 +59,19 @@
 					{
 						step: ProgressStepsSwap.SIGN_TRANSFER,
 						text: $i18n.send.text.signing_transaction,
+						state: 'next'
+					}
+				] as ProgressSteps)
+			: []),
+		// Guarded against `sendWithApproval`, which already contributes an `APPROVE`
+		// row: two rows sharing one step id would break the in-progress lookup, which
+		// matches steps by id. The two props serve different wizards, so this is an
+		// invariant rather than a case that arises.
+		...(sendWithApprovalOnly && !sendWithApproval
+			? ([
+					{
+						step: ProgressStepsSwap.APPROVE,
+						text: $i18n.send.text.approving,
 						state: 'next'
 					}
 				] as ProgressSteps)

--- a/src/frontend/src/lib/constants/oisy-trade.constants.ts
+++ b/src/frontend/src/lib/constants/oisy-trade.constants.ts
@@ -19,6 +19,15 @@ export const OISY_TRADE_POLL_INTERVAL_MILLIS = 30_000;
 // here somebody is watching a spinner for exactly this interval.
 export const OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS = 2_000;
 
+// How long the background poller leaves a swap row that has no order id alone.
+//
+// Load-bearing rather than a nicety: every healthy swap passes through exactly
+// that signature in the window between the row's creation and `add_limit_order`
+// returning, so a tick landing inside it would withdraw the deposit out from
+// under an order placement still in flight. Comfortably longer than approve +
+// deposit + place, and well short of the deposit's 5-minute approve expiry.
+export const OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS = 5 * 60 * 1000;
+
 // The oisy_trade canister caps a `get_my_orders` page (`ByPage.length`) at 100.
 export const OISY_TRADE_ORDERS_PAGE_SIZE = 100;
 

--- a/src/frontend/src/lib/constants/oisy-trade.constants.ts
+++ b/src/frontend/src/lib/constants/oisy-trade.constants.ts
@@ -1,3 +1,5 @@
+import { ACTIVE_USER_TRANSACTIONS_POLL_INTERVAL_MILLIS } from '$lib/constants/app.constants';
+
 // Display name for the OISY Trade provider, shown on the Trading tab venue tag,
 // order rows, and deposit/withdraw flows.
 export const OISY_TRADE_PROVIDER_NAME = 'OISY Trade';
@@ -27,6 +29,19 @@ export const OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS = 2_000;
 // under an order placement still in flight. Comfortably longer than approve +
 // deposit + place, and well short of the deposit's 5-minute approve expiry.
 export const OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS = 5 * 60 * 1000;
+
+// That grace period as a count of the poller's own ticks, which is how it is
+// actually measured.
+//
+// Not as elapsed wall time: the row's `created_at_ns` comes from the backend
+// canister's clock while `Date.now()` comes from the browser's, and subtracting one
+// from the other makes the window depend on the difference between them. A device
+// clock five minutes fast collapses the budget to nothing, which would let a tick
+// act while approve and deposit are still in flight; one behind holds recovery off
+// for as long as it is behind. Counting the poller's own ticks needs neither clock.
+export const OISY_TRADE_SWAP_SETTLE_GRACE_OBSERVATIONS = Math.ceil(
+	OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS / ACTIVE_USER_TRANSACTIONS_POLL_INTERVAL_MILLIS
+);
 
 // The oisy_trade canister caps a `get_my_orders` page (`ByPage.length`) at 100.
 export const OISY_TRADE_ORDERS_PAGE_SIZE = 100;

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "This swap transaction was replaced or dropped before it was confirmed.",
 			"near_intents_quote_unverified": "This swap quote could not be verified as genuine, so no funds were sent. Please try again or choose a different provider.",
 			"near_intents_quote_expired": "This swap quote has expired, so no funds were sent. Please try again to get a fresh quote.",
+			"oisy_trade_not_trackable": "This swap could not be started because it could not be recorded for tracking. No funds have left your wallet. Please try again.",
 			"oisy_trade_order_killed": "The order could not be filled in full at the reviewed price, so it was canceled and your funds were returned to your wallet. You were only charged network fees.",
 			"oisy_trade_settlement_unresolved": "The order could no longer be found, and neither token is held on OISY Trade. Please check your balances in the Trading tab before trying again.",
 			"oisy_trade_order_not_placed": "OISY Trade did not accept the order, so your funds were returned to your wallet. You were only charged network fees.",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1253,6 +1253,7 @@
 			"swap_replaced_or_dropped": "",
 			"near_intents_quote_unverified": "",
 			"near_intents_quote_expired": "",
+			"oisy_trade_not_trackable": "",
 			"oisy_trade_order_killed": "",
 			"oisy_trade_settlement_unresolved": "",
 			"oisy_trade_order_not_placed": "",

--- a/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
@@ -171,6 +171,22 @@ const pollOisyTradeTransaction = async ({
 	const orderIdRef = refs[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID];
 	const hasDeposited = nonNullish(refs[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]);
 
+	// Everything this poller withdraws is a delta from these, so a row whose baselines
+	// cannot be read is left strictly alone — logged, non-terminal, still visible —
+	// exactly like one whose tokens cannot be resolved. Substituting zero would be the
+	// destructive guess: it credits this order with the caller's whole free balance,
+	// which is how the swap ends up withdrawing a balance the user parked from the
+	// Trading tab, and how a held destination balance makes a killed order read as
+	// filled. Both baselines are written in the same call that creates the row, so this
+	// is a malformed row rather than an early one.
+	const source = toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]);
+	const destination = toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE]);
+
+	if (isNullish(source) || isNullish(destination)) {
+		consoleError('Unreadable balance baseline on an OISY Trade active user transaction', tx.id);
+		return;
+	}
+
 	// Without an order id the foreground may still be mid-flow, so the row is its
 	// business until it has been seen for the whole tick budget. With one there is
 	// nothing to wait for — settlement is this poller's job from the moment the order
@@ -193,10 +209,7 @@ const pollOisyTradeTransaction = async ({
 			orderId: orderIdRef,
 			sourceToken,
 			destinationToken,
-			baseline: {
-				source: toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]),
-				destination: toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE])
-			}
+			baseline: { source, destination }
 		});
 	} catch (err: unknown) {
 		// The retry policy, and the reason this branch exists at all. `retryable` covers
@@ -284,6 +297,27 @@ const pollOisyTradeTransaction = async ({
 			error: swapError.oisy_trade_settlement_unresolved
 		});
 
+		return;
+	}
+
+	// The order has resolved, but a non-dust leg of it is still at the venue: the
+	// withdrawal was refused definitively rather than transiently, which for a filled
+	// Buy is most often the reserve released by crossing below its limit. Terminalizing
+	// on the order's outcome alone would drop the row from the pending set and tell the
+	// user the swap succeeded, with their funds still in DEX custody and nothing left
+	// watching them — the accumulation this provider is most exposed to.
+	//
+	// Left non-terminal so the next tick tries again. Re-entry is idempotent because
+	// everything is re-derived from the baseline deltas, so the primary this attempt
+	// already withdrew reads as dust and only the residue is attempted. "Definitive"
+	// here means the canister's refusal was not classed transient, not that it can never
+	// clear, so retrying is the right response — and a row that keeps polling is visible
+	// and self-healing where a wrongly-succeeded one is neither.
+	//
+	// The primary's block index goes unrecorded until an attempt completes, which is a
+	// traceability loss on a rare path rather than a correctness one, and is the reason
+	// this returns rather than writing refs on every tick.
+	if (settlement.residueStranded) {
 		return;
 	}
 

--- a/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
@@ -6,7 +6,7 @@ import type {
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcToken } from '$icp/types/ic-token';
 import { OisyTradeError } from '$lib/canisters/oisy-trade.errors';
-import { OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS } from '$lib/constants/oisy-trade.constants';
+import { OISY_TRADE_SWAP_SETTLE_GRACE_OBSERVATIONS } from '$lib/constants/oisy-trade.constants';
 import { allSortedIcrcTokens } from '$lib/derived/all-tokens.derived';
 import {
 	applyActiveUserTransactionPollUpdate,
@@ -35,20 +35,40 @@ import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { get } from 'svelte/store';
 
-const NANOSECONDS_IN_MILLISECOND = 1_000_000n;
-
 /**
- * Whether the foreground has had long enough to finish placing the order.
+ * How many consecutive ticks each order-less row has been seen for.
  *
- * Only ever asked of a row with no order id, and load-bearing rather than a
+ * Only ever consulted for a row with no order id, and load-bearing rather than a
  * nicety: every healthy swap passes through exactly that signature in the window
  * between the row's creation and `add_limit_order` returning, so a tick landing
- * inside it would withdraw the deposit out from under an order placement still in
- * flight.
+ * inside it would act while the foreground still owns the flow — deleting the
+ * recovery record mid-deposit, or withdrawing the deposit out from under an order
+ * placement about to reserve it.
+ *
+ * Counted rather than clocked, which is the whole point. The row's timestamps come
+ * from the backend canister's clock and `Date.now()` from the browser's, so
+ * subtracting one from the other makes the window depend on the difference between
+ * them: a device five minutes fast has no window at all. Ticks are the poller's own
+ * cadence and need neither clock.
+ *
+ * Deliberately in-memory, as in `velora-active-tx.services` and
+ * `chain-fusion-swap-active-tx.services`: a refresh restarts the count, which at
+ * worst delays recovering an abandoned deposit and can never act early. Ticks do
+ * not accrue while the tab is hidden, for the same reason.
  */
-const isPastGracePeriod = ({ created_at_ns }: ActiveUserTransaction): boolean =>
-	BigInt(Date.now()) - created_at_ns / NANOSECONDS_IN_MILLISECOND >
-	BigInt(OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS);
+const orderlessObservations = new Map<string, number>();
+
+// Test seam — module-level state would otherwise leak between cases.
+export const resetOisyTradeOrderlessObservations = (): void => {
+	orderlessObservations.clear();
+};
+
+const recordOrderlessObservation = (id: string): number => {
+	const count = (orderlessObservations.get(id) ?? 0) + 1;
+	orderlessObservations.set(id, count);
+
+	return count;
+};
 
 /**
  * The two legs of a row, resolved back to the wallet's own tokens.
@@ -100,6 +120,9 @@ const applyTerminalUpdate = async ({
 		return;
 	}
 
+	// A terminal row leaves the pending set, so its tick count has no reader left.
+	orderlessObservations.delete(tx.id);
+
 	// Both legs can pay out — a Buy that crossed below its limit has its unspent
 	// reserve released alongside the fill — so the ref records every block index this
 	// settlement produced, not just the primary one.
@@ -149,10 +172,15 @@ const pollOisyTradeTransaction = async ({
 	const hasDeposited = nonNullish(refs[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]);
 
 	// Without an order id the foreground may still be mid-flow, so the row is its
-	// business until the grace period is up. With one there is nothing to wait for:
-	// settlement is this poller's job from the moment the order exists.
-	if (isNullish(orderIdRef) && !isPastGracePeriod(tx)) {
-		return;
+	// business until it has been seen for the whole tick budget. With one there is
+	// nothing to wait for — settlement is this poller's job from the moment the order
+	// exists — and the count has no reader left.
+	if (isNullish(orderIdRef)) {
+		if (recordOrderlessObservation(tx.id) < OISY_TRADE_SWAP_SETTLE_GRACE_OBSERVATIONS) {
+			return;
+		}
+	} else {
+		orderlessObservations.delete(tx.id);
 	}
 
 	const { error: swapError } = get(i18n).swap;
@@ -189,6 +217,17 @@ const pollOisyTradeTransaction = async ({
 		// why the reason is recorded on the row: the Trading tab is where the user can act
 		// on it.
 		if (err instanceof OisyTradeError) {
+			// …but only once an order exists to have been refused about. With no order id,
+			// the likeliest way a withdrawal gets definitively refused is that
+			// `add_limit_order` landed between the balance read and the withdraw and
+			// reserved the very funds it was about to move — `InsufficientBalance`, which is
+			// not retryable. Terminalizing there would mark the row failed while the order
+			// goes on to fill into DEX custody with nothing polling for it. The row is left
+			// alone and the next tick re-derives from what the canister then holds.
+			if (isNullish(orderIdRef)) {
+				return;
+			}
+
 			await applyActiveUserTransactionPollUpdate({
 				identity,
 				tx,
@@ -209,34 +248,41 @@ const pollOisyTradeTransaction = async ({
 	}
 
 	if (settlement.status === 'unresolved') {
-		// With an order id, "unresolved" is final: the canister no longer knows the order
-		// and neither leg holds anything attributable, so an earlier attempt already paid
-		// the withdrawal out and only the terminal write was lost. Nothing says which way
-		// it went, so it closes as a failure that points at the Trading tab rather than
-		// claiming a success it cannot evidence.
-		if (nonNullish(orderIdRef)) {
-			await applyTerminalUpdate({
-				identity,
-				tx,
-				refs,
-				settlement,
-				error: swapError.oisy_trade_settlement_unresolved
-			});
+		// A row still `Pending` that holds neither pointer never reached the canister —
+		// the user closed the modal at the approve prompt, or the approve failed — so it
+		// is *deleted* rather than failed: nothing happened, and a `Failed` row would
+		// invite the user to worry about funds that never moved.
+		if ('Pending' in tx.status && !hasDeposited) {
+			await deleteActiveUserTransaction({ identity, id: tx.id });
+			orderlessObservations.delete(tx.id);
 
 			return;
 		}
 
-		// Without one it is ambiguous, and the two readings are told apart by what the row
-		// itself records. A row still `Pending` that holds neither pointer never reached
-		// the canister — the user closed the modal at the approve prompt, or the approve
-		// failed — so it is *deleted* rather than failed: nothing happened, and a `Failed`
-		// row would invite the user to worry about funds that never moved. Anything else
-		// is a deposit whose order id was lost while the order itself may still be live,
-		// holding its reserve where no free balance can see it. That row is left to keep
-		// polling; terminalizing it would be the one unrecoverable mistake here.
-		if ('Pending' in tx.status && !hasDeposited) {
-			await deleteActiveUserTransaction({ identity, id: tx.id });
-		}
+		// Otherwise "unresolved" is final, whether or not an order id was ever recorded:
+		// nothing attributable is left on either leg, so the funds are already out of DEX
+		// custody. Either an earlier attempt paid the withdrawal out and only its reply or
+		// its terminal write was lost, or the user swept the balance from the Trading tab.
+		//
+		// The reading this does *not* have to fear is a live order hiding the funds behind
+		// its reserve. This branch is only reachable once the row has gone unwritten for
+		// the whole tick budget, and the order is fill-or-kill: it is decided in the
+		// matching round that follows its acceptance, so minutes later it has either
+		// filled, which shows as a destination delta, or been killed, which returns the
+		// source. Both are non-zero. Zero on both legs therefore cannot be an order still
+		// in flight.
+		//
+		// It closes as a failure with copy that points at the Trading tab rather than
+		// naming an outcome: a fill whose withdrawal reply was lost looks identical from
+		// here, so this cannot claim the success it has no evidence for — nor blame a
+		// placement that may well have happened.
+		await applyTerminalUpdate({
+			identity,
+			tx,
+			refs,
+			settlement,
+			error: swapError.oisy_trade_settlement_unresolved
+		});
 
 		return;
 	}

--- a/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
@@ -1,0 +1,296 @@
+import type {
+	ActiveUserTransaction,
+	OisyTradeData,
+	TokenId
+} from '$declarations/backend/backend.did';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import type { IcToken } from '$icp/types/ic-token';
+import { OisyTradeError } from '$lib/canisters/oisy-trade.errors';
+import { OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS } from '$lib/constants/oisy-trade.constants';
+import { allSortedIcrcTokens } from '$lib/derived/all-tokens.derived';
+import {
+	applyActiveUserTransactionPollUpdate,
+	deleteActiveUserTransaction
+} from '$lib/services/active-user-transactions.services';
+import {
+	isRetryableOisyTradeError,
+	settleOisyTradeSwap,
+	type OisyTradeSettlement
+} from '$lib/services/oisy-trade-swap.services';
+import { i18n } from '$lib/stores/i18n.store';
+import {
+	OISY_TRADE_EXTERNAL_REF_KEYS,
+	type OisyTradeExternalRefKey
+} from '$lib/types/oisy-trade-swap';
+import type { Token } from '$lib/types/token';
+import { advanceStatus } from '$lib/utils/active-user-transactions.utils';
+import { consoleError } from '$lib/utils/console.utils';
+import {
+	findOisyTradeRowToken,
+	toOisyTradeExternalRefs,
+	toOisyTradeExternalRefsMap,
+	toOisyTradeRefAmount
+} from '$lib/utils/oisy-trade-active-tx.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+import type { Identity } from '@icp-sdk/core/agent';
+import { get } from 'svelte/store';
+
+const NANOSECONDS_IN_MILLISECOND = 1_000_000n;
+
+/**
+ * Whether the foreground has had long enough to finish placing the order.
+ *
+ * Only ever asked of a row with no order id, and load-bearing rather than a
+ * nicety: every healthy swap passes through exactly that signature in the window
+ * between the row's creation and `add_limit_order` returning, so a tick landing
+ * inside it would withdraw the deposit out from under an order placement still in
+ * flight.
+ */
+const isPastGracePeriod = ({ created_at_ns }: ActiveUserTransaction): boolean =>
+	BigInt(Date.now()) - created_at_ns / NANOSECONDS_IN_MILLISECOND >
+	BigInt(OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS);
+
+/**
+ * The two legs of a row, resolved back to the wallet's own tokens.
+ *
+ * A pair leg the wallet does not know is unreachable by construction — the quote
+ * that opened the row drew both tokens from the swap universe this reads — but a
+ * row that cannot be resolved is left strictly alone rather than guessed at:
+ * settlement needs each token's ledger fee to tell a withdrawable balance from
+ * permanently unwithdrawable dust.
+ */
+const resolveRowTokens = ({
+	data,
+	tokens
+}: {
+	data: OisyTradeData;
+	tokens: Token[];
+}): { sourceToken: IcToken; destinationToken: IcToken } | undefined => {
+	const resolve = (tokenId: TokenId) => findOisyTradeRowToken({ tokenId, tokens });
+
+	const sourceToken = resolve(data.source_token);
+	const destinationToken = resolve(data.dest_token);
+
+	if (isNullish(sourceToken) || isNullish(destinationToken)) {
+		return undefined;
+	}
+
+	return { sourceToken, destinationToken };
+};
+
+const applyTerminalUpdate = async ({
+	identity,
+	tx,
+	refs,
+	settlement,
+	error
+}: {
+	identity: Identity;
+	tx: ActiveUserTransaction;
+	refs: Partial<Record<OisyTradeExternalRefKey, string>>;
+	settlement: OisyTradeSettlement;
+	error?: string;
+}): Promise<void> => {
+	const status = advanceStatus({
+		current: tx.status,
+		candidate: settlement.status === 'filled' ? { Succeeded: null } : { Failed: null }
+	});
+
+	if (isNullish(status)) {
+		return;
+	}
+
+	// Both legs can pay out — a Buy that crossed below its limit has its unspent
+	// reserve released alongside the fill — so the ref records every block index this
+	// settlement produced, not just the primary one.
+	const withdrawn = settlement.withdrawals.join(',');
+
+	await applyActiveUserTransactionPollUpdate({
+		identity,
+		tx,
+		update: {
+			status,
+			...(nonNullish(error) ? { error } : {}),
+			externalRefs: toOisyTradeExternalRefs({
+				...refs,
+				...(withdrawn !== ''
+					? { [OISY_TRADE_EXTERNAL_REF_KEYS.WITHDRAW_BLOCK_INDEX]: withdrawn }
+					: {})
+			})
+		}
+	});
+};
+
+const pollOisyTradeTransaction = async ({
+	identity,
+	tx,
+	tokens
+}: {
+	identity: Identity;
+	tx: ActiveUserTransaction;
+	tokens: Token[];
+}): Promise<void> => {
+	if (!('OisyTrade' in tx.data)) {
+		return;
+	}
+
+	const resolved = resolveRowTokens({ data: tx.data.OisyTrade, tokens });
+
+	if (isNullish(resolved)) {
+		consoleError('Unresolvable token on an OISY Trade active user transaction', tx.id);
+		return;
+	}
+
+	const { sourceToken, destinationToken } = resolved;
+
+	const refs = toOisyTradeExternalRefsMap(tx.external_refs);
+
+	const orderIdRef = refs[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID];
+	const hasDeposited = nonNullish(refs[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]);
+
+	// Without an order id the foreground may still be mid-flow, so the row is its
+	// business until the grace period is up. With one there is nothing to wait for:
+	// settlement is this poller's job from the moment the order exists.
+	if (isNullish(orderIdRef) && !isPastGracePeriod(tx)) {
+		return;
+	}
+
+	const { error: swapError } = get(i18n).swap;
+
+	let settlement: OisyTradeSettlement;
+
+	try {
+		settlement = await settleOisyTradeSwap({
+			identity,
+			orderId: orderIdRef,
+			sourceToken,
+			destinationToken,
+			baseline: {
+				source: toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]),
+				destination: toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE])
+			}
+		});
+	} catch (err: unknown) {
+		// The retry policy, and the reason this branch exists at all. `retryable` covers
+		// `LedgerTemporarilyUnavailable`, `OperationInProgress` and `CallFailed` — all
+		// transient, and `OperationInProgress` the likeliest, since it fires whenever
+		// another deposit or withdrawal is already in flight for the same
+		// `(caller, token)`. Terminalizing on one of those would mark the swap failed,
+		// stop the poller and leave the funds in DEX custody with nothing watching them.
+		// The row is left untouched instead — `advanceStatus` is forward-only, so an
+		// `Executing` row cannot fall back and does not need to — and the next tick asks
+		// again.
+		if (isRetryableOisyTradeError(err)) {
+			return;
+		}
+
+		// A definitive refusal from the canister ends the operation, with its own message
+		// rather than a hand-written one. The funds may still be in DEX custody, which is
+		// why the reason is recorded on the row: the Trading tab is where the user can act
+		// on it.
+		if (err instanceof OisyTradeError) {
+			await applyActiveUserTransactionPollUpdate({
+				identity,
+				tx,
+				update: {
+					status: advanceStatus({ current: tx.status, candidate: { Failed: null } }),
+					error: err.message
+				}
+			});
+
+			return;
+		}
+
+		throw err;
+	}
+
+	if (settlement.status === 'pending') {
+		return;
+	}
+
+	if (settlement.status === 'unresolved') {
+		// With an order id, "unresolved" is final: the canister no longer knows the order
+		// and neither leg holds anything attributable, so an earlier attempt already paid
+		// the withdrawal out and only the terminal write was lost. Nothing says which way
+		// it went, so it closes as a failure that points at the Trading tab rather than
+		// claiming a success it cannot evidence.
+		if (nonNullish(orderIdRef)) {
+			await applyTerminalUpdate({
+				identity,
+				tx,
+				refs,
+				settlement,
+				error: swapError.oisy_trade_settlement_unresolved
+			});
+
+			return;
+		}
+
+		// Without one it is ambiguous, and the two readings are told apart by what the row
+		// itself records. A row still `Pending` that holds neither pointer never reached
+		// the canister — the user closed the modal at the approve prompt, or the approve
+		// failed — so it is *deleted* rather than failed: nothing happened, and a `Failed`
+		// row would invite the user to worry about funds that never moved. Anything else
+		// is a deposit whose order id was lost while the order itself may still be live,
+		// holding its reserve where no free balance can see it. That row is left to keep
+		// polling; terminalizing it would be the one unrecoverable mistake here.
+		if ('Pending' in tx.status && !hasDeposited) {
+			await deleteActiveUserTransaction({ identity, id: tx.id });
+		}
+
+		return;
+	}
+
+	await applyTerminalUpdate({
+		identity,
+		tx,
+		refs,
+		settlement,
+		error:
+			settlement.status === 'filled'
+				? undefined
+				: // A kill and an order that was never placed both come home as the source
+					// token and both fail the row; only the reason differs, and the absence of
+					// an order id is what says which happened.
+					nonNullish(orderIdRef)
+					? swapError.oisy_trade_order_killed
+					: swapError.oisy_trade_order_not_placed
+	});
+};
+
+/**
+ * Advances the non-terminal OISY Trade rows: polls each one's order and, once it
+ * has resolved, withdraws what it added to both legs and closes the row.
+ *
+ * The settlement itself is `settleOisyTradeSwap`, shared verbatim with the swap
+ * flow that opened the row — this only decides what the outcome means for the row.
+ * Sequential rather than concurrent: the canister rejects a second withdrawal while
+ * one is already in flight for the same caller (`OperationInProgress`), so two rows
+ * settling together would race each other straight into it.
+ */
+export const pollOisyTradeActiveUserTransactions = async ({
+	identity,
+	transactions
+}: {
+	identity: Identity;
+	transactions: ActiveUserTransaction[];
+}): Promise<void> => {
+	if (transactions.length === 0) {
+		return;
+	}
+
+	// ICP is a pair leg like any other and is not in the ICRC list, which is the one
+	// place the two representations differ.
+	const tokens: Token[] = [ICP_TOKEN, ...get(allSortedIcrcTokens)];
+
+	for (const tx of transactions) {
+		try {
+			await pollOisyTradeTransaction({ identity, tx, tokens });
+		} catch (err: unknown) {
+			// Whatever reaches here is not the canister's verdict on this swap — a backend
+			// write that failed, a network blip — so the row is left exactly as it is and
+			// the next tick asks again. One failing row never poisons the batch.
+			consoleError(err);
+		}
+	}
+};

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -439,9 +439,12 @@ const withdrawFreeBalance = async ({
  * `add_limit_order` never returned an id — because it was never reached, or because
  * its reply was lost. There is nothing to poll, so the balances answer instead,
  * exactly as they do for an order the canister no longer knows. Both deltas at zero
- * then reads as `unresolved`, which is also what a *live* order looks like from the
- * outside (its reserve is locked, so neither leg holds anything free) — so the caller
- * must treat `unresolved` as "ask again later", never as "nothing happened".
+ * then reads as `unresolved`, which says only that nothing attributable is in custody
+ * — not how it got that way, and not that nothing happened. A *live* order looks
+ * identical from the outside, since its reserve holds no free balance, so a caller
+ * that can still be racing a placement must not read `unresolved` as terminal; the
+ * poller waits out its tick budget first, by which point a fill-or-kill order has
+ * necessarily resolved and left a non-zero delta on one leg.
  *
  * Everything it acts on is **the difference from that baseline**, never the
  * account-wide free balance. A user can arrive at a swap with either leg already

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -1,3 +1,4 @@
+import type { ActiveUserTransactionStatus } from '$declarations/backend/backend.did';
 import type {
 	OrderId,
 	OrderRecord,
@@ -14,21 +15,32 @@ import { OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy
 import { exchanges } from '$lib/derived/exchange.derived';
 import { PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import {
+	createActiveUserTransaction,
+	updateActiveUserTransaction
+} from '$lib/services/active-user-transactions.services';
 import { approveAndDepositOisyTrade } from '$lib/services/oisy-trade.deposit.services';
 import { placeLimitOrder } from '$lib/services/oisy-trade.services';
 import { OisyTradeSwapError } from '$lib/services/swap-errors.services';
 import { trackDepositWithdraw, trackLimitOrder } from '$lib/services/trading-analytics.services';
 import { i18n } from '$lib/stores/i18n.store';
 import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
-import type {
-	OisyTradeFee,
-	OisyTradeQuote,
-	OisyTradeQuoteResult,
-	OisyTradeResolvedOrder
+import {
+	OISY_TRADE_EXTERNAL_REF_KEYS,
+	type OisyTradeExternalRefKey,
+	type OisyTradeFee,
+	type OisyTradeQuote,
+	type OisyTradeQuoteResult,
+	type OisyTradeResolvedOrder
 } from '$lib/types/oisy-trade-swap';
 import { SwapProvider, type SwapMappedResult } from '$lib/types/swap';
 import { consoleError } from '$lib/utils/console.utils';
 import { replaceIcErrorFields } from '$lib/utils/error.utils';
+import {
+	toOisyTradeData,
+	toOisyTradeDisplayRefs,
+	toOisyTradeExternalRefs
+} from '$lib/utils/oisy-trade-active-tx.utils';
 import {
 	computeOisyTradeReceiveAmount,
 	findOisyTradePair,
@@ -423,6 +435,14 @@ const withdrawFreeBalance = async ({
  * rather than reading them from anywhere, so that poller can pass them straight out
  * of an Active User Transaction's refs.
  *
+ * A **nullish** `orderId` is the poller's case, not the wizard's: a row whose
+ * `add_limit_order` never returned an id — because it was never reached, or because
+ * its reply was lost. There is nothing to poll, so the balances answer instead,
+ * exactly as they do for an order the canister no longer knows. Both deltas at zero
+ * then reads as `unresolved`, which is also what a *live* order looks like from the
+ * outside (its reserve is locked, so neither leg holds anything free) — so the caller
+ * must treat `unresolved` as "ask again later", never as "nothing happened".
+ *
  * Everything it acts on is **the difference from that baseline**, never the
  * account-wide free balance. A user can arrive at a swap with either leg already
  * funded from the Trading tab, and withdrawing the account-wide total would evacuate
@@ -443,13 +463,14 @@ export const settleOisyTradeSwap = async ({
 	baseline
 }: {
 	identity: Identity;
-	orderId: OrderId;
+	// Absent only when no order was ever placed, or its id never came back.
+	orderId?: OrderId;
 	sourceToken: IcToken;
 	destinationToken: IcToken;
 	// Both legs' free balance as it stood before the deposit.
 	baseline: OisyTradeFreeBalances;
 }): Promise<OisyTradeSettlement> => {
-	const order = await readOisyTradeOrder({ identity, orderId });
+	const order = nonNullish(orderId) ? await readOisyTradeOrder({ identity, orderId }) : undefined;
 
 	// A live order's reserve is locked — "funds reserved by open orders are not
 	// withdrawable until the order fills or is canceled" — so there is nothing to
@@ -466,12 +487,13 @@ export const settleOisyTradeSwap = async ({
 		baseline: baseline.destination
 	});
 
-	// With the order still known, its status is the answer. Without it, what this order
-	// *added* is — which is what makes this correct however long the canister retains a
-	// terminal order: destination added means it filled, source added means it did not,
-	// and neither means the withdrawal already happened in an earlier attempt. Reading
-	// the account-wide balance here instead would call a killed order filled for any user
-	// who already held the destination token on the DEX.
+	// With the order still known, its status is the answer. Without it — never placed,
+	// its id lost, or evicted by the canister — what this order *added* is, which is what
+	// makes this correct however long a terminal order is retained: destination added
+	// means it filled, source added means it did not, and neither means either the
+	// withdrawal already happened or an order is still holding the reserve. Reading the
+	// account-wide balance here instead would call a killed order filled for any user who
+	// already held the destination token on the DEX.
 	const status: OisyTradeSettlementStatus = nonNullish(order)
 		? 'Filled' in order.status
 			? 'filled'
@@ -540,41 +562,6 @@ export const settleOisyTradeSwap = async ({
 };
 
 /**
- * Settles in the foreground, retrying until the order reaches a terminal state.
- *
- * Unbounded on purpose: the modal stays open until the user's funds are back in
- * their wallet, because until the next step's Active User Transaction row exists
- * there is nothing else watching them. A retryable failure — a ledger having a bad
- * minute, or a concurrent operation on the same token — is a reason to ask again,
- * never a reason to stop; anything else ends the swap.
- */
-const settleUntilTerminal = async (params: {
-	identity: Identity;
-	orderId: OrderId;
-	sourceToken: IcToken;
-	destinationToken: IcToken;
-	baseline: OisyTradeFreeBalances;
-}): Promise<OisyTradeSettlement> => {
-	for (;;) {
-		try {
-			const settlement = await settleOisyTradeSwap(params);
-
-			if (settlement.status !== 'pending') {
-				return settlement;
-			}
-		} catch (err: unknown) {
-			if (!isRetryableOisyTradeError(err)) {
-				throw err;
-			}
-		}
-
-		await new Promise((resolve) =>
-			setTimeout(resolve, OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS)
-		);
-	}
-};
-
-/**
  * Recovers a deposit whose order the canister refused to accept.
  *
  * Only the source leg: no order ever existed, so nothing has touched the
@@ -619,24 +606,28 @@ const recoverOisyTradeDeposit = async (params: {
 };
 
 /**
- * Executes a reviewed OISY Trade offer: approve → deposit → fill-or-kill order →
- * settle → withdraw.
+ * Executes a reviewed OISY Trade offer: open the recovery record, approve, deposit,
+ * place the fill-or-kill order — and stop there.
  *
  * The price and quantity come from the reviewed quote and are never re-derived. The
  * book moves, and re-resolving them here would silently change what the user agreed
  * to between Review and submit.
  *
- * Throws an `OisyTradeSwapError` on a killed order — and on one the canister
- * refused to accept. That is unlike every other provider, where a failed swap means
- * nothing moved: here the funds have been to the DEX and back, so in both cases the
- * error is raised only *after* the source token has been withdrawn — the user is
- * never told the swap failed while their money is still in someone else's custody.
- * The typed error is what lets the wizard present either as the expected outcome it
- * is, rather than as an unexpected failure.
+ * Settlement is deliberately **not** part of this: once the order is placed the
+ * operation belongs to its Active User Transaction row, which
+ * `pollOisyTradeActiveUserTransactions` drives to a fill or a kill with the modal
+ * closed, across a refresh and across a re-login. What this function still owns is
+ * everything that happens before there is an order to settle.
+ *
+ * Throws an `OisyTradeSwapError` when the row cannot be opened (before anything
+ * moves) and when the canister refuses the order (after the deposit has been
+ * recovered). The typed error is what lets the wizard present either as the
+ * expected outcome it is, rather than as an unexpected failure.
  */
 export const fetchOisyTradeSwap = async ({
 	identity,
 	progress,
+	swapId,
 	sourceToken,
 	destinationToken,
 	order,
@@ -644,12 +635,14 @@ export const fetchOisyTradeSwap = async ({
 }: {
 	identity: Identity;
 	progress: (step: ProgressStepsSwap) => void;
+	// The row's id, generated by the caller like every other tracked swap's.
+	swapId: string;
 	sourceToken: IcToken;
 	destinationToken: IcToken;
 	// The order the quote resolved and the user reviewed.
 	order: OisyTradeResolvedOrder;
 	enableDestinationToken?: () => Promise<void>;
-}): Promise<OisyTradeSettlement> => {
+}): Promise<void> => {
 	const { swap: swapI18n } = get(i18n);
 
 	// A swap-placed order genuinely *is* a deposit and a limit order, so both Trading
@@ -680,13 +673,100 @@ export const fetchOisyTradeSwap = async ({
 	// whatever the user already had on the DEX. It has to precede the deposit
 	// specifically: the deposit itself credits the source leg, and a baseline taken
 	// after it would make a killed order's returned reserve look like someone else's
-	// balance and be left behind. Step 2 captures this into the row's refs at creation,
-	// which is the same point in the flow.
+	// balance and be left behind. It goes into the row below, which is where the poller
+	// reads it back from in a later session.
 	const baseline = await readOisyTradeFreeBalances({
 		identity,
 		sourceToken,
 		destinationToken
 	});
+
+	const data = toOisyTradeData({
+		side: order.side,
+		sourceToken,
+		destinationToken,
+		amount: order.depositAmount
+	});
+
+	if (isNullish(data)) {
+		throw new OisyTradeSwapError(swapI18n.error.oisy_trade_not_trackable, 'not_trackable');
+	}
+
+	// Everything fixed at creation, so the row already describes the operation before
+	// the first canister call can fail halfway through it.
+	let refs: Partial<Record<OisyTradeExternalRefKey, string>> = {
+		...toOisyTradeDisplayRefs({
+			sourceToken,
+			destinationToken,
+			amount: depositAnalytics.amount,
+			usdSourceValue: nonNullish(depositAnalytics.usdValue)
+				? `${depositAnalytics.usdValue}`
+				: undefined
+		}),
+		[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_PRICE]: `${order.price}`,
+		[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_QUANTITY]: `${order.quantity}`,
+		[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]: `${baseline.source}`,
+		[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE]: `${baseline.destination}`
+	};
+
+	// **This inverts every other provider's rule.** OneSec, Velora, NEAR Intents and
+	// Chain Fusion all open their row best-effort and never let a failure here surface
+	// as a swap failure, because for them the row only *observes* a settlement that will
+	// happen anyway. Here it is the recovery record: an OISY Trade swap parks the user's
+	// funds in the DEX's custody mid-flow, and the row is what tells a later session
+	// which token to pull back out. Proceeding without one is exactly the stranded-funds
+	// case it exists to prevent — so this is not caught, and nothing has moved yet when
+	// it throws.
+	try {
+		await createActiveUserTransaction({
+			identity,
+			id: swapId,
+			data,
+			externalRefs: toOisyTradeExternalRefs(refs)
+		});
+	} catch (err: unknown) {
+		consoleError(err);
+
+		throw new OisyTradeSwapError(swapI18n.error.oisy_trade_not_trackable, 'not_trackable');
+	}
+
+	// Learned-mid-flow refs are written with the status they belong to, and swallowed on
+	// failure: the funds have already moved, so ending the swap over a bookkeeping write
+	// would be the worse outcome. The poller re-derives every fact it acts on from the
+	// canister's own balances, so a lost ref costs precision, never correctness — with
+	// one exception, guarded in `pollOisyTradeActiveUserTransactions`: a row is only ever
+	// *deleted* when it is still `Pending` and holds neither pointer.
+	//
+	// That exception is why every write carries the highest status reached so far, not
+	// just the one it advances to. A lost `Executing` write would otherwise leave a
+	// funded row `Pending` with no deposit ref — exactly the delete signature — and the
+	// backend accepts a same-status update, so re-sending it repairs the loss for free.
+	let rowStatus: ActiveUserTransactionStatus | undefined;
+
+	const advanceRow = async ({
+		status,
+		error,
+		learned = {}
+	}: {
+		status?: ActiveUserTransactionStatus;
+		error?: string;
+		learned?: Partial<Record<OisyTradeExternalRefKey, string>>;
+	}): Promise<void> => {
+		refs = { ...refs, ...learned };
+		rowStatus = status ?? rowStatus;
+
+		try {
+			await updateActiveUserTransaction({
+				identity,
+				id: swapId,
+				...(nonNullish(rowStatus) ? { status: rowStatus } : {}),
+				...(nonNullish(error) ? { error } : {}),
+				externalRefs: toOisyTradeExternalRefs(refs)
+			});
+		} catch (err: unknown) {
+			consoleError(err);
+		}
+	};
 
 	trackDepositWithdraw({
 		direction: 'deposit',
@@ -694,8 +774,10 @@ export const fetchOisyTradeSwap = async ({
 		...depositAnalytics
 	});
 
+	let depositBlockIndex: bigint;
+
 	try {
-		await approveAndDepositOisyTrade({
+		depositBlockIndex = await approveAndDepositOisyTrade({
 			identity,
 			token: sourceToken,
 			amount: order.depositAmount,
@@ -709,6 +791,9 @@ export const fetchOisyTradeSwap = async ({
 			error: replaceIcErrorFields(err)
 		});
 
+		// The row stays `Pending` with no deposit ref, which is what the poller reads as
+		// "never started" — nothing moved, so it deletes the row rather than reporting a
+		// failure about funds that never left the wallet.
 		throw err;
 	}
 
@@ -716,6 +801,14 @@ export const fetchOisyTradeSwap = async ({
 		direction: 'deposit',
 		resultStatus: PLAUSIBLE_EVENT_RESULT_STATUSES.SUCCESS,
 		...depositAnalytics
+	});
+
+	// The funds are in DEX custody from here on, which is what `Executing` records.
+	await advanceRow({
+		status: { Executing: null },
+		learned: {
+			[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]: `${depositBlockIndex}`
+		}
 	});
 
 	trackLimitOrder({
@@ -759,24 +852,32 @@ export const fetchOisyTradeSwap = async ({
 		// Anything else is ambiguous — the call may have reached the canister and
 		// only the reply been lost, so an order may exist with the reserve locked
 		// and no id to poll it by. Withdrawing here could race that live order, so
-		// the error is rethrown and the case belongs to the durable recovery record
-		// (the AUT row's "deposit landed, order never placed" path, step 2).
+		// the error is rethrown and the row is left as it is: `Executing`, with a
+		// deposit ref and no order id, which is precisely the signature the poller
+		// resolves once the grace period has passed.
 		if (err instanceof OisyTradeError) {
-			progress(ProgressStepsSwap.WITHDRAW);
-
 			try {
 				await recoverOisyTradeDeposit({ identity, sourceToken, destinationToken, baseline });
 			} catch (recoveryErr: unknown) {
 				consoleError(recoveryErr);
 
-				// The one error raised while funds are still in DEX custody, which is
-				// why its message points at the Trading tab, where the balance shows.
+				// The one error raised while funds are still in DEX custody, which is why
+				// its message points at the Trading tab, where the balance shows. The row
+				// is deliberately left non-terminal: it now carries a deposit ref and no
+				// order id, so the poller retries this same withdrawal for as long as the
+				// balance is there. That is exactly what opening the row early bought.
 				throw new OisyTradeSwapError(swapI18n.error.oisy_trade_recovery_failed, 'recovery_failed');
 			}
 
-			// Like a kill: the funds came back as the source token — refresh the
-			// wallet so the recovered balance is visible, and never enable — or
-			// reach the UPDATE_UI step for — a destination token that never arrived.
+			// The funds came back as the source token and there is nothing left to settle,
+			// so the row is closed here rather than left for the poller to re-derive.
+			await advanceRow({
+				status: { Failed: null },
+				error: swapI18n.error.oisy_trade_order_not_placed
+			});
+
+			// Never enable — or reach the UPDATE_UI step for — a destination token that
+			// never arrived; refresh so the recovered balance is visible.
 			await waitAndTriggerWallet();
 
 			throw new OisyTradeSwapError(swapI18n.error.oisy_trade_order_not_placed, 'not_placed');
@@ -790,35 +891,20 @@ export const fetchOisyTradeSwap = async ({
 		...orderAnalytics
 	});
 
-	progress(ProgressStepsSwap.WITHDRAW);
-
-	const settlement = await settleUntilTerminal({
-		identity,
-		orderId,
-		sourceToken,
-		destinationToken,
-		baseline
+	await advanceRow({
+		learned: { [OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]: orderId }
 	});
-
-	// Nothing was withdrawn and nothing says how the order ended, so there is no
-	// wallet change to refresh and no destination token to enable.
-	if (settlement.status === 'unresolved') {
-		throw new OisyTradeSwapError(swapI18n.error.oisy_trade_settlement_unresolved, 'unresolved');
-	}
-
-	// A killed order's funds came back as the *source* token: refresh the wallet
-	// so the recovered balance is visible, but never enable — and never reach the
-	// UPDATE_UI step for — a destination token the user did not receive.
-	if (settlement.status === 'killed') {
-		await waitAndTriggerWallet();
-
-		throw new OisyTradeSwapError(swapI18n.error.oisy_trade_order_killed, 'killed');
-	}
 
 	progress(ProgressStepsSwap.UPDATE_UI);
 
+	// Enabled on submission rather than on arrival, as every background-settling
+	// provider does: the modal is about to close, and the destination token has to be
+	// visible for the balance the poller's withdrawal will deliver to land somewhere the
+	// user can see. A killed order leaves it enabled and empty, which is the same
+	// trade-off 1Sec and Chain Fusion already make.
 	await enableDestinationToken?.();
-	await waitAndTriggerWallet();
 
-	return settlement;
+	// The deposit has left the wallet; the withdrawal that brings the other leg back is
+	// the poller's, and the loader refreshes again when the row terminalizes.
+	await waitAndTriggerWallet();
 };

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -245,6 +245,16 @@ export interface OisyTradeSettlement {
 	// Ledger block indices of the withdrawals this attempt paid out. Empty while
 	// pending, and on a terminal outcome whose free balances were all dust.
 	withdrawals: bigint[];
+	// A non-dust leg this attempt could not move, because withdrawing it was refused
+	// definitively rather than transiently. `status` still reports the order's true
+	// outcome, so this is what tells a caller that outcome is not the whole story:
+	// funds attributable to this order are still in DEX custody. Distinct from a leg
+	// that held only dust, which is unwithdrawable by construction and is not owed.
+	//
+	// A caller that can retry must not treat the outcome as final while this is set —
+	// succeeding the operation would report a swap that worked with the user's money
+	// still at the venue.
+	residueStranded: boolean;
 }
 
 /**
@@ -374,6 +384,10 @@ export const readOisyTradeFreeBalances = async ({
  * of what remains is ours. Under-counting leaves funds in DEX custody where the
  * Trading tab still shows them; over-counting would withdraw someone else's
  * deposit. Erring toward the former is the whole point of the baseline.
+ *
+ * This is about a baseline that is merely *stale*. One that cannot be read at all
+ * never reaches here: the caller declines to settle rather than passing a figure it
+ * does not trust, since a substituted zero would make the delta the whole balance.
  */
 const attributable = ({ current, baseline }: { current: bigint; baseline: bigint }): bigint =>
 	current > baseline ? current - baseline : ZERO;
@@ -479,7 +493,7 @@ export const settleOisyTradeSwap = async ({
 	// withdrawable until the order fills or is canceled" — so there is nothing to
 	// withdraw here, and asking would only fail.
 	if (nonNullish(order) && !isTerminalOrderStatus(order.status)) {
-		return { status: 'pending', withdrawals: [] };
+		return { status: 'pending', withdrawals: [], residueStranded: false };
 	}
 
 	const current = await readOisyTradeFreeBalances({ identity, sourceToken, destinationToken });
@@ -508,7 +522,7 @@ export const settleOisyTradeSwap = async ({
 				: 'unresolved';
 
 	if (status === 'unresolved') {
-		return { status, withdrawals: [] };
+		return { status, withdrawals: [], residueStranded: false };
 	}
 
 	// The leg the funds came back in, and the leg that may hold a residue. A Buy that
@@ -534,15 +548,18 @@ export const settleOisyTradeSwap = async ({
 	// propagates too, because the caller's retry loop re-enters this function, where the
 	// withdrawn primary's delta reads zero (dust-skipped) and only the residue is left —
 	// the baseline arithmetic is what makes the retry idempotent. A *definitive* failure
-	// is swallowed and logged instead: the smaller amount must not fail an operation
-	// whose funds have already arrived, and the outcome it reports — a fill or a kill —
-	// is true regardless. Surfacing that stranded residue to the user is deferred to
-	// step 2, where the AUT row is the right home for it.
+	// is not allowed to fail the whole operation either — the smaller amount must not
+	// discard a primary withdrawal that has already arrived, and the outcome it reports
+	// is true regardless — but it *is* reported, through `residueStranded`. Swallowing
+	// it outright, as an earlier cut did, let a caller succeed an operation with the
+	// user's funds still at the venue.
 	const primaryBlockIndex = await withdrawFreeBalance({
 		identity,
 		token: primary[0],
 		amount: primary[1]
 	});
+
+	let residueStranded = false;
 
 	const residueBlockIndex = await withdrawFreeBalance({
 		identity,
@@ -554,13 +571,15 @@ export const settleOisyTradeSwap = async ({
 		}
 
 		consoleError(err);
+		residueStranded = true;
 
 		return undefined;
 	});
 
 	return {
 		status,
-		withdrawals: [primaryBlockIndex, residueBlockIndex].filter(nonNullish)
+		withdrawals: [primaryBlockIndex, residueBlockIndex].filter(nonNullish),
+		residueStranded
 	};
 };
 

--- a/src/frontend/src/lib/services/swap-errors.services.ts
+++ b/src/frontend/src/lib/services/swap-errors.services.ts
@@ -33,17 +33,19 @@ export class SwapError extends Error {
 }
 
 /**
- * How an OISY Trade swap ended when the destination token did not arrive.
+ * How an OISY Trade swap ended before it could hand settlement to its Active User
+ * Transaction row. Everything after that hand-off — a fill, a kill, a stalled
+ * withdrawal — is reported by the row, not by an exception.
  *
- * `killed` is a fill-or-kill order the book could not fill — an expected market
- * outcome, and the source funds have already been withdrawn back to the wallet
- * when this is thrown. `not_placed` is an order the canister refused to accept —
- * likewise thrown only once the deposit has been recovered to the wallet.
- * `unresolved` means the settlement found neither the order nor any balance in
- * DEX custody, so there is nothing left to recover and nothing that says how the
- * order ended. `recovery_failed` is the one kind raised while funds are still in
- * DEX custody: the order was refused and withdrawing the deposit back failed, so
- * the message points the user at the Trading tab, where the balance is visible.
+ * `not_trackable` is the row itself failing to open. Unlike every other provider,
+ * whose tracking is best-effort, that aborts the swap before anything moves: the
+ * row is the recovery record, and a swap without one is precisely the
+ * stranded-funds case it exists to prevent. `not_placed` is an order the canister
+ * refused to accept, thrown only once the deposit has been recovered to the wallet.
+ * `recovery_failed` is the one kind raised while funds are still in DEX custody:
+ * the order was refused and withdrawing the deposit back failed, so the message
+ * points the user at the Trading tab, where the balance is visible — and the row is
+ * deliberately left non-terminal so the poller keeps trying.
  *
  * A dedicated class, and defined here rather than next to its thrower, so
  * `SwapIcpWizard` can recognize all of them by `instanceof` and present them in
@@ -54,7 +56,7 @@ export class SwapError extends Error {
 export class OisyTradeSwapError extends Error {
 	constructor(
 		message: string,
-		public readonly kind: 'killed' | 'not_placed' | 'unresolved' | 'recovery_failed'
+		public readonly kind: 'not_trackable' | 'not_placed' | 'recovery_failed'
 	) {
 		super(message);
 		this.name = 'OisyTradeSwapError';

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -979,6 +979,7 @@ interface I18nSwap {
 		swap_replaced_or_dropped: string;
 		near_intents_quote_unverified: string;
 		near_intents_quote_expired: string;
+		oisy_trade_not_trackable: string;
 		oisy_trade_order_killed: string;
 		oisy_trade_settlement_unresolved: string;
 		oisy_trade_order_not_placed: string;

--- a/src/frontend/src/lib/types/oisy-trade-swap.ts
+++ b/src/frontend/src/lib/types/oisy-trade-swap.ts
@@ -24,6 +24,11 @@ export const OISY_TRADE_EXTERNAL_REF_KEYS = {
 	// Trading tab, and those balances are neither this swap's to withdraw nor
 	// evidence of how its order resolved. Written at creation, which is already
 	// before the first canister call, so they cost no extra ordering.
+	//
+	// Both are written in that one call, so a row never holds only one of them. A row
+	// whose baselines cannot be read is therefore malformed, not early, and the poller
+	// declines to settle it rather than substituting zero — which would credit this
+	// order with the caller's entire free balance and re-create both harms above.
 	BASELINE_SOURCE_FREE: 'baseline_source_free',
 	BASELINE_DEST_FREE: 'baseline_dest_free',
 	// Display + analytics metadata snapshotted at creation. These reuse OneSec's

--- a/src/frontend/src/lib/types/oisy-trade-swap.ts
+++ b/src/frontend/src/lib/types/oisy-trade-swap.ts
@@ -18,6 +18,14 @@ export const OISY_TRADE_EXTERNAL_REF_KEYS = {
 	ORDER_QUANTITY: 'order_quantity',
 	// The destination (or recovered source) withdrawal that closes the row.
 	WITHDRAW_BLOCK_INDEX: 'withdraw_block_index',
+	// Both legs' free DEX balance as it stood *before* the deposit, in base units.
+	// Settlement acts on the difference from these, never on the account-wide
+	// total: a user can arrive at a swap with either leg already funded from the
+	// Trading tab, and those balances are neither this swap's to withdraw nor
+	// evidence of how its order resolved. Written at creation, which is already
+	// before the first canister call, so they cost no extra ordering.
+	BASELINE_SOURCE_FREE: 'baseline_source_free',
+	BASELINE_DEST_FREE: 'baseline_dest_free',
 	// Display + analytics metadata snapshotted at creation. These reuse OneSec's
 	// exact key strings — `ActiveUserTransactionItem` reads *every* row's refs
 	// through `toOneSecExternalRefsMap`, so a fifth swap provider renders for free

--- a/src/frontend/src/lib/utils/oisy-trade-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade-active-tx.utils.ts
@@ -115,20 +115,44 @@ export const toOisyTradeDisplayRefs = ({
 /**
  * A base-unit amount snapshotted as a ref, read back.
  *
- * A missing or unparsable ref reads as zero, which is the conservative direction:
- * a zero baseline attributes the whole current free balance to this order, and the
- * settlement it feeds withdraws it. That is only reachable if a ref was dropped,
- * and leaving the funds in custody would be the worse failure.
+ * Returns `undefined` for a ref that is missing, unparsable or negative, and the
+ * caller must decline to act rather than substitute a value. Zero is the one guess
+ * that must not be made here: it is not a neutral default but the most destructive
+ * reading available, because `attributable` then credits this order with the whole
+ * of the caller's current free balance. Settlement would withdraw a balance the user
+ * deliberately parked from the Trading tab, charging them a ledger fee to do it, and
+ * on the path where the order is no longer known it would let a pre-existing
+ * destination balance make a killed order read as filled — succeeding a row, and
+ * firing a success event, for a swap that never happened. Those are precisely the
+ * two harms the baseline exists to prevent.
+ *
+ * Leaving the funds in custody instead is recoverable: the row stays visible and
+ * keeps polling, and the Trading tab shows the balance. Moving someone's money on a
+ * guess is not. Same rule, and the same reasoning, as the unknown ledger fee in
+ * `withdrawFreeBalance` — not knowing a figure says nothing about what it would have
+ * been, so it is never treated as an answer.
+ *
+ * Unreachable in practice: creation writes both baselines in the same call that
+ * creates the row, so a row is never merely early in acquiring them, and no shipped
+ * version of the flow wrote rows without them. A row missing one is malformed.
  */
-export const toOisyTradeRefAmount = (value: string | undefined): bigint => {
-	if (isNullish(value)) {
-		return ZERO;
+export const toOisyTradeRefAmount = (value: string | undefined): bigint | undefined => {
+	// An empty string is the one input that would slip past the parse as a *real* zero:
+	// `BigInt('')` is `0n`, not an error. `toOisyTradeExternalRefs` drops empty values,
+	// so a written ref never comes back this way, but the reader must not depend on the
+	// writer to keep the destructive reading unreachable.
+	if (isNullish(value) || value.trim() === '') {
+		return undefined;
 	}
 
 	try {
-		return BigInt(value);
+		const amount = BigInt(value);
+
+		// A free balance cannot be negative, and a negative baseline would inflate the
+		// delta rather than merely mis-state it.
+		return amount < ZERO ? undefined : amount;
 	} catch (_: unknown) {
-		return ZERO;
+		return undefined;
 	}
 };
 

--- a/src/frontend/src/lib/utils/oisy-trade-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade-active-tx.utils.ts
@@ -1,0 +1,193 @@
+import type {
+	ActiveUserTransaction,
+	ActiveUserTransactionData,
+	ActiveUserTransactionRef,
+	OisyTradeSide,
+	TokenId
+} from '$declarations/backend/backend.did';
+import type { IcToken } from '$icp/types/ic-token';
+import { isIcToken } from '$icp/validation/ic-token.validation';
+import { ZERO } from '$lib/constants/app.constants';
+import {
+	OISY_TRADE_EXTERNAL_REF_KEYS,
+	type OisyTradeExternalRefKey
+} from '$lib/types/oisy-trade-swap';
+import { SwapProvider } from '$lib/types/swap';
+import type { Token } from '$lib/types/token';
+import type { LimitOrderSide } from '$lib/utils/oisy-trade.utils';
+import { toBackendTokenId, tokenIdKey } from '$lib/utils/token-id.utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
+
+export const isOisyTradeActiveUserTransaction = (tx: ActiveUserTransaction): boolean =>
+	'OisyTrade' in tx.data;
+
+// The candid discriminant for the resolved order's side. `Sell` spends the base
+// token, `Buy` the quote one — which, with the row's two token ids, is what fixes
+// the base/quote orientation the ids alone cannot express.
+export const toOisyTradeCandidDataSide = (side: LimitOrderSide): OisyTradeSide =>
+	side === 'sell' ? { Sell: null } : { Buy: null };
+
+/**
+ * Builds the `OisyTrade` AUT data variant: the order's side plus the canonical
+ * immutable trio (source token, destination token, source amount in base units).
+ *
+ * Everything learned mid-flow — the order id, the deposit and withdrawal block
+ * indices, the submitted price and quantity, the pre-deposit balance baselines —
+ * rides in `external_refs`, which need no Candid change to extend.
+ *
+ * Returns `undefined` when either token has no backend `TokenId`. Unlike every
+ * other provider, whose callers read that as "do not track this operation", the
+ * OISY Trade flow treats it as a reason to abort: the row is the recovery record,
+ * and an untracked swap is exactly the stranded-funds case it exists to prevent.
+ */
+export const toOisyTradeData = ({
+	side,
+	sourceToken,
+	destinationToken,
+	amount
+}: {
+	side: LimitOrderSide;
+	sourceToken: Token;
+	destinationToken: Token;
+	amount: bigint;
+}): ActiveUserTransactionData | undefined => {
+	const source_token = toBackendTokenId(sourceToken);
+	const dest_token = toBackendTokenId(destinationToken);
+
+	if (nonNullish(source_token) && nonNullish(dest_token)) {
+		return {
+			OisyTrade: { side: toOisyTradeCandidDataSide(side), source_token, dest_token, amount }
+		};
+	}
+};
+
+/**
+ * Builds a deterministic `(key, value)` external-ref array, dropping empties.
+ * Mirrors `toChainFusionExternalRefs`.
+ */
+export const toOisyTradeExternalRefs = (
+	refs: Partial<Record<OisyTradeExternalRefKey, string>>
+): ActiveUserTransactionRef[] =>
+	(Object.keys(refs) as OisyTradeExternalRefKey[])
+		.filter((key) => refs[key] !== undefined && refs[key] !== '')
+		.sort()
+		.map((key) => ({ key, value: refs[key] as string }));
+
+// Wire-format `(key, value)` array → keyed lookup.
+export const toOisyTradeExternalRefsMap = (
+	refs: ActiveUserTransactionRef[]
+): Partial<Record<OisyTradeExternalRefKey, string>> => {
+	const map: Partial<Record<OisyTradeExternalRefKey, string>> = {};
+
+	for (const { key, value } of refs) {
+		map[key as OisyTradeExternalRefKey] = value;
+	}
+
+	return map;
+};
+
+/**
+ * Snapshots the user-facing fields needed to render an AUT row and to fire its
+ * terminal-state analytics. Uses OneSec's key names, which is what lets
+ * `ActiveUserTransactionItem` render an OISY Trade row without a new layout.
+ */
+export const toOisyTradeDisplayRefs = ({
+	sourceToken,
+	destinationToken,
+	amount,
+	usdSourceValue
+}: {
+	sourceToken: Token;
+	destinationToken: Token;
+	amount: string;
+	usdSourceValue?: string;
+}): Partial<Record<OisyTradeExternalRefKey, string>> => ({
+	[OISY_TRADE_EXTERNAL_REF_KEYS.AMOUNT]: amount,
+	...(nonNullish(usdSourceValue)
+		? { [OISY_TRADE_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE]: usdSourceValue }
+		: {}),
+	[OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL]: sourceToken.symbol,
+	[OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL]: sourceToken.network.name,
+	[OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]: destinationToken.symbol,
+	[OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL]: destinationToken.network.name
+});
+
+/**
+ * A base-unit amount snapshotted as a ref, read back.
+ *
+ * A missing or unparsable ref reads as zero, which is the conservative direction:
+ * a zero baseline attributes the whole current free balance to this order, and the
+ * settlement it feeds withdraws it. That is only reachable if a ref was dropped,
+ * and leaving the funds in custody would be the worse failure.
+ */
+export const toOisyTradeRefAmount = (value: string | undefined): bigint => {
+	if (isNullish(value)) {
+		return ZERO;
+	}
+
+	try {
+		return BigInt(value);
+	} catch (_: unknown) {
+		return ZERO;
+	}
+};
+
+/**
+ * Resolves a row's backend `TokenId` back to the wallet's own token.
+ *
+ * Settlement needs the whole `IcToken` — the ledger fee decides what counts as
+ * unwithdrawable dust, and the decimals format the analytics — not just the ledger
+ * id the `TokenId` carries. Matching goes through `toBackendTokenId` so the two
+ * directions cannot drift; ICP resolves like any other ICRC ledger, because that
+ * is how it was written.
+ *
+ * Takes the candidate tokens as an argument rather than reading a store, for the
+ * same reason the swap utils take the pair table: a store-reading util would see an
+ * empty list in every vitest run.
+ */
+export const findOisyTradeRowToken = ({
+	tokenId,
+	tokens
+}: {
+	tokenId: TokenId;
+	tokens: Token[];
+}): IcToken | undefined => {
+	const key = tokenIdKey(tokenId);
+
+	if (isNullish(key)) {
+		return undefined;
+	}
+
+	return tokens.find((token): token is IcToken => {
+		if (!isIcToken(token)) {
+			return false;
+		}
+
+		const backendId = toBackendTokenId(token);
+
+		return nonNullish(backendId) && tokenIdKey(backendId) === key;
+	});
+};
+
+/**
+ * Builds the analytics metadata for an OISY Trade row that has just reached a
+ * terminal status. Same shape as every other swap provider's, resolved entirely
+ * off the row's `external_refs` snapshot so it survives refresh / resume.
+ */
+export const buildOisyTradeSwapTrackingMetadata = ({
+	tx
+}: {
+	tx: ActiveUserTransaction;
+}): Record<string, string> => {
+	const refs = toOisyTradeExternalRefsMap(tx.external_refs);
+
+	return {
+		sourceToken: refs[OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL] ?? '',
+		destinationToken: refs[OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL] ?? '',
+		dApp: SwapProvider.OISY_TRADE,
+		tokenAmount: refs[OISY_TRADE_EXTERNAL_REF_KEYS.AMOUNT] ?? '',
+		sourceNetwork: refs[OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL] ?? '',
+		destinationNetwork: refs[OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL] ?? '',
+		...(nonNullish(tx.error[0]) ? { error: tx.error[0] } : {})
+	};
+};

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpWizard.spec.ts
@@ -4,6 +4,7 @@ import SwapIcpWizard from '$icp/components/swap/SwapIcpWizard.svelte';
 import { IC_TOKEN_FEE_CONTEXT_KEY } from '$icp/stores/ic-token-fee.store';
 import type { IcToken } from '$icp/types/ic-token';
 import {
+	TRACK_COUNT_SWAP_ERROR,
 	TRACK_COUNT_SWAP_SUBMITTED,
 	TRACK_COUNT_SWAP_SUCCESS
 } from '$lib/constants/analytics.constants';
@@ -403,11 +404,11 @@ describe('SwapIcpWizard', () => {
 			};
 
 			beforeEach(() => {
-				mockOisyTradeFn.mockResolvedValue({ status: 'filled', withdrawals: [42n] });
+				mockOisyTradeFn.mockResolvedValue(undefined);
 				setOisyTradeContext();
 			});
 
-			it('dispatches the reviewed order and closes on success', async () => {
+			it('dispatches the reviewed order and closes on submission', async () => {
 				await submit();
 
 				expect(mockOisyTradeFn).toHaveBeenCalledExactlyOnceWith(
@@ -415,48 +416,51 @@ describe('SwapIcpWizard', () => {
 						sourceToken: mockToken,
 						destinationToken: mockDestToken,
 						// The order the quote resolved and the user reviewed — never re-derived.
-						order: mockOisyTradeProvider.swapDetails.order
+						order: mockOisyTradeProvider.swapDetails.order,
+						// The row's id, so the poller can be handed an operation to finish.
+						swapId: expect.any(String)
 					})
 				);
 				expect(BASE_PROPS.onClose).toHaveBeenCalledOnce();
 				expect(BASE_PROPS.onBack).not.toHaveBeenCalled();
 			});
 
-			// A killed fill-or-kill order is an expected market outcome whose funds are
-			// already back in the wallet, so it lands in Review as info — like
-			// slippage-exceeded — and never in the unexpected-error toast, where the
-			// reassuring copy would read as a failure detail.
-			it('presents a killed order in Review rather than as an unexpected error', async () => {
+			// The modal now closes once the order is placed: the withdrawal that brings
+			// either leg back out of DEX custody is the Active User Transaction poller's, and
+			// it is what reports success or failure.
+			it('reports the swap as submitted rather than succeeded', async () => {
+				const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+
+				await submit();
+
+				expect(trackEventSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						name: TRACK_COUNT_SWAP_SUBMITTED,
+						metadata: expect.objectContaining({ dApp: SwapProvider.OISY_TRADE })
+					})
+				);
+				expect(trackEventSpy).not.toHaveBeenCalledWith(
+					expect.objectContaining({ name: TRACK_COUNT_SWAP_SUCCESS })
+				);
+			});
+
+			// The row is the recovery record, so a swap that cannot open one never starts —
+			// and because nothing moved, it reads as info in Review rather than as an
+			// unexpected-error toast.
+			it('presents an untrackable swap in Review rather than as an unexpected error', async () => {
 				mockOisyTradeFn.mockRejectedValue(
-					new OisyTradeSwapError(en.swap.error.oisy_trade_order_killed, 'killed')
+					new OisyTradeSwapError(en.swap.error.oisy_trade_not_trackable, 'not_trackable')
 				);
 
 				await submit();
 
 				expect(readFailedSwapError()).toEqual({
-					message: en.swap.error.oisy_trade_order_killed,
+					message: en.swap.error.oisy_trade_not_trackable,
 					variant: 'info'
 				});
 				expect(toasts.toastsError).not.toHaveBeenCalled();
 				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
 				expect(BASE_PROPS.onClose).not.toHaveBeenCalled();
-			});
-
-			// An unresolved settlement asks the user to check the Trading tab, so it is a
-			// warning rather than info — but still a Review message, not a toast.
-			it('presents an unresolved settlement as a warning in Review', async () => {
-				mockOisyTradeFn.mockRejectedValue(
-					new OisyTradeSwapError(en.swap.error.oisy_trade_settlement_unresolved, 'unresolved')
-				);
-
-				await submit();
-
-				expect(readFailedSwapError()).toEqual({
-					message: en.swap.error.oisy_trade_settlement_unresolved,
-					variant: 'warning'
-				});
-				expect(toasts.toastsError).not.toHaveBeenCalled();
-				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
 			});
 
 			// An order the canister refused has had its deposit recovered by the time the
@@ -492,6 +496,41 @@ describe('SwapIcpWizard', () => {
 				});
 				expect(toasts.toastsError).not.toHaveBeenCalled();
 				expect(BASE_PROPS.onBack).toHaveBeenCalledOnce();
+			});
+
+			// Both kinds end with a `Failed` row — closed by the flow on `not_placed`, by the
+			// poller on `recovery_failed` — and the loader fires the swap's single error event
+			// off that row, as for every background-settling provider. Firing here too would
+			// count the same swap twice.
+			it.each(['not_placed', 'recovery_failed'] as const)(
+				'leaves the swap_error event to the row on %s',
+				async (kind) => {
+					const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+					mockOisyTradeFn.mockRejectedValue(new OisyTradeSwapError('refused', kind));
+
+					await submit();
+
+					expect(trackEventSpy).not.toHaveBeenCalledWith(
+						expect.objectContaining({ name: TRACK_COUNT_SWAP_ERROR })
+					);
+				}
+			);
+
+			// No row exists for an untrackable swap, so nothing else can report it.
+			it('still fires swap_error itself for an untrackable swap', async () => {
+				const trackEventSpy = vi.spyOn(analytics, 'trackEvent');
+				mockOisyTradeFn.mockRejectedValue(
+					new OisyTradeSwapError(en.swap.error.oisy_trade_not_trackable, 'not_trackable')
+				);
+
+				await submit();
+
+				expect(trackEventSpy).toHaveBeenCalledWith(
+					expect.objectContaining({
+						name: TRACK_COUNT_SWAP_ERROR,
+						metadata: expect.objectContaining({ errorKey: 'not_trackable' })
+					})
+				);
 			});
 		});
 

--- a/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
+++ b/src/frontend/src/tests/lib/components/active-user-transactions/ActiveUserTransactionItem.spec.ts
@@ -6,6 +6,7 @@ import {
 	mockChainFusionActiveUserTransaction,
 	mockLiquidiumActiveUserTransaction,
 	mockNearIntentsActiveUserTransaction,
+	mockOisyTradeActiveUserTransaction,
 	mockVeloraActiveUserTransaction
 } from '$tests/mocks/active-user-transactions.mock';
 import { fireEvent, render, screen } from '@testing-library/svelte';
@@ -58,6 +59,24 @@ describe('ActiveUserTransactionItem', () => {
 		expect(screen.getByText(`${en.swap.text.swap} 1 ckETH → ETH`)).toBeInTheDocument();
 		expect(container).toHaveTextContent('Internet Computer → Ethereum');
 		expect(container).toHaveTextContent('Chain Fusion');
+	});
+
+	// A fifth swap provider renders through the shared layout for free, because its
+	// display refs speak OneSec's exact key strings — and its provider entry is
+	// unconditional, so a row outliving a flag rollback keeps its name.
+	it('renders OISY Trade rows as a swap with the provider, collapsing the same-network line', () => {
+		const { container } = render(ActiveUserTransactionItem, {
+			props: {
+				tx: mockOisyTradeActiveUserTransaction,
+				isUnseen: false,
+				dismissing: false,
+				onDismiss: vi.fn()
+			}
+		});
+
+		expect(screen.getByText(`${en.swap.text.swap} 3 ICP → ckUSDC`)).toBeInTheDocument();
+		expect(container).toHaveTextContent('OISY Trade');
+		expect(container).not.toHaveTextContent('Internet Computer → Internet Computer');
 	});
 
 	it('renders Liquidium rows with the action, amount, asset and provider', () => {

--- a/src/frontend/src/tests/lib/components/loaders/LoaderActiveUserTransactions.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/LoaderActiveUserTransactions.spec.ts
@@ -15,6 +15,7 @@ import * as chainFusionPoller from '$lib/services/chain-fusion-swap-active-tx.se
 import * as liquidiumPoller from '$lib/services/liquidium-active-tx.services';
 import * as liquidiumServices from '$lib/services/liquidium.services';
 import * as nearIntentsPoller from '$lib/services/near-intents-active-tx.services';
+import * as oisyTradePoller from '$lib/services/oisy-trade-active-tx.services';
 import * as oneSecPoller from '$lib/services/onesec-swap.services';
 import * as veloraPoller from '$lib/services/velora-active-tx.services';
 import { activeUserTransactionsStore } from '$lib/stores/active-user-transactions.store';
@@ -25,6 +26,7 @@ import {
 	mockChainFusionActiveUserTransaction,
 	mockLiquidiumActiveUserTransaction,
 	mockNearIntentsActiveUserTransaction,
+	mockOisyTradeActiveUserTransaction,
 	mockVeloraActiveUserTransaction
 } from '$tests/mocks/active-user-transactions.mock';
 import { mockEthAddress } from '$tests/mocks/eth.mock';
@@ -95,6 +97,27 @@ const succeededChainFusion = (id: string) =>
 		id,
 		status: { Succeeded: null } as const
 	}) satisfies typeof mockChainFusionActiveUserTransaction;
+
+const pendingOisyTrade = (id: string) =>
+	({
+		...mockOisyTradeActiveUserTransaction,
+		id,
+		status: { Executing: null } as const
+	}) satisfies typeof mockOisyTradeActiveUserTransaction;
+
+const succeededOisyTrade = (id: string) =>
+	({
+		...mockOisyTradeActiveUserTransaction,
+		id,
+		status: { Succeeded: null } as const
+	}) satisfies typeof mockOisyTradeActiveUserTransaction;
+
+const failedOisyTrade = (id: string) =>
+	({
+		...mockOisyTradeActiveUserTransaction,
+		id,
+		status: { Failed: null } as const
+	}) satisfies typeof mockOisyTradeActiveUserTransaction;
 
 const pendingLiquidium = (id: string) =>
 	({
@@ -300,6 +323,32 @@ describe('LoaderActiveUserTransactions', () => {
 			});
 		});
 
+		it('polls OISY Trade rows on each tick when present', async () => {
+			const oneSecSpy = vi
+				.spyOn(oneSecPoller, 'pollOneSecActiveUserTransactions')
+				.mockResolvedValue();
+			const oisyTradeSpy = vi
+				.spyOn(oisyTradePoller, 'pollOisyTradeActiveUserTransactions')
+				.mockResolvedValue();
+			// `Executing`, not `Pending`: every OISY Trade row is `Executing` from the
+			// deposit onwards, so a partition matching on the `Pending` *status* rather than
+			// on non-terminal would never see a real settlement.
+			const tx = pendingOisyTrade('oisy-trade-a');
+
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: tx });
+
+			render(LoaderActiveUserTransactions);
+
+			await vi.advanceTimersByTimeAsync(ACTIVE_USER_TRANSACTIONS_POLL_INTERVAL_MILLIS);
+
+			expect(oneSecSpy).not.toHaveBeenCalled();
+			expect(oisyTradeSpy).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				transactions: [tx]
+			});
+		});
+
 		it('stops polling once all rows reach a terminal state', async () => {
 			const spy = vi.spyOn(oneSecPoller, 'pollOneSecActiveUserTransactions').mockResolvedValue();
 
@@ -433,6 +482,46 @@ describe('LoaderActiveUserTransactions', () => {
 				metadata: expect.objectContaining({ dApp: SwapProvider.CHAIN_FUSION })
 			});
 			expect(appliedFlags()).toEqual({ 'chain-fusion-a': true });
+		});
+
+		it('fires a swap_success event with the OISY Trade dApp when an order settles', async () => {
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: pendingOisyTrade('oisy-trade-a') });
+
+			render(LoaderActiveUserTransactions);
+			await tick();
+
+			expect(trackEventSpy).not.toHaveBeenCalled();
+
+			activeUserTransactionsStore.upsert({ transaction: succeededOisyTrade('oisy-trade-a') });
+			await tick();
+
+			expect(refreshSpy).toHaveBeenCalledOnce();
+			expect(trackEventSpy).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_SWAP_SUCCESS,
+				metadata: expect.objectContaining({ dApp: SwapProvider.OISY_TRADE })
+			});
+			expect(appliedFlags()).toEqual({ 'oisy-trade-a': true });
+		});
+
+		// Unlike every other provider: a failed OISY Trade swap is a killed fill-or-kill
+		// order whose *source* token has just been withdrawn back to the wallet, so the
+		// balance changed and the refresh has to fire on failure too.
+		it('refreshes the wallet even when an OISY Trade row fails', async () => {
+			activeUserTransactionsStore.init(mockIdentity.getPrincipal());
+			activeUserTransactionsStore.upsert({ transaction: pendingOisyTrade('oisy-trade-a') });
+
+			render(LoaderActiveUserTransactions);
+			await tick();
+
+			activeUserTransactionsStore.upsert({ transaction: failedOisyTrade('oisy-trade-a') });
+			await tick();
+
+			expect(refreshSpy).toHaveBeenCalledOnce();
+			expect(trackEventSpy).toHaveBeenCalledExactlyOnceWith({
+				name: TRACK_COUNT_SWAP_ERROR,
+				metadata: expect.objectContaining({ dApp: SwapProvider.OISY_TRADE })
+			});
 		});
 
 		it('fires a swap_error event without a wallet refresh when a ck row fails', async () => {

--- a/src/frontend/src/tests/lib/components/swap/SwapProgress.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapProgress.spec.ts
@@ -126,6 +126,68 @@ describe('SwapProgress', () => {
 		});
 	});
 
+	describe('sendWithApprovalOnly', () => {
+		// The row's own state, not merely its presence: the bug this flag fixes was a
+		// step driven into a list that did not render it, which matches nothing and
+		// leaves every row unhighlighted until the next step that does exist.
+		const inProgressText = (container: HTMLElement): string | undefined =>
+			container.querySelector('.step.in_progress .text')?.textContent?.trim();
+
+		it('renders the approve step without either signing step', () => {
+			const { container } = render(SwapProgress, {
+				props: { sendWithApprovalOnly: true }
+			});
+
+			expect(container).toHaveTextContent(baseStepTexts.approving);
+			expect(container).not.toHaveTextContent(baseStepTexts.signingApproval);
+			expect(container).not.toHaveTextContent(baseStepTexts.signingTransaction);
+		});
+
+		it('still renders base steps', () => {
+			const { container } = render(SwapProgress, {
+				props: { sendWithApprovalOnly: true }
+			});
+
+			expect(container).toHaveTextContent(baseStepTexts.initializing);
+			expect(container).toHaveTextContent(baseStepTexts.swapping);
+			expect(container).toHaveTextContent(baseStepTexts.refreshingUi);
+		});
+
+		it('highlights the approve step it renders', () => {
+			const { container } = render(SwapProgress, {
+				props: { sendWithApprovalOnly: true, swapProgressStep: ProgressStepsSwap.APPROVE }
+			});
+
+			expect(inProgressText(container)).toBe(baseStepTexts.approving);
+		});
+
+		// The regression. Without the flag the approve step exists nowhere in the list,
+		// so the whole progress list renders unhighlighted — which is what a user saw as
+		// an empty list for as long as the approve leg took.
+		it('leaves every row unhighlighted on the approve step without the flag', () => {
+			const { container } = render(SwapProgress, {
+				props: { swapProgressStep: ProgressStepsSwap.APPROVE }
+			});
+
+			expect(container.querySelector('.step.in_progress')).toBeNull();
+		});
+
+		// Two rows sharing one step id would break the in-progress lookup, which matches
+		// by id. The props serve different wizards, so this is an invariant.
+		it('adds no second approve row when sendWithApproval already contributes one', () => {
+			const { container } = render(SwapProgress, {
+				props: { sendWithApproval: true, sendWithApprovalOnly: true }
+			});
+
+			expect(
+				[...container.querySelectorAll('.step .text')].filter(
+					(el) => el.textContent?.trim() === baseStepTexts.approving
+				)
+			).toHaveLength(1);
+			expect(container).toHaveTextContent(baseStepTexts.signingApproval);
+		});
+	});
+
 	describe('swapWithActiveTransaction', () => {
 		it('replaces the swapping and refreshing copy with the background-settlement copy', () => {
 			const { container } = render(SwapProgress, {

--- a/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
@@ -166,6 +166,43 @@ describe('oisy-trade-active-tx.services', () => {
 			expect(consoleErrorSpy).toHaveBeenCalled();
 		});
 
+		// Every amount this poller withdraws is a delta from the baselines, so an
+		// unreadable one is left strictly alone for the same reason as an unresolvable
+		// token. Substituting zero is the destructive guess: it credits the order with the
+		// caller's entire free balance, so settlement would withdraw a balance the user
+		// parked from the Trading tab, and — on the path where status is inferred from the
+		// deltas — let a held destination balance make a killed order read as filled.
+		//
+		// Both baselines are written in the call that creates the row, so a row missing or
+		// mangling one is malformed rather than early.
+		it.each([
+			{ label: 'a missing baseline', [OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]: '' },
+			{
+				label: 'a malformed baseline',
+				[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE]: 'garbage'
+			},
+			{ label: 'a negative baseline', [OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]: '-1' }
+		])('leaves a row with $label alone, without withdrawing anything', async (override) => {
+			const consoleErrorSpy = vi
+				.spyOn(consoleUtils, 'consoleError')
+				.mockImplementation(() => undefined);
+
+			// The balance a naive zero baseline would have attributed to this order and paid
+			// out — the user's own, parked from the Trading tab.
+			getBalancesSpy.mockResolvedValue([
+				balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 500_000_000n }),
+				balance({ ledger: CKUSDC_LEDGER, free: 9_000_000n })
+			]);
+
+			await poll([row({ refs: { ...PLACED, ...override } })]);
+
+			expect(getMyOrdersSpy).not.toHaveBeenCalled();
+			expect(withdrawSpy).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+			expect(deleteSpy).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+
 		describe('a row with a placed order', () => {
 			it('withdraws the destination and succeeds on a filled order', async () => {
 				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
@@ -245,6 +282,59 @@ describe('oisy-trade-active-tx.services', () => {
 							status: { Failed: null },
 							error: en.swap.error.oisy_trade_settlement_unresolved
 						})
+					})
+				);
+			});
+
+			// The order resolved, but a non-dust leg of it is still at the venue because
+			// withdrawing it was refused definitively. Succeeding the row on the order's
+			// outcome alone would drop it from the pending set and tell the user the swap
+			// worked with their funds still in DEX custody. It stays non-terminal so the
+			// next tick retries, which is idempotent: settlement re-derives from the
+			// baseline, so the withdrawn primary reads as dust and only the residue is
+			// attempted.
+			it('leaves the row non-terminal while a leg is still stranded at the venue', async () => {
+				const consoleErrorSpy = vi
+					.spyOn(consoleUtils, 'consoleError')
+					.mockImplementation(() => undefined);
+
+				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
+				// A filled Buy that crossed below its limit: the destination is credited and
+				// the unspent source reserve is released alongside it.
+				getBalancesSpy.mockResolvedValue([
+					balance({ ledger: CKUSDC_LEDGER, free: 2_000_000n }),
+					balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 300_000_000n })
+				]);
+				const residueError = new OisyTradeRequestError({
+					message: 'ledger blew up',
+					reason: 'InternalError'
+				});
+				withdrawSpy.mockResolvedValueOnce({ block_index: 42n }).mockRejectedValueOnce(residueError);
+
+				await poll([row({ refs: PLACED })]);
+
+				// The primary landed, so the destination did reach the wallet.
+				expect(withdrawSpy).toHaveBeenCalledTimes(2);
+				expect(applySpy).not.toHaveBeenCalled();
+				expect(deleteSpy).not.toHaveBeenCalled();
+				expect(consoleErrorSpy).toHaveBeenCalledWith(residueError);
+			});
+
+			// Dust is not owed — `withdraw` refuses an amount at or below the ledger fee —
+			// so a settlement whose residue leg held only dust is complete and closes.
+			it('succeeds the row when the only leg left behind was dust', async () => {
+				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
+				getBalancesSpy.mockResolvedValue([
+					balance({ ledger: CKUSDC_LEDGER, free: 2_000_000n }),
+					balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 1_000n })
+				]);
+
+				await poll([row({ refs: PLACED })]);
+
+				expect(withdrawSpy).toHaveBeenCalledOnce();
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: expect.objectContaining({ status: { Succeeded: null } })
 					})
 				);
 			});

--- a/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
@@ -4,9 +4,12 @@ import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import * as oisyTradeApi from '$lib/api/oisy-trade.api';
 import { OisyTradeRequestError, OisyTradeTemporaryError } from '$lib/canisters/oisy-trade.errors';
 import { ZERO } from '$lib/constants/app.constants';
-import { OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS } from '$lib/constants/oisy-trade.constants';
+import { OISY_TRADE_SWAP_SETTLE_GRACE_OBSERVATIONS } from '$lib/constants/oisy-trade.constants';
 import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
-import { pollOisyTradeActiveUserTransactions } from '$lib/services/oisy-trade-active-tx.services';
+import {
+	pollOisyTradeActiveUserTransactions,
+	resetOisyTradeOrderlessObservations
+} from '$lib/services/oisy-trade-active-tx.services';
 import { OISY_TRADE_EXTERNAL_REF_KEYS } from '$lib/types/oisy-trade-swap';
 import * as consoleUtils from '$lib/utils/console.utils';
 import { toOisyTradeExternalRefs } from '$lib/utils/oisy-trade-active-tx.utils';
@@ -44,11 +47,6 @@ vi.mock(import('$lib/derived/all-tokens.derived'), async (importOriginal) => {
 
 const CKUSDC_LEDGER = ckUsdcFields.ledgerCanisterId;
 
-const nowNs = (): bigint => BigInt(Date.now()) * 1_000_000n;
-
-const beforeGraceNs = (): bigint =>
-	BigInt(Date.now() - OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS - 1_000) * 1_000_000n;
-
 const balance = ({ ledger, free }: { ledger: string; free: bigint }) =>
 	({
 		token: { id: { ledger_id: Principal.fromText(ledger) } },
@@ -61,7 +59,7 @@ const order = (status: object): UserOrder[] =>
 const row = ({
 	refs = {},
 	status = { Executing: null },
-	createdAtNs = beforeGraceNs()
+	createdAtNs = ZERO
 }: {
 	refs?: Partial<Record<string, string>>;
 	status?: ActiveUserTransaction['status'];
@@ -103,8 +101,17 @@ describe('oisy-trade-active-tx.services', () => {
 		const poll = (transactions: ActiveUserTransaction[]) =>
 			pollOisyTradeActiveUserTransactions({ identity: mockIdentity, transactions });
 
+		// An order-less row's wait is measured in the poller's own ticks rather than in
+		// elapsed wall time, so a test that wants the budget spent has to spend it.
+		const pollPastGrace = async (transactions: ActiveUserTransaction[]) => {
+			for (let i = 0; i < OISY_TRADE_SWAP_SETTLE_GRACE_OBSERVATIONS; i++) {
+				await poll(transactions);
+			}
+		};
+
 		beforeEach(() => {
 			vi.restoreAllMocks();
+			resetOisyTradeOrderlessObservations();
 
 			applySpy = vi
 				.spyOn(activeUserTransactionsServices, 'applyActiveUserTransactionPollUpdate')
@@ -275,15 +282,27 @@ describe('oisy-trade-active-tx.services', () => {
 		describe('a row with no order id', () => {
 			const DEPOSITED = { [OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]: '7' };
 
-			// The grace period is load-bearing rather than a nicety: every healthy swap
-			// passes through exactly this signature between the row's creation and
-			// `add_limit_order` returning, and a tick landing inside it would withdraw the
-			// deposit out from under an order placement still in flight.
-			it('leaves a row younger than the grace period to the foreground', async () => {
-				await poll([
-					row({ refs: DEPOSITED, createdAtNs: nowNs() }),
-					row({ status: { Pending: null }, createdAtNs: nowNs() })
-				]);
+			// The budget is load-bearing rather than a nicety: every healthy swap passes
+			// through exactly this signature between the row's creation and
+			// `add_limit_order` returning, and a tick landing inside it would act while the
+			// foreground still owns the flow.
+			//
+			// Measured in ticks, never in elapsed wall time. The row's timestamps come from
+			// the backend canister's clock and `Date.now()` from the browser's, so
+			// subtracting one from the other would make this window depend on the difference
+			// between them — a device five minutes fast would have no window at all. Hence
+			// the deliberately absurd `created_at_ns` of zero throughout this file: an epoch
+			// timestamp would read as ancient on any wall-clock comparison, so these tests
+			// fail loudly if one is ever reintroduced.
+			it('leaves a row inside the tick budget to the foreground', async () => {
+				const transactions = [
+					row({ refs: DEPOSITED }),
+					{ ...row({ status: { Pending: null } }), id: 'row-2' }
+				];
+
+				for (let i = 0; i < OISY_TRADE_SWAP_SETTLE_GRACE_OBSERVATIONS - 1; i++) {
+					await poll(transactions);
+				}
 
 				expect(getBalancesSpy).not.toHaveBeenCalled();
 				expect(withdrawSpy).not.toHaveBeenCalled();
@@ -294,7 +313,7 @@ describe('oisy-trade-active-tx.services', () => {
 			// Nothing happened, so there is nothing to report — and a `Failed` row would
 			// invite the user to worry about funds that never left their wallet.
 			it('deletes an abandoned row that never reached the canister', async () => {
-				await poll([row({ status: { Pending: null } })]);
+				await pollPastGrace([row({ status: { Pending: null } })]);
 
 				expect(deleteSpy).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ id: 'row-1' }));
 				expect(applySpy).not.toHaveBeenCalled();
@@ -307,7 +326,7 @@ describe('oisy-trade-active-tx.services', () => {
 					balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 300_000_000n })
 				]);
 
-				await poll([row({ refs: DEPOSITED })]);
+				await pollPastGrace([row({ refs: DEPOSITED })]);
 
 				// Never polled: there is no order id to poll by.
 				expect(getMyOrdersSpy).not.toHaveBeenCalled();
@@ -327,16 +346,56 @@ describe('oisy-trade-active-tx.services', () => {
 			// A deposit whose order id was lost looks identical to one that is still live,
 			// because a live order's reserve holds no free balance. Deleting or failing it
 			// would be the one unrecoverable mistake here, so it keeps polling.
+			// Past the budget, nothing attributable on either leg means the funds are already
+			// out of DEX custody: an earlier attempt's withdrawal landed and its reply or its
+			// terminal write was lost, or the user swept the balance from the Trading tab.
+			//
+			// The reading this no longer fears is a live order hiding the funds behind its
+			// reserve. The order is fill-or-kill, decided in the matching round after it is
+			// accepted, so by the time the budget is spent it has filled — a destination
+			// delta — or been killed — a source one. Zero on both cannot be an order in
+			// flight. Leaving the row alone here is what used to strand it non-terminal
+			// forever: undismissable, still polling, and never firing its analytics.
 			it.each([{ Executing: null }, { Pending: null }])(
-				'keeps polling a %s deposit whose order may still be live',
+				'closes a %s deposit that left nothing behind',
 				async (status) => {
-					await poll([row({ refs: DEPOSITED, status })]);
+					await pollPastGrace([row({ refs: DEPOSITED, status })]);
 
 					expect(withdrawSpy).not.toHaveBeenCalled();
-					expect(applySpy).not.toHaveBeenCalled();
 					expect(deleteSpy).not.toHaveBeenCalled();
+					// Copy that names no outcome: a fill whose withdrawal reply was lost looks
+					// identical from here, so it can claim neither success nor a failed placement.
+					expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+						expect.objectContaining({
+							update: expect.objectContaining({
+								status: { Failed: null },
+								error: en.swap.error.oisy_trade_settlement_unresolved
+							})
+						})
+					);
 				}
 			);
+
+			// The race the tick budget exists to avoid, taken at the one ordering the budget
+			// cannot rule out: the recovery withdrawal is refused because `add_limit_order`
+			// reserved the deposit between the balance read and the withdraw.
+			// `InsufficientBalance` is not retryable, so terminalizing here would mark the
+			// row failed while the order goes on to fill into DEX custody with nothing
+			// polling for it. The row has to survive so the next tick can re-derive.
+			it('leaves the row alone when the recovery withdrawal was outrun by the order', async () => {
+				getBalancesSpy.mockResolvedValue([
+					balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 300_000_000n })
+				]);
+				withdrawSpy.mockRejectedValue(
+					new OisyTradeRequestError({ message: 'nope', reason: 'InsufficientBalance' })
+				);
+
+				await pollPastGrace([row({ refs: DEPOSITED })]);
+
+				expect(withdrawSpy).toHaveBeenCalled();
+				expect(applySpy).not.toHaveBeenCalled();
+				expect(deleteSpy).not.toHaveBeenCalled();
+			});
 		});
 
 		// Sequential rather than concurrent — the canister rejects a second withdrawal

--- a/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
@@ -1,0 +1,362 @@
+import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import type { UserOrder, UserTokenBalance } from '$declarations/oisy_trade/oisy_trade.did';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import * as oisyTradeApi from '$lib/api/oisy-trade.api';
+import { OisyTradeRequestError, OisyTradeTemporaryError } from '$lib/canisters/oisy-trade.errors';
+import { ZERO } from '$lib/constants/app.constants';
+import { OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS } from '$lib/constants/oisy-trade.constants';
+import * as activeUserTransactionsServices from '$lib/services/active-user-transactions.services';
+import { pollOisyTradeActiveUserTransactions } from '$lib/services/oisy-trade-active-tx.services';
+import { OISY_TRADE_EXTERNAL_REF_KEYS } from '$lib/types/oisy-trade-swap';
+import * as consoleUtils from '$lib/utils/console.utils';
+import { toOisyTradeExternalRefs } from '$lib/utils/oisy-trade-active-tx.utils';
+import {
+	mockActiveUserTransaction,
+	mockNearIntentsActiveUserTransaction
+} from '$tests/mocks/active-user-transactions.mock';
+import en from '$tests/mocks/i18n.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { Principal } from '@icp-sdk/core/principal';
+
+// 6 dp, 10_000 (0.01 ckUSDC) ledger fee — the figure that decides what counts as
+// permanently unwithdrawable dust.
+const ckUsdcFields = vi.hoisted(() => ({
+	ledgerCanisterId: 'xevnm-gaaaa-aaaar-qafnq-cai',
+	symbol: 'ckUSDC',
+	decimals: 6,
+	fee: 10_000n
+}));
+
+// The poller resolves a row's `TokenId` legs back to the wallet's own tokens, because
+// settlement needs each one's ledger fee and decimals rather than just its ledger id.
+vi.mock(import('$lib/derived/all-tokens.derived'), async (importOriginal) => {
+	const actual = await importOriginal();
+	const { readable } = await import('svelte/store');
+	const { mockValidIcToken } = await import('$tests/mocks/ic-tokens.mock');
+
+	return {
+		...actual,
+		allSortedIcrcTokens: readable([
+			{ ...mockValidIcToken, ...ckUsdcFields, enabled: true }
+		]) as unknown as typeof actual.allSortedIcrcTokens
+	};
+});
+
+const CKUSDC_LEDGER = ckUsdcFields.ledgerCanisterId;
+
+const nowNs = (): bigint => BigInt(Date.now()) * 1_000_000n;
+
+const beforeGraceNs = (): bigint =>
+	BigInt(Date.now() - OISY_TRADE_SWAP_SETTLE_GRACE_PERIOD_MILLIS - 1_000) * 1_000_000n;
+
+const balance = ({ ledger, free }: { ledger: string; free: bigint }) =>
+	({
+		token: { id: { ledger_id: Principal.fromText(ledger) } },
+		balance: { free, reserved: ZERO }
+	}) as unknown as UserTokenBalance;
+
+const order = (status: object): UserOrder[] =>
+	[{ id: 'order-1', order: { status }, pair: {} }] as unknown as UserOrder[];
+
+const row = ({
+	refs = {},
+	status = { Executing: null },
+	createdAtNs = beforeGraceNs()
+}: {
+	refs?: Partial<Record<string, string>>;
+	status?: ActiveUserTransaction['status'];
+	createdAtNs?: bigint;
+} = {}): ActiveUserTransaction => ({
+	...mockActiveUserTransaction,
+	id: 'row-1',
+	status,
+	data: {
+		OisyTrade: {
+			side: { Sell: null },
+			source_token: { Icrc: Principal.fromText(ICP_TOKEN.ledgerCanisterId) },
+			dest_token: { Icrc: Principal.fromText(CKUSDC_LEDGER) },
+			amount: 300_000_000n
+		}
+	},
+	external_refs: toOisyTradeExternalRefs({
+		[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]: '0',
+		[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE]: '0',
+		...refs
+	}),
+	created_at_ns: createdAtNs,
+	updated_at_ns: createdAtNs
+});
+
+const PLACED = {
+	[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]: '7',
+	[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]: 'order-1'
+};
+
+describe('oisy-trade-active-tx.services', () => {
+	describe('pollOisyTradeActiveUserTransactions', () => {
+		let applySpy: ReturnType<typeof vi.spyOn>;
+		let deleteSpy: ReturnType<typeof vi.spyOn>;
+		let withdrawSpy: ReturnType<typeof vi.spyOn>;
+		let getBalancesSpy: ReturnType<typeof vi.spyOn>;
+		let getMyOrdersSpy: ReturnType<typeof vi.spyOn>;
+
+		const poll = (transactions: ActiveUserTransaction[]) =>
+			pollOisyTradeActiveUserTransactions({ identity: mockIdentity, transactions });
+
+		beforeEach(() => {
+			vi.restoreAllMocks();
+
+			applySpy = vi
+				.spyOn(activeUserTransactionsServices, 'applyActiveUserTransactionPollUpdate')
+				.mockResolvedValue();
+			deleteSpy = vi
+				.spyOn(activeUserTransactionsServices, 'deleteActiveUserTransaction')
+				.mockResolvedValue();
+
+			getMyOrdersSpy = vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([]);
+			getBalancesSpy = vi.spyOn(oisyTradeApi, 'getBalances').mockResolvedValue([]);
+			withdrawSpy = vi.spyOn(oisyTradeApi, 'withdraw').mockResolvedValue({ block_index: 42n });
+		});
+
+		it('no-ops on an empty list', async () => {
+			await poll([]);
+
+			expect(getMyOrdersSpy).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		it('ignores another provider’s row', async () => {
+			await poll([mockNearIntentsActiveUserTransaction]);
+
+			expect(getMyOrdersSpy).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+		});
+
+		// Settlement needs the ledger fee to tell a withdrawable balance from permanently
+		// unwithdrawable dust, so a row it cannot resolve is left strictly alone rather
+		// than guessed at.
+		it('leaves a row whose tokens it cannot resolve alone', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(consoleUtils, 'consoleError')
+				.mockImplementation(() => undefined);
+
+			await poll([
+				{
+					...row({ refs: PLACED }),
+					data: {
+						OisyTrade: {
+							side: { Sell: null },
+							source_token: { Icrc: Principal.fromText('mxzaz-hqaaa-aaaar-qaada-cai') },
+							dest_token: { Icrc: Principal.fromText(CKUSDC_LEDGER) },
+							amount: 1n
+						}
+					}
+				}
+			]);
+
+			expect(getMyOrdersSpy).not.toHaveBeenCalled();
+			expect(applySpy).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+
+		describe('a row with a placed order', () => {
+			it('withdraws the destination and succeeds on a filled order', async () => {
+				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
+				getBalancesSpy.mockResolvedValue([balance({ ledger: CKUSDC_LEDGER, free: 2_000_000n })]);
+
+				await poll([row({ refs: PLACED })]);
+
+				expect(withdrawSpy).toHaveBeenCalledOnce();
+				expect(withdrawSpy.mock.calls[0][0].request.token_id.ledger_id.toText()).toBe(
+					CKUSDC_LEDGER
+				);
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: expect.objectContaining({ status: { Succeeded: null } })
+					})
+				);
+				// Every block index this settlement paid out — a Buy that crossed below its
+				// limit has its released reserve withdrawn alongside the fill.
+				expect(applySpy.mock.calls[0][0].update.externalRefs).toEqual(
+					expect.arrayContaining([
+						{ key: OISY_TRADE_EXTERNAL_REF_KEYS.WITHDRAW_BLOCK_INDEX, value: '42' }
+					])
+				);
+			});
+
+			// A killed order is a failed swap whose funds are recovered: the source token
+			// comes back and the user is out only the ledger fees.
+			it.each([{ Expired: null }, { Canceled: null }])(
+				'withdraws the source and fails the row on %s',
+				async (status) => {
+					getMyOrdersSpy.mockResolvedValue(order(status));
+					getBalancesSpy.mockResolvedValue([
+						balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 300_000_000n })
+					]);
+
+					await poll([row({ refs: PLACED })]);
+
+					expect(withdrawSpy.mock.calls[0][0].request.token_id.ledger_id.toText()).toBe(
+						ICP_TOKEN.ledgerCanisterId
+					);
+					expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+						expect.objectContaining({
+							update: expect.objectContaining({
+								status: { Failed: null },
+								error: en.swap.error.oisy_trade_order_killed
+							})
+						})
+					);
+				}
+			);
+
+			// A live order's reserve is locked — "funds reserved by open orders are not
+			// withdrawable until the order fills or is canceled" — so asking would only fail.
+			it.each([{ Pending: null }, { Open: null }])(
+				'attempts no withdrawal while the order is %s',
+				async (status) => {
+					getMyOrdersSpy.mockResolvedValue(order(status));
+
+					await poll([row({ refs: PLACED })]);
+
+					expect(withdrawSpy).not.toHaveBeenCalled();
+					expect(applySpy).not.toHaveBeenCalled();
+				}
+			);
+
+			// The canister no longer knows the order and neither leg holds anything
+			// attributable, so an earlier attempt already paid the withdrawal out and only
+			// the terminal write was lost. Nothing says which way it went, so the row closes
+			// as a failure pointing at the Trading tab rather than claiming a success.
+			it('closes a vanished order that left nothing behind', async () => {
+				await poll([row({ refs: PLACED })]);
+
+				expect(withdrawSpy).not.toHaveBeenCalled();
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: expect.objectContaining({
+							status: { Failed: null },
+							error: en.swap.error.oisy_trade_settlement_unresolved
+						})
+					})
+				);
+			});
+
+			// The single most damaging bug this integration can ship: terminalizing on a
+			// transient failure stops the poller with the funds still in DEX custody.
+			it('leaves the row untouched on a retryable failure', async () => {
+				getMyOrdersSpy.mockRejectedValue(
+					new OisyTradeTemporaryError({ message: 'busy', reason: 'OperationInProgress' })
+				);
+
+				await poll([row({ refs: PLACED })]);
+
+				expect(applySpy).not.toHaveBeenCalled();
+				expect(deleteSpy).not.toHaveBeenCalled();
+			});
+
+			// Only a definitive refusal ends the operation, and with the canister's own
+			// message rather than a hand-written one.
+			it('fails the row with the canister’s reason on a non-retryable failure', async () => {
+				getMyOrdersSpy.mockRejectedValue(
+					new OisyTradeRequestError({ message: 'nope', reason: 'InsufficientBalance' })
+				);
+
+				await poll([row({ refs: PLACED })]);
+
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: { status: { Failed: null }, error: 'nope' }
+					})
+				);
+			});
+		});
+
+		describe('a row with no order id', () => {
+			const DEPOSITED = { [OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]: '7' };
+
+			// The grace period is load-bearing rather than a nicety: every healthy swap
+			// passes through exactly this signature between the row's creation and
+			// `add_limit_order` returning, and a tick landing inside it would withdraw the
+			// deposit out from under an order placement still in flight.
+			it('leaves a row younger than the grace period to the foreground', async () => {
+				await poll([
+					row({ refs: DEPOSITED, createdAtNs: nowNs() }),
+					row({ status: { Pending: null }, createdAtNs: nowNs() })
+				]);
+
+				expect(getBalancesSpy).not.toHaveBeenCalled();
+				expect(withdrawSpy).not.toHaveBeenCalled();
+				expect(applySpy).not.toHaveBeenCalled();
+				expect(deleteSpy).not.toHaveBeenCalled();
+			});
+
+			// Nothing happened, so there is nothing to report — and a `Failed` row would
+			// invite the user to worry about funds that never left their wallet.
+			it('deletes an abandoned row that never reached the canister', async () => {
+				await poll([row({ status: { Pending: null } })]);
+
+				expect(deleteSpy).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ id: 'row-1' }));
+				expect(applySpy).not.toHaveBeenCalled();
+			});
+
+			// Resolves exactly like a kill — the source comes back — but names the reason
+			// the absence of an order id says it is.
+			it('recovers a deposit whose order was never placed', async () => {
+				getBalancesSpy.mockResolvedValue([
+					balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 300_000_000n })
+				]);
+
+				await poll([row({ refs: DEPOSITED })]);
+
+				// Never polled: there is no order id to poll by.
+				expect(getMyOrdersSpy).not.toHaveBeenCalled();
+				expect(withdrawSpy.mock.calls[0][0].request.token_id.ledger_id.toText()).toBe(
+					ICP_TOKEN.ledgerCanisterId
+				);
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: expect.objectContaining({
+							status: { Failed: null },
+							error: en.swap.error.oisy_trade_order_not_placed
+						})
+					})
+				);
+			});
+
+			// A deposit whose order id was lost looks identical to one that is still live,
+			// because a live order's reserve holds no free balance. Deleting or failing it
+			// would be the one unrecoverable mistake here, so it keeps polling.
+			it.each([{ Executing: null }, { Pending: null }])(
+				'keeps polling a %s deposit whose order may still be live',
+				async (status) => {
+					await poll([row({ refs: DEPOSITED, status })]);
+
+					expect(withdrawSpy).not.toHaveBeenCalled();
+					expect(applySpy).not.toHaveBeenCalled();
+					expect(deleteSpy).not.toHaveBeenCalled();
+				}
+			);
+		});
+
+		// Sequential rather than concurrent — the canister rejects a second withdrawal
+		// while one is in flight for the same caller — so one row throwing must not stop
+		// the rows behind it.
+		it('settles the rows behind one that failed unexpectedly', async () => {
+			vi.spyOn(consoleUtils, 'consoleError').mockImplementation(() => undefined);
+			getMyOrdersSpy
+				.mockRejectedValueOnce(new Error('backend down'))
+				.mockResolvedValue(order({ Filled: null }));
+			getBalancesSpy.mockResolvedValue([balance({ ledger: CKUSDC_LEDGER, free: 2_000_000n })]);
+
+			await poll([row({ refs: PLACED }), { ...row({ refs: PLACED }), id: 'row-2' }]);
+
+			expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					tx: expect.objectContaining({ id: 'row-2' }),
+					update: expect.objectContaining({ status: { Succeeded: null } })
+				})
+			);
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -491,7 +491,7 @@ describe('oisy-trade-swap.services', () => {
 
 				const settlement = await settleOisyTradeSwap(settleParams);
 
-				expect(settlement).toEqual({ status: 'pending', withdrawals: [] });
+				expect(settlement).toEqual({ status: 'pending', withdrawals: [], residueStranded: false });
 				expect(withdrawSpy).not.toHaveBeenCalled();
 				// Not even read: a pending order settles nothing, so the balances are moot.
 				expect(balances).not.toHaveBeenCalled();
@@ -580,8 +580,30 @@ describe('oisy-trade-swap.services', () => {
 
 			expect(settlement.status).toBe('filled');
 			expect(settlement.withdrawals).toEqual([42n]);
-			// Swallowed, but not silently: the residue is still owed to the user.
+			// Reported, not merely logged. The order's outcome is true, but it is not the
+			// whole story: a leg of it is still at the venue, and a caller that succeeded
+			// the operation on `status` alone would tell the user their swap worked with
+			// their funds still there.
+			expect(settlement.residueStranded).toBeTruthy();
 			expect(consoleErrorSpy).toHaveBeenCalledWith(residueError);
+		});
+
+		// Dust is not owed: `withdraw` refuses an amount at or below the ledger fee, so a
+		// small enough residue is unwithdrawable by construction. Conflating it with a
+		// refused withdrawal would leave every dusty settlement permanently unfinished.
+		it('does not report dust as a stranded residue', async () => {
+			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+			// A source residue at the ledger fee exactly, so it is skipped rather than moved.
+			mockBalances({ source: ICP.fee, destination: 2_000_000n });
+			const withdrawSpy = vi
+				.spyOn(oisyTradeApi, 'withdraw')
+				.mockResolvedValue({ block_index: 42n });
+
+			const settlement = await settleOisyTradeSwap(settleParams);
+
+			expect(settlement.status).toBe('filled');
+			expect(settlement.residueStranded).toBeFalsy();
+			expect(withdrawSpy).toHaveBeenCalledOnce();
 		});
 
 		// A transient residue failure propagates instead: the caller's retry loop
@@ -660,7 +682,11 @@ describe('oisy-trade-swap.services', () => {
 					baseline: { source: 50_000_000n, destination: 100_000_000n }
 				});
 
-				expect(settlement).toEqual({ status: 'unresolved', withdrawals: [] });
+				expect(settlement).toEqual({
+					status: 'unresolved',
+					withdrawals: [],
+					residueStranded: false
+				});
 				expect(withdrawSpy).not.toHaveBeenCalled();
 			});
 
@@ -679,7 +705,7 @@ describe('oisy-trade-swap.services', () => {
 					baseline: { source: ZERO, destination: 100_000_000n }
 				});
 
-				expect(settlement).toEqual({ status: 'filled', withdrawals: [] });
+				expect(settlement).toEqual({ status: 'filled', withdrawals: [], residueStranded: false });
 				expect(withdrawSpy).not.toHaveBeenCalled();
 			});
 		});
@@ -750,7 +776,7 @@ describe('oisy-trade-swap.services', () => {
 
 			const settlement = await settleOisyTradeSwap(settleParams);
 
-			expect(settlement).toEqual({ status: 'unresolved', withdrawals: [] });
+			expect(settlement).toEqual({ status: 'unresolved', withdrawals: [], residueStranded: false });
 			expect(withdrawSpy).not.toHaveBeenCalled();
 		});
 

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -13,6 +13,10 @@ import { ZERO } from '$lib/constants/app.constants';
 import { OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
 import { PLAUSIBLE_EVENT_RESULT_STATUSES } from '$lib/enums/plausible';
 import { ProgressStepsSwap } from '$lib/enums/progress-steps';
+import {
+	createActiveUserTransaction,
+	updateActiveUserTransaction
+} from '$lib/services/active-user-transactions.services';
 import * as oisyTradeSwapServices from '$lib/services/oisy-trade-swap.services';
 import {
 	fetchOisyTradeQuote,
@@ -25,13 +29,18 @@ import {
 import { fetchSwapAmounts } from '$lib/services/swap.services';
 import * as tradingAnalytics from '$lib/services/trading-analytics.services';
 import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
-import type { OisyTradeResolvedOrder } from '$lib/types/oisy-trade-swap';
+import {
+	OISY_TRADE_EXTERNAL_REF_KEYS,
+	type OisyTradeResolvedOrder
+} from '$lib/types/oisy-trade-swap';
 import { SwapProvider } from '$lib/types/swap';
 import * as consoleUtils from '$lib/utils/console.utils';
+import { toOisyTradeExternalRefsMap } from '$lib/utils/oisy-trade-active-tx.utils';
 import * as walletUtils from '$lib/utils/wallet.utils';
 import en from '$tests/mocks/i18n.mock';
 import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
+import { nonNullish } from '@dfinity/utils';
 import { Principal } from '@icp-sdk/core/principal';
 import { get } from 'svelte/store';
 import type { MockInstance } from 'vitest';
@@ -58,6 +67,14 @@ vi.mock('$lib/api/kong_backend.api', () => ({
 vi.mock('$lib/services/icp-swap.services', () => ({
 	icpSwapAmounts: () => Promise.reject(new Error('icpSwap unavailable in test')),
 	icpSwapSupportedTokens: () => Promise.resolve(new Set<string>())
+}));
+
+// The recovery record the swap opens before it touches the canister. Mocked rather
+// than driven through the backend so the assertions can be about *when* it is
+// written, which is the whole point of it existing.
+vi.mock('$lib/services/active-user-transactions.services', () => ({
+	createActiveUserTransaction: vi.fn(),
+	updateActiveUserTransaction: vi.fn()
 }));
 
 const ICP_LEDGER = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
@@ -772,6 +789,7 @@ describe('oisy-trade-swap.services', () => {
 
 		const swapParams = {
 			identity: mockIdentity,
+			swapId: 'swap-1',
 			sourceToken: ICP,
 			destinationToken: CKUSDC,
 			order: sellOrder
@@ -781,7 +799,18 @@ describe('oisy-trade-swap.services', () => {
 		let depositSpy: MockInstance;
 		let addLimitOrderSpy: MockInstance;
 
+		// The refs of the nth row write, keyed — `updateActiveUserTransaction` replaces the
+		// whole array each time, so a write is only correct if it carries everything learned
+		// so far, not just what it added.
+		const rowRefs = (index: number): Partial<Record<string, string>> =>
+			toOisyTradeExternalRefsMap(
+				vi.mocked(updateActiveUserTransaction).mock.calls[index]?.[0].externalRefs ?? []
+			);
+
 		beforeEach(() => {
+			vi.mocked(createActiveUserTransaction).mockReset();
+			vi.mocked(updateActiveUserTransaction).mockReset();
+
 			vi.spyOn(appConstants, 'OISY_TRADE_CANISTER_ID', 'get').mockImplementation(() => 'aaaaa-aa');
 
 			approveSpy = vi.spyOn(icrcLedgerApi, 'approve').mockResolvedValue(1n);
@@ -821,6 +850,149 @@ describe('oisy-trade-swap.services', () => {
 
 			return spy;
 		};
+
+		// Ordering, not just presence. Every other provider opens its row once the funds
+		// have irreversibly left the wallet, because for them the only thing left to do is
+		// watch. Here the row *is* the recovery record: it is what tells a later session
+		// which token to pull back out of DEX custody, so it has to exist before the
+		// deposit that puts it there.
+		it('opens the recovery record before the first canister call', async () => {
+			const calls: string[] = [];
+
+			vi.mocked(createActiveUserTransaction).mockImplementation(() => {
+				calls.push('createRow');
+
+				return Promise.resolve();
+			});
+			approveSpy.mockImplementation(() => {
+				calls.push('approve');
+
+				return Promise.resolve(1n);
+			});
+			depositSpy.mockImplementation(() => {
+				calls.push('deposit');
+
+				return Promise.resolve({ block_index: 7n });
+			});
+
+			await run();
+
+			expect(calls).toEqual(['createRow', 'approve', 'deposit']);
+		});
+
+		// The one place this integration inverts every other provider's rule, which open
+		// their rows best-effort and never surface a tracking failure as a swap failure.
+		// Proceeding without the record is exactly the stranded-funds case it prevents.
+		it('aborts without depositing when the recovery record cannot be opened', async () => {
+			vi.mocked(createActiveUserTransaction).mockRejectedValue(new Error('backend down'));
+			vi.spyOn(consoleUtils, 'consoleError').mockImplementation(() => undefined);
+
+			await expect(run()).rejects.toMatchObject({
+				name: 'OisyTradeSwapError',
+				kind: 'not_trackable',
+				message: en.swap.error.oisy_trade_not_trackable
+			});
+
+			expect(approveSpy).not.toHaveBeenCalled();
+			expect(depositSpy).not.toHaveBeenCalled();
+		});
+
+		// The order parameters and the baseline are fixed at creation: the poller reads
+		// them back in a later session, where the book has moved and the account-wide
+		// balance no longer says what this order put there.
+		it('snapshots the reviewed order and the pre-deposit baseline onto the row', async () => {
+			resetBalanceReads().mockResolvedValue([
+				{
+					token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+					balance: { free: 50_000_000n, reserved: ZERO }
+				}
+			] as unknown as UserTokenBalance[]);
+
+			await run();
+
+			expect(createActiveUserTransaction).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					id: 'swap-1',
+					data: {
+						OisyTrade: {
+							side: { Sell: null },
+							source_token: { Icrc: Principal.fromText(ICP_LEDGER) },
+							dest_token: { Icrc: Principal.fromText(CKUSDC_LEDGER) },
+							amount: sellOrder.depositAmount
+						}
+					}
+				})
+			);
+
+			const refs = toOisyTradeExternalRefsMap(
+				vi.mocked(createActiveUserTransaction).mock.calls[0][0].externalRefs
+			);
+
+			expect(refs).toEqual(
+				expect.objectContaining({
+					[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_PRICE]: `${sellOrder.price}`,
+					[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_QUANTITY]: `${sellOrder.quantity}`,
+					[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]: '50000000',
+					[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE]: '0',
+					[OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL]: ICP.symbol,
+					[OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]: CKUSDC.symbol
+				})
+			);
+			// No settlement pointer exists yet, and the poller tells an abandoned row from a
+			// stalled one by exactly their absence.
+			expect(refs[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]).toBeUndefined();
+			expect(refs[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]).toBeUndefined();
+		});
+
+		it('records the deposit and then the order id as it learns them', async () => {
+			await run();
+
+			expect(updateActiveUserTransaction).toHaveBeenCalledTimes(2);
+
+			// The funds are in DEX custody from the deposit onwards, which is what
+			// `Executing` records — and the poller matches on non-terminal, not on `Pending`.
+			expect(vi.mocked(updateActiveUserTransaction).mock.calls[0][0]).toEqual(
+				expect.objectContaining({ id: 'swap-1', status: { Executing: null } })
+			);
+			expect(rowRefs(0)[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]).toBe('7');
+			expect(rowRefs(0)[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]).toBeUndefined();
+
+			expect(rowRefs(1)[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]).toBe('order-1');
+			// Carried forward, not replaced: the update writes the whole ref array.
+			expect(rowRefs(1)[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]).toBe('7');
+		});
+
+		// A row is only ever *deleted* when it is still `Pending` and holds no deposit ref.
+		// A lost `Executing` write would leave a funded row in exactly that state, so every
+		// later write re-sends the highest status reached and repairs it — the backend
+		// accepts a same-status update.
+		it('repairs a lost Executing write with the next one', async () => {
+			vi.spyOn(consoleUtils, 'consoleError').mockImplementation(() => undefined);
+			vi.mocked(updateActiveUserTransaction)
+				.mockRejectedValueOnce(new Error('backend blip'))
+				.mockResolvedValue();
+
+			await run();
+
+			expect(updateActiveUserTransaction).toHaveBeenCalledTimes(2);
+			expect(vi.mocked(updateActiveUserTransaction).mock.calls[1][0]).toEqual(
+				expect.objectContaining({ id: 'swap-1', status: { Executing: null } })
+			);
+			expect(rowRefs(1)[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]).toBe('7');
+			expect(rowRefs(1)[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]).toBe('order-1');
+		});
+
+		// The seam this step moved: the wizard's job ends at a placed order. Waiting for it
+		// here is what used to keep the modal open, and the row is what replaces it.
+		it('hands settlement to the row rather than waiting for it', async () => {
+			const getMyOrdersSpy = vi.spyOn(oisyTradeApi, 'getMyOrders');
+			const withdrawSpy = vi.spyOn(oisyTradeApi, 'withdraw');
+
+			await expect(run()).resolves.toBeUndefined();
+
+			expect(getMyOrdersSpy).not.toHaveBeenCalled();
+			expect(withdrawSpy).not.toHaveBeenCalled();
+		});
 
 		it('submits a fill-or-kill order at the reviewed price and quantity', async () => {
 			await run();
@@ -870,12 +1042,15 @@ describe('oisy-trade-swap.services', () => {
 
 			await run({ progress, enableDestinationToken });
 
+			// No withdraw step: the leg that comes back out of custody is the poller's, and
+			// the modal is closing.
 			expect(progress.mock.calls.flat()).toEqual([
 				ProgressStepsSwap.APPROVE,
 				ProgressStepsSwap.SWAP,
-				ProgressStepsSwap.WITHDRAW,
 				ProgressStepsSwap.UPDATE_UI
 			]);
+			// Enabled on submission rather than on arrival, as every background-settling
+			// provider does: the balance the poller delivers has to have somewhere to land.
 			expect(enableDestinationToken).toHaveBeenCalledOnce();
 		});
 
@@ -932,73 +1107,16 @@ describe('oisy-trade-swap.services', () => {
 			expect(calls.indexOf('deposit')).toBeGreaterThan(0);
 		});
 
-		it('never places an order when the deposit fails', async () => {
+		// The row is left `Pending` with neither pointer, which is precisely what the poller
+		// reads as "never started": nothing moved, so it deletes the row rather than
+		// reporting a failure about funds that never left the wallet.
+		it('never places an order when the deposit fails, and marks the row with nothing', async () => {
 			depositSpy.mockRejectedValue(new Error('deposit failed'));
 
 			await expect(run()).rejects.toThrow('deposit failed');
 
 			expect(addLimitOrderSpy).not.toHaveBeenCalled();
-		});
-
-		// The one case unlike every other provider: the swap failed, but the funds came back.
-		// The error is raised only *after* the source token has been withdrawn, so the user is
-		// never told the swap failed while their money is still in someone else's custody.
-		it('withdraws the source back before reporting a killed order', async () => {
-			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([
-				{ id: 'order-1', order: { status: { Expired: null } }, pair: {} }
-			] as unknown as UserOrder[]);
-			const withdrawSpy = vi.spyOn(oisyTradeApi, 'withdraw').mockResolvedValue({
-				block_index: 42n
-			});
-			// Baseline first (nothing held), then the source the kill released back.
-			resetBalanceReads()
-				.mockResolvedValueOnce([])
-				.mockResolvedValue([
-					{
-						token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
-						balance: { free: 300_000_000n, reserved: ZERO }
-					}
-				] as unknown as UserTokenBalance[]);
-
-			const progress = vi.fn();
-			const enableDestinationToken = vi.fn();
-			const walletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
-
-			// The typed error, with `kind`, is what the wizard branches on to present a
-			// kill as the expected market outcome it is rather than an unexpected failure.
-			await expect(run({ progress, enableDestinationToken })).rejects.toMatchObject({
-				name: 'OisyTradeSwapError',
-				kind: 'killed',
-				message: en.swap.error.oisy_trade_order_killed
-			});
-
-			expect(withdrawSpy).toHaveBeenCalledOnce();
-			expect(withdrawSpy.mock.calls[0][0].request.token_id.ledger_id.toText()).toBe(ICP_LEDGER);
-			// The recovered source balance is refreshed, but the user never received the
-			// destination token: nothing enables it, and the progress bar never reaches
-			// the final step.
-			expect(walletSpy).toHaveBeenCalledOnce();
-			expect(enableDestinationToken).not.toHaveBeenCalled();
-			expect(progress).not.toHaveBeenCalledWith(ProgressStepsSwap.UPDATE_UI);
-		});
-
-		// Nothing left in custody and nothing that says how the order ended: the error
-		// asks the user to check the Trading tab, and since nothing was withdrawn there
-		// is no wallet change to refresh and no destination token to enable.
-		it('reports an unresolved settlement without refreshing or enabling anything', async () => {
-			vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([]);
-			vi.spyOn(oisyTradeApi, 'getBalances').mockResolvedValue([]);
-			const walletSpy = vi.spyOn(walletUtils, 'waitAndTriggerWallet');
-			const enableDestinationToken = vi.fn();
-
-			await expect(run({ enableDestinationToken })).rejects.toMatchObject({
-				name: 'OisyTradeSwapError',
-				kind: 'unresolved',
-				message: en.swap.error.oisy_trade_settlement_unresolved
-			});
-
-			expect(walletSpy).not.toHaveBeenCalled();
-			expect(enableDestinationToken).not.toHaveBeenCalled();
+			expect(updateActiveUserTransaction).not.toHaveBeenCalled();
 		});
 
 		// The canister replying with an `Err` means the order was definitively not
@@ -1059,9 +1177,23 @@ describe('oisy-trade-swap.services', () => {
 				expect(enableDestinationToken).not.toHaveBeenCalled();
 				expect(progress.mock.calls.flat()).toEqual([
 					ProgressStepsSwap.APPROVE,
-					ProgressStepsSwap.SWAP,
-					ProgressStepsSwap.WITHDRAW
+					ProgressStepsSwap.SWAP
 				]);
+			});
+
+			// Nothing is left to settle once the deposit is back, so the row is closed here
+			// rather than left for the poller to re-derive from balances that no longer
+			// hold anything.
+			it('closes the row as failed once the deposit is recovered', async () => {
+				await expect(run()).rejects.toMatchObject({ kind: 'not_placed' });
+
+				expect(vi.mocked(updateActiveUserTransaction).mock.calls.at(-1)?.[0]).toEqual(
+					expect.objectContaining({
+						id: 'swap-1',
+						status: { Failed: null },
+						error: en.swap.error.oisy_trade_order_not_placed
+					})
+				);
 			});
 
 			it('reports a failed recovery pointing at the Trading tab', async () => {
@@ -1084,13 +1216,23 @@ describe('oisy-trade-swap.services', () => {
 				// The funds are still in DEX custody, so there is no wallet change to show.
 				expect(walletSpy).not.toHaveBeenCalled();
 				expect(consoleErrorSpy).toHaveBeenCalledWith(recoveryError);
+				// And the row is deliberately left non-terminal — a deposit ref, no order id
+				// — which is the signature the poller retries this same withdrawal from.
+				// Terminalizing it here would strand the balance with nothing watching it.
+				expect(
+					vi
+						.mocked(updateActiveUserTransaction)
+						.mock.calls.map(([{ status }]) => status)
+						.filter(nonNullish)
+				).toEqual([{ Executing: null }]);
 			});
 		});
 
 		// A failure that is not the canister's `Err` reply is ambiguous — the call may
 		// have landed and only the reply been lost, so an order may exist with the
 		// reserve locked. Withdrawing here could race that live order, so the error
-		// propagates untouched and the case belongs to step 2's durable recovery record.
+		// propagates untouched and the row is left as the poller's stalled-deposit case:
+		// `Executing`, with a deposit ref and no order id.
 		it('rethrows an ambiguous placement failure without touching the deposit', async () => {
 			addLimitOrderSpy.mockRejectedValue(new Error('reply lost'));
 			const withdrawSpy = vi.spyOn(oisyTradeApi, 'withdraw');
@@ -1100,107 +1242,22 @@ describe('oisy-trade-swap.services', () => {
 
 			expect(withdrawSpy).not.toHaveBeenCalled();
 			expect(walletSpy).not.toHaveBeenCalled();
+
+			expect(updateActiveUserTransaction).toHaveBeenCalledOnce();
+			expect(rowRefs(0)[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]).toBe('7');
+			expect(rowRefs(0)[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]).toBeUndefined();
 		});
 
-		describe('retrying', () => {
+		// The only loop left in the foreground: settlement's belongs to the poller now, but
+		// the deposit recovery has no row driving it — it has to finish inside the flow
+		// that started it, or the wizard reports a rejection with the funds still out.
+		describe('retrying the deposit recovery', () => {
 			beforeEach(() => {
 				vi.useFakeTimers();
 			});
 
 			afterEach(() => {
 				vi.useRealTimers();
-			});
-
-			const settleWithFakeTimers = async (promise: Promise<unknown>) => {
-				// One tick of the settle interval is all the mocks below need; the assertion
-				// is that the flow asked a second time rather than giving up on the first.
-				await vi.advanceTimersByTimeAsync(OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS);
-
-				return await promise;
-			};
-
-			it('keeps polling while the order has not settled yet', async () => {
-				const getMyOrdersSpy = vi
-					.spyOn(oisyTradeApi, 'getMyOrders')
-					.mockResolvedValueOnce([
-						{ id: 'order-1', order: { status: { Pending: null } }, pair: {} }
-					] as unknown as UserOrder[])
-					.mockResolvedValue([
-						{ id: 'order-1', order: { status: { Filled: null } }, pair: {} }
-					] as unknown as UserOrder[]);
-
-				await settleWithFakeTimers(run());
-
-				expect(getMyOrdersSpy).toHaveBeenCalledTimes(2);
-			});
-
-			// The most damaging bug this integration can ship is ending the operation on a
-			// transient failure, with the funds still in DEX custody and nothing watching them.
-			it('retries a retryable withdrawal failure rather than failing the swap', async () => {
-				const withdrawSpy = vi
-					.spyOn(oisyTradeApi, 'withdraw')
-					.mockRejectedValueOnce(
-						new OisyTradeTemporaryError({ message: 'busy', reason: 'OperationInProgress' })
-					)
-					.mockResolvedValue({ block_index: 42n });
-
-				const settlement = await settleWithFakeTimers(run());
-
-				expect(settlement).toEqual({ status: 'filled', withdrawals: [42n] });
-				expect(withdrawSpy).toHaveBeenCalledTimes(2);
-			});
-
-			// A filled Buy whose price-improved fill released unspent reserve: the primary
-			// (destination) withdrawal lands, the residue (source) withdrawal fails
-			// transiently, and the retry re-enters the settlement — where the withdrawn
-			// primary's delta reads zero and only the residue is left to take. The swap
-			// still succeeds, with no funds left behind.
-			it('retries a retryable residue withdrawal failure and still succeeds', async () => {
-				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue([
-					{ id: 'order-1', order: { status: { Filled: null } }, pair: {} }
-				] as unknown as UserOrder[]);
-				resetBalanceReads()
-					// Baseline: nothing on the DEX.
-					.mockResolvedValueOnce([])
-					// After the fill: the credited destination plus the released source reserve.
-					.mockResolvedValueOnce([
-						{
-							token: { id: { ledger_id: Principal.fromText(CKUSDC_LEDGER) } },
-							balance: { free: 2_000_000n, reserved: ZERO }
-						},
-						{
-							token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
-							balance: { free: 100_000_000n, reserved: ZERO }
-						}
-					] as unknown as UserTokenBalance[])
-					// After the primary withdrawal: only the residue remains.
-					.mockResolvedValue([
-						{
-							token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
-							balance: { free: 100_000_000n, reserved: ZERO }
-						}
-					] as unknown as UserTokenBalance[]);
-				const withdrawSpy = vi
-					.spyOn(oisyTradeApi, 'withdraw')
-					.mockResolvedValueOnce({ block_index: 42n })
-					.mockRejectedValueOnce(
-						new OisyTradeTemporaryError({ message: 'busy', reason: 'OperationInProgress' })
-					)
-					.mockResolvedValue({ block_index: 43n });
-
-				const promise = run();
-
-				// The retry's sleep is scheduled deep in a promise chain, so a single
-				// advance can complete before the timer even exists — `vi.waitFor`
-				// advances the fake timers by `interval` on every check instead.
-				await vi.waitFor(() => expect(withdrawSpy).toHaveBeenCalledTimes(3), {
-					interval: OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS,
-					timeout: 4 * OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS
-				});
-
-				// The second attempt's outcome: the primary is dust-skipped (already
-				// withdrawn) and the residue's block index is the one reported.
-				await expect(promise).resolves.toEqual({ status: 'filled', withdrawals: [43n] });
 			});
 
 			// The recovery withdrawal honours the same retry policy as settlement, and for
@@ -1245,16 +1302,28 @@ describe('oisy-trade-swap.services', () => {
 				});
 			});
 
-			// No timer advance: a non-retryable failure ends the swap on the first attempt,
-			// which is exactly the difference from the test above.
-			it('fails the swap on a withdrawal failure that is not retryable', async () => {
+			// No timer advance: a non-retryable failure ends the recovery on the first
+			// attempt, which is exactly the difference from the test above.
+			it('gives up on a recovery failure that is not retryable', async () => {
+				addLimitOrderSpy.mockRejectedValue(
+					new OisyTradeRequestError({ message: 'off grid', reason: 'InvalidQuantity' })
+				);
+				vi.spyOn(consoleUtils, 'consoleError').mockImplementation(() => undefined);
+				resetBalanceReads()
+					.mockResolvedValueOnce([])
+					.mockResolvedValue([
+						{
+							token: { id: { ledger_id: Principal.fromText(ICP_LEDGER) } },
+							balance: { free: 300_000_000n, reserved: ZERO }
+						}
+					] as unknown as UserTokenBalance[]);
 				const withdrawSpy = vi
 					.spyOn(oisyTradeApi, 'withdraw')
 					.mockRejectedValue(
 						new OisyTradeRequestError({ message: 'nope', reason: 'InsufficientBalance' })
 					);
 
-				await expect(run()).rejects.toThrow('nope');
+				await expect(run()).rejects.toMatchObject({ kind: 'recovery_failed' });
 
 				expect(withdrawSpy).toHaveBeenCalledOnce();
 			});

--- a/src/frontend/src/tests/lib/utils/oisy-trade-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade-active-tx.utils.spec.ts
@@ -1,0 +1,256 @@
+import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import { USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
+import { BTC_REGTEST_TOKEN } from '$env/tokens/tokens.btc.env';
+import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import type { IcToken } from '$icp/types/ic-token';
+import { ZERO } from '$lib/constants/app.constants';
+import { OISY_TRADE_EXTERNAL_REF_KEYS } from '$lib/types/oisy-trade-swap';
+import { SwapProvider } from '$lib/types/swap';
+import {
+	buildOisyTradeSwapTrackingMetadata,
+	findOisyTradeRowToken,
+	isOisyTradeActiveUserTransaction,
+	toOisyTradeCandidDataSide,
+	toOisyTradeData,
+	toOisyTradeDisplayRefs,
+	toOisyTradeExternalRefs,
+	toOisyTradeExternalRefsMap,
+	toOisyTradeRefAmount
+} from '$lib/utils/oisy-trade-active-tx.utils';
+import {
+	mockActiveUserTransaction,
+	mockNearIntentsActiveUserTransaction
+} from '$tests/mocks/active-user-transactions.mock';
+import { mockValidIcToken } from '$tests/mocks/ic-tokens.mock';
+import { Principal } from '@icp-sdk/core/principal';
+
+const CKUSDC_LEDGER = 'xevnm-gaaaa-aaaar-qafnq-cai';
+
+const CKUSDC: IcToken = {
+	...mockValidIcToken,
+	ledgerCanisterId: CKUSDC_LEDGER,
+	symbol: 'ckUSDC',
+	decimals: 6
+};
+
+const row = (overrides: Partial<ActiveUserTransaction> = {}): ActiveUserTransaction => ({
+	...mockActiveUserTransaction,
+	data: {
+		OisyTrade: {
+			side: { Sell: null },
+			source_token: { Icrc: Principal.fromText(ICP_TOKEN.ledgerCanisterId) },
+			dest_token: { Icrc: Principal.fromText(CKUSDC_LEDGER) },
+			amount: 300_000_000n
+		}
+	},
+	...overrides
+});
+
+describe('oisy-trade-active-tx.utils', () => {
+	describe('isOisyTradeActiveUserTransaction', () => {
+		it('recognizes an OISY Trade row', () => {
+			expect(isOisyTradeActiveUserTransaction(row())).toBeTruthy();
+		});
+
+		it('rejects another provider’s row', () => {
+			expect(isOisyTradeActiveUserTransaction(mockNearIntentsActiveUserTransaction)).toBeFalsy();
+		});
+	});
+
+	describe('toOisyTradeCandidDataSide', () => {
+		it.each([
+			{ side: 'sell', expected: { Sell: null } },
+			{ side: 'buy', expected: { Buy: null } }
+		] as const)('maps $side onto the candid discriminant', ({ side, expected }) => {
+			expect(toOisyTradeCandidDataSide(side)).toEqual(expected);
+		});
+	});
+
+	describe('toOisyTradeData', () => {
+		// The side is what fixes the base/quote orientation: `Sell` spends the base
+		// token, `Buy` the quote one, and the two token ids alone cannot say which.
+		it('carries the side alongside the immutable trio', () => {
+			expect(
+				toOisyTradeData({
+					side: 'buy',
+					sourceToken: CKUSDC,
+					destinationToken: ICP_TOKEN,
+					amount: 3_702_000n
+				})
+			).toEqual({
+				OisyTrade: {
+					side: { Buy: null },
+					source_token: { Icrc: Principal.fromText(CKUSDC_LEDGER) },
+					dest_token: { Icrc: Principal.fromText(ICP_TOKEN.ledgerCanisterId) },
+					amount: 3_702_000n
+				}
+			});
+		});
+
+		// The caller treats this as a reason to abort the swap rather than to proceed
+		// untracked, which is the opposite of every other provider's reading.
+		it('returns undefined when a token has no backend id', () => {
+			expect(
+				toOisyTradeData({
+					side: 'sell',
+					// Bitcoin regtest is the one asset with no backend `TokenId` variant.
+					sourceToken: BTC_REGTEST_TOKEN,
+					destinationToken: CKUSDC,
+					amount: 1n
+				})
+			).toBeUndefined();
+		});
+	});
+
+	describe('toOisyTradeExternalRefs', () => {
+		it('sorts the keys and drops empty values', () => {
+			expect(
+				toOisyTradeExternalRefs({
+					[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]: 'order-1',
+					[OISY_TRADE_EXTERNAL_REF_KEYS.AMOUNT]: '',
+					[OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX]: '7'
+				})
+			).toEqual([
+				{ key: OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX, value: '7' },
+				{ key: OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID, value: 'order-1' }
+			]);
+		});
+
+		// A zero baseline is a fact, not an absence: it says the user held nothing on the
+		// DEX, which is what makes the whole current balance attributable to this order.
+		it('keeps a zero baseline', () => {
+			expect(
+				toOisyTradeExternalRefs({
+					[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]: '0'
+				})
+			).toEqual([{ key: OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE, value: '0' }]);
+		});
+	});
+
+	describe('toOisyTradeExternalRefsMap', () => {
+		it('keys the wire-format array', () => {
+			expect(
+				toOisyTradeExternalRefsMap([
+					{ key: OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID, value: 'order-1' }
+				])
+			).toEqual({ [OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID]: 'order-1' });
+		});
+	});
+
+	describe('toOisyTradeDisplayRefs', () => {
+		// OneSec's exact key strings, which is the whole reason an OISY Trade row renders
+		// without a new layout: `ActiveUserTransactionItem` reads every row's refs through
+		// `toOneSecExternalRefsMap`.
+		it('snapshots both legs under OneSec’s key names', () => {
+			expect(
+				toOisyTradeDisplayRefs({
+					sourceToken: ICP_TOKEN,
+					destinationToken: CKUSDC,
+					amount: '3',
+					usdSourceValue: '36.5'
+				})
+			).toEqual({
+				amount: '3',
+				usd_source_value: '36.5',
+				source_token_symbol: ICP_TOKEN.symbol,
+				source_network_symbol: ICP_TOKEN.network.name,
+				destination_token_symbol: CKUSDC.symbol,
+				destination_network_symbol: CKUSDC.network.name
+			});
+		});
+
+		it('omits an unknown USD value rather than writing an empty ref', () => {
+			expect(
+				toOisyTradeDisplayRefs({
+					sourceToken: ICP_TOKEN,
+					destinationToken: CKUSDC,
+					amount: '3'
+				})
+			).not.toHaveProperty('usd_source_value');
+		});
+	});
+
+	describe('toOisyTradeRefAmount', () => {
+		it('reads a base-unit ref', () => {
+			expect(toOisyTradeRefAmount('300000000')).toBe(300_000_000n);
+		});
+
+		// Conservative on purpose: a zero baseline attributes the whole current balance to
+		// this order and settlement withdraws it. Leaving the funds in DEX custody because
+		// a ref was dropped would be the worse failure.
+		it.each([undefined, '', 'not a number'])('reads %s as zero', (value) => {
+			expect(toOisyTradeRefAmount(value)).toBe(ZERO);
+		});
+	});
+
+	describe('findOisyTradeRowToken', () => {
+		const tokens = [USDC_TOKEN, ICP_TOKEN, CKUSDC];
+
+		it('resolves an ICRC leg by ledger id', () => {
+			expect(
+				findOisyTradeRowToken({ tokenId: { Icrc: Principal.fromText(CKUSDC_LEDGER) }, tokens })
+			).toBe(CKUSDC);
+		});
+
+		// ICP is written as `Icrc` by ledger id, so it resolves the same way rather than
+		// through the `IcpNative` variant reserved for the exchange-rate path.
+		it('resolves the ICP leg by its ledger id', () => {
+			expect(
+				findOisyTradeRowToken({
+					tokenId: { Icrc: Principal.fromText(ICP_TOKEN.ledgerCanisterId) },
+					tokens
+				})
+			).toBe(ICP_TOKEN);
+		});
+
+		it('resolves nothing for a ledger the wallet does not know', () => {
+			expect(
+				findOisyTradeRowToken({
+					tokenId: { Icrc: Principal.fromText('mxzaz-hqaaa-aaaar-qaada-cai') },
+					tokens
+				})
+			).toBeUndefined();
+		});
+
+		// Settlement is ICRC-only by construction, and a non-IC token could not carry the
+		// ledger id or the fee it needs.
+		it('never resolves a non-IC token', () => {
+			expect(findOisyTradeRowToken({ tokenId: { EvmNative: 1n }, tokens })).toBeUndefined();
+		});
+	});
+
+	describe('buildOisyTradeSwapTrackingMetadata', () => {
+		// Resolved entirely off the refs snapshot, so it stays correct across a refresh, a
+		// re-login, and after the user disables one of the two tokens.
+		it('builds the shared swap metadata from the row’s refs', () => {
+			expect(
+				buildOisyTradeSwapTrackingMetadata({
+					tx: row({
+						external_refs: toOisyTradeExternalRefs({
+							[OISY_TRADE_EXTERNAL_REF_KEYS.AMOUNT]: '3',
+							[OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL]: 'ICP',
+							[OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL]: 'Internet Computer',
+							[OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL]: 'ckUSDC',
+							[OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL]: 'Internet Computer'
+						})
+					})
+				})
+			).toEqual({
+				sourceToken: 'ICP',
+				destinationToken: 'ckUSDC',
+				dApp: SwapProvider.OISY_TRADE,
+				tokenAmount: '3',
+				sourceNetwork: 'Internet Computer',
+				destinationNetwork: 'Internet Computer'
+			});
+		});
+
+		it('carries the row’s error onto a failed row’s metadata', () => {
+			expect(
+				buildOisyTradeSwapTrackingMetadata({
+					tx: row({ status: { Failed: null }, error: ['could not fill'] })
+				})
+			).toEqual(expect.objectContaining({ error: 'could not fill' }));
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/utils/oisy-trade-active-tx.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade-active-tx.utils.spec.ts
@@ -175,11 +175,27 @@ describe('oisy-trade-active-tx.utils', () => {
 			expect(toOisyTradeRefAmount('300000000')).toBe(300_000_000n);
 		});
 
-		// Conservative on purpose: a zero baseline attributes the whole current balance to
-		// this order and settlement withdraws it. Leaving the funds in DEX custody because
-		// a ref was dropped would be the worse failure.
-		it.each([undefined, '', 'not a number'])('reads %s as zero', (value) => {
-			expect(toOisyTradeRefAmount(value)).toBe(ZERO);
+		it('reads a zero baseline, which is a real figure rather than an absent one', () => {
+			expect(toOisyTradeRefAmount('0')).toBe(ZERO);
+		});
+
+		// Never zero. A substituted zero credits the order with the caller's entire free
+		// balance, so settlement would withdraw a balance the user parked from the Trading
+		// tab and could read a killed order as filled. The caller declines to settle
+		// instead, which leaves the funds recoverable rather than moving them on a guess.
+		// `''` earns its place here: `BigInt('')` is `0n` rather than an error, so it is
+		// the one input that would slip past the parse as a real zero.
+		it.each([undefined, '', '   ', 'not a number', '12.5'])(
+			'refuses to read %s as an amount',
+			(value) => {
+				expect(toOisyTradeRefAmount(value)).toBeUndefined();
+			}
+		);
+
+		// A free balance cannot be negative, and a negative baseline would inflate the
+		// delta rather than merely mis-state it.
+		it('refuses a negative baseline', () => {
+			expect(toOisyTradeRefAmount('-1')).toBeUndefined();
 		});
 	});
 

--- a/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
+++ b/src/frontend/src/tests/mocks/active-user-transactions.mock.ts
@@ -6,6 +6,7 @@ import type {
 	ChainFusionData,
 	LiquidiumData,
 	NearIntentsData,
+	OisyTradeData,
 	OneSecIcpToEvmData,
 	VeloraData
 } from '$declarations/backend/backend.did';
@@ -17,8 +18,10 @@ import type {
 import { CHAIN_FUSION_EXTERNAL_REF_KEYS } from '$lib/types/chain-fusion-swap';
 import { LIQUIDIUM_EXTERNAL_REF_KEYS } from '$lib/types/liquidium-active-tx';
 import { NEAR_INTENTS_EXTERNAL_REF_KEYS } from '$lib/types/near-intents';
+import { OISY_TRADE_EXTERNAL_REF_KEYS } from '$lib/types/oisy-trade-swap';
 import { VELORA_EXTERNAL_REF_KEYS } from '$lib/types/velora-swap';
 import { mockPrincipal } from '$tests/mocks/identity.mock';
+import { Principal } from '@icp-sdk/core/principal';
 
 export const mockActiveUserTransactionId = '11111111-1111-4111-8111-111111111111';
 
@@ -110,6 +113,35 @@ export const mockChainFusionActiveUserTransaction: ActiveUserTransaction = {
 		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL, value: 'Internet Computer' },
 		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL, value: 'ETH' },
 		{ key: CHAIN_FUSION_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL, value: 'Ethereum' }
+	],
+	created_at_ns: ZERO,
+	updated_at_ns: ZERO,
+	error: []
+};
+
+export const mockOisyTradeData: OisyTradeData = {
+	side: { Sell: null },
+	source_token: { Icrc: mockPrincipal },
+	dest_token: { Icrc: Principal.fromText('xevnm-gaaaa-aaaar-qafnq-cai') },
+	amount: 300_000_000n
+};
+
+export const mockOisyTradeActiveUserTransaction: ActiveUserTransaction = {
+	id: '55555555-5555-4555-8555-555555555555',
+	status: { Executing: null },
+	data: { OisyTrade: mockOisyTradeData },
+	progress_step: [],
+	// OneSec's exact display-ref key strings, which is what lets an OISY Trade row
+	// render through the shared layout.
+	external_refs: [
+		{ key: OISY_TRADE_EXTERNAL_REF_KEYS.DEPOSIT_BLOCK_INDEX, value: '7' },
+		{ key: OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_ID, value: 'order-1' },
+		{ key: OISY_TRADE_EXTERNAL_REF_KEYS.AMOUNT, value: '3' },
+		{ key: OISY_TRADE_EXTERNAL_REF_KEYS.USD_SOURCE_VALUE, value: '36.5' },
+		{ key: OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_TOKEN_SYMBOL, value: 'ICP' },
+		{ key: OISY_TRADE_EXTERNAL_REF_KEYS.SOURCE_NETWORK_SYMBOL, value: 'Internet Computer' },
+		{ key: OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_TOKEN_SYMBOL, value: 'ckUSDC' },
+		{ key: OISY_TRADE_EXTERNAL_REF_KEYS.DESTINATION_NETWORK_SYMBOL, value: 'Internet Computer' }
 	],
 	created_at_ns: ZERO,
 	updated_at_ns: ZERO,


### PR DESCRIPTION
# Motivation

Step 2 of the OISY Trade swap-provider spec, following step 1 on `main`.

Step 1 settled inside the wizard, so there was no recovery record: a closed tab or an expired delegation between the deposit and the withdrawal stranded funds in DEX custody with nothing in the wallet pointing at them. OISY Trade is the only provider where funds sit in a third party's balance under the user's own name, waiting on further calls from the wallet. This makes deposit → order → withdraw one durable operation, resumed after a refresh or a re-login.


# Changes

`settleOisyTradeSwap` is shared verbatim with the old foreground loop. Only its host moves.

- **The row.** `fetchOisyTradeSwap` opens an Active User Transaction row before the first OISY Trade canister call, writes the deposit index and order id as it learns them, then resolves without settling. Unlike every other provider a failure here aborts the swap, since the row is the recovery record. Every write re-sends the highest status reached, so a lost `Executing` write cannot leave a funded row looking abandoned.
- **The poller** (`oisy-trade-active-tx.services.ts`, new). Maps an outcome onto a row status and adds the cases only a cross-session poller sees: a not-found order resolved from `get_balances`, an abandoned row deleted, a stalled deposit withdrawn back. Retryable errors leave the row non-terminal; rows settle sequentially, since the canister rejects concurrent withdrawals per caller. A five-minute grace period gates the no-order-id case, which every healthy swap passes through briefly.
- **Utils and types.** `oisy-trade-active-tx.utils.ts` (new) follows the Chain Fusion equivalent. `findOisyTradeRowToken` is new work: no inverse of `toBackendTokenId` existed, and settlement needs each leg's ledger fee to tell a withdrawable balance from dust. Two baseline ref keys let the poller settle deltas rather than account-wide balances. `OisyTradeSwapError` drops `killed` and `unresolved`, gains `not_trackable`.
- **AUT surfaces.** One predicate and one partition added. The wallet refresh fires on failure too, because a killed order has just returned the source token.
- **Progress steps.** `SwapProgress` gains `sendWithApprovalOnly`. The flow drives the approve step, but that row only rendered under `sendWithApproval`, which also injects two signing rows this flow never performs. An unrendered step matches nothing, so the list sat unhighlighted for the whole approve leg. Included here because this PR already restructures the same step list.


# Tests

Added.
