### PR TITLE
refactor(frontend): decode where the kit instructions already live

### DIFF
--- a/src/frontend/src/sol/services/sol-simulation.services.ts
+++ b/src/frontend/src/sol/services/sol-simulation.services.ts
@@ -9,6 +9,7 @@ import type { SolanaNetworkType } from '$sol/types/network';
 import type { SolSimulationResult } from '$sol/types/sol-simulation';
 import type { CompilableTransactionMessage } from '$sol/types/sol-transaction-message';
 import { mapSolInstructionSummaries } from '$sol/utils/sol-instruction-summary.utils';
+import { asSolParsedRpcInstructionOrSelf } from '$sol/utils/sol-instructions.utils';
 import { deriveSolMessageSummary } from '$sol/utils/sol-message-summary.utils';
 import {
 	isEmptySolSimulationPreview,
@@ -92,7 +93,7 @@ const simulate = async ({
 	// The kit instructions are not parsed, so they contribute nothing themselves; iterating them is
 	// what attaches each simulated nested call to the instruction that made it.
 	const instructions = mapSolInstructionSummaries({
-		instructions: [...transactionMessage.instructions],
+		instructions: [...transactionMessage.instructions].map(asSolParsedRpcInstructionOrSelf),
 		innerInstructions: [...innerInstructions].map(({ index, instructions: inner }) => ({
 			index: Number(index),
 			instructions: [...inner]
@@ -110,7 +111,7 @@ const simulate = async ({
 	// the same transaction, which is what lets the review notice the two disagreeing.
 	const messageSummary = deriveSolMessageSummary({
 		instructions: mapSolInstructionSummaries({
-			instructions: [...transactionMessage.instructions],
+			instructions: [...transactionMessage.instructions].map(asSolParsedRpcInstructionOrSelf),
 			innerInstructions: [],
 			ownedAddresses: [address, ...ownedAddresses],
 			addressToToken

--- a/src/frontend/src/sol/services/wallet-connect.services.ts
+++ b/src/frontend/src/sol/services/wallet-connect.services.ts
@@ -41,6 +41,7 @@ import type { SplTokenAddress } from '$sol/types/spl';
 import { convertSolComputeUnitPriceToFee } from '$sol/utils/fee.utils';
 import { safeMapNetworkIdToNetwork } from '$sol/utils/safe-network.utils';
 import { mapSolInstructionSummaries } from '$sol/utils/sol-instruction-summary.utils';
+import { asSolParsedRpcInstructionOrSelf } from '$sol/utils/sol-instructions.utils';
 import {
 	createSigner,
 	signMessage as signMessageBytes,
@@ -180,7 +181,9 @@ export const decode = async ({
 		? namedInstructions
 		: await loadSolProgramNames({
 				instructions: mapSolInstructionSummaries({
-					instructions: [...parsedTransactionMessage.instructions],
+					instructions: [...parsedTransactionMessage.instructions].map(
+						asSolParsedRpcInstructionOrSelf
+					),
 					innerInstructions: [],
 					ownedAddresses: owned?.ownedAddresses ?? [],
 					includeUnrecognised: true

--- a/src/frontend/src/sol/types/sol-instructions.ts
+++ b/src/frontend/src/sol/types/sol-instructions.ts
@@ -33,6 +33,17 @@ export type SolParsedInstruction =
 
 export type SolInstruction = Instruction;
 
+/**
+ * A `jsonParsed` instruction, as both `simulateTransaction`'s inner instructions and
+ * `getTransaction` report them. The RPC picks the parsed arm per instruction, so the unparsed one
+ * survives in the union and says nothing.
+ */
+export interface SolParsedRpcInstruction {
+	program?: string;
+	programId: SolAddress;
+	parsed: { type: string; info: object };
+}
+
 export type SolRpcInstruction =
 	NonNullable<SolRpcTransactionRaw>['transaction']['message']['instructions'][number] & {
 		programAddress: Address;

--- a/src/frontend/src/sol/utils/sol-instruction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instruction-summary.utils.ts
@@ -1,39 +1,14 @@
 import { WSOL_TOKEN } from '$env/tokens/tokens-spl/tokens.wsol.env';
 import { ZERO } from '$lib/constants/app.constants';
-import {
-	ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS,
-	COMPUTE_BUDGET_PROGRAM_ADDRESS,
-	SYSTEM_PROGRAM_ADDRESS,
-	TOKEN_2022_PROGRAM_ADDRESS,
-	TOKEN_PROGRAM_ADDRESS
-} from '$sol/constants/sol.constants';
+import { COMPUTE_BUDGET_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import type { SolAddress } from '$sol/types/address';
 import type {
 	SolInstructionSummary,
 	SolInstructionSummaryKind
 } from '$sol/types/sol-instruction-summary';
-import type { SolInstruction, SolParsedInstruction } from '$sol/types/sol-instructions';
+import type { SolParsedRpcInstruction } from '$sol/types/sol-instructions';
 import type { SplTokenAddress } from '$sol/types/spl';
-import { parseSolAtaInstruction } from '$sol/utils/sol-instructions-ata.utils';
-import { parseSolSystemInstruction } from '$sol/utils/sol-instructions-system.utils';
-import { parseSolToken2022Instruction } from '$sol/utils/sol-instructions-token-2022.utils';
-import { parseSolTokenInstruction } from '$sol/utils/sol-instructions-token.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
-import { SystemInstruction } from '@solana-program/system';
-import { AssociatedTokenInstruction, TokenInstruction } from '@solana-program/token';
-import { Token2022Instruction } from '@solana-program/token-2022';
-import { type Option, unwrapOption } from '@solana/kit';
-
-/**
- * A `jsonParsed` instruction, as both `simulateTransaction`'s inner instructions and
- * `getTransaction` report them. The RPC picks the parsed arm per instruction, so the unparsed one
- * survives in the union and contributes nothing here.
- */
-interface SolParsedRpcInstruction {
-	program?: string;
-	programId: SolAddress;
-	parsed: { type: string; info: object };
-}
 
 export interface SolInstructionGroup {
 	index: number;
@@ -132,216 +107,6 @@ const programAddressOf = (instruction: unknown): SolAddress | undefined => {
 	}
 };
 
-const isKitInstruction = (instruction: unknown): instruction is SolInstruction =>
-	nonNullish(instruction) &&
-	typeof instruction === 'object' &&
-	'programAddress' in instruction &&
-	'data' in instruction &&
-	'accounts' in instruction;
-
-/**
- * How one program's decoded instructions are spelled in the RPC's vocabulary.
- *
- * The decoders name an instruction by an enum member and its accounts by role, which is almost
- * exactly what the RPC reports: `TransferChecked` against `transferChecked`, `source` against
- * `source`. Where the two genuinely disagree, the difference is written down here rather than
- * handled by a branch per instruction, so a program's whole instruction set is covered at once
- * and a variant nobody thought about still arrives named.
- */
-interface ProgramVocabulary {
-	program: string;
-	names: Record<number, string>;
-	types?: Record<string, string>;
-	accounts?: Record<string, string>;
-	fields?: Record<string, string>;
-}
-
-/**
- * Built per call rather than held in a table, so that merely importing this module does not read
- * every program's enum. Consumers that mock a program package would otherwise fail to load over a
- * decoding path they never take.
- */
-const vocabularyOf = (
-	programId: SolAddress
-):
-	| (ProgramVocabulary & { parse: (instruction: SolInstruction) => SolParsedInstruction })
-	| undefined => {
-	if (programId === SYSTEM_PROGRAM_ADDRESS) {
-		return {
-			program: 'system',
-			names: SystemInstruction,
-			parse: parseSolSystemInstruction,
-			// The RPC calls a SOL transfer `transfer` and its amount `lamports`, and the effects
-			// below are written against those.
-			types: { transferSol: 'transfer' },
-			fields: { amount: 'lamports' }
-		};
-	}
-
-	// `setAuthority` is the only instruction naming the account it acts on `owned`, and `mintTo`
-	// the only one naming it `token`. The RPC calls both `account`, as everything else does.
-	if (programId === TOKEN_PROGRAM_ADDRESS) {
-		return {
-			program: 'spl-token',
-			names: TokenInstruction,
-			parse: parseSolTokenInstruction,
-			accounts: { owned: 'account', token: 'account' }
-		};
-	}
-
-	if (programId === TOKEN_2022_PROGRAM_ADDRESS) {
-		return {
-			program: 'spl-token-2022',
-			names: Token2022Instruction,
-			parse: parseSolToken2022Instruction,
-			accounts: { owned: 'account', token: 'account' }
-		};
-	}
-
-	if (programId === ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS) {
-		return {
-			program: 'spl-associated-token-account',
-			names: AssociatedTokenInstruction,
-			parse: parseSolAtaInstruction,
-			types: {
-				createAssociatedToken: 'create',
-				createAssociatedTokenIdempotent: 'createIdempotent'
-			},
-			// The RPC names the new account `account`, the wallet it belongs to `wallet` and
-			// whoever funds it `source`. Only the mint is called the same thing by both.
-			accounts: { ata: 'account', owner: 'wallet', payer: 'source' }
-		};
-	}
-
-	// Stake and address lookup table are deliberately absent. No effect is derived from either, so
-	// decoding them changes not one line of what the review shows, and reaching for their packages
-	// here pulls both into the chunk the activity loads: 132KB for an identical screen.
-};
-
-const lowerFirst = (value: string): string => `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
-
-const addressOfMeta = (meta: unknown): SolAddress | undefined =>
-	nonNullish(meta) &&
-	typeof meta === 'object' &&
-	'address' in meta &&
-	typeof meta.address === 'string'
-		? meta.address
-		: undefined;
-
-/**
- * A decoded instruction's accounts and data, flattened the way the RPC reports them.
- *
- * The discriminator is dropped, since it says only which instruction this is, and an optional
- * field that carries nothing is dropped rather than reported as empty: an authority given up is
- * an authority with no name, not one named nothing.
- */
-const infoOf = ({
-	accounts,
-	data,
-	vocabulary: { accounts: renames = {}, fields = {} }
-}: {
-	accounts: Record<string, unknown>;
-	data: Record<string, unknown>;
-	vocabulary: ProgramVocabulary;
-}): object => {
-	const named = Object.entries(accounts).reduce<Record<string, unknown>>((acc, [role, meta]) => {
-		const value = addressOfMeta(meta);
-
-		return nonNullish(value) ? { ...acc, [renames[role] ?? role]: value } : acc;
-	}, {});
-
-	return Object.entries(data).reduce<Record<string, unknown>>((acc, [key, raw]) => {
-		if (key === 'discriminator') {
-			return acc;
-		}
-
-		const value = isSolOption(raw) ? unwrapOption(raw) : raw;
-
-		return nonNullish(value) ? { ...acc, [fields[key] ?? key]: value } : acc;
-	}, named);
-};
-
-const isSolOption = (value: unknown): value is Option<SolAddress> =>
-	nonNullish(value) && typeof value === 'object' && '__option' in value;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	nonNullish(value) && typeof value === 'object';
-
-/**
- * A kit instruction read into the shape the RPC reports.
- *
- * An unsigned message carries its instructions as raw bytes, so nothing below recognised them:
- * every WalletConnect request derived an empty effect list from the message itself, which left the
- * summary permanently unstated and, once the review started listing what it could not read, put
- * "unrecognised" against a plain SOL transfer. The wallet already decodes those bytes to name the
- * parties; this puts the same decoding in front of the effects, so what a message says it does is
- * read exactly as what a run did.
- *
- * Guarded, because the decoders assert on their input: a malformed or not yet supported variant
- * must leave the instruction unread, never throw into the signing flow.
- */
-const asRpcInstruction = (instruction: unknown): SolParsedRpcInstruction | undefined => {
-	const programId = programAddressOf(instruction);
-
-	if (isNullish(programId) || !isKitInstruction(instruction)) {
-		return;
-	}
-
-	const vocabulary = vocabularyOf(programId);
-
-	if (isNullish(vocabulary)) {
-		return;
-	}
-
-	try {
-		const decoded = vocabulary.parse(instruction);
-
-		if (!('instructionType' in decoded)) {
-			return;
-		}
-
-		const { instructionType } = decoded;
-
-		const name = vocabulary.names[Number(instructionType)];
-
-		if (isNullish(name)) {
-			return;
-		}
-
-		const spelled = lowerFirst(name);
-		const type = vocabulary.types?.[spelled] ?? spelled;
-
-		const accounts = 'accounts' in decoded && isRecord(decoded.accounts) ? decoded.accounts : {};
-		const data = 'data' in decoded && isRecord(decoded.data) ? decoded.data : {};
-
-		const info = infoOf({ accounts, data, vocabulary });
-
-		return {
-			program: vocabulary.program,
-			programId,
-			parsed: {
-				type,
-				// A checked transfer or approval states the decimals alongside the amount, and the
-				// RPC reports the pair nested. Both spellings are carried so neither reader has to
-				// know which side produced the instruction.
-				info:
-					'decimals' in info && 'amount' in info
-						? {
-								...info,
-								tokenAmount: {
-									amount: String(field({ info, key: 'amount' })),
-									decimals: field({ info, key: 'decimals' })
-								}
-							}
-						: info
-			}
-		};
-	} catch (_err: unknown) {
-		// An instruction the decoders cannot read stays unread, which is the same outcome an
-		// unknown program gets and the honest one.
-	}
-};
-
 const flatten = ({
 	instructions,
 	innerInstructions
@@ -352,11 +117,8 @@ const flatten = ({
 	instructions.flatMap((instruction, parentIndex) => {
 		const inner = innerInstructions.find(({ index }) => index === parentIndex)?.instructions ?? [];
 
-		// The inner calls a run reveals arrive parsed. The message's own instructions do not, and
-		// are decoded here into the same shape rather than dropped.
 		return [instruction, ...inner]
-			.map((candidate) => (isParsed(candidate) ? candidate : asRpcInstruction(candidate)))
-			.filter(nonNullish)
+			.filter(isParsed)
 			.map((parsed) => ({ parentIndex, instruction: parsed }));
 	});
 

--- a/src/frontend/src/sol/utils/sol-instructions.utils.ts
+++ b/src/frontend/src/sol/utils/sol-instructions.utils.ts
@@ -18,6 +18,7 @@ import type { SolanaNetworkType } from '$sol/types/network';
 import type {
 	SolInstruction,
 	SolParsedInstruction,
+	SolParsedRpcInstruction,
 	SolRpcInstruction
 } from '$sol/types/sol-instructions';
 import type { MappedSolTransaction, SolMappedTransaction } from '$sol/types/sol-transaction';
@@ -37,6 +38,7 @@ import { StakeInstruction } from '@solana-program/stake';
 import { SystemInstruction } from '@solana-program/system';
 import { AssociatedTokenInstruction, TokenInstruction } from '@solana-program/token';
 import { Token2022Instruction } from '@solana-program/token-2022';
+import { type Option, unwrapOption } from '@solana/kit';
 
 const ignoredInstruction = (): MappedSolTransaction => ({ amount: undefined });
 const unreviewedInstruction = (): MappedSolTransaction => ({
@@ -762,6 +764,222 @@ const mapSolStakeInstruction = (instruction: SolParsedInstruction): MappedSolTra
 	// Decoded or not, the honest answer is that this message does more than the summary shows.
 	return unreviewedInstruction();
 };
+
+const isKitInstruction = (instruction: unknown): instruction is SolInstruction =>
+	nonNullish(instruction) &&
+	typeof instruction === 'object' &&
+	'programAddress' in instruction &&
+	'data' in instruction &&
+	'accounts' in instruction;
+
+/**
+ * How one program's decoded instructions are spelled in the RPC's vocabulary.
+ *
+ * The decoders name an instruction by an enum member and its accounts by role, which is almost
+ * exactly what the RPC reports: `TransferChecked` against `transferChecked`, `source` against
+ * `source`. Where the two genuinely disagree, the difference is written down here rather than
+ * handled by a branch per instruction, so a program's whole instruction set is covered at once
+ * and a variant nobody thought about still arrives named.
+ */
+interface ProgramVocabulary {
+	program: string;
+	names: Record<number, string>;
+	types?: Record<string, string>;
+	accounts?: Record<string, string>;
+	fields?: Record<string, string>;
+}
+
+/**
+ * Built per call rather than held in a table, so that merely importing this module does not read
+ * every program's enum. Consumers that mock a program package would otherwise fail to load over a
+ * decoding path they never take.
+ */
+const vocabularyOf = (programId: SolAddress): ProgramVocabulary | undefined => {
+	if (programId === SYSTEM_PROGRAM_ADDRESS) {
+		return {
+			program: 'system',
+			names: SystemInstruction,
+			// The RPC calls a SOL transfer `transfer` and its amount `lamports`, and the effects
+			// below are written against those.
+			types: { transferSol: 'transfer' },
+			fields: { amount: 'lamports' }
+		};
+	}
+
+	// `setAuthority` is the only instruction naming the account it acts on `owned`, and `mintTo`
+	// the only one naming it `token`. The RPC calls both `account`, as everything else does.
+	if (programId === TOKEN_PROGRAM_ADDRESS) {
+		return {
+			program: 'spl-token',
+			names: TokenInstruction,
+			accounts: { owned: 'account', token: 'account' }
+		};
+	}
+
+	if (programId === TOKEN_2022_PROGRAM_ADDRESS) {
+		return {
+			program: 'spl-token-2022',
+			names: Token2022Instruction,
+			accounts: { owned: 'account', token: 'account' }
+		};
+	}
+
+	if (programId === ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ADDRESS) {
+		return {
+			program: 'spl-associated-token-account',
+			names: AssociatedTokenInstruction,
+			types: {
+				createAssociatedToken: 'create',
+				createAssociatedTokenIdempotent: 'createIdempotent'
+			},
+			// The RPC names the new account `account`, the wallet it belongs to `wallet` and
+			// whoever funds it `source`. Only the mint is called the same thing by both.
+			accounts: { ata: 'account', owner: 'wallet', payer: 'source' }
+		};
+	}
+
+	// Stake and address lookup table are deliberately absent. No effect is derived from either, so
+	// decoding them changes not one line of what the review shows, and reaching for their packages
+	// here pulls both into the chunk the activity loads: 132KB for an identical screen.
+};
+
+const fieldOf = ({ info, key }: { info: object; key: string }): unknown =>
+	(info as Record<string, unknown>)[key];
+
+const lowerFirst = (value: string): string => `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
+
+const addressOfMeta = (meta: unknown): SolAddress | undefined =>
+	nonNullish(meta) &&
+	typeof meta === 'object' &&
+	'address' in meta &&
+	typeof meta.address === 'string'
+		? meta.address
+		: undefined;
+
+/**
+ * A decoded instruction's accounts and data, flattened the way the RPC reports them.
+ *
+ * The discriminator is dropped, since it says only which instruction this is, and an optional
+ * field that carries nothing is dropped rather than reported as empty: an authority given up is
+ * an authority with no name, not one named nothing.
+ */
+const infoOf = ({
+	accounts,
+	data,
+	vocabulary: { accounts: renames = {}, fields = {} }
+}: {
+	accounts: Record<string, unknown>;
+	data: Record<string, unknown>;
+	vocabulary: ProgramVocabulary;
+}): object => {
+	const named = Object.entries(accounts).reduce<Record<string, unknown>>((acc, [role, meta]) => {
+		const value = addressOfMeta(meta);
+
+		return nonNullish(value) ? { ...acc, [renames[role] ?? role]: value } : acc;
+	}, {});
+
+	return Object.entries(data).reduce<Record<string, unknown>>((acc, [key, raw]) => {
+		if (key === 'discriminator') {
+			return acc;
+		}
+
+		const value = isSolOption(raw) ? unwrapOption(raw) : raw;
+
+		return nonNullish(value) ? { ...acc, [fields[key] ?? key]: value } : acc;
+	}, named);
+};
+
+const isSolOption = (value: unknown): value is Option<SolAddress> =>
+	nonNullish(value) && typeof value === 'object' && '__option' in value;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	nonNullish(value) && typeof value === 'object';
+
+/**
+ * A kit instruction read into the shape the RPC reports.
+ *
+ * An unsigned message carries its instructions as raw bytes, so nothing below recognised them:
+ * every WalletConnect request derived an empty effect list from the message itself, which left the
+ * summary permanently unstated and, once the review started listing what it could not read, put
+ * "unrecognised" against a plain SOL transfer. The wallet already decodes those bytes to name the
+ * parties; this puts the same decoding in front of the effects, so what a message says it does is
+ * read exactly as what a run did.
+ *
+ * Guarded, because the decoders assert on their input: a malformed or not yet supported variant
+ * must leave the instruction unread, never throw into the signing flow.
+ */
+export const asSolParsedRpcInstruction = (
+	instruction: unknown
+): SolParsedRpcInstruction | undefined => {
+	if (!isKitInstruction(instruction)) {
+		return;
+	}
+
+	const programId = instruction.programAddress;
+
+	const vocabulary = vocabularyOf(programId);
+
+	if (isNullish(vocabulary)) {
+		return;
+	}
+
+	try {
+		const decoded = parseSolInstruction(instruction);
+
+		if (!('instructionType' in decoded)) {
+			return;
+		}
+
+		const { instructionType } = decoded;
+
+		const name = vocabulary.names[Number(instructionType)];
+
+		if (isNullish(name)) {
+			return;
+		}
+
+		const spelled = lowerFirst(name);
+		const type = vocabulary.types?.[spelled] ?? spelled;
+
+		const accounts = 'accounts' in decoded && isRecord(decoded.accounts) ? decoded.accounts : {};
+		const data = 'data' in decoded && isRecord(decoded.data) ? decoded.data : {};
+
+		const info = infoOf({ accounts, data, vocabulary });
+
+		return {
+			program: vocabulary.program,
+			programId,
+			parsed: {
+				type,
+				// A checked transfer or approval states the decimals alongside the amount, and the
+				// RPC reports the pair nested. Both spellings are carried so neither reader has to
+				// know which side produced the instruction.
+				info:
+					'decimals' in info && 'amount' in info
+						? {
+								...info,
+								tokenAmount: {
+									amount: String(fieldOf({ info, key: 'amount' })),
+									decimals: fieldOf({ info, key: 'decimals' })
+								}
+							}
+						: info
+			}
+		};
+	} catch (_err: unknown) {
+		// An instruction the decoders cannot read stays unread, which is the same outcome an
+		// unknown program gets and the honest one.
+	}
+};
+
+/**
+ * The same, but total: an instruction the wallet cannot decode keeps its place in the list.
+ *
+ * Dropping it would shift every instruction after it, and both the route programs and the count of
+ * what could not be read are addressed by position.
+ */
+export const asSolParsedRpcInstructionOrSelf = (instruction: unknown): unknown =>
+	asSolParsedRpcInstruction(instruction) ?? instruction;
 
 export const mapSolInstruction = (instruction: SolInstruction): MappedSolTransaction => {
 	// Compute budget instructions can never move funds, but they do set the prioritisation

--- a/src/frontend/src/tests/sol/utils/sol-instruction-summary.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-instruction-summary.utils.spec.ts
@@ -2,6 +2,7 @@ import { WSOL_TOKEN } from '$env/tokens/tokens-spl/tokens.wsol.env';
 import { ZERO } from '$lib/constants/app.constants';
 import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
 import { mapSolInstructionSummaries } from '$sol/utils/sol-instruction-summary.utils';
+import { asSolParsedRpcInstructionOrSelf } from '$sol/utils/sol-instructions.utils';
 import { MOCK_SOL_INSTRUCTIONS } from '$tests/mocks/sol-instructions.mock';
 import { mockAtaAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
 import { getTransferSolInstruction } from '@solana-program/system';
@@ -503,8 +504,23 @@ describe('sol-instruction-summary.utils', () => {
 
 			const signer = (address: string) => ({ address }) as never;
 
+			// A message delivers kit instructions; the review decodes them before the effects are
+			// read. Going straight to the mapper would test a path no caller takes.
+			const summariesFromMessage = ({
+				instructions,
+				...rest
+			}: {
+				instructions: unknown[];
+				ownedAddresses: string[];
+				includeUnrecognised?: boolean;
+			}): SolInstructionSummary[] =>
+				mapSolInstructionSummaries({
+					...rest,
+					instructions: instructions.map(asSolParsedRpcInstructionOrSelf)
+				});
+
 			it('should read a plain SOL transfer as the send it is', () => {
-				const [transfer] = mapSolInstructionSummaries({
+				const [transfer] = summariesFromMessage({
 					instructions: [
 						getTransferSolInstruction({
 							source: signer(me),
@@ -526,7 +542,7 @@ describe('sol-instruction-summary.utils', () => {
 			it('should not call a transfer it can read unrecognised', () => {
 				expect(
 					kinds(
-						mapSolInstructionSummaries({
+						summariesFromMessage({
 							instructions: [
 								getTransferSolInstruction({
 									source: signer(me),
@@ -542,7 +558,7 @@ describe('sol-instruction-summary.utils', () => {
 			});
 
 			it('should read a checked SPL transfer with its mint and decimals', () => {
-				const [transfer] = mapSolInstructionSummaries({
+				const [transfer] = summariesFromMessage({
 					instructions: [
 						getTransferCheckedInstruction({
 							source: toAddress(mockAtaAddress),
@@ -565,7 +581,7 @@ describe('sol-instruction-summary.utils', () => {
 			// Granting a spender is the instruction behind most drains, so a message that carries one
 			// must not read as something the wallet could not make out.
 			it('should read an approval with its delegate', () => {
-				const [approval] = mapSolInstructionSummaries({
+				const [approval] = summariesFromMessage({
 					instructions: [
 						getApproveInstruction({
 							source: toAddress(mockAtaAddress),
@@ -584,7 +600,7 @@ describe('sol-instruction-summary.utils', () => {
 			});
 
 			it('should read a checked approval the same way', () => {
-				const [approval] = mapSolInstructionSummaries({
+				const [approval] = summariesFromMessage({
 					instructions: [
 						getApproveCheckedInstruction({
 							source: toAddress(mockAtaAddress),
@@ -604,7 +620,7 @@ describe('sol-instruction-summary.utils', () => {
 			});
 
 			it('should read a revocation', () => {
-				const [revocation] = mapSolInstructionSummaries({
+				const [revocation] = summariesFromMessage({
 					instructions: [
 						getRevokeInstruction({ source: toAddress(mockAtaAddress), owner: toAddress(me) })
 					],
@@ -618,7 +634,7 @@ describe('sol-instruction-summary.utils', () => {
 			// Handing an account to someone else moves nothing, so no amount and no balance change
 			// reports it. Naming the new authority is the only way the review can show it happening.
 			it('should read an authority handover with the authority it names', () => {
-				const [handover] = mapSolInstructionSummaries({
+				const [handover] = summariesFromMessage({
 					instructions: [
 						getSetAuthorityInstruction({
 							owned: toAddress(mockAtaAddress),
@@ -638,7 +654,7 @@ describe('sol-instruction-summary.utils', () => {
 			// Neither is a transfer, so no counterparty names either and nothing but the instruction
 			// says which way the balance went.
 			it('should read a burn as the tokens it destroys', () => {
-				const [burn] = mapSolInstructionSummaries({
+				const [burn] = summariesFromMessage({
 					instructions: [
 						getBurnInstruction({
 							account: toAddress(mockAtaAddress),
@@ -656,7 +672,7 @@ describe('sol-instruction-summary.utils', () => {
 			});
 
 			it('should read a mint as the tokens it creates', () => {
-				const [minted] = mapSolInstructionSummaries({
+				const [minted] = summariesFromMessage({
 					instructions: [
 						getMintToInstruction({
 							mint: toAddress(mint),
@@ -674,7 +690,7 @@ describe('sol-instruction-summary.utils', () => {
 
 			// A frozen account holds exactly what it held, so no balance anywhere reports it.
 			it('should read a freeze, which no balance change can show', () => {
-				const [frozen] = mapSolInstructionSummaries({
+				const [frozen] = summariesFromMessage({
 					instructions: [
 						getFreezeAccountInstruction({
 							account: toAddress(mockAtaAddress),
@@ -693,7 +709,7 @@ describe('sol-instruction-summary.utils', () => {
 			// variant they do not cover.
 			it('should leave an instruction it cannot decode unread rather than throwing', () => {
 				expect(() =>
-					mapSolInstructionSummaries({
+					summariesFromMessage({
 						instructions: [
 							{
 								programAddress: '11111111111111111111111111111111',


### PR DESCRIPTION
# Motivation

#13937 landed the message decoding inside the effect mapper, and that mapper is what the activity list uses to build its own instruction list. So the token, token-2022 and system packages ended up in the chunk the activity loads, to serve code only the WalletConnect review ever runs.

That is 120KB over the 100KB `compare-sizes` allows. The check failed on the merged commit; this is the fix that did not make it in with it.

It also leaves the same dispatch written twice. Choosing a parser by program address already exists as `parseSolInstruction`, in the module this moves to.

# Changes

- The decoding moves to `sol-instructions.utils`, which is WalletConnect-only and already holds every parser it needs.
- It reuses `parseSolInstruction` rather than carrying a second copy of the same program-address dispatch. The vocabulary now sits on top of that one dispatcher.
- The three WalletConnect callers decode their message before handing it over, so the effect mapper goes back to understanding exactly one shape, the one the RPC reports. Its only remaining new import is a type, which the build erases.
- An instruction that will not decode keeps its place in the list: dropping it would shift the ones after it, and both the route programs and the count of what could not be read are addressed by position.

# Tests

No behaviour change, so the existing cases carry it: the message tests now run through the decode the callers actually perform rather than reaching into the mapper directly, which is what a caller does.

Bundle measured with the check's own method: 14032KB, the same as the branch reads with the merged version of the changed file.