### PR TITLE
chore(backend): return a ready future from the composite exchange test mock

### DIFF
--- a/src/backend/src/exchange/composite.rs
+++ b/src/backend/src/exchange/composite.rs
@@ -88,7 +88,11 @@ pub(crate) async fn fetch_all_prices<P: ExchangePriceProvider>(
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc};
+    use std::{
+        cell::RefCell,
+        future::{ready, Future},
+        rc::Rc,
+    };
 
     use candid::Principal;
     use futures::executor::block_on;
@@ -106,11 +110,11 @@ mod tests {
     }
 
     impl ExchangePriceProvider for MockPrimaryProvider {
-        async fn fetch_prices(
+        fn fetch_prices(
             &self,
             _token_ids: &[StoredTokenId],
-        ) -> Result<Vec<(StoredTokenId, ExchangeData)>, String> {
-            self.result.clone()
+        ) -> impl Future<Output = Result<Vec<(StoredTokenId, ExchangeData)>, String>> {
+            ready(self.result.clone())
         }
     }
 


### PR DESCRIPTION
# Motivation

Rust 1.98 adds `clippy::unused_async_trait_impl`, which fires on an `async fn` in a trait impl whose body contains no `.await`. The backend lint job runs with `-D warnings`, so it becomes a hard error:

```
error: unused `async` for async trait impl function with no `.await` statements
  --> src/backend/src/exchange/composite.rs:109:9
error: could not compile `backend` (lib test) due to 1 previous error
```

This is the only occurrence in the repo. `PanickingPrimaryProvider::fetch_prices` right below it is exempt because its body diverges on `panic!`.

It currently blocks the toolchain bump in #13776, which fails on nothing else. Landing it separately keeps that PR a pure dependabot bump.

# Changes

`MockPrimaryProvider::fetch_prices` is a plain `fn` returning `impl Future` and wraps its value in `std::future::ready`, which is the form clippy suggests. Implementing a trait's `async fn` this way is allowed, and it compiles on 1.97.1 as well, so this does not depend on the bump landing first.

# Tests

- `cargo test -p backend --lib exchange::composite`: 8 passed, 0 failed.
- `./scripts/lint.rust.sh`: clean.

Both on the pinned 1.97.1. The 1.98 lint itself is verified by CI on #13776 once this is merged and that branch rebases.
