### PR TITLE
fix(frontend): name the NEAR Intents temporary swap limit instead of "not offered"

### DIFF
--- a/docs/ai/PRODUCT.md
+++ b/docs/ai/PRODUCT.md
@@ -342,6 +342,14 @@ Funds cannot move before the user has acknowledged the NEAR Intents terms of ser
 
 What this deliberately does not do: no BTC testnet or regtest support (mainnet only, like the rest of NEAR Intents), and no production enablement. With the flag off, production behavior is byte-for-byte the previous sections.
 
+### An amount NEAR Intents refuses as too small says so, and names the floor
+
+A swap the provider declines only because the amount is too small is not an unavailable swap, so it does not claim to be one. Where NEAR Intents names a minimum, the form repeats it instead of the generic "This swap is currently not offered.", and the user can act on it without guessing.
+
+NEAR Intents enforces two unrelated floors, and they are quoted in different things. A **per-route bridge minimum** applies to every route and is a cost of getting funds out on the far side, so it is small and denominated in the token being paid: a few thousand satoshi out of Bitcoin, a fraction of a cent out of Ethereum toward an L2, and noticeably more toward Bitcoin than toward Base. It is shown in the pay token's own units. Separately, some chains carry a **flat fiat floor** — $1,000 on Polygon and BSC at the time of writing, applying whether the chain is the pay side or the receive side, and described by the provider as temporary. Because that limit is enforced in money rather than in tokens, it is shown as money, converted into whichever display currency the user has selected rather than as a hardcoded dollar figure. It is deliberately not restated in token units, which would drift with the price and read as more exact than the constraint is. While a currency switch is still settling and no exchange rate is available, the form says the amount is below the minimum without naming a figure, rather than showing a number with no currency attached.
+
+Neither floor is hardcoded, and neither is the list of chains that carry one: both are read from the provider's refusal, so a chain leaving or joining the restriction, or the figure moving, needs no change here. A minimum the provider does not name, or names in a form OISY does not recognise, falls back to the generic message. A quote from any other provider still wins over a NEAR Intents refusal, so a swap that one provider will not take at that size is still offered by whoever will.
+
 ### 1Sec restricted to the unwrapping direction
 
 1Sec (OneSec) bridges tokens between ICP and Ethereum, Base and Arbitrum. OISY offers only the way back out of a bridged position, never the way in: a user who already holds a bridged balance keeps a working exit, and nobody acquires a new one through OISY.

