### PR TITLE
fix(frontend): withdraw only what OISY Trade order could have credited

### DIFF
--- a/src/frontend/src/lib/oisy-trade/README.md
+++ b/src/frontend/src/lib/oisy-trade/README.md
@@ -4,6 +4,13 @@ Given an order-book snapshot, this module answers one question: **what is the
 largest fill-or-kill order this book is certain to fill, and what is it certain to
 produce?** That answer is what the Swap flow shows as an OISY Trade offer.
 
+It answers one thing more, for the settlement that follows rather than for the
+offer: **`maxSourceRelease`** — the most of the deposit the venue can hand back once
+the order fills. A Buy reserves at its limit price and fills at the book's, so the
+difference comes back, and the free balance settlement reads is account-wide, so
+without a bound it cannot tell that release from any other credit. The book is the
+only place that bound exists, which is why it is computed here.
+
 ## This code does not belong here
 
 It belongs in the `oisy_trade` canister, next to the book it reads and the matching

--- a/src/frontend/src/lib/oisy-trade/offer.ts
+++ b/src/frontend/src/lib/oisy-trade/offer.ts
@@ -75,11 +75,11 @@ const priceCoveringValue = ({
  * What acquiring `quantity` base tokens costs at the book's own prices, scaled by
  * `10^baseDecimals`.
  *
- * The engine matches from the best price outwards, so this is the **cheapest** the
- * fill can be — and therefore, subtracted from what the order reserves, the *most*
- * of that reserve the venue can hand back. Settlement needs that bound: the free
- * balance it reads is account-wide, so without one it cannot tell a released reserve
- * from any other credit that landed on the same leg.
+ * The engine matches from the best price outwards, so this is the cheapest the fill
+ * can be **against this snapshot** — and therefore, subtracted from what the order
+ * reserves, the most of that reserve the snapshot says can come back. It is what
+ * settlement bounds a source credit by; the caveat that the book moves afterwards
+ * belongs with the field, `OisyTradeOffer.maxSourceRelease`.
  *
  * Nothing when the levels cannot supply the quantity, which is unreachable for a
  * quantity this module derived: the price walk stopped at a level whose cumulative

--- a/src/frontend/src/lib/oisy-trade/offer.ts
+++ b/src/frontend/src/lib/oisy-trade/offer.ts
@@ -72,6 +72,45 @@ const priceCoveringValue = ({
 };
 
 /**
+ * What acquiring `quantity` base tokens costs at the book's own prices, scaled by
+ * `10^baseDecimals`.
+ *
+ * The engine matches from the best price outwards, so this is the **cheapest** the
+ * fill can be — and therefore, subtracted from what the order reserves, the *most*
+ * of that reserve the venue can hand back. Settlement needs that bound: the free
+ * balance it reads is account-wide, so without one it cannot tell a released reserve
+ * from any other credit that landed on the same leg.
+ *
+ * Nothing when the levels cannot supply the quantity, which is unreachable for a
+ * quantity this module derived: the price walk stopped at a level whose cumulative
+ * value already covers the spend, and every level up to it is priced at or below
+ * that limit, so those levels hold at least `quantity`.
+ */
+const sweptValue = ({
+	levels,
+	quantity
+}: {
+	levels: PriceLevel[];
+	quantity: bigint;
+}): bigint | undefined => {
+	let remaining = quantity;
+	let scaled = ZERO;
+
+	for (const level of levels) {
+		const taken = level.quantity < remaining ? level.quantity : remaining;
+
+		scaled += level.price * taken;
+		remaining -= taken;
+
+		if (remaining <= ZERO) {
+			return scaled;
+		}
+	}
+
+	return undefined;
+};
+
+/**
  * Quotes a fill-or-kill order against an order-book snapshot.
  *
  * Both sides run the same walk — accumulate levels until the order is covered, take
@@ -161,6 +200,16 @@ export const calculateOisyTradeOffer = ({
 		return reject('above_max_notional');
 	}
 
+	// Only levels at or below the limit can match, and a price-aggregated depth lists
+	// each price once, so this is exactly the prefix the fill sweeps.
+	const swept = isSell
+		? ZERO
+		: sweptValue({ levels: depth.asks.filter((level) => level.price <= price), quantity });
+
+	if (isNullish(swept)) {
+		return reject('no_liquidity');
+	}
+
 	return {
 		ok: true,
 		offer: {
@@ -171,7 +220,13 @@ export const calculateOisyTradeOffer = ({
 			// ledger fee and needs no withdrawal.
 			deposit: isSell ? quantity : notional,
 			// A Sell is paid in the quote token, a Buy receives the base token itself.
-			gross: isSell ? notional : quantity
+			gross: isSell ? notional : quantity,
+			// A Sell's reserve is the quantity itself and a full fill transfers all of it,
+			// so nothing can come back. A Buy reserves at its limit and fills at the
+			// book's, and the difference is released. The division floors the cost, which
+			// can overstate the release by under one quote unit — harmless, since
+			// settlement takes the lesser of this and the credit it measures.
+			maxSourceRelease: isSell ? ZERO : notional - swept / baseUnit
 		}
 	};
 };

--- a/src/frontend/src/lib/oisy-trade/offer.ts
+++ b/src/frontend/src/lib/oisy-trade/offer.ts
@@ -36,8 +36,6 @@ const priceCoveringQuantity = ({
 			return level.price;
 		}
 	}
-
-	return undefined;
 };
 
 /**
@@ -67,8 +65,6 @@ const priceCoveringValue = ({
 			return level.price;
 		}
 	}
-
-	return undefined;
 };
 
 /**
@@ -106,8 +102,6 @@ const sweptValue = ({
 			return scaled;
 		}
 	}
-
-	return undefined;
 };
 
 /**

--- a/src/frontend/src/lib/oisy-trade/types.ts
+++ b/src/frontend/src/lib/oisy-trade/types.ts
@@ -61,6 +61,18 @@ export interface OisyTradeOffer {
 	 * tokens and gets the unspent reserve back.
 	 */
 	gross: bigint;
+	/**
+	 * The **most** of `deposit` the venue can return on the source leg, in
+	 * source-token smallest units: zero for a Sell, and for a Buy the reserve at the
+	 * limit price less what the book charges at its own prices.
+	 *
+	 * Not a prediction — an upper bound, and settlement's only defence against a
+	 * free balance that is account-wide. Every other credit that can land on that
+	 * leg while the order runs (most easily the caller's own resting orders filling,
+	 * which a swap crosses the very book of) exceeds it, so it is what separates
+	 * "the venue gave this back" from "something else arrived".
+	 */
+	maxSourceRelease: bigint;
 }
 
 export type OisyTradeOfferResult =

--- a/src/frontend/src/lib/oisy-trade/types.ts
+++ b/src/frontend/src/lib/oisy-trade/types.ts
@@ -66,11 +66,18 @@ export interface OisyTradeOffer {
 	 * source-token smallest units: zero for a Sell, and for a Buy the reserve at the
 	 * limit price less what the book charges at its own prices.
 	 *
-	 * Not a prediction — an upper bound, and settlement's only defence against a
-	 * free balance that is account-wide. Every other credit that can land on that
-	 * leg while the order runs (most easily the caller's own resting orders filling,
-	 * which a swap crosses the very book of) exceeds it, so it is what separates
-	 * "the venue gave this back" from "something else arrived".
+	 * An upper bound **for the snapshot it was walked from**, not for the fill. The
+	 * order is placed later, at the same limit price but against whatever the book has
+	 * become: if the cheap asks are gone by then the fill costs more and releases less,
+	 * while this figure stays where it was. So it is a ceiling that can go stale high,
+	 * and settlement drawing a source credit within it can still take that much of a
+	 * credit the order did not make — the caller's own resting orders filling being the
+	 * likeliest source of one, on the very book a swap crosses.
+	 *
+	 * That bounds the mis-attribution rather than removing it: without this the whole
+	 * account-wide delta is withdrawn, which at a zero maker fee is the entire deposit.
+	 * Removing it needs the venue to report the order's executed cost, or to quote and
+	 * place atomically; a mutable book snapshot cannot establish it.
 	 */
 	maxSourceRelease: bigint;
 }

--- a/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
@@ -212,11 +212,25 @@ const pollOisyTradeTransaction = async ({
 		return;
 	}
 
+	const side = fromOisyTradeCandidDataSide(tx.data.OisyTrade.side);
+	const quantity = toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_QUANTITY]);
+
+	// A Buy's destination ceiling *is* the quantity, so settling without one would leave
+	// the primary leg withdrawing an account-wide delta — the very thing these bounds
+	// exist to stop. Written at row creation like the baselines, so an unreadable one is
+	// a malformed row and gets their treatment: logged, non-terminal, left alone. A Sell
+	// needs no such ceiling, and refusing to recover one over a ref it never reads would
+	// strand funds for nothing.
+	if (side === 'buy' && isNullish(quantity)) {
+		consoleError('Unreadable order quantity on an OISY Trade active user transaction', tx.id);
+		return;
+	}
+
 	// A row predating the release ref reads zero and so skips its source residue, leaving
 	// it visible in the Trading tab rather than sweeping a delta nothing bounds.
 	const bounds = toOisyTradeSettlementBounds({
-		side: fromOisyTradeCandidDataSide(tx.data.OisyTrade.side),
-		quantity: toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_QUANTITY]),
+		side,
+		quantity,
 		depositAmount: tx.data.OisyTrade.amount,
 		maxSourceRelease:
 			toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.MAX_SOURCE_RELEASE]) ?? ZERO

