### PR TITLE
fix(frontend): match the confirmation popup's modal breakpoint to Modal's

### DIFF
--- a/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
+++ b/src/frontend/src/lib/components/ui/BottomSheetConfirmationPopup.svelte
@@ -44,10 +44,11 @@
 	</div>
 {/snippet}
 
-<!-- Mobile: a slide-up bottom sheet. The bottom sheet only renders as a real
-     sheet below 1024px; above it collapses to a transparent, position-relative
-     block, so on desktop we render the same content as a centered modal instead. -->
-<Responsive down="lg">
+<!-- Mobile: a slide-up bottom sheet, below the same `sm` breakpoint (640px) where
+     `Modal.svelte`'s own dialog switches from full-bleed to a centered card
+     (see `gix.scss`) — otherwise the underlying modal looks desktop-sized while
+     this popup still renders as a full-width mobile sheet. -->
+<Responsive down="sm">
 	<div class="fixed inset-0 z-50">
 		<BottomSheetContainer transition>
 			{@render body()}
@@ -58,7 +59,7 @@
 </Responsive>
 
 <!-- Desktop: a smaller modal stacked over the underlying modal. -->
-<Responsive up="1.5lg">
+<Responsive up="md">
 	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
 		<Backdrop onClose={onCancel} />
 

--- a/src/frontend/src/tests/lib/components/ui/BottomSheetConfirmationPopup.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/BottomSheetConfirmationPopup.spec.ts
@@ -35,4 +35,17 @@ describe('BottomSheetConfirmationPopup', () => {
 		expect(getByTestId('confirmation-title')).toBeInTheDocument();
 		expect(getByTestId('confirmation-content')).toBeInTheDocument();
 	});
+
+	it('renders a centered modal card at the same breakpoint as Modal.svelte (>=640px)', () => {
+		// Regression: Modal.svelte's own dialog becomes a centered card at the `sm`
+		// breakpoint (640px, see gix.scss). This popup used to only switch at 1024px,
+		// so it rendered as a mobile bottom sheet while the parent modal already
+		// looked like a desktop dialog.
+		screensStore.set('md');
+
+		const { queryByTestId, getByTestId } = render(BottomSheetConfirmationPopup, { props });
+
+		expect(getByTestId(CONFIRMATION_POPUP_MODAL)).toBeInTheDocument();
+		expect(queryByTestId('bottom-sheet')).toBeNull();
+	});
 });


### PR DESCRIPTION
# Motivation

Opening the "Cancel this limit order?" confirmation on a mid-width window looked broken: the underlying "Order details" modal was already a centered desktop card, but the confirmation on top of it still slid up as a full-width mobile bottom sheet.

The two use different breakpoints. `Modal.svelte`'s dialog switches from full-bleed to a centered 560px card at Tailwind's `sm` breakpoint — `@media (width >= theme(--breakpoint-sm))`, 640px, in `gix.scss`. `BottomSheetConfirmationPopup` (added in #13322) instead switched at 1024px, the threshold where the gix bottom sheet stops rendering as a real sheet. That left the 640px–1023px range with a desktop-shaped parent modal and a mobile-shaped confirmation on top of it.

Same range, same cause for every consumer of the shared popup, so deleting a personal note, deleting an address or contact, sharing a note and deleting a token from the token modal all showed it too.

# Changes

- `BottomSheetConfirmationPopup`: move the `Responsive` cutoff from `down="lg"` / `up="1.5lg"` to `down="sm"` / `up="md"`. Given how `getActiveScreen` buckets widths, that is exactly `< 640px` for the sheet and `>= 640px` for the centered modal — the same point `gix.scss` flips the dialog variables, so the confirmation and the modal it sits on now change shape together.
- Nothing else changes: both branches render the same markup as before, and the bottom sheet is now only ever mounted below 640px, well inside the range where it renders as a real sheet.
- Updated the comment to point at the breakpoint this now tracks, since the old one documented the 1024px gix threshold as the reason.

# Tests

- `npx prettier --check` and `npx eslint --max-warnings 0` clean on both files; `npm run check` (6017 files, 0 errors) and `npm run check:tests` (7320 files, 0 errors) pass.
- `BottomSheetConfirmationPopup.spec.ts`: added a case asserting the centered modal renders (and the bottom sheet does not) at the `md` bucket — the previously broken range. The two existing cases still cover `xs` (sheet) and `1.5lg` (modal) unchanged.
- Ran the specs of every consumer of this component — trading, notes, address book, tokens — 88 files / 524 tests, all passing. None of them set `screensStore`, so they all exercise the untouched mobile branch.
- Visually verified at 800px in the dev server, rendering the component over a stand-in 560px modal card: it now shows as a centered card matching the parent modal's shape. Mobile was not re-verified in the browser — the app's narrow-width boot needs a signed-in session — but that branch's markup is unchanged and covered by the `xs` test.

|Before|After|
|---|---|
|<img width="852" height="923" alt="image" src="https://github.com/user-attachments/assets/f20fcbad-dc2f-4142-ad7a-4e8f6812d5d9" />|<img width="852" height="923" alt="image" src="https://github.com/user-attachments/assets/972f2eb9-8d83-4aab-9a86-e86790f910f0" />|

Regression test on mobile
<img height="461" alt="image" src="https://github.com/user-attachments/assets/24299c38-c1c6-45b8-9fe5-65363d6cdefc" />


🤖 Generated with Claude Opus 5