### PR TITLE
feat(frontend): OISY trade swap offer calculations

### DIFF
--- a/docs/ai/frontend/structure.md
+++ b/docs/ai/frontend/structure.md
@@ -48,6 +48,11 @@ src/frontend/src/
 │   ├── assets/             SVG / images imported by code
 │   ├── actors/             Generic IC actor helpers
 │   ├── ic-pub-key/         Public-key derivation helpers
+│   ├── oisy-trade/         OISY Trade offer calculation — self-contained, speaks
+│   │                       only the oisy_trade declarations; belongs in that
+│   │                       canister and is deleted once it exposes a quote
+│   │                       endpoint (see its README; boundary enforced by
+│   │                       no-restricted-imports)
 │   ├── config/             Runtime config helpers
 │   └── i18n/               en.json (single source of truth) + structurally synced non-en locales
 │

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,16 +56,22 @@ export default [
 	// hosted here only until that canister can answer it. Keeping the dependency
 	// arrow one-way is what makes the eventual migration a deletion rather than an
 	// extraction, so the boundary is a build failure, not a convention. Only two
-	// things are conceded: the module's own files, and the shared `ZERO` (the repo
-	// bans the `0n` literal, so it is the only way to write zero).
-	// See src/frontend/src/lib/oisy-trade/README.md.
+	// things are conceded beyond the venue's own types: the module's own files, and
+	// the shared `ZERO` (the repo bans the `0n` literal, so it is the only way to
+	// write zero). See src/frontend/src/lib/oisy-trade/README.md.
+	//
+	// Written as an allow-list — deny everything, then re-admit that set — because
+	// the README states the boundary as one. Enumerating the wallet's aliases
+	// instead leaves everything outside them unmatched: `$declarations/backend`,
+	// `svelte`, and any npm package would import cleanly, so the boundary would
+	// erode in silence rather than fail. Measured before this was changed: of
+	// `$lib/types/token`, `$declarations/backend/backend.did`, `svelte/store` and
+	// `ethers/utils`, only the first was refused.
 	//
 	// The patterns follow gitignore semantics, where a path cannot be re-included
-	// once a parent directory is excluded. Hence `/**` rather than `/*`, and hence
-	// the bare `!$lib/oisy-trade` and `!$lib/constants` alongside the specific
-	// negations — without those directory re-inclusions the two allowed imports are
-	// rejected as well. Verified by probe: `$lib/constants/app.constants` passes
-	// while `$lib/constants/tokens.constants` is still refused.
+	// once an ancestor is excluded, so every ancestor is negated alongside the leaf
+	// it exists to admit. Verified by probe both ways: the five specifiers the
+	// module actually imports pass, and those same four intruders are now refused.
 	{
 		files: ['src/frontend/src/lib/oisy-trade/**/*'],
 		rules: {
@@ -75,23 +81,20 @@ export default [
 					patterns: [
 						{
 							group: [
-								'$lib/**',
-								'$btc/**',
-								'$eth/**',
-								'$evm/**',
-								'$icp/**',
-								'$sol/**',
-								'$icp-eth/**',
-								'$env/**',
-								'$routes/**',
-								'$app/**',
+								'**',
+								'!$declarations',
+								'!$declarations/oisy_trade',
+								'!$declarations/oisy_trade/**',
+								'!@dfinity',
+								'!@dfinity/**',
+								'!$lib',
 								'!$lib/oisy-trade',
 								'!$lib/oisy-trade/**',
 								'!$lib/constants',
 								'!$lib/constants/app.constants'
 							],
 							message:
-								'$lib/oisy-trade must not depend on wallet code — it speaks only the oisy_trade declarations. Allowed: $declarations/oisy_trade/*, @dfinity/*, and ZERO from $lib/constants/app.constants.'
+								'$lib/oisy-trade must not depend on wallet code — it speaks only the oisy_trade declarations. Allowed: $declarations/oisy_trade/*, @dfinity/*, ZERO from $lib/constants/app.constants, and the module’s own files.'
 						}
 					]
 				}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,53 @@ export default [
 		}
 	},
 
+	// `$lib/oisy-trade/` implements what belongs in the oisy_trade canister and is
+	// hosted here only until that canister can answer it. Keeping the dependency
+	// arrow one-way is what makes the eventual migration a deletion rather than an
+	// extraction, so the boundary is a build failure, not a convention. Only two
+	// things are conceded: the module's own files, and the shared `ZERO` (the repo
+	// bans the `0n` literal, so it is the only way to write zero).
+	// See src/frontend/src/lib/oisy-trade/README.md.
+	//
+	// The patterns follow gitignore semantics, where a path cannot be re-included
+	// once a parent directory is excluded. Hence `/**` rather than `/*`, and hence
+	// the bare `!$lib/oisy-trade` and `!$lib/constants` alongside the specific
+	// negations — without those directory re-inclusions the two allowed imports are
+	// rejected as well. Verified by probe: `$lib/constants/app.constants` passes
+	// while `$lib/constants/tokens.constants` is still refused.
+	{
+		files: ['src/frontend/src/lib/oisy-trade/**/*'],
+		rules: {
+			'no-restricted-imports': [
+				'error',
+				{
+					patterns: [
+						{
+							group: [
+								'$lib/**',
+								'$btc/**',
+								'$eth/**',
+								'$evm/**',
+								'$icp/**',
+								'$sol/**',
+								'$icp-eth/**',
+								'$env/**',
+								'$routes/**',
+								'$app/**',
+								'!$lib/oisy-trade',
+								'!$lib/oisy-trade/**',
+								'!$lib/constants',
+								'!$lib/constants/app.constants'
+							],
+							message:
+								'$lib/oisy-trade must not depend on wallet code — it speaks only the oisy_trade declarations. Allowed: $declarations/oisy_trade/*, @dfinity/*, and ZERO from $lib/constants/app.constants.'
+						}
+					]
+				}
+			]
+		}
+	},
+
 	{
 		rules: {
 			'no-restricted-syntax': ['error', ZERO_BIGINT_RESTRICTION, ...NULLISH_NEGATION_RESTRICTIONS]

--- a/src/frontend/src/env/oisy-trade-swap.ts
+++ b/src/frontend/src/env/oisy-trade-swap.ts
@@ -1,12 +1,26 @@
 import { OISY_TRADE_ENABLED } from '$env/oisy-trade';
-import { LOCAL } from '$lib/constants/app.constants';
+import { LOCAL, STAGING } from '$lib/constants/app.constants';
 
 // Gate for the OISY Trade *swap provider*, separate from `OISY_TRADE_ENABLED`,
 // which gates the Trading surface. The two answer different questions — "is the
 // swap integration ready?" versus "is the venue up?" — so the provider requires
 // both: a canister outage has to take the swap offer down with the Trading tab
 // rather than leave a provider quoting against a dead canister.
-export const OISY_TRADE_SWAP_ENABLED = LOCAL;
+//
+// Widened from `LOCAL` to include staging once the offer came from the real order
+// book (2026-09-04). While the quote was a 1:1 placeholder this had to stay local:
+// a fabricated rate out-ranks almost every real offer, so it would have been
+// pre-selected on any pair that is not near parity, showing a number the execution
+// could not honour.
+//
+// Deliberately still short of production. A staging build reaches whatever
+// `VITE_STAGING_OISY_TRADE_CANISTER_ID` points at, so if that is the production
+// canister these are real fill-or-kill orders against the live book — which is the
+// point at this stage (it is the only way to observe a real fill, and which leg the
+// venue withholds its taker fee from is still unconfirmed) but is also why the last
+// step is a separate decision. Note `STAGING` is also true for `test_fe_*`, `audit`
+// and `e2e` builds.
+export const OISY_TRADE_SWAP_ENABLED = LOCAL || STAGING;
 
 // The double gate expressed once, rather than re-anded at each call site.
 export const oisyTradeSwapEnabled = OISY_TRADE_SWAP_ENABLED && OISY_TRADE_ENABLED;

--- a/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
+++ b/src/frontend/src/icp/components/swap/SwapIcpForm.svelte
@@ -11,10 +11,7 @@
 	import Hr from '$lib/components/ui/Hr.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import { ZERO } from '$lib/constants/app.constants';
-	import {
-		fetchOisyTradeQuote,
-		oisyTradeSwapPairTable
-	} from '$lib/services/oisy-trade-swap.services';
+	import { oisyTradeSwapPairTable } from '$lib/services/oisy-trade-swap.services';
 	import { balancesStore } from '$lib/stores/balances.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import { oisyTradeStore } from '$lib/stores/oisy-trade.store';
@@ -30,7 +27,7 @@
 	import { formatToken } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { invalidAmount } from '$lib/utils/input.utils';
-	import { findOisyTradePair } from '$lib/utils/oisy-trade-swap.utils';
+	import { findOisyTradePair, oisyTradeAmountObjection } from '$lib/utils/oisy-trade-swap.utils';
 	import { formatTradeAmount, toPairView } from '$lib/utils/oisy-trade.utils';
 	import { tryParseToken } from '$lib/utils/parse.utils';
 	import { validateUserAmount } from '$lib/utils/user-amount.utils';
@@ -184,9 +181,8 @@
 		});
 	});
 
-	// Asked of the service rather than read off the fan-out: the fan-out carries offers
-	// only, so a rejection never reaches the store. The quote is a synchronous read over
-	// the already-cached pair table, so asking again here costs nothing.
+	// Derived from the pair rather than read off the fan-out: the fan-out carries offers
+	// only, so a rejection never reaches the store.
 	let oisyTradeErrorKind = $derived.by(() => {
 		if (
 			!noOfferQuoted ||
@@ -213,23 +209,16 @@
 			return undefined;
 		}
 
-		// Guarded even though the quote is contractually non-throwing: it converts a
-		// human price through `toPriceUnits`, and `Number.toFixed` switches to
-		// exponential notation at 1e21, which `BigInt` refuses. The registry's
-		// `getQuote` has the same catch. Here the call sits inside a `$derived.by`,
-		// where an escaping error would take the whole form down — and the worst
-		// outcome this branch can honestly report is "no explanation".
-		try {
-			const result = fetchOisyTradeQuote({
-				sourceToken: $sourceToken,
-				destinationToken: $destinationToken,
-				sourceAmount
-			});
-
-			return result.ok ? undefined : result.errorKind;
-		} catch (_: unknown) {
-			return undefined;
-		}
+		// Judged from the pair alone rather than by re-running the quote. The quote now
+		// awaits the order book, and this sits in a `$derived.by`, which cannot await —
+		// so the two objections a pair settles on its own are what the form can name.
+		// Anything book-dependent stays unexplained and falls back to the generic
+		// "swap is not offered". See `oisyTradeAmountObjection`.
+		return oisyTradeAmountObjection({
+			sourceToken: $sourceToken,
+			amount: sourceAmount,
+			pair: oisyTradePair
+		});
 	});
 
 	// The shipped Limit Order copy, filled from the same `toPairView` fields that
@@ -240,20 +229,20 @@
 			return undefined;
 		}
 
-		const {
-			baseSymbol,
-			quoteSymbol,
-			baseDecimals,
-			quoteDecimals,
-			lotSize,
-			minNotional,
-			maxNotional
-		} = toPairView(oisyTradePair);
+		const { baseSymbol, quoteSymbol, baseDecimals, quoteDecimals, lotSize, minNotional } =
+			toPairView(oisyTradePair);
 		const t = $i18n.trading.limit_order;
 
+		// Exhaustive over what `oisyTradeAmountObjection` can return, which is only these
+		// two. `max_notional` needs a price and so a book, and `balance` never arises at
+		// quote time — the quote validates with no balance on purpose, so an unaffordable
+		// amount still produces an offer and the form's own insufficient-funds check
+		// reports it, exactly as for every other provider.
 		switch (oisyTradeErrorKind) {
+			// The minimum, not the Limit Order form's "multiple": a Sell is floored onto the
+			// lot grid, so the only lot objection left is an amount that cannot fill one.
 			case 'lot':
-				return replacePlaceholders(t.error_lot_multiple, {
+				return replacePlaceholders(t.error_lot_minimum, {
 					$step: formatTradeAmount({ amount: lotSize, decimals: baseDecimals }),
 					$symbol: baseSymbol
 				});
@@ -262,16 +251,6 @@
 					$amount: formatTradeAmount({ amount: minNotional, decimals: quoteDecimals }),
 					$symbol: quoteSymbol
 				});
-			case 'max_notional':
-				return replacePlaceholders(t.error_max_notional, {
-					$amount: formatTradeAmount({ amount: maxNotional ?? 0, decimals: quoteDecimals }),
-					$symbol: quoteSymbol
-				});
-			// `balance` is unreachable here: the quote deliberately validates with no balance,
-			// so an unaffordable amount still produces an offer and the form's own
-			// insufficient-funds check reports it, exactly as for every other provider.
-			default:
-				return undefined;
 		}
 	});
 

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "Exceeds your free balance: $amount $symbol available",
 			"error_balance_buy": "Costs $cost $symbol, only $available free",
 			"error_lot_multiple": "Amount must be a multiple of $step $symbol",
+			"error_lot_minimum": "Amount must be at least $step $symbol",
 			"error_tick_multiple": "Price must be a multiple of $step",
 			"error_min_notional": "Order value must be at least $amount $symbol",
 			"error_max_notional": "Order value can't exceed $amount $symbol",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1938,6 +1938,7 @@
 			"error_balance_sell": "",
 			"error_balance_buy": "",
 			"error_lot_multiple": "",
+			"error_lot_minimum": "",
 			"error_tick_multiple": "",
 			"error_min_notional": "",
 			"error_max_notional": "",

--- a/src/frontend/src/lib/oisy-trade/README.md
+++ b/src/frontend/src/lib/oisy-trade/README.md
@@ -24,13 +24,16 @@ and the shapes in `types.ts` already describe what that endpoint returns.
 
 This module may import **only**:
 
