### PR TITLE
feat(frontend): state the chain an EVM typed-data signature is bound to

### DIFF
--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectMessage.svelte
@@ -111,6 +111,9 @@
 	// all the same chain and all hash alike. Comparing the text matched one form only.
 	let domainChainId = $derived(toTypedDataDomainChainId(chainId));
 
+	// The chain the domain binds the signature to, which is what makes the same struct a different
+	// signature on Ethereum and on Arbitrum. It is stated whether or not the schema is one OISY can
+	// summarize: a request whose contents cannot be described still says which chain it is for.
 	let domainNetwork = $derived(
 		nonNullish(domainChainId)
 			? [...$enabledEthereumNetworks, ...$enabledEvmNetworks].find(
@@ -270,12 +273,19 @@
 			</ul>
 		{/if}
 
+		<!-- Above the token rather than inside it: the token is only resolved for a schema OISY
+		     recognises, while the chain is known for every domain that states one. There is no second
+		     network to distinguish this one from, since a token is matched on this very chain id. -->
+		{#if nonNullish(domainNetwork)}
+			<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.network}</p>
+			<p class="mb-4 font-normal" data-tid="wallet-connect-domain-network">
+				{domainNetwork.name}
+			</p>
+		{/if}
+
 		{#if nonNullish(token)}
 			<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.token}</p>
 			<p class="mb-4 font-normal">{token.symbol}</p>
-
-			<p class="mb-0.5 font-bold">{$i18n.wallet_connect.text.network}</p>
-			<p class="mb-4 font-normal">{token.network.name}</p>
 		{:else if nonNullish(address)}
 			<!-- A token OISY does not list is still the contract the allowance is over, so the address is
 	     shown rather than the row dropped: an unnamed contract is a fact, its absence is not. -->

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
@@ -447,13 +447,16 @@ describe('EthWalletConnectMessage', () => {
 		});
 
 		expect(queryByText(en.wallet_connect.text.token)).not.toBeInTheDocument();
-		expect(queryByText(en.wallet_connect.text.network)).not.toBeInTheDocument();
 		expect(queryByText(en.wallet_connect.text.amount)).not.toBeInTheDocument();
 		expect(queryByText(en.wallet_connect.text.spender)).not.toBeInTheDocument();
 		expect(queryByText(en.wallet_connect.text.expiration)).not.toBeInTheDocument();
 
 		expect(queryByText(USDC_TOKEN.symbol)).not.toBeInTheDocument();
 		expect(queryByText('0x2222222222222222222222222222222222222222')).not.toBeInTheDocument();
+
+		// The chain is a domain member, not a message key, so it is unaffected by what the schema
+		// declines to declare.
+		expect(getByTestId('wallet-connect-domain-network')).toHaveTextContent(ETHEREUM_NETWORK.name);
 
 		// The full payload stays available in the raw message viewer, one tab over.
 		await openRawTab(getByRole);
@@ -477,10 +480,10 @@ describe('EthWalletConnectMessage', () => {
 		expect(getByText(en.wallet_connect.text.token)).toBeInTheDocument();
 		expect(getByText('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBeInTheDocument();
 
-		// Nothing is claimed that is not known: no symbol, no network, and no scaled figure.
-		expect(queryByText(en.wallet_connect.text.network)).not.toBeInTheDocument();
+		// Nothing is claimed that is not known: no symbol and no scaled figure. The chain is read off
+		// the domain rather than off the token, so it survives the token going unlisted.
 		expect(queryByText(USDC_TOKEN.symbol)).not.toBeInTheDocument();
-		expect(queryByText(USDC_TOKEN.network.name)).not.toBeInTheDocument();
+		expect(getByTestId('wallet-connect-domain-network')).toHaveTextContent(ETHEREUM_NETWORK.name);
 
 		expect(
 			queryByText(
@@ -532,17 +535,18 @@ describe('EthWalletConnectMessage', () => {
 			}
 		} as WalletKitTypes.SessionRequest;
 
-		const { queryByText } = render(EthWalletConnectMessage, {
+		const { getByTestId, queryByText } = render(EthWalletConnectMessage, {
 			props: {
 				request: newRequest
 			}
 		});
 
 		expect(queryByText(`${en.wallet_connect.text.token}:`)).not.toBeInTheDocument();
-		expect(queryByText(`${en.wallet_connect.text.network}:`)).not.toBeInTheDocument();
 
 		expect(queryByText(USDC_TOKEN.symbol)).not.toBeInTheDocument();
-		expect(queryByText(USDC_TOKEN.network.name)).not.toBeInTheDocument();
+
+		// Ethereum is stated because the domain binds to it, not because a token resolved to it.
+		expect(getByTestId('wallet-connect-domain-network')).toHaveTextContent(ETHEREUM_NETWORK.name);
 	});
 
 	it('should handle errors when getting sign parameters', async () => {
@@ -603,17 +607,18 @@ describe('EthWalletConnectMessage', () => {
 			}
 		} as WalletKitTypes.SessionRequest;
 
-		const { queryByText } = render(EthWalletConnectMessage, {
+		const { getByTestId, queryByText } = render(EthWalletConnectMessage, {
 			props: {
 				request: newRequest
 			}
 		});
 
 		expect(queryByText(`${en.wallet_connect.text.token}:`)).not.toBeInTheDocument();
-		expect(queryByText(`${en.wallet_connect.text.network}:`)).not.toBeInTheDocument();
 
 		expect(queryByText(USDC_TOKEN.symbol)).not.toBeInTheDocument();
-		expect(queryByText(USDC_TOKEN.network.name)).not.toBeInTheDocument();
+
+		// Ethereum is stated because the domain binds to it, not because a token resolved to it.
+		expect(getByTestId('wallet-connect-domain-network')).toHaveTextContent(ETHEREUM_NETWORK.name);
 	});
 
 	it('should handle empty details in the message', () => {
@@ -645,17 +650,18 @@ describe('EthWalletConnectMessage', () => {
 			}
 		} as WalletKitTypes.SessionRequest;
 
-		const { queryByText } = render(EthWalletConnectMessage, {
+		const { getByTestId, queryByText } = render(EthWalletConnectMessage, {
 			props: {
 				request: newRequest
 			}
 		});
 
 		expect(queryByText(`${en.wallet_connect.text.token}:`)).not.toBeInTheDocument();
-		expect(queryByText(`${en.wallet_connect.text.network}:`)).not.toBeInTheDocument();
 
 		expect(queryByText(USDC_TOKEN.symbol)).not.toBeInTheDocument();
-		expect(queryByText(USDC_TOKEN.network.name)).not.toBeInTheDocument();
+
+		// Ethereum is stated because the domain binds to it, not because a token resolved to it.
+		expect(getByTestId('wallet-connect-domain-network')).toHaveTextContent(ETHEREUM_NETWORK.name);
 	});
 
 	it('should not render the invalid typed-data warning by default', () => {

--- a/src/frontend/src/tests/eth/components/wallet-connect/WalletConnectSignReview.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/WalletConnectSignReview.spec.ts
@@ -254,4 +254,29 @@ describe('WalletConnectSignReview', () => {
 
 		expect(queryByText(en.wallet_connect.text.unreviewable_typed_data)).not.toBeInTheDocument();
 	});
+
+	// The chain the domain binds to, on a request whose schema says nothing else: the same struct
+	// signed for Arbitrum is not the signature it would be for Ethereum, and that much is knowable
+	// even where the contents are not.
+	it('states the network of a schema it cannot describe', () => {
+		const { getByText, getByTestId } = render(WalletConnectSignReview, {
+			props: { ...props, request: hyperliquidAcceptTermsRequest() }
+		});
+
+		expect(getByText(en.wallet_connect.text.network)).toBeInTheDocument();
+		expect(getByTestId('wallet-connect-domain-network')).toHaveTextContent(
+			ARBITRUM_MAINNET_NETWORK.name
+		);
+	});
+
+	// Stated once, from the domain. The token is matched on that same chain id, so a row per source
+	// would print the same network twice under one label.
+	it('states the network once for a schema it can describe', () => {
+		const { getAllByText, getByTestId } = render(WalletConnectSignReview, {
+			props: { ...props, request: daiPermitRequest(true) }
+		});
+
+		expect(getAllByText(en.wallet_connect.text.network)).toHaveLength(1);
+		expect(getByTestId('wallet-connect-domain-network')).toHaveTextContent(ETHEREUM_NETWORK.name);
+	});
 });


### PR DESCRIPTION
# Motivation

A WalletConnect signature review states the network only when the typed data is a schema OISY summarizes and the token it approves is one OISY lists. The row lives inside the token block, so a request OISY cannot describe (a Hyperliquid action, an ERC-3009 authorization, any unrecognised struct) is reviewed without it.

The chain is the one fact that is knowable whatever the schema turns out to be: the EIP-712 domain separates the digest by `chainId`, so the same struct signed for Arbitrum is not the signature it would be for Ethereum. The component already resolved that network to build the verifying contract's explorer link; it just never rendered it.

This is not a regression. `git log -S 'text.network'` on the component returns a single commit, #9249, which introduced the row inside the token block, and v2.5.3, v2.5.4 and v2.5.5 all gate it the same way.

# Changes

- State the network from the domain's `chainId`, so it is shown for any request whose domain names a chain OISY supports, not only for a recognised approval over a listed token.
- Move the row above the token instead of inside it. There is no second network to distinguish it from: a token is matched on that very chain id, so the value the token row carried and this one are always the same network.

# Tests

- Updated `EthWalletConnectMessage.spec.ts`: the cases where no token resolves (token not enabled, invalid token address, missing or empty details, undeclared message keys) now assert the network is stated from the domain rather than absent.
- Added to `WalletConnectSignReview.spec.ts`: a Hyperliquid `AcceptTerms` request states Arbitrum One, and a DAI permit states Ethereum exactly once.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` and `npm run test` all pass (1097 files, 18781 tests).