--- a/docs/ai/spec-driven-development/specs/2026-09-11-impr-near-intents-minimum-swap-amount.md
+++ b/docs/ai/spec-driven-development/specs/2026-09-11-impr-near-intents-minimum-swap-amount.md
@@ -1,0 +1,267 @@
+> This spec follows the workflow defined in `docs/ai/spec-driven-development/workflow.md`.
+
+# Spec: Tell the user the NEAR Intents minimum swap amount before they hit it
+
+- **Type:** `impr`
+- **Area:** Frontend, swap (NEAR Intents provider, swap form)
+- **Status:** Draft for implementation in Claude Code
+
+---
+
+## 1. Motivation
+
+A NEAR Intents swap below the provider's minimum produces no offer. Today the user learns
+this only by entering an amount, waiting out a quote round, and reading the result — and
+for the largest minimum of all, the one that actually prompted this spec, the message they
+get is wrong.
+
+`fix(frontend): surface the NEAR Intents minimum-amount refusal in the swap form` (#13820)
+built the reactive half of this: `fetchNearIntentsQuote`
+(`src/frontend/src/lib/rest/near-intents.rest.ts`) matches a 400 whose message reads
+`Amount is too low for bridge, try at least 8300`, parses the minimum, and throws
+`SwapAmountTooLowError` (`src/frontend/src/lib/types/errors.ts`);
+`reduceSettledSwapResults` (`src/frontend/src/lib/services/swap.services.ts`) rethrows it
+when no provider quoted; `SwapAmountsContext.svelte` puts it in the store as
+`quoteError: { type: 'amount-too-low', minAmount }`; and `SwapForm.svelte` renders
+`swap.text.swap_amount_too_low_minimum` in place of the generic
+`swap.text.swap_is_not_offered`.
+
+Two gaps remain.
+
+**The 1Click API has a second, unrelated refusal message that the parser does not match.**
+Swapping into or out of Polygon or BSC below **$1,000** fails with
+`Temporary swap limits: minimum swap amount is $1,000`. The `/amount is too low/i` pattern
+does not match it, so the refusal falls through to the generic "This swap is currently not
+offered." — which is the symptom that was reported: a BTC→Polygon swap of a few hundred
+dollars looks unsupported rather than under-sized. This is the bug half of this spec.
+
+**Even when matched, the minimum arrives too late.** The user must commit to an amount and
+wait for a failed round before the form tells them the floor. The minimum for a token pair
+is knowable the moment the pair is chosen, which is the improvement half of this spec.
+
+## 2. What the 1Click API does and does not expose
+
+Verified against the live API on 2026-09-11. Recording it here because none of it is
+documented and all of it shapes the design.
+
+**There is no structured minimum anywhere.** Not in `GET /v0/tokens` (the per-token fields
+are `assetId`, `decimals`, `blockchain`, `symbol`, `price`, `priceUpdatedAt`,
+`contractAddress`, `coingeckoId` — no minimum), not in the 400 body (`{message,
+correlationId, timestamp, path}`), and not in the OpenAPI contract at
+`https://1click.chaindefuser.com/docs/v0/openapi.yaml` (v0.1.10), where
+`BadRequestResponse` is `{ message: string }` and nothing more — no error code, no numeric
+field. There is no limits-style endpoint; the full path set is `auth/authenticate`,
+`auth/refresh`, `account/balances`, `account/history`, `tokens`, `quote`, `status`,
+`any-input/withdrawals`, `deposit/submit`, `generate-intent`, `submit-intent`, `orders`.
+The SDK is a generated client over that same spec, so it cannot expose what the API does
+not send. **The message string is the only carrier, and parsing it is the only option.**
+
+`NearIntentsQuote.minAmountIn` (`src/frontend/src/lib/types/near-intents.ts`) is _not_ this
+minimum and must not be used for it: per the spec it is the slippage-buffer deposit floor
+(`amountIn` less slippage), and it is only present when a quote already succeeded.
+
+**There are exactly two refusal shapes, with different units and different scope:**
+
+|                    | `Amount is too low for bridge, try at least N` | `Temporary swap limits: minimum swap amount is $1,000` |
+| ------------------ | ---------------------------------------------- | ------------------------------------------------------ |
+| Unit of the number | base units of the **origin asset**             | **USD**                                                |
+| Scope              | per route                                      | per chain, either side of the route                    |
+| Applies to         | every route                                    | only `pol` and `bsc`                                   |
+| Checked            | **after** address validation                   | **before** address validation                          |
+| Magnitude          | roughly the destination's withdrawal cost      | flat $1,000                                            |
+
+Measured examples of the per-route bridge minimum: BTC→ETH, →SOL, →Base, →Arbitrum and
+→ETH-USDC all report `8300` sats (≈ $6.56); ETH→Base and ETH→Arbitrum report
+`35000000000001` wei (≈ $0.09); ETH→BTC reports ≈ `2.54e15` wei (≈ $6.6); ETH→SOL ≈
+`3.98e13` wei (≈ $0.10); SOL→ETH `993028`; ETH-USDC→BTC `6603820`. The number tracks the
+cost of getting funds out on the destination side, expressed in the origin asset — hence
+BTC destinations being expensive from anywhere and L2 destinations being cheap.
+
+The `$1,000` limit is evaluated on the input's USD value at 1Click's own `price`: BTC→POL
+at 1,266,000 sats is refused, at 1,270,000 sats (`amountInUsd: 1000.4171`) it quotes. It
+fires on **either** side — `pol`→ETH and `bsc`→ETH are refused just as ETH→`pol` and
+ETH→`bsc` are. A sweep of all 34 chains as destination found `pol` and `bsc` to be the only
+restricted ones; of the six chains in `NEAR_INTENTS_BLOCKCHAIN_MAP`
+(`src/frontend/src/lib/constants/swap.constants.ts`) those two are affected and Ethereum,
+Arbitrum, Base and Solana are not. Notably this is not a property of the underlying bridge:
+`avax`, `op`, `scroll`, `monad` and `xlayer` route over the same HOT Omni bridge as `pol`
+and are unrestricted.
+
+**A probe amount that is too small produces useless messages rather than the minimum.**
+Below roughly three base units of the origin asset the API answers `Failed to get quote`,
+`No liquidity available` or `Internal server error` instead of naming a minimum (BTC→ETH:
+1 sat → `Failed to get quote`, 2 sats → `No liquidity available`, 3 sats → the minimum).
+`Internal server error` is transient — the same request that produced it returned the
+minimum on all 5 immediate retries. A probe must therefore be small enough to stay under
+the minimum but not degenerate, and must treat an unrecognised message as "unknown" rather
+than as "no minimum".
+
+Because the bridge-minimum check runs **after** address validation, a probe that wants that
+number has to send addresses the destination chain accepts; an invalid `recipient` or
+`refundTo` masks it (`recipient is not valid` / `refundTo is not valid`). The `$1,000` check
+runs first and surfaces regardless.
+
+## 3. Design
+
+### 3.1 A minimum is either token-denominated or USD-denominated
+
+Replace the single `minAmount?: bigint` with a discriminated description, because the two
+refusals genuinely differ in kind and rendering a USD limit as a token amount would be a
+lie the price moves out from under:
+
+```ts
+export type SwapAmountMinimum =
+	| { type: 'token'; value: bigint } // origin asset base units
+	| { type: 'usd'; value: number }; // USD
+```
+
+`SwapAmountTooLowError` (`src/frontend/src/lib/types/errors.ts`) carries this instead of
+`minAmount`, and so does `SwapQuoteError` (`src/frontend/src/lib/types/swap.ts`). The
+existing `minAmount?: bigint` becomes the `'token'` case; no call site loses information.
+
+### 3.2 Parse both shapes in one place
+
+`near-intents.rest.ts` gains a second pattern beside the existing two. Both live in the rest
+layer, next to the request that produces them, and both produce `SwapAmountTooLowError`:
+
+- `/amount is too low/i` with `/try at least (\d+)/i` → `{ type: 'token', value }`
+  (unchanged behaviour).
+- A pattern for the temporary-limit shape, matching on `minimum swap amount` and extracting
+  the dollar figure tolerant of thousands separators → `{ type: 'usd', value }`.
+
+Match on `minimum swap amount` rather than on `Temporary swap limits`: the number and the
+chain set are the volatile parts of that message and the word "Temporary" is a promise the
+API may well keep, so anchor on the part that states the constraint. If a future message
+states a minimum in a shape neither pattern matches, the generic `Error` path and today's
+"not offered" message remain the fallback — no regression, just no improvement.
+
+### 3.3 Probe the minimum when the pair is chosen
+
+A new `fetchNearIntentsMinimumAmount` in
+`src/frontend/src/lib/services/near-intents.services.ts` asks for a deliberately tiny
+`dry: true` quote and reads the refusal:
+
+- **Probe amount** = `max(3, floor(0.01 / price * 10 ** decimals))`, from the `price` and
+  `decimals` of the origin asset in the already-cached `/tokens` response (`cachedTokens`).
+  $0.01 sits below every minimum observed (the smallest was ≈ $0.09) and above the
+  degenerate floor; the `3` guards a token whose $0.01 rounds to nothing.
+- **Addresses** are the real ones the quote fan-out already passes (`userAddress`,
+  `recipientAddress` in `NearIntentsQuoteParams`, `src/frontend/src/lib/types/swap.ts`), so
+  the bridge-minimum check is reached. The swap form only offers destinations whose address
+  the user holds, so they are always available.
+- **`dry: true`**, so no deposit address is allocated. Everything else mirrors
+  `buildNearIntentsQuoteRequest`.
+
+Outcomes: a `SwapAmountTooLowError` yields the minimum; a **successful** quote means no
+minimum above ~$0.01 and yields none; any other error yields none. "None" is indistinguishable
+from "not yet known" to the UI, and in both cases the form behaves exactly as it does today.
+
+**Caching and request budget.** One probe per `(originAsset, destinationAsset)` pair, cached
+for the session in a module-level map alongside `cachedTokens`, keyed by asset id pair. The
+probe must **not** run inside `loadSwapAmounts`, which repeats every
+`SWAP_AMOUNTS_PERIODIC_FETCH_INTERVAL_MS` (5 s) — that would turn one extra request into a
+steady stream against an endpoint we call unauthenticated and which documents a 429
+`rate-limit-exceeded`. It runs once when the pair changes. A failed probe is not cached, so
+switching away and back retries it.
+
+### 3.4 Show it as guidance, then as the reason
+
+The proactive minimum is **information, not an error**: it appears in tertiary text near the
+source amount input, which is the field it constrains, and it does not block anything or
+turn the form red. When the user then enters an amount below it, the existing red
+destination-side message stays the mechanism that says "this is why you have no offer" —
+that path keeps working from the real failed quote, so the two never disagree.
+
+New `swap.text` keys in `src/frontend/src/lib/i18n/en.json`, beside the existing
+`swap_amount_too_low*` pair:
+
+- a token-denominated hint, taking `$amount` and `$symbol`, formatted with `formatToken` and
+  the source token's decimals exactly as `quoteErrorMinAmount` does in `SwapForm.svelte`;
+- a USD-denominated hint, taking the formatted dollar figure;
+- a USD-denominated refusal, the error-state counterpart of `swap_amount_too_low_minimum`
+  for the reactive path.
+
+Other locales are structurally synced by the existing i18n workflow, which does not
+translate; translations follow the project's usual route and are not part of this change.
+
+## 4. Non-goals
+
+- **No hardcoded chain list and no hardcoded $1,000.** The API calls the limit "Temporary";
+  a constant for it would go stale silently and invisibly. Everything comes from the live
+  response.
+- **No blocking.** The form does not disable Review or refuse input below the minimum. The
+  quote round is still the authority on whether a swap is possible, and a minimum read from
+  a probe a few seconds old must never be what prevents a swap the provider would accept.
+- **No change to any other provider.** Velora, ICPSwap, KongSwap, Chain Fusion, 1Sec and
+  OISY Trade keep their current behaviour, including Chain Fusion's own
+  `swap.text.chain_fusion_minimum_amount` and OISY Trade's minimum notional, which are
+  separate mechanisms with their own sources.
+- **No binary search for an exact minimum.** One probe, one number, straight from the API.
+- **No use of the quote's `minAmountIn`** for this purpose (see §2).
+- **No new API key or authenticated access.** Probes go out unauthenticated like every other
+  1Click call today.
+
+## 5. Acceptance criteria
+
+- A BTC→Polygon swap of a few hundred dollars no longer says "This swap is currently not
+  offered."; it says the amount is below the provider's minimum and names $1,000. The same
+  holds for BSC, and for Polygon and BSC as the **source** side.
+- Selecting a pair whose route has a minimum shows that minimum before any amount is
+  entered, in non-error styling, in the source token's units for the per-route bridge
+  minimum and in USD for the temporary chain limit.
+- Selecting a pair with no minimum above ~$0.01, or one whose probe fails or returns an
+  unrecognised message, shows no hint and behaves exactly as today.
+- Entering an amount below the minimum still produces the red destination-side refusal from
+  the real quote round; entering an amount above it quotes normally.
+- The pre-existing `Amount is too low for bridge` behaviour is unchanged in message and in
+  formatting.
+- Switching pairs repeatedly issues at most one probe per pair; the 5-second periodic quote
+  refresh issues none.
+- No provider other than NEAR Intents changes behaviour, and a successful quote from another
+  provider still wins over a NEAR Intents refusal, as `reduceSettledSwapResults` already
+  guarantees.
+
+## 6. Tests
+
+The `test-coverage` gate enforces whole-project thresholds, so this lands with its tests:
+
+- `src/frontend/src/tests/lib/rest/near-intents.rest.spec.ts` — both refusal shapes, the
+  thousands separator, an unrecognised message falling through to plain `Error`, and a
+  message that says "minimum swap amount" with no parseable figure.
+- `src/frontend/src/tests/lib/services/near-intents.services.spec.ts` — probe amount
+  derivation from `price`/`decimals` including the `3`-unit floor, the cache (one request per
+  pair, no caching of failures), a successful probe yielding no minimum, and a non-amount
+  error yielding no minimum.
+- `src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts` — hint rendering for both
+  minimum kinds, absence when unknown, and the reactive red refusal for the USD shape.
+- `docs/ai/PRODUCT.md` updated in this PR, per Step 4 — Build (Claude Code).
+
+## 7. Implementation plan: atomic PRs
+
+1. `fix(frontend): name the NEAR Intents temporary swap limit instead of "not offered"`
+   §3.1 and §3.2 plus the USD refusal key and its rendering in the existing reactive path.
+   This alone fixes the reported Polygon symptom and is shippable on its own.
+2. `feat(frontend): show the NEAR Intents minimum before an amount is entered` (needs 1)
+   §3.3 and the hint half of §3.4, plus the `PRODUCT.md` update.
+
+## 8. Open questions (facts to confirm)
+
+- Is the $1,000 restriction on `pol`/`bsc` genuinely temporary, and is NEAR able to say what
+  drives it and when it lifts? The design does not depend on the answer — nothing is
+  hardcoded — but it tells us whether this is worth a follow-up at all or will vanish.
+- Does 1Click rate-limit unauthenticated callers in a way one probe per pair could trip? The
+  spec documents a 429 `rate-limit-exceeded`; the practical budget for an unauthenticated
+  integration is not documented. If it is tight, the probe should move behind the first
+  focus of the amount field rather than pair selection.
+
+## 9. Pending decisions (facts are clear, someone must decide)
+
+- **Should the USD minimum also be shown converted into source-token units?** Facts: the
+  limit is enforced in USD at 1Click's own price, and the input field is in token units, so
+  the honest figure and the actionable one differ. Showing only USD is accurate but leaves
+  the user converting; showing both is more useful and slightly less precise. Owner: product
+  and design.
+- **Should the hint appear on pair selection or on first interaction with the amount field?**
+  Facts: eager is more helpful and costs one request per pair; lazy costs nothing for users
+  who never reach that field. Interacts with the rate-limit open question above. Owner:
+  product.

--- a/docs/ai/spec-driven-development/specs/2026-09-11-impr-near-intents-minimum-swap-amount.md
+++ b/docs/ai/spec-driven-development/specs/2026-09-11-impr-near-intents-minimum-swap-amount.md
@@ -172,14 +172,33 @@ turn the form red. When the user then enters an amount below it, the existing re
 destination-side message stays the mechanism that says "this is why you have no offer" —
 that path keeps working from the real failed quote, so the two never disagree.
 
+The probe fires **when the pair is selected**, so the hint is on screen before the user
+touches the amount field.
+
+**A USD minimum is shown in the user's display currency, never as a raw dollar figure.**
+The API enforces the limit in USD, but OISY does not show the user USD unless that is what
+they picked, so the figure goes through the same path as every other fiat amount in the app
+— `formatCurrency` (`src/frontend/src/lib/utils/format.utils.ts`) with `$currentCurrency`
+(`$lib/derived/currency.derived`), `$currencyExchangeStore`
+(`$lib/stores/currency-exchange.store`) and `$currentLanguage` (`$lib/derived/i18n.derived`),
+the pattern used in `LiquidiumPositionCard.svelte` and its siblings. The minimum is not
+converted into source-token units: the constraint really is a fiat one, and a token figure
+would drift with the price while reading as precise.
+
+`formatCurrency` returns `undefined` while the exchange rate still belongs to the previous
+currency (right after a switch) or is missing. Treat that exactly like an unknown minimum:
+show no hint, and in the reactive path fall back to the minimum-less
+`swap.text.swap_amount_too_low`, never a bare number with no currency on it.
+
 New `swap.text` keys in `src/frontend/src/lib/i18n/en.json`, beside the existing
 `swap_amount_too_low*` pair:
 
 - a token-denominated hint, taking `$amount` and `$symbol`, formatted with `formatToken` and
   the source token's decimals exactly as `quoteErrorMinAmount` does in `SwapForm.svelte`;
-- a USD-denominated hint, taking the formatted dollar figure;
-- a USD-denominated refusal, the error-state counterpart of `swap_amount_too_low_minimum`
-  for the reactive path.
+- a fiat-denominated hint, taking a single `$amount` placeholder that already carries the
+  currency symbol from `formatCurrency` — the key must not hardcode `$` or any currency;
+- a fiat-denominated refusal, the error-state counterpart of `swap_amount_too_low_minimum`
+  for the reactive path, with the same placeholder contract.
 
 Other locales are structurally synced by the existing i18n workflow, which does not
 translate; translations follow the project's usual route and are not part of this change.
@@ -198,17 +217,21 @@ translate; translations follow the project's usual route and are not part of thi
   separate mechanisms with their own sources.
 - **No binary search for an exact minimum.** One probe, one number, straight from the API.
 - **No use of the quote's `minAmountIn`** for this purpose (see §2).
+- **No conversion of the fiat minimum into source-token units** (see §3.4).
 - **No new API key or authenticated access.** Probes go out unauthenticated like every other
   1Click call today.
 
 ## 5. Acceptance criteria
 
 - A BTC→Polygon swap of a few hundred dollars no longer says "This swap is currently not
-  offered."; it says the amount is below the provider's minimum and names $1,000. The same
-  holds for BSC, and for Polygon and BSC as the **source** side.
+  offered."; it says the amount is below the provider's minimum and names the $1,000 limit
+  in the user's display currency. The same holds for BSC, and for Polygon and BSC as the
+  **source** side.
 - Selecting a pair whose route has a minimum shows that minimum before any amount is
   entered, in non-error styling, in the source token's units for the per-route bridge
-  minimum and in USD for the temporary chain limit.
+  minimum and in the user's display currency for the temporary chain limit.
+- Switching display currency re-renders the fiat minimum in the new currency; while the
+  exchange rate is still catching up, no hint is shown and no uncurrencied number appears.
 - Selecting a pair with no minimum above ~$0.01, or one whose probe fails or returns an
   unrecognised message, shows no hint and behaves exactly as today.
 - Entering an amount below the minimum still produces the red destination-side refusal from
@@ -233,7 +256,8 @@ The `test-coverage` gate enforces whole-project thresholds, so this lands with i
   pair, no caching of failures), a successful probe yielding no minimum, and a non-amount
   error yielding no minimum.
 - `src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts` — hint rendering for both
