### PR TITLE
fix(frontend): judge a Bitcoin fee against the rate it was quoted at

### DIFF
--- a/src/frontend/src/btc/services/btc-send.services.ts
+++ b/src/frontend/src/btc/services/btc-send.services.ts
@@ -1,10 +1,9 @@
 import { BTC_SEND_FEE_TOLERANCE_PERCENTAGE } from '$btc/constants/btc.constants';
 import { loadBtcPendingSentTransactions } from '$btc/services/btc-pending-sent-transactions.services';
-import { getFeeRateFromPercentiles } from '$btc/services/btc-utxos.service';
 import type { BtcAddress } from '$btc/types/address';
 import { BtcSendValidationError, BtcValidationError, type UtxosFee } from '$btc/types/btc-send';
 import { convertNumberToSatoshis } from '$btc/utils/btc-send.utils';
-import { estimateTransactionVSize, extractUtxoOutpoints } from '$btc/utils/btc-utxos.utils';
+import { calculateFeeSatoshis, extractUtxoOutpoints } from '$btc/utils/btc-utxos.utils';
 import type { SendBtcResponse, SignBtcResponse } from '$declarations/signer/signer.did';
 import { getPendingTransactionUtxoOutpoints, txidStringToUint8Array } from '$icp/utils/btc.utils';
 import { addPendingBtcTransaction } from '$lib/api/backend.api';
