### PR TITLE
test(frontend): pin how Solana records survive the backend cache

### DIFF
--- a/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
+++ b/src/frontend/src/tests/lib/utils/transactions.utils.spec.ts
@@ -15,6 +15,11 @@ import {
 } from '$env/tokens/tokens-evm/tokens-bsc/tokens.bnb.env';
 import { BONK_TOKEN, BONK_TOKEN_ID } from '$env/tokens/tokens-spl/tokens.bonk.env';
 import {
+	USDC_DECIMALS as SPL_USDC_DECIMALS,
+	USDC_TOKEN as SPL_USDC_TOKEN,
+	USDC_TOKEN_ID as SPL_USDC_TOKEN_ID
+} from '$env/tokens/tokens-spl/tokens.usdc.env';
+import {
 	BTC_MAINNET_TOKEN,
 	BTC_MAINNET_TOKEN_ID,
 	BTC_REGTEST_TOKEN,
@@ -55,6 +60,10 @@ import {
 } from '$lib/utils/transactions.utils';
 import type { SolCertifiedTransactionsData } from '$sol/stores/sol-transactions.store';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
+import {
+	mapSolTransactionToUserTransaction,
+	mapUserTransactionToSolTransaction
+} from '$sol/utils/user-transactions.utils';
 import { createMockBtcTransactionsUi } from '$tests/mocks/blockchain-transactions.mock';
 import {
 	createMockEthCertifiedTransactions,
@@ -689,6 +698,54 @@ describe('transactions.utils', () => {
 				});
 
 				expect(result).toHaveLength(2);
+			});
+
+			describe('a SOL to USDC swap restored from the backend cache', () => {
+				const usdcReceived = {
+					delta: 75_000_000n,
+					tokenAddress: SPL_USDC_TOKEN.address,
+					decimals: SPL_USDC_DECIMALS
+				};
+
+				// Shaped as the service shapes a swap: typed by its outgoing half, valued by the SOL spent.
+				const swap: SolTransactionUi = {
+					...createMockSolTransactionsUi(1)[0],
+					value: 500_000_000n,
+					type: 'send',
+					summary: { kind: 'swap', spent: { delta: -500_000_000n }, received: usdcReceived },
+					netChanges: [{ delta: -500_000_000n }, usdcReceived]
+				};
+
+				const restored = mapUserTransactionToSolTransaction({
+					transaction: mapSolTransactionToUserTransaction({ ...swap, id: String(swap.signature) }),
+					address: swap.from
+				});
+
+				// Defect: the backend cache drops the summary, so a restored swap keeps only its SOL row,
+				// and the record under USDC is a `send` of the 500_000_000n lamports spent.
+				it.fails('should keep both sides of the swap, the USDC side positive and in USDC', () => {
+					const result = mapAllTransactionsUi({
+						tokens: [SOLANA_TOKEN, SPL_USDC_TOKEN],
+						$ethTransactions: {},
+						...rest,
+						$solTransactions: {
+							[SOLANA_TOKEN_ID]: [{ data: restored, certified: false }],
+							[SPL_USDC_TOKEN_ID]: [{ data: restored, certified: false }]
+						}
+					});
+
+					expect(result.map(({ token: { symbol } }) => symbol)).toEqual([
+						SOLANA_TOKEN.symbol,
+						SPL_USDC_TOKEN.symbol
+					]);
+
+					const usdc = result.find(({ token }) => token === SPL_USDC_TOKEN);
+
+					// The row renders the net change of its own token, so that is what must survive.
+					expect((usdc?.transaction as SolTransactionUi | undefined)?.netChanges).toContainEqual(
+						usdcReceived
+					);
+				});
 			});
 
 			it('should keep all non-native transactions and only remove the native one when multiple ERC-20 transfers share the same hash', () => {

--- a/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
+++ b/src/frontend/src/tests/sol/components/transactions/SolTransaction.spec.ts
@@ -1,10 +1,20 @@
+import { USDC_DECIMALS, USDC_TOKEN } from '$env/tokens/tokens-spl/tokens.usdc.env';
 import { SOLANA_TOKEN } from '$env/tokens/tokens.sol.env';
 import { EIGHT_DECIMALS } from '$lib/constants/app.constants';
 import { formatToken, shortenWithMiddleEllipsis } from '$lib/utils/format.utils';
 import { getTokenDisplaySymbol } from '$lib/utils/token.utils';
 import SolTransaction from '$sol/components/transactions/SolTransaction.svelte';
+import type { SolInstructionSummary } from '$sol/types/sol-instruction-summary';
+import type { SolTransactionUi } from '$sol/types/sol-transaction';
+import type { SolNetBalanceChange } from '$sol/types/sol-transaction-summary';
+import { deriveSolTransactionSummary } from '$sol/utils/sol-transaction-summary.utils';
+import {
+	mapSolTransactionToUserTransaction,
+	mapUserTransactionToSolTransaction
+} from '$sol/utils/user-transactions.utils';
 import en from '$tests/mocks/i18n.mock';
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
+import { mockAtaAddress, mockSolAddress } from '$tests/mocks/sol.mock';
 import { assertNonNullish } from '@dfinity/utils';
 import { render } from '@testing-library/svelte';
 
@@ -226,6 +236,76 @@ describe('SolTransaction', () => {
 			assertNonNullish(amount);
 
 			expect(amount.textContent).toContain('-0.001005');
+		});
+	});
+
+	// One record per signature is stored under every token whose history returned it, and the
+	// backend cache keeps its value and direction but not the summary or the net changes.
+	describe('a SOL to USDC swap restored from the backend cache', () => {
+		const netChanges: SolNetBalanceChange[] = [
+			{ delta: -500_000_000n },
+			{ tokenAddress: USDC_TOKEN.address, decimals: USDC_DECIMALS, delta: 75_000_000n }
+		];
+
+		const instructions: SolInstructionSummary[] = [
+			{ kind: 'createTokenAccount', account: mockAtaAddress, rent: 2_039_280n },
+			{ kind: 'wrap', amount: 500_000_000n },
+			{ kind: 'unwrap', account: mockAtaAddress, returned: 502_039_280n }
+		];
+
+		const summary = deriveSolTransactionSummary({ netChanges, instructions });
+
+		// Shaped as the service shapes a swap: typed by its outgoing half, valued by the SOL spent.
+		const derived: SolTransactionUi = {
+			...mockTrx,
+			id: mockTrx.signature,
+			value: 500_000_000n,
+			type: 'send',
+			from: mockSolAddress,
+			to: mockSolAddress,
+			fee: 5_000n,
+			summary,
+			netChanges,
+			instructions
+		};
+
+		const restored = mapUserTransactionToSolTransaction({
+			transaction: mapSolTransactionToUserTransaction(derived),
+			address: mockSolAddress
+		});
+
+		const usdcReceived = `${formatToken({
+			value: 75_000_000n,
+			displayDecimals: EIGHT_DECIMALS,
+			unitName: USDC_DECIMALS,
+			showPlusSign: true
+		})} ${getTokenDisplaySymbol(USDC_TOKEN)}`;
+
+		const amountOf = (transaction: SolTransactionUi): string => {
+			const { container } = render(SolTransaction, {
+				props: { transaction, token: USDC_TOKEN }
+			});
+
+			const amount = container.querySelector('div.leading-5>span.justify-end');
+
+			assertNonNullish(amount);
+
+			return amount.textContent ?? '';
+		};
+
+		it('should be a swap that spent the SOL', () => {
+			expect(summary.kind).toBe('swap');
+			expect(summary.spent?.delta).toBe(-500_000_000n);
+		});
+
+		it('should show the USDC received on the USDC row while the record is fresh', () => {
+			expect(amountOf(derived)).toBe(usdcReceived);
+		});
+
+		// Defect: the restored record has no net changes, so the row falls back to the SOL lamports,
+		// negated as a send and read in USDC decimals.
+		it.fails('should still show the USDC received once restored', () => {
+			expect(amountOf(restored)).toBe(usdcReceived);
 		});
 	});
 

