### PR TITLE
feat(frontend): name the struct an EVM typed-data signature hashes

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -54,6 +54,10 @@
 		}
 	});
 
+	// The struct EIP-712 hashes. The RPC method above says how the request arrived; this says what
+	// it is, which is the difference between "a typed-data signature" and "an unlimited allowance".
+	let primaryType = $derived(json?.primaryType);
+
 	// Only the members the schema declares are previewed: EIP-712 hashes those and nothing else, so
 	// a key the schema leaves out is not part of what the user would sign and is not shown as if it
 	// were. That the request carried such keys is stated instead.
@@ -164,6 +168,15 @@
 
 		<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.method}</p>
 		<p class="mb-4 font-normal">{method}</p>
+
+		{#if nonNullish(primaryType)}
+			<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.type}</p>
+			<!-- Monospaced like the struct names below it: this is the dApp's own text, not OISY's
+			     copy, and it should not read as though the wallet vouched for the wording. -->
+			<p class="mb-4 font-normal">
+				<span class="font-mono text-sm break-all">{primaryType}</span>
+			</p>
+		{/if}
 
 		<!-- The RPC method above names how the request arrived. What it would authorize is the struct being
      hashed, which is the only thing left to state once the summary rows come up empty. -->

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1620,6 +1620,7 @@
 			"application": "",
 			"review": "مراجعة الأذونات المطلوبة لـ $chain_name ($key)",
 			"method": "الطريقة",
+			"type": "",
 			"methods": "الطرق",
 			"events": "الأحداث",
 			"message": "الرسالة",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1620,6 +1620,7 @@
 			"application": "Aplikace",
 			"review": "Zkontrolovat požadovaná oprávnění $chain_name ($key)",
 			"method": "Metoda",
+			"type": "",
 			"methods": "Metody",
 			"events": "Události",
 			"message": "Zpráva",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1620,6 +1620,7 @@
 			"application": "",
 			"review": "Erforderliche Berechtigungen für $chain_name ($key) prüfen",
 			"method": "Methode",
+			"type": "",
 			"methods": "Methoden",
 			"events": "Ereignisse",
 			"message": "Nachricht",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1620,6 +1620,7 @@
 			"application": "Application",
 			"review": "Review $chain_name ($key) required permissions",
 			"method": "Method",
+			"type": "Type",
 			"methods": "Methods",
 			"events": "Events",
 			"message": "Message",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1620,6 +1620,7 @@
 			"application": "Aplicación",
 			"review": "Revisar los permisos requeridos de $chain_name ($key)",
 			"method": "Método",
+			"type": "",
 			"methods": "Métodos",
 			"events": "Eventos",
 			"message": "Mensaje",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1620,6 +1620,7 @@
 			"application": "Application",
 			"review": "Vérifier les permissions requises pour $chain_name ($key)",
 			"method": "Méthode",
+			"type": "",
 			"methods": "Méthodes",
 			"events": "Événements",
 			"message": "Message",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1620,6 +1620,7 @@
 			"application": "",
 			"review": "$chain_name ($key) आवश्यक अनुमतियाँ समीक्षा करें",
 			"method": "विधि",
+			"type": "",
 			"methods": "विधियाँ",
 			"events": "घटनाएँ",
 			"message": "संदेश",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1620,6 +1620,7 @@
 			"application": "",
 			"review": "Rivedi i permessi richiesti per $chain_name ($key)",
 			"method": "Metodo",
+			"type": "",
 			"methods": "Metodi",
 			"events": "Eventi",
 			"message": "Messaggio",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1620,6 +1620,7 @@
 			"application": "アプリケーション",
 			"review": "$chain_name ($key)のに必須な権限を確認",
 			"method": "方法",
+			"type": "",
 			"methods": "方法",
 			"events": "イベント",
 			"message": "メッセージ",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1620,6 +1620,7 @@
 			"application": "애플리케이션",
 			"review": "$chain_name ($key) 필수 권한 검토",
 			"method": "메서드",
+			"type": "",
 			"methods": "메서드",
 			"events": "이벤트",
 			"message": "메시지",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1620,6 +1620,7 @@
 			"application": "",
 			"review": "Przejrzyj wymagane uprawnienia $chain_name ($key)",
 			"method": "Metoda",
+			"type": "",
 			"methods": "Metody",
 			"events": "Wydarzenia",
 			"message": "Wiadomość",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1620,6 +1620,7 @@
 			"application": "",
 			"review": "Rever permissões necessárias de $chain_name ($key)",
 			"method": "Método",
+			"type": "",
 			"methods": "Métodos",
 			"events": "Eventos",
 			"message": "Mensagem",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1620,6 +1620,7 @@
 			"application": "Приложение",
 			"review": "Проверить необходимые разрешения $chain_name ($key)",
 			"method": "Метод",
