### PR TITLE
fix(frontend): the Hero net worth in the AI assistant balance tool

### DIFF
--- a/src/frontend/src/env/trading.ts
+++ b/src/frontend/src/env/trading.ts
@@ -3,4 +3,4 @@ import { OISY_TRADE_ENABLED } from '$env/oisy-trade';
 // At least one trading provider active. The temporary whole-surface feature
 // flag was removed once Limit Orders shipped; the Trading surface is now gated
 // purely by the per-provider flags.
-export const anyTradingProviderEnabled = OISY_TRADE_ENABLED;
+export const anyTradingProviderEnabled: boolean = OISY_TRADE_ENABLED;

--- a/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
+++ b/src/frontend/src/lib/components/exchange/ExchangeBalance.svelte
@@ -2,17 +2,13 @@
 	import { nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
 	import { page } from '$app/state';
-	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
-	import { anyTradingProviderEnabled } from '$env/trading';
 	import IconDots from '$lib/components/icons/IconDots.svelte';
 	import IconEyeOff from '$lib/components/icons/lucide/IconEyeOff.svelte';
 	import DelayedTooltip from '$lib/components/ui/DelayedTooltip.svelte';
-	import { allBalancesZero } from '$lib/derived/balances.derived';
+	import { allBalancesZero, providersUsdBalance } from '$lib/derived/balances.derived';
 	import { currentCurrency } from '$lib/derived/currency.derived';
 	import { currentLanguage } from '$lib/derived/i18n.derived';
-	import { liquidiumNetValueUsd } from '$lib/derived/liquidium.derived';
 	import { enabledFungibleNetworkTokensUi } from '$lib/derived/network-tokens-ui.derived';
-	import { oisyTradeUsdValue } from '$lib/derived/oisy-trade.derived';
 	import {
 		tokenCategoryFilter,
 		showTokenCategoryFilter,
@@ -26,7 +22,7 @@
 	import { isRouteTokens } from '$lib/utils/nav.utils';
 	import { setPrivacyMode } from '$lib/utils/privacy.utils';
 	import { filterTokensUiByCategory } from '$lib/utils/token-tag.utils';
-	import { sumTokensUiUsdBalance, sumTokensUiUsdStakeBalance } from '$lib/utils/tokens.utils';
+	import { sumTotalUsdBalance } from '$lib/utils/tokens.utils';
 
 	interface Props {
 		hideBalance?: boolean;
@@ -47,19 +43,13 @@
 			: $enabledFungibleNetworkTokensUi
 	);
 
-	const totalUsd = $derived(sumTokensUiUsdBalance(heroTokens));
-
-	const totalStakeUsd = $derived(sumTokensUiUsdStakeBalance(heroTokens));
-
-	// DEX-deposited balances (free + reserved) count toward net worth; gated by
-	// the Trading feature/provider flags so the production hero stays unchanged.
-	const totalTradeUsd = $derived(anyTradingProviderEnabled ? $oisyTradeUsdValue : 0);
-
-	const totalLiquidiumUsd = $derived(anyLendBorrowProviderEnabled ? $liquidiumNetValueUsd : 0);
+	const totalUsd = $derived(
+		sumTotalUsdBalance({ tokens: heroTokens, providersUsdBalance: $providersUsdBalance })
+	);
 
 	let balance = $derived(
 		formatCurrency({
-			value: $loaded ? totalUsd + totalStakeUsd + totalTradeUsd + totalLiquidiumUsd : 0,
+			value: $loaded ? totalUsd : 0,
 			currency: $currentCurrency,
 			exchangeRate: $currencyExchangeStore,
 			language: $currentLanguage

--- a/src/frontend/src/lib/derived/balances.derived.ts
+++ b/src/frontend/src/lib/derived/balances.derived.ts
@@ -1,9 +1,15 @@
+import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
+import { anyTradingProviderEnabled } from '$env/trading';
 import { ZERO } from '$lib/constants/app.constants';
+import { liquidiumNetValueUsd } from '$lib/derived/liquidium.derived';
 import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
+import { oisyTradeUsdValue } from '$lib/derived/oisy-trade.derived';
+import { enabledMainnetFungibleTokensUi } from '$lib/derived/tokens-ui.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { token } from '$lib/stores/token.store';
 import type { OptionBalance } from '$lib/types/balance';
 import { checkAllBalancesZero, checkAnyNonZeroBalance } from '$lib/utils/balances.utils';
+import { sumTotalUsdBalance } from '$lib/utils/tokens.utils';
 import { nonNullish } from '@dfinity/utils';
 import { derived, type Readable } from 'svelte/store';
 
@@ -37,4 +43,30 @@ export const allBalancesZero: Readable<boolean> = derived(
 export const noPositiveBalanceAndNotAllBalancesZero: Readable<boolean> = derived(
 	[anyBalanceNonZero, allBalancesZero],
 	([$anyBalanceNonZero, $allBalancesZero]) => !$anyBalanceNonZero && !$allBalancesZero
+);
+
+/**
+ * Value the user holds with a provider rather than in a wallet token: DEX deposits (free +
+ * reserved) and the lend/borrow net value, each gated behind its provider flag.
+ *
+ * Portfolio-wide, so it does not narrow with a token or network filter.
+ */
+export const providersUsdBalance: Readable<number> = derived(
+	[oisyTradeUsdValue, liquidiumNetValueUsd],
+	([$oisyTradeUsdValue, $liquidiumNetValueUsd]) =>
+		(anyTradingProviderEnabled ? $oisyTradeUsdValue : 0) +
+		(anyLendBorrowProviderEnabled ? $liquidiumNetValueUsd : 0)
+);
+
+/**
+ * Net worth over every enabled mainnet fungible token — the whole-wallet total, independent of
+ * the selected network and of any UI filter.
+ */
+export const enabledMainnetTotalUsdBalance: Readable<number> = derived(
+	[enabledMainnetFungibleTokensUi, providersUsdBalance],
+	([$enabledMainnetFungibleTokensUi, $providersUsdBalance]) =>
+		sumTotalUsdBalance({
+			tokens: $enabledMainnetFungibleTokensUi,
+			providersUsdBalance: $providersUsdBalance
+		})
 );

--- a/src/frontend/src/lib/services/ai-assistant.services.ts
+++ b/src/frontend/src/lib/services/ai-assistant.services.ts
@@ -9,6 +9,7 @@ import {
 	AI_ASSISTANT_TEXTUAL_RESPONSE_RECEIVED,
 	AI_ASSISTANT_TOOL_EXECUTION_TRIGGERED
 } from '$lib/constants/analytics.constants';
+import { enabledMainnetTotalUsdBalance } from '$lib/derived/balances.derived';
 import { extendedAddressContacts as extendedAddressContactsStore } from '$lib/derived/contacts.derived';
 import { networks } from '$lib/derived/networks.derived';
 import { enabledMainnetFungibleTokensUi } from '$lib/derived/tokens-ui.derived';
@@ -130,7 +131,8 @@ export const executeTool = ({
 		result = parseShowBalanceToolArguments({
 			filterParams,
 			tokensUi: get(enabledMainnetFungibleTokensUi),
-			networks: get(networks)
+			networks: get(networks),
+			totalUsdBalance: get(enabledMainnetTotalUsdBalance)
 		});
 
 		additionalTrackingMetadata = {

--- a/src/frontend/src/lib/utils/ai-assistant.utils.ts
+++ b/src/frontend/src/lib/utils/ai-assistant.utils.ts
@@ -195,11 +195,17 @@ export const parseReviewSendTokensToolArguments = ({
 export const parseShowBalanceToolArguments = ({
 	filterParams,
 	tokensUi,
-	networks
+	networks,
+	totalUsdBalance
 }: {
 	filterParams: ToolCallArgument[];
 	tokensUi: TokenUi[];
 	networks: Network[];
+	// The unfiltered net worth, from the same store the hero reads, so the assistant cannot
+	// quote a different total than the one on screen. Only the unfiltered branch can use it:
+	// the provider-held value it carries is portfolio-wide, so folding it into a per-token or
+	// per-network answer would overstate that answer.
+	totalUsdBalance: number;
 }): ShowBalanceToolResult => {
 	const { tokenSymbolFilter, networkIdFilter } = filterParams.reduce<{
 		tokenSymbolFilter?: string;
@@ -280,7 +286,7 @@ export const parseShowBalanceToolArguments = ({
 
 	return {
 		mainCard: {
-			totalUsdBalance: sumTokensUiUsdBalance(tokensUi)
+			totalUsdBalance
 		}
 	};
 };

--- a/src/frontend/src/lib/utils/tokens.utils.ts
+++ b/src/frontend/src/lib/utils/tokens.utils.ts
@@ -379,6 +379,28 @@ export const sumTokensUiUsdStakeBalance = (tokens: TokenUi[]): number =>
 	);
 
 /**
+ * Calculates the net worth: the wallet and staked balances of the provided UI tokens, plus the
+ * value held with a provider.
+ *
+ * Single source of truth for the total the hero shows, so any other surface quoting "the user's
+ * balance" cannot drift from it.
+ *
+ * @param tokens - The list of UI tokens to account for.
+ * @param providersUsdBalance - The portfolio-wide provider-held value, which does not narrow with
+ * the token list — so it belongs only in an unfiltered total, never in a per-token or per-network
+ * one.
+ * @returns The sum of the UI tokens' USD balance and stake balance, plus the provider-held value.
+ */
+export const sumTotalUsdBalance = ({
+	tokens,
+	providersUsdBalance
+}: {
+	tokens: TokenUi[];
+	providersUsdBalance: number;
+}): number =>
+	sumTokensUiUsdBalance(tokens) + sumTokensUiUsdStakeBalance(tokens) + providersUsdBalance;
+
+/**
  * Calculates total USD balance of mainnet tokens per network from the provided tokens list.
  *
  * @param tokens - The list of UI tokens for filtering by network env and total USD balance calculation.

--- a/src/frontend/src/tests/lib/components/exchange/ExchangeBalance.spec.ts
+++ b/src/frontend/src/tests/lib/components/exchange/ExchangeBalance.spec.ts
@@ -1,10 +1,8 @@
-import * as lendBorrowEnv from '$env/lend-borrow';
 import ExchangeBalance from '$lib/components/exchange/ExchangeBalance.svelte';
 import { AppPath, ROUTE_ID_GROUP_APP } from '$lib/constants/routes.constants';
 import * as balancesDerived from '$lib/derived/balances.derived';
 import * as currencyDerived from '$lib/derived/currency.derived';
 import * as i18nDerived from '$lib/derived/i18n.derived';
-import * as liquidiumDerived from '$lib/derived/liquidium.derived';
 import * as networkTokensUiDerived from '$lib/derived/network-tokens-ui.derived';
 import * as settingsDerived from '$lib/derived/settings.derived';
 import { Currency } from '$lib/enums/currency';
@@ -386,36 +384,27 @@ describe('ExchangeBalance', () => {
 		});
 	});
 
-	describe('Liquidium net value', () => {
+	// Which providers contribute, and their feature gating, is `providersUsdBalance`' own concern
+	// (covered in balances.derived.spec). Here we only assert the hero adds it to the token total.
+	describe('provider-held value', () => {
 		beforeEach(() => {
 			mockHeroContext.loading.set(false);
 		});
 
-		it('should add supplied-minus-borrowed net value to the total when enabled', () => {
-			vi.spyOn(lendBorrowEnv, 'anyLendBorrowProviderEnabled', 'get').mockReturnValue(true);
-			vi.spyOn(liquidiumDerived, 'liquidiumNetValueUsd', 'get').mockReturnValue(staticStore(500));
+		it('should add the provider-held value to the total', () => {
+			vi.spyOn(balancesDerived, 'providersUsdBalance', 'get').mockReturnValue(staticStore(500));
 
 			const { getByText } = renderComponent();
 
 			expect(getByText('$835.00')).toBeInTheDocument();
 		});
 
-		it('should deduct a negative net value (net debt) from the total when enabled', () => {
-			vi.spyOn(lendBorrowEnv, 'anyLendBorrowProviderEnabled', 'get').mockReturnValue(true);
-			vi.spyOn(liquidiumDerived, 'liquidiumNetValueUsd', 'get').mockReturnValue(staticStore(-100));
+		it('should deduct a negative provider-held value (net debt) from the total', () => {
+			vi.spyOn(balancesDerived, 'providersUsdBalance', 'get').mockReturnValue(staticStore(-100));
 
 			const { getByText } = renderComponent();
 
 			expect(getByText('$235.00')).toBeInTheDocument();
-		});
-
-		it('should ignore Liquidium net value when the feature is disabled', () => {
-			vi.spyOn(lendBorrowEnv, 'anyLendBorrowProviderEnabled', 'get').mockReturnValue(false);
-			vi.spyOn(liquidiumDerived, 'liquidiumNetValueUsd', 'get').mockReturnValue(staticStore(500));
-
-			const { getByText } = renderComponent();
-
-			expect(getByText('$335.00')).toBeInTheDocument();
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/derived/balances.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/balances.derived.spec.ts
@@ -1,23 +1,62 @@
+import * as lendBorrowEnv from '$env/lend-borrow';
 import { BONK_TOKEN } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
+import * as tradingEnv from '$env/trading';
 import { ZERO } from '$lib/constants/app.constants';
 import {
 	allBalancesZero,
 	anyBalanceNonZero,
 	balance,
 	balanceZero,
-	noPositiveBalanceAndNotAllBalancesZero
+	enabledMainnetTotalUsdBalance,
+	noPositiveBalanceAndNotAllBalancesZero,
+	providersUsdBalance
 } from '$lib/derived/balances.derived';
 import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 import { balancesStore } from '$lib/stores/balances.store';
 import { token } from '$lib/stores/token.store';
 import type { Token } from '$lib/types/token';
+import type { TokenUi } from '$lib/types/token-ui';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { splCustomTokensStore } from '$sol/stores/spl-custom-tokens.store';
 import { splDefaultTokensStore } from '$sol/stores/spl-default-tokens.store';
 import { bn1Bi } from '$tests/mocks/balances.mock';
 import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { get } from 'svelte/store';
+
+// The net worth is assembled from stores of their own; override just those so the tests can drive
+// the values without standing up a DEX deposit, a Liquidium portfolio or a token list.
+const { oisyTradeUsdValueMock, liquidiumNetValueUsdMock, enabledMainnetFungibleTokensUiMock } =
+	vi.hoisted(() => {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const { writable: createWritable } = require('svelte/store');
+		return {
+			oisyTradeUsdValueMock: createWritable(0),
+			liquidiumNetValueUsdMock: createWritable(0),
+			enabledMainnetFungibleTokensUiMock: createWritable([])
+		};
+	});
+
+vi.mock(import('$lib/derived/oisy-trade.derived'), async (importOriginal) => ({
+	...(await importOriginal()),
+	get oisyTradeUsdValue() {
+		return oisyTradeUsdValueMock;
+	}
+}));
+
+vi.mock(import('$lib/derived/liquidium.derived'), async (importOriginal) => ({
+	...(await importOriginal()),
+	get liquidiumNetValueUsd() {
+		return liquidiumNetValueUsdMock;
+	}
+}));
+
+vi.mock(import('$lib/derived/tokens-ui.derived'), async (importOriginal) => ({
+	...(await importOriginal()),
+	get enabledMainnetFungibleTokensUi() {
+		return enabledMainnetFungibleTokensUiMock;
+	}
+}));
 
 describe('balances.derived', () => {
 	describe('balance', () => {
@@ -383,6 +422,114 @@ describe('balances.derived', () => {
 			balancesStore.reset(tokens[1].id);
 
 			expect(get(noPositiveBalanceAndNotAllBalancesZero)).toBeTruthy();
+		});
+	});
+
+	describe('providersUsdBalance', () => {
+		beforeEach(() => {
+			vi.restoreAllMocks();
+
+			oisyTradeUsdValueMock.set(0);
+			liquidiumNetValueUsdMock.set(0);
+		});
+
+		it('should sum the DEX deposits and the lend/borrow net value', () => {
+			oisyTradeUsdValueMock.set(40);
+			liquidiumNetValueUsdMock.set(15);
+
+			expect(get(providersUsdBalance)).toBe(55);
+		});
+
+		it('should deduct a negative lend/borrow net value (net debt)', () => {
+			oisyTradeUsdValueMock.set(40);
+			liquidiumNetValueUsdMock.set(-100);
+
+			expect(get(providersUsdBalance)).toBe(-60);
+		});
+
+		it('should ignore the DEX deposits when no trading provider is enabled', () => {
+			vi.spyOn(tradingEnv, 'anyTradingProviderEnabled', 'get').mockReturnValue(false);
+
+			oisyTradeUsdValueMock.set(40);
+			liquidiumNetValueUsdMock.set(15);
+
+			expect(get(providersUsdBalance)).toBe(15);
+		});
+
+		it('should ignore the lend/borrow net value when no provider is enabled', () => {
+			vi.spyOn(lendBorrowEnv, 'anyLendBorrowProviderEnabled', 'get').mockReturnValue(false);
+
+			oisyTradeUsdValueMock.set(40);
+			liquidiumNetValueUsdMock.set(15);
+
+			expect(get(providersUsdBalance)).toBe(40);
+		});
+	});
+
+	describe('enabledMainnetTotalUsdBalance', () => {
+		const tokenUi = (financialData: Partial<TokenUi>): TokenUi => ({
+			...ICP_TOKEN,
+			...financialData
+		});
+
+		beforeEach(() => {
+			vi.restoreAllMocks();
+
+			oisyTradeUsdValueMock.set(0);
+			liquidiumNetValueUsdMock.set(0);
+			enabledMainnetFungibleTokensUiMock.set([]);
+		});
+
+		it('should sum the wallet balances of every enabled mainnet token', () => {
+			enabledMainnetFungibleTokensUiMock.set([
+				tokenUi({ usdBalance: 100 }),
+				tokenUi({ usdBalance: 20.5 })
+			]);
+
+			expect(get(enabledMainnetTotalUsdBalance)).toBe(120.5);
+		});
+
+		it('should add the staked balance and its claimable rewards', () => {
+			enabledMainnetFungibleTokensUiMock.set([
+				tokenUi({ usdBalance: 100, stakeUsdBalance: 30, claimableStakeBalanceUsd: 7 })
+			]);
+
+			expect(get(enabledMainnetTotalUsdBalance)).toBe(137);
+		});
+
+		it('should treat missing financial data as zero', () => {
+			enabledMainnetFungibleTokensUiMock.set([tokenUi({}), tokenUi({ usdBalance: 50 })]);
+
+			expect(get(enabledMainnetTotalUsdBalance)).toBe(50);
+		});
+
+		it('should add the provider-held value', () => {
+			enabledMainnetFungibleTokensUiMock.set([tokenUi({ usdBalance: 100 })]);
+
+			oisyTradeUsdValueMock.set(40);
+			liquidiumNetValueUsdMock.set(15);
+
+			expect(get(enabledMainnetTotalUsdBalance)).toBe(155);
+		});
+
+		it('should keep the provider-held value when no token is enabled', () => {
+			oisyTradeUsdValueMock.set(40);
+			liquidiumNetValueUsdMock.set(15);
+
+			expect(get(enabledMainnetTotalUsdBalance)).toBe(55);
+		});
+
+		it('should react to the token list changing', () => {
+			enabledMainnetFungibleTokensUiMock.set([tokenUi({ usdBalance: 100 })]);
+
+			expect(get(enabledMainnetTotalUsdBalance)).toBe(100);
+
+			enabledMainnetFungibleTokensUiMock.set([
+				tokenUi({ usdBalance: 100 }),
+				tokenUi({ usdBalance: 250 })
+			]);
+
+			expect(get(enabledMainnetTotalUsdBalance)).toBe(350);
 		});
 	});
 });

--- a/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/ai-assistant.services.spec.ts
@@ -1,6 +1,7 @@
 import type { chat_response_v1 } from '$declarations/llm/llm.did';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import { llmChat } from '$lib/api/llm.api';
+import * as balancesDerived from '$lib/derived/balances.derived';
 import { extendedAddressContacts } from '$lib/derived/contacts.derived';
 import * as aiAssistantServices from '$lib/services/ai-assistant.services';
 import { contactsStore } from '$lib/stores/contacts.store';
@@ -8,7 +9,7 @@ import type { ContactUi } from '$lib/types/contact';
 import { getMockContactsUi, mockContactBtcAddressUi } from '$tests/mocks/contacts.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { fromNullable, toNullable } from '@dfinity/utils';
-import { get } from 'svelte/store';
+import { get, readable } from 'svelte/store';
 
 vi.mock('$lib/api/llm.api');
 
@@ -34,6 +35,13 @@ describe('ai-assistant.services', () => {
 		function: {
 			name: 'show_balance',
 			arguments: [{ name: 'tokenSymbol', value: 'ICP' }]
+		}
+	};
+	const showTotalBalanceToolCall = {
+		id: 'test',
+		function: {
+			name: 'show_balance',
+			arguments: []
 		}
 	};
 
@@ -182,6 +190,26 @@ describe('ai-assistant.services', () => {
 					mainCard: {
 						token: { ...ICP_TOKEN, balance: undefined, usdBalance: undefined },
 						totalUsdBalance: 0
+					}
+				}
+			});
+		});
+
+		it('reports the unfiltered show_balance total from the same store as the hero', () => {
+			vi.spyOn(balancesDerived, 'enabledMainnetTotalUsdBalance', 'get').mockReturnValue(
+				readable(1234.5)
+			);
+
+			const result = aiAssistantServices.executeTool({
+				toolCall: showTotalBalanceToolCall,
+				requestStartTimestamp: 1000
+			});
+
+			expect(result).toEqual({
+				type: 'show_balance',
+				result: {
+					mainCard: {
+						totalUsdBalance: 1234.5
 					}
 				}
 			});

--- a/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/ai-assistant.utils.spec.ts
@@ -290,6 +290,10 @@ describe('ai-assistant.utils', () => {
 		const usdcBep20TokenUi = { ...USDC_TOKEN_BEP20, usdBalance: 1000, balance: 1000n };
 		const usdcSplTokenUi = { ...USDC_TOKEN_SPL, usdBalance: 1000, balance: 1000n };
 
+		// Deliberately unequal to any sum of the token balances above, so the assertions can tell
+		// the net worth passed in apart from a total recomputed from the token list.
+		const totalUsdBalance = 9999;
+
 		beforeEach(() => {
 			vi.clearAllMocks();
 		});
@@ -308,7 +312,8 @@ describe('ai-assistant.utils', () => {
 						}
 					],
 					tokensUi: [icpTokenUi, { ...ETHEREUM_TOKEN, usdBalance: 1000, balance: 1000n }],
-					networks: [ICP_NETWORK, ETHEREUM_NETWORK]
+					networks: [ICP_NETWORK, ETHEREUM_NETWORK],
+					totalUsdBalance
 				})
 			).toEqual({
 				mainCard: {
@@ -328,7 +333,8 @@ describe('ai-assistant.utils', () => {
 						}
 					],
 					tokensUi: [usdcErc20TokenUi, usdcBep20TokenUi, usdcSplTokenUi, ckUsdcTokenUi],
-					networks: [ETHEREUM_NETWORK, SOLANA_MAINNET_NETWORK, BSC_MAINNET_NETWORK]
+					networks: [ETHEREUM_NETWORK, SOLANA_MAINNET_NETWORK, BSC_MAINNET_NETWORK],
+					totalUsdBalance
 				})
 			).toEqual({
 				mainCard: {
@@ -353,7 +359,8 @@ describe('ai-assistant.utils', () => {
 						}
 					],
 					tokensUi: [usdcErc20TokenUi, usdcBep20TokenUi, usdcSplTokenUi],
-					networks: [ETHEREUM_NETWORK, SOLANA_MAINNET_NETWORK, BSC_MAINNET_NETWORK]
+					networks: [ETHEREUM_NETWORK, SOLANA_MAINNET_NETWORK, BSC_MAINNET_NETWORK],
+					totalUsdBalance
 				})
 			).toEqual({
 				mainCard: {
@@ -364,17 +371,17 @@ describe('ai-assistant.utils', () => {
 			});
 		});
 
-		it('returns correct result when no filters provided', () => {
+		it('returns the provided net worth, not the token sum, when no filters provided', () => {
 			expect(
 				parseShowBalanceToolArguments({
 					filterParams: [],
 					tokensUi: [usdcErc20TokenUi, usdcBep20TokenUi, usdcSplTokenUi],
-					networks: [ETHEREUM_NETWORK, SOLANA_MAINNET_NETWORK, BSC_MAINNET_NETWORK]
+					networks: [ETHEREUM_NETWORK, SOLANA_MAINNET_NETWORK, BSC_MAINNET_NETWORK],
+					totalUsdBalance
 				})
 			).toEqual({
 				mainCard: {
-					totalUsdBalance:
-						usdcErc20TokenUi.usdBalance + usdcBep20TokenUi.usdBalance + usdcSplTokenUi.usdBalance
+					totalUsdBalance
 				}
 			});
 		});

--- a/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/tokens.utils.spec.ts
@@ -46,6 +46,7 @@ import {
 	sumMainnetTokensUsdStakeBalancesPerNetwork,
 	sumTokensUiUsdBalance,
 	sumTokensUiUsdStakeBalance,
+	sumTotalUsdBalance,
 	tokenListEqual
 } from '$lib/utils/tokens.utils';
 import { parseTokenGroupId } from '$lib/validation/token-group.validation';
@@ -1015,6 +1016,42 @@ describe('tokens.utils', () => {
 			const result = sumTokensUiUsdStakeBalance([]);
 
 			expect(result).toEqual(0);
+		});
+	});
+
+	describe('sumTotalUsdBalance', () => {
+		it('should sum the wallet balances, the stake balances and the provider-held value', () => {
+			const tokens: TokenUi[] = [
+				{ ...ICP_TOKEN, usdBalance: 100, stakeUsdBalance: 30, claimableStakeBalanceUsd: 7 },
+				{ ...ETHEREUM_TOKEN, usdBalance: 200 }
+			];
+
+			const result = sumTotalUsdBalance({ tokens, providersUsdBalance: 55 });
+
+			expect(result).toEqual(392);
+		});
+
+		it('should treat missing financial data as zero', () => {
+			const tokens: TokenUi[] = [{ ...ICP_TOKEN }, { ...ETHEREUM_TOKEN, usdBalance: 50 }];
+
+			const result = sumTotalUsdBalance({ tokens, providersUsdBalance: 0 });
+
+			expect(result).toEqual(50);
+		});
+
+		// The provider-held value is portfolio-wide, so it survives an empty token list.
+		it('should return the provider-held value when the tokens list is empty', () => {
+			const result = sumTotalUsdBalance({ tokens: [], providersUsdBalance: 55 });
+
+			expect(result).toEqual(55);
+		});
+
+		it('should deduct a negative provider-held value', () => {
+			const tokens: TokenUi[] = [{ ...ICP_TOKEN, usdBalance: 100 }];
+
+			const result = sumTotalUsdBalance({ tokens, providersUsdBalance: -30 });
+
+			expect(result).toEqual(70);
 		});
 	});
 


### PR DESCRIPTION
# Motivation

The AI assistant's `show_balance` tool reported a smaller number than the hero for the same wallet. The hero total is composed inline in `ExchangeBalance.svelte` from four addends; the tool summed only wallet `usdBalance`, so staking, OISY TRADE deposits and Liquidium net value were missing. With no shared store, the two were free to drift.


# Changes

- Add `initTotalUsdBalance(tokens)` to `balances.derived.ts` — the hero formula verbatim, as a store factory (the callers have different token universes: the hero is network- and category-scoped, the assistant is all-mainnet). Plus `enabledMainnetTotalUsdBalance` as the whole-wallet instance.
- `ExchangeBalance.svelte` consumes it. **Displayed balance unchanged.**
- `show_balance` reads it for the unfiltered total only.


# Tests

Updated.