-  minimum kinds, absence when unknown, and the reactive red refusal for the USD shape.
+  minimum kinds, absence when unknown, the reactive red refusal for the fiat shape, and the
+  `formatCurrency`-returns-`undefined` case rendering no number.
 - `docs/ai/PRODUCT.md` updated in this PR, per Step 4 — Build (Claude Code).
 
 ## 7. Implementation plan: atomic PRs
@@ -251,17 +275,18 @@ The `test-coverage` gate enforces whole-project thresholds, so this lands with i
   hardcoded — but it tells us whether this is worth a follow-up at all or will vanish.
 - Does 1Click rate-limit unauthenticated callers in a way one probe per pair could trip? The
   spec documents a 429 `rate-limit-exceeded`; the practical budget for an unauthenticated
-  integration is not documented. If it is tight, the probe should move behind the first
-  focus of the amount field rather than pair selection.
+  integration is not documented. The probe fires on pair selection (§9); if the budget turns
+  out to be tight, moving it behind the first focus of the amount field is a contained
+  change to when the probe is called, not to any of its mechanics.
 
-## 9. Pending decisions (facts are clear, someone must decide)
+## 9. Pending decisions
 
-- **Should the USD minimum also be shown converted into source-token units?** Facts: the
-  limit is enforced in USD at 1Click's own price, and the input field is in token units, so
-  the honest figure and the actionable one differ. Showing only USD is accurate but leaves
-  the user converting; showing both is more useful and slightly less precise. Owner: product
-  and design.
-- **Should the hint appear on pair selection or on first interaction with the amount field?**
-  Facts: eager is more helpful and costs one request per pair; lazy costs nothing for users
-  who never reach that field. Interacts with the rate-limit open question above. Owner:
-  product.
+None outstanding. Both were decided on 2026-09-11 and are folded into §3.4:
+
+- **The fiat minimum is shown in the user's display currency and is not converted into
+  source-token units.** The limit is genuinely a fiat constraint, so it is rendered through
+  the app's normal `formatCurrency` path rather than as a hardcoded dollar figure, and a
+  token-unit rendering would drift with the price while reading as exact.
+- **The probe fires on pair selection**, not on first interaction with the amount field, so
+  the minimum is visible before the user commits to a number — which is the point of the
+  improvement. The cost is one cached request per pair.

