### PR TITLE
fix(frontend): price a Max send against the fee it is actually signed with

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -20,6 +20,7 @@
 
 	interface Props {
 		amount: OptionAmount;
+		amountSetToMax?: boolean;
 		insufficientFunds: boolean;
 		nativeEthereumToken: Token;
 		onTokensList: () => void;
@@ -27,6 +28,7 @@
 
 	let {
 		amount = $bindable(),
+		amountSetToMax = $bindable(false),
 		insufficientFunds = $bindable(),
 		nativeEthereumToken,
 		onTokensList
@@ -99,11 +101,6 @@
 			);
 		}
 	};
-
-	/**
-	 * Reevaluate max amount if the user has used the "Max" button and the fees are changing.
-	 */
-	let amountSetToMax = $state(false);
 </script>
 
 <div class="mb-4">

--- a/src/frontend/src/eth/components/send/EthSendForm.svelte
+++ b/src/frontend/src/eth/components/send/EthSendForm.svelte
@@ -18,6 +18,7 @@
 
 	interface Props {
 		amount: OptionAmount;
+		amountSetToMax?: boolean;
 		destination?: string;
 		nativeEthereumToken: Token;
 		selectedContact?: ContactUi;
@@ -29,6 +30,7 @@
 
 	let {
 		amount = $bindable(),
+		amountSetToMax = $bindable(false),
 		destination = $bindable(''),
 		nativeEthereumToken,
 		selectedContact,
@@ -58,7 +60,13 @@
 	{selectedContact}
 >
 	{#snippet sendAmount()}
-		<EthSendAmount {nativeEthereumToken} {onTokensList} bind:amount bind:insufficientFunds />
+		<EthSendAmount
+			{nativeEthereumToken}
+			{onTokensList}
+			bind:amount
+			bind:amountSetToMax
+			bind:insufficientFunds
+		/>
 	{/snippet}
 
 	{#snippet priority()}

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -286,8 +286,13 @@
 			return;
 		}
 
+		// One snapshot for both the signature and the cap below. Rebuilding a literal from parts of it
+		// would let any term the rebuild omits - such as the OP-stack `l1Fee` - drop out of the ceiling
+		// the cap enforces, which is the very shortfall the cap exists to prevent.
 		// https://github.com/ethers-io/ethers.js/discussions/2439#discussioncomment-1857403
-		const { maxFeePerGas, maxPriorityFeePerGas, gas } = $feeStore;
+		const feeData = $feeStore;
+
+		const { maxFeePerGas, maxPriorityFeePerGas, gas } = feeData;
 
 		// https://docs.ethers.org/v5/api/providers/provider/#Provider-getFeeData
 		// exceeds block gas limit
@@ -322,7 +327,7 @@
 				? capSendAmountToFee({
 						amount: parsedAmount,
 						balance: $sendBalance,
-						feeData: { maxFeePerGas, maxPriorityFeePerGas, gas }
+						feeData
 					})
 				: parsedAmount;
 

--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -16,8 +16,10 @@
 	} from '$eth/stores/eth-fee.store';
 	import type { EthereumNetwork } from '$eth/types/network';
 	import type { ProgressStep } from '$eth/types/send';
-	import { shouldSendWithApproval } from '$eth/utils/send.utils';
+	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
+	import { capSendAmountToFee, shouldSendWithApproval } from '$eth/utils/send.utils';
 	import { isErc20Icp } from '$eth/utils/token.utils';
+	import { isSupportedEvmNativeTokenId } from '$evm/utils/native-token.utils';
 	import { assertCkEthMinterInfoLoaded } from '$icp-eth/services/cketh.services';
 	import { ckEthMinterInfoStore } from '$icp-eth/stores/cketh.store';
 	import { toCkErc20HelperContractAddress } from '$icp-eth/utils/cketh.utils';
@@ -29,6 +31,7 @@
 		TRACK_COUNT_ETH_SEND_ERROR,
 		TRACK_COUNT_ETH_SEND_SUCCESS
 	} from '$lib/constants/analytics.constants';
+	import { ZERO } from '$lib/constants/app.constants';
 	import { ethAddress } from '$lib/derived/address.derived';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { exchanges } from '$lib/derived/exchange.derived';
@@ -50,8 +53,14 @@
 	 * Send context store
 	 */
 
-	const { sendTokenDecimals, sendTokenId, sendToken, sendEthCustomNonce, sendEthFeePriority } =
-		getContext<SendContext>(SEND_CONTEXT_KEY);
+	const {
+		sendTokenDecimals,
+		sendTokenId,
+		sendToken,
+		sendBalance,
+		sendEthCustomNonce,
+		sendEthFeePriority
+	} = getContext<SendContext>(SEND_CONTEXT_KEY);
 
 	/**
 	 * Props
@@ -102,6 +111,14 @@
 	);
 
 	let customNonce = $derived($sendEthCustomNonce);
+
+	// Set by the amount step's "Max" button, and read again at send time: only a "Max" amount stands
+	// for "whatever is left" rather than a figure the user typed.
+	let amountSetToMax = $state(false);
+
+	let feeIsPaidFromAmount = $derived(
+		isSupportedEthTokenId($sendTokenId) || isSupportedEvmNativeTokenId($sendTokenId)
+	);
 
 	/**
 	 * Fee context store
@@ -289,6 +306,33 @@
 			return;
 		}
 
+		const parsedAmount = parseToken({
+			value: `${amount}`,
+			unitName: $sendTokenDecimals
+		});
+
+		// The fee context keeps refetching through the review step - `observe` only stops at
+		// `SENDING` - while the amount stopped moving the moment the amount step was left, because
+		// the "Max" button that re-applies it is unmounted there. So a "Max" amount is priced
+		// against an older sample than the one being signed just above, and a fee that has risen in
+		// between leaves it unable to cover `gas * maxFeePerGas`. The chain drops such a transaction
+		// without reporting anything: the broadcast returns a hash and it is simply never included.
+		const sendAmount =
+			amountSetToMax && feeIsPaidFromAmount
+				? capSendAmountToFee({
+						amount: parsedAmount,
+						balance: $sendBalance,
+						feeData: { maxFeePerGas, maxPriorityFeePerGas, gas }
+					})
+				: parsedAmount;
+
+		if (sendAmount <= ZERO) {
+			toastsError({
+				msg: { text: $i18n.send.assertion.insufficient_funds_for_gas }
+			});
+			return;
+		}
+
 		onNext();
 
 		const sendTrackingEventMetadata = {
@@ -306,10 +350,7 @@
 				to: isErc20Icp($sendToken) ? destination : mapAddressStartsWith0x(destination),
 				progress: (step: ProgressStep) => (sendProgressStep = step),
 				token: $sendToken,
-				amount: parseToken({
-					value: `${amount}`,
-					unitName: $sendTokenDecimals
-				}),
+				amount: sendAmount,
 				maxFeePerGas,
 				maxPriorityFeePerGas,
 				gas,
@@ -380,6 +421,7 @@
 				{selectedContact}
 				bind:destination
 				bind:amount
+				bind:amountSetToMax
 			>
 				{#snippet cancel()}
 					<ButtonBack onclick={back} />

--- a/src/frontend/src/eth/utils/send.utils.ts
+++ b/src/frontend/src/eth/utils/send.utils.ts
@@ -1,7 +1,10 @@
 import type { OptionEthAddress } from '$eth/types/address';
+import { maxGasFee } from '$eth/utils/fee.utils';
 import { isNotSupportedErc20TwinTokenId } from '$eth/utils/token.utils';
+import type { OptionBalance } from '$lib/types/balance';
 import type { TokenId } from '$lib/types/token';
-import { nonNullish } from '@dfinity/utils';
+import type { TransactionFeeData } from '$lib/types/transaction';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 export const isDestinationContractAddress = ({
 	contractAddress,
@@ -40,4 +43,37 @@ export const shouldSendWithApproval = ({
 	}
 
 	return true;
+};
+
+/**
+ * Caps a native send at what the fee it will actually be signed with still leaves affordable.
+ *
+ * "Max" is priced against the fee sampled when the button is pressed, but the transaction is
+ * signed with whatever the fee store holds at send time, and those are not the same sample: the
+ * review step no longer re-applies "Max", while the fee keeps being refetched underneath it. When
+ * the fee has risen in between, the frozen amount no longer leaves enough to cover
+ * `gas * maxFeePerGas`, and the chain drops the transaction without reporting anything.
+ *
+ * Caps rather than re-derives upwards: a fee that has fallen leaves the reviewed amount untouched,
+ * so the send never moves more than the user was shown. Only a "Max" send is capped, because only
+ * there does the amount stand for "whatever is left" rather than a figure the user chose.
+ */
+export const capSendAmountToFee = ({
+	amount,
+	balance,
+	feeData
+}: {
+	amount: bigint;
+	balance: OptionBalance;
+	feeData: TransactionFeeData;
+}): bigint => {
+	const gasFee = maxGasFee(feeData);
+
+	if (isNullish(balance) || isNullish(gasFee)) {
+		return amount;
+	}
+
+	const affordable = balance - gasFee;
+
+	return affordable < amount ? affordable : amount;
 };

--- a/src/frontend/src/tests/eth/utils/send.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/send.utils.spec.ts
@@ -1,0 +1,48 @@
+import { maxGasFee } from '$eth/utils/fee.utils';
+import { capSendAmountToFee } from '$eth/utils/send.utils';
+import { ZERO } from '$lib/constants/app.constants';
+
+describe('capSendAmountToFee', () => {
+	const gas = 21_000n;
+	const balance = 2_453_569_936_352_484n;
+
+	// The sample "Max" was priced against.
+	const quoted = { maxFeePerGas: 22_200_000n, maxPriorityFeePerGas: 2_200_000n, gas };
+	const maxAmount = balance - (maxGasFee(quoted) ?? ZERO);
+
+	it('leaves the amount alone when the fee has not moved', () => {
+		expect(capSendAmountToFee({ amount: maxAmount, balance, feeData: quoted })).toBe(maxAmount);
+	});
+
+	// The defect: a fee that rose between the amount step and signing leaves the frozen amount
+	// unable to cover `gas * maxFeePerGas`, and the chain drops the transaction silently.
+	it('caps the amount when the fee has risen', () => {
+		const risen = { ...quoted, maxFeePerGas: 22_213_310n };
+
+		const capped = capSendAmountToFee({ amount: maxAmount, balance, feeData: risen });
+
+		expect(capped).toBeLessThan(maxAmount);
+		expect(capped + (maxGasFee(risen) ?? ZERO)).toBeLessThanOrEqual(balance);
+	});
+
+	it('never raises the amount when the fee has fallen, so the send stays what was reviewed', () => {
+		const fallen = { ...quoted, maxFeePerGas: 11_000_000n };
+
+		expect(capSendAmountToFee({ amount: maxAmount, balance, feeData: fallen })).toBe(maxAmount);
+	});
+
+	it('goes non-positive when the fee alone exceeds the balance, so the caller can refuse', () => {
+		const unaffordable = { ...quoted, maxFeePerGas: balance };
+
+		expect(
+			capSendAmountToFee({ amount: maxAmount, balance, feeData: unaffordable })
+		).toBeLessThanOrEqual(ZERO);
+	});
+
+	it.each([
+		{ label: 'the balance is unknown', balance: undefined, feeData: quoted },
+		{ label: 'the ceiling is unknown', balance, feeData: { ...quoted, maxFeePerGas: null } }
+	])('leaves the amount alone when $label', ({ balance: bal, feeData }) => {
+		expect(capSendAmountToFee({ amount: maxAmount, balance: bal, feeData })).toBe(maxAmount);
+	});
+});

--- a/src/frontend/src/tests/eth/utils/send.utils.spec.ts
+++ b/src/frontend/src/tests/eth/utils/send.utils.spec.ts
@@ -31,6 +31,19 @@ describe('capSendAmountToFee', () => {
 		expect(capSendAmountToFee({ amount: maxAmount, balance, feeData: fallen })).toBe(maxAmount);
 	});
 
+	// The cap is only as complete as the snapshot it is handed. On an OP-stack chain the ceiling
+	// includes the L1 data fee, so a caller that rebuilds the fee object from parts and omits it
+	// would cap against a ceiling lower than the chain's and reopen the shortfall.
+	it('counts the OP-stack L1 data fee in the ceiling it caps against', () => {
+		const l1Fee = 1_583_231_633n;
+		const withL1 = { ...quoted, l1Fee };
+
+		const capped = capSendAmountToFee({ amount: maxAmount, balance, feeData: withL1 });
+
+		expect(capped).toBe(maxAmount - l1Fee);
+		expect(capped + (maxGasFee(withL1) ?? ZERO)).toBeLessThanOrEqual(balance);
+	});
+
 	it('goes non-positive when the fee alone exceeds the balance, so the caller can refuse', () => {
 		const unaffordable = { ...quoted, maxFeePerGas: balance };
 


### PR DESCRIPTION
# Motivation

A **Max** send on Base is broadcast, returns a hash, reports success, and is never included. Reproduced three times on fe2; the third landed only because the fee happened to fall.

`EthFeeContext` keeps refetching through the review step, since `observe` is `currentStep !== SENDING`. The amount, however, stops moving the moment the amount step is left: the `MaxBalanceButton` that re-applies Max is unmounted there. So a Max amount is priced against an older fee sample than the one `send` reads out of the fee store to sign with. If the fee rose in between, the frozen amount no longer leaves enough to cover `gas * maxFeePerGas`.

The evidence is in the transaction that did land, `0xc998eeda…`:

| | wei |
| --- | --- |
| Ceiling Max subtracted | 693,000,189,000 |
| Ceiling the signed transaction carried | 466,479,510,000 |
| Actual L1 fee | 1,929,505,935 |
| Headroom the transaction ended up leaving | 226,520,679,000 |

Two different samples, 117x more slack than needed. On the attempt before it, the same arithmetic ran the other way: the amount was priced at a ceiling of 467,783,231,633 and the observed send-time values came to 468,409,015,935, short by 625,784,302. A **0.34% rise** in `maxFeePerGas` is enough, and on Base the suggested tip jitters constantly (0.011, 0.0222, 0.0223, 0.025, 0.0228 gwei within one session).

Nothing catches it: `customValidate` runs on the amount step against the old sample, and the node returns a hash rather than an error.

# Changes

- Re-derive a Max amount in `send` against the same fee snapshot it signs with, via `capSendAmountToFee`.
- **Cap only, never raise.** A fee that has fallen leaves the reviewed amount untouched, so the send never moves more than the user was shown.
- Only a Max amount is capped. A typed figure is what the user chose and must not be silently changed; it keeps failing loudly instead.
- Refuse outright when the fee alone now exceeds the balance, rather than signing a non-positive value.
- `amountSetToMax` is plumbed from `EthSendAmount` up through `EthSendForm` to the wizard, which is what distinguishes the two cases.

# Tests

Six cases in a new `send.utils.spec.ts`: unchanged fee leaves the amount alone; a risen fee caps it and the result provably fits the balance; a fallen fee never raises it; the fee exceeding the balance goes non-positive so the caller can refuse; unknown balance or unknown ceiling leave it alone.

The risen-fee case uses the real numbers above, so it pins the observed defect rather than the implementation.

# Notes

Independent of, and complementary to, the L1 data fee work: that one is a fixed shortfall on OP-stack chains, this one is a moving one on every chain. Base makes it visible because its L1 fee is the only headroom Max leaves, so any upward tick eats it.
