### PR TITLE
test(frontend): pin the Solana wallet sync before it moves to one worker per network

### DIFF
--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -15,10 +15,13 @@ import { SolanaNetworks } from '$sol/types/network';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
-import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
+import {
+	createMockSolTransactionUi,
+	createMockSolTransactionsUi
+} from '$tests/mocks/sol-transactions.mock';
 import { mockAtaAddress, mockSolAddress, mockSolAddress2 } from '$tests/mocks/sol.mock';
 import type { TestUtil } from '$tests/types/utils';
-import { jsonReplacer, nonNullish } from '@dfinity/utils';
+import { jsonReplacer, jsonReviver, nonNullish } from '@dfinity/utils';
 import { lamports } from '@solana/kit';
 import type { MockInstance } from 'vitest';
 
@@ -656,6 +659,173 @@ describe('sol-wallet.scheduler', () => {
 				tokenId: { SplDevnet: DEVNET_USDC_TOKEN.address },
 				transactions: [correctedTransaction, correctedSameSignatureTransaction]
 			});
+		});
+	});
+
+	describe('delta sync', () => {
+		const solMainnetData: PostMessageDataRequestSol = {
+			address: {
+				certified: false,
+				data: mockSolAddress
+			},
+			solanaNetwork: SolanaNetworks.mainnet
+		};
+
+		const solDevnetData: PostMessageDataRequestSol = {
+			...solMainnetData,
+			solanaNetwork: SolanaNetworks.devnet
+		};
+
+		const splDevnetData: PostMessageDataRequestSol = {
+			...solDevnetData,
+			tokenAddress: DEVNET_USDC_TOKEN.address,
+			tokenOwnerAddress: DEVNET_USDC_TOKEN.owner
+		};
+
+		const toCertified = (transactions: SolTransactionUi[]) =>
+			transactions.map((transaction) => ({ data: transaction, certified: false }));
+
+		const walletPosts = () =>
+			postMessageMock.mock.calls
+				.map(([message]) => message)
+				.filter(({ msg }) => msg === 'syncSolWallet');
+
+		const postedTransactions = (post: { data: { wallet: { newTransactions: string } } }) =>
+			JSON.parse(post.data.wallet.newTransactions, jsonReviver);
+
+		let scheduler: SolWalletScheduler;
+
+		beforeEach(() => {
+			// Other describes leave their own backend responses behind; start every case from an empty backend.
+			vi.mocked(loadSolUserTransactions).mockResolvedValue(undefined);
+
+			scheduler = new SolWalletScheduler();
+		});
+
+		afterEach(() => {
+			scheduler.stop();
+		});
+
+		it('should post the stored records together with the RPC records on the initial sync', async () => {
+			const storedTransactions = ['stored-1', 'stored-2'].map((id) => ({
+				...createMockSolTransactionUi(id),
+				summary: { kind: 'send' as const }
+			}));
+
+			vi.mocked(loadSolUserTransactions).mockResolvedValue({
+				transactions: storedTransactions,
+				newestBlockIndex: 100n,
+				oldestBlockIndex: 50n,
+				nextStart: undefined,
+				totalStored: 2n
+			});
+
+			await scheduler.trigger(solMainnetData);
+
+			const posts = walletPosts();
+
+			expect(posts).toHaveLength(1);
+			expect(postedTransactions(posts[0])).toEqual(
+				toCertified([...mockSolTransactions, ...storedTransactions])
+			);
+		});
+
+		it('should post only the new transactions on a later sync', async () => {
+			await scheduler.trigger(solMainnetData);
+
+			const newTransaction = createMockSolTransactionUi('txn-new');
+			spyLoadTransactions.mockResolvedValue([newTransaction, ...mockSolTransactions]);
+			postMessageMock.mockClear();
+
+			await scheduler.trigger(solMainnetData);
+
+			const posts = walletPosts();
+
+			expect(posts).toHaveLength(1);
+			expect(postedTransactions(posts[0])).toEqual(toCertified([newTransaction]));
+		});
+
+		it('should not post when the RPC returns only known transactions and the balance is unchanged', async () => {
+			await scheduler.trigger(solMainnetData);
+
+			postMessageMock.mockClear();
+
+			await scheduler.trigger(solMainnetData);
+
+			expect(walletPosts()).toHaveLength(0);
+		});
+
+		it('should post the balance with no transactions when only the balance changed', async () => {
+			await scheduler.trigger(solMainnetData);
+
+			spyLoadSolBalance.mockResolvedValue(lamports(200n));
+			postMessageMock.mockClear();
+
+			await scheduler.trigger(solMainnetData);
+
+			const posts = walletPosts();
+
+			expect(posts).toHaveLength(1);
+			expect(posts[0].data.wallet.balance).toEqual({ data: lamports(200n), certified: false });
+			expect(postedTransactions(posts[0])).toEqual([]);
+		});
+
+		it('should reset the store when triggered for another token', async () => {
+			await scheduler.trigger(solMainnetData);
+
+			const splTransaction = createMockSolTransactionUi('spl-1');
+			spyLoadTransactions.mockResolvedValue([splTransaction]);
+			postMessageMock.mockClear();
+			vi.mocked(loadSolUserTransactions).mockClear();
+
+			await scheduler.trigger(splDevnetData);
+
+			// A fresh store makes this the initial sync of the new token, so the backend is read again.
+			expect(loadSolUserTransactions).toHaveBeenCalledOnce();
+			expect(scheduler['store'].transactions).toEqual({
+				[splTransaction.id]: { data: splTransaction, certified: false }
+			});
+
+			const posts = walletPosts();
+
+			expect(posts).toHaveLength(1);
+			expect(posts[0].ref).toBe(`${DEVNET_USDC_TOKEN.address}-${SolanaNetworks.devnet}`);
+			expect(postedTransactions(posts[0])).toEqual(toCertified([splTransaction]));
+		});
+
+		it('should reset the store when triggered for the same token on another network', async () => {
+			await scheduler.trigger(solMainnetData);
+
+			postMessageMock.mockClear();
+
+			await scheduler.trigger(solDevnetData);
+
+			const posts = walletPosts();
+
+			// Same balance and same RPC records: only the reset makes them count as new again.
+			expect(posts).toHaveLength(1);
+			expect(posts[0].ref).toBe(`${SOLANA_TOKEN.symbol}-${SolanaNetworks.devnet}`);
+			expect(postedTransactions(posts[0])).toEqual(expectedSoLTransactions);
+		});
+
+		it('should reset the store when started again for another token', async () => {
+			await scheduler.start(solMainnetData);
+
+			await awaitJobExecution();
+
+			scheduler.stop();
+
+			postMessageMock.mockClear();
+
+			await scheduler.start(solDevnetData);
+
+			await awaitJobExecution();
+
+			const posts = walletPosts();
+
+			expect(posts).toHaveLength(1);
+			expect(posts[0].ref).toBe(`${SOLANA_TOKEN.symbol}-${SolanaNetworks.devnet}`);
+			expect(postedTransactions(posts[0])).toEqual(expectedSoLTransactions);
 		});
 	});
 });

