### PR TITLE
test(frontend): pin the Solana signature services before loading history by signature

### DIFF
--- a/src/frontend/src/tests/mocks/sol-signatures.mock.ts
+++ b/src/frontend/src/tests/mocks/sol-signatures.mock.ts
@@ -8,14 +8,18 @@ export const mockSolSignature = () => {
 	return signature(base58);
 };
 
-export const mockSolSignatureResponse = (): SolSignature => ({
+export const mockSolSignatureResponse = (overrides: Partial<SolSignature> = {}): SolSignature => ({
 	signature: mockSolSignature(),
 	err: null,
 	confirmationStatus: 'finalized',
 	blockTime: 1234567890n as UnixTimestamp,
 	slot: 1234567890n,
-	memo: 'Some memo'
+	memo: 'Some memo',
+	...overrides
 });
+
+export const mockSolSignatureResponsesAtSlots = (slots: bigint[]): SolSignature[] =>
+	slots.map((slot) => mockSolSignatureResponse({ slot }));
 
 export const mockSolSignatureWithErrorResponse = () => ({
 	signature: mockSolSignature(),

--- a/src/frontend/src/tests/sol/api/solana.api.spec.ts
+++ b/src/frontend/src/tests/sol/api/solana.api.spec.ts
@@ -9,6 +9,7 @@ import {
 	checkIfAccountExists,
 	estimatePriorityFee,
 	fetchSignatures,
+	fetchTransactionDetailForSignature,
 	getAccountInfo,
 	getAccountOwner,
 	getSolCreateAccountFee,
@@ -22,9 +23,12 @@ import { TOKEN_PROGRAM_ADDRESS } from '$sol/constants/sol.constants';
 import * as solRpcProviders from '$sol/providers/sol-rpc.providers';
 import { SolanaNetworks } from '$sol/types/network';
 import {
+	mockSolSignature,
 	mockSolSignatureResponse,
+	mockSolSignatureResponses,
 	mockSolSignatureWithErrorResponse
 } from '$tests/mocks/sol-signatures.mock';
+import { mockSolTransactionDetail } from '$tests/mocks/sol-transactions.mock';
 import {
 	mockAtaAddress,
 	mockSolAddress,
@@ -425,6 +429,148 @@ describe('solana.api', () => {
 			});
 
 			expect(transactions).toHaveLength(1);
+		});
+
+		it('should keep paging until it holds limit successful signatures, in order', async () => {
+			const [first, second, third, fourth] = mockSolSignatureResponses(4);
+
+			mockGetSignaturesForAddress
+				.mockReturnValueOnce({
+					send: () =>
+						Promise.resolve([
+							first,
+							mockSolSignatureWithErrorResponse(),
+							mockSolSignatureWithErrorResponse()
+						])
+				})
+				.mockReturnValueOnce({
+					send: () =>
+						Promise.resolve([
+							mockSolSignatureWithErrorResponse(),
+							second,
+							mockSolSignatureWithErrorResponse()
+						])
+				})
+				.mockReturnValueOnce({
+					send: () => Promise.resolve([third, fourth, mockSolSignatureWithErrorResponse()])
+				});
+
+			const signatures = await fetchSignatures({
+				wallet: address(mockSolAddress),
+				network: SolanaNetworks.mainnet,
+				limit: 3
+			});
+
+			expect(signatures).toEqual([first, second, third]);
+			expect(mockGetSignaturesForAddress).toHaveBeenCalledTimes(3);
+		});
+
+		it('should page on from the last fetched signature even when it errored', async () => {
+			const start = mockSolSignature();
+			const erroredLast = mockSolSignatureWithErrorResponse();
+
+			mockGetSignaturesForAddress
+				.mockReturnValueOnce({
+					send: () =>
+						Promise.resolve([mockSolSignatureResponse(), mockSolSignatureResponse(), erroredLast])
+				})
+				.mockReturnValueOnce({
+					send: () => Promise.resolve([])
+				});
+
+			await fetchSignatures({
+				wallet: address(mockSolAddress),
+				network: SolanaNetworks.mainnet,
+				before: start,
+				limit: 3
+			});
+
+			expect(mockGetSignaturesForAddress).toHaveBeenCalledTimes(2);
+			expect(mockGetSignaturesForAddress).toHaveBeenNthCalledWith(1, address(mockSolAddress), {
+				before: start,
+				limit: 3
+			});
+			expect(mockGetSignaturesForAddress).toHaveBeenNthCalledWith(2, address(mockSolAddress), {
+				before: erroredLast.signature,
+				limit: 3
+			});
+		});
+	});
+
+	describe('fetchTransactionDetailForSignature', () => {
+		let mockGetTransaction: MockInstance;
+
+		beforeEach(() => {
+			mockGetTransaction = vi.fn().mockReturnValue({
+				send: () => Promise.resolve(mockSolTransactionDetail)
+			});
+
+			const mockSolanaHttpRpc = vi.fn().mockReturnValue({
+				getTransaction: mockGetTransaction
+			});
+
+			vi.mocked(solRpcProviders.solanaHttpRpc).mockImplementation(mockSolanaHttpRpc);
+		});
+
+		it('should cache a finalized transaction per network', async () => {
+			const signature = mockSolSignatureResponse();
+
+			const first = await fetchTransactionDetailForSignature({
+				signature,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(first).toEqual({
+				...mockSolTransactionDetail,
+				confirmationStatus: 'finalized',
+				id: expect.any(String),
+				signature: signature.signature
+			});
+			expect(mockGetTransaction).toHaveBeenCalledExactlyOnceWith(signature.signature, {
+				maxSupportedTransactionVersion: 0,
+				encoding: 'jsonParsed'
+			});
+
+			const second = await fetchTransactionDetailForSignature({
+				signature,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(second).toBe(first);
+			expect(mockGetTransaction).toHaveBeenCalledOnce();
+
+			await fetchTransactionDetailForSignature({ signature, network: SolanaNetworks.devnet });
+
+			expect(mockGetTransaction).toHaveBeenCalledTimes(2);
+		});
+
+		it('should not cache a confirmed transaction', async () => {
+			const signature = mockSolSignatureResponse({ confirmationStatus: 'confirmed' });
+
+			const first = await fetchTransactionDetailForSignature({
+				signature,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(first?.confirmationStatus).toBe('confirmed');
+
+			await fetchTransactionDetailForSignature({ signature, network: SolanaNetworks.mainnet });
+
+			expect(mockGetTransaction).toHaveBeenCalledTimes(2);
+		});
+
+		it('should return null when the RPC has no transaction', async () => {
+			mockGetTransaction.mockReturnValue({ send: () => Promise.resolve(null) });
+
+			const signature = mockSolSignatureResponse();
+
+			await expect(
+				fetchTransactionDetailForSignature({ signature, network: SolanaNetworks.mainnet })
+			).resolves.toBeNull();
+
+			await fetchTransactionDetailForSignature({ signature, network: SolanaNetworks.mainnet });
+
+			expect(mockGetTransaction).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -292,7 +292,7 @@ describe('sol-signatures.services', () => {
 
 			// Sorted so that the page boundary cases stay red only for the hole they pin, not for the order.
 			const slotsNewestFirst = (signatures: SolSignature[]): bigint[] =>
-				signatures.map(({ slot }) => slot).sort((a, b) => Number(b - a));
+				signatures.map(({ slot }) => slot).sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
 
 			it('should return every signature when each source holds fewer than the limit', async () => {
 				mockHistories({

--- a/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
+++ b/src/frontend/src/tests/sol/services/sol-signatures.services.spec.ts
@@ -20,7 +20,8 @@ import { mockIdentity } from '$tests/mocks/identity.mock';
 import {
 	mockSolSignature,
 	mockSolSignatureResponse,
-	mockSolSignatureResponses
+	mockSolSignatureResponses,
+	mockSolSignatureResponsesAtSlots
 } from '$tests/mocks/sol-signatures.mock';
 import { createMockSolTransactionsUi } from '$tests/mocks/sol-transactions.mock';
 import {
@@ -29,8 +30,9 @@ import {
 	mockSolAddress,
 	mockSplAddress
 } from '$tests/mocks/sol.mock';
+import { isNullish } from '@dfinity/utils';
 import * as solProgramToken from '@solana-program/token';
-import { address, type Address } from '@solana/kit';
+import { address, type Address, type Signature } from '@solana/kit';
 import type { MockInstance } from 'vitest';
 
 vi.mock('@solana-program/token', () => ({
@@ -218,6 +220,171 @@ describe('sol-signatures.services', () => {
 
 			await expect(getSolSignatures(mockParams)).rejects.toThrow(mockError);
 		});
+
+		// One flaky token account costs the whole page, wallet signatures included: pinned so the
+		// refactor changes it on purpose rather than by accident.
+		it('should reject when a single token account lookup fails', async () => {
+			spyFetchSignatures.mockImplementation(({ wallet }: { wallet: Address }) =>
+				wallet.toString() === mockAtaAddress ? Promise.reject(mockError) : mockSignaturesSol
+			);
+
+			await expect(getSolSignatures(mockParams)).rejects.toThrow(mockError);
+		});
+
+		// Looking them up one after the other would make a page take longer with every token held.
+		it('should look up the token accounts concurrently', async () => {
+			const resolvers: (() => void)[] = [];
+
+			spyFetchSignatures.mockImplementation(({ wallet }: { wallet: Address }) =>
+				wallet.toString() === mockSolAddress
+					? []
+					: new Promise<SolSignature[]>((resolve) => resolvers.push(() => resolve([])))
+			);
+
+			const result = getSolSignatures(mockParams);
+
+			await vi.waitFor(() =>
+				expect(spyFetchSignatures).toHaveBeenCalledTimes(1 + mockTokensList.length)
+			);
+
+			resolvers.forEach((resolve) => resolve());
+
+			await expect(result).resolves.toEqual([]);
+		});
+
+		describe('paging across the wallet and its token accounts', () => {
+			const limit = 3;
+
+			// Answers like the RPC: the newest signatures of the account strictly older than `before`.
+			const mockHistories = ({
+				wallet,
+				tokenAccount
+			}: {
+				wallet: SolSignature[];
+				tokenAccount: SolSignature[];
+			}) => {
+				const histories: Record<string, SolSignature[]> = {
+					[mockSolAddress]: wallet,
+					[mockAtaAddress]: tokenAccount,
+					[mockAtaAddress2]: []
+				};
+
+				const allSignatures = [...wallet, ...tokenAccount];
+
+				spyFetchSignatures.mockImplementation(
+					({
+						wallet: account,
+						before,
+						limit: pageLimit
+					}: {
+						wallet: Address;
+						before?: Signature;
+						limit: number;
+					}) => {
+						const beforeSlot = allSignatures.find(({ signature }) => signature === before)?.slot;
+
+						return histories[account.toString()]
+							.filter(({ slot }) => isNullish(beforeSlot) || slot < beforeSlot)
+							.slice(0, pageLimit);
+					}
+				);
+			};
+
+			// Sorted so that the page boundary cases stay red only for the hole they pin, not for the order.
+			const slotsNewestFirst = (signatures: SolSignature[]): bigint[] =>
+				signatures.map(({ slot }) => slot).sort((a, b) => Number(b - a));
+
+			it('should return every signature when each source holds fewer than the limit', async () => {
+				mockHistories({
+					wallet: mockSolSignatureResponsesAtSlots([100n, 90n]),
+					tokenAccount: mockSolSignatureResponsesAtSlots([80n])
+				});
+
+				const signatures = await getSolSignatures({ ...mockParams, limit });
+
+				expect(signatures.map(({ slot }) => slot)).toEqual([100n, 90n, 80n]);
+			});
+
+			// Defect: the wallet page and each token account page are concatenated, not merged newest first.
+			it.fails('should return the signatures newest first', async () => {
+				mockHistories({
+					wallet: mockSolSignatureResponsesAtSlots([100n, 90n]),
+					tokenAccount: mockSolSignatureResponsesAtSlots([95n, 85n])
+				});
+
+				const signatures = await getSolSignatures({ ...mockParams, limit });
+
+				expect(signatures.map(({ slot }) => slot)).toEqual([100n, 95n, 90n, 85n]);
+			});
+
+			// Defect: the page runs past the oldest wallet signature fetched, over wallet signatures never fetched.
+			it.fails(
+				'should end the page at the newest of the oldest signatures of the full sources',
+				async () => {
+					mockHistories({
+						wallet: mockSolSignatureResponsesAtSlots([100n, 95n, 91n, 88n]),
+						tokenAccount: mockSolSignatureResponsesAtSlots([99n, 70n, 50n, 40n])
+					});
+
+					const signatures = await getSolSignatures({ ...mockParams, limit });
+
+					expect(slotsNewestFirst(signatures)).toEqual([100n, 99n, 95n, 91n]);
+				}
+			);
+
+			// Defect: a source that ran out of signatures still stretches the page past the full ones.
+			it.fails('should not end the page at a source that holds fewer than the limit', async () => {
+				mockHistories({
+					wallet: mockSolSignatureResponsesAtSlots([100n, 95n, 91n, 88n]),
+					tokenAccount: mockSolSignatureResponsesAtSlots([99n, 80n])
+				});
+
+				const signatures = await getSolSignatures({ ...mockParams, limit });
+
+				expect(slotsNewestFirst(signatures)).toEqual([100n, 99n, 95n, 91n]);
+			});
+
+			// Defect: paging on from the oldest signature of each page skips wallet signatures for good.
+			it.fails(
+				'should reach every signature when paging on from the oldest signature of each page',
+				async () => {
+					mockHistories({
+						wallet: mockSolSignatureResponsesAtSlots([100n, 95n, 91n, 88n, 86n, 60n]),
+						tokenAccount: mockSolSignatureResponsesAtSlots([99n, 70n, 50n, 40n])
+					});
+
+					const collected: SolSignature[] = [];
+					let before: string | undefined;
+
+					for (let page = 0; page < 10; page++) {
+						const signatures = await getSolSignatures({ ...mockParams, before, limit });
+
+						if (signatures.length === 0) {
+							break;
+						}
+
+						collected.push(...signatures);
+
+						before = signatures.reduce((oldest, current) =>
+							current.slot < oldest.slot ? current : oldest
+						).signature;
+					}
+
+					expect(slotsNewestFirst(collected)).toEqual([
+						100n,
+						99n,
+						95n,
+						91n,
+						88n,
+						86n,
+						70n,
+						60n,
+						50n,
+						40n
+					]);
+				}
+			);
+		});
 	});
 
 	describe('getSolTransactions', () => {
@@ -274,6 +441,61 @@ describe('sol-signatures.services', () => {
 				tokenProgram: address(TOKEN_PROGRAM_ADDRESS),
 				mint: mockSplAddress
 			});
+		});
+
+		// The token account only picks which signatures to load: the mapper derives it again from the
+		// owner and matches balance changes against the owner, so it must be handed the owner.
+		it('should load the signatures of the token account but map them for the owner', async () => {
+			spyFindAssociatedTokenPda.mockResolvedValueOnce([address(mockAtaAddress)]);
+
+			await getSolTransactions({
+				identity: mockIdentity,
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet,
+				tokenAddress: mockSplAddress,
+				tokenOwnerAddress: TOKEN_PROGRAM_ADDRESS
+			});
+
+			expect(spyFetchSignatures).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining({ wallet: address(mockAtaAddress) })
+			);
+
+			expect(spyFetchTransactionsForSignature).toHaveBeenCalledTimes(mockSignatures.length);
+
+			mockSignatures.forEach((signature, index) => {
+				expect(spyFetchTransactionsForSignature).toHaveBeenNthCalledWith(index + 1, {
+					signature,
+					network: SolanaNetworks.mainnet,
+					address: mockSolAddress,
+					tokenAddress: mockSplAddress,
+					tokenOwnerAddress: TOKEN_PROGRAM_ADDRESS
+				});
+			});
+		});
+
+		it('should return the transactions in the order of their signatures', async () => {
+			const transactionsBySignature = createMockSolTransactionsUi(mockSignatures.length);
+
+			// The newest signature settles last, so the order cannot come from which lookup ends first.
+			spyFetchTransactionsForSignature.mockImplementation(
+				async ({ signature }: { signature: SolSignature }) => {
+					const index = mockSignatures.indexOf(signature);
+
+					for (let tick = index; tick < mockSignatures.length; tick++) {
+						await Promise.resolve();
+					}
+
+					return [transactionsBySignature[index]];
+				}
+			);
+
+			const transactions = await getSolTransactions({
+				identity: mockIdentity,
+				address: mockSolAddress,
+				network: SolanaNetworks.mainnet
+			});
+
+			expect(transactions).toEqual(transactionsBySignature);
 		});
 
 		it('should handle before parameter', async () => {


### PR DESCRIPTION
# Motivation

Spec #14012 builds Solana history on `getSolSignatures`, which nothing in the app calls yet. These tests pin it and the API layer under it before the refactor, and confirm the defects the spec lists.

# Changes

- `getSolSignatures`, `it.fails` (the fix flips them): the result is not sorted newest first; the merged page does not end at the newest of the per-source oldest signatures (full source and short source cases); paging on from each page skips signatures of the busier sources.
- `getSolSignatures`, plain: one failing token account lookup rejects the whole call; the lookups run concurrently; sources under the limit return everything.
- `getSolTransactions`: signatures come from the token account while the mapping uses the owner, and transactions keep signature order.
- `fetchSignatures`: pages until `limit` successful signatures, continues from the last fetched one even when it errored. `fetchTransactionDetailForSignature`: finalized cached per network, confirmed not cached, null on null.
- `sol-signatures.mock.ts`: overrides and a helper for signatures at given slots.

# Tests

Tests only, no production change. 78 passing and 4 expected fails in the two specs; the five other specs using the mock still pass (209).