### PR TITLE
fix(frontend): price a Max send against the balance it is signed with

### DIFF
--- a/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
+++ b/src/frontend/src/eth/components/send/EthSendTokenWizard.svelte
@@ -6,6 +6,7 @@
 	import EthSendForm from '$eth/components/send/EthSendForm.svelte';
 	import EthSendReview from '$eth/components/send/EthSendReview.svelte';
 	import { sendSteps } from '$eth/constants/steps.constants';
+	import { reloadEthereumBalance } from '$eth/services/eth-balance.services';
 	import { sendNft } from '$eth/services/nft-send.services';
 	import { send as executeSend } from '$eth/services/send.services';
 	import {
@@ -316,20 +317,36 @@
 			unitName: $sendTokenDecimals
 		});
 
+		const isMaxNativeSend = amountSetToMax && feeIsPaidFromAmount;
+
+		// The balance a "Max" amount was priced against is a poll sample, and every transaction the
+		// wallet sends in between - an ERC-20 transfer, an approval, a swap - pays its gas out of
+		// this very balance. Until the next poll lands, that sample still holds gas the account has
+		// already spent, and an amount drawn from it reserves more than there is left to reserve.
+		// Re-reading the balance here is what makes the cap below a cap on what the account actually
+		// has, rather than on what it had when the field was filled in.
+		const pricedAgainstBalance = $sendBalance;
+
+		if (isMaxNativeSend) {
+			await reloadEthereumBalance($sendToken);
+		}
+
 		// The fee is frozen from the review step on, so the sample signed just above is the one the
 		// amount step last showed. The "Max" button, however, re-applies its amount half a second
 		// after each fee change, so a click on "Review" inside that window carries an amount priced
 		// against the sample before. A fee that has risen in between leaves it unable to cover
 		// `gas * maxFeePerGas`, and the chain drops such a transaction without reporting anything:
 		// the broadcast returns a hash and it is simply never included.
