### PR TITLE
ci(devops): raise the backend reserved cycles limit to 20 TC on every deploy

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -138,6 +138,11 @@ permissions: {}
 
 env:
   DFX_WARNING: '-mainnet_plaintext_identity'
+  # Upper bound on the cycles the subnet may set aside for the backend's storage (20 TC).
+  # The IC default is 5 TC. Once a subnet passes 450 GiB of storage every new memory
+  # allocation reserves cycles, and a canister whose reserve has hit its limit can no
+  # longer grow. The test backend already had to reserve 11 TC on a subnet past 750 GiB.
+  BACKEND_RESERVED_CYCLES_LIMIT: '20000000000000'
 
 jobs:
   deployment:
@@ -516,3 +521,14 @@ jobs:
           FORCE_BACKEND: ${{ github.event.inputs.force-backend }}
           DFX_DEPLOY_KEY: ${{ steps.set-outputs.outputs.DFX_DEPLOY_KEY }}
           BASE_REF: ${{ github.base_ref }}
+
+      # Applied on every backend run, not only when the wasm changed, so that the limit
+      # cannot drift away from the value above. Production is controlled by the Orbit
+      # station and is set through an Orbit request instead (see README.md, "Ops").
+      - name: Apply Backend Canister Settings
+        run: |
+          if [ "$deploy_backend" == "true" ]; then
+            dfx canister update-settings backend --network "$NETWORK" --reserved-cycles-limit "$BACKEND_RESERVED_CYCLES_LIMIT"
+          fi
+        env:
+          DFX_DEPLOY_KEY: ${{ steps.set-outputs.outputs.DFX_DEPLOY_KEY }}

