### PR TITLE
feat(frontend): enable the EVM send transaction priority flag on all environments

### DIFF
--- a/src/frontend/src/env/send-transaction-priority.env.ts
+++ b/src/frontend/src/env/send-transaction-priority.env.ts
@@ -1,6 +1,3 @@
-import { LOCAL, STAGING } from '$lib/constants/app.constants';
-
 // Gates the whole "transaction priority" work on the EVM send flow: the priority row and its
-// options, and the estimated-fee row that replaces the max-fee one. Local and staging only
-// while the design settles; BETA and PROD keep the previous single-tier send form unchanged.
-export const SEND_TRANSACTION_PRIORITY_ENABLED = LOCAL || STAGING;
+// options, and the estimated-fee row that replaces the max-fee one. Enabled on every environment.
+export const SEND_TRANSACTION_PRIORITY_ENABLED = true;


### PR DESCRIPTION
# Motivation

The EVM send transaction priority work (priority row and its options, plus the estimated-fee row that replaces the max-fee one) was gated to local and staging while the design settled. It is now ready to ship everywhere, so the flag can go on for all environments.

# Changes

- `SEND_TRANSACTION_PRIORITY_ENABLED` is now `true` instead of `LOCAL || STAGING`, matching the `= true` shape of the other always-on flags in `$env`.
- Dropped the now unused `LOCAL` / `STAGING` import and updated the comment.

# Tests

- `npm run format`, `npm run lint -- --max-warnings 0` and `npm run check` are clean.
- `npm run test` passes, including the eth send, wallet-connect and fee specs that branch on the flag.