-- `$declarations/oisy_trade/oisy_trade.did` — the venue's own types;
-- `@dfinity/utils`, and `ZERO` from `$lib/constants/app.constants` (the `0n` literal
-  is banned repo-wide).
+- `$declarations/oisy_trade/*` — the venue's own generated types;
+- `@dfinity/*`;
+- `ZERO` from `$lib/constants/app.constants` (the `0n` literal is banned repo-wide);
+- its own files.
 
-Nothing about swaps, tokens, stores, i18n or the wallet. A `no-restricted-imports`
-override in `eslint.config.mjs` enforces it, so the boundary fails the build rather
-than eroding.
+Nothing else — no swaps, tokens, stores, i18n or wallet code, and equally no other
+canister's declarations, no Svelte and no third-party package. The
+`no-restricted-imports` override in `eslint.config.mjs` states that set as an
+allow-list: it denies every specifier and re-admits those four, so anything new
+fails the build instead of eroding the boundary quietly.
 
 Consequences worth knowing before editing:
 

--- a/src/frontend/src/lib/oisy-trade/README.md
+++ b/src/frontend/src/lib/oisy-trade/README.md
@@ -1,0 +1,64 @@
+# OISY Trade — offer calculation
+
+Given an order-book snapshot, this module answers one question: **what is the
+largest fill-or-kill order this book is certain to fill, and what is it certain to
+produce?** That answer is what the Swap flow shows as an OISY Trade offer.
+
+## This code does not belong here
+
+It belongs in the `oisy_trade` canister, next to the book it reads and the matching
+engine it predicts. It cannot go there yet: `oisy_trade` lives in the separate
+[`dfinity/oisy-trade`](https://github.com/dfinity/oisy-trade) repository and reaches
+this one as a pinned release (`OISY_TRADE_RELEASE` in
+`scripts/build.oisy_trade.sh`), so adding an endpoint is a cross-repo change plus a
+release bump.
+
+So it is hosted here, deliberately at arm's length from the wallet, in the same
+spirit as `$lib/ic-pub-key/`.
+
+**Delete this folder** once `oisy_trade` exposes a quote endpoint. The call site
+(`$lib/utils/oisy-trade-swap.utils.ts`) then moves to `$lib/api/oisy-trade.api.ts`
+and the shapes in `types.ts` already describe what that endpoint returns.
+
+## The boundary
+
+This module may import **only**:
+
+- `$declarations/oisy_trade/oisy_trade.did` — the venue's own types;
+- `@dfinity/utils`, and `ZERO` from `$lib/constants/app.constants` (the `0n` literal
+  is banned repo-wide).
+
+Nothing about swaps, tokens, stores, i18n or the wallet. A `no-restricted-imports`
+override in `eslint.config.mjs` enforces it, so the boundary fails the build rather
+than eroding.
+
+Consequences worth knowing before editing:
+
+- **It speaks candid, not OISY.** The side is the venue's `Side` variant, amounts are
+  smallest units, and rejections are venue-shaped (`below_lot`, `no_liquidity`, …)
+  rather than the Swap form's `FieldErrorKind`. The swap adapter translates.
+- **It takes the depth snapshot as an argument.** No canister call, no fetching, no
+  clock — which is what keeps it a pure function, and what a canister implementation
+  would do differently (it would read the book directly).
+- **It stops before fees.** `takerFeeBps` is on the pair, but the destination
+  ledger fee is a wallet fact the venue has no business knowing, so this returns
+  `gross` and the caller subtracts both.
+
+## Units
+
+Straight from the did, and never converted to floats:
+
+| Value      | Unit                                                 |
+| ---------- | ---------------------------------------------------- |
+| `price`    | quote smallest units per **one whole** base token    |
+| `quantity` | base smallest units, a multiple of `lot_size`        |
+| `notional` | `price × quantity / 10^baseDecimals`, in quote units |
+
+## Tests and fixtures
+
+The worked examples live in `src/frontend/src/tests/fixtures/oisy-trade/` as
+language-neutral JSON: one order book, with cases covering both sides plus the
+boundaries where no order is offerable. They are written that way on purpose:
+when this calculation is implemented in Rust upstream, the file is a ready set of
+test vectors, and it is the only artifact here worth keeping after the folder is
+deleted.

--- a/src/frontend/src/lib/oisy-trade/index.ts
+++ b/src/frontend/src/lib/oisy-trade/index.ts
@@ -1,0 +1,7 @@
+export { calculateOisyTradeOffer } from '$lib/oisy-trade/offer';
+export type {
+	OisyTradeOffer,
+	OisyTradeOfferRejection,
+	OisyTradeOfferRequest,
+	OisyTradeOfferResult
+} from '$lib/oisy-trade/types';

--- a/src/frontend/src/lib/oisy-trade/offer.ts
+++ b/src/frontend/src/lib/oisy-trade/offer.ts
@@ -1,0 +1,177 @@
+import type { PriceLevel } from '$declarations/oisy_trade/oisy_trade.did';
+import { ZERO } from '$lib/constants/app.constants';
+import type {
+	OisyTradeOfferRejection,
+	OisyTradeOfferRequest,
+	OisyTradeOfferResult
+} from '$lib/oisy-trade/types';
+import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+
+const reject = (reason: OisyTradeOfferRejection): OisyTradeOfferResult => ({ ok: false, reason });
+
+const floorToLot = ({ value, lotSize }: { value: bigint; lotSize: bigint }): bigint =>
+	value - (value % lotSize);
+
+/**
+ * The price at which the book can absorb `quantity` base tokens outright.
+ *
+ * Walks the bids (price-descending) accumulating quantity, and returns the price of
+ * the level that completes the order. That is the *highest* price the whole quantity
+ * can still find a counterparty at: any higher and part of it goes unmatched, which
+ * for a fill-or-kill order means the entire order is killed.
+ */
+const priceCoveringQuantity = ({
+	bids,
+	quantity
+}: {
+	bids: PriceLevel[];
+	quantity: bigint;
+}): bigint | undefined => {
+	let cumulative = ZERO;
+
+	for (const level of bids) {
+		cumulative += level.quantity;
+
+		if (cumulative >= quantity) {
+			return level.price;
+		}
+	}
+
+	return undefined;
+};
+
+/**
+ * The price at which the book's cumulative value covers `sourceAmount` quote tokens.
+ *
+ * Walks the asks (price-ascending) accumulating each level's value and returns the
+ * price of the level that covers the spend.
+ *
+ * Accumulates `price × quantity` — value scaled by `10^baseDecimals` — and compares
+ * against a likewise-scaled target, rather than reducing each level to quote units
+ * first: a per-level floor would under-count the book's capacity by up to one quote
+ * unit per level, and could report a book too thin when it is not.
+ */
+const priceCoveringValue = ({
+	asks,
+	scaledTarget
+}: {
+	asks: PriceLevel[];
+	scaledTarget: bigint;
+}): bigint | undefined => {
+	let cumulative = ZERO;
+
+	for (const level of asks) {
+		cumulative += level.price * level.quantity;
+
+		if (cumulative >= scaledTarget) {
+			return level.price;
+		}
+	}
+
+	return undefined;
+};
+
+/**
+ * Quotes a fill-or-kill order against an order-book snapshot.
+ *
+ * Both sides run the same walk — accumulate levels until the order is covered, take
+ * the price of the last one — because that last price is the worst price the order
+ * can accept and still be certain to fill. What differs is what accumulates, and
+ * what is then derived:
+ *
+ * - a **Sell** knows its quantity (the caller spends the base token outright), so it
+ *   accumulates base quantity and derives its proceeds from the price;
+ * - a **Buy** knows only its spend, so it accumulates the levels' quote value and
+ *   derives its *quantity* from the price — because the canister reserves at the
+ *   limit price rather than at the price the order fills for, so a limit of `P` caps
+ *   the quantity at `sourceAmount / P` however cheaply it ends up filling.
+ *
+ * Because the returned price is one the book can absorb the whole order at, the
+ * order fills in full and `gross` is a floor rather than an estimate. The caller may
+ * receive more (a Sell sweeping levels better than its limit) but never less.
+ *
+ * Returns a reason rather than throwing when there is simply no offerable order — a
+ * book too thin, an amount below one lot, a notional outside the pair's bounds.
+ */
+export const calculateOisyTradeOffer = ({
+	pair,
+	side,
+	sourceAmount,
+	depth
+}: OisyTradeOfferRequest): OisyTradeOfferResult => {
+	// A pair whose grid is non-positive is malformed, not merely unquotable: the
+	// canister guarantees both are positive, and dividing by either would surface as
+	// an opaque RangeError rather than as the bad input it is.
+	if (pair.lot_size <= ZERO) {
+		throw new Error(`OISY Trade pair has a non-positive lot size: ${pair.lot_size}`);
+	}
+
+	if (sourceAmount <= ZERO) {
+		return reject('below_lot');
+	}
+
+	const isSell = 'Sell' in side;
+	const baseUnit = 10n ** BigInt(pair.base.metadata.decimals);
+
+	// A Sell spends the base token outright, so its quantity is on the lot grid
+	// before the walk begins — and is what the walk has to cover. Zero on a Buy,
+	// where the quantity is not knowable until the price is.
+	const sellQuantity = isSell ? floorToLot({ value: sourceAmount, lotSize: pair.lot_size }) : ZERO;
+
+	// Ahead of the walk, so an amount that cannot fill a single lot names the lot
+	// whatever the book holds. Asking afterwards would let an empty opposite side
+	// rename the reason to `no_liquidity`, which the caller cannot act on.
+	if (isSell && sellQuantity <= ZERO) {
+		return reject('below_lot');
+	}
+
+	const price = isSell
+		? priceCoveringQuantity({ bids: depth.bids, quantity: sellQuantity })
+		: priceCoveringValue({ asks: depth.asks, scaledTarget: sourceAmount * baseUnit });
+
+	if (isNullish(price)) {
+		return reject('no_liquidity');
+	}
+
+	if (price <= ZERO) {
+		throw new Error('OISY Trade order book returned a non-positive price level');
+	}
+
+	// A Buy's quantity is what the spend affords at the limit price, on the lot grid
+	// — inverting the did's `notional = price × quantity / 10^base_decimals`.
+	const quantity = isSell
+		? sellQuantity
+		: floorToLot({ value: (sourceAmount * baseUnit) / price, lotSize: pair.lot_size });
+
+	if (quantity <= ZERO) {
+		return reject('below_lot');
+	}
+
+	// Gross, and the value the pair's bounds are measured against — the did's own
+	// formula, in quote smallest units.
+	const notional = (price * quantity) / baseUnit;
+
+	if (notional < pair.min_notional) {
+		return reject('below_min_notional');
+	}
+
+	const maxNotional = fromNullable(pair.max_notional);
+
+	if (nonNullish(maxNotional) && notional > maxNotional) {
+		return reject('above_max_notional');
+	}
+
+	return {
+		ok: true,
+		offer: {
+			price,
+			quantity,
+			// Deposit exactly what the order reserves, in source units. The remainder of
+			// an off-grid amount never leaves the caller's wallet, where it costs no
+			// ledger fee and needs no withdrawal.
+			deposit: isSell ? quantity : notional,
+			// A Sell is paid in the quote token, a Buy receives the base token itself.
+			gross: isSell ? notional : quantity
+		}
+	};
+};

--- a/src/frontend/src/lib/oisy-trade/types.ts
+++ b/src/frontend/src/lib/oisy-trade/types.ts
@@ -1,0 +1,67 @@
+import type {
+	OrderBookDepth,
+	Side,
+	TradingPairInfo
+} from '$declarations/oisy_trade/oisy_trade.did';
+
+/**
+ * What a quote needs: the pair, which way round, how much the caller is spending,
+ * and the book to answer against.
+ *
+ * Shaped as the request record a future `quote_swap` endpoint on `oisy_trade` would
+ * take, minus `depth` — the canister would read the book itself rather than being
+ * handed it. See the README for why that difference is the point.
+ */
+export interface OisyTradeOfferRequest {
+	pair: TradingPairInfo;
+	/** The venue's own variant, so this module never invents a side vocabulary. */
+	side: Side;
+	/**
+	 * What the caller is spending, in **source**-token smallest units: base units on
+	 * a Sell, quote units on a Buy.
+	 */
+	sourceAmount: bigint;
+	/** A price-aggregated snapshot: `bids` price-descending, `asks` price-ascending. */
+	depth: OrderBookDepth;
+}
+
+/**
+ * Why no order is offerable. Venue vocabulary, deliberately not the Swap form's
+ * `FieldErrorKind` — the mapping onto that lives in the swap adapter.
+ */
+export type OisyTradeOfferRejection =
+	/** The opposite side is empty, or too thin to fill the order outright. */
+	| 'no_liquidity'
+	/** The orderable quantity floors to zero: the amount does not buy one lot. */
+	| 'below_lot'
+	/** Gross notional under the pair's floor. */
+	| 'below_min_notional'
+	/** Gross notional over the pair's ceiling. */
+	| 'above_max_notional';
+
+/** A fill-or-kill order the book is certain to fill, and what it is certain to produce. */
+export interface OisyTradeOffer {
+	/**
+	 * Limit price, in quote smallest units per one whole base token. Always a price
+	 * read off the book, so it is a valid `tick_size` multiple by construction.
+	 */
+	price: bigint;
+	/** Order quantity, in base smallest units, a multiple of `lot_size`. */
+	quantity: bigint;
+	/**
+	 * What the order reserves, in **source**-token smallest units — the quantity on a
+	 * Sell, the reserve at the limit price on a Buy. Never more than `sourceAmount`,
+	 * so the unorderable remainder stays with the caller.
+	 */
+	deposit: bigint;
+	/**
+	 * The **minimum** the order produces, in **destination**-token smallest units,
+	 * before the taker fee and any ledger fee. Fills use maker prices, so the real
+	 * proceeds of a Sell can exceed this; a Buy receives exactly this many base
+	 * tokens and gets the unspent reserve back.
+	 */
+	gross: bigint;
+}
+
+export type OisyTradeOfferResult =
+	{ ok: true; offer: OisyTradeOffer } | { ok: false; reason: OisyTradeOfferRejection };

--- a/src/frontend/src/lib/providers/swap.providers.ts
+++ b/src/frontend/src/lib/providers/swap.providers.ts
@@ -36,28 +36,24 @@ export const swapProviders: SwapProviderConfig[] = [
 	},
 	{
 		key: SwapProvider.OISY_TRADE,
-		// The quote itself is synchronous — it reads the cached pair table — so the
-		// registry's async contract is satisfied here rather than inside it. The
-		// fan-out only carries offers, so a rejection collapses to `undefined` at
-		// this boundary; its `errorKind` stays on the service for the form's
-		// empty-offer-list explanation.
+		// The fan-out only carries offers, so a rejection collapses to `undefined`
+		// here — which is why the service names no reason for one: nothing past this
+		// boundary could read it, and the form explains an empty offer list from the
+		// pair instead. A thrown failure — the depth query — is left to propagate, so
+		// it lands in the per-provider `SWAP_OFFER` error analytics where an empty
+		// result would hide it.
 		//
-		// The catch is load-bearing rather than defensive. `fetchSwapAmountsICP`
-		// calls every `getQuote` inside a `.map()` and only hands the resulting
-		// array to `Promise.allSettled` afterwards, so a *synchronous* throw here
-		// would escape the settling and reject the whole fan-out — taking ICPSwap's
-		// and KongSwap's offers down with it. Those two are async functions, which
-		// gives them this containment for free; a sync quote has to ask for it.
-		// Rejecting rather than swallowing keeps a genuine failure in the per-provider
-		// `SWAP_OFFER` error analytics, where an empty result would hide it.
-		getQuote: (params) => {
-			try {
-				const result = fetchOisyTradeQuote(params);
+		// This used to wrap the call in a `try/catch` that re-threw as a rejection,
+		// because `fetchSwapAmountsICP` calls every `getQuote` inside a `.map()` and
+		// only hands the resulting array to `Promise.allSettled` afterwards — so a
+		// *synchronous* throw escaped the settling and rejected the whole fan-out,
+		// taking ICPSwap's and KongSwap's offers with it. Now that the quote awaits
+		// the order book it is an async function like its two siblings, which gives
+		// it that containment for free.
+		getQuote: async (params) => {
+			const result = await fetchOisyTradeQuote(params);
 
-				return Promise.resolve(result.ok ? result.quote : undefined);
-			} catch (err: unknown) {
-				return Promise.reject(err);
-			}
+			return result.ok ? result.quote : undefined;
 		},
 		mapQuoteResult: mapOisyTradeQuoteResult,
 		isEnabled: oisyTradeSwapEnabled,

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -8,7 +8,13 @@ import type {
 } from '$declarations/oisy_trade/oisy_trade.did';
 import type { IcToken } from '$icp/types/ic-token';
 import { getTokenFee } from '$icp/utils/token.utils';
-import { getBalances, getMyOrders, getTradingPairs, withdraw } from '$lib/api/oisy-trade.api';
+import {
+	getBalances,
+	getMyOrders,
+	getOrderBookDepth,
+	getTradingPairs,
+	withdraw
+} from '$lib/api/oisy-trade.api';
 import { OisyTradeError } from '$lib/canisters/oisy-trade.errors';
 import { ZERO } from '$lib/constants/app.constants';
 import { OISY_TRADE_SWAP_SETTLE_POLL_INTERVAL_MILLIS } from '$lib/constants/oisy-trade.constants';
@@ -43,31 +49,20 @@ import {
 	toOisyTradeExternalRefs
 } from '$lib/utils/oisy-trade-active-tx.utils';
 import {
-	computeOisyTradeReceiveAmount,
 	findOisyTradePair,
+	oisyTradeAmountObjection,
 	oisyTradeSupportedSourceTokens,
 	resolveOisyTradeOrder,
 	toOisyTradeCandidSide,
 	toOisyTradePairTable
 } from '$lib/utils/oisy-trade-swap.utils';
-import { toPairView } from '$lib/utils/oisy-trade.utils';
+import { toPairView, toTradingPair } from '$lib/utils/oisy-trade.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
 import { formatUnits } from 'ethers/utils';
 import { get } from 'svelte/store';
-
-/**
- * The placeholder rate: one whole quote token per one whole base token.
- *
- * Replaced by the real order-book walk in its own spec. Everything downstream —
- * the quantity, the reserve, the notional gate, the receive amount — is derived
- * from the price, so that follow-up changes where this number comes from and
- * nothing else. See the spec's "The 1:1 placeholder" section for why the flag
- * must stay `false` until then.
- */
-const OISY_TRADE_PLACEHOLDER_PRICE = 1;
 
 const BASIS_POINTS = 10_000n;
 
@@ -103,51 +98,46 @@ export const loadOisyTradeSwapPairs = async ({
 export const oisyTradeSwapPairTable = (): TradingPairInfo[] =>
 	toOisyTradePairTable(get(oisyTradeStore).pairs ?? []);
 
+// Rounded **up**, so the offer is never a base unit more than the venue will pay.
+// The displayed amount is a floor the user is entitled to, and every rounding on
+// the way to it has to lean the same way.
 const takerFeeAmount = ({ gross, takerFeeBps }: { gross: bigint; takerFeeBps: number }): bigint =>
-	(gross * BigInt(takerFeeBps)) / BASIS_POINTS;
+	(gross * BigInt(takerFeeBps) + BASIS_POINTS - 1n) / BASIS_POINTS;
 
 /**
- * Quotes a fill-or-kill order, or the reason there is none.
+ * Quotes a fill-or-kill order against the live book, or the reason there is none.
  *
  * Returns `ok: false` rather than throwing on every "cannot quote" case — no
- * pair, a halted pair, an unorderable amount, a missing ledger fee. The fan-out
- * discards rejections anyway, but a rejection keeps a non-offer out of the error
- * analytics, where it would read as a broken provider rather than an absent one,
- * and `errorKind` is what the form's empty-offer-list explanation names.
+ * pair, a halted pair, an unorderable amount, a book too thin, a missing ledger
+ * fee. The fan-out discards rejections anyway, but a rejection keeps a non-offer
+ * out of the error analytics, where it would read as a broken provider rather than
+ * an absent one.
  *
- * Synchronous: `getSupportedTokens` has already cached the pair table by the
- * time any quote runs, so there is nothing to await. The registry's `getQuote`
- * contract is async, and the adaptation happens at that boundary rather than by
- * making this function pretend to be asynchronous.
+ * A depth query that *fails*, by contrast, is allowed to throw: that is a broken
+ * provider and belongs in the per-provider `SWAP_OFFER` analytics, where an empty
+ * result would hide it. `fetchSwapAmountsICP` settles every provider's promise
+ * independently, so it costs no sibling its offer.
+ *
+ * The book is fetched last, after every disqualification that does not need it, so
+ * neither an unquotable pair nor an unorderable amount costs a canister call.
  */
-export const fetchOisyTradeQuote = ({
+export const fetchOisyTradeQuote = async ({
+	identity,
 	sourceToken,
 	destinationToken,
 	sourceAmount
 }: {
+	identity: Identity;
 	sourceToken: IcToken;
 	destinationToken: IcToken;
 	sourceAmount: bigint;
-}): OisyTradeQuoteResult => {
+}): Promise<OisyTradeQuoteResult> => {
 	const table = oisyTradeSwapPairTable();
 	const pair = findOisyTradePair({ sourceToken, destinationToken, table });
 
 	if (isNullish(pair)) {
 		return { ok: false };
 	}
-
-	const resolution = resolveOisyTradeOrder({
-		sourceToken,
-		amount: sourceAmount,
-		price: OISY_TRADE_PLACEHOLDER_PRICE,
-		pair
-	});
-
-	if (!resolution.ok) {
-		return { ok: false, errorKind: resolution.errorKind };
-	}
-
-	const { order } = resolution;
 
 	const sourceLedgerFee = getTokenFee(sourceToken);
 	const destinationLedgerFee = getTokenFee(destinationToken);
@@ -156,24 +146,38 @@ export const fetchOisyTradeQuote = ({
 		return { ok: false };
 	}
 
-	const pairView = toPairView(pair);
+	// The two objections the pair settles on its own — a Sell below one lot, a Buy
+	// spending less than `min_notional`. Both are certain, so asking before the
+	// fetch spares a canister query on every keystroke and every 5s re-quote tick
+	// for an amount no book could rescue. The same function answers the form's
+	// empty-offer-list message, which is why the two cannot come to disagree.
+	if (nonNullish(oisyTradeAmountObjection({ sourceToken, amount: sourceAmount, pair }))) {
+		return { ok: false };
+	}
 
-	// What the order fills for, before the venue and the ledger take their cuts.
-	// At the placeholder price this is the deposited amount rescaled to the
-	// destination's decimals; the real calculation replaces the price it derives
-	// from, not this step.
-	//
-	// `depositAmount` was derived from the *pair's* decimals (`toPairView` reads
-	// them off the canister's leg metadata) and is rescaled here with the *token's*
-	// — two records describing the same two ledgers. They agree by construction, and
-	// nothing enforces it: a disagreement would move the receive amount by a power
-	// of ten silently, so the pair is the authority for anything the canister will
-	// check and the token only ever formats what the wallet displays.
-	const gross = computeOisyTradeReceiveAmount({
-		amount: order.depositAmount,
-		sourceDecimals: sourceToken.decimals,
-		destinationDecimals: destinationToken.decimals
+	// `limit` unset takes the canister's 100 levels per side. A walk that runs out
+	// of levels reports a book too thin, which is pessimistic rather than wrong on a
+	// book deeper than that — and no real pair is expected to be.
+	const depth = await getOrderBookDepth({
+		identity,
+		request: { trading_pair: toTradingPair(pair), limit: [] },
+		nullishIdentityErrorMessage: get(i18n).auth.error.no_internet_identity
 	});
+
+	const resolution = resolveOisyTradeOrder({
+		sourceToken,
+		amount: sourceAmount,
+		depth,
+		pair
+	});
+
+	if (!resolution.ok) {
+		return { ok: false };
+	}
+
+	const { order, gross } = resolution;
+
+	const pairView = toPairView(pair);
 
 	const takerFee = takerFeeAmount({ gross, takerFeeBps: pairView.takerFeeBps });
 

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1610,6 +1610,7 @@ interface I18nTrading {
 		error_balance_sell: string;
 		error_balance_buy: string;
 		error_lot_multiple: string;
+		error_lot_minimum: string;
 		error_tick_multiple: string;
 		error_min_notional: string;
 		error_max_notional: string;

--- a/src/frontend/src/lib/types/oisy-trade-swap.ts
+++ b/src/frontend/src/lib/types/oisy-trade-swap.ts
@@ -1,7 +1,7 @@
 import type { TradingPair } from '$declarations/oisy_trade/oisy_trade.did';
 import type { ProviderFee } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
-import type { FieldErrorKind, LimitOrderSide } from '$lib/utils/oisy-trade.utils';
+import type { LimitOrderSide } from '$lib/utils/oisy-trade.utils';
 
 export const OISY_TRADE_EXTERNAL_REF_KEYS = {
 	// The poll key. `get_my_orders` with `ById` is the only settlement oracle,
@@ -103,17 +103,15 @@ export interface OisyTradeQuote {
 }
 
 /**
- * A quote, or the named reason there is none.
+ * A quote, or nothing.
  *
- * The fan-out itself only carries offers — the registry adapter drops the
- * rejection — but `errorKind` maps one-to-one onto the shipped Limit Order i18n
- * copy, and it is what lets the form explain an empty offer list (via
- * `notOfferedExplained` + `message`) instead of the generic "swap is not
- * offered". Rejections without a kind (no pair, halted pair, unknown ledger fee)
- * have nothing user-actionable to say.
+ * Rejection carries no reason: the fan-out only transports offers, so nothing
+ * downstream could read one. The form explains an empty offer list from the pair
+ * instead (`oisyTradeAmountObjection`), which is the only explanation available
+ * without awaiting the order book. A rejection is still distinct from a throw —
+ * "no offer" must not reach the per-provider error analytics.
  */
-export type OisyTradeQuoteResult =
-	{ ok: true; quote: OisyTradeQuote } | { ok: false; errorKind?: FieldErrorKind };
+export type OisyTradeQuoteResult = { ok: true; quote: OisyTradeQuote } | { ok: false };
 
 export interface OisyTradeSwapDetails {
 	// Itemized, never summed: the three fees are denominated in two different

--- a/src/frontend/src/lib/utils/oisy-trade-swap.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade-swap.utils.ts
@@ -1,20 +1,16 @@
-import type { TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
-import { ZERO } from '$lib/constants/app.constants';
+import type { OrderBookDepth, TradingPairInfo } from '$declarations/oisy_trade/oisy_trade.did';
+import { calculateOisyTradeOffer } from '$lib/oisy-trade';
 import type { OisyTradeResolvedOrder } from '$lib/types/oisy-trade-swap';
 import type { SwapCategorizedTokenIds } from '$lib/types/swap';
 import type { Token } from '$lib/types/token';
 import {
-	floorToStep,
 	toCandidSide,
-	toPairView,
-	toPriceUnits,
 	toTradingPair,
-	validateAmount,
 	type FieldErrorKind,
 	type LimitOrderSide
 } from '$lib/utils/oisy-trade.utils';
 import { resolveSwapTokenLookup } from '$lib/utils/swap-tokens-filter.utils';
-import { fromNullable, isNullish, nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 /**
  * Adapter from the swap flow onto the shipped Trading helpers — deliberately
@@ -149,61 +145,49 @@ export const resolveOisyTradeSide = ({
 };
 
 export type OisyTradeOrderResolution =
-	{ ok: true; order: OisyTradeResolvedOrder } | { ok: false; errorKind?: FieldErrorKind };
+	| {
+			ok: true;
+			order: OisyTradeResolvedOrder;
+			/**
+			 * The minimum the order produces, in destination smallest units, before the
+			 * taker fee and the withdrawal ledger fee. The caller nets both off it.
+			 */
+			gross: bigint;
+	  }
+	| { ok: false };
 
 /**
  * The typed source amount resolved into a submittable fill-or-kill order.
  *
- * Every value the canister will check — the quantity, the price and the notional
- * — is derived in **bigint**, and the three grid rules are re-checked exactly
- * against the pair's own base-unit steps after `validateAmount` has had its say.
+ * A thin adapter, deliberately: the arithmetic lives in `$lib/oisy-trade`, which
+ * knows the venue and nothing else, and this function only decides which side of
+ * the pair the source token sits on and re-words the outcome for the Swap form.
  *
- * That exactness is not belt-and-braces. `validateAmount` and its helpers work in
- * the human float domain, which is safe for 6- and 8-decimal tokens but not for
- * 18: converting base units to a human float and back is not an identity, and
- * `isMultipleOfStep` allows a 1e-6 *relative* tolerance, which for an 18-decimal
- * token is ~1e9 base units of slack. Measured, 7.3% of on-grid ckETH amounts —
- * starting at 0.009 ckETH — came back from the float round-trip one base unit off
- * the lot grid while still passing the float check. The canister rejects such an
- * order with `InvalidQuantity`, and it does so *after* `deposit` has already moved
- * the funds into DEX custody, so a float verdict here is a stranded-funds bug
- * rather than a rounding curiosity. The shipped Limit Order form has the same
- * float round-trip, but nothing precedes its `add_limit_order`, so there the same
- * rejection costs nothing.
- *
- * `validateAmount` is still the gate for affordability and for the `errorKind`
- * precedence the form's messages depend on, so the two surfaces cannot disagree
- * about *why* an amount is unorderable — only about the last base unit, where this
- * one is right.
+ * Nothing here converts a price to a float. Every price the walk can return is one
+ * read off the book, so it is already a valid `tick_size` multiple and already in
+ * the canister's own units — which is what retired the float round-trip this
+ * function used to carry, along with the `validateAmount` call that needed it. That
+ * call had also become redundant: no caller ever passed `freeBalance`, so its
+ * affordability leg never fired, and its two grid checks are now made exactly, in
+ * bigint, inside the module.
  *
  * Returns `ok: false` rather than throwing when the amount is not orderable —
- * OISY Trade simply contributes no offer, and `errorKind` lets the form name the
- * reason when no other provider quoted either.
+ * OISY Trade simply contributes no offer. The module's reason is deliberately not
+ * carried across: nothing downstream of the fan-out can read one, and the form
+ * derives its own explanation from the pair (`oisyTradeAmountObjection`), which is
+ * the only one it can reach without awaiting the book.
  */
 export const resolveOisyTradeOrder = ({
 	sourceToken,
 	amount,
-	price,
-	freeBalance,
+	depth,
 	pair
 }: {
 	sourceToken: Token;
 	// Source-token smallest units, as the quote fan-out carries it.
 	amount: bigint;
-	// Human quote-per-whole-base rate. Snapped to the tick grid here.
-	price: number;
-	/**
-	 * Human source-token balance the order has to fit inside.
-	 *
-	 * Optional because the quote path has no balance to offer — `SwapQuoteParams`
-	 * carries only the identity, the two tokens and the amount. Left unset, the
-	 * affordability leg of `validateAmount` is a no-op and only the grid rules
-	 * apply, which is also the behaviour the offer list wants: every other provider
-	 * quotes an unaffordable amount and lets the form report insufficient funds, so
-	 * suppressing the offer here would make OISY Trade blink out where its peers
-	 * still appear. Execution passes the real figure.
-	 */
-	freeBalance?: number;
+	// The book the order will cross, as `get_order_book_depth` returned it.
+	depth: OrderBookDepth;
 	pair: TradingPairInfo;
 }): OisyTradeOrderResolution => {
 	const side = resolveOisyTradeSide({ sourceToken, pair });
@@ -212,78 +196,29 @@ export const resolveOisyTradeOrder = ({
 		return { ok: false };
 	}
 
-	const pairView = toPairView(pair);
-	const tickedPrice = floorToStep({ value: price, step: pairView.tickSize });
+	const result = calculateOisyTradeOffer({
+		pair,
+		side: toCandidSide(side),
+		sourceAmount: amount,
+		depth
+	});
 
-	if (!(tickedPrice > 0)) {
+	if (!result.ok) {
 		return { ok: false };
 	}
 
-	const priceUnits = toPriceUnits({
-		price: tickedPrice,
-		quoteDecimals: pairView.quoteDecimals
-	});
-
-	if (priceUnits <= ZERO || priceUnits % pair.tick_size !== ZERO) {
-		return { ok: false };
-	}
-
-	const baseUnit = 10n ** BigInt(pairView.baseDecimals);
-
-	// A Sell spends the base token outright, so the typed amount *is* the quantity —
-	// no conversion, and so no rounding residue at all. A Buy's quantity is derived
-	// (the base amount its quote spend affords at the limit price), which the user
-	// cannot control by typing, so only there is it floored to the grid and the
-	// deposit shrunk to the order's reserve. Inverting the did's
-	// `notional = price × quantity / 10^base_decimals` gives the affordable quantity.
-	const rawQuantity = side === 'sell' ? amount : (amount * baseUnit) / priceUnits;
-	const quantity = side === 'sell' ? rawQuantity : rawQuantity - (rawQuantity % pair.lot_size);
-
-	if (quantity <= ZERO) {
-		return { ok: false, errorKind: 'lot' };
-	}
-
-	// In quote smallest units. Exact, and the same value the Buy path deposits.
-	const notional = (priceUnits * quantity) / baseUnit;
-
-	const { ok, errorKind } = validateAmount({
-		side,
-		baseAmount: Number(quantity) / 10 ** pairView.baseDecimals,
-		price: tickedPrice,
-		freeBalance: freeBalance ?? Number.POSITIVE_INFINITY,
-		pair: pairView
-	});
-
-	if (!ok) {
-		return { ok: false, errorKind };
-	}
-
-	// The exact re-check of what the canister enforces. A float verdict can accept
-	// each of these for an 18-decimal token — see the note above — and every
-	// rejection here would otherwise land after the deposit.
-	if (quantity % pair.lot_size !== ZERO) {
-		return { ok: false, errorKind: 'lot' };
-	}
-
-	if (notional < pair.min_notional) {
-		return { ok: false, errorKind: 'min_notional' };
-	}
-
-	const maxNotional = fromNullable(pair.max_notional);
-
-	if (nonNullish(maxNotional) && notional > maxNotional) {
-		return { ok: false, errorKind: 'max_notional' };
-	}
+	const { price, quantity, deposit, gross } = result.offer;
 
 	return {
 		ok: true,
 		order: {
 			side,
 			pair: toTradingPair(pair),
-			price: priceUnits,
+			price,
 			quantity,
-			depositAmount: side === 'sell' ? quantity : notional
-		}
+			depositAmount: deposit
+		},
+		gross
 	};
 };
 
@@ -291,22 +226,51 @@ export const resolveOisyTradeOrder = ({
 export const toOisyTradeCandidSide = toCandidSide;
 
 /**
- * Placeholder receive amount: the source amount at a 1:1 *human-unit* rate.
+ * Why a typed amount can never yield an OISY Trade order, judged from the pair
+ * alone — for the form's empty-offer-list explanation.
  *
- * A decimal rescale, not a copy — `receiveAmount` is in destination base units,
- * so 1 ICP (8 dp) → 1 ckUSDT (6 dp) is `1_000_000`, not `100_000_000`. Passing
- * the bigint through unchanged would be wrong by `10^(dest − source)`.
+ * Deliberately **not** the full walk. Naming the reason is a synchronous question
+ * (`$derived.by` cannot await) and the answer has to survive without an order-book
+ * snapshot, so this reports only the two objections a pair settles on its own, and
+ * both are certain rather than likely:
  *
- * Replaced wholesale by the real order-book walk in its own spec; nothing
- * downstream reads anything but the result, so this is the only function that
- * changes. Multiplication first, integer division last, bigint throughout.
+ * - a **Sell** below one lot floors to a zero quantity, whatever the book says;
+ * - a **Buy** spending less than `min_notional` cannot clear the floor either, since
+ *   an order's notional is its reserve and the reserve never exceeds the spend.
+ *
+ * They are also the only two objections a user can act on: both say "type more".
+ * Every other absence — a book too thin, a notional that only binds once the price
+ * is known — depends on the book, so it returns `undefined` and the form falls back
+ * to the generic "swap is not offered", which is true and needs no new copy.
+ *
+ * Where both bind at once the module may name the lot and this the notional. Both
+ * statements are true and both point the same way, and the notional is the one the
+ * user can satisfy with certainty, so it wins here.
+ *
+ * The return type is narrowed to the two kinds this can actually reach, rather
+ * than the whole of `FieldErrorKind`: `max_notional` needs a price and so a book,
+ * and `balance` cannot arise at quote time. Narrowing keeps the caller's message
+ * switch from carrying branches nothing can select — and, being an `Extract`, it
+ * fails to compile if either member is ever renamed out of the shared union.
  */
-export const computeOisyTradeReceiveAmount = ({
+export const oisyTradeAmountObjection = ({
+	sourceToken,
 	amount,
-	sourceDecimals,
-	destinationDecimals
+	pair
 }: {
+	sourceToken: Token;
 	amount: bigint;
-	sourceDecimals: number;
-	destinationDecimals: number;
-}): bigint => (amount * 10n ** BigInt(destinationDecimals)) / 10n ** BigInt(sourceDecimals);
+	pair: TradingPairInfo;
+}): Extract<FieldErrorKind, 'lot' | 'min_notional'> | undefined => {
+	const side = resolveOisyTradeSide({ sourceToken, pair });
+
+	if (isNullish(side)) {
+		return undefined;
+	}
+
+	if (side === 'sell') {
+		return amount < pair.lot_size ? 'lot' : undefined;
+	}
+
+	return amount < pair.min_notional ? 'min_notional' : undefined;
+};

--- a/src/frontend/src/tests/fixtures/oisy-trade/offer-calculation.json
+++ b/src/frontend/src/tests/fixtures/oisy-trade/offer-calculation.json
@@ -1,0 +1,203 @@
+{
+	"pair": {
+		"baseSymbol": "ICP",
+		"baseDecimals": 8,
+		"quoteSymbol": "USDT",
+		"quoteDecimals": 6,
+		"lotSize": "12000000",
+		"tickSize": "1",
+		"minNotional": "0",
+		"maxNotional": null,
+		"takerFeeBps": 100,
+		"makerFeeBps": 0
+	},
+	"fees": {
+		"$comment": "Ledger withdrawal fees, subtracted by the swap layer, not by the module.",
+		"baseLedgerFee": "10000",
+		"quoteLedgerFee": "10000"
+	},
+	"book": {
+		"$comment": "bids price-descending, asks price-ascending, as get_order_book_depth returns them.",
+		"bids": [
+			{ "price": "5000000", "quantity": "200000000" },
+			{ "price": "4000000", "quantity": "200000000" },
+			{ "price": "3000000", "quantity": "200000000" },
+			{ "price": "2000000", "quantity": "1000000000" }
+		],
+		"asks": [
+			{ "price": "8000000", "quantity": "200000000" },
+			{ "price": "10000000", "quantity": "200000000" },
+			{ "price": "20000000", "quantity": "200000000" },
+			{ "price": "24000000", "quantity": "1000000000" }
+		]
+	},
+	"cases": [
+		{
+			"id": "D",
+			"description": "sell 1 ICP: floors to 8 lots, absorbed by the best bid alone",
+			"side": "sell",
+			"sourceAmount": "100000000",
+			"expect": {
+				"price": "5000000",
+				"quantity": "96000000",
+				"deposit": "96000000",
+				"gross": "4800000"
+			},
+			"expectReceive": "4742000"
+		},
+		{
+			"id": "E",
+			"description": "sell 4 ICP: 33 lots, needs the first two bid levels",
+			"side": "sell",
+			"sourceAmount": "400000000",
+			"expect": {
+				"price": "4000000",
+				"quantity": "396000000",
+				"deposit": "396000000",
+				"gross": "15840000"
+			},
+			"expectReceive": "15671600"
+		},
+		{
+			"id": "F",
+			"description": "sell 10 ICP: 83 lots, needs all four bid levels",
+			"side": "sell",
+			"sourceAmount": "1000000000",
+			"expect": {
+				"price": "2000000",
+				"quantity": "996000000",
+				"deposit": "996000000",
+				"gross": "19920000"
+			},
+			"expectReceive": "19710800"
+		},
+		{
+			"id": "H",
+			"description": "buy with 10 USDT: covered by the best ask, affords 10 lots",
+			"side": "buy",
+			"sourceAmount": "10000000",
+			"expect": {
+				"price": "8000000",
+				"quantity": "120000000",
+				"deposit": "9600000",
+				"gross": "120000000"
+			},
+			"expectReceive": "118790000"
+		},
+		{
+			"id": "I",
+			"description": "buy with 30 USDT: lands on exactly 25 lots, so the lot floor is a no-op",
+			"side": "buy",
+			"sourceAmount": "30000000",
+			"expect": {
+				"price": "10000000",
+				"quantity": "300000000",
+				"deposit": "30000000",
+				"gross": "300000000"
+			},
+			"expectReceive": "296990000"
+		},
+		{
+			"id": "J",
+			"description": "buy with 40 USDT: value covered at the third ask level",
+			"side": "buy",
+			"sourceAmount": "40000000",
+			"expect": {
+				"price": "20000000",
+				"quantity": "192000000",
+				"deposit": "38400000",
+				"gross": "192000000"
+			},
+			"expectReceive": "190070000"
+		},
+		{
+			"id": "K",
+			"description": "buy with 100 USDT: value covered only at the deepest ask level",
+			"side": "buy",
+			"sourceAmount": "100000000",
+			"expect": {
+				"price": "24000000",
+				"quantity": "408000000",
+				"deposit": "97920000",
+				"gross": "408000000"
+			},
+			"expectReceive": "403910000"
+		},
+		{
+			"id": "sell-beyond-bid-depth",
+			"description": "sell 20 ICP against 16 ICP of bids: the order cannot fill outright",
+			"side": "sell",
+			"sourceAmount": "2000000000",
+			"expect": { "reason": "no_liquidity" }
+		},
+		{
+			"id": "buy-beyond-ask-value",
+			"description": "buy with 400 USDT against 316 USDT of asks: the spend is never covered",
+			"side": "buy",
+			"sourceAmount": "40000000000",
+			"expect": { "reason": "no_liquidity" }
+		},
+		{
+			"id": "sell-below-one-lot",
+			"description": "sell 0.1 ICP under a 0.12 ICP lot",
+			"side": "sell",
+			"sourceAmount": "10000000",
+			"expect": { "reason": "below_lot" }
+		},
+		{
+			"id": "buy-below-one-lot",
+			"description": "buy with 0.5 USDT, which affords 0.0625 ICP at the best ask",
+			"side": "buy",
+			"sourceAmount": "500000",
+			"expect": { "reason": "below_lot" }
+		},
+		{
+			"id": "sell-empty-book",
+			"description": "no bids at all",
+			"side": "sell",
+			"sourceAmount": "400000000",
+			"book": { "bids": [], "asks": [] },
+			"expect": { "reason": "no_liquidity" }
+		},
+		{
+			"id": "sell-below-one-lot-empty-book",
+			"description": "sub-lot sell with no bids: the lot is the reason, not the empty book",
+			"side": "sell",
+			"sourceAmount": "10000000",
+			"book": { "bids": [], "asks": [] },
+			"expect": { "reason": "below_lot" }
+		},
+		{
+			"id": "buy-empty-book",
+			"description": "no asks at all",
+			"side": "buy",
+			"sourceAmount": "40000000",
+			"book": { "bids": [], "asks": [] },
+			"expect": { "reason": "no_liquidity" }
+		},
+		{
+			"id": "sell-below-min-notional",
+			"description": "column D's 4.8 USDT notional against a 5 USDT floor",
+			"side": "sell",
+			"sourceAmount": "100000000",
+			"pair": { "minNotional": "5000000" },
+			"expect": { "reason": "below_min_notional" }
+		},
+		{
+			"id": "sell-above-max-notional",
+			"description": "column E's 15.84 USDT notional against a 10 USDT ceiling",
+			"side": "sell",
+			"sourceAmount": "400000000",
+			"pair": { "maxNotional": "10000000" },
+			"expect": { "reason": "above_max_notional" }
+		},
+		{
+			"id": "buy-above-max-notional",
+			"description": "column J's 38.4 USDT reserve against a 20 USDT ceiling",
+			"side": "buy",
+			"sourceAmount": "40000000",
+			"pair": { "maxNotional": "20000000" },
+			"expect": { "reason": "above_max_notional" }
+		}
+	]
+}

--- a/src/frontend/src/tests/icp/components/swap/SwapIcpForm.spec.ts
+++ b/src/frontend/src/tests/icp/components/swap/SwapIcpForm.spec.ts
@@ -588,8 +588,8 @@ describe('SwapIcpForm', () => {
 			fee: 10_000n
 		};
 
-		// A 0.01 ICP lot, so 1.23 sits on the grid and 1.234 does not. The tick is 0.001
-		// ckUSDC per whole ICP, which the 1:1 placeholder price floors onto exactly.
+		// A 0.01 ICP lot. An off-grid amount is no longer an objection — a Sell floors
+		// onto the grid — so the cases below use an amount *below* one lot instead.
 		const buildPair = ({ minNotional = 1_000n }: { minNotional?: bigint } = {}) =>
 			({
 				status: { Trading: null },
@@ -609,7 +609,7 @@ describe('SwapIcpForm', () => {
 				taker_fee_bps: 10
 			}) as unknown as TradingPairInfo;
 
-		const lotMessage = replacePlaceholders(en.trading.limit_order.error_lot_multiple, {
+		const lotMessage = replacePlaceholders(en.trading.limit_order.error_lot_minimum, {
 			$step: '0.01',
 			$symbol: 'ICP'
 		});
@@ -621,32 +621,38 @@ describe('SwapIcpForm', () => {
 			amountForSwap,
 			minNotional,
 			pairs = [buildPair({ minNotional })],
-			isSourceTokenIcrc2 = true
+			isSourceTokenIcrc2 = true,
+			// Reversed for the Buy-side cases: spending the *quote* token is what makes
+			// `min_notional` answerable without an order book.
+			sourceToken = icpToken,
+			destinationToken = usdcToken
 		}: {
 			swaps?: SwapMappedResult[];
 			amountForSwap: number;
 			minNotional?: bigint;
 			pairs?: TradingPairInfo[];
 			isSourceTokenIcrc2?: boolean;
+			sourceToken?: typeof icpToken;
+			destinationToken?: typeof usdcToken;
 		}) => {
 			oisyTradeStore.setPairs(pairs);
 
 			balancesStore.set({
-				id: icpToken.id,
+				id: sourceToken.id,
 				data: { data: 100_000_000_000n, certified: true }
 			});
 
 			mockContext.set(SWAP_CONTEXT_KEY, {
 				...initSwapContext({
-					sourceToken: icpToken as IcTokenToggleable,
-					destinationToken: usdcToken as IcTokenToggleable
+					sourceToken: sourceToken as IcTokenToggleable,
+					destinationToken: destinationToken as IcTokenToggleable
 				}),
 				sourceTokenExchangeRate: readable(10),
 				destinationTokenExchangeRate: readable(2),
 				isSourceTokenIcrc2: readable(isSourceTokenIcrc2)
 			});
 
-			icTokenFeeStore.setIcTokenFee({ tokenSymbol: icpToken.symbol, fee: 1000n });
+			icTokenFeeStore.setIcTokenFee({ tokenSymbol: sourceToken.symbol, fee: 1000n });
 
 			const amountsStore = initSwapAmountsStore();
 			amountsStore.setSwaps({ swaps, amountForSwap, selectedProvider: swaps[0] });
@@ -662,24 +668,41 @@ describe('SwapIcpForm', () => {
 			oisyTradeStore.reset();
 		});
 
-		it('names the lot grid when no provider quoted the amount', async () => {
-			const { container, getByText } = renderWithOisyTradePair({ amountForSwap: 1.234 });
+		it('names the lot grid when the amount is below one lot', async () => {
+			const { container, getByText } = renderWithOisyTradePair({ amountForSwap: 0.005 });
 
-			await enterAmount({ container, value: '1.234' });
+			await enterAmount({ container, value: '0.005' });
 
 			await waitFor(() => {
 				expect(getByText(lotMessage)).toBeInTheDocument();
 			});
 		});
 
-		// The generic message and the specific one contradict each other: a swap *is* offered,
-		// just not for this amount. `notOfferedExplained` is what suppresses the generic one.
-		it('replaces the generic not-offered message rather than doubling it', async () => {
+		// An off-grid Sell is floored onto the lot grid rather than refused, so it is
+		// orderable and there is nothing to explain. Any absence of an offer at this
+		// amount is the book's doing, which no amount-field message can honestly name.
+		it('says nothing about an off-grid amount, which is now floored rather than refused', async () => {
 			const { container, getByText, queryByText } = renderWithOisyTradePair({
 				amountForSwap: 1.234
 			});
 
 			await enterAmount({ container, value: '1.234' });
+
+			await waitFor(() => {
+				expect(getByText(en.swap.text.swap_is_not_offered)).toBeInTheDocument();
+			});
+
+			expect(queryByText(lotMessage)).not.toBeInTheDocument();
+		});
+
+		// The generic message and the specific one contradict each other: a swap *is* offered,
+		// just not for this amount. `notOfferedExplained` is what suppresses the generic one.
+		it('replaces the generic not-offered message rather than doubling it', async () => {
+			const { container, getByText, queryByText } = renderWithOisyTradePair({
+				amountForSwap: 0.005
+			});
+
+			await enterAmount({ container, value: '0.005' });
 
 			await waitFor(() => {
 				expect(getByText(lotMessage)).toBeInTheDocument();
@@ -688,11 +711,15 @@ describe('SwapIcpForm', () => {
 			expect(queryByText(en.swap.text.swap_is_not_offered)).not.toBeInTheDocument();
 		});
 
-		// A 1 ICP order at the 1:1 placeholder is a notional of 1 ckUSDC, under a floor of 10.
-		it('names the minimum order value when the amount is on the grid but too small', async () => {
+		// Spending 1 ckUSDC against a 10 ckUSDC floor. An order's notional is its
+		// reserve and the reserve never exceeds the spend, so this is unorderable at
+		// any price the book could offer — which is what makes it nameable without one.
+		it('names the minimum order value when a buy spends less than the floor', async () => {
 			const { container, getByText } = renderWithOisyTradePair({
 				amountForSwap: 1,
-				minNotional: 10_000_000n
+				minNotional: 10_000_000n,
+				sourceToken: usdcToken,
+				destinationToken: icpToken
 			});
 
 			await enterAmount({ container, value: '1' });
@@ -710,15 +737,16 @@ describe('SwapIcpForm', () => {
 		});
 
 		// The single highest-risk behaviour in the integration: an ICP source has five
-		// providers, and OISY Trade's lot grid must never reach `errorType` and disable Review
-		// for someone swapping 1.234 ICP through a provider that does not care about lots.
-		it('leaves Review enabled for an off-grid amount another provider quotes', async () => {
+		// providers, and OISY Trade's grid must never reach `errorType` and disable Review
+		// for someone swapping through a provider that has no lot size. The amount is
+		// below one lot, so the objection would fire if the offer list were empty.
+		it('leaves Review enabled for an unorderable amount another provider quotes', async () => {
 			const { container, getByText, queryByText } = renderWithOisyTradePair({
 				swaps: [mockOneSecProvider],
-				amountForSwap: 1.234
+				amountForSwap: 0.005
 			});
 
-			await enterAmount({ container, value: '1.234' });
+			await enterAmount({ container, value: '0.005' });
 
 			await waitFor(() => {
 				expect(getByText(en.swap.text.review_button).closest('button')).not.toBeDisabled();

--- a/src/frontend/src/tests/lib/oisy-trade/offer.spec.ts
+++ b/src/frontend/src/tests/lib/oisy-trade/offer.spec.ts
@@ -1,0 +1,252 @@
+import type {
+	OrderBookDepth,
+	PriceLevel,
+	Side,
+	TradingPairInfo
+} from '$declarations/oisy_trade/oisy_trade.did';
+import { ZERO } from '$lib/constants/app.constants';
+import { calculateOisyTradeOffer, type OisyTradeOfferRejection } from '$lib/oisy-trade';
+import fixture from '$tests/fixtures/oisy-trade/offer-calculation.json';
+import { Principal } from '@dfinity/principal';
+import { toNullable } from '@dfinity/utils';
+
+interface FixtureLevel {
+	price: string;
+	quantity: string;
+}
+
+interface FixtureCase {
+	id: string;
+	description: string;
+	side: string;
+	sourceAmount: string;
+	book?: { bids: FixtureLevel[]; asks: FixtureLevel[] };
+	pair?: { minNotional?: string; maxNotional?: string };
+	expect: {
+		price?: string;
+		quantity?: string;
+		deposit?: string;
+		gross?: string;
+		reason?: string;
+	};
+	expectReceive?: string;
+}
+
+const BASIS_POINTS = 10_000n;
+
+const { pair: fixturePair, fees, book, cases } = fixture;
+
+const baseUnit = 10n ** BigInt(fixturePair.baseDecimals);
+
+const toLevels = (levels: FixtureLevel[]): PriceLevel[] =>
+	levels.map(({ price, quantity }) => ({ price: BigInt(price), quantity: BigInt(quantity) }));
+
+const toDepth = (source: { bids: FixtureLevel[]; asks: FixtureLevel[] }): OrderBookDepth => ({
+	bids: toLevels(source.bids),
+	asks: toLevels(source.asks)
+});
+
+const leg = ({ symbol, decimals }: { symbol: string; decimals: number }) => ({
+	id: { ledger_id: Principal.anonymous() },
+	metadata: { symbol, decimals }
+});
+
+const toPair = (overrides?: { minNotional?: string; maxNotional?: string }): TradingPairInfo => ({
+	status: { Trading: null },
+	base: leg({ symbol: fixturePair.baseSymbol, decimals: fixturePair.baseDecimals }),
+	quote: leg({ symbol: fixturePair.quoteSymbol, decimals: fixturePair.quoteDecimals }),
+	lot_size: BigInt(fixturePair.lotSize),
+	tick_size: BigInt(fixturePair.tickSize),
+	min_notional: BigInt(overrides?.minNotional ?? fixturePair.minNotional),
+	max_notional: toNullable(
+		(overrides?.maxNotional ?? fixturePair.maxNotional) === null
+			? undefined
+			: BigInt((overrides?.maxNotional ?? fixturePair.maxNotional) as string)
+	),
+	maker_fee_bps: fixturePair.makerFeeBps,
+	taker_fee_bps: fixturePair.takerFeeBps
+});
+
+const toSide = (side: string): Side => (side === 'sell' ? { Sell: null } : { Buy: null });
+
+const request = (testCase: FixtureCase) => ({
+	pair: toPair(testCase.pair),
+	side: toSide(testCase.side),
+	sourceAmount: BigInt(testCase.sourceAmount),
+	depth: toDepth(testCase.book ?? book)
+});
+
+/**
+ * What the order actually clears at maker prices, walking the same snapshot: the
+ * quote proceeds of a Sell, and the quote cost of a Buy. The venue matches at the
+ * resting order's price, not at the incoming limit, so this is what the offer is
+ * measured against.
+ */
+const replayFill = ({
+	levels,
+	quantity
+}: {
+	levels: PriceLevel[];
+	quantity: bigint;
+}): { filled: bigint; value: bigint } => {
+	let remaining = quantity;
+	let value = ZERO;
+
+	for (const level of levels) {
+		if (remaining <= ZERO) {
+			break;
+		}
+
+		const taken = level.quantity < remaining ? level.quantity : remaining;
+
+		value += level.price * taken;
+		remaining -= taken;
+	}
+
+	return { filled: quantity - remaining, value: value / baseUnit };
+};
+
+const offerCases = (cases as FixtureCase[]).filter(({ expect: { reason } }) => !reason);
+
+describe('calculateOisyTradeOffer', () => {
+	describe('the worked examples', () => {
+		it.each(cases as FixtureCase[])('$id — $description', (testCase) => {
+			const result = calculateOisyTradeOffer(request(testCase));
+
+			if (testCase.expect.reason) {
+				expect(result).toEqual({ ok: false, reason: testCase.expect.reason });
+
+				return;
+			}
+
+			expect(result).toEqual({
+				ok: true,
+				offer: {
+					price: BigInt(testCase.expect.price as string),
+					quantity: BigInt(testCase.expect.quantity as string),
+					deposit: BigInt(testCase.expect.deposit as string),
+					gross: BigInt(testCase.expect.gross as string)
+				}
+			});
+		});
+	});
+
+	describe('the offer is a floor the venue cannot undercut', () => {
+		it.each(offerCases)('$id fills in full and clears at least the offer', (testCase) => {
+			const result = calculateOisyTradeOffer(request(testCase));
+
+			assert(result.ok);
+
+			const { price, quantity, deposit, gross } = result.offer;
+			const depth = toDepth(testCase.book ?? book);
+
+			if (testCase.side === 'sell') {
+				// Only levels at or above the limit may match a Sell.
+				const crossing = depth.bids.filter((level) => level.price >= price);
+				const { filled, value } = replayFill({ levels: crossing, quantity });
+
+				expect(filled).toBe(quantity);
+				expect(value).toBeGreaterThanOrEqual(gross);
+
+				return;
+			}
+
+			// A Buy receives exactly the quantity it ordered, and can only match levels
+			// at or below its limit — so the offer holds iff the book supplies it there.
+			const crossing = depth.asks.filter((level) => level.price <= price);
+			const { filled, value } = replayFill({ levels: crossing, quantity });
+
+			expect(filled).toBe(quantity);
+			expect(gross).toBe(quantity);
+			// The reserve is taken at the limit price, so the real cost cannot exceed it.
+			expect(value).toBeLessThanOrEqual(deposit);
+		});
+	});
+
+	describe('the deposit never exceeds what the caller typed', () => {
+		it.each(offerCases)('$id', (testCase) => {
+			const result = calculateOisyTradeOffer(request(testCase));
+
+			assert(result.ok);
+
+			expect(result.offer.deposit).toBeLessThanOrEqual(BigInt(testCase.sourceAmount));
+			expect(result.offer.quantity % BigInt(fixturePair.lotSize)).toBe(ZERO);
+		});
+	});
+
+	describe('malformed input is not a rejection', () => {
+		const sell = { ...request(offerCases[0]), side: toSide('sell') };
+
+		it('throws on a non-positive lot size', () => {
+			expect(() =>
+				calculateOisyTradeOffer({
+					...sell,
+					pair: { ...sell.pair, lot_size: ZERO }
+				})
+			).toThrow(/non-positive lot size/);
+		});
+
+		it('throws on a non-positive price level', () => {
+			expect(() =>
+				calculateOisyTradeOffer({
+					...sell,
+					depth: { bids: [{ price: ZERO, quantity: 10_000_000_000n }], asks: [] }
+				})
+			).toThrow(/non-positive price/);
+		});
+	});
+
+	describe('rejections', () => {
+		it('rejects a non-positive source amount', () => {
+			const result = calculateOisyTradeOffer({ ...request(offerCases[0]), sourceAmount: ZERO });
+
+			expect(result).toEqual({
+				ok: false,
+				reason: 'below_lot' satisfies OisyTradeOfferRejection
+			});
+		});
+
+		it('does not floor a Buy level down before accumulating its value', () => {
+			// Two asks each worth half a quote unit: individually they floor to nothing,
+			// together they cover a spend of one. Reducing each level to quote units
+			// before summing would report `no_liquidity` on a book that can fill.
+			const base = request(offerCases[3]);
+			const result = calculateOisyTradeOffer({
+				...base,
+				pair: { ...base.pair, lot_size: 1n },
+				sourceAmount: 1n,
+				depth: {
+					bids: [],
+					asks: [
+						{ price: 5_000_000n, quantity: 10n },
+						{ price: 5_000_000n, quantity: 10n }
+					]
+				}
+			});
+
+			assert(result.ok);
+
+			expect(result.offer).toEqual({
+				price: 5_000_000n,
+				quantity: 20n,
+				deposit: 1n,
+				gross: 20n
+			});
+		});
+	});
+});
+
+describe('the offer-calculation fixture', () => {
+	it('declares receive amounts consistent with its own fees', () => {
+		const takerFeeBps = BigInt(fixturePair.takerFeeBps);
+
+		offerCases.forEach(({ id, side, expect: expected, expectReceive }) => {
+			const gross = BigInt(expected.gross as string);
+			// Rounded up, so the quoted amount is never a base unit optimistic.
+			const takerFee = (gross * takerFeeBps + BASIS_POINTS - 1n) / BASIS_POINTS;
+			const ledgerFee = BigInt(side === 'sell' ? fees.quoteLedgerFee : fees.baseLedgerFee);
+
+			expect(gross - takerFee - ledgerFee, `case ${id}`).toBe(BigInt(expectReceive as string));
+		});
+	});
+});

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -291,21 +291,32 @@ describe('oisy-trade-swap.services', () => {
 
 		// The displayed amount is a floor the user is entitled to, so a fee that does
 		// not divide evenly rounds against us rather than for us.
+		//
+		// Reaching the remainder takes a deliberately chosen price. On the shipped grid
+		// a price is a multiple of `tick_size` and a quantity a multiple of `lot_size`,
+		// which forces the gross to a round figure whose fee usually divides exactly —
+		// so most plausible-looking numbers here would pass under a floor too, and
+		// assert nothing. This price carries a trailing tick to leave a remainder.
 		it('rounds the taker fee up so the offer is never a base unit optimistic', async () => {
-			// 0.15 ICP at 10 → 1_500_000 gross; 10 bps of that is 1_500 exactly, so
-			// nudge the rate to 7 bps: 1_500_000 × 7 / 10_000 = 1_050.
-			oisyTradeStore.setPairs([buildPair({ base: ICP, quote: CKUSDC, takerFeeBps: 7 })]);
+			// One lot of ICP at a tick-aligned 100.001 ckUSDC grosses 1_000_010, and the
+			// pair's 10 bps of that is 1000.01 exactly — the fraction a floor would drop.
+			vi.spyOn(oisyTradeApi, 'getOrderBookDepth').mockResolvedValue({
+				bids: [{ price: 100_001_000n, quantity: 500_000_000n }],
+				asks: []
+			});
 
 			const result = await quote({
 				sourceToken: ICP,
 				destinationToken: CKUSDC,
-				sourceAmount: 15_000_000n
+				sourceAmount: 1_000_000n
 			});
 
 			assert(result.ok);
 
-			// 1_499_999 / 10_000 × 7 would floor to 1_049; the ceiling keeps the extra unit.
-			expect(result.quote.swapDetails.fees[1].fee).toBe(1_050n);
+			// A floor would charge 1_000 and hand the user a base unit the venue keeps.
+			expect(result.quote.swapDetails.fees[1].fee).toBe(1_001n);
+			// And the extra unit reaches the offer, rather than stopping at the fee list.
+			expect(result.quote.receiveAmount).toBe(1_000_010n - 1_001n - 10_000n);
 		});
 
 		it('carries the taker rate and the pair floor for the sheet', async () => {

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -1,4 +1,5 @@
 import type {
+	OrderBookDepth,
 	OrderStatus,
 	TradingPairInfo,
 	UserOrder,
@@ -150,6 +151,13 @@ const buildPair = ({
 
 const icpUsdc = buildPair({ base: ICP, quote: CKUSDC });
 
+// 10 ckUSDC/ICP, 5 ICP of bids and 50 ICP of asks — deep enough for every order
+// quoted here, since a Buy is covered by the levels' value rather than their quantity.
+const depth: OrderBookDepth = {
+	bids: [{ price: 10_000_000n, quantity: 500_000_000n }],
+	asks: [{ price: 10_000_000n, quantity: 5_000_000_000n }]
+};
+
 describe('oisy-trade-swap.services', () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
@@ -199,14 +207,23 @@ describe('oisy-trade-swap.services', () => {
 	});
 
 	describe('fetchOisyTradeQuote', () => {
+		const mockDepth = () => vi.spyOn(oisyTradeApi, 'getOrderBookDepth').mockResolvedValue(depth);
+
+		const quote = (params: {
+			sourceToken: IcToken;
+			destinationToken: IcToken;
+			sourceAmount: bigint;
+		}) => fetchOisyTradeQuote({ identity: mockIdentity, ...params });
+
 		beforeEach(() => {
 			oisyTradeStore.setPairs([icpUsdc]);
+			mockDepth();
 		});
 
-		it('quotes a sell, netting both destination-denominated fees off the fill', () => {
-			// 2 ICP at the 1:1 placeholder → 2 ckUSDC gross (2_000_000 at 6 dp).
-			// Taker 10 bps = 2_000; withdrawal ledger fee = 10_000.
-			const result = fetchOisyTradeQuote({
+		it('quotes a sell, netting both destination-denominated fees off the fill', async () => {
+			// 2 ICP at 10 ckUSDC/ICP → 20 ckUSDC gross (20_000_000 at 6 dp).
+			// Taker 10 bps = 20_000; withdrawal ledger fee = 10_000.
+			const result = await quote({
 				sourceToken: ICP,
 				destinationToken: CKUSDC,
 				sourceAmount: 200_000_000n
@@ -214,15 +231,16 @@ describe('oisy-trade-swap.services', () => {
 
 			assert(result.ok);
 
-			expect(result.quote.receiveAmount).toBe(2_000_000n - 2_000n - 10_000n);
+			expect(result.quote.receiveAmount).toBe(20_000_000n - 20_000n - 10_000n);
 			expect(result.quote.swapDetails.order.side).toBe('sell');
 			expect(result.quote.swapDetails.order.depositAmount).toBe(200_000_000n);
+			expect(result.quote.swapDetails.order.price).toBe(10_000_000n);
 		});
 
-		it('quotes a buy in the other direction', () => {
-			// 2 ckUSDC at 1:1 → 2 ICP gross (200_000_000 at 8 dp).
-			// Taker 10 bps = 200_000; withdrawal ledger fee = 10_000.
-			const result = fetchOisyTradeQuote({
+		it('quotes a buy in the other direction', async () => {
+			// 2 ckUSDC at 10 ckUSDC/ICP buys 0.2 ICP → 20_000_000 gross (8 dp).
+			// Taker 10 bps = 20_000; withdrawal ledger fee = 10_000.
+			const result = await quote({
 				sourceToken: CKUSDC,
 				destinationToken: ICP,
 				sourceAmount: 2_000_000n
@@ -230,12 +248,32 @@ describe('oisy-trade-swap.services', () => {
 
 			assert(result.ok);
 
-			expect(result.quote.receiveAmount).toBe(200_000_000n - 200_000n - 10_000n);
+			expect(result.quote.receiveAmount).toBe(20_000_000n - 20_000n - 10_000n);
 			expect(result.quote.swapDetails.order.side).toBe('buy');
+			// The reserve at the limit price, which is the whole typed spend here.
+			expect(result.quote.swapDetails.order.depositAmount).toBe(2_000_000n);
 		});
 
-		it('itemizes the three fees in their own tokens and never sums them', () => {
-			const result = fetchOisyTradeQuote({
+		it('asks for the pair it is quoting, at the canister default depth', async () => {
+			const spy = mockDepth();
+
+			await quote({
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				sourceAmount: 200_000_000n
+			});
+
+			expect(spy).toHaveBeenCalledOnce();
+
+			const [[{ request }]] = spy.mock.calls;
+
+			expect(request.limit).toEqual([]);
+			expect(request.trading_pair.base.toText()).toBe(ICP_LEDGER);
+			expect(request.trading_pair.quote.toText()).toBe(CKUSDC_LEDGER);
+		});
+
+		it('itemizes the three fees in their own tokens and never sums them', async () => {
+			const result = await quote({
 				sourceToken: ICP,
 				destinationToken: CKUSDC,
 				sourceAmount: 200_000_000n
@@ -246,13 +284,32 @@ describe('oisy-trade-swap.services', () => {
 			expect(result.quote.swapDetails.fees).toEqual([
 				// Two source ledger fees — approve and transfer_from — paid on top.
 				{ labelPath: 'swap.text.oisy_trade_deposit_fee', fee: 20_000n, token: ICP },
-				{ labelPath: 'swap.text.oisy_trade_taker_fee', fee: 2_000n, token: CKUSDC },
+				{ labelPath: 'swap.text.oisy_trade_taker_fee', fee: 20_000n, token: CKUSDC },
 				{ labelPath: 'swap.text.oisy_trade_withdrawal_fee', fee: 10_000n, token: CKUSDC }
 			]);
 		});
 
-		it('carries the taker rate and the pair floor for the sheet', () => {
-			const result = fetchOisyTradeQuote({
+		// The displayed amount is a floor the user is entitled to, so a fee that does
+		// not divide evenly rounds against us rather than for us.
+		it('rounds the taker fee up so the offer is never a base unit optimistic', async () => {
+			// 0.15 ICP at 10 → 1_500_000 gross; 10 bps of that is 1_500 exactly, so
+			// nudge the rate to 7 bps: 1_500_000 × 7 / 10_000 = 1_050.
+			oisyTradeStore.setPairs([buildPair({ base: ICP, quote: CKUSDC, takerFeeBps: 7 })]);
+
+			const result = await quote({
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				sourceAmount: 15_000_000n
+			});
+
+			assert(result.ok);
+
+			// 1_499_999 / 10_000 × 7 would floor to 1_049; the ceiling keeps the extra unit.
+			expect(result.quote.swapDetails.fees[1].fee).toBe(1_050n);
+		});
+
+		it('carries the taker rate and the pair floor for the sheet', async () => {
+			const result = await quote({
 				sourceToken: ICP,
 				destinationToken: CKUSDC,
 				sourceAmount: 200_000_000n
@@ -266,71 +323,145 @@ describe('oisy-trade-swap.services', () => {
 			expect(result.quote.swapDetails.quoteToken).toBe(CKUSDC);
 		});
 
-		it('rejects a halted pair without a reason to name', () => {
+		it('rejects a halted pair without a reason to name', async () => {
 			oisyTradeStore.setPairs([buildPair({ base: ICP, quote: CKUSDC, halted: true })]);
 
-			expect(
-				fetchOisyTradeQuote({
+			await expect(
+				quote({
 					sourceToken: ICP,
 					destinationToken: CKUSDC,
 					sourceAmount: 200_000_000n
 				})
-			).toEqual({ ok: false });
+			).resolves.toEqual({ ok: false });
 		});
 
-		it('rejects tokens that share no pair', () => {
-			expect(
-				fetchOisyTradeQuote({
+		it('rejects tokens that share no pair', async () => {
+			await expect(
+				quote({
 					sourceToken: ICP,
 					destinationToken: CKBTC,
 					sourceAmount: 200_000_000n
 				})
-			).toEqual({ ok: false });
+			).resolves.toEqual({ ok: false });
 		});
 
-		it('rejects every quote while the pair table has not loaded', () => {
+		it('rejects every quote while the pair table has not loaded', async () => {
 			oisyTradeStore.reset();
 
-			expect(
-				fetchOisyTradeQuote({
+			await expect(
+				quote({
 					sourceToken: ICP,
 					destinationToken: CKUSDC,
 					sourceAmount: 200_000_000n
 				})
-			).toEqual({ ok: false });
+			).resolves.toEqual({ ok: false });
 		});
 
-		it('rejects an amount off the lot grid, naming the reason for the form', () => {
-			expect(
-				fetchOisyTradeQuote({
+		it('rejects an amount below one lot', async () => {
+			await expect(
+				quote({
 					sourceToken: ICP,
 					destinationToken: CKUSDC,
 					sourceAmount: 100_000n
 				})
-			).toEqual({ ok: false, errorKind: 'lot' });
+			).resolves.toEqual({ ok: false });
 		});
 
-		it('rejects a quote whose fees would swallow the whole fill', () => {
-			// 0.01 ICP → 10_000 gross ckUSDC, exactly the withdrawal ledger fee.
-			expect(
-				fetchOisyTradeQuote({
+		it('rejects an order the book cannot absorb', async () => {
+			await expect(
+				quote({
+					sourceToken: ICP,
+					destinationToken: CKUSDC,
+					sourceAmount: 600_000_000n
+				})
+			).resolves.toEqual({ ok: false });
+		});
+
+		it('rejects a quote whose fees would swallow the whole fill', async () => {
+			// One lot of ICP against a 0.001 ckUSDC/ICP book grosses 10 units — three
+			// orders of magnitude under the 10_000 withdrawal ledger fee. Needs a pair
+			// with no notional floor, or the floor would reject it first.
+			oisyTradeStore.setPairs([buildPair({ base: ICP, quote: CKUSDC, minNotional: ZERO })]);
+			vi.spyOn(oisyTradeApi, 'getOrderBookDepth').mockResolvedValue({
+				bids: [{ price: 1_000n, quantity: 500_000_000n }],
+				asks: []
+			});
+
+			await expect(
+				quote({
 					sourceToken: ICP,
 					destinationToken: CKUSDC,
 					sourceAmount: 1_000_000n
 				})
-			).toEqual({ ok: false });
+			).resolves.toEqual({ ok: false });
 		});
 
-		it('rejects a quote when a ledger fee is unknown', () => {
+		it('rejects a quote when a ledger fee is unknown', async () => {
 			const feeless = { ...CKUSDC, fee: undefined } as unknown as IcToken;
 
-			expect(
-				fetchOisyTradeQuote({
+			await expect(
+				quote({
 					sourceToken: ICP,
 					destinationToken: feeless,
 					sourceAmount: 200_000_000n
 				})
-			).toEqual({ ok: false });
+			).resolves.toEqual({ ok: false });
+		});
+
+		// The cheap disqualifications come first so an unquotable pair costs no
+		// canister call — the quote runs on every keystroke and every 5s tick.
+		it('does not fetch the book for a pair it cannot quote', async () => {
+			const spy = mockDepth();
+
+			await quote({
+				sourceToken: ICP,
+				destinationToken: CKBTC,
+				sourceAmount: 200_000_000n
+			});
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		// Nor for an amount the pair alone already refuses: no book could rescue a Sell
+		// that floors to zero quantity, or a Buy that cannot reach `min_notional`.
+		it('does not fetch the book for a sell below one lot', async () => {
+			const spy = mockDepth();
+
+			await quote({
+				sourceToken: ICP,
+				destinationToken: CKUSDC,
+				sourceAmount: 100_000n
+			});
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		it('does not fetch the book for a buy under the pair floor', async () => {
+			const spy = mockDepth();
+
+			// A spend under `min_notional` cannot clear the floor at any price: the
+			// order's notional is its reserve, and the reserve never exceeds the spend.
+			await quote({
+				sourceToken: CKUSDC,
+				destinationToken: ICP,
+				sourceAmount: 500n
+			});
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		// A failing depth query is a broken provider, not an absent one: it belongs in
+		// the per-provider `SWAP_OFFER` error analytics, which an empty result hides.
+		it('propagates a depth query failure rather than reporting no offer', async () => {
+			vi.spyOn(oisyTradeApi, 'getOrderBookDepth').mockRejectedValue(new Error('depth down'));
+
+			await expect(
+				quote({
+					sourceToken: ICP,
+					destinationToken: CKUSDC,
+					sourceAmount: 200_000_000n
+				})
+			).rejects.toThrow('depth down');
 		});
 	});
 
@@ -351,6 +482,7 @@ describe('oisy-trade-swap.services', () => {
 
 		beforeEach(() => {
 			oisyTradeStore.setPairs([icpUsdc]);
+			vi.spyOn(oisyTradeApi, 'getOrderBookDepth').mockResolvedValue(depth);
 		});
 
 		it('carries an OISY Trade quote through the fan-out into the results', async () => {
@@ -365,7 +497,7 @@ describe('oisy-trade-swap.services', () => {
 			const offer = results.find(({ provider }) => provider === SwapProvider.OISY_TRADE);
 
 			expect(offer).toBeDefined();
-			expect(offer?.receiveAmount).toBe(2_000_000n - 2_000n - 10_000n);
+			expect(offer?.receiveAmount).toBe(20_000_000n - 20_000n - 10_000n);
 		});
 
 		it('drops the offer when the source ledger has no ICRC-2', async () => {
@@ -397,14 +529,13 @@ describe('oisy-trade-swap.services', () => {
 		});
 
 		// Every `getQuote` is called inside a `.map()` whose array only afterwards
-		// reaches `Promise.allSettled`, so a *synchronous* throw escapes the settling
-		// and rejects the entire fan-out — losing ICPSwap's and KongSwap's offers
-		// along with OISY Trade's. The two siblings are async functions and get that
-		// containment for free; this entry is a sync quote and has to ask for it.
-		// `fetchOisyTradeQuote` is written not to throw, so this pins the containment
-		// rather than a reachable path — and the order-book walk that replaces the
-		// placeholder lands in exactly this function.
-		it('contains a synchronous quote failure rather than rejecting the fan-out', async () => {
+		// reaches `Promise.allSettled`, so a *synchronous* throw would escape the
+		// settling and reject the entire fan-out — losing ICPSwap's and KongSwap's
+		// offers along with OISY Trade's. Now that the quote awaits the order book it
+		// is an async function like its two siblings, which turns any throw inside it
+		// into a rejected promise the settling absorbs. This pins that: the registry
+		// entry no longer carries a `try/catch`, and it must not need one again.
+		it('contains a quote failure rather than rejecting the fan-out', async () => {
 			vi.spyOn(oisyTradeSwapServices, 'fetchOisyTradeQuote').mockImplementation(() => {
 				throw new Error('synchronous quote failure');
 			});
@@ -422,10 +553,12 @@ describe('oisy-trade-swap.services', () => {
 	});
 
 	describe('mapOisyTradeQuoteResult', () => {
-		it('tags the mapped offer with the OISY Trade provider', () => {
+		it('tags the mapped offer with the OISY Trade provider', async () => {
 			oisyTradeStore.setPairs([icpUsdc]);
+			vi.spyOn(oisyTradeApi, 'getOrderBookDepth').mockResolvedValue(depth);
 
-			const result = fetchOisyTradeQuote({
+			const result = await fetchOisyTradeQuote({
+				identity: mockIdentity,
 				sourceToken: ICP,
 				destinationToken: CKUSDC,
 				sourceAmount: 200_000_000n

--- a/src/frontend/src/tests/lib/utils/oisy-trade-swap.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade-swap.utils.spec.ts
@@ -3,9 +3,9 @@ import type { IcToken } from '$icp/types/ic-token';
 import { ZERO } from '$lib/constants/app.constants';
 import type { Token } from '$lib/types/token';
 import {
-	computeOisyTradeReceiveAmount,
 	findOisyTradePair,
 	isOisyTradePair,
+	oisyTradeAmountObjection,
 	oisyTradeCompatibleDestinations,
 	oisyTradeSupportedSourceTokens,
 	resolveOisyTradeOrder,
@@ -174,13 +174,21 @@ describe('oisy-trade-swap.utils', () => {
 	});
 
 	describe('resolveOisyTradeOrder', () => {
+		// 10 ckUSDC/ICP on both sides. The bids hold 5 ICP, which every Sell below stays
+		// inside except the one testing a book too thin; the asks hold 50 ICP, since a
+		// Buy is covered by the levels' *value* and 5 ICP is only 50 ckUSDC of it. These
+		// cases are about the adaptation rather than the walk, which has its own suite
+		// over the shared fixtures in `oisy-trade/offer.spec.ts`.
+		const depth = {
+			bids: [{ price: 10_000_000n, quantity: 500_000_000n }],
+			asks: [{ price: 10_000_000n, quantity: 5_000_000_000n }]
+		};
+
 		it('deposits exactly the ordered quantity on a sell', () => {
-			// 2 ICP at 10 ckUSDC — already a lot multiple, so nothing is floored away.
 			const result = resolveOisyTradeOrder({
 				sourceToken: ICP,
 				amount: 200_000_000n,
-				price: 10,
-				freeBalance: 5,
+				depth,
 				pair: icpUsdc
 			});
 
@@ -189,8 +197,10 @@ describe('oisy-trade-swap.utils', () => {
 			expect(result.order.side).toBe('sell');
 			expect(result.order.quantity).toBe(200_000_000n);
 			expect(result.order.depositAmount).toBe(200_000_000n);
-			// 10 ckUSDC (6 dp) per whole base.
+			// 10 ckUSDC (6 dp) per whole base, straight off the book.
 			expect(result.order.price).toBe(10_000_000n);
+			// 2 ICP at 10 → 20 ckUSDC, before the taker and ledger fees the caller nets.
+			expect(result.gross).toBe(20_000_000n);
 		});
 
 		it('deposits the order reserve on a buy, computed exactly in bigint', () => {
@@ -199,8 +209,7 @@ describe('oisy-trade-swap.utils', () => {
 			const result = resolveOisyTradeOrder({
 				sourceToken: CKUSDC,
 				amount: 50_000_000n,
-				price: 10,
-				freeBalance: 100,
+				depth,
 				pair: icpUsdc
 			});
 
@@ -209,24 +218,28 @@ describe('oisy-trade-swap.utils', () => {
 			expect(result.order.side).toBe('buy');
 			expect(result.order.quantity).toBe(500_000_000n);
 			expect(result.order.depositAmount).toBe(50_000_000n);
+			// A buy is paid in the base token, so the gross *is* the quantity.
+			expect(result.gross).toBe(500_000_000n);
 		});
 
-		it('refuses a sell amount off the lot grid rather than rounding it, like the Limit Order form', () => {
-			// 2.005 ICP against a 0.01 ICP lot is not a lot multiple. The form never
-			// lets such an amount through (it validates, and floors only in the Max
-			// link), so the swap contributes no offer instead of silently selling less
-			// than the user typed.
+		// Reverses what this file previously locked: a Sell is floored onto the lot grid
+		// instead of refused. At a realistic lot almost every amount a person types is
+		// off-grid, so validating meant OISY Trade contributed no Sell offer at all,
+		// while the Buy side had been spending less than typed since the provider
+		// shipped. The residue never leaves the wallet.
+		it('floors a sell amount onto the lot grid rather than refusing it', () => {
+			// 2.005 ICP against a 0.01 ICP lot floors to 2.00.
 			const result = resolveOisyTradeOrder({
 				sourceToken: ICP,
 				amount: 200_500_000n,
-				price: 10,
-				freeBalance: 5,
+				depth,
 				pair: icpUsdc
 			});
 
-			assert(!result.ok);
+			assert(result.ok);
 
-			expect(result.errorKind).toBe('lot');
+			expect(result.order.quantity).toBe(200_000_000n);
+			expect(result.order.depositAmount).toBe(200_000_000n);
 		});
 
 		it('floors the derived buy quantity to the lot grid, shrinking the deposit to the reserve', () => {
@@ -237,8 +250,7 @@ describe('oisy-trade-swap.utils', () => {
 			const result = resolveOisyTradeOrder({
 				sourceToken: CKUSDC,
 				amount: 50_050_000n,
-				price: 10,
-				freeBalance: 100,
+				depth,
 				pair: icpUsdc
 			});
 
@@ -248,94 +260,95 @@ describe('oisy-trade-swap.utils', () => {
 			expect(result.order.depositAmount).toBe(50_000_000n);
 		});
 
-		it('snaps the price down to the tick grid', () => {
+		it('prices at the level that absorbs the whole order, not at the top of book', () => {
+			// 3 ICP against 2 ICP at 10 and 2 ICP at 9: only the second level completes
+			// the order, so 9 is the highest price the whole quantity can still fill at.
 			const result = resolveOisyTradeOrder({
 				sourceToken: ICP,
-				amount: 200_000_000n,
-				price: 10.00099,
-				freeBalance: 5,
+				amount: 300_000_000n,
+				depth: {
+					bids: [
+						{ price: 10_000_000n, quantity: 200_000_000n },
+						{ price: 9_000_000n, quantity: 200_000_000n }
+					],
+					asks: []
+				},
 				pair: icpUsdc
 			});
 
 			assert(result.ok);
 
-			// tick is 0.001 ckUSDC, so 10.00099 → 10.000.
-			expect(result.order.price).toBe(10_000_000n);
+			expect(result.order.price).toBe(9_000_000n);
+			expect(result.gross).toBe(27_000_000n);
 		});
 
+		// Every rejection is bare: the fan-out transports offers only, so a reason would
+		// have no reader. Which reason applies is the module's own concern and is
+		// asserted over the shared fixtures in `oisy-trade/offer.spec.ts`.
 		it('refuses an amount below one lot', () => {
-			const result = resolveOisyTradeOrder({
-				sourceToken: ICP,
-				amount: 100_000n,
-				price: 10,
-				freeBalance: 5,
-				pair: icpUsdc
-			});
-
-			expect(result.ok).toBeFalsy();
+			expect(
+				resolveOisyTradeOrder({
+					sourceToken: ICP,
+					amount: 100_000n,
+					depth,
+					pair: icpUsdc
+				})
+			).toEqual({ ok: false });
 		});
 
-		it('refuses a notional below the pair floor, naming the reason', () => {
+		it('refuses a notional below the pair floor', () => {
 			// 0.01 ICP at 10 ckUSDC is a 0.1 ckUSDC notional, under the 5 ckUSDC floor.
-			const result = resolveOisyTradeOrder({
-				sourceToken: ICP,
-				amount: 1_000_000n,
-				price: 10,
-				freeBalance: 5,
-				pair: icpUsdc
-			});
-
-			assert(!result.ok);
-
-			expect(result.errorKind).toBe('min_notional');
+			expect(
+				resolveOisyTradeOrder({
+					sourceToken: ICP,
+					amount: 1_000_000n,
+					depth,
+					pair: icpUsdc
+				})
+			).toEqual({ ok: false });
 		});
 
-		it('refuses an order the wallet balance cannot cover', () => {
-			const result = resolveOisyTradeOrder({
-				sourceToken: ICP,
-				amount: 200_000_000n,
-				price: 10,
-				freeBalance: 1,
-				pair: icpUsdc
-			});
+		it('refuses an order the book cannot absorb', () => {
+			expect(
+				resolveOisyTradeOrder({
+					sourceToken: ICP,
+					amount: 600_000_000n,
+					depth,
+					pair: icpUsdc
+				})
+			).toEqual({ ok: false });
+		});
 
-			assert(!result.ok);
-
-			expect(result.errorKind).toBe('balance');
+		it('refuses an order when the opposite side is empty', () => {
+			expect(
+				resolveOisyTradeOrder({
+					sourceToken: ICP,
+					amount: 200_000_000n,
+					depth: { bids: [], asks: depth.asks },
+					pair: icpUsdc
+				})
+			).toEqual({ ok: false });
 		});
 
 		it('refuses a token that is not a leg of the pair', () => {
 			const result = resolveOisyTradeOrder({
 				sourceToken: CKBTC,
 				amount: 200_000_000n,
-				price: 10,
-				freeBalance: 5,
+				depth,
 				pair: icpUsdc
 			});
 
 			expect(result.ok).toBeFalsy();
 		});
 
-		it('refuses a price that floors to zero on the tick grid', () => {
-			const result = resolveOisyTradeOrder({
-				sourceToken: ICP,
-				amount: 200_000_000n,
-				price: 0.0001,
-				freeBalance: 5,
-				pair: icpUsdc
-			});
-
-			expect(result.ok).toBeFalsy();
-		});
-
-		// An 18-decimal base token is where the human-float round-trip the shipped
-		// Limit Order form uses stops being safe: one lot is 1e15 base units, far
-		// below the 1e-6 *relative* slack `isMultipleOfStep` allows, so a float
-		// verdict can pass a quantity the canister then rejects with
-		// `InvalidQuantity` — after `deposit` has already moved the funds.
+		// An 18-decimal base token is where a human-float round-trip stops being safe:
+		// one lot is 1e15 base units, far below the 1e-6 *relative* slack the float
+		// helpers allow, so a float verdict could pass a quantity the canister then
+		// rejects with `InvalidQuantity` — after `deposit` has already moved the funds.
+		// The path is now bigint end to end, and these cases keep it that way.
 		describe('18-decimal precision', () => {
 			// The same 18-decimal ckETH token the unpaired-token cases use, here given a
-			// pair of its own. 18 dp base, 6 dp quote; lot 0.001 ckETH, tick 0.001 ckUSDC.
+			// pair of its own. 18 dp base, 6 dp quote; lot 0.001 ckETH.
 			const cketh = UNPAIRED;
 			const ckethUsdc = buildPair({
 				base: cketh,
@@ -343,20 +356,23 @@ describe('oisy-trade-swap.utils', () => {
 				lotSize: 1_000_000_000_000_000n
 			});
 
+			// 1000 ckUSDC per whole ckETH, deep enough for every order below. Well above
+			// the 5 ckUSDC floor at these sizes.
+			const level = { price: 1_000_000_000n, quantity: 10_000_000_000_000_000_000_000n };
+
 			const resolve = ({ sourceToken = cketh, amount }: { sourceToken?: Token; amount: bigint }) =>
 				resolveOisyTradeOrder({
 					sourceToken,
 					amount,
-					// Well above the 5 ckUSDC floor at these sizes, and on the tick grid.
-					price: 1000,
+					depth: { bids: [level], asks: [level] },
 					pair: ckethUsdc
 				});
 
-			// The exact case that regressed: 0.009 ckETH is a clean multiple of the
-			// 0.001 lot, but 9e15/1e18 has no exact binary form, so multiplying back
-			// out produced 8999999999999999 — one base unit off the grid, while the
-			// float lot check still passed. Note 9e15 is *below* `2^53`, so this is the
-			// divide-then-multiply round-trip rather than an unsafe-integer problem.
+			// 0.009 ckETH is a clean multiple of the 0.001 lot, but 9e15/1e18 has no
+			// exact binary form: a divide-then-multiply round-trip produced
+			// 8999999999999999, one base unit off the grid, while a float lot check
+			// still passed. Note 9e15 is *below* `2^53`, so this is the round-trip
+			// rather than an unsafe-integer problem.
 			it('keeps an on-grid 0.009 ckETH sell exactly on the lot grid', () => {
 				const result = resolve({ amount: 9_000_000_000_000_000n });
 
@@ -364,8 +380,9 @@ describe('oisy-trade-swap.utils', () => {
 
 				expect(result.order.quantity).toBe(9_000_000_000_000_000n);
 				expect(result.order.quantity % ckethUsdc.lot_size).toBe(ZERO);
-				// A Sell deposits the ordered quantity exactly — acceptance criterion 10.
 				expect(result.order.depositAmount).toBe(9_000_000_000_000_000n);
+				// 0.009 ckETH at 1000 → 9 ckUSDC, exactly.
+				expect(result.gross).toBe(9_000_000n);
 			});
 
 			// From 5 lots up, since at this price one lot is 1 ckUSDC and the pair's
@@ -382,20 +399,23 @@ describe('oisy-trade-swap.utils', () => {
 				expect(drifted).toEqual([]);
 			});
 
-			// Off the grid by 1e9 base units — a 1e-9 *relative* deviation, which the
-			// float check's 1e-6 tolerance waves through. Only an exact check rejects
-			// it, and rejecting it here is what keeps the deposit from happening.
-			it('refuses an amount off the grid by less than the float tolerance', () => {
+			// Off the grid by 1e9 base units — a 1e-9 *relative* deviation, which a
+			// float check's 1e-6 tolerance waves through. Flooring has to land on the
+			// exact multiple, not near it: the canister rejects anything else after the
+			// deposit has moved.
+			it('floors an off-grid amount onto the exact lot multiple', () => {
 				const result = resolve({ amount: 9_000_000_000_000_000n + 1_000_000_000n });
 
-				assert(!result.ok);
+				assert(result.ok);
 
-				expect(result.errorKind).toBe('lot');
+				expect(result.order.quantity).toBe(9_000_000_000_000_000n);
+				expect(result.order.quantity % ckethUsdc.lot_size).toBe(ZERO);
 			});
 
 			// Above 1e21 base units `Number.toFixed(0)` switches to exponential
-			// notation, which `BigInt` refuses — the old conversion threw a
-			// `SyntaxError` out of a function documented as never throwing.
+			// notation, which `BigInt` refuses — an earlier conversion threw a
+			// `SyntaxError` out of a function documented as never throwing. Nothing on
+			// this path converts any more, and this is what would notice a relapse.
 			it('resolves an amount past the exponential-notation threshold', () => {
 				const amount = 1_000_007_000_000_000_000_000n;
 
@@ -423,47 +443,39 @@ describe('oisy-trade-swap.utils', () => {
 		});
 	});
 
-	describe('computeOisyTradeReceiveAmount', () => {
-		it('rescales down across a decimals mismatch', () => {
-			// 1 ICP (8 dp) at 1:1 is 1 ckUSDC (6 dp) — a plain bigint copy is 100× wrong.
-			expect(
-				computeOisyTradeReceiveAmount({
-					amount: 100_000_000n,
-					sourceDecimals: 8,
-					destinationDecimals: 6
-				})
-			).toBe(1_000_000n);
+	// The form's empty-offer-list explanation. Book-free by construction: it runs in a
+	// `$derived.by`, which cannot await the depth query the quote now makes.
+	describe('oisyTradeAmountObjection', () => {
+		it('names the lot when a sell is below one lot', () => {
+			expect(oisyTradeAmountObjection({ sourceToken: ICP, amount: 100_000n, pair: icpUsdc })).toBe(
+				'lot'
+			);
 		});
 
-		it('rescales up in the other direction', () => {
+		it('names the floor when a buy spends less than min_notional', () => {
+			// The reserve never exceeds the spend, so this cannot clear the floor
+			// whatever price the walk finds.
 			expect(
-				computeOisyTradeReceiveAmount({
-					amount: 1_000_000n,
-					sourceDecimals: 6,
-					destinationDecimals: 8
-				})
-			).toBe(100_000_000n);
+				oisyTradeAmountObjection({ sourceToken: CKUSDC, amount: 4_000_000n, pair: icpUsdc })
+			).toBe('min_notional');
 		});
 
-		it('passes the amount through when the decimals match', () => {
+		it('says nothing about an orderable sell, whose absence would be the book', () => {
 			expect(
-				computeOisyTradeReceiveAmount({
-					amount: 12_345n,
-					sourceDecimals: 8,
-					destinationDecimals: 8
-				})
-			).toBe(12_345n);
+				oisyTradeAmountObjection({ sourceToken: ICP, amount: 200_000_000n, pair: icpUsdc })
+			).toBeUndefined();
 		});
 
-		it('floors rather than rounding, so it never over-quotes', () => {
-			// 0.000000019 ICP has no representation at 6 dp; the fraction is dropped.
+		it('says nothing about an orderable buy', () => {
 			expect(
-				computeOisyTradeReceiveAmount({
-					amount: 19n,
-					sourceDecimals: 8,
-					destinationDecimals: 6
-				})
-			).toBe(ZERO);
+				oisyTradeAmountObjection({ sourceToken: CKUSDC, amount: 50_000_000n, pair: icpUsdc })
+			).toBeUndefined();
+		});
+
+		it('says nothing for a token that is not a leg of the pair', () => {
+			expect(
+				oisyTradeAmountObjection({ sourceToken: CKBTC, amount: 100_000n, pair: icpUsdc })
+			).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
# Motivation

The OISY Trade swap provider quoted a placeholder: the destination amount was the source amount at a 1:1 rate. That is why its flag was `LOCAL`. A fabricated 1:1 rate out-ranks almost every real offer, so with the flag on it would have been pre-selected as the best rate showing a number the execution could not honour.

This derives the offer from the live order book instead. The quoted amount is a floor: the venue fills at maker prices, so the user may receive more and never less.

# Changes

- Adds `$lib/oisy-trade/`, a pure bigint calculation over an order-book snapshot. One pass down the opposite side of the book, accumulating until the order is covered, taking the price of the last level needed. That is the worst price the order can accept and still be certain to fill completely, which is what a fill-or-kill order needs. A Sell accumulates quantity across the bids; a Buy accumulates quote value across the asks and derives its quantity from the resulting price.
- The calculation belongs in the `oisy_trade` canister, which lives in another repository and arrives here as a pinned release. It is hosted here at arm's length in the manner of `$lib/ic-pub-key/`, with a `no-restricted-imports` override keeping the dependency arrow one-way so removing it later is a deletion, not an extraction. `docs/ai/frontend/structure.md` lists the new bucket.
- `resolveOisyTradeOrder` is now a thin adapter over it. The placeholder price, `computeOisyTradeReceiveAmount` and the quote-path `validateAmount` call are gone. Nothing on the path converts a price to a float any more.
- `fetchOisyTradeQuote` is async and fetches depth after the cheap disqualifications, so an unquotable pair or amount costs no canister call. A failing depth query propagates into the per-provider error analytics; a "cannot quote" case still just yields no offer. The registry's synchronous-throw guard is no longer needed and is removed.
- The taker fee rounds up, so the quote is never a base unit optimistic.
- A Sell's amount is floored to the lot grid rather than refused. At a realistic lot size nearly every typed amount is off-grid, so the old rule meant OISY Trade never contributed a Sell offer. The remainder never leaves the wallet.
- The form's empty-offer-list message is derived from the pair rather than by re-running the quote, which can no longer work now that the quote awaits the book. Book-dependent absences fall back to the generic copy. Because a Sell is floored, the lot message states a minimum rather than a multiple, which adds one i18n key.
- `OISY_TRADE_SWAP_ENABLED` widens from `LOCAL` to `LOCAL || STAGING`. Production stays off.


# Tests

Added/updated.