--- a/README.md
+++ b/README.md
@@ -200,16 +200,24 @@ A reserved cycles limit is a canister setting: it survives upgrades, and `dfx de
 
 The production backend (`doked-biaaa-aaaar-qag2a-cai`) is controlled by the `oisy-prod` Orbit station, so the limit is set through a station request that reviewers approve.
 
-There is currently no `dfx-orbit` command for it. `request canister update-settings` only builds a controller list and leaves every other field unset, and routing it as a `request canister call` to the management canister is rejected by the station at request creation. So today this is done from the Orbit web UI, by configuring the backend canister's native settings and setting `reserved_cycles_limit` to `20_000_000_000_000`. Leave every other field untouched.
+There is no `dfx-orbit` command that can submit it. `request canister update-settings` only ever builds a controller list and leaves every other setting unset. Routing it as a `request canister call` to the management canister does not work either: the station has exactly one external canister registered, the backend itself, so a call request against `aaaaa-aa` is refused whatever permissions the caller holds.
 
-Once submitted, the request is reviewed and approved the same way as any other:
+The operation that does work is `ConfigureExternalCanister` with the `NativeSettings` kind, against the registered backend, which needs the `Change` permission on that canister. Submit it either from the Orbit web UI or with a direct station call:
+
+```
+dfx canister call 7hkwe-3qaaa-aaaal-amhvq-cai create_request --network ic '(record { operation = variant { ConfigureExternalCanister = record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai"; kind = variant { NativeSettings = record { reserved_cycles_limit = opt (20_000_000_000_000 : nat) } } } }; title = opt "Raise backend reserved cycles limit to 20 TC"; summary = null; execution_plan = null; expiration_dt = null; deduplication_key = null; tags = null })'
+```
+
+Every settings field other than `reserved_cycles_limit` is omitted, which the management canister reads as unchanged, so the controller list is untouched.
+
+From there it is the normal review flow. Reviewers approve rather than verify, since `dfx-orbit verify canister update-settings` only compares controller sets and would report a mismatch:
 
 ```
 dfx-orbit --station oisy-prod review list --only-approvable
 dfx-orbit --station oisy-prod review id $REQUEST_ID --approve
 ```
 
-Note that `dfx-orbit` reports station rejections as `The station API returned an error: 0`, which is a formatting bug in the tool rather than the real reason.
+Note that `dfx-orbit` prints every station rejection as `The station API returned an error: 0`. That is a formatting bug in the tool, not the real reason, so do not read anything into the number.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,23 @@ dfx canister call backend set_new_user_signups_allowed '(true)'
 - **New users (no existing profile):** sign-up is rejected with `SignupsClosed`. They cannot create a profile or use the wallet until the flag is flipped back to `true`.
 - **Existing users (profile already created):** unaffected. They can keep signing in and using the wallet exactly as before.
 
+### Backend reserved cycles limit
+
+Once a subnet holds more than 450 GiB of storage, every new memory allocation makes the IC set aside cycles from the canister's main balance as a reserve for that storage. The reserve is capped by the canister's `reserved_cycles_limit` (5 TC by default). A canister whose reserve has reached the limit can no longer allocate memory, so the backend runs with a limit of **20 TC** on every environment.
+
+#### How it is applied
+
+- **Staging, beta, test and audit backends:** the `deploy-to-environment` workflow runs `dfx canister update-settings --reserved-cycles-limit` on every backend deployment run, whether or not the wasm changed. The value lives in `BACKEND_RESERVED_CYCLES_LIMIT` in [`.github/workflows/deploy-to-environment.yml`](.github/workflows/deploy-to-environment.yml).
+- **Production:** the production backend is controlled by the Orbit station, and `dfx-orbit request canister update-settings` only manages controllers. Raise the limit with an Orbit request that configures the external canister's native settings (`reserved_cycles_limit`), then have it approved through the station.
+
+To check the current limit and the reserve in use:
+
+```
+dfx canister status backend --network <network>
+```
+
+The output reports both `Reserved cycles limit` and `Reserved`.
+
 ## Dependencies
 
 [//]: # 'TODO: Add fonts that are bought and owned by DFINITY too.'

--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ Once a subnet holds more than 450 GiB of storage, every new memory allocation ma
 
 #### How it is applied
 
-- **Staging, beta, test and audit backends:** the `deploy-to-environment` workflow runs `dfx canister update-settings --reserved-cycles-limit` on every backend deployment run, whether or not the wasm changed. The value lives in `BACKEND_RESERVED_CYCLES_LIMIT` in [`.github/workflows/deploy-to-environment.yml`](.github/workflows/deploy-to-environment.yml).
-- **Production:** the production backend is controlled by the Orbit station, and `dfx-orbit request canister update-settings` only manages controllers. Raise the limit with an Orbit request that configures the external canister's native settings (`reserved_cycles_limit`), then have it approved through the station.
+A reserved cycles limit is a canister setting: it survives upgrades, and `dfx deploy` never resets it. `initialization_values` in `dfx.json` is not enough either, because dfx only applies those when it _creates_ a canister and every backend canister already exists. The limit therefore has to be set explicitly, once per canister.
+
+- **Staging, beta, test and audit backends:** the `deploy-to-environment` workflow runs `dfx canister update-settings --reserved-cycles-limit` on every backend deployment run, whether or not the wasm changed. The value lives in `BACKEND_RESERVED_CYCLES_LIMIT` in [`.github/workflows/deploy-to-environment.yml`](.github/workflows/deploy-to-environment.yml). Staging is covered on the next push to `main`, beta on the next release tag.
+- **Production:** no workflow deploys the production backend, so CI never touches its settings. The canister is controlled by the Orbit station, and the `dfx-orbit` CLI cannot set this field (`request canister update-settings` only adds and removes controllers). It takes a `ConfigureExternalCanister` request whose operation kind is `NativeSettings`, carrying `reserved_cycles_limit`, submitted and approved through the station.
 
 To check the current limit and the reserve in use:
 

--- a/README.md
+++ b/README.md
@@ -198,45 +198,39 @@ A reserved cycles limit is a canister setting: it survives upgrades, and `dfx de
 
 #### Raising the limit on production
 