--- a/src/frontend/src/tests/sol/services/sol-listener.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-listener.services.spec.ts
@@ -2,7 +2,10 @@ import { balancesStore } from '$lib/stores/balances.store';
 import type { TokenId } from '$lib/types/token';
 import { parseTokenId } from '$lib/validation/token.validation';
 import { syncWallet, syncWalletError } from '$sol/services/sol-listener.services';
-import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
+import {
+	solTransactionsStore,
+	type SolCertifiedTransaction
+} from '$sol/stores/sol-transactions.store';
 import type { SolBalance } from '$sol/types/sol-balance';
 import type { SolPostMessageDataResponseWallet } from '$sol/types/sol-post-message';
 import { mockSolCertifiedTransactions } from '$tests/mocks/sol-transactions.mock';
@@ -72,6 +75,56 @@ describe('sol-listener.services', () => {
 				const transactions = get(solTransactionsStore);
 
 				expect(transactions?.[tokenId]).toEqual(mockSolCertifiedTransactions);
+			});
+
+			// Older builds stored one row per instruction (`<signature>-<index>`); the current worker
+			// emits one record per signature, so those rows must go once the record arrives.
+			describe('stale per-instruction rows', () => {
+				const [{ data: baseTransaction }, otherTransaction] = mockSolCertifiedTransactions;
+				const signature = String(baseTransaction.signature);
+
+				const toCertified = (id: string): SolCertifiedTransaction => ({
+					data: { ...baseTransaction, id },
+					certified: false
+				});
+
+				const instructionRows = [toCertified(`${signature}-0`), toCertified(`${signature}-1`)];
+				const record = toCertified(signature);
+
+				const syncTransactions = (transactions: SolCertifiedTransaction[]) =>
+					syncWallet({
+						data: mockPostMessage({
+							newTransactions: JSON.stringify(transactions, jsonReplacer)
+						}),
+						tokenId
+					});
+
+				it('should replace the per-instruction rows of a signature with its record', () => {
+					solTransactionsStore.set({ tokenId, transactions: instructionRows });
+
+					syncTransactions([record]);
+
+					expect(get(solTransactionsStore)?.[tokenId]).toEqual([record]);
+				});
+
+				it('should keep the rows of other signatures', () => {
+					solTransactionsStore.set({
+						tokenId,
+						transactions: [...instructionRows, otherTransaction]
+					});
+
+					syncTransactions([record]);
+
+					expect(get(solTransactionsStore)?.[tokenId]).toEqual([record, otherTransaction]);
+				});
+
+				it('should not duplicate a record re-sent with the same id', () => {
+					solTransactionsStore.set({ tokenId, transactions: [record, otherTransaction] });
+
+					syncTransactions([record]);
+
+					expect(get(solTransactionsStore)?.[tokenId]).toEqual([record, otherTransaction]);
+				});
 			});
 		});
 

