### PR TITLE
chore(frontend): remove the send transaction priority feature flag

### DIFF
--- a/src/frontend/src/env/send-transaction-priority.env.ts
+++ b/src/frontend/src/env/send-transaction-priority.env.ts
@@ -1,3 +1,0 @@
-// Gates the whole "transaction priority" work on the EVM send flow: the priority row and its
-// options, and the estimated-fee row that replaces the max-fee one. Enabled on every environment.
-export const SEND_TRANSACTION_PRIORITY_ENABLED = true;

--- a/src/frontend/src/eth/components/send/EthSendAmount.svelte
+++ b/src/frontend/src/eth/components/send/EthSendAmount.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { SEND_TRANSACTION_PRIORITY_ENABLED } from '$env/send-transaction-priority.env';
 	import { ETH_FEE_CONTEXT_KEY, type EthFeeContext } from '$eth/stores/eth-fee.store';
 	import { isSupportedEthTokenId } from '$eth/utils/eth.utils';
 	import { isSupportedEvmNativeTokenId } from '$evm/utils/native-token.utils';
@@ -113,10 +112,8 @@
 	// OP-stack chain, the L1 data fee, so the ceiling is what decides whether a native send is
 	// affordable. `minGasFee` omits the base fee entirely and therefore bounds nothing the chain
 	// enforces. Falling back to the tip rather than to zero: an unknown ceiling must not weaken the
-	// check below what it was before the flag.
-	let gasFee = $derived(
-		SEND_TRANSACTION_PRIORITY_ENABLED ? ($maxGasFee ?? $minGasFee ?? ZERO) : ($minGasFee ?? ZERO)
-	);
+	// check below what the tip alone already enforces.
+	let gasFee = $derived($maxGasFee ?? $minGasFee ?? ZERO);
 
 	// Native only: the balance does not cover the gas on its own, so "Max" is 0 and no amount would
 	// go through. Reported by `EthSendForm`'s fee box - the same box the ERC-20 fee shortfall uses,

--- a/src/frontend/src/eth/components/send/EthSendForm.svelte
+++ b/src/frontend/src/eth/components/send/EthSendForm.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import type { Snippet } from 'svelte';
-	import { SEND_TRANSACTION_PRIORITY_ENABLED } from '$env/send-transaction-priority.env';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
 	import EthFeePriority from '$eth/components/fee/EthFeePriority.svelte';
 	import EthSendAmount from '$eth/components/send/EthSendAmount.svelte';