-The production backend (`doked-biaaa-aaaar-qag2a-cai`) is controlled by the `oisy-prod` Orbit station (`7hkwe-3qaaa-aaaal-amhvq-cai`). This follows the usual developer-requests / reviewers-approve flow from the internal OISY to Orbit guide, with one difference: there is nothing to rebuild, so reviewers read the request instead of reproducing a Wasm with `dfx-orbit verify`.
+The production backend (`doked-biaaa-aaaar-qag2a-cai`) is controlled by the `oisy-prod` Orbit station, so this follows the usual developer-requests / reviewers-approve flow.
 
-Everyone involved first points at the right station:
+`dfx-orbit request canister update-settings` only adds and removes controllers, so the limit is set by having the station call the management canister for the backend. The station is a controller, so the call is accepted. Every settings field other than `reserved_cycles_limit` is omitted, which the management canister reads as unchanged, so the controller list is untouched.
+
+Point at the station first:
 
 ```
 dfx-orbit station use oisy-prod
 dfx-orbit me
 ```
 
-**Developer.** `dfx-orbit request canister update-settings` only adds and removes controllers, so this request is submitted as a direct station call:
+The **developer** submits the request:
 
 ```
-dfx canister call 7hkwe-3qaaa-aaaal-amhvq-cai create_request --network ic '(record { operation = variant { ConfigureExternalCanister = record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai"; kind = variant { NativeSettings = record { reserved_cycles_limit = opt (20_000_000_000_000 : nat) } } } }; title = opt "Raise backend reserved cycles limit to 20 TC" })'
+dfx-orbit --station oisy-prod \
+  request canister call aaaaa-aa update_settings \
+  '(record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai"; settings = record { reserved_cycles_limit = opt (20_000_000_000_000 : nat) } })'
 ```
 
-Take the request id out of the reply and share it with the reviewers.
-
-**Reviewers.** Find it and approve it:
+The resulting request id goes to the **reviewers**. There is no Wasm to rebuild here, but the argument is checksummed, so they verify it rather than approving blind:
 
 ```
-dfx-orbit review list --only-approvable
-dfx-orbit review id "$REQUEST_ID" --approve
+dfx-orbit --station oisy-prod \
+  verify $REQUEST_ID --and-approve \
+  canister call aaaaa-aa update_settings \
+  '(record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai"; settings = record { reserved_cycles_limit = opt (20_000_000_000_000 : nat) } })'
 ```
 
-Before approving, check the printed request targets `doked-biaaa-aaaar-qag2a-cai`, sets `reserved_cycles_limit` to `20_000_000_000_000`, and leaves every other field null. Null means unchanged, so the controller list must not be listed there.
-
-**Afterwards.** A non-controller cannot call `dfx canister status` on the production backend, so read it back through the station:
+Once it has executed, the request shows the call and its reply:
 
 ```
-dfx canister call 7hkwe-3qaaa-aaaal-amhvq-cai canister_status --network ic '(record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai" })'
+dfx-orbit --station oisy-prod review id $REQUEST_ID
 ```