@@ -126,7 +125,7 @@ export const validateBtcSend = async ({
 		throw new BtcValidationError(BtcSendValidationError.InvalidAmount);
 	}
 
-	const { utxos, feeSatoshis } = utxosFee;
+	const { utxos, feeSatoshis, feeRateMiliSatoshisPerVByte } = utxosFee;
 	const amountSatoshis = convertNumberToSatoshis({ amount });
 
 	if (utxos.length === 0) {
@@ -179,21 +178,25 @@ export const validateBtcSend = async ({
 		throw new BtcValidationError(BtcSendValidationError.InvalidUtxoData);
 	}
 
-	// 4. Validate fee calculation matches expected transaction structure ( recipient + change)
-	const feeRateMiliSatoshisPerVByte = await getFeeRateFromPercentiles({
-		network,
-		identity
-	});
-	const estimatedTxVSize = estimateTransactionVSize({
+	// 4. Validate the fee prices the transaction structure this selection will broadcast
+	// (recipient + change), at the rate it was quoted with.
+	//
+	// The rate comes from the fee itself, never from a fresh sample of the percentiles. The
+	// two are not interchangeable: the median percentile shifts by more than this tolerance
+	// within a minute of ordinary mempool movement, and near the 1 sat/vByte floor a single
+	// slot of drift already exceeds 10%. Checking the quoted fee against a later sample
+	// therefore rejected sends whose fee was correct when it was quoted and still is. A
+	// stale preview is a reason to refresh the preview, not to block a broadcast the user
+	// has approved.
+	const expectedFee = calculateFeeSatoshis({
 		numInputs: utxos.length,
-		numOutputs: 2
+		feeRateMiliSatoshisPerVByte
 	});
-	const expectedMinFee = (BigInt(estimatedTxVSize) * feeRateMiliSatoshisPerVByte) / 1000n;
 
 	// Allow some tolerance for fee calculation differences (±10%)
-	const feeToleranceRange = expectedMinFee / BTC_SEND_FEE_TOLERANCE_PERCENTAGE;
-	const minAcceptableFee = expectedMinFee - feeToleranceRange;
-	const maxAcceptableFee = expectedMinFee + feeToleranceRange;
+	const feeToleranceRange = expectedFee / BTC_SEND_FEE_TOLERANCE_PERCENTAGE;
+	const minAcceptableFee = expectedFee - feeToleranceRange;
+	const maxAcceptableFee = expectedFee + feeToleranceRange;
 
 	if (feeSatoshis < minAcceptableFee || feeSatoshis > maxAcceptableFee) {
 		throw new BtcValidationError(BtcSendValidationError.InvalidFeeCalculation);

--- a/src/frontend/src/btc/services/btc-utxos.service.ts
+++ b/src/frontend/src/btc/services/btc-utxos.service.ts
@@ -37,6 +37,7 @@ export const prepareBtcSend = ({
 	if (isNullish(pendingUtxoOutpoints)) {
 		return {
 			feeSatoshis: ZERO,
+			feeRateMiliSatoshisPerVByte,
 			utxos: [],
 			error: BtcPrepareSendError.PendingTransactionsNotAvailable
 		};
@@ -48,6 +49,7 @@ export const prepareBtcSend = ({
 	if (allUtxos.length === 0) {
 		return {
 			feeSatoshis: ZERO,
+			feeRateMiliSatoshisPerVByte,
 			utxos: [],
 			error: BtcPrepareSendError.InsufficientBalance
 		};
@@ -65,6 +67,7 @@ export const prepareBtcSend = ({
 	if (filteredUtxos.length === 0) {
 		return {
 			feeSatoshis: ZERO,
+			feeRateMiliSatoshisPerVByte,
 			utxos: [],
 			error: BtcPrepareSendError.UtxoLocked
 		};
@@ -81,6 +84,7 @@ export const prepareBtcSend = ({
 	if (!selection.sufficientFunds) {
 		return {
 			feeSatoshis: selection.feeSatoshis,
+			feeRateMiliSatoshisPerVByte,
 			utxos: filteredUtxos,
 			error: BtcPrepareSendError.InsufficientBalanceForFee
 		};
@@ -89,6 +93,7 @@ export const prepareBtcSend = ({
 	// Fee is already calculated in the selection process
 	return {
 		feeSatoshis: selection.feeSatoshis,
+		feeRateMiliSatoshisPerVByte,
 		utxos: selection.selectedUtxos
 	};
 };

--- a/src/frontend/src/btc/types/btc-send.ts
+++ b/src/frontend/src/btc/types/btc-send.ts
@@ -35,6 +35,10 @@ export enum BtcSendValidationError {
 
 export interface UtxosFee {
 	feeSatoshis: bigint;
+	// The rate `feeSatoshis` was priced at. Carried with the fee rather than re-sampled by
+	// the consumer: the median percentile it comes from moves between the preview and the
+	// confirmation, so a second sample cannot be used to check the first.
+	feeRateMiliSatoshisPerVByte: bigint;
 	utxos: CkBtcMinterDid.Utxo[];
 	error?: BtcPrepareSendError | BtcSendValidationError;
 }

--- a/src/frontend/src/btc/utils/btc-open-crypto-pay.utils.ts
+++ b/src/frontend/src/btc/utils/btc-open-crypto-pay.utils.ts
@@ -82,7 +82,8 @@ export const validateBtcTransfer = ({
 		satoshisAmount: amount,
 		utxosFee: {
 			utxos: btcFee.utxos,
-			feeSatoshis: btcFee.feeSatoshis
+			feeSatoshis: btcFee.feeSatoshis,
+			feeRateMiliSatoshisPerVByte: btcFee.feeRateMiliSatoshisPerVByte
 		}
 	};
 };

--- a/src/frontend/src/btc/utils/btc-utxos.utils.ts
+++ b/src/frontend/src/btc/utils/btc-utxos.utils.ts
@@ -50,6 +50,25 @@ export const estimateTransactionVSize = ({
 };
 
 /**
+ * Fee in satoshis for a P2WPKH transaction with `numInputs` inputs and the recipient +
+ * change output pair every selection produces.
+ *
+ * Rounds up, so the transaction is never priced below the requested rate. Shared with the
+ * pre-broadcast validation, which must arrive at the same number for the same inputs.
+ */
+export const calculateFeeSatoshis = ({
+	numInputs,
+	feeRateMiliSatoshisPerVByte
+}: {
+	numInputs: number;
+	feeRateMiliSatoshisPerVByte: bigint;
+}): bigint => {
+	const txVSize = estimateTransactionVSize({ numInputs, numOutputs: 2 });
+
+	return (BigInt(txVSize) * feeRateMiliSatoshisPerVByte + 999n) / 1000n;
+};
+
+/**
  * Main function to select UTXOs for a transaction with fee consideration.
  *
  * Algorithm (greedy, smallest-sufficient):
@@ -81,10 +100,8 @@ export const calculateUtxoSelection = ({
 		};
 	}
 
-	const calcFee = (numInputs: number): bigint => {
-		const txVSize = estimateTransactionVSize({ numInputs, numOutputs: 2 });
-		return (BigInt(txVSize) * feeRateMiliSatoshisPerVByte + 999n) / 1000n;
-	};
+	const calcFee = (numInputs: number): bigint =>
+		calculateFeeSatoshis({ numInputs, feeRateMiliSatoshisPerVByte });
 
 	const selectedUtxos: CkBtcMinterDid.Utxo[] = [];
 	let totalInputValue = ZERO;

--- a/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
@@ -123,6 +123,7 @@ describe('BtcConvertTokenWizard', () => {
 
 		vi.spyOn(btcUtxosService, 'prepareBtcSend').mockResolvedValue({
 			feeSatoshis: mockUtxosFee.feeSatoshis,
+			feeRateMiliSatoshisPerVByte: mockUtxosFee.feeRateMiliSatoshisPerVByte,
 			utxos: mockUtxosFee.utxos
 		});
 		vi.spyOn(bitcoinApi, 'getUtxosQuery').mockResolvedValue({
@@ -154,6 +155,7 @@ describe('BtcConvertTokenWizard', () => {
 			network: mapToSignerBitcoinNetwork({ network: BTC_MAINNET_TOKEN.network.env }),
 			utxosToSpend: mockUtxosFee.utxos,
 			feeSatoshis: toNullable(mockUtxosFee.feeSatoshis),
+			feeRateMiliSatoshisPerVByte: 4000n,
 			outputs: [
 				{
 					destination_address: mockBtcAddress,

--- a/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/convert/BtcConvertTokenWizard.spec.ts
@@ -155,7 +155,6 @@ describe('BtcConvertTokenWizard', () => {
 			network: mapToSignerBitcoinNetwork({ network: BTC_MAINNET_TOKEN.network.env }),
 			utxosToSpend: mockUtxosFee.utxos,
 			feeSatoshis: toNullable(mockUtxosFee.feeSatoshis),
-			feeRateMiliSatoshisPerVByte: 4000n,
 			outputs: [
 				{
 					destination_address: mockBtcAddress,

--- a/src/frontend/src/tests/btc/components/fee/UtxosFeeLoader.spec.ts
+++ b/src/frontend/src/tests/btc/components/fee/UtxosFeeLoader.spec.ts
@@ -28,6 +28,7 @@ describe('UtxosFeeLoader', () => {
 
 	const mockBtcReviewResult = {
 		feeSatoshis: 700n,
+		feeRateMiliSatoshisPerVByte: 4000n,
 		utxos: []
 	};
 
@@ -109,6 +110,7 @@ describe('UtxosFeeLoader', () => {
 			expect(setUtxosFeeSpy).toHaveBeenCalledExactlyOnceWith({
 				utxosFee: {
 					feeSatoshis: mockBtcReviewResult.feeSatoshis,
+					feeRateMiliSatoshisPerVByte: 4000n,
 					utxos: mockBtcReviewResult.utxos
 				},
 				amountForFee: amount
@@ -240,6 +242,7 @@ describe('UtxosFeeLoader', () => {
 		utxosFeeStore.setUtxosFee({
 			utxosFee: {
 				feeSatoshis: 100n,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: []
 			},
 			amountForFee: amount
@@ -264,6 +267,7 @@ describe('UtxosFeeLoader', () => {
 		utxosFeeStore.setUtxosFee({
 			utxosFee: {
 				feeSatoshis: 100n,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: []
 			},
 			amountForFee: 1

--- a/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
@@ -110,6 +110,7 @@ describe('BtcSendTokenWizard', () => {
 
 		vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
 			feeSatoshis: mockUtxosFee.feeSatoshis,
+			feeRateMiliSatoshisPerVByte: mockUtxosFee.feeRateMiliSatoshisPerVByte,
 			utxos: mockUtxosFee.utxos
 		});
 		vi.spyOn(bitcoinApi, 'getUtxosQuery').mockResolvedValue({
@@ -140,6 +141,7 @@ describe('BtcSendTokenWizard', () => {
 			network: mapToSignerBitcoinNetwork({ network: BTC_MAINNET_TOKEN.network.env }),
 			utxosToSpend: mockUtxosFee.utxos,
 			feeSatoshis: toNullable(mockUtxosFee.feeSatoshis),
+			feeRateMiliSatoshisPerVByte: 4000n,
 			outputs: [
 				{
 					destination_address: mockBtcAddress,

--- a/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendTokenWizard.spec.ts
@@ -141,7 +141,6 @@ describe('BtcSendTokenWizard', () => {
 			network: mapToSignerBitcoinNetwork({ network: BTC_MAINNET_TOKEN.network.env }),
 			utxosToSpend: mockUtxosFee.utxos,
 			feeSatoshis: toNullable(mockUtxosFee.feeSatoshis),
-			feeRateMiliSatoshisPerVByte: 4000n,
 			outputs: [
 				{
 					destination_address: mockBtcAddress,

--- a/src/frontend/src/tests/btc/components/send/BtcSendWarnings.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcSendWarnings.spec.ts
@@ -8,6 +8,7 @@ import { render } from '@testing-library/svelte';
 describe('BtcSendWarnings', () => {
 	const mockUtxosFee: UtxosFee = {
 		feeSatoshis: 1000n,
+		feeRateMiliSatoshisPerVByte: 4000n,
 		utxos: [mockUtxo]
 	};
 
@@ -242,6 +243,7 @@ describe('BtcSendWarnings', () => {
 					pendingTransactionsStatus: BtcPendingSentTransactionsStatus.NONE,
 					utxosFee: {
 						feeSatoshis: 1000n,
+						feeRateMiliSatoshisPerVByte: 4000n,
 						utxos: []
 					}
 				}

--- a/src/frontend/src/tests/btc/components/send/BtcUtxosFeeDisplay.spec.ts
+++ b/src/frontend/src/tests/btc/components/send/BtcUtxosFeeDisplay.spec.ts
@@ -48,6 +48,7 @@ describe('BtcUtxosFeeDisplay', () => {
 		utxosFeeStore.setUtxosFee({
 			utxosFee: {
 				feeSatoshis: mockFeeSatoshis,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: []
 			}
 		});
@@ -70,6 +71,7 @@ describe('BtcUtxosFeeDisplay', () => {
 		utxosFeeStore.setUtxosFee({
 			utxosFee: {
 				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: []
 			}
 		});
@@ -107,6 +109,7 @@ describe('BtcUtxosFeeDisplay', () => {
 		utxosFeeStore.setUtxosFee({
 			utxosFee: {
 				feeSatoshis: mockFeeSatoshis,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: []
 			}
 		});

--- a/src/frontend/src/tests/btc/components/swap/SwapBtcForm.spec.ts
+++ b/src/frontend/src/tests/btc/components/swap/SwapBtcForm.spec.ts
@@ -235,6 +235,7 @@ describe('SwapBtcForm', () => {
 			context: createContext({
 				utxosFee: {
 					feeSatoshis: ZERO,
+					feeRateMiliSatoshisPerVByte: 4000n,
 					utxos: [mockUtxo],
 					error: BtcPrepareSendError.UtxoLocked
 				}
@@ -263,6 +264,7 @@ describe('SwapBtcForm', () => {
 					offered: false,
 					utxosFee: {
 						feeSatoshis: ZERO,
+						feeRateMiliSatoshisPerVByte: 4000n,
 						utxos: [mockUtxo],
 						error: BtcPrepareSendError.UtxoLocked
 					}
@@ -286,7 +288,9 @@ describe('SwapBtcForm', () => {
 	it('explains a selection with no available inputs', () => {
 		const { getByText } = render(SwapBtcForm, {
 			props,
-			context: createContext({ utxosFee: { feeSatoshis: ZERO, utxos: [] } })
+			context: createContext({
+				utxosFee: { feeSatoshis: ZERO, feeRateMiliSatoshisPerVByte: 4000n, utxos: [] }
+			})
 		});
 
 		expect(getByText(en.send.info.no_available_utxos)).toBeInTheDocument();

--- a/src/frontend/src/tests/btc/services/btc-open-crypto-pay.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-open-crypto-pay.services.spec.ts
@@ -68,6 +68,7 @@ describe('btc-open-crypto-pay.services', () => {
 
 		const mockUtxosFee: UtxosFee = {
 			feeSatoshis: 1000n,
+			feeRateMiliSatoshisPerVByte: 4000n,
 			utxos: []
 		};
 
@@ -192,6 +193,7 @@ describe('btc-open-crypto-pay.services', () => {
 			it('should return the result from prepareBtcSend', () => {
 				const expectedFee: UtxosFee = {
 					feeSatoshis: 5000n,
+					feeRateMiliSatoshisPerVByte: 4000n,
 					utxos: [{ value: 100000n }] as unknown as UtxosFee['utxos']
 				};
 
@@ -223,6 +225,7 @@ describe('btc-open-crypto-pay.services', () => {
 			sumInUSD: 50.5,
 			fee: {
 				feeSatoshis: 1000n,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: []
 			}
 		} as PayableTokenWithConvertedAmount;
@@ -232,6 +235,7 @@ describe('btc-open-crypto-pay.services', () => {
 			satoshisAmount: 100000n,
 			utxosFee: {
 				feeSatoshis: 1000n,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: []
 			}
 		};

--- a/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-send.services.spec.ts
@@ -236,8 +236,10 @@ describe('btc-send.services', () => {
 			}
 		};
 
+		// 1 input + 2 outputs = 141 vB, at 4 sat/vByte = 564 satoshis.
 		const validUtxosFee: UtxosFee = {
-			feeSatoshis: 1000n, // 250 * 4 = 1000, within tolerance
+			feeSatoshis: 564n,
+			feeRateMiliSatoshisPerVByte: 4000n,
 			utxos: [validUtxo]
 		};
 
@@ -260,8 +262,6 @@ describe('btc-send.services', () => {
 			).mockResolvedValue({ success: true });
 			vi.spyOn(btcUtils, 'getPendingTransactionUtxoOutpoints').mockReturnValue([]);
 			vi.spyOn(btcUtxosUtils, 'extractUtxoOutpoints').mockReturnValue(['txid1:0', 'txid2:0']);
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
 		});
 
 		it('should pass validation for valid UTXOs and parameters', async () => {
@@ -419,10 +419,6 @@ describe('btc-send.services', () => {
 
 		describe('InvalidFeeCalculation validation', () => {
 			it('should throw InvalidFeeCalculation error when fee is too low', async () => {
-				// Mock estimated transaction size and fee rate to make expected fee higher than provided fee
-				vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(1000);
-				vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(10000n);
-
 				const params = {
 					...defaultValidateParams,
 					utxosFee: { ...validUtxosFee, feeSatoshis: 100n } // Very low fee
@@ -440,10 +436,6 @@ describe('btc-send.services', () => {
 			});
 
 			it('should throw InvalidFeeCalculation error when fee is too high', async () => {
-				// Mock estimated transaction size to make expected fee much lower than provided fee
-				vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(100);
-				vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1n);
-
 				const params = {
 					...defaultValidateParams,
 					utxosFee: { ...validUtxosFee, feeSatoshis: 50000n } // Very high fee
@@ -462,14 +454,15 @@ describe('btc-send.services', () => {
 		});
 
 		it('should throw InsufficientBalanceForFee error when UTXOs have insufficient funds', async () => {
-			// Use smaller fee and transaction size for consistent calculation
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
-
 			const params = {
 				...defaultValidateParams,
 				amount: 1, // 1 BTC = 100,000,000 satoshis, but UTXO only has 100,000
-				utxosFee: { ...validUtxosFee, feeSatoshis: 250n } // 250 * 1 = 250, within tolerance
+				// 141 vB at 1 sat/vByte = 141 satoshis, a valid fee for this selection
+				utxosFee: {
+					...validUtxosFee,
+					feeSatoshis: 141n,
+					feeRateMiliSatoshisPerVByte: 1000n
+				}
 			};
 
 			await expect(validateBtcSend(params)).rejects.toThrow(BtcValidationError);
@@ -484,17 +477,13 @@ describe('btc-send.services', () => {
 		});
 
 		it('should accept fee within tolerance range', async () => {
-			// Mock transaction size for predictable fee calculation
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
-
-			const expectedFee = BigInt(250) * 4n; // 1000 satoshis
-			const toleranceRange = expectedFee / 10n; // 100 satoshis
+			const expectedFee = 564n;
+			const toleranceRange = expectedFee / 10n; // 56 satoshis
 
 			// Test fee at upper tolerance boundary
 			const paramsUpperBound = {
 				...defaultValidateParams,
-				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee + toleranceRange } // 1100
+				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee + toleranceRange } // 620
 			};
 
 			await expect(validateBtcSend(paramsUpperBound)).resolves.not.toThrow();
@@ -502,7 +491,7 @@ describe('btc-send.services', () => {
 			// Test fee at lower tolerance boundary
 			const paramsLowerBound = {
 				...defaultValidateParams,
-				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee - toleranceRange } // 900
+				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee - toleranceRange } // 508
 			};
 
 			await expect(validateBtcSend(paramsLowerBound)).resolves.not.toThrow();
@@ -518,15 +507,13 @@ describe('btc-send.services', () => {
 				}
 			};
 
-			// Mock the transaction size estimation for 2 inputs
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(370);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(3000n);
-
 			const params = {
 				...defaultValidateParams,
 				utxosFee: {
 					...validUtxosFee,
-					feeSatoshis: 1110n, // 370 * 3 = 1110, within tolerance
+					// 2 inputs + 2 outputs = 209 vB, at 3 sat/vByte = 627 satoshis
+					feeSatoshis: 627n,
+					feeRateMiliSatoshisPerVByte: 3000n,
 					utxos: [validUtxo, utxo2]
 				}
 			};
@@ -534,35 +521,48 @@ describe('btc-send.services', () => {
 			await expect(validateBtcSend(params)).resolves.not.toThrow();
 		});
 
-		it('should call getFeeRateFromPercentiles with correct parameters', async () => {
+		it('should not re-sample the fee rate', async () => {
 			const getFeeRateFromPercentilesSpy = vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles');
 
 			await validateBtcSend(defaultValidateParams);
 
-			expect(getFeeRateFromPercentilesSpy).toHaveBeenCalledWith({
-				network: defaultValidateParams.network,
-				identity: defaultValidateParams.identity
-			});
+			expect(getFeeRateFromPercentilesSpy).not.toHaveBeenCalled();
+		});
+
+		it('should accept a fee the mempool has since moved away from', async () => {
+			// The percentile median that priced this fee shifts within a minute of ordinary
+			// mempool movement, and near the 1 sat/vByte floor one slot of drift already
+			// exceeds the tolerance. The fee is judged against the rate it was quoted at, so
+			// the send survives the drift instead of failing on the confirmation step.
+			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
+
+			const params = {
+				...defaultValidateParams,
+				utxosFee: {
+					...validUtxosFee,
+					feeSatoshis: 181n,
+					feeRateMiliSatoshisPerVByte: 1284n
+				}
+			};
+
+			await expect(validateBtcSend(params)).resolves.not.toThrow();
 		});
 
 		it('should validate exact fee tolerance boundaries', async () => {
-			vi.spyOn(btcUtxosUtils, 'estimateTransactionVSize').mockReturnValue(250);
-			vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(4000n);
-
-			const expectedFee = 250n * 4n; // 1000 satoshis
-			const toleranceRange = expectedFee / 10n; // 100 satoshis
+			const expectedFee = 564n;
+			const toleranceRange = expectedFee / 10n; // 56 satoshis
 
 			// Test fee just outside tolerance (should fail)
 			const paramsOutsideUpper = {
 				...defaultValidateParams,
-				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee + toleranceRange + 1n } // 1101
+				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee + toleranceRange + 1n } // 621
 			};
 
 			await expect(validateBtcSend(paramsOutsideUpper)).rejects.toThrow(BtcValidationError);
 
 			const paramsOutsideLower = {
 				...defaultValidateParams,
-				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee - toleranceRange - 1n } // 899
+				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee - toleranceRange - 1n } // 507
 			};
 
 			await expect(validateBtcSend(paramsOutsideLower)).rejects.toThrow(BtcValidationError);
@@ -570,7 +570,7 @@ describe('btc-send.services', () => {
 			// Test fee exactly at tolerance boundary (should pass)
 			const paramsExactUpper = {
 				...defaultValidateParams,
-				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee + toleranceRange } // 1100
+				utxosFee: { ...validUtxosFee, feeSatoshis: expectedFee + toleranceRange } // 620
 			};
 
 			await expect(validateBtcSend(paramsExactUpper)).resolves.not.toThrow();

--- a/src/frontend/src/tests/btc/services/btc-utxos.service.spec.ts
+++ b/src/frontend/src/tests/btc/services/btc-utxos.service.spec.ts
@@ -118,6 +118,7 @@ describe('btc-utxos.service', () => {
 
 			expect(result).toEqual({
 				feeSatoshis: expect.any(BigInt),
+				feeRateMiliSatoshisPerVByte: mockFeeRateFromPercentiles,
 				utxos: expect.any(Array),
 				error: undefined
 			});
@@ -133,6 +134,7 @@ describe('btc-utxos.service', () => {
 
 			expect(result).toEqual({
 				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: mockFeeRateFromPercentiles,
 				utxos: [],
 				error: BtcPrepareSendError.InsufficientBalance
 			});
@@ -146,6 +148,7 @@ describe('btc-utxos.service', () => {
 
 			expect(result).toEqual({
 				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: mockFeeRateFromPercentiles,
 				utxos: [],
 				error: BtcPrepareSendError.PendingTransactionsNotAvailable
 			});
@@ -161,6 +164,7 @@ describe('btc-utxos.service', () => {
 
 			expect(result).toEqual({
 				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: mockFeeRateFromPercentiles,
 				utxos: [],
 				error: BtcPrepareSendError.PendingTransactionsNotAvailable
 			});
@@ -176,6 +180,7 @@ describe('btc-utxos.service', () => {
 
 			expect(result).toEqual({
 				feeSatoshis: expect.any(BigInt),
+				feeRateMiliSatoshisPerVByte: mockFeeRateFromPercentiles,
 				utxos: expect.any(Array),
 				error: undefined
 			});
@@ -209,6 +214,7 @@ describe('btc-utxos.service', () => {
 
 			expect(result).toEqual({
 				feeSatoshis: expect.any(BigInt),
+				feeRateMiliSatoshisPerVByte: mockFeeRateFromPercentiles,
 				utxos: expect.any(Array),
 				error: undefined
 			});
@@ -290,6 +296,7 @@ describe('btc-utxos.service', () => {
 
 			expect(result).toEqual({
 				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: mockFeeRateFromPercentiles,
 				utxos: [],
 				error: BtcPrepareSendError.UtxoLocked
 			});
@@ -312,6 +319,7 @@ describe('btc-utxos.service', () => {
 
 			expect(result).toEqual({
 				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: mockFeeRateFromPercentiles,
 				utxos: [],
 				error: BtcPrepareSendError.UtxoLocked
 			});

--- a/src/frontend/src/tests/btc/utils/btc-open-crypto-pay.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-open-crypto-pay.utils.spec.ts
@@ -256,7 +256,8 @@ describe('btc-open-crypto-pay.utils', () => {
 				satoshisAmount: mockAmount,
 				utxosFee: {
 					utxos: mockUtxosFee.utxos,
-					feeSatoshis: mockUtxosFee.feeSatoshis
+					feeSatoshis: mockUtxosFee.feeSatoshis,
+					feeRateMiliSatoshisPerVByte: mockUtxosFee.feeRateMiliSatoshisPerVByte
 				}
 			});
 		});

--- a/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-send.utils.spec.ts
@@ -44,7 +44,9 @@ describe('isInvalidUtxosFee', () => {
 	});
 
 	it('returns true when no UTXOs were selected', () => {
-		expect(isInvalidUtxosFee({ feeSatoshis: ZERO, utxos: [] })).toBeTruthy();
+		expect(
+			isInvalidUtxosFee({ feeSatoshis: ZERO, feeRateMiliSatoshisPerVByte: 4000n, utxos: [] })
+		).toBeTruthy();
 	});
 });
 
@@ -78,7 +80,10 @@ describe('mapUtxosFeeErrorToMessage', () => {
 
 	it('falls back to the no-available-UTXOs message', () => {
 		expect(
-			mapUtxosFeeErrorToMessage({ utxosFee: { feeSatoshis: ZERO, utxos: [] }, i18n: en })
+			mapUtxosFeeErrorToMessage({
+				utxosFee: { feeSatoshis: ZERO, feeRateMiliSatoshisPerVByte: 4000n, utxos: [] },
+				i18n: en
+			})
 		).toBe(en.send.info.no_available_utxos);
 	});
 });

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -2,6 +2,7 @@ import { allUtxosStore } from '$btc/stores/all-utxos.store';
 import { btcPendingSentTransactionsStore } from '$btc/stores/btc-pending-sent-transactions.store';
 import { feeRatePercentilesStore } from '$btc/stores/fee-rate-percentiles.store';
 import {
+	calculateFeeSatoshis,
 	calculateUtxoSelection,
 	estimateTransactionVSize,
 	extractUtxoOutpoints,
@@ -83,6 +84,43 @@ describe('btc-utxos.utils', () => {
 			const result = extractUtxoOutpoints([]);
 
 			expect(result).toEqual([]);
+		});
+	});
+
+	describe('calculateFeeSatoshis', () => {
+		it('should price the recipient and change outputs at the given rate', () => {
+			// 1 input + 2 outputs = 141 vB, at 4 sat/vByte
+			expect(
+				calculateFeeSatoshis({ numInputs: 1, feeRateMiliSatoshisPerVByte: 4000n })
+			).toEqual(564n);
+
+			// 2 inputs + 2 outputs = 209 vB, at 3 sat/vByte
+			expect(
+				calculateFeeSatoshis({ numInputs: 2, feeRateMiliSatoshisPerVByte: 3000n })
+			).toEqual(627n);
+		});
+
+		it('should round up so the transaction is never priced below the rate', () => {
+			// 141 vB at 1.234 sat/vByte = 173.9 satoshis
+			expect(
+				calculateFeeSatoshis({ numInputs: 1, feeRateMiliSatoshisPerVByte: 1234n })
+			).toEqual(174n);
+		});
+
+		it('should agree with the fee the selection reports', () => {
+			const feeRateMiliSatoshisPerVByte = 2500n;
+			const { selectedUtxos, feeSatoshis } = calculateUtxoSelection({
+				availableUtxos: [createMockUtxo({ value: 100_000 })],
+				amountSatoshis: 10_000n,
+				feeRateMiliSatoshisPerVByte
+			});
+
+			expect(feeSatoshis).toEqual(
+				calculateFeeSatoshis({
+					numInputs: selectedUtxos.length,
+					feeRateMiliSatoshisPerVByte
+				})
+			);
 		});
 	});
 

--- a/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
+++ b/src/frontend/src/tests/btc/utils/btc-utxos.utils.spec.ts
@@ -90,21 +90,21 @@ describe('btc-utxos.utils', () => {
 	describe('calculateFeeSatoshis', () => {
 		it('should price the recipient and change outputs at the given rate', () => {
 			// 1 input + 2 outputs = 141 vB, at 4 sat/vByte
-			expect(
-				calculateFeeSatoshis({ numInputs: 1, feeRateMiliSatoshisPerVByte: 4000n })
-			).toEqual(564n);
+			expect(calculateFeeSatoshis({ numInputs: 1, feeRateMiliSatoshisPerVByte: 4000n })).toEqual(
+				564n
+			);
 
 			// 2 inputs + 2 outputs = 209 vB, at 3 sat/vByte
-			expect(
-				calculateFeeSatoshis({ numInputs: 2, feeRateMiliSatoshisPerVByte: 3000n })
-			).toEqual(627n);
+			expect(calculateFeeSatoshis({ numInputs: 2, feeRateMiliSatoshisPerVByte: 3000n })).toEqual(
+				627n
+			);
 		});
 
 		it('should round up so the transaction is never priced below the rate', () => {
 			// 141 vB at 1.234 sat/vByte = 173.9 satoshis
-			expect(
-				calculateFeeSatoshis({ numInputs: 1, feeRateMiliSatoshisPerVByte: 1234n })
-			).toEqual(174n);
+			expect(calculateFeeSatoshis({ numInputs: 1, feeRateMiliSatoshisPerVByte: 1234n })).toEqual(
+				174n
+			);
 		});
 
 		it('should agree with the fee the selection reports', () => {

--- a/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/repay/LiquidiumRepayBtcWizard.spec.ts
@@ -92,6 +92,7 @@ describe('LiquidiumRepayBtcWizard', () => {
 		});
 		vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
 			feeSatoshis: mockUtxosFee.feeSatoshis,
+			feeRateMiliSatoshisPerVByte: mockUtxosFee.feeRateMiliSatoshisPerVByte,
 			utxos: mockUtxosFee.utxos
 		});
 		vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
@@ -168,6 +169,7 @@ describe('LiquidiumRepayBtcWizard', () => {
 			// UTXOs cannot fund the broadcast — the signer would reject the transaction.
 			vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
 				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: [],
 				error: BtcPrepareSendError.UtxoLocked
 			});

--- a/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/supply/LiquidiumSupplyBtcWizard.spec.ts
@@ -76,6 +76,7 @@ describe('LiquidiumSupplyBtcWizard', () => {
 		});
 		vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
 			feeSatoshis: mockUtxosFee.feeSatoshis,
+			feeRateMiliSatoshisPerVByte: mockUtxosFee.feeRateMiliSatoshisPerVByte,
 			utxos: mockUtxosFee.utxos
 		});
 		vi.spyOn(btcUtxosService, 'getFeeRateFromPercentiles').mockResolvedValue(1000n);
@@ -156,6 +157,7 @@ describe('LiquidiumSupplyBtcWizard', () => {
 			// UTXOs cannot fund the broadcast — the signer would reject the transaction.
 			vi.spyOn(btcUtxosService, 'prepareBtcSend').mockReturnValue({
 				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: 4000n,
 				utxos: [],
 				error: BtcPrepareSendError.UtxoLocked
 			});

--- a/src/frontend/src/tests/lib/services/chain-fusion-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/chain-fusion-swap.services.spec.ts
@@ -944,13 +944,22 @@ describe('chain-fusion-swap.services', () => {
 			BtcPrepareSendError.InsufficientBalanceForFee,
 			BtcPrepareSendError.UtxoLocked
 		])('should not quote when the UTXO selection fails with %s', async (error) => {
-			vi.mocked(prepareBtcSend).mockReturnValue({ feeSatoshis: ZERO, utxos: [], error });
+			vi.mocked(prepareBtcSend).mockReturnValue({
+				feeSatoshis: ZERO,
+				feeRateMiliSatoshisPerVByte: 4000n,
+				utxos: [],
+				error
+			});
 
 			await expect(btcQuote()).resolves.toBeUndefined();
 		});
 
 		it('should not quote when the UTXO selection picked no inputs', async () => {
-			vi.mocked(prepareBtcSend).mockReturnValue({ feeSatoshis: 1_000n, utxos: [] });
+			vi.mocked(prepareBtcSend).mockReturnValue({
+				feeSatoshis: 1_000n,
+				feeRateMiliSatoshisPerVByte: 4000n,
+				utxos: []
+			});
 
 			await expect(btcQuote()).resolves.toBeUndefined();
 		});

--- a/src/frontend/src/tests/mocks/btc.mock.ts
+++ b/src/frontend/src/tests/mocks/btc.mock.ts
@@ -16,5 +16,6 @@ export const mockUtxo: CkBtcMinterDid.Utxo = {
 
 export const mockUtxosFee: UtxosFee = {
 	feeSatoshis: 1000n,
+	feeRateMiliSatoshisPerVByte: 4000n,
 	utxos: [mockUtxo]
 };

--- a/src/frontend/src/tests/mocks/btc.mock.ts
+++ b/src/frontend/src/tests/mocks/btc.mock.ts
@@ -14,8 +14,10 @@ export const mockUtxo: CkBtcMinterDid.Utxo = {
 	}
 };
 
+// The fee and the rate must stay consistent: the pre-broadcast validation reprices this
+// single-input selection (141 vB) at the rate below and rejects a fee more than 10% off it.
 export const mockUtxosFee: UtxosFee = {
 	feeSatoshis: 1000n,
-	feeRateMiliSatoshisPerVByte: 4000n,
+	feeRateMiliSatoshisPerVByte: 7000n,
 	utxos: [mockUtxo]
 };


### PR DESCRIPTION
# Motivation

A Bitcoin swap through NEAR Intents fails on the review step with "Bitcoin transaction fee validation failed", and the wizard bounces back to the form. The same defect blocks BTC Send and Convert, where the wizard returns to the previous step without a message, which is why it surfaced first in the swap flow.

The fee preview prices the selected UTXOs once, at the median fee percentile read when the flow opened. `validateBtcSend` then fetched the percentiles again just before broadcasting and required the quoted fee to sit within 10% of what that second sample implies. Both samples measure the same volatile quantity minutes apart, so the check fails on ordinary mempool movement rather than on a bad fee.

Sampled from the staging backend once a minute (its percentile cache refreshes every minute), in msat/vByte:

| time (UTC) | median |
| --- | --- |
| 08:04 to 08:09 | 1191 |
| 08:10 to 08:11 | 1982 |
| 08:12 to 08:21 | 464 |
| 08:22 to 08:24 | 428 |

Values under 1000 are clamped to the 1 sat/vByte floor. A fee quoted while the median read 1982 and confirmed three minutes later is checked against 1000, roughly half the rate it was priced at, so it lands at about twice the maximum acceptable and the send is refused. Near the floor the percentile slots sit 5 to 10% apart, so even a single slot of drift already exceeds the tolerance. The reported failure shows a 181 satoshi fee, which corresponds to one input at about 1.28 sat/vByte, squarely in that range.

# Changes

- `UtxosFee` carries `feeRateMiliSatoshisPerVByte`, the rate its `feeSatoshis` was priced at. `prepareBtcSend` records it and the Open Crypto Pay path forwards it.
- `validateBtcSend` reprices from that recorded rate instead of sampling the percentiles again. It stays a check of the selection's own arithmetic, and the 10% tolerance now only has to absorb rounding.
- The fee formula moves into `calculateFeeSatoshis`, shared by the selection and the validation so the two cannot drift apart.

One behaviour changes deliberately: a fee the market has since moved away from no longer blocks the broadcast. Underpaying delays confirmation rather than losing funds, the fee is shown on the review step before the user confirms, and the previous guard rejected correct fees far more often than stale ones. Refreshing the preview when the rate moves is the fix for staleness and is left out of this PR.

# Tests

- `validateBtcSend` gains a regression case: a fee quoted at 1284 msat/vByte still validates while the live percentiles read the 1000 floor, the exact drift that produced the report.
- A second case asserts the percentiles are no longer sampled during validation, replacing the test that asserted the opposite.
- The existing fee-band cases now drive the rate through the recorded value and use real vSize numbers instead of mocking the estimator.
- `calculateFeeSatoshis` gets direct coverage, including that it agrees with the fee the selection reports.
- Full frontend suite: 18574 passed, 1 skipped, 1 todo. `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check` and `npm run check:tests` all clean.