-		const sendAmount =
-			amountSetToMax && feeIsPaidFromAmount
-				? capSendAmountToFee({
-						amount: parsedAmount,
-						balance: $sendBalance,
-						feeData
-					})
-				: parsedAmount;
+		const sendAmount = isMaxNativeSend
+			? capSendAmountToFee({
+					amount: parsedAmount,
+					// A re-read that failed leaves no balance behind rather than the previous one, and
+					// capping against nothing caps nothing: fall back to the sample the amount was
+					// priced against, so re-reading can only ever tighten this cap, never drop it.
+					balance: $sendBalance ?? pricedAgainstBalance,
+					feeData
+				})
+			: parsedAmount;
 
 		if (sendAmount <= ZERO) {
 			toastsError({

--- a/src/frontend/src/eth/services/eth-transaction.services.ts
+++ b/src/frontend/src/eth/services/eth-transaction.services.ts
@@ -1,3 +1,4 @@
+import { enabledEthEvmNativeTokens } from '$eth/derived/native-tokens.derived';
 import { alchemyProviders } from '$eth/providers/alchemy.providers';
 import { reloadEthereumBalance } from '$eth/services/eth-balance.services';
 import { reloadEthereumTransactions } from '$eth/services/eth-transactions.services';
@@ -142,6 +143,22 @@ const processMinedTransaction = async ({
 
 	await reloadEthereumTransactions({ identity, tokenId, networkId, chainId, standard });
 
-	// Reload balance as a transaction has been mined
-	await reloadEthereumBalance(token);
+	// Reload balance as a transaction has been mined.
+	//
+	// The gas is paid in the network's native coin whatever the transaction moved, so an ERC-20
+	// transfer leaves that balance overstated as well, not only the balance of the token it sent.
+	// Nothing else corrects it until the next balance poll, and in that window "Max" prices a native
+	// send against a balance that still holds the gas already spent: the amount plus the gas it
+	// reserves exceeds what the account has, and the chain rejects the transaction outright rather
+	// than trimming it.
+	const nativeToken = get(enabledEthEvmNativeTokens).find(
+		({ network: { id } }) => id === networkId
+	);
+
+	const tokensToReload: Token[] = [
+		token,
+		...(nonNullish(nativeToken) && nativeToken.id !== tokenId ? [nativeToken] : [])
+	];
+
+	await Promise.all(tokensToReload.map((tokenToReload) => reloadEthereumBalance(tokenToReload)));
 };

--- a/src/frontend/src/tests/eth/components/send/EthSendTokenWizard.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendTokenWizard.spec.ts
@@ -1,6 +1,7 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import EthSendTokenWizard from '$eth/components/send/EthSendTokenWizard.svelte';
+import * as ethBalanceServices from '$eth/services/eth-balance.services';
 import * as feeServices from '$eth/services/fee.services';
 import * as nftSendServices from '$eth/services/nft-send.services';
 import * as sendServices from '$eth/services/send.services';
@@ -12,13 +13,14 @@ import {
 } from '$eth/stores/eth-fee.store';
 import * as tokenUtils from '$eth/utils/token.utils';
 import * as ckethServices from '$icp-eth/services/cketh.services';
-import { REVIEW_FORM_SEND_BUTTON } from '$lib/constants/test-ids.constants';
+import { MAX_BUTTON, REVIEW_FORM_SEND_BUTTON } from '$lib/constants/test-ids.constants';
 import * as addrDerived from '$lib/derived/address.derived';
 import * as idDerived from '$lib/derived/auth.derived';
 import * as exchDerived from '$lib/derived/exchange.derived';
 import { ProgressStepsSend } from '$lib/enums/progress-steps';
 import { WizardStepsSend } from '$lib/enums/wizard-steps';
 import * as analytics from '$lib/services/analytics.services';
+import { balancesStore } from '$lib/stores/balances.store';
 import { initSendContext, SEND_CONTEXT_KEY } from '$lib/stores/send.store';
 import * as toasts from '$lib/stores/toasts.store';
 import type { Nft, NonFungibleToken } from '$lib/types/nft';
@@ -287,6 +289,107 @@ describe('EthSendTokenWizard.spec', () => {
 			// The amount shown for review was priced against the fee in hand; a fresh sample would
 			// move the fee underneath it, and a spike right before "Send" would be signed as is.
 			expect(feeServices.getEthFeeDataWithProvider).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('max send', () => {
+		// The fee the amount is capped against, as the frozen `feeState` above prices it:
+		// `maxFeePerGas * gas`, with no L1 data fee on Ethereum.
+		const gasFee = 2_000_000n * 100n;
+		// What the poll last saw, and what "Max" therefore offers.
+		const staleBalance = 1_000_000_000_000_000_000n;
+		// What the account holds by the time the transaction is signed, the difference being gas
+		// already spent by a transfer the poll has not caught up with.
+		const freshBalance = staleBalance - 500_000_000n;
+
+		const renderMaxSend = () => {
+			balancesStore.set({
+				id: ETHEREUM_TOKEN.id,
+				data: { data: staleBalance, certified: false }
+			});
+
+			return render(EthSendTokenWizardTestHost, {
+				props: {
+					currentStep: { name: WizardStepsSend.SEND, title: WizardStepsSend.SEND },
+					destination,
+					sendContext: initSendContext({ token: ETHEREUM_TOKEN }),
+					sourceNetwork: ETHEREUM_NETWORK,
+					nativeEthereumToken: ETHEREUM_TOKEN,
+					onCloseStep: vi.fn()
+				}
+			});
+		};
+
+		beforeEach(() => {
+			vi.spyOn(feeServices, 'getEthFeeDataWithProvider').mockRejectedValue(new Error('offline'));
+
+			vi.spyOn(feeStoreMod, 'initEthFeeContext').mockImplementation((ctx) => ({
+				...ctx,
+				maxGasFee: readable(gasFee),
+				minGasFee: readable(gasFee),
+				estimatedGasFee: readable(gasFee),
+				feePrioritiesStore: writable(undefined)
+			}));
+
+			vi.spyOn(ethBalanceServices, 'reloadEthereumBalance').mockImplementation(() => {
+				balancesStore.set({
+					id: ETHEREUM_TOKEN.id,
+					data: { data: freshBalance, certified: false }
+				});
+
+				return Promise.resolve({ success: true });
+			});
+		});
+
+		afterEach(() => {
+			balancesStore.reset(ETHEREUM_TOKEN.id);
+		});
+
+		it('signs a Max amount that fits the balance as it is at signing time', async () => {
+			const { getByTestId, rerender } = renderMaxSend();
+
+			await fireEvent.click(getByTestId(MAX_BUTTON));
+			await vi.runOnlyPendingTimersAsync();
+
+			await rerender({
+				currentStep: { name: WizardStepsSend.REVIEW, title: WizardStepsSend.REVIEW }
+			});
+
+			await fireEvent.click(getByTestId(REVIEW_FORM_SEND_BUTTON));
+			await vi.runOnlyPendingTimersAsync();
+
+			expect(ethBalanceServices.reloadEthereumBalance).toHaveBeenCalledWith(ETHEREUM_TOKEN);
+
+			// Not `staleBalance - gasFee`: that amount plus the gas it reserves is more than the
+			// account holds, and the chain refuses such a transaction outright.
+			expect(sendServices.send).toHaveBeenCalledWith(
+				expect.objectContaining({ amount: freshBalance - gasFee })
+			);
+		});
+
+		it('still caps against the balance the amount was priced with when the re-read fails', async () => {
+			// A failed re-read empties the balance in the store rather than leaving the previous one.
+			vi.spyOn(ethBalanceServices, 'reloadEthereumBalance').mockImplementation(() => {
+				balancesStore.reset(ETHEREUM_TOKEN.id);
+
+				return Promise.resolve({ success: false });
+			});
+
+			const { getByTestId, rerender } = renderMaxSend();
+
+			await fireEvent.click(getByTestId(MAX_BUTTON));
+			await vi.runOnlyPendingTimersAsync();
+
+			await rerender({
+				currentStep: { name: WizardStepsSend.REVIEW, title: WizardStepsSend.REVIEW }
+			});
+
+			await fireEvent.click(getByTestId(REVIEW_FORM_SEND_BUTTON));
+			await vi.runOnlyPendingTimersAsync();
+
+			expect(sendServices.send).toHaveBeenCalledWith(
+				expect.objectContaining({ amount: staleBalance - gasFee })
+			);
 		});
 	});
 

--- a/src/frontend/src/tests/eth/services/eth-transaction.services.spec.ts
+++ b/src/frontend/src/tests/eth/services/eth-transaction.services.spec.ts
@@ -1,0 +1,81 @@
+import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
+import { ETHEREUM_TOKEN, SEPOLIA_TOKEN } from '$env/tokens/tokens.eth.env';
+import * as nativeTokensDerived from '$eth/derived/native-tokens.derived';
+import * as ethBalanceServices from '$eth/services/eth-balance.services';
+import { processErc20Transaction } from '$eth/services/eth-transaction.services';
+import * as ethTransactionsServices from '$eth/services/eth-transactions.services';
+import type { RequiredToken } from '$lib/types/token';
+import { mockValidErc20Token } from '$tests/mocks/erc20-tokens.mock';
+import { mockIdentity } from '$tests/mocks/identity.mock';
+import { readable } from 'svelte/store';
+
+describe('eth-transaction.services', () => {
+	describe('processErc20Transaction', () => {
+		const hash = '0x5f97b634e4173d1b167c23386b677976a8d807b91eefe9e407b0025cff4fe441';
+
+		const mockNativeTokens = (tokens: RequiredToken[]) =>
+			vi
+				.spyOn(nativeTokensDerived, 'enabledEthEvmNativeTokens', 'get')
+				.mockReturnValue(readable(tokens));
+
+		const processMined = (token: Parameters<typeof processErc20Transaction>[0]['token']) =>
+			processErc20Transaction({
+				identity: mockIdentity,
+				hash,
+				value: 1n,
+				token,
+				type: 'mined'
+			});
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+
+			vi.spyOn(ethTransactionsServices, 'reloadEthereumTransactions').mockResolvedValue({
+				success: true
+			});
+			vi.spyOn(ethBalanceServices, 'reloadEthereumBalance').mockResolvedValue({ success: true });
+
+			mockNativeTokens([ETHEREUM_TOKEN as RequiredToken]);
+		});
+
+		it('reloads the native balance too, since the mined transfer paid its gas out of it', async () => {
+			await processMined(mockValidErc20Token);
+
+			expect(ethBalanceServices.reloadEthereumBalance).toHaveBeenCalledTimes(2);
+
+			expect(ethBalanceServices.reloadEthereumBalance).toHaveBeenCalledWith(mockValidErc20Token);
+
+			expect(ethBalanceServices.reloadEthereumBalance).toHaveBeenCalledWith(ETHEREUM_TOKEN);
+		});
+
+		it('reloads the balance once when the token that was sent is the native one', async () => {
+			await processMined(ETHEREUM_TOKEN);
+
+			expect(ethBalanceServices.reloadEthereumBalance).toHaveBeenCalledExactlyOnceWith(
+				ETHEREUM_TOKEN
+			);
+		});
+
+		it('reloads only the token that was sent when no native token matches its network', async () => {
+			mockNativeTokens([SEPOLIA_TOKEN as RequiredToken]);
+
+			await processMined(mockValidErc20Token);
+
+			expect(ethBalanceServices.reloadEthereumBalance).toHaveBeenCalledExactlyOnceWith(
+				mockValidErc20Token
+			);
+		});
+
+		it('reloads the transactions of the token that was sent', async () => {
+			await processMined(mockValidErc20Token);
+
+			expect(ethTransactionsServices.reloadEthereumTransactions).toHaveBeenCalledExactlyOnceWith({
+				identity: mockIdentity,
+				tokenId: mockValidErc20Token.id,
+				networkId: ETHEREUM_NETWORK.id,
+				chainId: ETHEREUM_NETWORK.chainId,
+				standard: mockValidErc20Token.standard
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Stacked on #14001, which fixes the balance staleness that caused the reported failure. This is the second layer: it makes a "Max" send unable to overspend even when the balance in the store is behind, whatever put it behind.

The balance "Max" draws from is a poll sample. Gas spent between that sample and the signature is invisible to it, and it need not come from this tab: another session, another device, or a transaction whose reload has not landed yet. `capSendAmountToFee` already caps the amount at signing time, but it capped against that same sample, so a stale balance passed straight through it.

# Changes

- Re-read the balance before capping a "Max" native send, so the cap is applied to what the account holds when the transaction is built.
- Fall back to the balance the amount was priced against when the re-read fails, since a failed read empties the balance in the store rather than leaving the previous one, and capping against nothing caps nothing. Re-reading can only tighten the cap, never drop it.

# Tests

- `EthSendTokenWizard.spec.ts`: a Max amount clicked against a stale balance is signed against the fresh one, and a failed re-read still caps against the balance the amount was priced with.
- Both new tests were checked against the unpatched code and fail there.
- `npm run format`, `npm run lint -- --max-warnings 0`, `npm run check`, `npm run check:tests` and `npm run test` (1098 files, 18790 tests) all pass.
