### PR TITLE
fix(frontend): net the ATA fee against the accounts a transaction closes

### DIFF
--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -33,7 +33,7 @@
 	import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
 	import { solAccountExplorerUrl } from '$sol/utils/sol-explorer.utils';
 	import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
-	import { formatSolTransactionSummary } from '$sol/utils/sol-transaction-summary.utils';
+	import { formatSolTransactionSummary, solAtaFee } from '$sol/utils/sol-transaction-summary.utils';
 	import { findEnabledSplToken } from '$sol/utils/spl.utils';
 
 	interface Props {
@@ -149,15 +149,10 @@
 		})()
 	);
 
-	// The rent the transaction paid to open token accounts, stated apart like the send form does:
-	// it is not part of the fee, and folded into a delta it reads as value lost to the transfer.
-	let ataFee = $derived(
-		(instructions ?? []).reduce(
-			(acc, { kind, rent }) =>
-				kind === 'createTokenAccount' && nonNullish(rent) ? acc + rent : acc,
-			ZERO
-		)
-	);
+	// The rent the transaction paid to open token accounts, net of what the ones it closed handed
+	// back, stated apart like the send form does: it is not part of the fee, and folded into a
+	// delta it reads as value lost to the transfer.
+	let ataFee = $derived(solAtaFee(instructions ?? []));
 
 	// The venue of a routed swap: the program its legs ran through.
 	let routeProgram = $derived(

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -36,7 +36,8 @@
 	import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
 	import {
 		flattenInstructions,
-		formatSolTransactionSummary
+		formatSolTransactionSummary,
+		solAtaFee
 	} from '$sol/utils/sol-transaction-summary.utils';
 
 	interface Props {
@@ -99,20 +100,7 @@
 	// What the token accounts cost this message: the rent of the ones it opens, less what the ones
 	// it closes hand back. Charged like a fee and part of neither the base nor the bid, so it is
 	// stated as its own line rather than folded into either.
-	let ataFee = $derived(
-		maxBigInt(
-			(instructions ?? []).reduce((acc, { kind, rent, returned }) => {
-				if (kind === 'createTokenAccount' && nonNullish(rent)) {
-					return acc + rent;
-				}
-
-				// A message that opens one account and closes another charges the difference. Netting
-				// below zero would turn a refund into a negative fee, which is not what a fee is.
-				return kind === 'closeTokenAccount' && nonNullish(returned) ? acc - returned : acc;
-			}, ZERO),
-			ZERO
-		)
-	);
+	let ataFee = $derived(solAtaFee(instructions ?? []));
 
 	let feeExchangeRate = $derived($exchanges?.[feeToken.id]?.usd);
 

--- a/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
@@ -32,21 +32,40 @@ export const flattenInstructions = (
  * with, and calling that a fee below zero says something a fee cannot say. It nets to nothing, and
  * a caller shows nothing.
  *
- * Only `closeTokenAccount` is netted. An unwrap closes an account too, but hands back the SOL that
- * was wrapped along with the rent, and subtracting a whole swap's worth of SOL here would cancel
- * rent the user genuinely paid.
+ * An unwrap nets too, but only by the rent. What it hands back is the account's whole balance, the
+ * wrapped SOL included, and subtracting that would cancel rent the user genuinely paid on every
+ * swap that wraps. The rent it gets back is the rent the same transaction paid to open that
+ * account, which the opening instruction states exactly, so the account is what ties the two
+ * together. An unwrap of an account opened by some earlier transaction nets nothing: its rent was
+ * never this transaction's to charge.
  */
-export const solAtaFee = (instructions: SolInstructionSummary[]): bigint =>
-	maxBigInt(
-		flattenInstructions(instructions).reduce((acc, { kind, rent, returned }) => {
+export const solAtaFee = (instructions: SolInstructionSummary[]): bigint => {
+	const flattened = flattenInstructions(instructions);
+
+	const rentPaidFor = flattened.reduce<Record<string, bigint>>((acc, { kind, account, rent }) => {
+		if (kind !== 'createTokenAccount' || isNullish(account) || isNullish(rent)) {
+			return acc;
+		}
+
+		return { ...acc, [account]: rent };
+	}, {});
+
+	return maxBigInt(
+		flattened.reduce((acc, { kind, account, rent, returned }) => {
 			if (kind === 'createTokenAccount' && nonNullish(rent)) {
 				return acc + rent;
 			}
 
+			if (kind === 'unwrap') {
+				return acc - (nonNullish(account) ? (rentPaidFor[account] ?? ZERO) : ZERO);
+			}
+
+			// A plain token account holds nothing but its rent, so what it hands back is the rent.
 			return kind === 'closeTokenAccount' && nonNullish(returned) ? acc - returned : acc;
 		}, ZERO),
 		ZERO
 	);
+};
 
 /**
  * The tokens the transaction actually trades, read from its legs.

--- a/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
@@ -1,6 +1,6 @@
 import { SOLANA_DEFAULT_DECIMALS } from '$env/tokens/tokens.sol.env';
 import { ZERO } from '$lib/constants/app.constants';
-import { absBigInt } from '$lib/utils/bigint.utils';
+import { absBigInt, maxBigInt } from '$lib/utils/bigint.utils';
 import { formatToken } from '$lib/utils/format.utils';
 import { replacePlaceholders } from '$lib/utils/i18n.utils';
 import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
@@ -19,6 +19,34 @@ export const flattenInstructions = (
 		instruction,
 		...flattenInstructions(instruction.children ?? [])
 	]);
+
+/**
+ * What the token accounts cost the transaction: the rent of the ones it opens, less what the ones
+ * it closes hand back.
+ *
+ * A transaction that opens one account and closes another charges only the difference, and one
+ * that closes as many as it opens charges nothing at all. Reporting the rent of the opens alone
+ * bills the user for accounts they no longer have.
+ *
+ * Never negative: a transaction that closes more than it opens ends up with SOL it did not start
+ * with, and calling that a fee below zero says something a fee cannot say. It nets to nothing, and
+ * a caller shows nothing.
+ *
+ * Only `closeTokenAccount` is netted. An unwrap closes an account too, but hands back the SOL that
+ * was wrapped along with the rent, and subtracting a whole swap's worth of SOL here would cancel
+ * rent the user genuinely paid.
+ */
+export const solAtaFee = (instructions: SolInstructionSummary[]): bigint =>
+	maxBigInt(
+		flattenInstructions(instructions).reduce((acc, { kind, rent, returned }) => {
+			if (kind === 'createTokenAccount' && nonNullish(rent)) {
+				return acc + rent;
+			}
+
+			return kind === 'closeTokenAccount' && nonNullish(returned) ? acc - returned : acc;
+		}, ZERO),
+		ZERO
+	);
 
 /**
  * The tokens the transaction actually trades, read from its legs.

--- a/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
@@ -13,7 +13,7 @@ import {
 import en from '$tests/mocks/i18n.mock';
 import { MOCK_SOL_BALANCES } from '$tests/mocks/sol-balances.mock';
 import { MOCK_SOL_INSTRUCTIONS } from '$tests/mocks/sol-instructions.mock';
-import { mockAtaAddress } from '$tests/mocks/sol.mock';
+import { mockAtaAddress, mockAtaAddress2 } from '$tests/mocks/sol.mock';
 
 const USER = '5Dqoon9MdWRgwmJ839FJ2ZTpTAcc1MMprZeNyaxpaV1Q';
 
@@ -178,11 +178,32 @@ describe('sol-transaction-summary.utils', () => {
 			expect(solAtaFee([close(), close()])).toBe(ZERO);
 		});
 
-		// An unwrap hands back the wrapped SOL along with the rent. Netting the whole balance would
-		// cancel rent the user genuinely paid, on every swap that wraps.
-		it('should leave an unwrap out of the netting', () => {
+		// A wrap opens an account and the unwrap closes it, so its rent comes back like any other.
+		// What must not come back is the wrapped SOL the close hands over with it.
+		it('should net an unwrap by the rent alone, not by the SOL it unwrapped', () => {
 			expect(
 				solAtaFee([create(), { kind: 'unwrap', account: mockAtaAddress, returned: 5_000_000_000n }])
+			).toBe(ZERO);
+		});
+
+		it('should still charge an account it opens beside a wrap it unwraps', () => {
+			expect(
+				solAtaFee([
+					create(),
+					{ kind: 'createTokenAccount', account: mockAtaAddress2, rent: RENT },
+					{ kind: 'unwrap', account: mockAtaAddress2, returned: 5_000_000_000n }
+				])
+			).toBe(RENT);
+		});
+
+		// Its rent was paid by whatever transaction opened it, so this one has nothing to refund.
+		// Crediting the balance would report a fee of zero for rent this transaction did pay.
+		it('should net nothing for an unwrap of an account it did not open', () => {
+			expect(
+				solAtaFee([
+					create(),
+					{ kind: 'unwrap', account: mockAtaAddress2, returned: 5_000_000_000n }
+				])
 			).toBe(RENT);
 		});
 

--- a/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
@@ -7,11 +7,13 @@ import { mapSolNetBalanceChanges } from '$sol/utils/sol-net-changes.utils';
 import {
 	deriveSolTransactionSummary,
 	formatSolInstructionSummary,
-	formatSolTransactionSummary
+	formatSolTransactionSummary,
+	solAtaFee
 } from '$sol/utils/sol-transaction-summary.utils';
 import en from '$tests/mocks/i18n.mock';
 import { MOCK_SOL_BALANCES } from '$tests/mocks/sol-balances.mock';
 import { MOCK_SOL_INSTRUCTIONS } from '$tests/mocks/sol-instructions.mock';
+import { mockAtaAddress } from '$tests/mocks/sol.mock';
 
 const USER = '5Dqoon9MdWRgwmJ839FJ2ZTpTAcc1MMprZeNyaxpaV1Q';
 
@@ -135,6 +137,61 @@ describe('sol-transaction-summary.utils', () => {
 					instructions: [{ kind: 'approve', counterparty: 'spender', account: 'ata' }]
 				}).kind
 			).toBe('other');
+		});
+	});
+
+	describe('solAtaFee', () => {
+		const RENT = 2_039_280n;
+
+		const create = (rent = RENT): SolInstructionSummary => ({
+			kind: 'createTokenAccount',
+			account: mockAtaAddress,
+			rent
+		});
+
+		const close = (returned = RENT): SolInstructionSummary => ({
+			kind: 'closeTokenAccount',
+			account: mockAtaAddress,
+			returned
+		});
+
+		it('should charge the rent of an account it only opens', () => {
+			expect(solAtaFee([create()])).toBe(RENT);
+		});
+
+		it('should charge the rent of each of several accounts', () => {
+			expect(solAtaFee([create(), create()])).toBe(RENT * 2n);
+		});
+
+		// The account is gone by the end of the transaction, so its rent is back in the wallet.
+		// Billing the open alone charges the user for something they no longer have.
+		it('should charge nothing when it closes what it opened', () => {
+			expect(solAtaFee([create(), close()])).toBe(ZERO);
+		});
+
+		it('should charge only the difference when it opens more than it closes', () => {
+			expect(solAtaFee([create(), create(), close()])).toBe(RENT);
+		});
+
+		// A refund is not a negative fee. It nets to nothing, and the caller shows nothing.
+		it('should never go below zero when it closes more than it opens', () => {
+			expect(solAtaFee([close(), close()])).toBe(ZERO);
+		});
+
+		// An unwrap hands back the wrapped SOL along with the rent. Netting the whole balance would
+		// cancel rent the user genuinely paid, on every swap that wraps.
+		it('should leave an unwrap out of the netting', () => {
+			expect(
+				solAtaFee([create(), { kind: 'unwrap', account: mockAtaAddress, returned: 5_000_000_000n }])
+			).toBe(RENT);
+		});
+
+		it('should read the accounts a route opened under it', () => {
+			expect(solAtaFee([{ kind: 'route', children: [create(), close()] }])).toBe(ZERO);
+		});
+
+		it('should charge nothing for a transaction that touches no account', () => {
+			expect(solAtaFee([])).toBe(ZERO);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The transaction modal charged the rent of every token account a transaction opened and ignored the ones it closed. A transaction that opened one account and closed another billed the user for an account they no longer have, and one that closed as many as it opened still showed a fee for nothing.

The WalletConnect review already netted the plain closes, so the same number was derived twice and neither derivation credited a wrap.

# Changes

- One derivation, `solAtaFee`, in `sol-transaction-summary.utils`, read by both the transaction modal and the WalletConnect review.
- An unwrap nets too, by the rent alone. A close hands back the account's whole balance, the wrapped SOL included, so the amount credited is the rent the same transaction paid to open that account, tied to it by the account address. An unwrap of an account opened by an earlier transaction nets nothing: its rent was never this transaction's to charge.
- Floored at zero: a transaction that closes more than it opens ends up with SOL it did not start with, and a fee below zero says something a fee cannot say. Both surfaces already hid a zero, so a transaction that nets to nothing now shows no line at all.

# Tests

Eleven cases on `solAtaFee`: one account opened, several opened, opened and closed netting to zero, more opened than closed, more closed than opened, a wrap netted by its rent rather than by the SOL it unwrapped, a second account still charged beside a wrap, an unwrap of an account this transaction did not open, accounts opened inside a route, and a transaction touching no account at all.