### PR TITLE
style(frontend): put the WalletConnect tabs on the same rhythm as the rows below

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -151,7 +151,7 @@
 {/if}
 
 <Tabs
-	styleClass="mt-4"
+	contentStyleClass="mt-4"
 	tabs={[
 		{ label: $i18n.wallet_connect.text.tab_summary, id: 'summary' },
 		{ label: $i18n.wallet_connect.text.tab_raw_data, id: 'raw' }

--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
@@ -223,7 +223,7 @@
 	{/if}
 
 	<Tabs
-		styleClass="mt-4"
+		contentStyleClass="mt-4"
 		tabs={[
 			{ label: $i18n.wallet_connect.text.tab_summary, id: 'summary' },
 			{ label: $i18n.wallet_connect.text.tab_raw_data, id: 'raw' }

--- a/src/frontend/src/lib/components/ui/Tabs.svelte
+++ b/src/frontend/src/lib/components/ui/Tabs.svelte
@@ -16,6 +16,9 @@
 		activeTab: string;
 		children?: Snippet;
 		styleClass?: string;
+		// The gap between the tab row and its content. The default suits a full page; a modal whose
+		// other rows sit `mb-4` apart wants the tabs on the same rhythm rather than looser.
+		contentStyleClass?: string;
 		tabVariant?: TabVariant;
 		trackEventName?: string;
 	}
@@ -25,6 +28,7 @@
 		activeTab = $bindable(),
 		tabs,
 		styleClass,
+		contentStyleClass = 'mt-6',
 		tabVariant = 'default',
 		trackEventName
 	}: Props = $props();
@@ -80,6 +84,6 @@
 	{/each}
 </div>
 
-<div class="mt-6">
+<div class={contentStyleClass}>
 	{@render children?.()}
 </div>

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -289,7 +289,7 @@
 	     material a user checks the summary against, not part of the summary: on a routed swap they
 	     are a dozen lines, and above the amounts they bury the one figure that matters. -->
 	<Tabs
-		styleClass="mt-4"
+		contentStyleClass="mt-4"
 		tabs={[
 			{ label: $i18n.transaction.text.tab_summary, id: 'summary' },
 			{ label: $i18n.wallet_connect.text.tab_operations, id: 'operations' }


### PR DESCRIPTION
# Motivation

QA on the WalletConnect modals: the tab row is too far from the modal header, and its content too far from the tabs.

The block sat 16px below the header and its content another 24px below the tabs, while every row inside that content is 16px apart. It read as though it belonged to a different modal.

# Changes

Drops the gap above the tabs, since the modal header already carries a divider, and brings the gap below down to the same 16px the rows use.

`Tabs` takes the content gap as an optional prop rather than changing its default, so the assets page and the send destination tabs keep the looser spacing that suits a full page.

Applied to all three WalletConnect review modals: EVM send, EVM message, Solana sign.

The Solana **activity** modal uses the same `mt-4` pattern but is a different surface, not a WalletConnect review, so it is left alone. Say the word if it should follow.

# Tests

No behaviour change, so no new specs. `check`, `eslint --max-warnings 0` and `prettier` clean; the WalletConnect and UI suites pass (438).
