### PR TITLE
fix(frontend): show the real order type in the OISY Trade order detail

### DIFF
--- a/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
+++ b/src/frontend/src/lib/components/trading/TradingOrderDetailModal.svelte
@@ -58,7 +58,9 @@
 
 	let { order }: Props = $props();
 
-	let { side, base, quote, quantity, price, filledQuantity } = $derived(order);
+	let { side, base, quote, quantity, price, filledQuantity, timeInForce } = $derived(order);
+
+	const fillOrKill = $derived(timeInForce === 'FillOrKill');
 
 	const baseSymbol = $derived(getTokenDisplaySymbol(base));
 	const quoteSymbol = $derived(getTokenDisplaySymbol(quote));
@@ -201,12 +203,12 @@
 	const confirmCancel = async () => {
 		canceling = true;
 		// `quantity` and `price` are JS numbers, so stringify them via Decimal to get plain
-		// decimal strings (no `1e-7`/float artifacts). The order view carries no time-in-force,
-		// so `order_type` is omitted on cancel.
+		// decimal strings (no `1e-7`/float artifacts).
 		const orderFields: Omit<TrackLimitOrderParams, 'action' | 'resultStatus' | 'error'> = {
 			base: baseSymbol,
 			quote: quoteSymbol,
 			side,
+			orderType: fillOrKill ? 'FOK' : 'GTC',
 			baseAmount: new Decimal(quantity).toFixed(),
 			price: new Decimal(price).toFixed(),
 			baseUsdPrice,
@@ -273,8 +275,11 @@
 
 		<LimitOrderTermsList
 			{makerFee}
-			orderTypeLabel={$i18n.trading.limit_order.order_type_gtc}
+			orderTypeLabel={fillOrKill
+				? $i18n.trading.limit_order.order_type_fok
+				: $i18n.trading.limit_order.order_type_gtc}
 			{takerFee}
+			takerOnly={fillOrKill}
 		/>
 		{#if showFilled}
 			<ModalValue>

--- a/src/frontend/src/lib/types/oisy-trade.ts
+++ b/src/frontend/src/lib/types/oisy-trade.ts
@@ -31,6 +31,8 @@ export interface OisyTradeOrderView {
 	// Cumulative filled quantity in whole base tokens.
 	filledQuantity: number;
 	status: OisyTradeOrderStatus;
+	// Time-in-force the order was placed with.
+	timeInForce: OisyTradeTimeInForce;
 	// Submission time in nanoseconds since the Unix epoch — shown as the history
 	// row's meta line (when the order was placed).
 	createdAt: bigint;
@@ -38,6 +40,9 @@ export interface OisyTradeOrderView {
 
 // The five candid `OrderStatus` discriminants, flattened to a string union.
 export type OisyTradeOrderStatus = 'Pending' | 'Open' | 'Filled' | 'Canceled' | 'Expired';
+
+// The two candid `TimeInForce` discriminants, flattened to a string union.
+export type OisyTradeTimeInForce = 'FillOrKill' | 'GoodTilCanceled';
 
 // Display-only status: an Open order that has already partially filled is shown
 // as "Partial" (still active). Not a candid discriminant.

--- a/src/frontend/src/lib/utils/oisy-trade.utils.ts
+++ b/src/frontend/src/lib/utils/oisy-trade.utils.ts
@@ -3,6 +3,7 @@ import type {
 	OrderStatus,
 	PriceLevel,
 	Side,
+	TimeInForce,
 	TradingPair,
 	TradingPairInfo,
 	UserOrder,
@@ -18,6 +19,7 @@ import type {
 	OisyTradeOrderDisplayStatus,
 	OisyTradeOrderStatus,
 	OisyTradeOrderView,
+	OisyTradeTimeInForce,
 	OisyTradeWithdrawToken
 } from '$lib/types/oisy-trade';
 import type { BadgeVariant } from '$lib/types/style';
@@ -464,10 +466,7 @@ export const isOrderValid = ({
 	if (!validateAmount({ side, baseAmount, price, freeBalance, pair }).ok) {
 		return false;
 	}
-	if (fillOrKill && !crossesBook({ side, price, bid, ask })) {
-		return false;
-	}
-	return true;
+	return !(fillOrKill && !crossesBook({ side, price, bid, ask }));
 };
 
 // Max for the spend side. Sell: free base floored to lot. Buy: free quote
@@ -711,6 +710,10 @@ export const toCandidSide = (side: LimitOrderSide): Side =>
 const orderStatusKey = (status: OrderStatus): OisyTradeOrderStatus =>
 	Object.keys(status)[0] as OisyTradeOrderStatus;
 
+// The candid `TimeInForce` variant flattened to its single discriminant.
+const timeInForceKey = (timeInForce: TimeInForce): OisyTradeTimeInForce =>
+	Object.keys(timeInForce)[0] as OisyTradeTimeInForce;
+
 // Cached per ledger so the synthetic `TokenId` (a symbol) stays stable across
 // derivations — a fresh id would never match balance/exchange lookups keyed by
 // token id and would churn object identity on every re-derive.
@@ -787,7 +790,7 @@ export const mapOisyTradeOrder = ({
 		return undefined;
 	}
 
-	const { side, price, quantity, filled_quantity, status, created_at } = order;
+	const { side, price, quantity, filled_quantity, status, created_at, time_in_force } = order;
 
 	return {
 		id,
@@ -800,6 +803,7 @@ export const mapOisyTradeOrder = ({
 		filledQuantity: Number(filled_quantity) / 10 ** base.decimals,
 		price: Number(price) / 10 ** quote.decimals,
 		status: orderStatusKey(status),
+		timeInForce: timeInForceKey(time_in_force),
 		createdAt: created_at
 	};
 };

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeActiveOrders.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeActiveOrders.svelte.spec.ts
@@ -46,6 +46,7 @@ const order: OisyTradeOrderView = {
 	price: 2.5,
 	filledQuantity: 0,
 	status: 'Open',
+	timeInForce: 'GoodTilCanceled',
 	createdAt: ZERO
 };
 

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeOrderHistory.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeOrderHistory.svelte.spec.ts
@@ -30,6 +30,7 @@ const order = (over: Partial<OisyTradeOrderView>): OisyTradeOrderView => ({
 	price: 2.5,
 	filledQuantity: 10,
 	status: 'Filled',
+	timeInForce: 'GoodTilCanceled',
 	createdAt: 1_718_452_800_000_000_000n,
 	...over
 });

--- a/src/frontend/src/tests/lib/components/trading/OisyTradeOrderRow.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/OisyTradeOrderRow.svelte.spec.ts
@@ -47,6 +47,7 @@ const order: OisyTradeOrderView = {
 	price: 2.5,
 	filledQuantity: 0,
 	status: 'Open',
+	timeInForce: 'GoodTilCanceled',
 	createdAt: CREATED_AT_NS
 };
 

--- a/src/frontend/src/tests/lib/components/trading/TradingOrderDetailModal.svelte.spec.ts
+++ b/src/frontend/src/tests/lib/components/trading/TradingOrderDetailModal.svelte.spec.ts
@@ -30,6 +30,7 @@ const buildOrder = (over: Partial<OisyTradeOrderView> = {}): OisyTradeOrderView 
 	price: 2.5,
 	filledQuantity: 0,
 	status: 'Open' as OisyTradeOrderStatus,
+	timeInForce: 'GoodTilCanceled',
 	createdAt: ZERO,
 	...over
 });
@@ -42,6 +43,24 @@ describe('TradingOrderDetailModal', () => {
 		expect(container).toHaveTextContent(en.trading.orders.status_open);
 		expect(container).toHaveTextContent('ICP');
 		expect(container).toHaveTextContent('ckUSDC');
+	});
+
+	it('labels the order type as good-til-canceled for a resting order', () => {
+		const { container } = render(TradingOrderDetailModal, { props: { order: buildOrder() } });
+
+		expect(container).toHaveTextContent(en.trading.limit_order.order_type_gtc);
+		expect(container).toHaveTextContent(en.trading.limit_order.fee_maker_taker);
+	});
+
+	it('labels the order type as fill-or-kill for a fill-or-kill order', () => {
+		const { container } = render(TradingOrderDetailModal, {
+			props: { order: buildOrder({ timeInForce: 'FillOrKill', status: 'Expired' }) }
+		});
+
+		expect(container).toHaveTextContent(en.trading.limit_order.order_type_fok);
+		// Fill-or-kill always executes as a taker, so only that rate is shown.
+		expect(container).toHaveTextContent(en.trading.limit_order.fee_taker);
+		expect(container).not.toHaveTextContent(en.trading.limit_order.order_type_gtc);
 	});
 
 	it('shows the cancel action for an active order', () => {

--- a/src/frontend/src/tests/lib/derived/oisy-trade.derived.spec.ts
+++ b/src/frontend/src/tests/lib/derived/oisy-trade.derived.spec.ts
@@ -66,7 +66,8 @@ describe('oisy-trade.derived — orders', () => {
 				price: 1n,
 				quantity: 100n,
 				filled_quantity: ZERO,
-				status: { [status]: null }
+				status: { [status]: null },
+				time_in_force: { GoodTilCanceled: null }
 			}
 		}) as unknown as UserOrder;
 

--- a/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/oisy-trade.utils.spec.ts
@@ -10,7 +10,8 @@ import type { ExchangesData } from '$lib/types/exchange';
 import type {
 	OisyTradeAsset,
 	OisyTradeOrderStatus,
-	OisyTradeOrderView
+	OisyTradeOrderView,
+	OisyTradeTimeInForce
 } from '$lib/types/oisy-trade';
 import {
 	type LimitOrderPairView,
@@ -734,6 +735,7 @@ describe('oisy-trade.utils — orders', () => {
 		quantity,
 		filledQuantity = ZERO,
 		status,
+		timeInForce = 'GoodTilCanceled',
 		createdAt = 42n,
 		base = baseLedgerId,
 		quote = quoteLedgerId
@@ -744,6 +746,7 @@ describe('oisy-trade.utils — orders', () => {
 		quantity: bigint;
 		filledQuantity?: bigint;
 		status: OisyTradeOrderStatus;
+		timeInForce?: OisyTradeTimeInForce;
 		createdAt?: bigint;
 		base?: string;
 		quote?: string;
@@ -757,6 +760,7 @@ describe('oisy-trade.utils — orders', () => {
 				quantity,
 				filled_quantity: filledQuantity,
 				status: { [status]: null },
+				time_in_force: { [timeInForce]: null },
 				created_at: createdAt
 			}
 		}) as unknown as UserOrder;
@@ -784,8 +788,24 @@ describe('oisy-trade.utils — orders', () => {
 				price: 2.75,
 				filledQuantity: 25,
 				status: 'Open',
+				timeInForce: 'GoodTilCanceled',
 				createdAt: 42n
 			});
+		});
+
+		it('maps the time-in-force of a fill-or-kill order', () => {
+			const view = mapOisyTradeOrder({
+				order: buildOrder({
+					side: 'Sell',
+					quantity: 100n * 100_000_000n,
+					price: 2_750_000n,
+					status: 'Expired',
+					timeInForce: 'FillOrKill'
+				}),
+				tokens
+			});
+
+			expect(view?.timeInForce).toBe('FillOrKill');
 		});
 
 		it('maps a buy order', () => {
@@ -1020,6 +1040,7 @@ describe('oisy-trade.utils — search', () => {
 		price: 2.5,
 		filledQuantity: 0,
 		status: 'Open',
+		timeInForce: 'GoodTilCanceled',
 		createdAt: ZERO
 	};
 


### PR DESCRIPTION
# Motivation

The order detail modal showed "Good until canceled" for every order, including fill-or-kill ones. `OisyTradeOrderView` dropped `OrderRecord.time_in_force` when mapping the canister's `UserOrder`, so the modal had nothing to branch on and hard-coded the GTC label.

# Changes

- `OisyTradeOrderView` carries `timeInForce`, flattened from the candid `TimeInForce` variant into `OisyTradeTimeInForce` (`'FillOrKill' | 'GoodTilCanceled'`) — same shape as the existing `OisyTradeOrderStatus`.
- `mapOisyTradeOrder` maps `time_in_force` via a `timeInForceKey` helper mirroring `orderStatusKey`.
- `TradingOrderDetailModal` picks `order_type_fok` / `order_type_gtc` from the order and passes `takerOnly` for fill-or-kill, so it shows the single taker rate instead of "maker / taker" — the same treatment `LimitOrderReview` already gives it.
- The cancel analytics now sends `order_type`, which was previously omitted only because the view model lacked the data.


# Tests

Updated.