-
-To check the current limit and the reserve in use:
-
-```
-dfx canister status backend --network <network>
-```
-
-The output reports both `Reserved cycles limit` and `Reserved`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -198,39 +198,18 @@ A reserved cycles limit is a canister setting: it survives upgrades, and `dfx de
 
 #### Raising the limit on production
 
-The production backend (`doked-biaaa-aaaar-qag2a-cai`) is controlled by the `oisy-prod` Orbit station, so this follows the usual developer-requests / reviewers-approve flow.
+The production backend (`doked-biaaa-aaaar-qag2a-cai`) is controlled by the `oisy-prod` Orbit station, so the limit is set through a station request that reviewers approve.
 
-`dfx-orbit request canister update-settings` only adds and removes controllers, so the limit is set by having the station call the management canister for the backend. The station is a controller, so the call is accepted. Every settings field other than `reserved_cycles_limit` is omitted, which the management canister reads as unchanged, so the controller list is untouched.
+There is currently no `dfx-orbit` command for it. `request canister update-settings` only builds a controller list and leaves every other field unset, and routing it as a `request canister call` to the management canister is rejected by the station at request creation. So today this is done from the Orbit web UI, by configuring the backend canister's native settings and setting `reserved_cycles_limit` to `20_000_000_000_000`. Leave every other field untouched.
 
-Point at the station first:
-
-```
-dfx-orbit station use oisy-prod
-dfx-orbit me
-```
-
-The **developer** submits the request:
+Once submitted, the request is reviewed and approved the same way as any other:
 
 ```