--- a/src/frontend/src/tests/sol/services/worker.sol-wallet.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/worker.sol-wallet.services.spec.ts
@@ -1,0 +1,193 @@
+import { SOLANA_DEVNET_TOKEN, SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
+import { AppWorker } from '$lib/services/_worker.services';
+import { solAddressDevnetStore, solAddressMainnetStore } from '$lib/stores/address.store';
+import {
+	syncWallet,
+	syncWalletError,
+	syncWalletFromCache
+} from '$sol/services/sol-listener.services';
+import { SolWalletWorker } from '$sol/services/worker.sol-wallet.services';
+import { SolanaNetworks } from '$sol/types/network';
+import { mockSolAddress, mockSplAddress } from '$tests/mocks/sol.mock';
+import { mockValidSplToken } from '$tests/mocks/spl-tokens.mock';
+
+vi.mock('$sol/services/sol-listener.services', () => ({
+	syncWallet: vi.fn(),
+	syncWalletError: vi.fn(),
+	syncWalletFromCache: vi.fn()
+}));
+
+// A single realm puts every token on the same pooled worker, so the `ref` filter is the only thing
+// keeping one token's messages out of another token's stores.
+vi.mock('$lib/utils/device.utils', async (importActual) => ({
+	...(await importActual()),
+	workerPoolSize: () => 1
+}));
+
+const postMessageSpy = vi.fn();
+
+type Listener = (event: MessageEvent) => void;
+
+class MockWorker {
+	postMessage = postMessageSpy;
+	onmessage: Listener | null = null;
+	terminate: () => void = vi.fn();
+	// Pooled wrappers each register their own listener on the shared worker, so keep all of them.
+	listeners = new Set<Listener>();
+	addEventListener = vi.fn((...args: [string, Listener]) => {
+		const [, listener] = args;
+		this.listeners.add(listener);
+	});
+	removeEventListener = vi.fn((...args: [string, Listener]) => {
+		const [, listener] = args;
+		this.listeners.delete(listener);
+	});
+	emit = (data: unknown) => {
+		this.listeners.forEach((listener) => listener({ data } as MessageEvent));
+	};
+}
+
+let workerInstance: MockWorker;
+
+vi.mock('$lib/workers/workers?worker', () => {
+	class MockWorkers {
+		constructor() {
+			workerInstance = new MockWorker();
+			return workerInstance;
+		}
+	}
+
+	return {
+		default: MockWorkers
+	};
+});
+
+const mockId = 'abcdefgh';
+
+vi.stubGlobal('crypto', {
+	randomUUID: vi.fn().mockReturnValue(mockId)
+});
+
+describe('worker.sol-wallet.services', () => {
+	describe('SolWalletWorker', () => {
+		const solMainnetRef = 'SOL-mainnet';
+		const splMainnetRef = `${mockSplAddress}-mainnet`;
+
+		const mockWalletData = { wallet: { balance: { data: 1000n, certified: false } } };
+
+		beforeEach(() => {
+			vi.clearAllMocks();
+			AppWorker.resetForTesting();
+
+			solAddressMainnetStore.set({ data: mockSolAddress, certified: true });
+			solAddressDevnetStore.set({ data: mockSolAddress, certified: true });
+		});
+
+		it('should sync the token from the IDB cache on init', async () => {
+			await SolWalletWorker.init({ token: SOLANA_TOKEN });
+
+			expect(syncWalletFromCache).toHaveBeenCalledExactlyOnceWith({
+				tokenId: SOLANA_TOKEN.id,
+				networkId: SOLANA_TOKEN.network.id
+			});
+		});
+
+		it.each([
+			{ name: 'native SOL on mainnet', token: SOLANA_TOKEN, poolKey: solMainnetRef },
+			{ name: 'native SOL on devnet', token: SOLANA_DEVNET_TOKEN, poolKey: 'SOL-devnet' },
+			{ name: 'an SPL token', token: mockValidSplToken, poolKey: splMainnetRef }
+		])(
+			'should get a pooled worker keyed by token and network for $name',
+			async ({ token, poolKey }) => {
+				const spy = vi.spyOn(AppWorker, 'getInstance');
+
+				await SolWalletWorker.init({ token });
+
+				expect(spy).toHaveBeenCalledExactlyOnceWith({ pooled: true, poolKey });
+			}
+		);
+
+		// The worker queue holds back further messages until the realm acks, which the mock never does,
+		// so each message gets its own test.
+		it.each([
+			{ action: 'start', msg: 'startSolWalletTimer' },
+			{ action: 'trigger', msg: 'triggerSolWalletTimer' },
+			{ action: 'stop', msg: 'stopSolWalletTimer' }
+		] as const)('should post $msg with the token data on $action', async ({ action, msg }) => {
+			const worker = await SolWalletWorker.init({ token: mockValidSplToken });
+
+			worker[action]();
+
+			expect(postMessageSpy).toHaveBeenCalledExactlyOnceWith({
+				msg,
+				workerId: mockId,
+				data: {
+					address: { data: mockSolAddress, certified: true },
+					solanaNetwork: SolanaNetworks.mainnet,
+					tokenAddress: mockValidSplToken.address,
+					tokenOwnerAddress: mockValidSplToken.owner
+				}
+			});
+		});
+
+		describe('onmessage', () => {
+			beforeEach(async () => {
+				await SolWalletWorker.init({ token: SOLANA_TOKEN });
+			});
+
+			// The scheduler's status messages carry no ref, so they must never reach the wallet stores.
+			it('should ignore a message without a ref', () => {
+				workerInstance.emit({ msg: 'syncSolWallet', data: mockWalletData });
+
+				expect(syncWallet).not.toHaveBeenCalled();
+			});
+
+			it('should ignore a message whose ref belongs to another token', () => {
+				workerInstance.emit({ ref: splMainnetRef, msg: 'syncSolWallet', data: mockWalletData });
+
+				expect(syncWallet).not.toHaveBeenCalled();
+			});
+
+			it('should ignore a message for the same token on another network', () => {
+				workerInstance.emit({ ref: 'SOL-devnet', msg: 'syncSolWallet', data: mockWalletData });
+
+				expect(syncWallet).not.toHaveBeenCalled();
+			});
+
+			it('should hand syncSolWallet to syncWallet', () => {
+				workerInstance.emit({ ref: solMainnetRef, msg: 'syncSolWallet', data: mockWalletData });
+
+				expect(syncWallet).toHaveBeenCalledExactlyOnceWith({
+					tokenId: SOLANA_TOKEN.id,
+					data: mockWalletData
+				});
+			});
+
+			it('should hand syncSolWalletError to syncWalletError with the toast hidden', () => {
+				const error = new Error('test');
+
+				workerInstance.emit({ ref: solMainnetRef, msg: 'syncSolWalletError', data: { error } });
+
+				expect(syncWalletError).toHaveBeenCalledExactlyOnceWith({
+					tokenId: SOLANA_TOKEN.id,
+					error,
+					hideToast: true
+				});
+				expect(syncWallet).not.toHaveBeenCalled();
+			});
+
+			it('should route each message only to its own token when tokens share a pooled worker', async () => {
+				await SolWalletWorker.init({ token: mockValidSplToken });
+
+				expect(workerInstance.listeners.size).toBe(2);
+
+				workerInstance.emit({ ref: splMainnetRef, msg: 'syncSolWallet', data: mockWalletData });
+
+				expect(syncWallet).toHaveBeenCalledExactlyOnceWith({
+					tokenId: mockValidSplToken.id,
+					data: mockWalletData
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
# Motivation

Spec #14012 moves Solana history from one pooled worker per token to one worker per network. These tests pin the sync behaviour that refactor has to keep, so a regression shows up red.

# Changes

- Listener: a record replaces the per-instruction rows of its signature (`<sig>-0`, `<sig>-1`), rows of other signatures survive, and a re-sent record does not duplicate.
- Scheduler: the first sync posts stored plus RPC records, later syncs post only new ones, nothing is posted when nothing changed, a balance-only change posts the balance alone, and the internal store resets on another token, another network, or a restart after stop.
- Worker (new spec): IDB cache sync on init, pool key per token and network, start/trigger/stop messages, messages for another token or network ignored, and error routing with `hideToast`.

Note for the refactor: `SchedulerTimer.start` returns early while its timer runs. That is unreachable today because the worker keeps one scheduler per token ref, but it matters once one scheduler serves a whole network.

# Tests

Tests only, no production change. 63 passing across the three specs.