### PR TITLE
fix(frontend): resolve Solana tokens the user has disabled

### DIFF
--- a/src/frontend/src/sol/components/transactions/SolInstructionsList.svelte
+++ b/src/frontend/src/sol/components/transactions/SolInstructionsList.svelte
@@ -5,7 +5,7 @@
 	import AddressActions from '$lib/components/ui/AddressActions.svelte';
 	import { i18n } from '$lib/stores/i18n.store';
 	import type { Token } from '$lib/types/token';
-	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import { splTokens } from '$sol/derived/spl.derived';
 	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
 	import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
 	import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
@@ -15,7 +15,7 @@
 		flattenInstructions,
 		formatSolInstructionSummary
 	} from '$sol/utils/sol-transaction-summary.utils';
-	import { findEnabledSplToken } from '$sol/utils/spl.utils';
+	import { findSplToken } from '$sol/utils/spl.utils';
 
 	interface Props {
 		instructions: SolInstructionSummary[];
@@ -28,8 +28,8 @@
 	let { instructions, token, netChanges }: Props = $props();
 
 	const splToken = (tokenAddress: string) =>
-		findEnabledSplToken({
-			tokens: $enabledSplTokens,
+		findSplToken({
+			tokens: $splTokens,
 			tokenAddress,
 			networkId: token.network.id
 		});
@@ -39,7 +39,7 @@
 	let unknownTokenAddresses = $derived(
 		solUnknownTokenAddresses({
 			tokenAddresses: flattenInstructions(instructions).map(({ tokenAddress }) => tokenAddress),
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: token.network.id,
 			metadata: $splTokenMetadataStore
 		})
@@ -48,7 +48,7 @@
 	const symbolOf = (tokenAddress: string | undefined): string =>
 		solTokenSymbol({
 			tokenAddress,
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: token.network.id,
 			metadata: $splTokenMetadataStore,
 			unknownTokenAddresses,

--- a/src/frontend/src/sol/components/transactions/SolTransaction.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransaction.svelte
@@ -10,7 +10,7 @@
 	import type { TransactionStatus } from '$lib/types/transaction';
 	import { absBigInt } from '$lib/utils/bigint.utils';
 	import { formatToken } from '$lib/utils/format.utils';
-	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import { splTokens } from '$sol/derived/spl.derived';
 	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 	import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
@@ -56,7 +56,7 @@
 	let unknownTokenAddresses = $derived(
 		solUnknownTokenAddresses({
 			tokenAddresses: (netChanges ?? []).map(({ tokenAddress }) => tokenAddress),
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: token.network.id,
 			metadata: $splTokenMetadataStore
 		})
@@ -65,7 +65,7 @@
 	const symbolOf = (tokenAddress: string | undefined): string =>
 		solTokenSymbol({
 			tokenAddress,
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: token.network.id,
 			metadata: $splTokenMetadataStore,
 			unknownTokenAddresses,

--- a/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
+++ b/src/frontend/src/sol/components/transactions/SolTransactionModal.svelte
@@ -27,14 +27,14 @@
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkSolana } from '$lib/utils/network.utils';
 	import SolInstructionsList from '$sol/components/transactions/SolInstructionsList.svelte';
-	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import { splTokens } from '$sol/derived/spl.derived';
 	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
 	import type { SolTransactionUi } from '$sol/types/sol-transaction';
 	import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
 	import { solAccountExplorerUrl } from '$sol/utils/sol-explorer.utils';
 	import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
 	import { formatSolTransactionSummary, solAtaFee } from '$sol/utils/sol-transaction-summary.utils';
-	import { findEnabledSplToken } from '$sol/utils/spl.utils';
+	import { findSplToken } from '$sol/utils/spl.utils';
 
 	interface Props {
 		transaction: SolTransactionUi;
@@ -64,8 +64,8 @@
 
 	const splToken = (tokenAddress: string) =>
 		nonNullish(token)
-			? findEnabledSplToken({
-					tokens: $enabledSplTokens,
+			? findSplToken({
+					tokens: $splTokens,
 					tokenAddress,
 					networkId: token.network.id
 				})
@@ -76,7 +76,7 @@
 	let unknownTokenAddresses = $derived(
 		solUnknownTokenAddresses({
 			tokenAddresses: (netChanges ?? []).map(({ tokenAddress }) => tokenAddress),
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: token?.network.id ?? SOLANA_TOKEN.network.id,
 			metadata: $splTokenMetadataStore
 		})
@@ -85,7 +85,7 @@
 	const symbolOf = (tokenAddress: string | undefined): string =>
 		solTokenSymbol({
 			tokenAddress,
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: token?.network.id ?? SOLANA_TOKEN.network.id,
 			metadata: $splTokenMetadataStore,
 			unknownTokenAddresses,
@@ -140,8 +140,8 @@
 			}
 
 			return (
-				findEnabledSplToken({
-					tokens: $enabledSplTokens,
+				findSplToken({
+					tokens: $splTokens,
 					tokenAddress: change.tokenAddress,
 					networkId: token?.network.id ?? SOLANA_TOKEN.network.id
 				}) ?? token

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignModal.svelte
@@ -28,7 +28,7 @@
 	import SolWalletConnectSignReview from '$sol/components/wallet-connect/SolWalletConnectSignReview.svelte';
 	import { walletConnectSignSteps } from '$sol/constants/steps.constants';
 	import { SESSION_REQUEST_SOL_SIGN_AND_SEND_TRANSACTION } from '$sol/constants/wallet-connect.constants';
-	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import { splTokens } from '$sol/derived/spl.derived';
 	import {
 		sign as signService,
 		decode as decodeService
@@ -39,6 +39,7 @@
 	import type { SolSimulationPreview } from '$sol/types/sol-simulation';
 	import type { SolTransferParties } from '$sol/types/sol-transaction';
 	import type { SolTransactionSummary } from '$sol/types/sol-transaction-summary';
+	import { findSplToken } from '$sol/utils/spl.utils';
 
 	interface Props {
 		listener: OptionWalletConnectListener;
@@ -122,14 +123,11 @@
 		}
 	};
 
-	// When the transaction moves an SPL token we know, review it with that token's
-	// metadata; otherwise fall back to the network's native SOL token. The same mint
-	// can exist on several clusters, so we match the current network too.
+	// When the transaction moves an SPL token the wallet lists, review it with that token's
+	// metadata; otherwise fall back to the network's native SOL token.
 	let reviewToken = $derived(
 		nonNullish(tokenAddress)
-			? ($enabledSplTokens.find(
-					({ address, network: { id } }) => address === tokenAddress && id === networkId
-				) ?? token)
+			? (findSplToken({ tokens: $splTokens, tokenAddress, networkId }) ?? token)
 			: token
 	);
 

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSignReview.svelte
@@ -26,7 +26,7 @@
 		SOLANA_PRIORITIZATION_FEE_WARNING_MULTIPLIER,
 		SOLANA_TRANSACTION_FEE_IN_LAMPORTS
 	} from '$sol/constants/sol.constants';
-	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import { splTokens } from '$sol/derived/spl.derived';
 	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
 	import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
 	import type { SolSimulationPreview } from '$sol/types/sol-simulation';
@@ -140,7 +140,7 @@
 			tokenAddresses: [statedSummary?.spent, statedSummary?.received].map(
 				(change) => change?.tokenAddress
 			),
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: token.network.id,
 			metadata: $splTokenMetadataStore
 		})
@@ -154,7 +154,7 @@
 					symbolOf: (tokenAddress) =>
 						solTokenSymbol({
 							tokenAddress,
-							tokens: $enabledSplTokens,
+							tokens: $splTokens,
 							networkId: token.network.id,
 							metadata: $splTokenMetadataStore,
 							unknownTokenAddresses: summaryTokenAddresses,

--- a/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
+++ b/src/frontend/src/sol/components/wallet-connect/SolWalletConnectSimulationPreview.svelte
@@ -8,12 +8,13 @@
 	import type { Token } from '$lib/types/token';
 	import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 	import SolAddressActions from '$sol/components/wallet-connect/SolAddressActions.svelte';
-	import { enabledSplTokens } from '$sol/derived/spl.derived';
+	import { splTokens } from '$sol/derived/spl.derived';
 	import { splTokenMetadataStore } from '$sol/stores/spl-token-metadata.store';
 	import type { SolSimulationControlField, SolSimulationPreview } from '$sol/types/sol-simulation';
 	import type { SplTokenAddress } from '$sol/types/spl';
 	import type { SplCustomToken } from '$sol/types/spl-custom-token';
 	import { solTokenSymbol, solUnknownTokenAddresses } from '$sol/utils/sol-token-name.utils';
+	import { findSplToken } from '$sol/utils/spl.utils';
 
 	interface Props {
 		preview: SolSimulationPreview;
@@ -25,11 +26,8 @@
 
 	let { solDelta, tokenDeltas, controlChanges } = $derived(preview);
 
-	// The same mint can exist on several clusters, so the network is matched too.
 	const splToken = (tokenAddress: SplTokenAddress): SplCustomToken | undefined =>
-		$enabledSplTokens.find(
-			({ address, network: { id } }) => address === tokenAddress && id === feeToken.network.id
-		);
+		findSplToken({ tokens: $splTokens, tokenAddress, networkId: feeToken.network.id });
 
 	// Mints nothing can name, in the order they appear. The wallet's own list answers first, then
 	// the name a Token-2022 mint carries in its own account; the numbered placeholder is what is
@@ -37,7 +35,7 @@
 	let unknownTokenAddresses = $derived(
 		solUnknownTokenAddresses({
 			tokenAddresses: tokenDeltas.map(({ tokenAddress }) => tokenAddress),
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: feeToken.network.id,
 			metadata: $splTokenMetadataStore
 		})
@@ -46,7 +44,7 @@
 	const symbol = (tokenAddress: SplTokenAddress): string =>
 		solTokenSymbol({
 			tokenAddress,
-			tokens: $enabledSplTokens,
+			tokens: $splTokens,
 			networkId: feeToken.network.id,
 			metadata: $splTokenMetadataStore,
 			unknownTokenAddresses,

--- a/src/frontend/src/sol/utils/sol-token-name.utils.ts
+++ b/src/frontend/src/sol/utils/sol-token-name.utils.ts
@@ -3,7 +3,7 @@ import type { SplTokenMetadata, SplTokenMetadataData } from '$sol/stores/spl-tok
 import type { SplTokenAddress } from '$sol/types/spl';
 import type { SplCustomToken } from '$sol/types/spl-custom-token';
 import { mapNetworkIdToNetwork } from '$sol/utils/network.utils';
-import { findEnabledSplToken } from '$sol/utils/spl.utils';
+import { findSplToken } from '$sol/utils/spl.utils';
 import { isNullish, nonNullish, notEmptyString } from '@dfinity/utils';
 
 /**
@@ -30,6 +30,9 @@ const namesOn = ({
  * a single view holds more than one of them: two rows reading "Unknown token" are worse than an
  * address, because nothing distinguishes them.
  *
+ * The list the caller passes is the wallet's whole one, disabled tokens included: hiding a token
+ * from the asset list says nothing about how to read a transaction that moves it.
+ *
  * The order comes from the caller because the caller is what defines the view: a list of deltas,
  * a list of instructions, a single row.
  */
@@ -54,7 +57,7 @@ export const solTokenSymbol = ({
 		return nativeSymbol;
 	}
 
-	const listed = findEnabledSplToken({ tokens, tokenAddress, networkId })?.symbol;
+	const listed = findSplToken({ tokens, tokenAddress, networkId })?.symbol;
 
 	if (nonNullish(listed)) {
 		return listed;
@@ -94,7 +97,7 @@ export const solUnknownTokenAddresses = ({
 		if (
 			isNullish(tokenAddress) ||
 			acc.includes(tokenAddress) ||
-			nonNullish(findEnabledSplToken({ tokens, tokenAddress, networkId })) ||
+			nonNullish(findSplToken({ tokens, tokenAddress, networkId })) ||
 			notEmptyString(names[tokenAddress]?.symbol)
 		) {
 			return acc;

--- a/src/frontend/src/sol/utils/spl.utils.ts
+++ b/src/frontend/src/sol/utils/spl.utils.ts
@@ -10,12 +10,16 @@ export const isTokenSplCustomToken = (token: Token): token is SplCustomToken =>
 	isTokenSpl(token) && isTokenToggleable(token);
 
 /**
- * The enabled SPL token of a mint on a network, or nothing when the wallet does not list it.
+ * The SPL token of a mint on a network, or nothing when the wallet does not list it.
  *
  * The same mint can exist on several clusters, which is why the network is part of the key. One
  * lookup for every surface that names a token, so an unlisted mint fails the same way everywhere.
+ *
+ * Enablement is not part of the question: it says which tokens the user wants to hold, not which
+ * ones the wallet knows how to read. Callers pass the full list, so a disabled token is still
+ * named and still carries its decimals.
  */
-export const findEnabledSplToken = ({
+export const findSplToken = ({
 	tokens,
 	tokenAddress,
 	networkId

--- a/src/frontend/src/tests/sol/components/transactions/SolInstructionsList.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolInstructionsList.spec.ts
@@ -1,8 +1,10 @@
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import SolInstructionsList from '$sol/components/transactions/SolInstructionsList.svelte';
+import { splCustomTokensStore } from '$sol/stores/spl-custom-tokens.store';
 import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
 import en from '$tests/mocks/i18n.mock';
-import { mockSolAddress2 } from '$tests/mocks/sol.mock';
+import { mockSolAddress2, mockSplAddress } from '$tests/mocks/sol.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
 import { render } from '@testing-library/svelte';
 
 describe('SolInstructionsList', () => {
@@ -12,6 +14,10 @@ describe('SolInstructionsList', () => {
 		decimals: 6,
 		tokenAddress,
 		counterparty: mockSolAddress2
+	});
+
+	beforeEach(() => {
+		splCustomTokensStore.resetAll();
 	});
 
 	// Two lines both reading "Unknown token" say less than the addresses would, since nothing
@@ -43,6 +49,44 @@ describe('SolInstructionsList', () => {
 		);
 		expect(getByTestId('sol-instructions-list')).not.toHaveTextContent(
 			`${en.transaction.text.unknown_token} 1`
+		);
+	});
+
+	// A token the user hid from the asset list is still one the wallet lists and can therefore
+	// read. The list resolved enabled tokens only, so disabling a mint turned every line that
+	// moved it into an unnamed one.
+	it('should name a disabled token', () => {
+		splCustomTokensStore.setAll([
+			{ data: { ...mockValidSplToken, version: undefined, enabled: false }, certified: false }
+		]);
+
+		const { getByTestId } = render(SolInstructionsList, {
+			props: { instructions: [send(mockSplAddress)], token: SOLANA_TOKEN }
+		});
+
+		expect(getByTestId('sol-instructions-list')).toHaveTextContent(mockValidSplToken.symbol);
+		expect(getByTestId('sol-instructions-list')).not.toHaveTextContent(
+			en.transaction.text.unknown_token
+		);
+	});
+
+	// An unchecked transfer states no decimals of its own, so the token's are the only ones the
+	// line has. Without them the amount reads in base units, which is a wrong figure rather than
+	// a missing one.
+	it('should scale an amount with the decimals of a disabled token', () => {
+		splCustomTokensStore.setAll([
+			{ data: { ...mockValidSplToken, version: undefined, enabled: false }, certified: false }
+		]);
+
+		const { getByTestId } = render(SolInstructionsList, {
+			props: {
+				instructions: [{ ...send(mockSplAddress), decimals: undefined }],
+				token: SOLANA_TOKEN
+			}
+		});
+
+		expect(getByTestId('sol-instructions-list')).toHaveTextContent(
+			`0.01 ${mockValidSplToken.symbol}`
 		);
 	});
 });

--- a/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
+++ b/src/frontend/src/tests/sol/components/wallet-connect/SolWalletConnectSimulationPreview.spec.ts
@@ -171,6 +171,22 @@ describe('SolWalletConnectSimulationPreview', () => {
 
 			expect(getByTestId('simulated-token-delta')).toHaveTextContent(mockValidSplToken.symbol);
 		});
+
+		// Hiding a token from the asset list says which assets the user wants to hold, not which
+		// ones the wallet can read. The review resolved enabled tokens only, so disabling one
+		// turned every change that moved it anonymous.
+		it('should name a mint the user disabled', () => {
+			splCustomTokensStore.setAll([
+				{ data: { ...mockValidSplToken, version: undefined, enabled: false }, certified: false }
+			]);
+
+			const { getByTestId } = render(
+				SolWalletConnectSimulationPreview,
+				props({ tokenDeltas: [delta(mockValidSplToken.address)], controlChanges: [] })
+			);
+
+			expect(getByTestId('simulated-token-delta')).toHaveTextContent(mockValidSplToken.symbol);
+		});
 	});
 
 	// An authority change moves nothing, so it has to be named in its own right or it is invisible.


### PR DESCRIPTION
# Motivation

A WalletConnect request that moves an SPL token the user has disabled reads as if OISY knew nothing about it. The operations tab names it "Unknown token" and, since an unchecked transfer states no decimals of its own, prints the amount in base units: `Send 9744305 Unknown token` where an enabled WSOL gives `Send 0.009735782 WSOL`.

Enabling a token says which assets the user wants to hold. It says nothing about which mints the wallet can read, so it has no business deciding whether a transaction under review can be named.

# Changes

The Solana naming path now looks a mint up in the wallet's whole token list rather than the enabled one. `findEnabledSplToken` becomes `findSplToken`, and every surface that names a mint passes `splTokens` instead of `enabledSplTokens`: the WalletConnect review, its simulated changes and its operations tab, plus the transaction row and modal that share the same list and the same lookup.

Two call sites that repeated the address-plus-network matching rule inline now use that lookup as well.

# Tests

`SolInstructionsList`: a disabled token is named, and its decimals scale an amount the instruction does not state. `SolWalletConnectSimulationPreview`: a disabled mint keeps its ticker. Both fail on the previous behaviour.

Full frontend suite green: 1096 files, 18681 tests.