-dfx-orbit --station oisy-prod \
-  request canister call aaaaa-aa update_settings \
-  '(record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai"; settings = record { reserved_cycles_limit = opt (20_000_000_000_000 : nat) } })'
+dfx-orbit --station oisy-prod review list --only-approvable
+dfx-orbit --station oisy-prod review id $REQUEST_ID --approve
 ```
 
-The resulting request id goes to the **reviewers**. There is no Wasm to rebuild here, but the argument is checksummed, so they verify it rather than approving blind:
-
-```
-dfx-orbit --station oisy-prod \
-  verify $REQUEST_ID --and-approve \
-  canister call aaaaa-aa update_settings \
-  '(record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai"; settings = record { reserved_cycles_limit = opt (20_000_000_000_000 : nat) } })'
-```
-
-Once it has executed, the request shows the call and its reply:
-
-```
-dfx-orbit --station oisy-prod review id $REQUEST_ID
-```
+Note that `dfx-orbit` reports station rejections as `The station API returned an error: 0`, which is a formatting bug in the tool rather than the real reason.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,41 @@ Once a subnet holds more than 450 GiB of storage, every new memory allocation ma
 A reserved cycles limit is a canister setting: it survives upgrades, and `dfx deploy` never resets it. `initialization_values` in `dfx.json` is not enough either, because dfx only applies those when it _creates_ a canister and every backend canister already exists. The limit therefore has to be set explicitly, once per canister.
 
 - **Staging, beta, test and audit backends:** the `deploy-to-environment` workflow runs `dfx canister update-settings --reserved-cycles-limit` on every backend deployment run, whether or not the wasm changed. The value lives in `BACKEND_RESERVED_CYCLES_LIMIT` in [`.github/workflows/deploy-to-environment.yml`](.github/workflows/deploy-to-environment.yml). Staging is covered on the next push to `main`, beta on the next release tag.
-- **Production:** no workflow deploys the production backend, so CI never touches its settings. The canister is controlled by the Orbit station, and the `dfx-orbit` CLI cannot set this field (`request canister update-settings` only adds and removes controllers). It takes a `ConfigureExternalCanister` request whose operation kind is `NativeSettings`, carrying `reserved_cycles_limit`, submitted and approved through the station.
+- **Production:** no workflow deploys the production backend, so CI never touches its settings. It goes through the Orbit station — see below.
+
+#### Raising the limit on production
+
+The production backend (`doked-biaaa-aaaar-qag2a-cai`) is controlled by the `oisy-prod` Orbit station (`7hkwe-3qaaa-aaaal-amhvq-cai`). This follows the usual developer-requests / reviewers-approve flow from the internal OISY to Orbit guide, with one difference: there is nothing to rebuild, so reviewers read the request instead of reproducing a Wasm with `dfx-orbit verify`.
+
+Everyone involved first points at the right station:
+
+```
+dfx-orbit station use oisy-prod
+dfx-orbit me
+```
+
+**Developer.** `dfx-orbit request canister update-settings` only adds and removes controllers, so this request is submitted as a direct station call:
+
+```
+dfx canister call 7hkwe-3qaaa-aaaal-amhvq-cai create_request --network ic '(record { operation = variant { ConfigureExternalCanister = record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai"; kind = variant { NativeSettings = record { reserved_cycles_limit = opt (20_000_000_000_000 : nat) } } } }; title = opt "Raise backend reserved cycles limit to 20 TC" })'
+```
+
+Take the request id out of the reply and share it with the reviewers.
+
+**Reviewers.** Find it and approve it:
+
+```
+dfx-orbit review list --only-approvable
+dfx-orbit review id "$REQUEST_ID" --approve
+```
+
+Before approving, check the printed request targets `doked-biaaa-aaaar-qag2a-cai`, sets `reserved_cycles_limit` to `20_000_000_000_000`, and leaves every other field null. Null means unchanged, so the controller list must not be listed there.
+
+**Afterwards.** A non-controller cannot call `dfx canister status` on the production backend, so read it back through the station:
+
+```
+dfx canister call 7hkwe-3qaaa-aaaal-amhvq-cai canister_status --network ic '(record { canister_id = principal "doked-biaaa-aaaar-qag2a-cai" })'
+```
 
 To check the current limit and the reserve in use:
 


### PR DESCRIPTION
# Motivation

Every canister starts with a reserved cycles limit of 5 TC. Once a subnet holds more than 450 GiB of storage, each new memory allocation sets cycles aside from the canister's main balance, and a canister whose reserve has reached its limit can no longer grow. The test backend on a subnet past 750 GiB has already reserved 11 TC and was raised to 20 TC by hand. If the fiduciary subnet fills up again the production backend hits the same wall, so the backend should run with a 20 TC limit everywhere.

Measured current state:

| Environment | Reserved cycles limit | Reserved |
| --- | --- | --- |
| staging | 5 TC | 0 |
| beta | 5 TC | 0 |
| audit | 5 TC | 0 |
| test_be_1 | 20 TC | 11.06 TC |
| production | not readable without station access | — |

A reserved cycles limit is a canister setting: it survives upgrades and `dfx deploy` never resets it. `initialization_values` in `dfx.json` would not help either, since dfx applies those only when it creates a canister and every backend canister already exists. The limit has to be set explicitly with `dfx canister update-settings`.

# Changes

- `deploy-to-environment.yml`: a new `BACKEND_RESERVED_CYCLES_LIMIT` (20 TC) and an `Apply Backend Canister Settings` step that runs `dfx canister update-settings backend --reserved-cycles-limit` on every backend deployment run, even when the wasm is unchanged, so the value cannot drift. This covers staging, beta, test_be and audit.
- `README.md`: an Ops entry describing the limit, how each environment gets it, and how to check it.

# What this PR does not do

This PR alone does not close the ticket.

- **Production is not covered.** No workflow deploys the production backend, so CI never touches its settings. It is controlled by the `oisy-prod` Orbit station and needs a request submitted by a developer and approved by reviewers. `dfx-orbit request canister update-settings` only handles controllers, so the README documents doing it with `dfx-orbit request canister call` on the management canister, which the station is a controller for. Reviewers verify the argument checksum with `dfx-orbit verify --and-approve`.
- **Staging and beta only change on their next deploy** — the next push to `main` and the next release tag respectively. Applying it sooner means running `dfx canister update-settings` by hand.

Note: this touches `.github/workflows/`, which is a restricted area.

# Tests

- `npx prettier --check` on both files passes.
- `actionlint` reports only pre-existing shellcheck notes on untouched steps.
- `zizmor --persona pedantic .github` reports the same four pre-existing findings on this workflow before and after the change.
- Controller access was confirmed for staging, beta, audit and test_be_1 by reading `dfx canister status backend`, which is a controller-only call, so the new step will not fail for want of permissions on the environments CI deploys.
- Verify after a deploy with `dfx canister status backend --network <network>`, which should print a `Reserved cycles limit` of 20 TC.

