### PR TITLE
style(frontend): keep the folded type schema at the bottom of the raw data

### DIFF
--- a/src/frontend/src/lib/components/ui/Json.svelte
+++ b/src/frontend/src/lib/components/ui/Json.svelte
@@ -59,13 +59,21 @@
 	// A folded entry still holds the width of a line where it sits, so leaving it in place keeps
 	// pushing down what the caller wanted read first. Order within each group is left untouched, and
 	// arrays are left alone entirely: their order is data, not presentation.
-	const collapsedLast = (entries: [string, unknown][]): [string, unknown][] =>
-		isArray
-			? entries
-			: [
-					...entries.filter(([key]) => !collapsedKeys.includes(key)),
-					...entries.filter(([key]) => collapsedKeys.includes(key))
-				];
+	const collapsedLast = (entries: [string, unknown][]): [string, unknown][] => {
+		if (isArray) {
+			return entries;
+		}
+
+		const folded = new Set(collapsedKeys);
+		const open: [string, unknown][] = [];
+		const closed: [string, unknown][] = [];
+
+		for (const entry of entries) {
+			(folded.has(entry[0]) ? closed : open).push(entry);
+		}
+
+		return [...open, ...closed];
+	};
 
 	let children = $derived(isExpandable ? collapsedLast(Object.entries(json as object)) : []);
 	let hasChildren = $derived(children.length > 0);

--- a/src/frontend/src/lib/components/ui/Json.svelte
+++ b/src/frontend/src/lib/components/ui/Json.svelte
@@ -6,9 +6,10 @@
 	interface Props {
 		json?: unknown;
 		defaultExpandedLevel?: number;
-		// Entries of this node that start folded. Deliberately not handed down to the children: the
-		// caller chooses the entries it can name, and a key deeper in the tree that happens to carry
-		// the same name is somebody else's data, which must not be hidden by a rule meant for this level.
+		// Entries of this node that start folded, and are moved below the entries that stay open.
+		// Deliberately not handed down to the children: the caller chooses the entries it can name, and
+		// a key deeper in the tree that happens to carry the same name is somebody else's data, which
+		// must not be hidden by a rule meant for this level.
 		collapsedKeys?: string[];
 		_key?: string;
 		_level?: number;
@@ -54,9 +55,20 @@
 	let isExpandable = $derived(valueType === 'object');
 	let value = $derived(isExpandable ? json : stringifyJson({ value: json }));
 	let keyLabel = $derived(`${_key}${_key.length > 0 ? ': ' : ''}`);
-	let children = $derived(isExpandable ? Object.entries(json as object) : []);
-	let hasChildren = $derived(children.length > 0);
 	let isArray = $derived(Array.isArray(json));
+	// A folded entry still holds the width of a line where it sits, so leaving it in place keeps
+	// pushing down what the caller wanted read first. Order within each group is left untouched, and
+	// arrays are left alone entirely: their order is data, not presentation.
+	const collapsedLast = (entries: [string, unknown][]): [string, unknown][] =>
+		isArray
+			? entries
+			: [
+					...entries.filter(([key]) => !collapsedKeys.includes(key)),
+					...entries.filter(([key]) => collapsedKeys.includes(key))
+				];
+
+	let children = $derived(isExpandable ? collapsedLast(Object.entries(json as object)) : []);
+	let hasChildren = $derived(children.length > 0);
 	let openBracket = $derived(isArray ? '[' : '{');
 	let closeBracket = $derived(isArray ? ']' : '}');
 	let root = $derived(_level === 1);

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectMessage.spec.ts
@@ -127,6 +127,25 @@ describe('EthWalletConnectMessage', () => {
 		expect(getByText('"uint160"')).toBeInTheDocument();
 	});
 
+	it('should move the folded type schema below the entries that stay open', async () => {
+		const { getByRole, getByTestId } = render(EthWalletConnectMessage, {
+			props: {
+				request
+			}
+		});
+
+		await openRawTab(getByRole);
+
+		// The payload declares `types` first, and a folded node still holds the line it sits on, so
+		// the schema would keep the domain, the type and the message a scroll away. It is moved last
+		// instead, wherever the application happens to have put it.
+		const entries = Array.from(
+			(getByTestId('json').parentElement as HTMLElement).querySelectorAll(':scope > ul > li')
+		).map((li) => li.textContent?.trim().split(':')[0]);
+
+		expect(entries).toEqual(['domain', 'primaryType', 'message', 'types']);
+	});
+
 	it.each(['Enter', ' '])(
 		'should open the folded type schema on %s, not by pointer alone',
 		async (key) => {


### PR DESCRIPTION
# Motivation

The raw data tab of a WalletConnect EVM typed-data request folds `types`, but the fold only hides the schema, it does not move it. `types` is declared first in most EIP-712 payloads, so the folded node keeps the top line and the domain, the primary type and the message still start below it.

# Changes

- `Json` moves the entries named in `collapsedKeys` under the entries that stay open. Order within each group is untouched, and arrays are left alone entirely: their order is data, not presentation.
- Nothing changes for the caller: the EVM typed-data raw data tab keeps passing `['types']`, and the schema stays one click from reading as it did.

# Tests

- New spec in `EthWalletConnectMessage.spec.ts`: the top-level entries render as `domain`, `primaryType`, `message`, `types`, from a payload that declares `types` first. Verified it fails without the change.
- `npm run format`, `npm run lint -- --max-warnings 0` clean. `npm run check` / `npm run check:tests` report only pre-existing errors in unrelated files (Liquidium wizards, Solana instruction specs) from this worktree borrowing the root install; neither changed file appears.
