### PR TITLE
fix(frontend): level a token whose history arrives late in the Activity list

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { onDestroy, type Snippet, untrack } from 'svelte';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
+	import { ACTIVITY_LEVELLING_MAX_PAGES } from '$lib/constants/app.constants';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
 	import { transactionsStoreWithTokens } from '$lib/derived/transactions.derived';
@@ -39,14 +41,16 @@
 		destroyed = true;
 	});
 
-	// The oldest transaction on screen across every token. Tokens whose history stops short of it
-	// would leave gaps in the merged list, so they get paged down to it.
-	const oldestLoadedTimestamp = (): number =>
+	const oldestTimestamp = (rows: AllTransactionUiWithCmp[]): number =>
 		Math.min(
-			...transactions.map(({ transaction: { timestamp } }) =>
+			...rows.map(({ transaction: { timestamp } }) =>
 				nonNullish(timestamp) ? normalizeTimestampToSeconds(timestamp) : Infinity
 			)
 		);
+
+	// The oldest transaction on screen across every token. Tokens whose history stops short of it
+	// would leave gaps in the merged list, so they get paged down to it.
+	const oldestLoadedTimestamp = (): number => oldestTimestamp(transactions);
 
 	const pageToken = async ({
 		token,
@@ -80,49 +84,97 @@
 		return success;
 	};
 
-	// Pulls each token back until it reaches `minTimestamp` or runs out of history.
-	const levelToOldest = async (minTimestamp: number) => {
-		const levelOne = async (token: Token) => {
-			// We call the function again in case the last transaction is not the last one that we need
-			while (await pageToken({ token, minTimestamp })) {
-				// Each chain loader stops the loop by returning `success: false` once its oldest loaded
-				// transaction has reached the floor.
+	// Levelling in flight per token. A run for a token already being levelled is chained after the
+	// current one instead of started alongside it, so the two never fetch the same page.
+	const levellingByToken = new SvelteMap<TokenId, Promise<void>>();
+
+	// Pulls a token back until it reaches `minTimestamp`, runs out of history, or hits the page cap.
+	const levelToken = ({
+		token,
+		minTimestamp
+	}: {
+		token: Token;
+		minTimestamp: number;
+	}): Promise<void> => {
+		const run = async () => {
+			// Each chain loader ends the run by returning `success: false` once its oldest loaded
+			// transaction has reached the floor. The cap only guards against one that never does.
+			for (let page = 0; page < ACTIVITY_LEVELLING_MAX_PAGES; page++) {
+				if (!(await pageToken({ token, minTimestamp }))) {
+					return;
+				}
 			}
 		};
 
-		await Promise.allSettled($enabledFungibleNetworkTokens.map(levelOne));
+		const inFlight = levellingByToken.get(token.id);
+
+		// Started right away when nothing is in flight, so the first page is requested within the same
+		// update rather than a microtask later.
+		const next = (isNullish(inFlight) ? run() : inFlight.then(run))
+			// A failed page only ends this token's run; the others carry on.
+			.catch(() => undefined);
+
+		levellingByToken.set(token.id, next);
+
+		return next;
 	};
 
-	let levelling: Promise<void> | undefined;
-
-	let relevelRequested = false;
-
-	const levelLoadedSet = async () => {
-		do {
-			relevelRequested = false;
-
-			if (destroyed || isNullish($authIdentity) || transactions.length === 0) {
-				return;
-			}
-
-			await levelToOldest(oldestLoadedTimestamp());
-		} while (relevelRequested);
+	const levelTokens = async ({
+		tokens,
+		minTimestamp
+	}: {
+		tokens: Token[];
+		minTimestamp: number;
+	}) => {
+		await Promise.all(tokens.map((token) => levelToken({ token, minTimestamp })));
 	};
 
-	// One levelling pass at a time. A change landing mid-pass is not lost: it earns exactly one more
-	// pass once the current one ends, which then sees everything that arrived in between.
-	const loadMissingTransactions = (): Promise<void> => {
-		if (nonNullish(levelling)) {
-			relevelRequested = true;
+	// The floor every token is levelled to. Set from the oldest row on screen when levelling first
+	// runs, deepened by `loadMore`, and lowered by a token whose history arrives late with older rows.
+	// Rows a token pages in while being levelled never move it: if they did, each run would overshoot
+	// the floor, lower it, and set every other token off again, until all of them had walked back to
+	// the start of their history.
+	let levelFloor: number | undefined;
 
-			return levelling;
+	// Tokens whose rows the floor already accounts for.
+	const accountedTokenIds = new SvelteSet<TokenId>();
+
+	// Stores fill at different times. Without a warm IndexedDB cache a token with little history can
+	// bring in a row from months ago while a busier token still holds only its first, recent page, or
+	// nothing at all yet. Levelling once after mount missed whatever arrived after it, and the scroll
+	// reveals rows already in memory without asking for more, so the gap stayed on screen. Each token
+	// is therefore levelled when its first rows arrive, and only then: at most once per token.
+	const levelNewcomers = () => {
+		if (destroyed || isNullish($authIdentity) || transactions.length === 0) {
+			return;
 		}
 
-		levelling = levelLoadedSet().finally(() => {
-			levelling = undefined;
-		});
+		const newcomers = $enabledFungibleNetworkTokens.filter(
+			(token) => !accountedTokenIds.has(token.id) && loadedTransactionsCount(token) > 0
+		);
 
-		return levelling;
+		if (newcomers.length === 0) {
+			return;
+		}
+
+		newcomers.forEach(({ id }) => accountedTokenIds.add(id));
+
+		const newcomerIds = new Set(newcomers.map(({ id }) => id));
+
+		const newcomersOldest = isNullish(levelFloor)
+			? oldestLoadedTimestamp()
+			: oldestTimestamp(transactions.filter(({ token: { id } }) => newcomerIds.has(id)));
+
+		// Older than the current floor: every token has to reach the new one, not just the newcomers.
+		if (isNullish(levelFloor) || newcomersOldest < levelFloor) {
+			levelFloor = newcomersOldest;
+
+			levelTokens({ tokens: $enabledFungibleNetworkTokens, minTimestamp: levelFloor });
+
+			return;
+		}
+
+		levelTokens({ tokens: newcomers, minTimestamp: levelFloor });
 	};
 
 	const totalLoaded = (): number =>
@@ -138,26 +190,23 @@
 
 		const loadedBefore = totalLoaded();
 
-		// Let a running pass settle first, so the page below starts from where it left each token
+		// Let running levelling settle first, so the page below starts from where it left each token
 		// rather than fetching the same page twice.
-		await levelling;
+		await Promise.all(levellingByToken.values());
 
 		// One unconditional page per token first: without it every token already sits at the floor
 		// and levelling alone would find nothing left to do.
 		await Promise.allSettled($enabledFungibleNetworkTokens.map((token) => pageToken({ token })));
 
-		await loadMissingTransactions();
+		levelFloor = oldestLoadedTimestamp();
+
+		await levelTokens({ tokens: $enabledFungibleNetworkTokens, minTimestamp: levelFloor });
 
 		return totalLoaded() > loadedBefore;
 	};
 
 	let allStoresAreLoaded = $derived(areTransactionsStoresLoaded($transactionsStoreWithTokens));
 
-	// Levelled again on every change to the loaded set, not once after mount. Stores fill at different
-	// times: without a warm IndexedDB cache a token with little history can bring in a row from
-	// months ago while a busier token still holds only its first, recent page, or nothing yet. A
-	// single pass taken before that settles never pages the busier token down to the old row, and
-	// the scroll reveals rows already in memory without asking for more, so the gap stayed on screen.
 	$effect(() => {
 		if (!allStoresAreLoaded) {
 			return;
@@ -165,7 +214,7 @@
 
 		[transactions];
 
-		untrack(() => loadMissingTransactions());
+		untrack(levelNewcomers);
 	});
 
 	let exhausted = $derived(

--- a/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsLoader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
-	import { onDestroy, type Snippet } from 'svelte';
+	import { onDestroy, type Snippet, untrack } from 'svelte';
 	import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
 	import { authIdentity } from '$lib/derived/auth.derived';
 	import { enabledFungibleNetworkTokens } from '$lib/derived/network-tokens.derived';
@@ -93,12 +93,36 @@
 		await Promise.allSettled($enabledFungibleNetworkTokens.map(levelOne));
 	};
 
-	const loadMissingTransactions = async () => {
-		if (isNullish($authIdentity) || transactions.length === 0) {
-			return;
+	let levelling: Promise<void> | undefined;
+
+	let relevelRequested = false;
+
+	const levelLoadedSet = async () => {
+		do {
+			relevelRequested = false;
+
+			if (destroyed || isNullish($authIdentity) || transactions.length === 0) {
+				return;
+			}
+
+			await levelToOldest(oldestLoadedTimestamp());
+		} while (relevelRequested);
+	};
+
+	// One levelling pass at a time. A change landing mid-pass is not lost: it earns exactly one more
+	// pass once the current one ends, which then sees everything that arrived in between.
+	const loadMissingTransactions = (): Promise<void> => {
+		if (nonNullish(levelling)) {
+			relevelRequested = true;
+
+			return levelling;
 		}
 
-		await levelToOldest(oldestLoadedTimestamp());
+		levelling = levelLoadedSet().finally(() => {
+			levelling = undefined;
+		});
+
+		return levelling;
 	};
 
 	const totalLoaded = (): number =>
@@ -114,24 +138,34 @@
 
 		const loadedBefore = totalLoaded();
 
+		// Let a running pass settle first, so the page below starts from where it left each token
+		// rather than fetching the same page twice.
+		await levelling;
+
 		// One unconditional page per token first: without it every token already sits at the floor
 		// and levelling alone would find nothing left to do.
 		await Promise.allSettled($enabledFungibleNetworkTokens.map((token) => pageToken({ token })));
 
-		await levelToOldest(oldestLoadedTimestamp());
+		await loadMissingTransactions();
 
 		return totalLoaded() > loadedBefore;
 	};
 
 	let allStoresAreLoaded = $derived(areTransactionsStoresLoaded($transactionsStoreWithTokens));
 
-	let firstLoad = $state(false);
-
+	// Levelled again on every change to the loaded set, not once after mount. Stores fill at different
+	// times: without a warm IndexedDB cache a token with little history can bring in a row from
+	// months ago while a busier token still holds only its first, recent page, or nothing yet. A
+	// single pass taken before that settles never pages the busier token down to the old row, and
+	// the scroll reveals rows already in memory without asking for more, so the gap stayed on screen.
 	$effect(() => {
-		if (allStoresAreLoaded && !firstLoad) {
-			firstLoad = true;
-			loadMissingTransactions();
+		if (!allStoresAreLoaded) {
+			return;
 		}
+
+		[transactions];
+
+		untrack(() => loadMissingTransactions());
 	});
 
 	let exhausted = $derived(

--- a/src/frontend/src/lib/constants/app.constants.ts
+++ b/src/frontend/src/lib/constants/app.constants.ts
@@ -176,6 +176,11 @@ export const NFT_TIMER_INTERVAL_MILLIS = (SECONDS_IN_MINUTE / 3) * 1_000; // 20 
 // Wallets
 export const WALLET_TIMER_INTERVAL_MILLIS = (SECONDS_IN_MINUTE / 2) * 1_000; // 30 seconds in milliseconds
 export const WALLET_PAGINATION = 10n;
+
+// Most pages the Activity list fetches for one token in a single levelling run. A safety net for a
+// chain loader that keeps reporting progress without its oldest transaction moving, not a throttle:
+// a token it stops is picked up again by the next page the user scrolls to.
+export const ACTIVITY_LEVELLING_MAX_PAGES = 50;
 // How many consecutive jobs must fail to fetch the transactions of an IC token before we tell the user about it.
 // At the interval above, that is about 90 seconds of silence - long enough to skip transient hiccups.
 export const IC_TRANSACTIONS_UNAVAILABLE_THRESHOLD = 3;

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsLoader.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsLoader.spec.ts
@@ -14,7 +14,7 @@ import { icrcCustomTokensStore } from '$icp/stores/icrc-custom-tokens.store';
 import type { IcTransactionUi } from '$icp/types/ic-transaction';
 import { normalizeTimestampToSeconds } from '$icp/utils/date.utils';
 import AllTransactionsLoader from '$lib/components/transactions/AllTransactionsLoader.svelte';
-import { WALLET_PAGINATION } from '$lib/constants/app.constants';
+import { ACTIVITY_LEVELLING_MAX_PAGES, WALLET_PAGINATION } from '$lib/constants/app.constants';
 import type { Token } from '$lib/types/token';
 import type { Transaction } from '$lib/types/transaction';
 import type { AllTransactionUiWithCmp } from '$lib/types/transaction-ui';
@@ -490,10 +490,12 @@ describe('AllTransactionsLoader', () => {
 		});
 	});
 
-	// A cold start, e.g. an incognito window: no IndexedDB cache, so every token arrives on its own
-	// first network page and the loaded set keeps changing after the first levelling pass.
-	describe('when the loaded set changes after the first pass', () => {
-		const solRow = ({
+	// A cold start, e.g. an incognito window: no IndexedDB cache, so each token arrives on its own
+	// first network page, some of them after levelling has already run.
+	describe('when a late token arrives after levelling ran', () => {
+		const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+		const lateRow = ({
 			token,
 			timestamp
 		}: {
@@ -505,39 +507,59 @@ describe('AllTransactionsLoader', () => {
 			token
 		});
 
+		const arrive = ({ token, timestamp }: { token: Token; timestamp: bigint }) => {
+			const row = lateRow({ token, timestamp });
+
+			solTransactionsStore.append({
+				tokenId: token.id,
+				transactions: [{ data: row.transaction as SolTransactionUi, certified: false }]
+			});
+
+			return row;
+		};
+
+		// USDC in the reported case: nothing loaded yet when levelling first runs.
+		const withoutLateToken = mockTransactions.filter(({ token }) => token.id !== mockSplToken.id);
+
 		beforeEach(() => {
 			spyLoadNextIcTransactions.mockResolvedValue({ success: false });
 			spyLoadNextSolTransactions.mockResolvedValue({ success: false });
+
+			solTransactionsStore.reset(mockSplToken.id);
 		});
 
-		it('should level a token whose first page arrived after the first pass', async () => {
-			const { rerender } = render(AllTransactionsLoader, { props });
+		it('should level the late token down to the floor, and only that token', async () => {
+			const { rerender } = render(AllTransactionsLoader, {
+				props: { transactions: withoutLateToken }
+			});
 
 			await waitFor(() => {
 				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
 			});
 
 			spyLoadNextSolTransactions.mockClear();
+			spyLoadNextIcTransactions.mockClear();
 
-			await rerender({
-				transactions: [
-					...mockTransactions,
-					solRow({ token: mockSplToken, timestamp: mockMaxTimestamp })
-				]
-			});
+			const row = arrive({ token: mockSplToken, timestamp: mockMaxTimestamp });
+
+			await rerender({ transactions: [...withoutLateToken, row] });
 
 			await waitFor(() => {
-				expect(spyLoadNextSolTransactions).toHaveBeenCalledWith({
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledExactlyOnceWith({
 					identity: mockIdentity,
 					minTimestamp: mockMinTimestamp,
 					token: mockSplToken,
 					signalEnd: expect.any(Function)
 				});
 			});
+
+			expect(spyLoadNextIcTransactions).not.toHaveBeenCalled();
 		});
 
-		it('should level every token down to an older row that arrived after the first pass', async () => {
-			const { rerender } = render(AllTransactionsLoader, { props });
+		it('should level every token down to older rows the late token brings', async () => {
+			const { rerender } = render(AllTransactionsLoader, {
+				props: { transactions: withoutLateToken }
+			});
 
 			await waitFor(() => {
 				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
@@ -547,68 +569,63 @@ describe('AllTransactionsLoader', () => {
 
 			const olderTimestamp = mockMinTimestampStart - 1n;
 
-			await rerender({
-				transactions: [
-					...mockTransactions,
-					solRow({ token: mockSplDefaultToken, timestamp: olderTimestamp })
-				]
-			});
+			const row = arrive({ token: mockSplToken, timestamp: olderTimestamp });
+
+			await rerender({ transactions: [...withoutLateToken, row] });
 
 			await waitFor(() => {
-				solTokens.forEach(([token]) => {
-					expect(spyLoadNextSolTransactions).toHaveBeenCalledWith({
-						identity: mockIdentity,
-						minTimestamp: normalizeTimestampToSeconds(olderTimestamp),
-						token,
-						signalEnd: expect.any(Function)
-					});
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
+			});
+
+			solTokens.forEach(([token]) => {
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					minTimestamp: normalizeTimestampToSeconds(olderTimestamp),
+					token,
+					signalEnd: expect.any(Function)
 				});
 			});
 		});
 
-		it('should run one follow-up pass for changes landing mid-pass, not one pass each', async () => {
-			let releaseFirstPass: (() => void) | undefined;
-
-			const firstPass = new Promise<void>((resolve) => {
-				releaseFirstPass = resolve;
-			});
-
-			spyLoadNextSolTransactions.mockImplementation(async () => {
-				await firstPass;
-
-				return { success: false };
-			});
-
+		// The rows levelling pages in usually reach past the floor. Treating them as a new floor would
+		// set every token off again, and again, until each had loaded its whole history.
+		it('should not level again for rows that levelling itself paged in', async () => {
 			const { rerender } = render(AllTransactionsLoader, { props });
 
 			await waitFor(() => {
 				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
 			});
 
-			await rerender({
-				transactions: [
-					...mockTransactions,
-					solRow({ token: mockSplToken, timestamp: mockMaxTimestamp })
-				]
-			});
-			await rerender({
-				transactions: [
-					...mockTransactions,
-					solRow({ token: mockSplToken, timestamp: mockMaxTimestamp + 1n })
-				]
-			});
+			spyLoadNextSolTransactions.mockClear();
+			spyLoadNextIcTransactions.mockClear();
 
-			expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
+			const overshoot = arrive({ token: SOLANA_TOKEN, timestamp: mockMinTimestampStart - 1n });
 
-			releaseFirstPass?.();
+			await rerender({ transactions: [...mockTransactions, overshoot] });
+
+			await settle();
+
+			expect(spyLoadNextSolTransactions).not.toHaveBeenCalled();
+			expect(spyLoadNextIcTransactions).not.toHaveBeenCalled();
+		});
+
+		it('should stop levelling a token at the page cap', async () => {
+			// A loader that keeps reporting progress without its oldest transaction ever moving.
+			spyLoadNextSolTransactions.mockResolvedValue({ success: true });
+
+			render(AllTransactionsLoader, { props });
 
 			await waitFor(() => {
-				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length * 2);
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(
+					solTokens.length * ACTIVITY_LEVELLING_MAX_PAGES
+				);
 			});
 
-			await new Promise((resolve) => setTimeout(resolve, 0));
+			await settle();
 
-			expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length * 2);
+			expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(
+				solTokens.length * ACTIVITY_LEVELLING_MAX_PAGES
+			);
 		});
 	});
 

--- a/src/frontend/src/tests/lib/components/transactions/AllTransactionsLoader.spec.ts
+++ b/src/frontend/src/tests/lib/components/transactions/AllTransactionsLoader.spec.ts
@@ -490,6 +490,128 @@ describe('AllTransactionsLoader', () => {
 		});
 	});
 
+	// A cold start, e.g. an incognito window: no IndexedDB cache, so every token arrives on its own
+	// first network page and the loaded set keeps changing after the first levelling pass.
+	describe('when the loaded set changes after the first pass', () => {
+		const solRow = ({
+			token,
+			timestamp
+		}: {
+			token: Token;
+			timestamp: bigint;
+		}): AllTransactionUiWithCmp => ({
+			transaction: { ...createMockSolTransactionsUi(1)[0], id: `late-${timestamp}`, timestamp },
+			component: 'solana' as const,
+			token
+		});
+
+		beforeEach(() => {
+			spyLoadNextIcTransactions.mockResolvedValue({ success: false });
+			spyLoadNextSolTransactions.mockResolvedValue({ success: false });
+		});
+
+		it('should level a token whose first page arrived after the first pass', async () => {
+			const { rerender } = render(AllTransactionsLoader, { props });
+
+			await waitFor(() => {
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
+			});
+
+			spyLoadNextSolTransactions.mockClear();
+
+			await rerender({
+				transactions: [
+					...mockTransactions,
+					solRow({ token: mockSplToken, timestamp: mockMaxTimestamp })
+				]
+			});
+
+			await waitFor(() => {
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledWith({
+					identity: mockIdentity,
+					minTimestamp: mockMinTimestamp,
+					token: mockSplToken,
+					signalEnd: expect.any(Function)
+				});
+			});
+		});
+
+		it('should level every token down to an older row that arrived after the first pass', async () => {
+			const { rerender } = render(AllTransactionsLoader, { props });
+
+			await waitFor(() => {
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
+			});
+
+			spyLoadNextSolTransactions.mockClear();
+
+			const olderTimestamp = mockMinTimestampStart - 1n;
+
+			await rerender({
+				transactions: [
+					...mockTransactions,
+					solRow({ token: mockSplDefaultToken, timestamp: olderTimestamp })
+				]
+			});
+
+			await waitFor(() => {
+				solTokens.forEach(([token]) => {
+					expect(spyLoadNextSolTransactions).toHaveBeenCalledWith({
+						identity: mockIdentity,
+						minTimestamp: normalizeTimestampToSeconds(olderTimestamp),
+						token,
+						signalEnd: expect.any(Function)
+					});
+				});
+			});
+		});
+
+		it('should run one follow-up pass for changes landing mid-pass, not one pass each', async () => {
+			let releaseFirstPass: (() => void) | undefined;
+
+			const firstPass = new Promise<void>((resolve) => {
+				releaseFirstPass = resolve;
+			});
+
+			spyLoadNextSolTransactions.mockImplementation(async () => {
+				await firstPass;
+
+				return { success: false };
+			});
+
+			const { rerender } = render(AllTransactionsLoader, { props });
+
+			await waitFor(() => {
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
+			});
+
+			await rerender({
+				transactions: [
+					...mockTransactions,
+					solRow({ token: mockSplToken, timestamp: mockMaxTimestamp })
+				]
+			});
+			await rerender({
+				transactions: [
+					...mockTransactions,
+					solRow({ token: mockSplToken, timestamp: mockMaxTimestamp + 1n })
+				]
+			});
+
+			expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length);
+
+			releaseFirstPass?.();
+
+			await waitFor(() => {
+				expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length * 2);
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(spyLoadNextSolTransactions).toHaveBeenCalledTimes(solTokens.length * 2);
+		});
+	});
+
 	describe('load more', () => {
 		interface LoaderControls {
 			loadMore: () => Promise<boolean>;


### PR DESCRIPTION
# Motivation

On a cold start (an incognito window, or right after logging out, which clears the IndexedDB cache) the Activity list can show one side of a Solana swap and not the other. Reported case: "Swap USDC to RAY" showed only the +RAY row, and the USDC row appeared only after opening the USDC token page.

`AllTransactionsLoader` levels every token down to the oldest row on screen, but only once, when the stores first report loaded. Without a cache the stores keep filling after that: a token with little history (RAY) can bring in a row from months ago while a busier one (USDC) holds only its first, recent page, or nothing yet. Nothing levelled again, and the scroll reveals rows already in memory without asking for more, so the gap stayed on screen. With a warm cache the stores already hold that history on mount, which is why it did not reproduce in a normal browser, and why opening the token page "fixed" it for good.

# Changes

- Level each token when its first rows arrive, not only once after mount. At most once per token, so levelling cannot feed itself.
- One floor, `levelFloor`: set from the oldest row when levelling first runs, deepened by `loadMore`, and lowered only by a late token that brings older rows. Rows a token pages in while being levelled never move it; if they did, each run would overshoot the floor and set every token off again until all of them had loaded their whole history.
- Runs for the same token are chained, never concurrent, so they cannot fetch the same page twice.
- Cap a levelling run at `ACTIVITY_LEVELLING_MAX_PAGES` (50) pages per token. The old `while (await pageToken(...))` had no bound, so a loader reporting progress without its oldest transaction moving spun forever.

# Tests

- New specs: a late token is levelled to the floor and nothing else is; a late token with older rows lowers the floor for every token; rows levelling itself paged in trigger nothing; a token that never stops reporting progress stops at the cap.
- On main the late-token spec fails and the cap spec never ends (the vitest worker dies). All pass here.
- `npm run test` (1097 files), `npm run check`, `npm run check:tests`, prettier and eslint on the changed files are clean.