### PR TITLE
fix(frontend): re-arm the infinite scroll when it is re-enabled

### DIFF
--- a/src/frontend/src/lib/components/transactions/AllTransactionsScroll.svelte
+++ b/src/frontend/src/lib/components/transactions/AllTransactionsScroll.svelte
@@ -54,18 +54,20 @@
 
 	let disableInfiniteScroll = $derived(everythingLoadedIsOnScreen && !canFetchMore);
 
-	const onIntersect = async () => {
+	// Resolves whether it made progress, so `InfiniteScroll` checks the end of the list again even when
+	// a filter keeps the displayed list from growing.
+	const onIntersect = async (): Promise<boolean> => {
 		// Still revealing what is already in memory.
 		if (!everythingLoadedIsOnScreen) {
 			pages++;
 
-			return;
+			return true;
 		}
 
 		// The user reached the end of the loaded set, so go get more from the chains themselves.
 		// Without this the list stopped at whatever the initial levelling pass had fetched.
 		if (isNullish(onLoadMore) || !canFetchMore || loading) {
-			return;
+			return false;
 		}
 
 		const lengthBeforeFetch = sortedTransactions.length;
@@ -86,12 +88,14 @@
 		if (loadedMore) {
 			pages++;
 
-			return;
+			return true;
 		}
 
 		// Nothing loaded. Stop asking until the list grows again, otherwise the observer would keep
 		// firing against chains that have nothing left.
 		dryAtLength = lengthBeforeFetch;
+
+		return false;
 	};
 
 	$effect(() => {

--- a/src/frontend/src/lib/components/ui/InfiniteScroll.svelte
+++ b/src/frontend/src/lib/components/ui/InfiniteScroll.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
-	import { onDestroy, type Snippet } from 'svelte';
+	import { onDestroy, type Snippet, tick } from 'svelte';
 
 	interface Props {
-		onIntersect: () => Promise<void>;
+		/**
+		 * Resolve `true` when the call made progress the list's height may not show, such as history
+		 * loaded behind a filter, so the end of the list is checked again.
+		 */
+		onIntersect: () => Promise<void | boolean>;
 		disabled?: boolean;
 		testId?: string;
 		options?: IntersectionObserverInit;
@@ -23,27 +27,14 @@
 
 	let intersectionTarget: HTMLDivElement | undefined;
 
-	const onIntersection = async (entries: IntersectionObserverEntry[]) => {
-		const intersecting: IntersectionObserverEntry | undefined = entries.find(
-			({ isIntersecting }: IntersectionObserverEntry) => isIntersecting
-		);
+	let busy = false;
 
-		if (isNullish(intersecting)) {
-			return;
-		}
-
-		await onIntersect();
-	};
-
-	// svelte-ignore state_referenced_locally
-	const observer: IntersectionObserver = new IntersectionObserver(onIntersection, options);
-
-	// Re-armed from scratch on every change rather than only re-observed: `observe` on a target the
-	// observer already holds is a no-op, so an intersection that never ended is never reported again.
-	// A list re-enabled while its end sat on screen (a fetch that came back empty, then new rows
-	// arriving) therefore stopped loading until the user scrolled away and back. Disconnecting first
-	// makes the browser deliver a fresh initial entry.
-	$effect(() => {
+	// The browser only reports a change of intersection, and `observe` on a target the observer
+	// already holds is a no-op. So while the end of the list stays on screen, which on a tall window
+	// is the case after revealing one more page, nothing is ever reported again and the list stops
+	// until the user scrolls away and back. Disconnecting first makes the browser deliver a fresh
+	// initial entry.
+	const arm = () => {
 		observer.disconnect();
 
 		if (isNullish(intersectionTarget) || disabled) {
@@ -51,7 +42,43 @@
 		}
 
 		observer.observe(intersectionTarget);
-	});
+	};
+
+	const onIntersection = async (entries: IntersectionObserverEntry[]) => {
+		const intersecting: IntersectionObserverEntry | undefined = entries.find(
+			({ isIntersecting }: IntersectionObserverEntry) => isIntersecting
+		);
+
+		if (isNullish(intersecting) || busy) {
+			return;
+		}
+
+		busy = true;
+
+		const endBefore = intersectionTarget?.offsetTop;
+
+		let progressed = false;
+
+		try {
+			progressed = (await onIntersect()) === true;
+			await tick();
+		} finally {
+			busy = false;
+		}
+
+		// Re-armed only after progress: the end of the list moved, or the caller says it loaded more.
+		// That keeps loading while there is more to show and the end is still on screen, and cannot
+		// spin: a call that changed nothing is not asked again until the user scrolls or the list is
+		// re-enabled.
+		if (progressed || intersectionTarget?.offsetTop !== endBefore) {
+			arm();
+		}
+	};
+
+	// svelte-ignore state_referenced_locally
+	const observer: IntersectionObserver = new IntersectionObserver(onIntersection, options);
+
+	$effect(arm);
 
 	onDestroy(() => observer.disconnect());
 </script>

--- a/src/frontend/src/lib/components/ui/InfiniteScroll.svelte
+++ b/src/frontend/src/lib/components/ui/InfiniteScroll.svelte
@@ -38,28 +38,15 @@
 	// svelte-ignore state_referenced_locally
 	const observer: IntersectionObserver = new IntersectionObserver(onIntersection, options);
 
-	// Svelte workaround: beforeUpdate is called twice when bindings are used -> https://github.com/sveltejs/svelte/issues/6016
-	let skipContainerNextUpdate = false;
-
-	// We disconnect previous observer before any update. We do want to trigger an intersection in case of layout shifting.
-	$effect.pre(() => {
-		if (!skipContainerNextUpdate) {
-			observer.disconnect();
-		}
-
-		skipContainerNextUpdate = isNullish(intersectionTarget);
-	});
-
+	// Re-armed from scratch on every change rather than only re-observed: `observe` on a target the
+	// observer already holds is a no-op, so an intersection that never ended is never reported again.
+	// A list re-enabled while its end sat on screen (a fetch that came back empty, then new rows
+	// arriving) therefore stopped loading until the user scrolled away and back. Disconnecting first
+	// makes the browser deliver a fresh initial entry.
 	$effect(() => {
-		// The DOM has been updated. We reset the observer to the current last HTML element of the infinite list.
+		observer.disconnect();
 
-		// If no element to observe
-		if (isNullish(intersectionTarget)) {
-			return;
-		}
-
-		// If the infinite scroll is disabled, no observation should happen
-		if (disabled) {
+		if (isNullish(intersectionTarget) || disabled) {
 			return;
 		}
 

--- a/src/frontend/src/tests/lib/components/ui/InfiniteScroll.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/InfiniteScroll.spec.ts
@@ -116,6 +116,32 @@ describe('InfiniteScroll', () => {
 		expect(getObserver().observe).not.toHaveBeenCalled();
 	});
 
+	// `observe` on a target already observed is a no-op in the browser, so re-enabling must disconnect
+	// first or an intersection still under way is never reported again.
+	it('should re-arm the observer from scratch when re-enabled', async () => {
+		const { rerender } = render(InfiniteScroll, {
+			onIntersect: vi.fn(),
+			children: mockSnippet
+		});
+
+		const observer = getObserver();
+
+		await waitFor(() => expect(observer.observe).toHaveBeenCalledOnce());
+
+		await rerender({ disabled: true });
+		await rerender({ disabled: false });
+
+		expect(observer.observe).toHaveBeenCalledTimes(2);
+
+		const [firstObserve, secondObserve] = observer.observe.mock.invocationCallOrder;
+
+		expect(
+			observer.disconnect.mock.invocationCallOrder.some(
+				(order) => order > firstObserve && order < secondObserve
+			)
+		).toBeTruthy();
+	});
+
 	it('should call onIntersect only when an observed entry intersects', async () => {
 		const onIntersect = vi.fn<() => Promise<void>>(() => Promise.resolve());
 

--- a/src/frontend/src/tests/lib/components/ui/InfiniteScroll.spec.ts
+++ b/src/frontend/src/tests/lib/components/ui/InfiniteScroll.spec.ts
@@ -71,10 +71,20 @@ const getObserver = (): ControlledIntersectionObserver => {
 };
 
 describe('InfiniteScroll', () => {
+	// jsdom lays nothing out, so every `offsetTop` is 0. Tests move the end of the list by hand.
+	let endOfListTop = 0;
+	const originalOffsetTop = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetTop');
+
 	beforeEach(() => {
 		ControlledIntersectionObserver.instances = [];
 
 		vi.stubGlobal('IntersectionObserver', ControlledIntersectionObserver);
+
+		endOfListTop = 0;
+		Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
+			configurable: true,
+			get: () => endOfListTop
+		});
 	});
 
 	afterEach(() => {
@@ -82,6 +92,10 @@ describe('InfiniteScroll', () => {
 
 		vi.unstubAllGlobals();
 		vi.clearAllMocks();
+
+		if (originalOffsetTop) {
+			Object.defineProperty(HTMLElement.prototype, 'offsetTop', originalOffsetTop);
+		}
 	});
 
 	it('should render children and observe the intersection target', async () => {
@@ -140,6 +154,90 @@ describe('InfiniteScroll', () => {
 				(order) => order > firstObserve && order < secondObserve
 			)
 		).toBeTruthy();
+	});
+
+	// On a tall window the end of the list is still on screen after one more page is revealed, and
+	// the browser reports nothing new for an intersection that never ended.
+	it('should re-arm after a call that grew the list', async () => {
+		const onIntersect = vi.fn<() => Promise<void>>(() => {
+			endOfListTop += 100;
+
+			return Promise.resolve();
+		});
+
+		render(InfiniteScroll, { onIntersect, children: mockSnippet });
+
+		const observer = getObserver();
+
+		await waitFor(() => expect(observer.observe).toHaveBeenCalledOnce());
+
+		observer.trigger([{ isIntersecting: true }]);
+
+		await waitFor(() => expect(observer.observe).toHaveBeenCalledTimes(2));
+
+		const [firstObserve, secondObserve] = observer.observe.mock.invocationCallOrder;
+
+		expect(
+			observer.disconnect.mock.invocationCallOrder.some(
+				(order) => order > firstObserve && order < secondObserve
+			)
+		).toBeTruthy();
+	});
+
+	it('should not re-arm after a call that changed nothing', async () => {
+		const onIntersect = vi.fn<() => Promise<void>>(() => Promise.resolve());
+
+		render(InfiniteScroll, { onIntersect, children: mockSnippet });
+
+		const observer = getObserver();
+
+		await waitFor(() => expect(observer.observe).toHaveBeenCalledOnce());
+
+		observer.trigger([{ isIntersecting: true }]);
+
+		await waitFor(() => expect(onIntersect).toHaveBeenCalledOnce());
+		await tick();
+
+		expect(observer.observe).toHaveBeenCalledOnce();
+	});
+
+	// History loaded behind a filter leaves the displayed list as long as it was.
+	it('should re-arm after a call that reported progress, even if the list did not move', async () => {
+		const onIntersect = vi.fn<() => Promise<boolean>>(() => Promise.resolve(true));
+
+		render(InfiniteScroll, { onIntersect, children: mockSnippet });
+
+		const observer = getObserver();
+
+		await waitFor(() => expect(observer.observe).toHaveBeenCalledOnce());
+
+		observer.trigger([{ isIntersecting: true }]);
+
+		await waitFor(() => expect(observer.observe).toHaveBeenCalledTimes(2));
+	});
+
+	it('should ignore intersections while a call is still running', async () => {
+		let finish: (() => void) | undefined;
+
+		const onIntersect = vi.fn<() => Promise<void>>(
+			() =>
+				new Promise<void>((resolve) => {
+					finish = resolve;
+				})
+		);
+
+		render(InfiniteScroll, { onIntersect, children: mockSnippet });
+
+		const observer = getObserver();
+
+		await waitFor(() => expect(observer.observe).toHaveBeenCalledOnce());
+
+		observer.trigger([{ isIntersecting: true }]);
+		observer.trigger([{ isIntersecting: true }]);
+
+		expect(onIntersect).toHaveBeenCalledOnce();
+
+		finish?.();
 	});
 
 	it('should call onIntersect only when an observed entry intersects', async () => {


### PR DESCRIPTION
# Motivation

Scrolling the Activity list to the bottom could stop loading older transactions until the user scrolled away and back. Reproduced on fe2: on a tall window the list stayed at two pages, and each scroll away and back revealed exactly one more page.

The browser only reports a change of intersection, and `observe` on a target the observer already holds is a no-op. `InfiniteScroll` never re-armed its observer: the `$effect.pre` meant to disconnect it before every update reads no reactive state, so it only ran at mount. So while the end of the list stays inside the viewport (plus the 300px margin) after a page is revealed or loaded, nothing is reported again. The same happens when the list is disabled after a fetch that came back empty and re-enabled with the end still on screen.

# Changes

- Re-arm (disconnect, then observe) whenever `disabled` changes, so the browser delivers a fresh initial entry.
- After each call, re-arm only if it made progress: the end of the list moved, or the call resolved `true`. A call that changed nothing is not asked again until the user scrolls or the list is re-enabled, so it cannot spin.
- Ignore intersections while a call is still running.
- `AllTransactionsScroll` resolves `true` when it revealed a page or the loader reported new history, which covers history loaded behind a filter that leaves the displayed list the same length.
- Drop the dead `$effect.pre` and its `skipContainerNextUpdate` workaround.

Applies to every list using `InfiniteScroll`: Activity and the SOL, ICP and ETH token pages. Those three return nothing, so they re-arm only when their list actually grew.

# Tests

- New specs: re-arm when re-enabled, re-arm after a call that grew the list, re-arm after a call that reported progress, no re-arm after a call that changed nothing, intersections ignored while a call runs. The growth and busy specs fail on the previous version.
- The 34 spec files of `InfiniteScroll` and its consumers, `npm run test` (1097 files), `npm run check`, `npm run check:tests`, prettier and eslint on the changed files are clean.