### PR TITLE
feat(frontend): add empty state to the Borrow page

### DIFF
--- a/src/frontend/src/lib/components/borrow/AllBorrowOpportunityCardList.svelte
+++ b/src/frontend/src/lib/components/borrow/AllBorrowOpportunityCardList.svelte
@@ -1,19 +1,30 @@
 <script lang="ts">
 	import { nonNullish } from '@dfinity/utils';
 	import DefaultEarningOpportunityCard from '$lib/components/earning/DefaultEarningOpportunityCard.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import { borrowData } from '$lib/derived/borrow.derived';
 	import { borrowProviders } from '$lib/providers/borrow.providers';
+	import { i18n } from '$lib/stores/i18n.store';
+
+	let anyProviderData = $derived(borrowProviders.some(({ id }) => nonNullish($borrowData[id])));
 </script>
 
-<div class="mt-5 flex grid grid-cols-1 gap-3 sm:grid-cols-2 md:flex-row">
-	{#each borrowProviders as provider, i (`${provider.id}-${i}`)}
-		{#if nonNullish($borrowData[provider.id])}
-			<DefaultEarningOpportunityCard
-				badgeLabelKey="borrow.text.borrow_apr_from"
-				badgeValueClass="text-warning-primary"
-				cardData={provider.card}
-				cardFields={$borrowData[provider.id]}
-			/>
-		{/if}
-	{/each}
-</div>
+{#if anyProviderData}
+	<div class="mt-5 flex grid grid-cols-1 gap-3 sm:grid-cols-2 md:flex-row">
+		{#each borrowProviders as provider, i (`${provider.id}-${i}`)}
+			{#if nonNullish($borrowData[provider.id])}
+				<DefaultEarningOpportunityCard
+					badgeLabelKey="borrow.text.borrow_apr_from"
+					badgeValueClass="text-warning-primary"
+					cardData={provider.card}
+					cardFields={$borrowData[provider.id]}
+				/>
+			{/if}
+		{/each}
+	</div>
+{:else}
+	<EmptyState
+		description={$i18n.borrow.provider_unavailable.description}
+		title={$i18n.borrow.provider_unavailable.title}
+	/>
+{/if}

--- a/src/frontend/src/lib/components/borrow/Borrow.svelte
+++ b/src/frontend/src/lib/components/borrow/Borrow.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
-	import { anyLendBorrowProviderEnabled } from '$env/lend-borrow';
 	import AllBorrowOpportunityCardList from '$lib/components/borrow/AllBorrowOpportunityCardList.svelte';
 	import BorrowHeader from '$lib/components/borrow/BorrowHeader.svelte';
 	import StakeContentSection from '$lib/components/stake/StakeContentSection.svelte';
-	import { AppPath } from '$lib/constants/routes.constants';
 	import {
 		PLAUSIBLE_EVENT_CONTEXTS,
 		PLAUSIBLE_EVENT_VALUES,
@@ -15,11 +12,6 @@
 	import { i18n } from '$lib/stores/i18n.store';
 
 	onMount(() => {
-		if (!anyLendBorrowProviderEnabled) {
-			goto(AppPath.Earn);
-			return;
-		}
-
 		trackEvent({
 			name: PLAUSIBLE_EVENTS.PAGE_OPEN,
 			metadata: {
@@ -30,16 +22,14 @@
 	});
 </script>
 
-{#if anyLendBorrowProviderEnabled}
-	<div class="flex flex-col gap-6 pb-6">
-		<BorrowHeader />
-		<StakeContentSection>
-			{#snippet title()}
-				<h4>{$i18n.borrow.text.borrowing_options}</h4>
-			{/snippet}
-			{#snippet content()}
-				<AllBorrowOpportunityCardList />
-			{/snippet}
-		</StakeContentSection>
-	</div>
-{/if}
+<div class="flex flex-col gap-6 pb-6">
+	<BorrowHeader />
+	<StakeContentSection>
+		{#snippet title()}
+			<h4>{$i18n.borrow.text.borrowing_options}</h4>
+		{/snippet}
+		{#snippet content()}
+			<AllBorrowOpportunityCardList />
+		{/snippet}
+	</StakeContentSection>
+</div>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -20,6 +20,10 @@
 				"description": "Borrow USDC, USDT or BTC against your supplied collateral.",
 				"action": "Borrow"
 			}
+		},
+		"provider_unavailable": {
+			"title": "Borrowing is temporarily unavailable",
+			"description": "No borrowing provider is available right now. Your balances are safe and you can borrow again once a provider is back online."
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -20,6 +20,10 @@
 				"description": "",
 				"action": ""
 			}
+		},
+		"provider_unavailable": {
+			"title": "",
+			"description": ""
 		}
 	},
 	"borrowings": {

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -18,6 +18,7 @@ interface I18nBorrow {
 		borrow_apr_from: string;
 	};
 	cards: { liquidium: { title: string; description: string; action: string } };
+	provider_unavailable: { title: string; description: string };
 }
 
 interface I18nBorrowings {

--- a/src/frontend/src/tests/lib/components/borrow/AllBorrowOpportunityCardList.spec.ts
+++ b/src/frontend/src/tests/lib/components/borrow/AllBorrowOpportunityCardList.spec.ts
@@ -76,5 +76,16 @@ describe('AllBorrowOpportunityCardList', () => {
 
 		expect(screen.queryByText('mock.liquidium.title')).not.toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'mock.liquidium.action' })).not.toBeInTheDocument();
+		expect(screen.getByText(get(i18n).borrow.provider_unavailable.title)).toBeInTheDocument();
+	});
+
+	it('renders the provider-unavailable empty state when no provider is registered', () => {
+		vi.spyOn(borrowRegistry, 'borrowProviders', 'get').mockReturnValue([]);
+		vi.spyOn(borrowDerived, 'borrowData', 'get').mockReturnValue(readable({}));
+
+		render(AllBorrowOpportunityCardList);
+
+		expect(screen.getByText(get(i18n).borrow.provider_unavailable.title)).toBeInTheDocument();
+		expect(screen.getByText(get(i18n).borrow.provider_unavailable.description)).toBeInTheDocument();
 	});
 });

--- a/src/frontend/src/tests/lib/components/borrow/Borrow.spec.ts
+++ b/src/frontend/src/tests/lib/components/borrow/Borrow.spec.ts
@@ -1,9 +1,12 @@
 import Borrow from '$lib/components/borrow/Borrow.svelte';
 import { ZERO } from '$lib/constants/app.constants';
+import * as borrowDerived from '$lib/derived/borrow.derived';
+import * as borrowRegistry from '$lib/providers/borrow.providers';
 import { liquidiumStore } from '$lib/stores/liquidium.store';
 import type { LiquidiumMarket, LiquidiumPortfolio } from '$lib/types/liquidium';
 import en from '$tests/mocks/i18n.mock';
 import { render } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
 
 const mockGoto = vi.fn();
 vi.mock('$app/navigation', () => ({
@@ -11,7 +14,7 @@ vi.mock('$app/navigation', () => ({
 	afterNavigate: vi.fn()
 }));
 
-// Force the provider flags on (off by default outside staging) so the page renders.
+// Force the provider flag on (off by default outside staging) so Liquidium is registered.
 vi.mock('$env/lend-borrow', () => ({
 	anyLendBorrowProviderEnabled: true
 }));
@@ -85,5 +88,31 @@ describe('Borrow', () => {
 
 		expect(container).not.toHaveTextContent(en.earning.card_fields.currentBorrowing);
 		expect(container).not.toHaveTextContent(en.earning.card_fields.interestPerYear);
+	});
+
+	describe('when no borrow provider is available', () => {
+		beforeEach(() => {
+			vi.spyOn(borrowRegistry, 'borrowProviders', 'get').mockReturnValue([]);
+			vi.spyOn(borrowDerived, 'borrowData', 'get').mockReturnValue(readable({}));
+		});
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		it('still renders the page with the provider-unavailable empty state', () => {
+			const { container } = render(Borrow);
+
+			expect(container).toHaveTextContent(en.borrow.text.header_title);
+			expect(container).toHaveTextContent(en.borrow.text.borrowing_options);
+			expect(container).toHaveTextContent(en.borrow.provider_unavailable.title);
+			expect(container).not.toHaveTextContent(en.borrow.cards.liquidium.title);
+		});
+
+		it('does not navigate away', () => {
+			render(Borrow);
+
+			expect(mockGoto).not.toHaveBeenCalled();
+		});
 	});
 });


### PR DESCRIPTION
# Motivation

The Borrow page had no empty state: with no provider available it redirected to `/earn`, so a user clicking the (ungated) Borrow nav item was silently bounced. Now that #14021 removed `LEND_BORROW_ENABLED`, `LIQUIDIUM_ENABLED` is the only gate — a kill-switch meant to be flipped if the provider is unreachable, so that state must render something rather than redirect.


# Changes

- Add a provider-unavailable empty state, mirroring `TradingList`: new `borrow.provider_unavailable` i18n keys rendered by `AllBorrowOpportunityCardList` when no registered provider has data. In the list rather than the page, so it also replaces the unexplained empty grid a provider without a data store used to produce.
- Remove the redirect and the flag wrapper from `Borrow.svelte` — header and options section always render, `onMount` keeps only the `PAGE_OPEN` tracking. The Liquidium provider page keeps its redirect, matching `OisyTradeProvider`.
- `npm run i18n` regenerated `i18n.d.ts` and synced the non-`en` locales with empty strings.


# Tests

Updated.