+			"type": "",
 			"methods": "Методы",
 			"events": "События",
 			"message": "Сообщение",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1620,6 +1620,7 @@
 			"application": "",
 			"review": "Xem lại quyền cần thiết của $chain_name ($key)",
 			"method": "Hàm",
+			"type": "",
 			"methods": "Hàm",
 			"events": "Sự kiện",
 			"message": "Tin nhắn",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1620,6 +1620,7 @@
 			"application": "应用",
 			"review": "审核 $chain_name ($key) 所需的权限",
 			"method": "方法",
+			"type": "",
 			"methods": "方法",
 			"events": "事件",
 			"message": "消息",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1303,6 +1303,7 @@ interface I18nWallet_connect {
 		application: string;
 		review: string;
 		method: string;
+		type: string;
 		methods: string;
 		events: string;
 		message: string;

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
@@ -122,6 +122,34 @@ describe('EthWalletConnectMessage', () => {
 		expect(getByText(SESSION_REQUEST_ETH_SIGN_V4)).toBeInTheDocument();
 	});
 
+	it('should name the struct being signed, not just how the request arrived', () => {
+		// The RPC method says a typed-data signature; only the primary type says it is an allowance.
+		const { getByText } = render(EthWalletConnectMessage, { props: { request } });
+
+		expect(getByText(en.wallet_connect.text.type)).toBeInTheDocument();
+
+		expect(getByText('PermitSingle')).toBeInTheDocument();
+	});
+
+	it('should say nothing about a type for a request that is not typed data', () => {
+		const { queryByText } = render(EthWalletConnectMessage, {
+			props: {
+				request: {
+					...request,
+					params: {
+						...request.params,
+						request: {
+							method: 'personal_sign',
+							params: ['0xdeadbeef', '0xf2e508d5b8f44f08bd81c7d19e9f1f5277e31f95']
+						}
+					}
+				} as WalletKitTypes.SessionRequest
+			}
+		});
+
+		expect(queryByText(en.wallet_connect.text.type)).not.toBeInTheDocument();
+	});
+
 	it('should render the token if it is enabled', () => {
 		const { getByText } = render(EthWalletConnectMessage, {
 			props: {

--- a/src/frontend/src/tests/eth/components/wallet-connect/WalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/WalletConnectSignReview.spec.ts
@@ -225,12 +225,16 @@ describe('WalletConnectSignReview', () => {
 	// The RPC method is `eth_signTypedData_v4` for a permit and for a drainer alike, so it is the
 	// struct that says what is being signed.
 	it('names the struct an unrecognised signature hashes', () => {
-		const { getByText } = render(WalletConnectSignReview, {
+		const { getByText, getAllByText } = render(WalletConnectSignReview, {
 			props: { ...props, request: transferWithAuthorizationRequest() }
 		});
 
 		expect(getByText(en.wallet_connect.text.methods)).toBeInTheDocument();
-		expect(getByText('TransferWithAuthorization')).toBeInTheDocument();
+
+		// Twice on purpose: the `Type` row states the struct that is hashed, the list below states
+		// the whole type graph it belongs to. The row is not a duplicate of the list's first entry,
+		// it is the labelled version of it.
+		expect(getAllByText('TransferWithAuthorization')).toHaveLength(2);
 	});
 
 	it('does not name structs for a schema it can describe', () => {


### PR DESCRIPTION
# Motivation

QA: the sign modal titles itself "USD Coin" and never says what the signature actually does.

The title is the EIP-712 **domain name**, which for USDC is literally `"USD Coin"`. That is deliberate and worth keeping: it is the contract the signature is held against. What was missing is the action.

The review already states the RPC method, but `eth_signTypedData_v4` says how the request arrived, not what it is: a permit, a gasless transfer and an order all arrive that way. The struct being hashed is what separates them, and it sat only in the raw JSON tab.

# Changes

A **Type** row under Method, carrying the typed data's `primaryType`. A USDC permit now reads `Permit`; an ERC-3009 authorization reads `TransferWithAuthorization`.

Monospaced like the struct names below it, because it is the dApp's own text rather than OISY's copy and should not read as though the wallet vouched for the wording.

Absent for a request that is not typed data, where there is no struct to name.

Title unchanged.

# Tests

Two new cases: a typed-data request names its struct, and a `personal_sign` request shows no Type row.

Verified by mutation: removing the row fails the first, falling back to the RPC method fails the second.

One existing assertion changed by design. For unreviewable typed data the struct list already names the primary type, so `TransferWithAuthorization` now appears twice: once as the labelled Type, once in the type graph. The test asserts both rather than one, with a comment on why that is not duplication.

`check`, `check:tests`, `tsc --project tsconfig.spec.json`, `eslint --max-warnings 0` and `prettier` clean; `tests/eth` 4181 passed.
