### PR TITLE
refactor(frontend): remove the LEND_BORROW_ENABLED feature flag

### DIFF
--- a/src/frontend/src/env/lend-borrow.ts
+++ b/src/frontend/src/env/lend-borrow.ts
@@ -1,9 +1,3 @@
 import { LIQUIDIUM_ENABLED } from '$env/liquidium';
 
-// Route-level gate for the lend & borrow surface (provider pages, Borrow page,
-// Liabilities tab, nav). Layered over per-provider flags: a provider is active
-// only when both this and that provider are on.
-export const LEND_BORROW_ENABLED = true;
-
-// At least one lend & borrow provider active (feature on AND provider on).
-export const anyLendBorrowProviderEnabled: boolean = LEND_BORROW_ENABLED && LIQUIDIUM_ENABLED;
+export const anyLendBorrowProviderEnabled: boolean = LIQUIDIUM_ENABLED;

--- a/src/frontend/src/env/liquidium.ts
+++ b/src/frontend/src/env/liquidium.ts
@@ -1,2 +1,1 @@
-// Per-provider gate for Liquidium, layered under LEND_BORROW_ENABLED.
 export const LIQUIDIUM_ENABLED = true;

--- a/src/frontend/src/lib/components/borrow/Borrow.svelte
+++ b/src/frontend/src/lib/components/borrow/Borrow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { LEND_BORROW_ENABLED } from '$env/lend-borrow';
+	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 	import AllBorrowOpportunityCardList from '$lib/components/borrow/AllBorrowOpportunityCardList.svelte';
 	import BorrowHeader from '$lib/components/borrow/BorrowHeader.svelte';
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
@@ -15,7 +15,7 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	onMount(() => {
-		if (!LEND_BORROW_ENABLED) {
+		if (!anyLendBorrowProviderEnabled) {
 			goto(AppPath.Earn);
 			return;
 		}
@@ -30,7 +30,7 @@
 	});
 </script>
 
-{#if LEND_BORROW_ENABLED}
+{#if anyLendBorrowProviderEnabled}
 	<div class="flex flex-col gap-6 pb-6">
 		<BorrowHeader />
 		<StakeContentSection>

--- a/src/frontend/src/lib/components/earning/EarningsList.svelte
+++ b/src/frontend/src/lib/components/earning/EarningsList.svelte
@@ -52,7 +52,7 @@
 	});
 
 	// Liquidium supply positions sit alongside the vault stakes (grouped by type, each card
-	// carrying its own provider tag). Gated by the lend & borrow feature flag.
+	// carrying its own provider tag). Gated by the lend & borrow provider flags.
 	let supplyReserves = $derived(
 		anyLendBorrowProviderEnabled
 			? ($liquidiumPortfolio?.reserves ?? []).filter(({ deposited }) => deposited > ZERO)

--- a/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
+++ b/src/frontend/src/lib/components/liquidium/LiquidiumProvider.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { LEND_BORROW_ENABLED } from '$env/lend-borrow';
+	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 	import { LIQUIDIUM_ENABLED } from '$env/liquidium';
 	import IntervalLoader from '$lib/components/core/IntervalLoader.svelte';
 	import LiquidiumBorrowedRow from '$lib/components/liquidium/LiquidiumBorrowedRow.svelte';
@@ -45,13 +45,13 @@
 		loadLiquidium({ identity: $authIdentity, ethAddress: $ethAddress });
 
 	onMount(() => {
-		if (!LEND_BORROW_ENABLED) {
+		if (!anyLendBorrowProviderEnabled) {
 			goto(AppPath.Earn);
 		}
 	});
 </script>
 
-{#if LEND_BORROW_ENABLED}
+{#if anyLendBorrowProviderEnabled}
 	{#if LIQUIDIUM_ENABLED}
 		<IntervalLoader interval={LIQUIDIUM_POLL_INTERVAL_MILLIS} onLoad={load} />
 	{/if}

--- a/src/frontend/src/lib/components/loaders/Loader.svelte
+++ b/src/frontend/src/lib/components/loaders/Loader.svelte
@@ -6,7 +6,6 @@
 		loadBtcAddressRegtest,
 		loadBtcAddressTestnet
 	} from '$btc/services/btc-address.services';
-	import { LEND_BORROW_ENABLED } from '$env/lend-borrow';
 	import { LIQUIDIUM_ENABLED } from '$env/liquidium';
 	import { loadEthAddress } from '$eth/services/eth-address.services';
 	import { LOCAL } from '$lib/constants/app.constants';
@@ -75,12 +74,10 @@
 	const debounceLoadSolAddressDevnet = debounce(loadSolAddressDevnet);
 	const debounceLoadSolAddressLocal = debounce(loadSolAddressLocal);
 
-	const isLiquidiumProviderEnabled = LEND_BORROW_ENABLED && LIQUIDIUM_ENABLED;
-
 	$effect(() => {
 		if (progressDone) {
 			if (
-				($networkEthereumEnabled || $networkEvmMainnetEnabled || isLiquidiumProviderEnabled) &&
+				($networkEthereumEnabled || $networkEvmMainnetEnabled || LIQUIDIUM_ENABLED) &&
 				isNullish($ethAddress)
 			) {
 				debounceLoadEthAddress();

--- a/src/frontend/src/tests/lib/components/borrow/Borrow.spec.ts
+++ b/src/frontend/src/tests/lib/components/borrow/Borrow.spec.ts
@@ -11,9 +11,8 @@ vi.mock('$app/navigation', () => ({
 	afterNavigate: vi.fn()
 }));
 
-// Force the feature flags on (off by default outside staging) so the page renders.
+// Force the provider flags on (off by default outside staging) so the page renders.
 vi.mock('$env/lend-borrow', () => ({
-	LEND_BORROW_ENABLED: true,
 	anyLendBorrowProviderEnabled: true
 }));
 

--- a/src/frontend/src/tests/lib/components/liquidium/LiquidiumProvider.spec.ts
+++ b/src/frontend/src/tests/lib/components/liquidium/LiquidiumProvider.spec.ts
@@ -10,9 +10,8 @@ vi.mock('$app/navigation', () => ({
 	afterNavigate: vi.fn()
 }));
 
-// Force the feature flags on (off by default outside staging) so the page renders.
+// Force the provider flags on (off by default outside staging) so the page renders.
 vi.mock('$env/lend-borrow', () => ({
-	LEND_BORROW_ENABLED: true,
 	anyLendBorrowProviderEnabled: true
 }));
 vi.mock('$env/liquidium', () => ({ LIQUIDIUM_ENABLED: true }));

--- a/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
+++ b/src/frontend/src/tests/lib/components/loaders/Loader.spec.ts
@@ -3,7 +3,6 @@ import {
 	loadBtcAddressRegtest,
 	loadBtcAddressTestnet
 } from '$btc/services/btc-address.services';
-import type * as LendBorrowEnv from '$env/lend-borrow';
 import { loadEthAddress } from '$eth/services/eth-address.services';
 import Loader from '$lib/components/loaders/Loader.svelte';
 import * as appConstants from '$lib/constants/app.constants';
@@ -38,16 +37,8 @@ import { setupUserNetworksStore } from '$tests/utils/user-networks.test-utils';
 import { toNullable } from '@dfinity/utils';
 import { render, waitFor } from '@testing-library/svelte';
 
-const { mockLendBorrowEnabled, mockLiquidiumEnabled } = vi.hoisted(() => ({
-	mockLendBorrowEnabled: { value: true },
+const { mockLiquidiumEnabled } = vi.hoisted(() => ({
 	mockLiquidiumEnabled: { value: true }
-}));
-
-vi.mock('$env/lend-borrow', async (importOriginal) => ({
-	...(await importOriginal<typeof LendBorrowEnv>()),
-	get LEND_BORROW_ENABLED() {
-		return mockLendBorrowEnabled.value;
-	}
 }));
 
 vi.mock('$env/liquidium', () => ({
@@ -138,7 +129,6 @@ describe('Loader', () => {
 
 			ethAddressStore.reset();
 
-			mockLendBorrowEnabled.value = true;
 			mockLiquidiumEnabled.value = true;
 		});
 
@@ -152,11 +142,8 @@ describe('Loader', () => {
 			});
 		});
 
-		it.each([
-			{ flag: 'the lend & borrow feature', disable: () => (mockLendBorrowEnabled.value = false) },
-			{ flag: 'the Liquidium provider', disable: () => (mockLiquidiumEnabled.value = false) }
-		])('should not load the ETH address when $flag is disabled', async ({ disable }) => {
-			disable();
+		it('should not load the ETH address when the Liquidium provider is disabled', async () => {
+			mockLiquidiumEnabled.value = false;
 
 			setupUserNetworksStore('allDisabled');
 


### PR DESCRIPTION
# Motivation

`LEND_BORROW_ENABLED` was the temporary whole-surface gate for lend & borrow, layered over the per-provider flags. Lend & borrow is shipped and the flag has been `true` everywhere, so it is dead weight. 

# Changes

- Remove `LEND_BORROW_ENABLED` (`$env/lend-borrow`); `anyLendBorrowProviderEnabled` collapses to `LIQUIDIUM_ENABLED`, which stays as the independent per-provider kill-switch.
- Whole-surface call sites move to `anyLendBorrowProviderEnabled`: `Borrow` (page lists all borrow providers) and `LiquidiumProvider` (route gate + redirect; its inner `LIQUIDIUM_ENABLED` guards are unchanged, matching `OisyTradeProvider`).
- `Loader` reads `LIQUIDIUM_ENABLED` directly instead of the aggregate: the eager ETH-address load exists because Liquidium profiles are ETH-keyed, so it belongs on the provider flag, not on a surface flag that merely happens to equal it today.
- Drop the stale flag references from the `$env/liquidium` and `EarningsList` comments.


# Tests

Updated.