--- a/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-active-tx.services.ts
@@ -7,6 +7,7 @@ import type {
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import type { IcToken } from '$icp/types/ic-token';
 import { OisyTradeError } from '$lib/canisters/oisy-trade.errors';
+import { ZERO } from '$lib/constants/app.constants';
 import { OISY_TRADE_SWAP_SETTLE_GRACE_OBSERVATIONS } from '$lib/constants/oisy-trade.constants';
 import { allSortedIcrcTokens } from '$lib/derived/all-tokens.derived';
 import {
@@ -16,6 +17,7 @@ import {
 import {
 	isRetryableOisyTradeError,
 	settleOisyTradeSwap,
+	toOisyTradeSettlementBounds,
 	toOisyTradeSettlementRowUpdate,
 	type OisyTradeSettlement
 } from '$lib/services/oisy-trade-swap.services';
@@ -28,6 +30,7 @@ import { advanceStatus } from '$lib/utils/active-user-transactions.utils';
 import { consoleError } from '$lib/utils/console.utils';
 import {
 	findOisyTradeRowToken,
+	fromOisyTradeCandidDataSide,
 	toOisyTradeExternalRefs,
 	toOisyTradeExternalRefsMap,
 	toOisyTradeRefAmount
@@ -209,6 +212,16 @@ const pollOisyTradeTransaction = async ({
 		return;
 	}
 
+	// A row predating the release ref reads zero and so skips its source residue, leaving
+	// it visible in the Trading tab rather than sweeping a delta nothing bounds.
+	const bounds = toOisyTradeSettlementBounds({
+		side: fromOisyTradeCandidDataSide(tx.data.OisyTrade.side),
+		quantity: toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_QUANTITY]),
+		depositAmount: tx.data.OisyTrade.amount,
+		maxSourceRelease:
+			toOisyTradeRefAmount(refs[OISY_TRADE_EXTERNAL_REF_KEYS.MAX_SOURCE_RELEASE]) ?? ZERO
+	});
+
 	let settlement: OisyTradeSettlement;
 
 	try {
@@ -217,7 +230,8 @@ const pollOisyTradeTransaction = async ({
 			orderId: orderIdRef,
 			sourceToken,
 			destinationToken,
-			baseline: { source, destination }
+			baseline: { source, destination },
+			bounds
 		});
 	} catch (err: unknown) {
 		// The retry policy, and the reason this branch exists at all. `retryable` covers

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -56,7 +56,7 @@ import {
 	toOisyTradeCandidSide,
 	toOisyTradePairTable
 } from '$lib/utils/oisy-trade-swap.utils';
-import { toPairView, toTradingPair } from '$lib/utils/oisy-trade.utils';
+import { toPairView, toTradingPair, type LimitOrderSide } from '$lib/utils/oisy-trade.utils';
 import { waitAndTriggerWallet } from '$lib/utils/wallet.utils';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { Identity } from '@icp-sdk/core/agent';
@@ -449,6 +449,50 @@ const attributable = ({ current, baseline }: { current: bigint; baseline: bigint
 	current > baseline ? current - baseline : ZERO;
 
 /**
+ * The most this order can have credited to each leg settlement withdraws from.
+ *
+ * The baseline makes a delta *this flow's*, which is not the same as *this order's*: a
+ * swap crosses the very book the caller's own resting orders sit on, and their proceeds
+ * land on the same legs in the same round. At a zero maker fee a self-matched Buy is
+ * credited exactly the reserve it spent, so the delta alone cannot tell that from an
+ * order that filled for nothing — and withdrawing it hands the user their own maker
+ * proceeds. Every ceiling errs toward leaving funds at the venue, where the Trading tab
+ * still shows them.
+ */
+export interface OisyTradeSettlementBounds {
+	// See `OisyTradeOffer.maxSourceRelease`.
+	filledSourceRelease: bigint;
+	// Undefined on a Sell, which fills at maker prices: capping would strand the price
+	// improvement the offer promised.
+	filledDestinationCredit: bigint | undefined;
+	// The deposit, since a killed fill-or-kill order has zero execution.
+	killedSourceReturn: bigint;
+}
+
+/**
+ * `quantity` is optional for the poller's sake: a row whose ref cannot be read leaves a
+ * Buy's destination unbounded rather than zero, which would strand a successful fill.
+ */
+export const toOisyTradeSettlementBounds = ({
+	side,
+	quantity,
+	depositAmount,
+	maxSourceRelease
+}: {
+	side: LimitOrderSide;
+	quantity: bigint | undefined;
+	depositAmount: bigint;
+	maxSourceRelease: bigint;
+}): OisyTradeSettlementBounds => ({
+	filledSourceRelease: maxSourceRelease,
+	filledDestinationCredit: side === 'buy' ? quantity : undefined,
+	killedSourceReturn: depositAmount
+});
+
+const capped = ({ delta, cap }: { delta: bigint; cap: bigint | undefined }): bigint =>
+	isNullish(cap) || delta < cap ? delta : cap;
+
+/**
  * Withdraws an amount from a token's free DEX balance, or nothing when it is dust.
  *
  * `withdraw` refuses an `amount` at or below the ledger fee (`AmountTooSmall`), so a
@@ -523,6 +567,10 @@ const withdrawFreeBalance = async ({
  * move. The same distinction decides the status: a pre-existing destination balance
  * must not let a killed order read as filled.
  *
+ * That difference is necessary and **not sufficient**: it is this flow's, but not
+ * necessarily this order's, so each leg is additionally taken within
+ * `OisyTradeSettlementBounds`.
+ *
  * The terminal action is *withdraw what this order added to both legs*: a Buy that
  * crosses below its limit price has its unspent reserve released back to free
  * balance, so even a successful swap can leave source behind. The fill / kill
@@ -533,7 +581,8 @@ export const settleOisyTradeSwap = async ({
 	orderId,
 	sourceToken,
 	destinationToken,
-	baseline
+	baseline,
+	bounds
 }: {
 	identity: Identity;
 	// Absent only when no order was ever placed, or its id never came back.
@@ -542,6 +591,8 @@ export const settleOisyTradeSwap = async ({
 	destinationToken: IcToken;
 	// Both legs' free balance as it stood before the deposit.
 	baseline: OisyTradeFreeBalances;
+	// The most this order can have credited to each leg. See `OisyTradeSettlementBounds`.
+	bounds: OisyTradeSettlementBounds;
 }): Promise<OisyTradeSettlement> => {
 	const order = nonNullish(orderId) ? await readOisyTradeOrder({ identity, orderId }) : undefined;
 
@@ -587,12 +638,19 @@ export const settleOisyTradeSwap = async ({
 	const [primary, residue] =
 		status === 'filled'
 			? ([
-					[destinationToken, destinationAdded],
-					[sourceToken, sourceAdded]
+					[
+						destinationToken,
+						capped({ delta: destinationAdded, cap: bounds.filledDestinationCredit })
+					],
+					[sourceToken, capped({ delta: sourceAdded, cap: bounds.filledSourceRelease })]
 				] as const)
 			: ([
-					[sourceToken, sourceAdded],
-					[destinationToken, destinationAdded]
+					[sourceToken, capped({ delta: sourceAdded, cap: bounds.killedSourceReturn })],
+					// A killed order has zero execution, so it never credited the destination
+					// leg at all: whatever is there arrived from something else — most likely
+					// another of the caller's orders filling — and none of it is this swap's to
+					// move. Left at the venue rather than withdrawn, and dust-skipped below.
+					[destinationToken, ZERO]
 				] as const);
 
 	// Sequential, not concurrent: the canister rejects a second withdrawal while one is
@@ -661,6 +719,7 @@ const settleUntilTerminal = async (params: {
 	sourceToken: IcToken;
 	destinationToken: IcToken;
 	baseline: OisyTradeFreeBalances;
+	bounds: OisyTradeSettlementBounds;
 }): Promise<OisyTradeResolvedSettlement> => {
 	for (;;) {
 		try {
@@ -687,8 +746,10 @@ const settleUntilTerminal = async (params: {
  *
  * Only the source leg: no order ever existed, so nothing has touched the
  * destination. And only what the deposit added — the delta from the pre-deposit
- * baseline, not `depositAmount`, so a concurrent Trading-tab withdrawal cannot
- * make it over-draw a balance the user moved themselves.
+ * baseline, so a concurrent Trading-tab withdrawal cannot make it over-draw a
+ * balance the user moved themselves — capped at `depositAmount`, since the deposit
+ * is the only credit this flow produced and anything beyond it arrived from
+ * elsewhere, most easily one of the caller's own orders filling meanwhile.
  *
  * Retries transient failures unbounded, exactly like `settleUntilTerminal` and
  * for the same reason: giving up on a ledger's bad minute would end the flow with
@@ -700,8 +761,9 @@ const recoverOisyTradeDeposit = async (params: {
 	sourceToken: IcToken;
 	destinationToken: IcToken;
 	baseline: OisyTradeFreeBalances;
+	depositAmount: bigint;
 }): Promise<void> => {
-	const { identity, sourceToken, baseline } = params;
+	const { identity, sourceToken, baseline, depositAmount } = params;
 
 	for (;;) {
 		try {
@@ -710,7 +772,10 @@ const recoverOisyTradeDeposit = async (params: {
 			await withdrawFreeBalance({
 				identity,
 				token: sourceToken,
-				amount: attributable({ current: current.source, baseline: baseline.source })
+				amount: capped({
+					delta: attributable({ current: current.source, baseline: baseline.source }),
+					cap: depositAmount
+				})
 			});
 
 			return;
@@ -834,6 +899,7 @@ export const fetchOisyTradeSwap = async ({
 		}),
 		[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_PRICE]: `${order.price}`,
 		[OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_QUANTITY]: `${order.quantity}`,
+		[OISY_TRADE_EXTERNAL_REF_KEYS.MAX_SOURCE_RELEASE]: `${order.maxSourceRelease}`,
 		[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]: `${baseline.source}`,
 		[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE]: `${baseline.destination}`
 	};
@@ -986,7 +1052,13 @@ export const fetchOisyTradeSwap = async ({
 		// resolves once the grace period has passed.
 		if (err instanceof OisyTradeError) {
 			try {
-				await recoverOisyTradeDeposit({ identity, sourceToken, destinationToken, baseline });
+				await recoverOisyTradeDeposit({
+					identity,
+					sourceToken,
+					destinationToken,
+					baseline,
+					depositAmount: order.depositAmount
+				});
 			} catch (recoveryErr: unknown) {
 				consoleError(recoveryErr);
 
@@ -1039,7 +1111,8 @@ export const fetchOisyTradeSwap = async ({
 		orderId,
 		sourceToken,
 		destinationToken,
-		baseline
+		baseline,
+		bounds: toOisyTradeSettlementBounds(order)
 	});
 
 	// This session reports the outcome itself — the wizard fires the swap funnel's

--- a/src/frontend/src/lib/services/oisy-trade-swap.services.ts
+++ b/src/frontend/src/lib/services/oisy-trade-swap.services.ts
@@ -456,22 +456,35 @@ const attributable = ({ current, baseline }: { current: bigint; baseline: bigint
  * land on the same legs in the same round. At a zero maker fee a self-matched Buy is
  * credited exactly the reserve it spent, so the delta alone cannot tell that from an
  * order that filled for nothing — and withdrawing it hands the user their own maker
- * proceeds. Every ceiling errs toward leaving funds at the venue, where the Trading tab
- * still shows them.
+ * proceeds.
+ *
+ * The deposit and quantity ceilings are exact. `filledSourceRelease` is not: it is
+ * walked from the quote's book snapshot, so a book that worsens before the order lands
+ * leaves it high and a credit can still be drawn on within it. It bounds that draw by
+ * the quoted price improvement instead of leaving it at the whole deposit; closing it
+ * needs the venue to report the executed cost. See `OisyTradeOffer.maxSourceRelease`.
  */
 export interface OisyTradeSettlementBounds {
 	// See `OisyTradeOffer.maxSourceRelease`.
 	filledSourceRelease: bigint;
-	// Undefined on a Sell, which fills at maker prices: capping would strand the price
-	// improvement the offer promised.
+	// Undefined on a Sell, deliberately and not for want of a ceiling: sweeping the bids
+	// would give the symmetric one. This leg is the *primary* rather than a residue, and
+	// a cap that binds leaves part of the swap's own output at the venue with nothing
+	// marking it, since a filled row closes. Withdrawing too much moves the caller's own
+	// money to their own wallet; withdrawing too little looks like a swap that did not
+	// deliver. The cost of leaving it open is real — quote-token free balance is
+	// account-wide across pairs, so any resting order of the caller's that shares the
+	// quote token credits this leg — and it stands until the venue reports the executed
+	// proceeds.
 	filledDestinationCredit: bigint | undefined;
 	// The deposit, since a killed fill-or-kill order has zero execution.
 	killedSourceReturn: bigint;
 }
 
 /**
- * `quantity` is optional for the poller's sake: a row whose ref cannot be read leaves a
- * Buy's destination unbounded rather than zero, which would strand a successful fill.
+ * `quantity` is optional only because a Sell has no use for it. A Buy without one would
+ * be built unbounded on the leg that most needs a ceiling, so the poller refuses such a
+ * row before reaching here rather than settling it.
  */
 export const toOisyTradeSettlementBounds = ({
 	side,

--- a/src/frontend/src/lib/types/oisy-trade-swap.ts
+++ b/src/frontend/src/lib/types/oisy-trade-swap.ts
@@ -16,6 +16,15 @@ export const OISY_TRADE_EXTERNAL_REF_KEYS = {
 	// and the row has to keep describing the order the user reviewed.
 	ORDER_PRICE: 'order_price',
 	ORDER_QUANTITY: 'order_quantity',
+	// The most of the deposit the venue can hand back on the source leg, from the
+	// book the quote walked. Settlement withdraws the source residue of a filled
+	// order within this, because the delta it measures is account-wide and the
+	// caller's own resting orders filling — on the very pair the swap crosses —
+	// credits the same leg with far more than the order can have released. With a
+	// zero maker fee those proceeds are exactly the deposit, so the delta alone
+	// cannot tell them apart. Snapshotted at creation, since the book has moved by
+	// the time a later session polls.
+	MAX_SOURCE_RELEASE: 'max_source_release',
 	// The destination (or recovered source) withdrawal that closes the row.
 	WITHDRAW_BLOCK_INDEX: 'withdraw_block_index',
 	// Set when the order has resolved but a non-dust leg is still at the venue because
@@ -89,6 +98,10 @@ export interface OisyTradeResolvedOrder {
 	// the typed amount in the user's wallet, where it costs no fee and needs no
 	// withdrawal.
 	depositAmount: bigint;
+	// The ceiling on what settlement may withdraw back from the source leg of a
+	// filled order, in source-token smallest units — zero on a Sell, the reserve
+	// less the book's own cost on a Buy. See `OisyTradeOffer.maxSourceRelease`.
+	maxSourceRelease: bigint;
 }
 
 /**

--- a/src/frontend/src/lib/utils/oisy-trade-active-tx.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade-active-tx.utils.ts
@@ -27,6 +27,9 @@ export const isOisyTradeActiveUserTransaction = (tx: ActiveUserTransaction): boo
 export const toOisyTradeCandidDataSide = (side: LimitOrderSide): OisyTradeSide =>
 	side === 'sell' ? { Sell: null } : { Buy: null };
 
+export const fromOisyTradeCandidDataSide = (side: OisyTradeSide): LimitOrderSide =>
+	'Sell' in side ? 'sell' : 'buy';
+
 /**
  * Builds the `OisyTrade` AUT data variant: the order's side plus the canonical
  * immutable trio (source token, destination token, source amount in base units).

--- a/src/frontend/src/lib/utils/oisy-trade-swap.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade-swap.utils.ts
@@ -207,7 +207,7 @@ export const resolveOisyTradeOrder = ({
 		return { ok: false };
 	}
 
-	const { price, quantity, deposit, gross } = result.offer;
+	const { price, quantity, deposit, gross, maxSourceRelease } = result.offer;
 
 	return {
 		ok: true,
@@ -216,7 +216,8 @@ export const resolveOisyTradeOrder = ({
 			pair: toTradingPair(pair),
 			price,
 			quantity,
-			depositAmount: deposit
+			depositAmount: deposit,
+			maxSourceRelease
 		},
 		gross
 	};

--- a/src/frontend/src/tests/fixtures/oisy-trade/offer-calculation.json
+++ b/src/frontend/src/tests/fixtures/oisy-trade/offer-calculation.json
@@ -41,7 +41,8 @@
 				"price": "5000000",
 				"quantity": "96000000",
 				"deposit": "96000000",
-				"gross": "4800000"
+				"gross": "4800000",
+				"maxSourceRelease": "0"
 			},
 			"expectReceive": "4742000"
 		},
@@ -54,7 +55,8 @@
 				"price": "4000000",
 				"quantity": "396000000",
 				"deposit": "396000000",
-				"gross": "15840000"
+				"gross": "15840000",
+				"maxSourceRelease": "0"
 			},
 			"expectReceive": "15671600"
 		},
@@ -67,7 +69,8 @@
 				"price": "2000000",
 				"quantity": "996000000",
 				"deposit": "996000000",
-				"gross": "19920000"
+				"gross": "19920000",
+				"maxSourceRelease": "0"
 			},
 			"expectReceive": "19710800"
 		},
@@ -80,7 +83,8 @@
 				"price": "8000000",
 				"quantity": "120000000",
 				"deposit": "9600000",
-				"gross": "120000000"
+				"gross": "120000000",
+				"maxSourceRelease": "0"
 			},
 			"expectReceive": "118790000"
 		},
@@ -93,7 +97,8 @@
 				"price": "10000000",
 				"quantity": "300000000",
 				"deposit": "30000000",
-				"gross": "300000000"
+				"gross": "300000000",
+				"maxSourceRelease": "4000000"
 			},
 			"expectReceive": "296990000"
 		},
@@ -106,7 +111,8 @@
 				"price": "20000000",
 				"quantity": "192000000",
 				"deposit": "38400000",
-				"gross": "192000000"
+				"gross": "192000000",
+				"maxSourceRelease": "23040000"
 			},
 			"expectReceive": "190070000"
 		},
@@ -119,9 +125,31 @@
 				"price": "24000000",
 				"quantity": "408000000",
 				"deposit": "97920000",
-				"gross": "408000000"
+				"gross": "408000000",
+				"maxSourceRelease": "60320000"
 			},
 			"expectReceive": "403910000"
+		},
+		{
+			"id": "buy-two-asks-releases-the-improvement",
+			"description": "buy with 10 USDT across two asks: it reserves at the 3.4 limit, clears the 2.98 level first, and the release is exactly that improvement — the bound that separates a returned reserve from a maker credit on the same leg",
+			"side": "buy",
+			"sourceAmount": "10000000",
+			"book": {
+				"bids": [],
+				"asks": [
+					{ "price": "2980000", "quantity": "129000000" },
+					{ "price": "3400000", "quantity": "300000000" }
+				]
+			},
+			"expect": {
+				"price": "3400000",
+				"quantity": "288000000",
+				"deposit": "9792000",
+				"gross": "288000000",
+				"maxSourceRelease": "541800"
+			},
+			"expectReceive": "285110000"
 		},
 		{
 			"id": "sell-beyond-bid-depth",

--- a/src/frontend/src/tests/lib/components/swap/SwapDetailsOisyTrade.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapDetailsOisyTrade.spec.ts
@@ -29,7 +29,8 @@ describe('SwapDetailsOisyTrade', () => {
 		pair: {} as unknown as TradingPair,
 		price: 10_000_000n,
 		quantity: 200_000_000n,
-		depositAmount: 200_000_000n
+		depositAmount: 200_000_000n,
+		maxSourceRelease: ZERO
 	};
 
 	const makeProvider = (swapDetails: Partial<OisyTradeSwapDetails> = {}) => ({

--- a/src/frontend/src/tests/lib/oisy-trade/offer.spec.ts
+++ b/src/frontend/src/tests/lib/oisy-trade/offer.spec.ts
@@ -27,6 +27,7 @@ interface FixtureCase {
 		quantity?: string;
 		deposit?: string;
 		gross?: string;
+		maxSourceRelease?: string;
 		reason?: string;
 	};
 	expectReceive?: string;
@@ -125,7 +126,8 @@ describe('calculateOisyTradeOffer', () => {
 					price: BigInt(testCase.expect.price as string),
 					quantity: BigInt(testCase.expect.quantity as string),
 					deposit: BigInt(testCase.expect.deposit as string),
-					gross: BigInt(testCase.expect.gross as string)
+					gross: BigInt(testCase.expect.gross as string),
+					maxSourceRelease: BigInt(testCase.expect.maxSourceRelease as string)
 				}
 			});
 		});
@@ -137,7 +139,7 @@ describe('calculateOisyTradeOffer', () => {
 
 			assert(result.ok);
 
-			const { price, quantity, deposit, gross } = result.offer;
+			const { price, quantity, deposit, gross, maxSourceRelease } = result.offer;
 			const depth = toDepth(testCase.book ?? book);
 
 			if (testCase.side === 'sell') {
@@ -147,6 +149,9 @@ describe('calculateOisyTradeOffer', () => {
 
 				expect(filled).toBe(quantity);
 				expect(value).toBeGreaterThanOrEqual(gross);
+				// A Sell reserves the quantity and a full fill transfers all of it, so the
+				// venue has nothing of the source leg left to hand back.
+				expect(maxSourceRelease).toBe(ZERO);
 
 				return;
 			}
@@ -160,6 +165,9 @@ describe('calculateOisyTradeOffer', () => {
 			expect(gross).toBe(quantity);
 			// The reserve is taken at the limit price, so the real cost cannot exceed it.
 			expect(value).toBeLessThanOrEqual(deposit);
+			// And the reserve the venue releases is precisely the part the fill did not
+			// spend — the bound settlement withdraws the source residue within.
+			expect(maxSourceRelease).toBe(deposit - value);
 		});
 	});
 
@@ -230,7 +238,8 @@ describe('calculateOisyTradeOffer', () => {
 				price: 5_000_000n,
 				quantity: 20n,
 				deposit: 1n,
-				gross: 20n
+				gross: 20n,
+				maxSourceRelease: ZERO
 			});
 		});
 	});

--- a/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
@@ -534,12 +534,31 @@ describe('oisy-trade-active-tx.services', () => {
 				);
 			});
 
-			// Zero here would strand a successful swap.
-			it('withdraws a filled Buy’s whole destination when the quantity is unreadable', async () => {
+			// The quantity is a Buy's destination ceiling, so settling without one would
+			// withdraw an account-wide delta on the primary leg. Left alone like a row whose
+			// baselines cannot be read, rather than settled uncapped or skipped as zero.
+			it('leaves a Buy row alone when its quantity cannot be read', async () => {
+				const consoleErrorSpy = vi
+					.spyOn(consoleUtils, 'consoleError')
+					.mockImplementation(() => undefined);
 				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
 				getBalancesSpy.mockResolvedValue([balance({ ledger: CKUSDC_LEDGER, free: 5_000_000n })]);
 
 				await pollPastBudget([row({ side: { Buy: null }, refs: PLACED })]);
+
+				expect(withdrawSpy).not.toHaveBeenCalled();
+				expect(applySpy).not.toHaveBeenCalled();
+				expect(deleteSpy).not.toHaveBeenCalled();
+				expect(consoleErrorSpy).toHaveBeenCalled();
+			});
+
+			// A Sell never reads the quantity, so refusing to recover one over an unreadable
+			// ref would strand funds for nothing.
+			it('settles a Sell row whose quantity cannot be read', async () => {
+				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
+				getBalancesSpy.mockResolvedValue([balance({ ledger: CKUSDC_LEDGER, free: 5_000_000n })]);
+
+				await pollPastBudget([row({ refs: PLACED })]);
 
 				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
 					expect.objectContaining({

--- a/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-active-tx.services.spec.ts
@@ -1,4 +1,4 @@
-import type { ActiveUserTransaction } from '$declarations/backend/backend.did';
+import type { ActiveUserTransaction, OisyTradeSide } from '$declarations/backend/backend.did';
 import type { UserOrder, UserTokenBalance } from '$declarations/oisy_trade/oisy_trade.did';
 import { ICP_TOKEN } from '$env/tokens/tokens.icp.env';
 import * as oisyTradeApi from '$lib/api/oisy-trade.api';
@@ -60,18 +60,20 @@ const order = (status: object): UserOrder[] =>
 const row = ({
 	refs = {},
 	status = { Executing: null },
-	createdAtNs = ZERO
+	createdAtNs = ZERO,
+	side = { Sell: null }
 }: {
 	refs?: Partial<Record<string, string>>;
 	status?: ActiveUserTransaction['status'];
 	createdAtNs?: bigint;
+	side?: OisyTradeSide;
 } = {}): ActiveUserTransaction => ({
 	...mockActiveUserTransaction,
 	id: 'row-1',
 	status,
 	data: {
 		OisyTrade: {
-			side: { Sell: null },
+			side,
 			source_token: { Icrc: Principal.fromText(ICP_TOKEN.ledgerCanisterId) },
 			dest_token: { Icrc: Principal.fromText(CKUSDC_LEDGER) },
 			amount: 300_000_000n
@@ -80,6 +82,9 @@ const row = ({
 	external_refs: toOisyTradeExternalRefs({
 		[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_SOURCE_FREE]: '0',
 		[OISY_TRADE_EXTERNAL_REF_KEYS.BASELINE_DEST_FREE]: '0',
+		// Room for every source residue the cases below release, so the cap is not what
+		// they are measuring. It has its own case.
+		[OISY_TRADE_EXTERNAL_REF_KEYS.MAX_SOURCE_RELEASE]: '300000000',
 		...refs
 	}),
 	created_at_ns: createdAtNs,
@@ -463,6 +468,107 @@ describe('oisy-trade-active-tx.services', () => {
 				await pollPastBudget([row({ refs: PLACED })]);
 
 				expect(withdrawSpy).toHaveBeenCalledOnce();
+				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						update: expect.objectContaining({ status: { Succeeded: null } })
+					})
+				);
+			});
+
+			// The delta is account-wide, so it counts credits this order never made — most
+			// easily the caller's own resting orders filling against the very swap that is
+			// settling. The row carries what the order could possibly have released, and the
+			// residue is taken within it; the rest stays at the venue.
+			it('withdraws a source residue only up to what the order could release', async () => {
+				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
+				getBalancesSpy.mockResolvedValue([
+					balance({ ledger: CKUSDC_LEDGER, free: 2_000_000n }),
+					balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 300_000_000n })
+				]);
+
+				await pollPastBudget([
+					row({
+						refs: { ...PLACED, [OISY_TRADE_EXTERNAL_REF_KEYS.MAX_SOURCE_RELEASE]: '500000' }
+					})
+				]);
+
+				expect(withdrawSpy).toHaveBeenCalledTimes(2);
+				expect(withdrawSpy.mock.calls[1][0]).toEqual(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 500_000n })
+					})
+				);
+			});
+
+			// The deposit comes off the row's data variant, not a ref.
+			it('withdraws a killed order’s source back only up to the row’s deposit', async () => {
+				getMyOrdersSpy.mockResolvedValue(order({ Expired: null }));
+				getBalancesSpy.mockResolvedValue([
+					balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 500_000_000n })
+				]);
+
+				await pollPastBudget([row({ refs: PLACED })]);
+
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 300_000_000n })
+					})
+				);
+			});
+
+			it('withdraws a filled Buy’s destination only up to the row’s quantity', async () => {
+				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
+				getBalancesSpy.mockResolvedValue([balance({ ledger: CKUSDC_LEDGER, free: 5_000_000n })]);
+
+				await pollPastBudget([
+					row({
+						side: { Buy: null },
+						refs: { ...PLACED, [OISY_TRADE_EXTERNAL_REF_KEYS.ORDER_QUANTITY]: '2000000' }
+					})
+				]);
+
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 2_000_000n })
+					})
+				);
+			});
+
+			// Zero here would strand a successful swap.
+			it('withdraws a filled Buy’s whole destination when the quantity is unreadable', async () => {
+				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
+				getBalancesSpy.mockResolvedValue([balance({ ledger: CKUSDC_LEDGER, free: 5_000_000n })]);
+
+				await pollPastBudget([row({ side: { Buy: null }, refs: PLACED })]);
+
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 5_000_000n })
+					})
+				);
+			});
+
+			// A row opened before the cap ref existed. Skipping its residue leaves the
+			// release at the venue, where the Trading tab still shows it and the user can
+			// withdraw it themselves — the same direction the cap errs in, and the opposite
+			// of sweeping a delta nothing bounds.
+			it('skips the source residue of a row written before the cap existed', async () => {
+				getMyOrdersSpy.mockResolvedValue(order({ Filled: null }));
+				getBalancesSpy.mockResolvedValue([
+					balance({ ledger: CKUSDC_LEDGER, free: 2_000_000n }),
+					balance({ ledger: ICP_TOKEN.ledgerCanisterId, free: 300_000_000n })
+				]);
+
+				await pollPastBudget([
+					row({ refs: { ...PLACED, [OISY_TRADE_EXTERNAL_REF_KEYS.MAX_SOURCE_RELEASE]: '' } })
+				]);
+
+				expect(withdrawSpy).toHaveBeenCalledOnce();
+				expect(withdrawSpy.mock.calls[0][0].request.token_id.ledger_id.toText()).toBe(
+					CKUSDC_LEDGER
+				);
+				// Still a complete settlement: an unwithdrawn residue that was never this
+				// order's does not keep the row open.
 				expect(applySpy).toHaveBeenCalledExactlyOnceWith(
 					expect.objectContaining({
 						update: expect.objectContaining({ status: { Succeeded: null } })

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -1085,8 +1085,8 @@ describe('oisy-trade-swap.services', () => {
 			});
 		});
 
-		// The poller's case. Unbounded rather than zero, which would leave a successful
-		// swap's fill at the venue.
+		// The builder invents no ceiling it was not given. Only a Sell reaches it this way:
+		// the poller refuses a Buy row whose quantity ref will not parse.
 		it('leaves a Buy’s destination unbounded without a quantity', () => {
 			expect(
 				toOisyTradeSettlementBounds({ side: 'buy', ...facts, quantity: undefined })

--- a/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/oisy-trade-swap.services.spec.ts
@@ -25,7 +25,8 @@ import {
 	loadOisyTradeSwapPairs,
 	mapOisyTradeQuoteResult,
 	oisyTradeSwapPairTable,
-	settleOisyTradeSwap
+	settleOisyTradeSwap,
+	toOisyTradeSettlementBounds
 } from '$lib/services/oisy-trade-swap.services';
 import { fetchSwapAmounts } from '$lib/services/swap.services';
 import * as tradingAnalytics from '$lib/services/trading-analytics.services';
@@ -591,13 +592,20 @@ describe('oisy-trade-swap.services', () => {
 
 		// A zero baseline means nothing was on the DEX before the deposit, so everything
 		// free is this order's and the assertions below read as plain balances. The
-		// pre-existing-balance cases pass their own.
+		// pre-existing-balance cases pass their own. The bounds are likewise wide enough for
+		// every credit here, so these cases stay about the withdrawal rather than the
+		// ceilings — which have their own.
 		const settleParams = {
 			identity: mockIdentity,
 			orderId: ORDER_ID,
 			sourceToken: ICP,
 			destinationToken: CKUSDC,
-			baseline: { source: ZERO, destination: ZERO }
+			baseline: { source: ZERO, destination: ZERO },
+			bounds: {
+				filledSourceRelease: 200_000_000n,
+				filledDestinationCredit: undefined,
+				killedSourceReturn: 200_000_000n
+			}
 		};
 
 		const userOrder = (status: OrderStatus) =>
@@ -855,6 +863,130 @@ describe('oisy-trade-swap.services', () => {
 			});
 		});
 
+		// The baseline makes a delta this *flow's*, which is not the same as this *order's*.
+		// A swap crosses the same book the caller's own resting orders sit on, so those
+		// orders fill against it and their proceeds land on the same leg, in the same
+		// settling round — and at a zero maker fee they come to exactly the reserve the
+		// order spent. So the residue leg is additionally capped at what the order can
+		// possibly have released.
+		describe('a credit the order did not make', () => {
+			// The incident that found this (staging, 2026-09-08): a Buy of 2.94 ICP reserving
+			// 9.996 ckUSDT crossed two of the caller's own asks. It filled at 9.4542, released
+			// 0.5418 — and was credited the 9.4542 back as the maker, so the delta read the
+			// entire pay amount and settlement withdrew it. Only the release was ever the
+			// order's.
+			it('withdraws only the reserve the venue could release', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+				mockBalances({ source: 9_996_000n, destination: 2_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap({
+					...settleParams,
+					bounds: { ...settleParams.bounds, filledSourceRelease: 541_800n }
+				});
+
+				expect(settlement.status).toBe('filled');
+				expect(withdrawSpy).toHaveBeenCalledTimes(2);
+				expect(withdrawSpy.mock.calls[1][0]).toEqual(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 541_800n })
+					})
+				);
+				// The rest stays at the venue, where the Trading tab shows it — not stranded,
+				// because it was never owed.
+				expect(settlement.residueStranded).toBeFalsy();
+			});
+
+			// A Sell reserves the quantity itself and a full fill transfers every base unit of
+			// it, so there is nothing to release: a source credit on a filled Sell can only
+			// have come from somewhere else.
+			it('withdraws no source residue when the order could release nothing', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+				mockBalances({ source: 300_000_000n, destination: 2_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap({
+					...settleParams,
+					bounds: { ...settleParams.bounds, filledSourceRelease: ZERO }
+				});
+
+				expect(settlement.status).toBe('filled');
+				expect(withdrawSpy).toHaveBeenCalledOnce();
+				expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(CKUSDC_LEDGER);
+			});
+
+			// Zero execution, so the unreserve is the deposit and nothing more.
+			it('withdraws a killed order’s source back only up to the deposit', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Expired: null }));
+				mockBalances({ source: 500_000_000n, destination: ZERO });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap({
+					...settleParams,
+					bounds: { ...settleParams.bounds, killedSourceReturn: 300_000_000n }
+				});
+
+				expect(settlement.status).toBe('killed');
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 300_000_000n })
+					})
+				);
+			});
+
+			it('withdraws a filled Buy’s destination only up to the quantity', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+				mockBalances({ source: ZERO, destination: 5_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap({
+					...settleParams,
+					bounds: { ...settleParams.bounds, filledDestinationCredit: 2_000_000n }
+				});
+
+				expect(settlement.status).toBe('filled');
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 2_000_000n })
+					})
+				);
+			});
+
+			// Maker prices, so the proceeds can exceed what the quote promised.
+			it('withdraws a filled Sell’s whole destination credit', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Filled: null }));
+				mockBalances({ source: ZERO, destination: 5_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				await settleOisyTradeSwap({
+					...settleParams,
+					bounds: { ...settleParams.bounds, filledDestinationCredit: undefined }
+				});
+
+				expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({
+						request: expect.objectContaining({ amount: 5_000_000n })
+					})
+				);
+			});
+
+			// A killed order has zero execution, so it never credited the destination leg at
+			// all. Whatever is there arrived from something else and is not this swap's to
+			// move — the mirror of the source cap on the other outcome.
+			it('leaves a killed order’s destination credit at the venue', async () => {
+				vi.spyOn(oisyTradeApi, 'getMyOrders').mockResolvedValue(userOrder({ Expired: null }));
+				mockBalances({ source: 200_000_000n, destination: 5_000_000n });
+				const withdrawSpy = mockWithdraw();
+
+				const settlement = await settleOisyTradeSwap(settleParams);
+
+				expect(settlement.status).toBe('killed');
+				expect(withdrawSpy).toHaveBeenCalledOnce();
+				expect(ledgerOf(withdrawSpy.mock.calls[0][0])).toBe(ICP_LEDGER);
+				expect(settlement.residueStranded).toBeFalsy();
+			});
+		});
+
 		// An unknown ledger fee says nothing about whether the balance is withdrawable, so
 		// it must not share the dust skip: skipping would report the swap settled with the
 		// funds still in DEX custody. `IcTokenSchema` requires `fee`, so reaching this at
@@ -936,6 +1068,33 @@ describe('oisy-trade-swap.services', () => {
 		});
 	});
 
+	describe('toOisyTradeSettlementBounds', () => {
+		const facts = { quantity: 300_000_000n, depositAmount: 9_792_000n, maxSourceRelease: 541_800n };
+
+		it('bounds a Buy on every leg but a Sell’s destination', () => {
+			expect(toOisyTradeSettlementBounds({ side: 'buy', ...facts })).toEqual({
+				filledSourceRelease: 541_800n,
+				filledDestinationCredit: 300_000_000n,
+				killedSourceReturn: 9_792_000n
+			});
+
+			expect(toOisyTradeSettlementBounds({ side: 'sell', ...facts })).toEqual({
+				filledSourceRelease: 541_800n,
+				filledDestinationCredit: undefined,
+				killedSourceReturn: 9_792_000n
+			});
+		});
+
+		// The poller's case. Unbounded rather than zero, which would leave a successful
+		// swap's fill at the venue.
+		it('leaves a Buy’s destination unbounded without a quantity', () => {
+			expect(
+				toOisyTradeSettlementBounds({ side: 'buy', ...facts, quantity: undefined })
+					.filledDestinationCredit
+			).toBeUndefined();
+		});
+	});
+
 	describe('fetchOisyTradeSwap', () => {
 		// Distinctive values, so the assertions below prove these were carried through from
 		// the reviewed quote rather than re-derived from the amount and the pair.
@@ -947,15 +1106,20 @@ describe('oisy-trade-swap.services', () => {
 			},
 			price: 1_234_000n,
 			quantity: 300_000_000n,
-			depositAmount: 300_000_000n
+			depositAmount: 300_000_000n,
+			// A Sell reserves the quantity itself and a full fill transfers all of it, so
+			// there is never a source release to withdraw back.
+			maxSourceRelease: ZERO
 		};
 
 		// A Buy spends the quote token, so the deposit is the order's reserve at the limit
-		// price — `price × quantity / 10^baseDecimals` — not the typed amount.
+		// price — `price × quantity / 10^baseDecimals` — not the typed amount. It reserves
+		// at that limit and fills at the book's, so part of the reserve can come back.
 		const buyOrder: OisyTradeResolvedOrder = {
 			...sellOrder,
 			side: 'buy',
-			depositAmount: 3_702_000n
+			depositAmount: 3_702_000n,
+			maxSourceRelease: 41_000n
 		};
 
 		const swapParams = {
@@ -1261,6 +1425,36 @@ describe('oisy-trade-swap.services', () => {
 					request: expect.objectContaining({ amount: buyOrder.depositAmount })
 				})
 			);
+			// Snapshotted from the reviewed offer, because the book it was derived from has
+			// moved by the time a later session settles this row.
+			expect(
+				toOisyTradeExternalRefsMap(
+					vi.mocked(createActiveUserTransaction).mock.calls[0][0].externalRefs
+				)[OISY_TRADE_EXTERNAL_REF_KEYS.MAX_SOURCE_RELEASE]
+			).toBe(`${buyOrder.maxSourceRelease}`);
+		});
+
+		// End to end: the reviewed order is what bounds settlement, not the balance read.
+		it('withdraws a filled Buy’s destination within the reviewed quantity', async () => {
+			resetBalanceReads()
+				.mockResolvedValueOnce([])
+				.mockResolvedValue([
+					{
+						token: { id: { ledger_id: Principal.fromText(CKUSDC_LEDGER) } },
+						balance: { free: buyOrder.quantity * 2n, reserved: ZERO }
+					}
+				] as unknown as UserTokenBalance[]);
+			const withdrawSpy = vi
+				.spyOn(oisyTradeApi, 'withdraw')
+				.mockResolvedValue({ block_index: 42n });
+
+			await run({ order: buyOrder });
+
+			expect(withdrawSpy).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({
+					request: expect.objectContaining({ amount: buyOrder.quantity })
+				})
+			);
 		});
 
 		it('walks the progress steps and enables the destination token', async () => {
@@ -1422,7 +1616,10 @@ describe('oisy-trade-swap.services', () => {
 				.mockImplementation(() => undefined);
 			const markSpy = vi.spyOn(activeUserTransactionsStore, 'markTerminalSideEffectsApplied');
 
-			// A filled Buy whose price improvement released part of the source reserve.
+			// A filled Buy whose price improvement released part of the source reserve. The
+			// balance holds more than that, as it would if another of the caller's orders had
+			// filled meanwhile, so what is attempted is the release the offer bounded —
+			// `buyOrder.maxSourceRelease`, above the ledger fee and so genuinely owed.
 			resetBalanceReads()
 				.mockResolvedValueOnce([])
 				.mockResolvedValue([
@@ -1444,7 +1641,7 @@ describe('oisy-trade-swap.services', () => {
 				.mockRejectedValue(residueError);
 
 			// The destination arrived, so the swap itself succeeded.
-			await expect(run()).resolves.toBeUndefined();
+			await expect(run({ order: buyOrder })).resolves.toBeUndefined();
 
 			expect(consoleErrorSpy).toHaveBeenCalledWith(residueError);
 			// No terminal write: the row is the poller's to finish, because retrying the

--- a/src/frontend/src/tests/mocks/swap.mocks.ts
+++ b/src/frontend/src/tests/mocks/swap.mocks.ts
@@ -1,5 +1,6 @@
 import type { SwapAmountsReply } from '$declarations/kong_backend/kong_backend.did';
 import type { IcToken } from '$icp/types/ic-token';
+import { ZERO } from '$lib/constants/app.constants';
 import type { NearIntentsQuoteResponse } from '$lib/types/near-intents';
 import {
 	SwapProvider,
@@ -97,7 +98,8 @@ export const mockOisyTradeProvider: Extract<
 			},
 			price: 10_000_000n,
 			quantity: 100_000_000n,
-			depositAmount: 100_000_000n
+			depositAmount: 100_000_000n,
+			maxSourceRelease: ZERO
 		}
 	},
 	type: undefined


### PR DESCRIPTION
# Motivation

An OISY Trade swap settles on the delta from a pre-deposit balance baseline. That delta is this *flow's*, not this *order's*: a swap crosses the same book the caller's own resting orders sit on, so their maker proceeds land on the same leg. On staging, a Buy that crossed the caller's own asks read its whole deposit back and settlement withdrew the caller's own maker proceeds while reporting a swap that cost nothing.

# Changes

- `calculateOisyTradeOffer` returns `maxSourceRelease`: the reserve less the swept asks' cost, zero on a Sell. Snapshotted into a new `max_source_release` AUT ref.
- `settleOisyTradeSwap` takes `bounds` and withdraws each leg within what the order could have credited: filled source ≤ `maxSourceRelease`, filled Buy destination ≤ quantity, killed source ≤ deposit, killed destination = 0. A filled Sell's destination stays uncapped (maker-price improvement). Deposit recovery is capped at the deposit.
- Poller builds the same bounds from the row's data and refs; legacy rows without the release ref skip the source residue.


# Tests

Updated.
