### PR TITLE
style(frontend): fold the type schema in the WalletConnect raw data tab

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -229,8 +229,6 @@
 	{:else}
 		<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.message}</p>
 		{#if nonNullish(signedJson)}
-			<!-- Opened rather than collapsed: the tab exists to be read, and a reader who switched to
-			     it has already said the summary was not enough. The schema is the one exception. -->
 			<div class="mt-4 rounded-xs bg-disabled p-4">
 				<Json _collapsed={false} collapsedKeys={RAW_DATA_COLLAPSED_KEYS} json={signedJson} />
 			</div>

--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -138,6 +138,11 @@
 
 	// Levels of indentation the list will render before it stops widening.
 	const MAX_NESTING_INDENT = 4;
+
+	// The type schema is usually longer than the rest of the payload put together, and it declares the
+	// shape of what is signed rather than stating any of it. Folded, the domain, the primary type and
+	// the message all fit on screen; open, they were pushed below a wall of field declarations.
+	const RAW_DATA_COLLAPSED_KEYS = ['types'];
 </script>
 
 {#if invalidTypedData}
@@ -225,9 +230,9 @@
 		<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.message}</p>
 		{#if nonNullish(signedJson)}
 			<!-- Opened rather than collapsed: the tab exists to be read, and a reader who switched to
-			     it has already said the summary was not enough. -->
+			     it has already said the summary was not enough. The schema is the one exception. -->
 			<div class="mt-4 rounded-xs bg-disabled p-4">
-				<Json _collapsed={false} json={signedJson} />
+				<Json _collapsed={false} collapsedKeys={RAW_DATA_COLLAPSED_KEYS} json={signedJson} />
 			</div>
 		{:else}
 			<p class="mb-4 font-normal">

--- a/src/frontend/src/lib/components/ui/Json.svelte
+++ b/src/frontend/src/lib/components/ui/Json.svelte
@@ -6,6 +6,10 @@
 	interface Props {
 		json?: unknown;
 		defaultExpandedLevel?: number;
+		// Entries of this node that start folded. Deliberately not handed down to the children: the
+		// caller chooses the entries it can name, and a key deeper in the tree that happens to carry
+		// the same name is somebody else's data, which must not be hidden by a rule meant for this level.
+		collapsedKeys?: string[];
 		_key?: string;
 		_level?: number;
 		_collapsed?: boolean;
@@ -14,6 +18,7 @@
 	let {
 		json,
 		defaultExpandedLevel = Infinity,
+		collapsedKeys = [],
 		_key = '',
 		_level = 1,
 		_collapsed
@@ -101,7 +106,13 @@
 		<ul>
 			{#each children as [key, value] (key)}
 				<li>
-					<Self _key={key} _level={_level + 1} {defaultExpandedLevel} json={value} />
+					<Self
+						_collapsed={collapsedKeys.includes(key) ? true : undefined}
+						_key={key}
+						_level={_level + 1}
+						{defaultExpandedLevel}
+						json={value}
+					/>
 				</li>
 			{/each}
 		</ul>

--- a/src/frontend/src/lib/components/ui/Json.svelte
+++ b/src/frontend/src/lib/components/ui/Json.svelte
@@ -69,36 +69,53 @@
 	const toggle = () => {
 		collapsed = !collapsed;
 	};
+
+	// A span carrying role="button" is activated by a pointer only, so a folded node would be
+	// unreachable without a mouse.
+	const toggleOnKey = (event: KeyboardEvent) => {
+		const { key } = event;
+
+		if (key !== 'Enter' && key !== ' ') {
+			return;
+		}
+
+		// Space scrolls the page on anything that is not a real button.
+		event.preventDefault();
+
+		toggle();
+	};
 </script>
 
 {#if isExpandable && hasChildren}
 	{#if collapsed}
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<span
 			class="key"
 			class:arrow={isExpandable && hasChildren}
 			class:collapsed
 			class:expanded={!collapsed}
 			class:root
+			aria-expanded={!collapsed}
 			aria-label="Toggle"
 			data-tid={testId}
 			onclick={stopPropagation(toggle)}
+			onkeydown={toggleOnKey}
 			role="button"
 			tabindex="0"
 			>{keyLabel}
 			<span class="bracket">{openBracket} ... {closeBracket}</span>
 		</span>
 	{:else}
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<span
 			class="key"
 			class:arrow={isExpandable && hasChildren}
 			class:collapsed
 			class:expanded={!collapsed}
 			class:root
+			aria-expanded={!collapsed}
 			aria-label="Toggle"
 			data-tid={testId}
 			onclick={stopPropagation(toggle)}
+			onkeydown={toggleOnKey}
 			role="button"
 			tabindex="0">{keyLabel}<span class="bracket open">{openBracket}</span></span
 		>

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
@@ -98,6 +98,31 @@ describe('EthWalletConnectMessage', () => {
 		expect(getByTestId('json')).toBeInTheDocument();
 	});
 
+	it('should fold the type schema and leave the rest of the payload open', async () => {
+		const { getByRole, getByText, queryByText } = render(EthWalletConnectMessage, {
+			props: {
+				request
+			}
+		});
+
+		await openRawTab(getByRole);
+
+		// The schema declares the shape of the message without stating any of it, and it is longer
+		// than everything that does, so it starts folded.
+		expect(queryByText('"uint160"')).not.toBeInTheDocument();
+
+		// What the signature covers is what the tab opens on: the domain, the type and the message.
+		expect(getByText('"Permit2"')).toBeInTheDocument();
+		expect(getByText('"PermitSingle"')).toBeInTheDocument();
+		expect(getByText('sigDeadline:')).toBeInTheDocument();
+		expect(getByText('"0x66a9893cc07d91d95644aedd05d03f95e1dba8af"')).toBeInTheDocument();
+
+		// Folded, not dropped. The schema is one click away from reading as it did before.
+		await fireEvent.click(getByText('{ ... }'));
+
+		expect(getByText('"uint160"')).toBeInTheDocument();
+	});
+
 	it('should render the application', () => {
 		const { getByText } = render(EthWalletConnectMessage, {
 			props: {

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
@@ -123,6 +123,27 @@ describe('EthWalletConnectMessage', () => {
 		expect(getByText('"uint160"')).toBeInTheDocument();
 	});
 
+	it.each(['Enter', ' '])(
+		'should open the folded type schema on %s, not by pointer alone',
+		async (key) => {
+			// Folding it makes opening it a required interaction, so it has to be one a keyboard can
+			// perform: the node is a span carrying role="button", which activates on a pointer only.
+			const { getByRole, getByText, queryByText } = render(EthWalletConnectMessage, {
+				props: {
+					request
+				}
+			});
+
+			await openRawTab(getByRole);
+
+			expect(queryByText('"uint160"')).not.toBeInTheDocument();
+
+			await fireEvent.keyDown(getByRole('button', { name: 'Toggle', expanded: false }), { key });
+
+			expect(getByText('"uint160"')).toBeInTheDocument();
+		}
+	);
+
 	it('should render the application', () => {
 		const { getByText } = render(EthWalletConnectMessage, {
 			props: {


### PR DESCRIPTION
# Motivation

The raw data tab of a WalletConnect EVM typed-data request opens the whole EIP-712 payload expanded. `types` is almost always longer than everything else put together, and it only declares the shape of the message rather than stating any of it, so the domain, the primary type and the message itself get pushed below a wall of field declarations.

# Changes

- `Json` takes an optional `collapsedKeys`: entries of that node which start folded. It is deliberately not handed down to the children, so a key deeper in the tree that happens to carry the same name is never hidden by a rule meant for the top level.
- The EVM typed-data raw data tab passes `['types']`. Everything else stays open as before, and `types` is one click from reading as it did.

# Tests

- New spec in `EthWalletConnectMessage.spec.ts`: the schema is absent on open, the domain / primary type / message are present, and a click on the folded node brings the schema back. Verified it fails without the change.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` all clean.
- Deployed to fe2 for a manual check of a real Permit2 request.
