### PR TITLE
chore(frontend): stop downloading a ckBAT logo nothing imports

### DIFF
--- a/scripts/build.tokens.ckerc20.ts
+++ b/scripts/build.tokens.ckerc20.ts
@@ -36,7 +36,9 @@ const SKIP_CANISTER_IDS_LOGOS: LedgerCanisterIdText[] = [
 	// ckEURC
 	'pe5t5-diaaa-aaaar-qahwa-cai',
 	// ckXAUT
-	'nza5v-qaaaa-aaaar-qahzq-cai'
+	'nza5v-qaaaa-aaaar-qahzq-cai',
+	// ckBAT
+	'j7x7x-syaaa-aaaar-qcbea-cai'
 ];
 
 const orchestratorInfo = async ({


### PR DESCRIPTION
# Motivation

The token update job downloads each ckERC20 ledger logo into `$icp-eth/assets`, and the ERC20 env files import those files as the token icon. `SKIP_CANISTER_IDS_LOGOS` opts out the tokens whose ERC20 logo is curated by hand instead, which today is ckUSDC, ckUSDT, ckSepoliaUSDC, ckEURC and ckXAUT, all of them served from `$eth/assets`.

BAT joined that group in #13918: the official logo now lives at `$eth/assets/bat.svg` and is imported by the ERC20, SPL and group env files. The ckBAT ledger logo the job keeps writing to `$icp-eth/assets/bat.svg` is imported by nothing, and since `saveIcon` only writes when the file is missing, deleting it just brings it back on the next run.

# Changes

- Add the ckBAT ledger canister id to `SKIP_CANISTER_IDS_LOGOS` in `scripts/build.tokens.ckerc20.ts`.

# Tests

`npm run format`, `npm run lint -- --max-warnings 0` and `npm run check` are clean. `scripts/` is outside the vitest include glob (`src/frontend/src/**`), so no test covers this file, and no runtime code changed: the file the job stops writing has no importer.