--- a/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
+++ b/src/frontend/src/lib/components/swap/SwapAmountsContext.svelte
@@ -141,7 +141,7 @@
 				amountForSwap: parsedAmount,
 				selectedProvider: undefined,
 				...(err instanceof SwapAmountTooLowError && {
-					quoteError: { type: 'amount-too-low', minAmount: err.minAmount }
+					quoteError: { type: 'amount-too-low', minimum: err.minimum }
 				})
 			});
 		} finally {

--- a/src/frontend/src/lib/components/swap/SwapForm.svelte
+++ b/src/frontend/src/lib/components/swap/SwapForm.svelte
@@ -22,6 +22,9 @@
 		SWAP_SLIPPAGE_VELORA_INVALID_VALUE
 	} from '$lib/constants/swap.constants';
 	import { SLIDE_DURATION } from '$lib/constants/transition.constants';
+	import { currentCurrency } from '$lib/derived/currency.derived';
+	import { currentLanguage } from '$lib/derived/i18n.derived';
+	import { currencyExchangeStore } from '$lib/stores/currency-exchange.store';
 	import { i18n } from '$lib/stores/i18n.store';
 	import {
 		SWAP_AMOUNTS_CONTEXT_KEY,
@@ -31,7 +34,7 @@
 	import type { OptionAmount } from '$lib/types/send';
 	import type { DisplayUnit } from '$lib/types/swap';
 	import type { TokenActionErrorType } from '$lib/types/token-action';
-	import { formatToken, formatTokenBigintToNumber } from '$lib/utils/format.utils';
+	import { formatCurrency, formatToken, formatTokenBigintToNumber } from '$lib/utils/format.utils';
 	import { replacePlaceholders } from '$lib/utils/i18n.utils';
 	import { isNetworkIdICP } from '$lib/utils/network.utils';
 	import { parseToken } from '$lib/utils/parse.utils';
@@ -114,17 +117,36 @@
 			: undefined
 	);
 