@@ -76,19 +75,13 @@
 	{/snippet}
 
 	{#snippet priority()}
-		{#if SEND_TRANSACTION_PRIORITY_ENABLED}
-			<EthFeePriority />
-		{/if}
+		<EthFeePriority />
 	{/snippet}
 
 	{#snippet fee()}
-		<EthFeeDisplay estimated={SEND_TRANSACTION_PRIORITY_ENABLED}>
+		<EthFeeDisplay estimated>
 			{#snippet label()}
-				<Html
-					text={SEND_TRANSACTION_PRIORITY_ENABLED
-						? $i18n.fee.text.estimated_fee_eth
-						: $i18n.fee.text.max_fee_eth}
-				/>
+				<Html text={$i18n.fee.text.estimated_fee_eth} />
 			{/snippet}
 		</EthFeeDisplay>
 	{/snippet}

--- a/src/frontend/src/eth/components/send/EthSendReview.svelte
+++ b/src/frontend/src/eth/components/send/EthSendReview.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { isNullish } from '@dfinity/utils';
 	import { getContext, onMount } from 'svelte';
-	import { SEND_TRANSACTION_PRIORITY_ENABLED } from '$env/send-transaction-priority.env';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
 	import { ETH_FEE_REVIEW_EXPIRY_DELAY } from '$eth/constants/eth.constants';
 	import { ETH_FEE_CONTEXT_KEY, type EthFeeContext } from '$eth/stores/eth-fee.store';
@@ -56,13 +55,9 @@
 
 <SendReview {amount} {destination} disabled={invalid} {nft} {onBack} {onSend} {selectedContact}>
 	{#snippet fee()}
-		<EthFeeDisplay estimated={SEND_TRANSACTION_PRIORITY_ENABLED}>
+		<EthFeeDisplay estimated>
 			{#snippet label()}
-				<Html
-					text={SEND_TRANSACTION_PRIORITY_ENABLED
-						? $i18n.fee.text.estimated_fee_eth
-						: $i18n.fee.text.max_fee_eth}
-				/>
+				<Html text={$i18n.fee.text.estimated_fee_eth} />
 			{/snippet}
 		</EthFeeDisplay>
 	{/snippet}

--- a/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
+++ b/src/frontend/src/eth/components/wallet-connect/EthWalletConnectSendReview.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { getContext } from 'svelte';
-	import { SEND_TRANSACTION_PRIORITY_ENABLED } from '$env/send-transaction-priority.env';
 	import EthFeeDisplay from '$eth/components/fee/EthFeeDisplay.svelte';
 	import EthFeePriority from '$eth/components/fee/EthFeePriority.svelte';
 	import EthWalletConnectCallMethods from '$eth/components/wallet-connect/EthWalletConnectCallMethods.svelte';
@@ -19,7 +18,6 @@
 	import SendData from '$lib/components/send/SendData.svelte';
 	import SendDataSpender from '$lib/components/send/SendDataSpender.svelte';
 	import ContentWithToolbar from '$lib/components/ui/ContentWithToolbar.svelte';
-	import Html from '$lib/components/ui/Html.svelte';
 	import MessageBox from '$lib/components/ui/MessageBox.svelte';
 	import Tabs from '$lib/components/ui/Tabs.svelte';
 	import WalletConnectActions from '$lib/components/wallet-connect/WalletConnectActions.svelte';
@@ -282,18 +280,12 @@
 				<span id={FEE_SECTION_LABEL} class="font-bold">{$i18n.fee.text.fee}</span>
 
 				<div class="mb-4" aria-labelledby={FEE_SECTION_LABEL} role="group">
-					{#if SEND_TRANSACTION_PRIORITY_ENABLED}
-						<EthFeePriority gas={signedGas} styleClass="mb-2" />
-					{/if}
+					<EthFeePriority gas={signedGas} styleClass="mb-2" />
 
-					<EthFeeDisplay estimated={SEND_TRANSACTION_PRIORITY_ENABLED} gas={signedGas}>
+					<EthFeeDisplay estimated gas={signedGas}>
 						{#snippet label()}
 							<!-- "Fee" is the heading above; repeating it in the row would say it twice. -->
-							{#if SEND_TRANSACTION_PRIORITY_ENABLED}
-								{$i18n.fee.text.estimated}
-							{:else}
-								<Html text={$i18n.fee.text.max_fee_eth} />
-							{/if}
+							{$i18n.fee.text.estimated}
 						{/snippet}
 					</EthFeeDisplay>
 				</div>

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "رسوم شبكة البيتكوين المقدرة",
 			"estimated_inter_network": "رسوم الشبكة البينية المقدرة",
 			"estimated_eth": "رسوم الإيثيريوم المقدرة",
-			"max_fee_eth": "الحد الأقصى للرسوم <small>(على الأرجح في < 30 ثانية)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Odhadovaný poplatek za síť BTC",
 			"estimated_inter_network": "Odhadovaný mezisíťový poplatek",
 			"estimated_eth": "Odhadovaný poplatek za Ethereum",
-			"max_fee_eth": "Maximální poplatek <small>(pravděpodobně za < 30 sekund)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Geschätzte Bitcoin Gebühr",
 			"estimated_inter_network": "Geschätzte Inter-Netzwerk-Gebühr",
 			"estimated_eth": "Geschätzte Ethereum Gebühr",
-			"max_fee_eth": "Maximale Gebühr <small>(wahrscheinlich in &lt; 30 Sekunden)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Estimated BTC Network Fee",
 			"estimated_inter_network": "Estimated Inter-network Fee",
 			"estimated_eth": "Estimated Ethereum Fee",
-			"max_fee_eth": "Max fee <small>(likely in &lt; 30 seconds)</small>",
 			"estimated_fee_eth": "Estimated fee",
 			"estimated": "Estimated",
 			"priority": "Priority",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Comisión de Red BTC Estimada",
 			"estimated_inter_network": "Comisión Inter-red Estimada",
 			"estimated_eth": "Comisión de Ethereum Estimada",
-			"max_fee_eth": "Comisión máx. <small>(probablemente en &lt; 30 segundos)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Frais réseau BTC estimés",
 			"estimated_inter_network": "Frais inter-réseaux estimés",
 			"estimated_eth": "Frais Ethereum estimés",
-			"max_fee_eth": "Frais max <small>(probablement dans &lt; 30 secondes)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "अनुमानित BTC नेटवर्क शुल्क",
 			"estimated_inter_network": "अनुमानित अंतर-नेटवर्क शुल्क",
 			"estimated_eth": "अनुमानित एथेरियम शुल्क",
-			"max_fee_eth": "अधिकतम शुल्क <small>(संभवतः < 30 सेकंड में)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Fee di rete BTC stimata",
 			"estimated_inter_network": "Fee inter-rete stimata",
 			"estimated_eth": "Fee Ethereum stimata",
-			"max_fee_eth": "Fee massima <small>(probabilmente in < 30 secondi)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "推定BTCネットワーク手数料",
 			"estimated_inter_network": "推定ネットワーク間手数料",
 			"estimated_eth": "推定Ethereum手数料",
-			"max_fee_eth": "最大手数料<small>（おそらく30秒以内）</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "예상 BTC 네트워크 수수료",
 			"estimated_inter_network": "예상 네트워크 간 수수료",
 			"estimated_eth": "예상 이더리움 수수료",
-			"max_fee_eth": "최대 수수료 <small>(보통 &lt; 30초 이내)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Szacowana opłata sieciowa BTC",
 			"estimated_inter_network": "Szacowana opłata między sieciami",
 			"estimated_eth": "Szacowana opłata Ethereum",
-			"max_fee_eth": "Maksymalna opłata <small>(prawdopodobnie w < 30 sekund)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Taxa de Rede BTC estimada",
 			"estimated_inter_network": "Taxa Inter-Rede estimada",
 			"estimated_eth": "Taxa Ethereum estimada",
-			"max_fee_eth": "Taxa máxima <small>(provavelmente em < 30 segundos)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Примерная комиссия сети BTC",
 			"estimated_inter_network": "Примерная межсетевая комиссия",
 			"estimated_eth": "Примерная комиссия Ethereum",
-			"max_fee_eth": "Максимальная комиссия <small>(отправка, менее чем за 30 секунд)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "Phí Mạng BTC ước tính",
 			"estimated_inter_network": "Phí network nội ước tính",
 			"estimated_eth": "Phí Ethereum ước tính",
-			"max_fee_eth": "Phí tối đa <small>(có thể trong < 30 giây)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1561,7 +1561,6 @@
 			"estimated_btc": "预计 BTC 网络手续费",
 			"estimated_inter_network": "预计跨网络手续费",
 			"estimated_eth": "预计以太坊手续费",
-			"max_fee_eth": "最高手续费 <small>(通常少于 30 秒)</small>",
 			"estimated_fee_eth": "",
 			"estimated": "",
 			"priority": "",

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -1251,7 +1251,6 @@ interface I18nFee {
 		estimated_btc: string;
 		estimated_inter_network: string;
 		estimated_eth: string;
-		max_fee_eth: string;
 		estimated_fee_eth: string;
 		estimated: string;
 		priority: string;

--- a/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendForm.spec.ts
@@ -1,5 +1,4 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
-import { SEND_TRANSACTION_PRIORITY_ENABLED } from '$env/send-transaction-priority.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import EthSendForm from '$eth/components/send/EthSendForm.svelte';
 import { ETH_FEE_CONTEXT_KEY, initEthFeeContext, initEthFeeStore } from '$eth/stores/eth-fee.store';
@@ -78,7 +77,7 @@ describe('EthSendForm', () => {
 	const toolbarSelector = 'div[data-tid="toolbar"]';
 
 	it('should render all fields', () => {
-		const { container, getByTestId, getByText, queryByTestId } = render(EthSendForm, {
+		const { container, getByTestId, getByText } = render(EthSendForm, {
 			props,
 			context: mockContext
 		});
@@ -89,21 +88,9 @@ describe('EthSendForm', () => {
 
 		expect(getByTestId(SEND_DESTINATION_SECTION)).toBeInTheDocument();
 
-		// The label follows the feature flag: the estimate only replaces the ceiling where the
-		// priority work is enabled.
-		expect(
-			getByText(
-				SEND_TRANSACTION_PRIORITY_ENABLED
-					? en.fee.text.estimated_fee_eth
-					: // max_fee_eth contains HTML, so match the leading plain-text fragment only
-						'Max fee'
-			)
-		).toBeInTheDocument();
+		expect(getByText(en.fee.text.estimated_fee_eth)).toBeInTheDocument();
 
-		// The priority row follows the same flag, so beta and production keep today's form.
-		expect(queryByTestId(ETH_FEE_PRIORITY)).toStrictEqual(
-			SEND_TRANSACTION_PRIORITY_ENABLED ? expect.anything() : null
-		);
+		expect(getByTestId(ETH_FEE_PRIORITY)).toBeInTheDocument();
 
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
 

--- a/src/frontend/src/tests/eth/components/send/EthSendReview.spec.ts
+++ b/src/frontend/src/tests/eth/components/send/EthSendReview.spec.ts
@@ -1,4 +1,3 @@
-import { SEND_TRANSACTION_PRIORITY_ENABLED } from '$env/send-transaction-priority.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import EthSendReview from '$eth/components/send/EthSendReview.svelte';
 import { ETH_FEE_REVIEW_EXPIRY_DELAY } from '$eth/constants/eth.constants';
@@ -66,16 +65,7 @@ describe('EthSendReview', () => {
 
 		expect(getByText(props.destination)).toBeInTheDocument();
 
-		// The label follows the feature flag: the estimate only replaces the ceiling where the
-		// priority work is enabled.
-		expect(
-			getByText(
-				SEND_TRANSACTION_PRIORITY_ENABLED
-					? en.fee.text.estimated_fee_eth
-					: // max_fee_eth contains HTML, so match the leading plain-text fragment only
-						'Max fee'
-			)
-		).toBeInTheDocument();
+		expect(getByText(en.fee.text.estimated_fee_eth)).toBeInTheDocument();
 
 		const toolbar: HTMLDivElement | null = container.querySelector(toolbarSelector);
 

--- a/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectSendReview.spec.ts
+++ b/src/frontend/src/tests/eth/components/wallet-connect/EthWalletConnectSendReview.spec.ts
@@ -1,5 +1,4 @@
 import { ETHEREUM_NETWORK } from '$env/networks/networks.eth.env';
-import { SEND_TRANSACTION_PRIORITY_ENABLED } from '$env/send-transaction-priority.env';
 import { USDC_SYMBOL, USDC_TOKEN } from '$env/tokens/tokens-erc20/tokens.usdc.env';
 import { ETHEREUM_TOKEN } from '$env/tokens/tokens.eth.env';
 import EthWalletConnectSendReview from '$eth/components/wallet-connect/EthWalletConnectSendReview.svelte';
@@ -750,12 +749,8 @@ describe('EthWalletConnectSendReview', () => {
 		it('should price the maximum fee on the gas limit the dApp requested, not on the estimate', () => {
 			const { getByRole, getByText, queryByText } = renderWithGas({ requestedGas: 2_000_000n });
 
-			// The label follows the feature flag: the request quotes an expected cost only where the
-			// priority work is enabled, and says "Estimated" rather than repeating the "Fee" heading
-			// above it. max_fee_eth contains HTML, so match its plain-text fragment.
-			expect(
-				getByText(SEND_TRANSACTION_PRIORITY_ENABLED ? en.fee.text.estimated : 'Max fee')
-			).toBeInTheDocument();
+			// The row says "Estimated" rather than repeating the "Fee" heading above it.
+			expect(getByText(en.fee.text.estimated)).toBeInTheDocument();
 
 			// By role, not by text: the heading has to actually name the group for a screen reader,
 			// which a bare `label` pointing at a `div` would not do while still reading correctly.


### PR DESCRIPTION
# Motivation

`SEND_TRANSACTION_PRIORITY_ENABLED` has been `true` on every environment since #13979 and shipped to production in v2.5.6, so the flag and its fallback branches are dead code.

# Changes

- Delete `env/send-transaction-priority.env.ts`.
- EVM send form, send review and WalletConnect send review always show the priority selector and the estimated-fee row.
- The native-balance fee check in `EthSendAmount` always uses the max fee (the previous flagged-on behaviour).
- Remove the now unused `fee.text.max_fee_eth` i18n key from all locales and the generated types.

# Tests

Updated the three specs that branched on the flag to assert the flagged-on behaviour only.