--- a/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
+++ b/src/frontend/src/tests/sol/schedulers/sol-wallet.scheduler.spec.ts
@@ -13,6 +13,10 @@ import {
 import * as accountServices from '$sol/services/spl-accounts.services';
 import { SolanaNetworks } from '$sol/types/network';
 import type { SolTransactionUi } from '$sol/types/sol-transaction';
+import {
+	mapSolTransactionToUserTransaction,
+	mapUserTransactionToSolTransaction
+} from '$sol/utils/user-transactions.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
@@ -539,6 +543,39 @@ describe('sol-wallet.scheduler', () => {
 			for (const tx of storedTransactions) {
 				expect(store[tx.id]).toBeUndefined();
 			}
+		});
+
+		// Current behaviour, not the goal: the backend cache keeps none of the derived fields, so a
+		// record that went through it reads as predating the summary and the worker always re-fetches.
+		it('should never short-circuit on records restored from the backend cache', async () => {
+			const [base] = createMockSolTransactionsUi(1);
+
+			const derived: SolTransactionUi = {
+				...base,
+				id: String(base.signature),
+				from: mockSolAddress,
+				summary: { kind: 'send', spent: { delta: -100n }, counterparty: mockSolAddress2 },
+				netChanges: [{ delta: -100n }]
+			};
+
+			const restored = mapUserTransactionToSolTransaction({
+				transaction: mapSolTransactionToUserTransaction(derived),
+				address: mockSolAddress
+			});
+
+			vi.mocked(loadSolUserTransactions).mockResolvedValue({
+				transactions: [restored],
+				newestBlockIndex: 100n,
+				oldestBlockIndex: 100n,
+				nextStart: undefined,
+				totalStored: 1n
+			});
+
+			await scheduler.trigger(startData);
+
+			expect(spyLoadTransactions).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ exitIfFirstSignatureMatches: undefined })
+			);
 		});
 
 		it('should still load RPC transactions when backend load fails', async () => {

--- a/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-transactions.services.spec.ts
@@ -18,11 +18,16 @@ import { solTransactionsStore } from '$sol/stores/sol-transactions.store';
 import { SolanaNetworks, type SolanaNetworkType } from '$sol/types/network';
 import type { LoadNextSolTransactionsParams } from '$sol/types/sol-api';
 import type { SolRpcTransaction, SolSignature, SolTransactionUi } from '$sol/types/sol-transaction';
+import {
+	mapSolTransactionToUserTransaction,
+	mapUserTransactionToSolTransaction
+} from '$sol/utils/user-transactions.utils';
 import { mockAuthStore } from '$tests/mocks/auth.mock';
 import { mockIdentity } from '$tests/mocks/identity.mock';
 import { mockSolSignature, mockSolSignatureResponse } from '$tests/mocks/sol-signatures.mock';
 import {
 	createMockSolTransactionsUi,
+	mockSolRpcSendTransaction,
 	mockSolTransactionDetail
 } from '$tests/mocks/sol-transactions.mock';
 import {
@@ -519,6 +524,47 @@ describe('sol-transactions.services', () => {
 			await loadNextSolTransactions(mockParams);
 
 			expect(spyGetTransactions).toHaveBeenCalledWith(
+				expect.objectContaining({ exitIfFirstSignatureMatches: undefined })
+			);
+		});
+
+		// Current behaviour, not the goal: the backend cache keeps none of the derived fields, so
+		// every record it restores reads as predating the summary and the head load always re-fetches.
+		it('should never short-circuit a head load on records restored from the backend cache', async () => {
+			vi.spyOn(solanaApi, 'fetchTransactionDetailForSignature').mockResolvedValueOnce(
+				mockSolRpcSendTransaction
+			);
+
+			const [derived] = await fetchSolTransactionsForSignature({
+				signature: {
+					...mockSolSignatureResponse(),
+					signature: mockSolRpcSendTransaction.signature
+				},
+				network: 'mainnet',
+				address: mockSolAddress
+			});
+
+			expect(derived.summary).toBeDefined();
+
+			const restored = mapUserTransactionToSolTransaction({
+				transaction: mapSolTransactionToUserTransaction(derived),
+				address: mockSolAddress
+			});
+
+			expect(restored.summary).toBeUndefined();
+
+			vi.mocked(loadSolUserTransactions).mockResolvedValue({
+				transactions: [restored],
+				newestBlockIndex: mockSolRpcSendTransaction.slot,
+				oldestBlockIndex: mockSolRpcSendTransaction.slot,
+				nextStart: undefined,
+				totalStored: 1n
+			});
+			spyGetTransactions.mockResolvedValueOnce([]);
+
+			await loadNextSolTransactions(mockParams);
+
+			expect(spyGetTransactions).toHaveBeenCalledExactlyOnceWith(
 				expect.objectContaining({ exitIfFirstSignatureMatches: undefined })
 			);
 		});

--- a/src/frontend/src/tests/sol/utils/user-transactions.utils.spec.ts
+++ b/src/frontend/src/tests/sol/utils/user-transactions.utils.spec.ts
@@ -251,6 +251,55 @@ describe('user-transactions.utils', () => {
 			expect(result.type).toBe('send');
 			expect(result.status).toBe('finalized');
 		});
+
+		// Since one record is derived per signature, its id is the signature itself, with no
+		// instruction suffix to split off.
+		describe('a record derived under its signature id', () => {
+			const derived: SolTransactionUi = {
+				...mockSolUserTransactionUi,
+				id: mockSignature,
+				status: 'confirmed',
+				summary: { kind: 'send', spent: { delta: -5000n }, counterparty: mockSolAddress2 },
+				netChanges: [{ delta: -5000n }],
+				instructions: [{ kind: 'send', amount: 5000n, counterparty: mockSolAddress2 }]
+			};
+
+			const restore = (): SolTransactionUi =>
+				mapUserTransactionToSolTransaction({
+					transaction: mapSolTransactionToUserTransaction(derived),
+					address: mockSolAddress
+				});
+
+			it('should keep its id and signature', () => {
+				const result = restore();
+
+				expect(result.id).toBe(mockSignature);
+				expect(result.signature).toEqual(signature(mockSignature));
+			});
+
+			it('should keep the fee and both owners', () => {
+				const result = restore();
+
+				expect(result.fee).toBe(derived.fee);
+				expect(result.fromOwner).toBe(derived.fromOwner);
+				expect(result.toOwner).toBe(derived.toOwner);
+			});
+
+			// Only finalized records are saved, so whatever the commitment was when it was derived,
+			// what comes back is finalized.
+			it('should come back finalized', () => {
+				expect(restore().status).toBe('finalized');
+			});
+
+			// The backend UserTransaction has no room for them: pinned so a change to that is noticed.
+			it('should come back without the summary, the net changes and the instructions', () => {
+				const result = restore();
+
+				expect(result.summary).toBeUndefined();
+				expect(result.netChanges).toBeUndefined();
+				expect(result.instructions).toBeUndefined();
+			});
+		});
 	});
 
 	describe('isSolTransactionFinalized', () => {


### PR DESCRIPTION
# Motivation

A Solana record is derived per signature and saved to the backend under every token whose history returned it, but the backend keeps only a lossy copy (no summary, no net changes, one `value`). These tests pin what that does today, as input for spec #14012.

# Changes

- F4, `it.fails`: a SOL to USDC swap restored under USDC renders `-500 USDC` on the USDC row instead of `+75 USDC`, because `value` is the spent SOL.
- F4, `it.fails`: in the Activity list the restored swap keeps a single row (`['SOL']` instead of `['SOL', 'USDC']`), so one side of it disappears.
- F3, plain tests: records restored from the backend never engage the head short-circuit (`exitIfFirstSignatureMatches` stays unset), in both `loadNextSolTransactions` and the wallet scheduler.
- Round-trip of the two mappers: id, signature, fee and owners are kept, status comes back `finalized`, summary, net changes and instructions are lost.

# Tests

Tests only, no production change. 210 passing and 2 expected fails across the five specs.