-	let quoteErrorMinAmount = $derived(
-		quoteError?.type === 'amount-too-low' &&
-			nonNullish(quoteError.minAmount) &&
-			nonNullish($sourceToken)
-			? formatToken({
-					value: quoteError.minAmount,
-					unitName: $sourceToken.decimals,
-					displayDecimals: $sourceToken.decimals
-				})
-			: undefined
+	let quoteErrorMinimum = $derived(
+		quoteError?.type === 'amount-too-low' ? quoteError.minimum : undefined
 	);
+
+	// The token minimum is in the source token's own units; the fiat one is enforced in USD
+	// and shown in the user's display currency. `formatCurrency` returns undefined while the
+	// exchange rate still belongs to the previously selected currency, in which case the
+	// minimum is treated as unknown rather than rendered as a number with no currency on it.
+	let quoteErrorMinAmount = $derived.by(() => {
+		if (isNullish(quoteErrorMinimum)) {
+			return undefined;
+		}
+
+		if (quoteErrorMinimum.type === 'token') {
+			return nonNullish($sourceToken)
+				? formatToken({
+						value: quoteErrorMinimum.value,
+						unitName: $sourceToken.decimals,
+						displayDecimals: $sourceToken.decimals
+					})
+				: undefined;
+		}
+
+		return formatCurrency({
+			value: quoteErrorMinimum.value,
+			currency: $currentCurrency,
+			exchangeRate: $currencyExchangeStore,
+			language: $currentLanguage
+		});
+	});
 
 	let isSwitchTokensButtonDisabled = $derived(() => {
 		if (isNullish($destinationToken?.network.id) || isNullish($sourceToken?.network.id)) {
@@ -265,10 +287,14 @@
 								{#if showSwapNotOfferedError}
 									<div class="text-error-primary" transition:slide={SLIDE_DURATION}
 										>{#if quoteError?.type === 'amount-too-low'}
-											{#if nonNullish(quoteErrorMinAmount) && nonNullish($sourceToken)}
+											{#if nonNullish(quoteErrorMinAmount) && quoteErrorMinimum?.type === 'token' && nonNullish($sourceToken)}
 												{replacePlaceholders($i18n.swap.text.swap_amount_too_low_minimum, {
 													$amount: quoteErrorMinAmount,
 													$symbol: $sourceToken.symbol
+												})}
+											{:else if nonNullish(quoteErrorMinAmount) && quoteErrorMinimum?.type === 'usd'}
+												{replacePlaceholders($i18n.swap.text.swap_amount_too_low_minimum_fiat, {
+													$amount: quoteErrorMinAmount
 												})}
 											{:else}
 												{$i18n.swap.text.swap_amount_too_low}

--- a/src/frontend/src/lib/i18n/ar.json
+++ b/src/frontend/src/lib/i18n/ar.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "هذا التبديل غير متاح حاليًا.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "جاري تنفيذ المعاملة...",
 			"initializing": "جاري تهيئة المعاملة...",
 			"swapping": "جاري التبديل...",

--- a/src/frontend/src/lib/i18n/cs.json
+++ b/src/frontend/src/lib/i18n/cs.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Tato výměna v současné době není nabízena.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Provádění transakce...",
 			"initializing": "Inicializace transakce...",
 			"swapping": "Výměna...",

--- a/src/frontend/src/lib/i18n/de.json
+++ b/src/frontend/src/lib/i18n/de.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Dieser Tausch ist derzeit nicht verfügbar.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Führe Transaktion aus...",
 			"initializing": "Transaktion initialisieren...",
 			"swapping": "Tausche...",

--- a/src/frontend/src/lib/i18n/en.json
+++ b/src/frontend/src/lib/i18n/en.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "This swap is currently not offered.",
 			"swap_amount_too_low": "The amount is below the provider's minimum. Please enter a higher amount.",
 			"swap_amount_too_low_minimum": "The amount is below the provider's minimum. Enter at least $amount $symbol.",
+			"swap_amount_too_low_minimum_fiat": "The amount is below the provider's minimum. Enter at least $amount.",
 			"executing_transaction": "Executing transaction...",
 			"initializing": "Initializing transaction...",
 			"swapping": "Swapping...",

--- a/src/frontend/src/lib/i18n/es.json
+++ b/src/frontend/src/lib/i18n/es.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Este intercambio no se ofrece actualmente.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Ejecutando transacción...",
 			"initializing": "Inicializando transacción...",
 			"swapping": "Intercambiando...",

--- a/src/frontend/src/lib/i18n/fr.json
+++ b/src/frontend/src/lib/i18n/fr.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Cet échange n'est actuellement pas proposé.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Exécution de la transaction...",
 			"initializing": "Initialisation de la transaction...",
 			"swapping": "Échange en cours...",

--- a/src/frontend/src/lib/i18n/hi.json
+++ b/src/frontend/src/lib/i18n/hi.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "यह स्वैप वर्तमान में पेश नहीं किया गया है।",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "लेनदेन निष्पादित हो रहा है...",
 			"initializing": "लेनदेन प्रारंभ कर रहा है...",
 			"swapping": "स्वैप कर रहा है...",

--- a/src/frontend/src/lib/i18n/it.json
+++ b/src/frontend/src/lib/i18n/it.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Questo scambio non è attualmente offerto.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Esecuzione transazione...",
 			"initializing": "Inizializzazione transazione...",
 			"swapping": "Scambio...",

--- a/src/frontend/src/lib/i18n/ja.json
+++ b/src/frontend/src/lib/i18n/ja.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "このスワップは現在提供されていません。",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "トランザクションを実行中...",
 			"initializing": "トランザクションを初期化中...",
 			"swapping": "スワップ中...",

--- a/src/frontend/src/lib/i18n/ko-KR.json
+++ b/src/frontend/src/lib/i18n/ko-KR.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "이 스왑은 현재 제공되지 않습니다.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "트랜잭션 실행 중...",
 			"initializing": "트랜잭션 초기화 중...",
 			"swapping": "스왑 중...",

--- a/src/frontend/src/lib/i18n/pl.json
+++ b/src/frontend/src/lib/i18n/pl.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Ta wymiana nie jest obecnie oferowana.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Wykonywanie transakcji...",
 			"initializing": "Inicjowanie transakcji...",
 			"swapping": "Wymiana...",

--- a/src/frontend/src/lib/i18n/pt.json
+++ b/src/frontend/src/lib/i18n/pt.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Esta troca não é oferecida atualmente.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Executando transação...",
 			"initializing": "Inicializando transação...",
 			"swapping": "Trocando...",

--- a/src/frontend/src/lib/i18n/ru.json
+++ b/src/frontend/src/lib/i18n/ru.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Этот обмен в настоящее время не предлагается.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Выполнение транзакции...",
 			"initializing": "Инициализация транзакции...",
 			"swapping": "Обмен...",

--- a/src/frontend/src/lib/i18n/vi.json
+++ b/src/frontend/src/lib/i18n/vi.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "Hoán đổi này hiện không được cung cấp.",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "Đang thực hiện giao dịch...",
 			"initializing": "Đang khởi tạo giao dịch...",
 			"swapping": "Đang hoán đổi...",

--- a/src/frontend/src/lib/i18n/zh-CN.json
+++ b/src/frontend/src/lib/i18n/zh-CN.json
@@ -1197,6 +1197,7 @@
 			"swap_is_not_offered": "当前不支持此兑换。",
 			"swap_amount_too_low": "",
 			"swap_amount_too_low_minimum": "",
+			"swap_amount_too_low_minimum_fiat": "",
 			"executing_transaction": "正在执行交易...",
 			"initializing": "正在初始化交易...",
 			"swapping": "正在兑换...",

--- a/src/frontend/src/lib/rest/near-intents.rest.ts
+++ b/src/frontend/src/lib/rest/near-intents.rest.ts
@@ -7,7 +7,7 @@ import type {
 	NearIntentsStatusResponse,
 	NearIntentsToken
 } from '$lib/types/near-intents';
-import { nonNullish } from '@dfinity/utils';
+import { isNullish, nonNullish } from '@dfinity/utils';
 
 const buildHeaders = (): HeadersInit => ({
 	'Content-Type': 'application/json'
@@ -32,6 +32,28 @@ export const fetchNearIntentsTokens = async (): Promise<NearIntentsToken[]> => {
 const AMOUNT_TOO_LOW_PATTERN = /amount is too low/i;
 const AMOUNT_TOO_LOW_MINIMUM_PATTERN = /try at least (\d+)/i;
 
+// A second, unrelated refusal: 1Click caps some chains (Polygon and BSC at the time of
+// writing, on either side of the route) below a fiat floor, with a 400 reading
+// "Temporary swap limits: minimum swap amount is $1,000". The figure is USD, not token
+// units, and the API exposes it nowhere structured, so the message is the only source.
+// Matched on the part that states the constraint rather than on "Temporary swap limits":
+// the wording of the preamble, the amount and the affected chains are all volatile.
+const MINIMUM_SWAP_AMOUNT_PATTERN = /minimum swap amount/i;
+const MINIMUM_SWAP_AMOUNT_FIGURE_PATTERN = /minimum swap amount is\s*\$\s*([\d,]+(?:\.\d+)?)/i;
+
+const parseUsdMinimum = (message: string): number | undefined => {
+	const matched = MINIMUM_SWAP_AMOUNT_FIGURE_PATTERN.exec(message)?.[1];
+
+	if (isNullish(matched)) {
+		return;
+	}
+
+	const parsed = Number(matched.replace(/,/g, ''));
+
+	// A separator-only capture parses as 0, which would advertise a minimum of nothing.
+	return !isFinite(parsed) || parsed <= 0 ? undefined : parsed;
+};
+
 // https://docs.near-intents.org/api-reference/oneclick/request-a-swap-quote
 export const fetchNearIntentsQuote = async (
 	request: NearIntentsQuoteRequest
@@ -52,7 +74,16 @@ export const fetchNearIntentsQuote = async (
 
 			throw new SwapAmountTooLowError(
 				`NEAR Intents quote failed: ${message}`,
-				nonNullish(minAmount) ? BigInt(minAmount) : undefined
+				nonNullish(minAmount) ? { type: 'token', value: BigInt(minAmount) } : undefined
+			);
+		}
+
+		if (MINIMUM_SWAP_AMOUNT_PATTERN.test(message)) {
+			const usdMinimum = parseUsdMinimum(message);
+
+			throw new SwapAmountTooLowError(
+				`NEAR Intents quote failed: ${message}`,
+				nonNullish(usdMinimum) ? { type: 'usd', value: usdMinimum } : undefined
 			);
 		}
 

--- a/src/frontend/src/lib/types/errors.ts
+++ b/src/frontend/src/lib/types/errors.ts
@@ -1,3 +1,5 @@
+import type { SwapAmountMinimum } from '$lib/types/swap';
+
 export class UserProfileNotFoundError extends Error {}
 
 export class SignupsClosedError extends Error {}
@@ -38,13 +40,13 @@ export class AuthClientNotInitializedError extends Error {}
 /**
  * A swap quote provider refused the requested amount as below its minimum.
  *
- * `minAmount` is the provider's minimum, in the source token's smallest unit,
- * when the provider names one.
+ * `minimum` is the provider's minimum, when the provider names one. See
+ * `SwapAmountMinimum` for why it carries its own denomination.
  */
 export class SwapAmountTooLowError extends Error {
 	constructor(
 		message: string,
-		readonly minAmount?: bigint
+		readonly minimum?: SwapAmountMinimum
 	) {
 		super(message);
 	}

--- a/src/frontend/src/lib/types/i18n.d.ts
+++ b/src/frontend/src/lib/types/i18n.d.ts
@@ -920,6 +920,7 @@ interface I18nSwap {
 		swap_is_not_offered: string;
 		swap_amount_too_low: string;
 		swap_amount_too_low_minimum: string;
+		swap_amount_too_low_minimum_fiat: string;
 		executing_transaction: string;
 		initializing: string;
 		swapping: string;

--- a/src/frontend/src/lib/types/swap.ts
+++ b/src/frontend/src/lib/types/swap.ts
@@ -98,14 +98,24 @@ export interface FetchSwapAmountsParams {
 export type Slippage = string | number;
 
 /**
+ * A provider's minimum swap amount, which is not always denominated in the token
+ * being swapped.
+ *
+ * NEAR Intents enforces two unrelated minimums: a per-route bridge minimum, quoted in
+ * the source token's smallest unit, and a per-chain limit quoted in fiat. The fiat one
+ * cannot be converted to token units for display without inventing precision the
+ * constraint does not have, so the denomination travels with the value.
+ */
+export type SwapAmountMinimum = { type: 'token'; value: bigint } | { type: 'usd'; value: number };
+
+/**
  * The reason no offer could be quoted, when a provider named one.
  *
- * `minAmount` is the provider's minimum, in the source token's smallest unit,
- * when the provider communicated it.
+ * `minimum` is the provider's minimum, when the provider communicated it.
  */
 export interface SwapQuoteError {
 	type: 'amount-too-low';
-	minAmount?: bigint;
+	minimum?: SwapAmountMinimum;
 }
 
 export type SwapMappedResult =

--- a/src/frontend/src/tests/lib/components/swap/SwapAmountsContext.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapAmountsContext.spec.ts
@@ -202,7 +202,10 @@ describe('SwapAmountsContext.svelte', () => {
 
 	it('sets the quote error when fetchSwapAmounts throws an amount-too-low refusal', async () => {
 		vi.spyOn(swapService, 'fetchSwapAmounts').mockRejectedValue(
-			new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', 8300n)
+			new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', {
+				type: 'token',
+				value: 8300n
+			})
 		);
 
 		await renderWithContext({
@@ -219,7 +222,10 @@ describe('SwapAmountsContext.svelte', () => {
 		expect(value?.swaps).toEqual([]);
 		expect(value?.selectedProvider).toBeUndefined();
 		expect(value?.amountForSwap).toBe(20);
-		expect(value?.quoteError).toEqual({ type: 'amount-too-low', minAmount: 8300n });
+		expect(value?.quoteError).toEqual({
+			type: 'amount-too-low',
+			minimum: { type: 'token', value: 8300n }
+		});
 	});
 
 	it('debounces fetchSwapAmounts calls', async () => {

--- a/src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts
+++ b/src/frontend/src/tests/lib/components/swap/SwapForm.spec.ts
@@ -8,6 +8,9 @@ import {
 	TOKEN_INPUT_AMOUNT_EXCHANGE_VALUE,
 	TOKEN_INPUT_CURRENCY_TOKEN
 } from '$lib/constants/test-ids.constants';
+import * as currencyDerived from '$lib/derived/currency.derived';
+import { Currency } from '$lib/enums/currency';
+import * as currencyExchangeStoreModule from '$lib/stores/currency-exchange.store';
 import {
 	SWAP_AMOUNTS_CONTEXT_KEY,
 	initSwapAmountsStore,
@@ -344,6 +347,28 @@ describe('SwapForm', () => {
 	});
 
 	describe('swap not offered error', () => {
+		// The currency tests below spy on the currency stores; nothing global restores spies
+		// in this file, so keep them from leaking into the rest of the block.
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		const mockCurrency = ({
+			currency,
+			exchangeRateToUsd
+		}: {
+			currency: Currency;
+			exchangeRateToUsd: number | null;
+		}) => {
+			vi.spyOn(currencyDerived, 'currentCurrency', 'get').mockReturnValue(readable(currency));
+			vi.spyOn(currencyExchangeStoreModule, 'currencyExchangeStore', 'get').mockReturnValue({
+				...readable({ currency, exchangeRateToUsd, exchangeRate24hChangeMultiplier: null }),
+				setExchangeRate: vi.fn(),
+				setExchangeRateCurrency: vi.fn(),
+				setExchangeRate24hChangeMultiplier: vi.fn()
+			});
+		};
+
 		it('should show error when swap is not offered', () => {
 			setupSwapAmountsStore({
 				amountForSwap: 1,
@@ -449,7 +474,7 @@ describe('SwapForm', () => {
 				amountForSwap: 1,
 				swaps: [],
 				selectedProvider: undefined,
-				quoteError: { type: 'amount-too-low', minAmount: 8300n }
+				quoteError: { type: 'amount-too-low', minimum: { type: 'token', value: 8300n } }
 			});
 			setupIcTokenFeeStore();
 
@@ -475,6 +500,107 @@ describe('SwapForm', () => {
 					})
 				)
 			).toBeInTheDocument();
+			expect(queryByText(en.swap.text.swap_is_not_offered)).not.toBeInTheDocument();
+		});
+
+		it('should show a fiat provider minimum in the display currency', () => {
+			setupSwapAmountsStore({
+				amountForSwap: 1,
+				swaps: [],
+				selectedProvider: undefined,
+				quoteError: { type: 'amount-too-low', minimum: { type: 'usd', value: 1000 } }
+			});
+			setupIcTokenFeeStore();
+
+			const { getByText, queryByText } = render(SwapForm, {
+				props: {
+					swapAmount: '1',
+					receiveAmount: undefined,
+					slippageValue: undefined,
+					isSwapAmountsLoading: false,
+					onCustomValidate: vi.fn(),
+					onShowTokensList: vi.fn(),
+					onClose: vi.fn(),
+					onNext: vi.fn()
+				},
+				context: mockContext
+			});
+
+			expect(
+				getByText(
+					replacePlaceholders(en.swap.text.swap_amount_too_low_minimum_fiat, {
+						$amount: '$1,000.00'
+					})
+				)
+			).toBeInTheDocument();
+			expect(queryByText(en.swap.text.swap_is_not_offered)).not.toBeInTheDocument();
+		});
+
+		it('should convert a fiat provider minimum into the selected currency', () => {
+			mockCurrency({ currency: Currency.EUR, exchangeRateToUsd: 1.25 });
+
+			setupSwapAmountsStore({
+				amountForSwap: 1,
+				swaps: [],
+				selectedProvider: undefined,
+				quoteError: { type: 'amount-too-low', minimum: { type: 'usd', value: 1000 } }
+			});
+			setupIcTokenFeeStore();
+
+			const { getByText } = render(SwapForm, {
+				props: {
+					swapAmount: '1',
+					receiveAmount: undefined,
+					slippageValue: undefined,
+					isSwapAmountsLoading: false,
+					onCustomValidate: vi.fn(),
+					onShowTokensList: vi.fn(),
+					onClose: vi.fn(),
+					onNext: vi.fn()
+				},
+				context: mockContext
+			});
+
+			// $1,000 at 1.25 USD per EUR
+			expect(
+				getByText(
+					replacePlaceholders(en.swap.text.swap_amount_too_low_minimum_fiat, {
+						$amount: '€800.00'
+					})
+				)
+			).toBeInTheDocument();
+		});
+
+		it('should omit the figure entirely while the exchange rate lags a currency switch', () => {
+			// Switching currency nulls the rate until the worker refreshes it, which makes
+			// formatCurrency return undefined. A bare number with no currency on it would be
+			// worse than saying nothing.
+			mockCurrency({ currency: Currency.EUR, exchangeRateToUsd: null });
+
+			setupSwapAmountsStore({
+				amountForSwap: 1,
+				swaps: [],
+				selectedProvider: undefined,
+				quoteError: { type: 'amount-too-low', minimum: { type: 'usd', value: 1000 } }
+			});
+			setupIcTokenFeeStore();
+
+			const { getByText, queryByText } = render(SwapForm, {
+				props: {
+					swapAmount: '1',
+					receiveAmount: undefined,
+					slippageValue: undefined,
+					isSwapAmountsLoading: false,
+					onCustomValidate: vi.fn(),
+					onShowTokensList: vi.fn(),
+					onClose: vi.fn(),
+					onNext: vi.fn()
+				},
+				context: mockContext
+			});
+
+			expect(getByText(en.swap.text.swap_amount_too_low)).toBeInTheDocument();
+			expect(queryByText(/1,000/)).not.toBeInTheDocument();
 			expect(queryByText(en.swap.text.swap_is_not_offered)).not.toBeInTheDocument();
 		});
 

--- a/src/frontend/src/tests/lib/rest/near-intents.rest.spec.ts
+++ b/src/frontend/src/tests/lib/rest/near-intents.rest.spec.ts
@@ -117,7 +117,7 @@ describe('near-intents.rest', () => {
 			await expect(result).rejects.toThrow(SwapAmountTooLowError);
 			await expect(result).rejects.toMatchObject({
 				message: 'NEAR Intents quote failed: Amount is too low for bridge, try at least 8300',
-				minAmount: 8300n
+				minimum: { type: 'token', value: 8300n }
 			});
 		});
 
@@ -131,7 +131,106 @@ describe('near-intents.rest', () => {
 			const result = fetchNearIntentsQuote(quoteRequest);
 
 			await expect(result).rejects.toThrow(SwapAmountTooLowError);
-			await expect(result).rejects.toMatchObject({ minAmount: undefined });
+			await expect(result).rejects.toMatchObject({ minimum: undefined });
+		});
+
+		it('throws SwapAmountTooLowError with a fiat minimum for the temporary swap limit', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Request',
+				json: () =>
+					Promise.resolve({
+						message: 'Temporary swap limits: minimum swap amount is $1,000'
+					})
+			} as unknown as Response);
+
+			const result = fetchNearIntentsQuote(quoteRequest);
+
+			await expect(result).rejects.toThrow(SwapAmountTooLowError);
+			await expect(result).rejects.toMatchObject({
+				message: 'NEAR Intents quote failed: Temporary swap limits: minimum swap amount is $1,000',
+				minimum: { type: 'usd', value: 1000 }
+			});
+		});
+
+		it.each([
+			{
+				description: 'no thousands separator',
+				message: 'minimum swap amount is $1000',
+				expected: 1000
+			},
+			{
+				description: 'several separators',
+				message: 'minimum swap amount is $1,000,000',
+				expected: 1000000
+			},
+			{
+				description: 'a decimal figure',
+				message: 'minimum swap amount is $1,000.50',
+				expected: 1000.5
+			},
+			{
+				description: 'a space after the sign',
+				message: 'minimum swap amount is $ 250',
+				expected: 250
+			}
+		])('parses the fiat minimum with $description', async ({ message, expected }) => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Request',
+				json: () => Promise.resolve({ message })
+			} as unknown as Response);
+
+			const result = fetchNearIntentsQuote(quoteRequest);
+
+			await expect(result).rejects.toMatchObject({
+				minimum: { type: 'usd', value: expected }
+			});
+		});
+
+		it('prefers the token minimum when a message somehow carries both shapes', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Request',
+				json: () =>
+					Promise.resolve({
+						message:
+							'Amount is too low for bridge, try at least 8300, minimum swap amount is $1,000'
+					})
+			} as unknown as Response);
+
+			const result = fetchNearIntentsQuote(quoteRequest);
+
+			await expect(result).rejects.toMatchObject({
+				minimum: { type: 'token', value: 8300n }
+			});
+		});
+
+		it('throws SwapAmountTooLowError without a minimum when the fiat limit names no parseable figure', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Request',
+				json: () =>
+					Promise.resolve({ message: 'Temporary swap limits: minimum swap amount is unknown' })
+			} as unknown as Response);
+
+			const result = fetchNearIntentsQuote(quoteRequest);
+
+			await expect(result).rejects.toThrow(SwapAmountTooLowError);
+			await expect(result).rejects.toMatchObject({ minimum: undefined });
+		});
+
+		it('reports no minimum rather than zero when the figure is separators only', async () => {
+			vi.mocked(fetch).mockResolvedValueOnce({
+				ok: false,
+				statusText: 'Bad Request',
+				json: () => Promise.resolve({ message: 'minimum swap amount is $,,,' })
+			} as unknown as Response);
+
+			const result = fetchNearIntentsQuote(quoteRequest);
+
+			await expect(result).rejects.toThrow(SwapAmountTooLowError);
+			await expect(result).rejects.toMatchObject({ minimum: undefined });
 		});
 
 		it('throws a plain Error for other 400 messages', async () => {

--- a/src/frontend/src/tests/lib/services/swap.services.spec.ts
+++ b/src/frontend/src/tests/lib/services/swap.services.spec.ts
@@ -1273,7 +1273,10 @@ describe('swap.services', () => {
 		it('rethrows an amount-too-low refusal when no provider quoted', async () => {
 			mockVeloraGetQuote.mockResolvedValueOnce(undefined);
 			mockEvmNearIntentsGetQuote.mockRejectedValueOnce(
-				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', 8300n)
+				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', {
+					type: 'token',
+					value: 8300n
+				})
 			);
 
 			await expect(
@@ -1295,7 +1298,10 @@ describe('swap.services', () => {
 				type: 'delta'
 			});
 			mockEvmNearIntentsGetQuote.mockRejectedValueOnce(
-				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', 8300n)
+				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', {
+					type: 'token',
+					value: 8300n
+				})
 			);
 
 			const result = await fetchSwapAmountsEVM({
@@ -1398,7 +1404,10 @@ describe('swap.services', () => {
 
 		it('should rethrow an amount-too-low refusal when no provider quoted', async () => {
 			mockSolGetQuote.mockRejectedValueOnce(
-				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', 8300n)
+				new SwapAmountTooLowError('Amount is too low for bridge, try at least 8300', {
+					type: 'token',
+					value: 8300n
+				})
 			);
 
 			await expect(

--- a/src/frontend/src/tests/lib/stores/swap-amounts.store.spec.ts
+++ b/src/frontend/src/tests/lib/stores/swap-amounts.store.spec.ts
@@ -50,13 +50,13 @@ describe('swap-amounts.store', () => {
 		store.setSwaps({
 			swaps: [],
 			amountForSwap: '1000000',
-			quoteError: { type: 'amount-too-low', minAmount: 8300n }
+			quoteError: { type: 'amount-too-low', minimum: { type: 'token', value: 8300n } }
 		});
 
 		expect(get(store)).toEqual({
 			swaps: [],
 			amountForSwap: '1000000',
-			quoteError: { type: 'amount-too-low', minAmount: 8300n }
+			quoteError: { type: 'amount-too-low', minimum: { type: 'token', value: 8300n } }
 		});
 	});
 
@@ -66,7 +66,7 @@ describe('swap-amounts.store', () => {
 		store.setSwaps({
 			swaps: [],
 			amountForSwap: '1000000',
-			quoteError: { type: 'amount-too-low', minAmount: 8300n }
+			quoteError: { type: 'amount-too-low', minimum: { type: 'token', value: 8300n } }
 		});
 
 		store.setSwaps({


### PR DESCRIPTION
# Motivation

Swapping into or out of Polygon or BSC below $1,000 shows "This swap is currently not offered." The swap _is_ offered — the amount is just too small, and the provider even names the floor.

1Click enforces two unrelated minimums, and reports them with two differently-worded 400s:

| | message | unit | scope |
| --- | --- | --- | --- |
| Per-route bridge minimum | `Amount is too low for bridge, try at least 8300` | origin asset's smallest unit | every route |
| Temporary chain limit | `Temporary swap limits: minimum swap amount is $1,000` | fiat | only `pol` and `bsc`, on either side of the route |

#13820 handles the first. Its `/amount is too low/i` pattern does not match the second, so that refusal fell through to the generic message. Verified against the live API on 2026-09-11: the limit applies whether the restricted chain is the pay side or the receive side, it is evaluated on the input's USD value at 1Click's own price, and of the six chains in `NEAR_INTENTS_BLOCKCHAIN_MAP` only Polygon and BSC carry it.

The minimum is not available anywhere structured — not in `/tokens`, not in the 400 body, not in the OpenAPI contract (`BadRequestResponse` is `{ message: string }`), and there is no limits endpoint — so parsing the message is the only option. The spec in this PR records the full investigation.

# Changes

- Spec `docs/ai/spec-driven-development/specs/2026-09-11-impr-near-intents-minimum-swap-amount.md`, covering this PR and a follow-up that surfaces the minimum before an amount is entered.
- New `SwapAmountMinimum` in `$lib/types/swap` — `{ type: 'token'; value: bigint } | { type: 'usd'; value: number }`. The two minimums are denominated differently, so the denomination travels with the value instead of `SwapAmountTooLowError` carrying a bare `bigint`. `SwapQuoteError.minAmount` becomes `minimum` accordingly.
- `fetchNearIntentsQuote` matches the fiat refusal and parses its figure, tolerating thousands separators, decimals and a space after the sign. Matched on `minimum swap amount` rather than on `Temporary swap limits`, since the preamble wording, the figure and the affected chains are all volatile; shape detection is deliberately separate from figure extraction so a named-but-unparseable minimum still reports "too low" rather than "not offered", matching the existing bridge-minimum path.
- `SwapForm` renders either denomination. The fiat one goes through `formatCurrency` with `currentCurrency` / `currencyExchangeStore` / `currentLanguage`, so it appears in the user's selected display currency rather than as a hardcoded dollar figure. It is deliberately not converted into token units, which would drift with the price and read as more exact than the constraint is. While an exchange rate is unavailable (`formatCurrency` returns `undefined` right after a currency switch) the form omits the figure instead of showing a number with no currency attached.
- New `swap.text.swap_amount_too_low_minimum_fiat` key, whose placeholder already carries the currency symbol.
- `PRODUCT.md` describes how a too-small amount is reported, including the deliberate "does not convert fiat into token units".

Nothing is hardcoded: neither the $1,000 figure nor the set of restricted chains, both of which come from the provider's refusal.

# Tests

`format`, `eslint --max-warnings 0`, `check` and `check:tests` all clean; 213 tests across the five affected specs pass.

- `near-intents.rest.spec.ts` — both refusal shapes, the separator/decimal/spacing variants, a message carrying both shapes, a fiat-shaped message with no parseable figure, a separators-only figure that must not report a minimum of zero, and other 400s still throwing a plain `Error`.
- `SwapForm.spec.ts` — the fiat minimum rendered as `$1,000.00` in USD, converted to `€800.00` at a 1.25 rate, and no figure at all when the exchange rate is null.
- `SwapAmountsContext.spec.ts`, `swap-amounts.store.spec.ts`, `swap.services.spec.ts` updated to the new shape; the pre-existing bridge-minimum behaviour is unchanged in message and formatting.

Not visually verified in the running app: reproducing the refusal needs an authenticated session with a Polygon or BSC pair. The change is text content inside the existing error slot, and the component tests assert the exact rendered strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
