### PR TITLE
fix(frontend): state what a swap traded, not the rent it paid on the way

### DIFF
--- a/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
+++ b/src/frontend/src/sol/utils/sol-transaction-summary.utils.ts
@@ -158,9 +158,23 @@ export const deriveSolTransactionSummary = ({
 }): SolTransactionSummary => {
 	const traded = tradedTokens(instructions);
 
-	const considered = netChanges.filter(
-		(change) => !isSolNetBalanceChangeSol(change) || traded.has(undefined)
-	);
+	// Rent leaves the wallet address but is not traded, and the balance the chain reports cannot
+	// tell the two apart. A swap of 0.001 SOL that opens an account on the way spends 0.00310888
+	// of it, and stating that as the amount traded overstates the trade by the rent every time.
+	//
+	// The account is still the user's and closing it hands the rent back, so what it costs the
+	// transaction is stated as a fee of its own, beside this line rather than inside it. The
+	// balance changes keep the figure the chain reports: this is what the transaction did, not
+	// what the address holds.
+	const rent = solAtaFee(instructions);
+
+	const considered = netChanges
+		.filter((change) => !isSolNetBalanceChangeSol(change) || traded.has(undefined))
+		.map((change) =>
+			isSolNetBalanceChangeSol(change) && rent !== ZERO
+				? { ...change, delta: change.delta + rent }
+				: change
+		);
 
 	const outs = considered.filter(({ delta }) => delta < ZERO);
 	const ins = considered.filter(({ delta }) => delta > ZERO);

--- a/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/sol-transaction-summary.utils.spec.ts
@@ -49,6 +49,60 @@ describe('sol-transaction-summary.utils', () => {
 			expect(result.counterparty).toBe('DkngoujigUiRtizQViQPpHUSgJWMg3o3dLVAfj7eEjT2');
 		});
 
+		// Taken from 469iBc7...VprPgtP on mainnet. The wallet address falls by 0.00310888 SOL, of
+		// which only 0.001 was wrapped and traded: the rest is the rent of the PUMP account the
+		// swap opened on the way. Stating the fall as the amount traded overstates the trade, and
+		// it does so on every swap that opens an account.
+		it('should state what a swap traded, not the rent it paid on the way', () => {
+			const wsol = mockAtaAddress;
+			const pump = mockAtaAddress2;
+
+			const result = deriveSolTransactionSummary({
+				netChanges: [
+					{ delta: -3_108_880n },
+					{
+						tokenAddress: 'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn',
+						delta: 37_272_943n,
+						decimals: 6
+					}
+				],
+				instructions: [
+					{ kind: 'createTokenAccount', account: wsol, rent: 2_039_280n },
+					{ kind: 'wrap', amount: 1_000_000n },
+					{ kind: 'unwrap', account: wsol, returned: 3_039_280n },
+					{ kind: 'createTokenAccount', account: pump, rent: 2_108_880n }
+				]
+			});
+
+			expect(result.kind).toBe('swap');
+			expect(result.spent?.delta).toBe(-1_000_000n);
+			expect(result.received?.delta).toBe(37_272_943n);
+		});
+
+		// The rent came straight back, so it never cost the transaction anything and the amount
+		// traded is the fall in the balance exactly.
+		it('should leave a swap alone when the accounts it opens are all closed again', () => {
+			const wsol = mockAtaAddress;
+
+			const result = deriveSolTransactionSummary({
+				netChanges: [
+					{ delta: -1_000_000n },
+					{
+						tokenAddress: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+						delta: 250_000n,
+						decimals: 6
+					}
+				],
+				instructions: [
+					{ kind: 'createTokenAccount', account: wsol, rent: 2_039_280n },
+					{ kind: 'wrap', amount: 1_000_000n },
+					{ kind: 'unwrap', account: wsol, returned: 3_039_280n }
+				]
+			});
+
+			expect(result.spent?.delta).toBe(-1_000_000n);
+		});
+
 		it('should call a routed swap a swap with the pair at its ends', () => {
 			const result = summary('JUPITER_SWAP');
 


### PR DESCRIPTION
# Motivation

A swap that opens a token account pays that account's rent out of the same balance it trades from, and the chain reports a single figure for both. The summary read that figure as the amount traded.

Found on staging and verified against the chain. Transaction `469iBc7...VprPgtP`:

| | lamports | SOL |
| --- | --- | --- |
| user's balance falls by | 3,128,042 | |
| less the fee | 19,162 | |
| net | 3,108,880 | 0.00310888 |
| of which wrapped and traded | 1,000,000 | 0.001 |
| of which rent for the PUMP account | 2,108,880 | 0.00210888 |

The modal states `0.00310888 SOL -> 37.272943 PUMP`. Only 0.001 SOL was traded. This happens on every swap that opens an account, and it overstates the trade by the rent each time.

# Changes

- Rent is taken out of the SOL side before the summary is read from it, using `solAtaFee`, the same netting the ATA fee line already does. The rent then appears once, as a fee of its own, rather than twice.
- A swap that closes every account it opens is unaffected: the rent came straight back, so it never cost the transaction anything and the fall in the balance is the amount traded exactly.
- The balance changes are deliberately untouched. They report what the chain reports, which is what the transaction did to the address, and that remains the right answer to a different question: the rent did leave the address, even though the account is still the user's and closing it hands it back.

# Tests

The transaction above, as its own case: it asserts `-1_000_000n`, and without the fix it produces `-3_108_880n`, the figure staging shows today. Plus the wrap-and-unwrap case, where nothing should change.